### PR TITLE
Fix grey sidebar when uploading files

### DIFF
--- a/app/assets/stylesheets/molecules/_form-molecules.scss
+++ b/app/assets/stylesheets/molecules/_form-molecules.scss
@@ -46,6 +46,7 @@
 
 .file-upload {
   display: block;
+  position: relative;
 }
 
 .doc-preview {


### PR DESCRIPTION
This is a weird Chrome-only bug: when clicking the "Select a file"
button, the page expands due to the `width: 100%` rule in the
`.document-upload .form__documentuploader` selector. I can't explain
why, it only happens in Chrome, and toggling the `width: 100%` rule off
and back on again fixes the page.

The problem is avoided by ensuring a new stacking context is created in
the `.file-upload` container.