### PR TITLE
Add Zendesk SMS <> ticket linking

### DIFF
--- a/app/controllers/email_controller.rb
+++ b/app/controllers/email_controller.rb
@@ -1,16 +1,32 @@
 class EmailController < ApplicationController
   skip_before_action :verify_authenticity_token, only: :create
 
+  # Edit this regex via: https://regex101.com/r/gm4p3C/2
+  ZENDESK_SMS_REGEX = /〒\nphone: \+(?<phone_number>[0-9]{11})\nticket_id: (?<ticket_id>[0-9]*)\nbody: (?<body>.+)\n〶/m
+
   def create
     raise StandardError unless params[:to].include?("zendesk-sms@hooks.vitataxhelp.org")
 
     body = params[:text]
-    # https://regex101.com/r/gm4p3C/2
-    regex = /〒\nphone: \+(?<phone_number>[0-9]{11})\nticket_id: (?<ticket_id>[0-9]*)\nbody: (?<body>.+)\n〶/m
-    matches_hash = body.match(regex).named_captures
-    @zendesk_ticket_id = matches_hash["ticket_id"].to_i
-    @phone_number = matches_hash["phone_number"]
-    @message_body = matches_hash["body"]
+    match = body.match(ZENDESK_SMS_REGEX)
+
+    raise "Could not parse Zendesk SMS Message" unless match
+
+    is_from_zendesk_text_user = (params[:from].include? "Text user: +") &&
+      (params[:from].include? "support@eitc.zendesk.com")
+
+    if is_from_zendesk_text_user
+      @zendesk_ticket_id = match["ticket_id"].to_i
+      @phone_number = match["phone_number"]
+      @message_body = match["body"]
+
+      ZendeskInboundSmsJob.perform_later(
+        sms_ticket_id: @zendesk_ticket_id,
+        phone_number: @phone_number,
+        message_body: @message_body
+      )
+    end
+
     render status: 200, json: "success"
   end
 end

--- a/app/helpers/eitc_zendesk_instance.rb
+++ b/app/helpers/eitc_zendesk_instance.rb
@@ -18,6 +18,8 @@ class EitcZendeskInstance
   INTAKE_STATUS = "360029025294"
   SIGNATURE_METHOD = "360029896814"
   HSA = "360031865033"
+  LINKED_TICKET = "360033135434"
+  NEEDS_RESPONSE = "360035388874"
 
   # Digital Intake Status value tags
   INTAKE_STATUS_IN_PROGRESS = "1._new_online_submission"

--- a/app/jobs/zendesk_inbound_sms_job.rb
+++ b/app/jobs/zendesk_inbound_sms_job.rb
@@ -1,0 +1,11 @@
+class ZendeskInboundSmsJob < ApplicationJob
+  queue_as :default
+
+  def perform(sms_ticket_id:, phone_number:, message_body:)
+    ZendeskSmsService.new.handle_inbound_sms(
+      sms_ticket_id: sms_ticket_id,
+      phone_number: phone_number,
+      message_body: message_body
+    )
+  end
+end

--- a/app/services/zendesk_sms_service.rb
+++ b/app/services/zendesk_sms_service.rb
@@ -1,9 +1,74 @@
 class ZendeskSmsService
-  def initialize(phone_number:)
-    @phone_number = phone_number
+  include ZendeskServiceHelper
+
+  class InboundSMSError < StandardError; end
+
+  def initialize; end
+
+  def handle_inbound_sms(phone_number:, sms_ticket_id:, message_body:)
+    users = User.where(phone_number: phone_number)
+    drop_offs = IntakeSiteDropOff.where(phone_number: phone_number)
+
+    if users.empty? && drop_offs.empty?
+      return append_comment_to_ticket(
+        ticket_id: sms_ticket_id,
+        comment: "This user could not be found.\ntext_user_not_found",
+      )
+    end
+
+    # get all associated tickets for intakes and drop offs
+    related_ticket_ids = (users.map { |user| user.intake.intake_ticket_id.to_s } +
+        drop_offs.map { |drop_off| drop_off.zendesk_ticket_id }).reject(&:blank?).uniq.sort
+
+    if related_ticket_ids.empty?
+      return append_comment_to_ticket(
+        ticket_id: sms_ticket_id,
+        comment: "This user has no associated tickets.\ntext_user_has_no_other_ticket",
+      )
+    end
+
+    related_ticket_comment_body = <<~BODY
+      New text message from client: #{phone_number}
+      Text message thread ticket: #{ticket_url(sms_ticket_id)}
+      ---------------------------
+      #{message_body}
+    BODY
+
+    related_ticket_fields = {
+      EitcZendeskInstance::LINKED_TICKET => ticket_url(sms_ticket_id),
+      EitcZendeskInstance::NEEDS_RESPONSE => true
+    }
+
+    related_tickets = []
+    related_ticket_ids.each do |related_ticket_id|
+      related_tickets << get_ticket(ticket_id: related_ticket_id)
+      append_comment_to_ticket(
+        ticket_id: related_ticket_id,
+        comment: related_ticket_comment_body,
+        fields: related_ticket_fields
+      )
+    end
+
+    # comment on sms ticket with related ticket id's
+    # update linked ticket field with related ticket id's
+    ticket_urls = related_ticket_ids.map { |id| ticket_url(id) }
+    comment_body = ticket_urls.reduce("Linked to related tickets:\n") { |body, url| body + "• #{url}\n" }
+    append_comment_to_ticket(
+      ticket_id: sms_ticket_id,
+      comment: comment_body,
+      fields: {
+        EitcZendeskInstance::LINKED_TICKET => ticket_urls.join(",")
+      }
+    )
+
+    # assign sms ticket to same group as most recently updated related ticket
+    most_recently_updated_ticket = related_tickets.sort_by(&:updated_at).last
+    assign_ticket_to_group(ticket_id: sms_ticket_id, group_id: most_recently_updated_ticket.group_id)
   end
 
