### PR TITLE
Send user sign in values with all mixpanel events

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -77,6 +77,9 @@ class ApplicationController < ActionController::Base
       controller_name: self.class.name.sub("Controller", ""),
       controller_action: "#{self.class.name}##{action_name}",
       controller_action_name: action_name,
+      sign_in_count: current_user&.sign_in_count,
+      current_sign_in_at: current_user&.current_sign_in_at,
+      last_sign_in_at: current_user&.last_sign_in_at,
     }
     MixpanelService.instance.run(
       unique_id: visitor_id,

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -166,6 +166,9 @@ RSpec.describe ApplicationController do
         controller_name: "Anonymous",
         controller_action: "AnonymousController#index",
         controller_action_name: "index",
+        sign_in_count: nil,
+        current_sign_in_at: nil,
+        last_sign_in_at: nil,
       }
       expect(mixpanel_spy).to have_received(:run).with(
         unique_id: "123",
@@ -182,6 +185,31 @@ RSpec.describe ApplicationController do
 
         subject.send_mixpanel_event(event_name: "beep")
         expect(mixpanel_spy).not_to have_received(:run)
+      end
+    end
+
+    context "as a logged in user" do
+      let(:user) { create(:user) }
+
+      before do
+        allow(subject).to receive(:current_user).and_return(user)
+      end
+
+      it "sends fields related to that user" do
+        get :index
+
+        subject.send_mixpanel_event(event_name: "doop")
+
+        expect(mixpanel_spy).to have_received(:run)
+          .with(
+            unique_id: "123",
+            event_name: "doop",
+            data: hash_including(
+              sign_in_count: user.sign_in_count,
+              current_sign_in_at: user.current_sign_in_at,
+              last_sign_in_at: user.last_sign_in_at,
+            )
+          )
       end
     end
   end


### PR DESCRIPTION
We added these via Devise trackable, let's put them in mixpanel for
future analysis.

https://www.pivotaltracker.com/story/show/171011580