### PR TITLE
Add Documents Overview Page

### DIFF
--- a/app/assets/images/paper.svg
+++ b/app/assets/images/paper.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="20" viewBox="0 0 16 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10 0H2C0.9 0 0.0100002 0.9 0.0100002 2L0 18C0 19.1 0.89 20 1.99 20H14C15.1 20 16 19.1 16 18V6L10 0ZM12 16H4V14H12V16ZM12 12H4V10H12V12ZM9 7V1.5L14.5 7H9Z" fill="black"/>
+</svg>

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,6 +15,7 @@
 @import 'cfa_styleguide_main';
 @import 'atoms/variables';
 @import 'atoms/form-elements';
+@import 'organisms/document-overview';
 @import 'organisms/flash-messages';
 @import 'molecules/form-molecules';
 @import 'organisms/form-cards';

--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -14,6 +14,13 @@
   }
 }
 
+.button--inline-action {
+  border-radius: 0.5rem;
+  font-size: 1.6rem;
+  line-height: 3rem;
+  padding: 0 1rem;
+}
+
 .button--cta {
   background-color: #008060;
   color: white;

--- a/app/assets/stylesheets/organisms/_document-overview.scss
+++ b/app/assets/stylesheets/organisms/_document-overview.scss
@@ -1,0 +1,31 @@
+.document-overview-list {
+  &:last-of-type {
+    margin-bottom: 5rem;
+  }
+}
+
+.document-overview-list__icon {
+  width: 2rem;
+  margin-right: 3rem;
+  vertical-align: text-bottom;
+}
+
+.document-overview-list__heading {
+  display: inline-block;
+  margin-bottom: 0;
+  margin-right: 2rem;
+}
+
+.document-overview-list__button {
+  margin-bottom: 0;
+}
+
+.document-overview-list__filenames {
+  font-size: 1.6rem;
+  margin-left: 5rem;
+  margin-bottom: 2rem;
+
+  > li {
+    margin-bottom: 1.3rem;
+  }
+}

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -3,7 +3,13 @@ class DocumentsController < ApplicationController
 
   def destroy
     document = current_intake.documents.find_by(id: params[:id])
-    document.destroy if document.present?
-    redirect_to params[:return_path]
+
+    if document.present?
+      document.destroy
+
+      redirect_to helpers.edit_document_path(document.document_type)
+    else
+      redirect_to documents_overview_questions_path
+    end
   end
 end

--- a/app/controllers/questions/documents_overview_controller.rb
+++ b/app/controllers/questions/documents_overview_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Questions
+  class DocumentsOverviewController < QuestionsController
+    layout "application"
+
+    def edit
+      @documents = current_intake.documents
+    end
+
+    def section_title
+      "Documents"
+    end
+  end
+end

--- a/app/forms/question_navigation.rb
+++ b/app/forms/question_navigation.rb
@@ -77,6 +77,7 @@ class QuestionNavigation
     # Documents
     Questions::W2sController,
     Questions::AdditionalDocumentsController,
+    Questions::DocumentsOverviewController,
 
     Questions::InterviewSchedulingController,
 

--- a/app/helpers/documents_overview_helper.rb
+++ b/app/helpers/documents_overview_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module DocumentsOverviewHelper
+  def edit_document_path(document_type)
+    document_controller = Document::DOCUMENT_CONTROLLERS[document_type]
+
+    unless document_controller
+      raise "Missing document type `#{document_type}` from Document::DOCUMENT_CONTROLLERS"
+    end
+
+    url_for(controller: document_controller.controller_path, action: :edit)
+  end
+end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -14,10 +14,13 @@
 #
 
 class Document < ApplicationRecord
-  DOCUMENT_TYPES = [
-    "W-2",
-    "Other"
-  ].freeze
+  # For the document overview page, we need a mapping of which controller
+  # corresponds to which Document Type.
+  DOCUMENT_CONTROLLERS = {
+    "W-2" => Questions::W2sController,
+    "Other" => Questions::AdditionalDocumentsController,
+  }.freeze
+  DOCUMENT_TYPES = DOCUMENT_CONTROLLERS.keys.freeze
 
   validates :document_type, inclusion: { in: DOCUMENT_TYPES }
   validates :intake, presence: true

--- a/app/views/layouts/document_upload.html.erb
+++ b/app/views/layouts/document_upload.html.erb
@@ -29,7 +29,7 @@
                   </div>
                   <div class="doc-preview__info">
                     <h2 class="h3 doc-preview__filename"><%= document.upload.filename %></h2>
-                    <%= link_to(document_path(document, return_path: current_path), method: :delete, class: "link--delete", data: { confirm: "Are you sure you want to remove \"#{document.upload.filename}\"?" }) do %>
+                    <%= link_to(document_path(document), method: :delete, class: "link--delete", data: { confirm: "Are you sure you want to remove \"#{document.upload.filename}\"?" }) do %>
                       Remove
                     <% end %>
                   </div>

--- a/app/views/questions/documents_overview/edit.html.erb
+++ b/app/views/questions/documents_overview/edit.html.erb
@@ -1,0 +1,50 @@
+<% content_for :page_title, "Great work! Here's a list of what we've collected." %>
+
+<% content_for :main do %>
+  <section class="slab slab--white">
+    <div class="grid">
+      <div class="grid__item width-three-fourths shift-one-eighth">
+        <h3 class="section-title">
+          <%= image_tag("#{section_title.parameterize}.svg", alt: "") %>
+          <%= section_title %>
+        </h3>
+
+        <main role="main">
+          <h1 class="form-question">
+            <%= content_for(:page_title) %>
+          </h1>
+
+          <% if @documents.empty? %>
+            <p>No documents were uploaded.</p>
+          <% end %>
+          <div class="document-overview-list">
+            <% documents_by_type = @documents.group_by(&:document_type) %>
+            <% documents_by_type.each do |type, documents| %>
+              <%= image_tag "paper.svg", alt: "", class: "document-overview-list__icon" %><h2 class="h3 document-overview-list__heading">
+                <%= type %>
+              </h2>
+              <a href="#TODO" class="button button--small document-overview-list__button">Edit</a>
+
+              <ul class="document-overview-list__filenames">
+                <% documents.each do |document| %>
+                  <li>
+                    <%= document.upload.filename %>
+                  </li>
+                <% end %>
+              </ul>
+            <% end %>
+          </div>
+
+          <%= link_to next_path, class: "button button--icon button--wide button--primary" do %>
+            <%= image_tag "checkmark--white.svg", alt: "" %>
+            I've uploaded all my documents
+          <% end %>
+
+          <%= link_to w2s_questions_path, class: "button button--wide" do %>
+            I have another document to share
+          <% end %>
+        </main>
+      </div>
+    </div>
+  </section>
+<% end %>

--- a/app/views/questions/documents_overview/edit.html.erb
+++ b/app/views/questions/documents_overview/edit.html.erb
@@ -24,7 +24,7 @@
                 <%= type %>
               </h2>
 
-              <%= link_to 'Edit', edit_document_path(type), class: "button button--small document-overview-list__button" %>
+              <%= link_to 'edit', edit_document_path(type), class: "button button--inline-action document-overview-list__button" %>
 
               <ul class="document-overview-list__filenames">
                 <% documents.each do |document| %>

--- a/app/views/questions/documents_overview/edit.html.erb
+++ b/app/views/questions/documents_overview/edit.html.erb
@@ -23,7 +23,8 @@
               <%= image_tag "paper.svg", alt: "", class: "document-overview-list__icon" %><h2 class="h3 document-overview-list__heading">
                 <%= type %>
               </h2>
-              <a href="#TODO" class="button button--small document-overview-list__button">Edit</a>
+
+              <%= link_to 'Edit', edit_document_path(type), class: "button button--small document-overview-list__button" %>
 
               <ul class="document-overview-list__filenames">
                 <% documents.each do |document| %>

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -13,16 +13,16 @@ RSpec.describe DocumentsController, type: :controller do
       expect(response).to redirect_to(identity_questions_path)
     end
 
-    context "with an authenticated user & expected params" do
+    context "with an authenticated user" do
       let(:params) do
-        { id: document.id, return_path: w2s_questions_path }
+        { id: document.id }
       end
 
       before do
         allow(controller).to receive(:current_user).and_return(user)
       end
 
-      it "allows them to delete their own document and redirects to redirect_path" do
+      it "allows them to delete their own document and redirects back" do
         expect do
           delete :destroy, params: params
         end.to change(Document, :count).by(-1)
@@ -32,22 +32,22 @@ RSpec.describe DocumentsController, type: :controller do
 
       context "with a document id that does not exist" do
         let(:params) do
-          { id: 123874619823764, return_path: w2s_questions_path }
+          { id: 123874619823764 }
         end
 
-        it "simply redirects to redirect_path" do
+        it "simply redirects to the documents overview page" do
           expect do
             delete :destroy, params: params
           end.not_to change(Document, :count)
 
-          expect(response).to redirect_to w2s_questions_path
+          expect(response).to redirect_to(documents_overview_questions_path)
         end
       end
 
       context "for another user's document" do
         let(:user) { create :user }
         let(:params) do
-          { id: document.id, return_path: w2s_questions_path }
+          { id: document.id }
         end
 
         it "does not delete the other document" do
@@ -55,7 +55,7 @@ RSpec.describe DocumentsController, type: :controller do
             delete :destroy, params: params
           end.not_to change(Document, :count)
 
-          expect(response).to redirect_to w2s_questions_path
+          expect(response).to redirect_to(documents_overview_questions_path)
         end
       end
     end

--- a/spec/controllers/questions/documents_overview_controller_spec.rb
+++ b/spec/controllers/questions/documents_overview_controller_spec.rb
@@ -33,10 +33,11 @@ RSpec.describe Questions::DocumentsOverviewController do
         ]
       end
 
