### PR TITLE
Fix thumbnails for W-2 uploads that aren't "variable"

### DIFF
--- a/app/views/questions/w2s/edit.html.erb
+++ b/app/views/questions/w2s/edit.html.erb
@@ -20,7 +20,13 @@
               <% @documents.each do |document| %>
 
                 <li class="doc-preview">
-                  <div class="doc-preview__thumb"><%= image_tag document.upload.variant(resize: "140x140"), alt: "" %></div>
+                  <div class="doc-preview__thumb">
+                    <% if document.upload.representable? %>
+                      <%= image_tag document.upload.representation(resize: "140x140"), alt: "" %>
+                    <% else %>
+                      <%= image_tag "documents.svg", alt: "" %>
+                    <% end %>
+                  </div>
                   <div class="doc-preview__info">
                     <h2 class="h3 doc-preview__filename"><%= document.upload.filename %></h2>
                     <%= link_to(document_path(document, return_path: current_path), method: :delete, class: "link--delete", data: { confirm: "Are you sure you want to remove \"#{document.upload.filename}\"?" }) do %>

--- a/spec/controllers/questions/w2s_controller_spec.rb
+++ b/spec/controllers/questions/w2s_controller_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Questions::W2sController do
+  render_views
+
   let(:intake) { create :intake }
 
   before do
@@ -11,19 +13,29 @@ RSpec.describe Questions::W2sController do
   describe "#edit" do
     context "with existing W-2 uploads" do
       it "assigns the documents to the form" do
-        w2_doc = create :document, document_type: "W-2", intake: intake
-        _other_doc = create :document, document_type: "Other", intake: intake
+        w2_doc = create :document, :with_upload, document_type: "W-2", intake: intake
+        _other_doc = create :document, :with_upload, document_type: "Other", intake: intake
 
         get :edit
 
         expect(assigns(:documents)).to eq [w2_doc]
       end
     end
+
+    context "with a non-image document" do
+      let(:document_path) { Rails.root.join("spec", "fixtures", "attachments", "document_bundle.pdf") }
+
+      it "renders the thumbnails" do
+        w2_doc = create :document, :with_upload, document_type: "W-2", intake: intake,
+          upload_path: document_path
+
+        expect { get :edit }.not_to raise_error
+        expect(response.body).to include('document_bundle.pdf')
+      end
+    end
   end
 
   describe "#update" do
-    render_views
-
     context "with valid params" do
       let(:valid_params) do
         {

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -16,6 +16,20 @@
 FactoryBot.define do
   factory :document do
     intake
+    upload { nil }
     document_type { "W-2" }
+
+    trait :with_upload do
+      transient do
+        upload_path { Rails.root.join("spec", "fixtures", "attachments", "picture_id.jpg") }
+      end
+
+      after(:build) do |document, evaluator|
+        document.upload.attach(
+          io: File.open(evaluator.upload_path),
+          filename: File.basename(evaluator.upload_path)
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
As I learned [in this article][1]...

A "variable" upload is one that ActiveStorage can create a variant of
(images) whereas PDFs are not transformable and are instead considered
"previewable" (i.e. the preview is a thumbnail of the first page).

Combined, "variants" and "previews" are considered "representations" of
the object, which is what we want for the thumbnail. We can use the
`#representable?` method to determine if a representation exists, so the
page will render either way.

As a fallback for when the representation doesn't exist, I found an icon
of a paper clip.

[1]: https://prograils.com/posts/rails-5-2-active-storage-new-approach-to-file-uploads