-  def find_associated_records
-    User.where(phone_number: @phone_number)
+  private
+
+  def ticket_url(ticket_id)
+    "https://#{EitcZendeskInstance::DOMAIN}.zendesk.com/agent/tickets/#{ticket_id}"
   end
 end

--- a/spec/jobs/zendesk_inbound_sms_job_spec.rb
+++ b/spec/jobs/zendesk_inbound_sms_job_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe ZendeskInboundSmsJob, type: :job do
+  let(:sms_ticket_id) { 1492 }
+  let(:phone_number) { "14158161286" }
+  let(:message_body) { "message_body here" }
+  let(:fake_zendesk_sms_service) { double(ZendeskSmsService) }
+
+  before do
+    allow(ZendeskSmsService).to receive(:new).and_return(fake_zendesk_sms_service)
+    allow(fake_zendesk_sms_service).to receive(:handle_inbound_sms).and_return(true)
+  end
+
+  describe "#perform" do
+    before do
+      described_class.perform_now(
+        sms_ticket_id: sms_ticket_id,
+        phone_number: phone_number,
+        message_body: message_body,
+      )
+    end
+
+    it "calls the service" do
+      expect(fake_zendesk_sms_service).to have_received(:handle_inbound_sms).with(
+        sms_ticket_id: sms_ticket_id,
+        phone_number: phone_number,
+        message_body: message_body,
+      )
+    end
+  end
+end
+

--- a/spec/services/zendesk_drop_off_service_spec.rb
+++ b/spec/services/zendesk_drop_off_service_spec.rb
@@ -181,7 +181,7 @@ describe ZendeskDropOffService do
     context "when only name is present" do
       it "searches with only name" do
         service.find_end_user("Gary Guava", nil, nil)
-        expect(service).to have_received(:search_zendesk_users).with("name:\"Gary Guava\"")
+        expect(service).to have_received(:search_zendesk_users).with("name:\"Gary Guava\" ")
       end
     end
 

--- a/spec/services/zendesk_sms_service_spec.rb
+++ b/spec/services/zendesk_sms_service_spec.rb
@@ -1,27 +1,145 @@
 require "rails_helper"
 
 describe ZendeskSmsService do
-  let(:phone_number) { "15557779999" }
-  let(:service) { described_class.new(phone_number: phone_number) }
+  let(:service) { described_class.new }
+  let(:sms_ticket_id) { 1492 }
+  let(:phone_number) { "14158161286" }
+  let(:sms_message_body) { "body here" }
 
-  describe "#find_associated_records" do
-    context "with a matching user" do
-      let!(:user) { create :user, phone_number: phone_number}
+  before do
+    allow(service).to receive(:append_comment_to_ticket).and_return true
+  end
 
-      it "returns the drop off" do
-        results = service.find_associated_records
-        expect(results.length).to eq 1
-        expect(results.first).to eq user
+  describe "#handle_inbound_sms" do
+    context "when there is no record with this phone number" do
+      it "leaves an internal note on the sms ticket" do
+        service.handle_inbound_sms(
+          phone_number: phone_number,
+          sms_ticket_id: sms_ticket_id,
+          message_body: sms_message_body
+        )
+
+        expect(service).to have_received(:append_comment_to_ticket).with(
+          ticket_id: sms_ticket_id,
+          comment: "This user could not be found.\ntext_user_not_found",
+        )
       end
     end
 
-    xcontext "with a matching intake_site_drop_off" do
-      let!(:intake_site_drop_off) { create :intake_site_drop_off, phone_number: phone_number}
+    context "when we found the phone number in our records but don't have any zendesk ticket ids" do
+      let!(:drop_off) do
+        create(:intake_site_drop_off, phone_number: phone_number, zendesk_ticket_id: nil)
+      end
+      let(:intake) { create :intake, intake_ticket_id: nil }
+      let!(:user) do
+        create(:user, intake: intake, phone_number: phone_number)
+      end
 