-      it "includes the sections" do
+      it "includes the sections with links to the document types" do
         get :edit
 
         expect(response.body).to include("W-2")
+        expect(response.body).to include(w2s_questions_path)
         expect(response.body).to include(documents[0].upload.filename.to_s)
       end
     end

--- a/spec/controllers/questions/documents_overview_controller_spec.rb
+++ b/spec/controllers/questions/documents_overview_controller_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe Questions::DocumentsOverviewController do
+  render_views
+
+  let(:intake) { create :intake }
+
+  before do
+    allow(subject).to receive(:user_signed_in?).and_return(true)
+    allow(subject).to receive(:current_intake).and_return intake
+  end
+
+  describe "#edit" do
+    before do
+      intake.documents = documents
+      intake.save
+    end
+
+    context "with no document uploads" do
+      let(:documents) { [] }
+
+      it "displays an empty message" do
+        get :edit
+        expect(response.body).to include("No documents were uploaded.")
+      end
+    end
+
+    context "with documents that have been uploaded" do
+      let(:documents) do
+        [
+          create(:document, :with_upload, intake: intake, document_type: "W-2"),
+          create(:document, :with_upload, intake: intake, document_type: "Other"),
+        ]
+      end
+
+      it "includes the sections" do
+        get :edit
+
+        expect(response.body).to include("W-2")
+        expect(response.body).to include(documents[0].upload.filename.to_s)
+      end
+    end
+  end
+end

