### PR TITLE
[WIP?] Allow users to return to pages later in the flow

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -114,7 +114,7 @@ class ApplicationController < ActionController::Base
 
   def require_sign_in
     unless user_signed_in?
-      redirect_to identity_questions_path
+      redirect_to identity_questions_path(after_login: request.path)
     end
   end
 

--- a/app/views/questions/identity/edit.html.erb
+++ b/app/views/questions/identity/edit.html.erb
@@ -13,7 +13,7 @@
               <%= image_tag("questions/#{illustration_path}", alt: "") %>
             </div>
 
-            <%= link_to user_idme_omniauth_authorize_path, class: "button button--primary button--wide text--centered", method: :post do %>
+            <%= link_to user_idme_omniauth_authorize_path(after_login: params[:after_login]), class: "button button--primary button--wide text--centered", method: :post do %>
               Sign in with <span class="sr-only">ID.me</span> <%= image_tag("ID.me.svg", alt: "", class: "button-logo--inline") %>
             <% end %>
 

--- a/lib/strategies/idme.rb
+++ b/lib/strategies/idme.rb
@@ -28,10 +28,6 @@ module OmniAuth
         }
       end
 
-      def callback_url
-        full_host + script_name + callback_path
-      end
-
       private
 
       def fields

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -319,4 +319,21 @@ RSpec.describe ApplicationController do
       end
     end
   end
+
+  describe "#require_sign_in" do
+    controller do
+      before_action :require_sign_in
+
+      def index
+        head :ok
+      end
+    end
+
+    it "adds the after_login param onto the URL" do
+      get :index
+ 
+      expected_path = controller.identity_questions_path(after_login: "/anonymous")
+      expect(response).to redirect_to(expected_path)
+    end
+  end
 end

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe DocumentsController, type: :controller do
         delete :destroy, params: { id: document.id }
       end.not_to change(Document, :count)
 
-      expect(response).to redirect_to(identity_questions_path)
+      expect(response).to redirect_to(identity_questions_path(after_login: document_path(document)))
     end
 
     context "with an authenticated user" do

--- a/spec/controllers/questions/identity_controller_spec.rb
+++ b/spec/controllers/questions/identity_controller_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe Questions::IdentityController do
+  render_views
+
+  describe "#edit" do
+    context "with a next_path param in the URL" do
+      let(:params) { { after_login: "/foo-bar" } }
+
+      it "links to the omniauth callback with that URL" do
+        get :edit, params: params
+        
+        expect(response.body).to include(user_idme_omniauth_authorize_path(after_login: "/foo-bar"))
+      end
+    end
+  end
+end

--- a/spec/controllers/questions/job_count_controller_spec.rb
+++ b/spec/controllers/questions/job_count_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Questions::JobCountController do
       it "redirects to ID.me login page" do
         get :edit
 
-        expect(response).to redirect_to identity_questions_path
+        expect(response).to redirect_to(identity_questions_path(after_login: job_count_questions_path))
       end
     end
   end

--- a/spec/features/web_intake/returning_filer_spec.rb
+++ b/spec/features/web_intake/returning_filer_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Returning user to online intake" do
     end
   end
 
-  scenario "client tries to return to a sign in protected page after being signed out" do
+  scenario "client tries to return to a sign in protected page after signing out" do
     silence_omniauth_logging do
       visit "/questions/wages"
     end
@@ -25,6 +25,6 @@ RSpec.feature "Returning user to online intake" do
     OmniAuth.config.mock_auth[:idme] = omniauth_idme_success
     click_on "Sign in with ID.me"
 
-    expect(page).to have_selector("h1", text: "What is your mailing address?")
+    expect(page).to have_selector("h1", text: "In 2019, did you receive wages or salary?")
   end
 end

--- a/spec/lib/strategies/idme_spec.rb
+++ b/spec/lib/strategies/idme_spec.rb
@@ -165,13 +165,4 @@ RSpec.describe OmniAuth::Strategies::IdMe do
       end
     end
   end
-
-  describe "#callback_url" do
-    it "is a combination of host, script name, and callback path" do
-      allow(subject).to receive(:full_host).and_return("https://example.com")
-      allow(subject).to receive(:script_name).and_return("/sub_uri")
-
-      expect(subject.callback_url).to eq("https://example.com/sub_uri/users/auth/idme/callback")
-    end
-  end
 end


### PR DESCRIPTION
**WIP because:** I'm not sure about the `callback_url` change in ID.me strategy, and removing the test because it didn't easily work. I wish I could have had more time to get the test working but I had to go.

---
For a returning user, we want them to be able to return to a later page,
e.g. the /documents/additional-documents after they log in. This
accomplishes it by adding a `next_path` param to the URL which is
carried through the "Sign in with ID.me" button and the OmniAuth
callback.

The change to the OmniAuth strategy (removing the overridden
`callback_url` method) is to return to the superclass's behavior of
including the query string when generating the callback URL. See:
https://github.com/omniauth/omniauth/blob/master/lib/omniauth/strategy.rb#L443-L445

As for testing, I added a couple light controller tests but the real
heavy lifter here is a surprisingly-existent feature spec that seemed to
be testing this behavior (but with a strange expectation). I updated the
expectation to match the intended behavior, and it now works.

https://www.pivotaltracker.com/story/show/171505178