-      it "returns the drop off" do
-        results = service.find_associated_records
-        expect(results.length).to eq 1
-        expect(results.first).to eq intake_site_drop_off
+      it "leaves an internal note on the sms ticket" do
+        service.handle_inbound_sms(
+          phone_number: phone_number,
+          sms_ticket_id: sms_ticket_id,
+          message_body: sms_message_body
+        )
+
+        expect(service).to have_received(:append_comment_to_ticket).with(
+          ticket_id: sms_ticket_id,
+          comment: "This user has no associated tickets.\ntext_user_has_no_other_ticket",
+          )
+      end
+    end
+
+    context "when there are users, drop offs and Zendesk tickets associated with this phone number" do
+      let(:fake_ticket_1) { double(ZendeskAPI::Ticket, id: 1, group_id: "1001", updated_at: DateTime.new(2020, 4, 15, 6, 1)) }
+      let(:fake_ticket_2) { double(ZendeskAPI::Ticket, id: 2, group_id: "1002", updated_at: DateTime.new(2020, 4, 15, 6, 2)) }
+      let(:fake_ticket_3) { double(ZendeskAPI::Ticket, id: 3, group_id: "1003", updated_at: DateTime.new(2020, 4, 15, 6, 3)) }
+      let(:fake_ticket_4) { double(ZendeskAPI::Ticket, id: 4, group_id: "1004", updated_at: DateTime.new(2020, 4, 15, 6, 4)) }
+      let!(:drop_offs) do
+        [
+          create(:intake_site_drop_off, phone_number: phone_number, zendesk_ticket_id: "1"),
+          create(:intake_site_drop_off, phone_number: phone_number, zendesk_ticket_id: "2")
+        ]
+      end
+      let(:first_intake) { create :intake, intake_ticket_id: 3 }
+      let(:second_intake) { create :intake, intake_ticket_id: 4 }
+      let!(:users) do
+        [
+          create(:user, intake: first_intake, phone_number: phone_number),
+          create(:user, intake: second_intake, phone_number: phone_number)
+        ]
+      end
+
+      before do
+        allow(service).to receive(:assign_ticket_to_group).and_return true
+        allow(service).to receive(:get_ticket).with(ticket_id: "1").and_return fake_ticket_1
+        allow(service).to receive(:get_ticket).with(ticket_id: "2").and_return fake_ticket_2
+        allow(service).to receive(:get_ticket).with(ticket_id: "3").and_return fake_ticket_3
+        allow(service).to receive(:get_ticket).with(ticket_id: "4").and_return fake_ticket_4
+      end
+
+      it "updates the sms ticket with a comment to link to the other relevant tickets" do
+        service.handle_inbound_sms(
+          phone_number: phone_number,
+          sms_ticket_id: sms_ticket_id,
+          message_body: sms_message_body
+        )
+
+        expected_comment_body = <<~BODY
+          Linked to related tickets:
+          • https://eitc.zendesk.com/agent/tickets/1
+          • https://eitc.zendesk.com/agent/tickets/2
+          • https://eitc.zendesk.com/agent/tickets/3
+          • https://eitc.zendesk.com/agent/tickets/4
+        BODY
+
+        expect(service).to have_received(:append_comment_to_ticket).with(
+          ticket_id: sms_ticket_id,
+          comment: expected_comment_body,
+          fields: {
+            EitcZendeskInstance::LINKED_TICKET => "https://eitc.zendesk.com/agent/tickets/1,https://eitc.zendesk.com/agent/tickets/2,https://eitc.zendesk.com/agent/tickets/3,https://eitc.zendesk.com/agent/tickets/4"
+          },
+        )
+      end
+
+      context "with existing tickets that have different group ids" do
+        it "updates the sms ticket with the group id of the most recently updated related ticket" do
+          service.handle_inbound_sms(
+            phone_number: phone_number,
+            sms_ticket_id: sms_ticket_id,
+            message_body: sms_message_body
+          )
+
+          expect(service).to have_received(:assign_ticket_to_group).with(
+            ticket_id: sms_ticket_id,
+            group_id: "1004"
+          )
+        end
+      end
+
+      it "updates each related ticket to link it and flag it" do
+        service.handle_inbound_sms(
+          phone_number: phone_number,
+          sms_ticket_id: sms_ticket_id,
+          message_body: sms_message_body
+        )
+
+        expected_comment_body = <<~BODY
+          New text message from client: 14158161286
+          Text message thread ticket: https://eitc.zendesk.com/agent/tickets/1492
+          ---------------------------
+          body here
+        BODY
+
+        ["1", "2", "3", "4"].map do |ticket_id|
+          expect(service).to have_received(:append_comment_to_ticket).with(
+            ticket_id: ticket_id,
+            comment: expected_comment_body,
+            fields: {
+              EitcZendeskInstance::LINKED_TICKET => "https://eitc.zendesk.com/agent/tickets/1492",
+              EitcZendeskInstance::NEEDS_RESPONSE => true
+            },
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
This adds the outline for the logic in
https://www.pivotaltracker.com/story/show/170411644.

This seems to work in Zendesk:
https://eitc.zendesk.com/agent/tickets/103 (text user ticket)
https://eitc.zendesk.com/agent/tickets/851 (primary ticket)

Still to do:
* Write a bunch of tests for when various look-ups fail.
* Verify the logic for finding the "primary ticket" - Is it the latest
one???
* Discuss testing strategy
* Clean up logic in `#handle_inbound_sms`
* Add test for `find_latest_ticket`