--- a/spec/features/web_intake/new_joint_filers_spec.rb
+++ b/spec/features/web_intake/new_joint_filers_spec.rb
@@ -266,6 +266,9 @@ RSpec.feature "Web Intake Joint Filers" do
     click_on "Upload"
     expect(page).to have_content("test-pattern.png")
     click_on "Done with this step"
+
+    expect(page).to have_selector("h1", text: "Great work! Here's a list of what we've collected.")
+    click_on "I've uploaded all my documents"
   end
 end
 

--- a/spec/features/web_intake/new_single_filer_spec.rb
+++ b/spec/features/web_intake/new_single_filer_spec.rb
@@ -186,5 +186,8 @@ RSpec.feature "Web Intake Single Filer" do
     click_on "Upload"
     expect(page).to have_content("test-pattern.png")
     click_on "Done with this step"
+
+    expect(page).to have_selector("h1", text: "Great work! Here's a list of what we've collected.")
+    click_on "I've uploaded all my documents"
   end
 end

--- a/spec/helpers/documents_overview_helper_spec.rb
+++ b/spec/helpers/documents_overview_helper_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe DocumentsOverviewHelper do
+  context "for a known document type" do
+    let(:document_type) { "W-2" }
+
+    it "returns the correct path" do
+      result = helper.edit_document_path(document_type)
+      expect(result).to eq("/questions/w2s")
+    end
+  end
+
+  context "for an unknown document type" do
+    let(:document_type) { "AnOldPieceOfParchment" }
+
+    it "raises an error" do
+      expect { helper.edit_document_path(document_type) }
+        .to raise_error(/Missing document type/)
+    end
+  end
+end


### PR DESCRIPTION
Ready for review now!

<img width="880" alt="image" src="https://user-images.githubusercontent.com/129120/74306530-9d7ca680-4d17-11ea-93a2-0f09fcb87217.png">


A couple outstanding design questions remain:
1. What is the destination for the "I have another document to upload". Right now, it goes all the way back to W-2's upload -- is that right?
2. Do we want to adjust the design given the appearance of the existing classes in the app? (Edit button is bigger than expected, button--wide is not wide enough)
3. Copy is inconsistent: Do users "upload", "share", or "file" documents.

Some non-design questions also:
1. The "return to previous page" behavior proved to be more complicated than I thought due to the fact that we'd have to pass through the parameter when the user deletes an existing file or uploads a new file. This is possible, but it would mean multiple params being passed around in some cases. I decided to skip this for now. Are we ok with that?
2. Are any analytics necessary for this feature?