### PR TITLE
Follow up docs page

### DIFF
--- a/app/controllers/documents/document_upload_question_controller.rb
+++ b/app/controllers/documents/document_upload_question_controller.rb
@@ -25,7 +25,6 @@ module Documents
 
     private
 
-
     def form_name
       "document_type_upload_form"
     end

--- a/app/controllers/documents/overview_controller.rb
+++ b/app/controllers/documents/overview_controller.rb
@@ -15,7 +15,10 @@ module Documents
     end
 
     def recommended_document_types
-      DocumentNavigation.new(self).types_for_intake(current_intake)
+      document_types = DocumentNavigation.new(self).types_for_intake(current_intake)
+      include_requested_documents = @documents.where(document_type: "Requested").exists?
+      document_types += ["Requested"] if include_requested_documents
+      document_types
     end
   end
 end

--- a/app/controllers/documents/requested_documents_controller.rb
+++ b/app/controllers/documents/requested_documents_controller.rb
@@ -1,0 +1,11 @@
+module Documents
+  class RequestedDocumentsController < DocumentUploadQuestionController
+    def self.show?(intake)
+      false
+    end
+
+    def next_path(params = {})
+      send_requested_documents_documents_path
+    end
+  end
+end

--- a/app/controllers/documents/send_requested_documents_controller.rb
+++ b/app/controllers/documents/send_requested_documents_controller.rb
@@ -1,0 +1,18 @@
+module Documents
+  class SendRequestedDocumentsController < DocumentUploadQuestionController
+    def edit
+      SendRequestedDocumentsToZendeskJob.perform_later(intake: current_intake)
+      flash[:notice] = "Thank you, your documents have been submitted."
+      redirect_to root_path
+    end
+
+    def self.show?
+      false
+    end
+
+    def self.form_class
+      NullForm
+    end
+  end
+end
+

--- a/app/jobs/send_requested_documents_to_zendesk_job.rb
+++ b/app/jobs/send_requested_documents_to_zendesk_job.rb
@@ -1,0 +1,8 @@
+class SendRequestedDocumentsToZendeskJob < ApplicationJob
+  queue_as :default
+
+  def perform(intake_id)
+    service = ZendeskFollowUpDocsService.new(Intake.find(intake_id))
+    service.send_requested_docs
+  end
+end

--- a/app/lib/document_navigation.rb
+++ b/app/lib/document_navigation.rb
@@ -29,12 +29,14 @@ class DocumentNavigation
     "W-2G" => Documents::W2gsController,
     "2018 Tax Return" => Documents::PriorTaxReturnsController,
     "Other" => Documents::AdditionalDocumentsController,
+    "Requested" => Documents::RequestedDocumentsController,
   }.freeze
   BEFORE_CONTROLLERS = [
     Documents::IntroController
   ].freeze
   AFTER_CONTROLLERS = [
-    Documents::OverviewController
+    Documents::OverviewController,
+    Documents::SendRequestedDocumentsController,
   ].freeze
   DOCUMENT_TYPES = DOCUMENT_CONTROLLERS.keys.freeze
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -2,11 +2,12 @@
 #
 # Table name: documents
 #
-#  id            :bigint           not null, primary key
-#  document_type :string           not null
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  intake_id     :bigint
+#  id                :bigint           not null, primary key
+#  document_type     :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  intake_id         :bigint
+#  zendesk_ticket_id :bigint
 #
 # Indexes
 #

--- a/app/services/zendesk_follow_up_docs_service.rb
+++ b/app/services/zendesk_follow_up_docs_service.rb
@@ -1,0 +1,37 @@
+class ZendeskFollowUpDocsService
+  include ZendeskServiceHelper
+  include ActiveStorage::Downloading
+
+  def initialize(intake)
+    @intake = intake
+  end
+
+  def send_requested_docs
+    new_requested_docs = @intake.documents.where(document_type: "Requested", zendesk_ticket_id: nil)
+    file_list = new_requested_docs.map do |document|
+      @document_blob = document.upload
+      tmpfile = Tempfile.open(["ZendeskFollowUpDocsService", blob.filename.extension_with_delimiter], Dir.tmpdir)
+      download_blob_to(tmpfile)
+
+      { file: tmpfile, filename: document.upload.filename.to_s }
+    end
+
+    output = append_multiple_files_to_ticket(
+      ticket_id: @intake.intake_ticket_id,
+      file_list: file_list,
+      comment: "The client added requested follow-up documents:\n" + new_requested_docs.map { |d| "* #{d.upload.filename}\n" }.join,
+    )
+
+    raise CouldNotSendFollowUpDocError unless output
+    new_requested_docs.each { |doc| doc.update(zendesk_ticket_id: @intake.intake_ticket_id) }
+    output
+  ensure
+    file_list.each { |entry| entry[:file].close! }
+  end
+
+  def blob
+    @document_blob
+  end
+
+  class CouldNotSendFollowUpDocError < ZendeskServiceError; end
+end

--- a/app/views/documents/requested_documents/edit.html.erb
+++ b/app/views/documents/requested_documents/edit.html.erb
@@ -1,0 +1,1 @@
+<% content_for :form_question, "Your tax specialist is requesting additional documents" %>

--- a/db/migrate/20200310224309_add_zendesk_ticket_id_to_document.rb
+++ b/db/migrate/20200310224309_add_zendesk_ticket_id_to_document.rb
@@ -1,0 +1,5 @@
+class AddZendeskTicketIdToDocument < ActiveRecord::Migration[5.2]
+  def change
+    add_column :documents, :zendesk_ticket_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_26_004131) do
+ActiveRecord::Schema.define(version: 2020_03_10_224309) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -74,6 +74,7 @@ ActiveRecord::Schema.define(version: 2020_02_26_004131) do
     t.bigint "intake_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "zendesk_ticket_id"
     t.index ["intake_id"], name: "index_documents_on_intake_id"
   end
 

--- a/spec/controllers/documents/overview_controller_spec.rb
+++ b/spec/controllers/documents/overview_controller_spec.rb
@@ -23,6 +23,11 @@ RSpec.describe Documents::OverviewController do
         get :edit
         expect(response.body).to include("No documents of this type were uploaded.")
       end
+
+      it "does not display requested documents in the list" do
+        get :edit
+        expect(response.body).not_to include("Requested")
+      end
     end
 
     context "with documents that have been uploaded" do
@@ -40,6 +45,23 @@ RSpec.describe Documents::OverviewController do
         expect(response.body).to include("W-2")
         expect(response.body).to include(w2s_documents_path)
         expect(response.body).to include(documents[0].upload.filename.to_s)
+        expect(response.body).not_to include("Requested")
+      end
+
+      context "requested documents" do
+        let(:documents) do
+          [
+            create(:document, :with_upload, intake: intake, document_type: "Requested")
+          ]
+        end
+
+        it "includes requested documents as a category only if documents of this type have been uploaded" do
+          get :edit
+
+          expect(response.body).to include("Requested")
+          expect(response.body).to include(requested_documents_documents_path)
+          expect(response.body).to include(documents[0].upload.filename.to_s)
+        end
       end
     end
 

--- a/spec/controllers/documents/requested_documents_controller_spec.rb
+++ b/spec/controllers/documents/requested_documents_controller_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe Documents::RequestedDocumentsController do
+  render_views
+
+  let(:intake) { create :intake }
+
+  before do
+    allow(subject).to receive(:user_signed_in?).and_return(true)
+    allow(subject).to receive(:current_intake).and_return intake
+  end
+
+  describe "#edit" do
+    context "with existing document uploads" do
+      it "assigns the documents to the form" do
+        doc = create :document, :with_upload, document_type: "Requested", intake: intake
+
+        get :edit
+
+        expect(assigns(:documents)).to include(doc)
+      end
+    end
+  end
+
+  describe "#next_path" do
+    it "returns send requested documents path" do
+      result = subject.next_path
+
+      expect(result).to eq send_requested_documents_documents_path
+    end
+  end
+end
+

--- a/spec/controllers/documents/send_requested_documents_controller_spec.rb
+++ b/spec/controllers/documents/send_requested_documents_controller_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe Documents::SendRequestedDocumentsController do
+  render_views
+
+  let(:intake) { create :intake }
+
+  before do
+    allow(subject).to receive(:user_signed_in?).and_return(true)
+    allow(subject).to receive(:current_intake).and_return intake
+  end
+
+  describe "#edit" do
+    it "sends the documents to zendesk, sets a flash notice, and redirects to the home page" do
+      get :edit
+
+      expect(SendRequestedDocumentsToZendeskJob).to have_been_enqueued
+      expect(flash[:notice]).to eq "Thank you, your documents have been submitted."
+    end
+  end
+end
+

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -2,11 +2,12 @@
 #
 # Table name: documents
 #
-#  id            :bigint           not null, primary key
-#  document_type :string           not null
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  intake_id     :bigint
+#  id                :bigint           not null, primary key
+#  document_type     :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  intake_id         :bigint
+#  zendesk_ticket_id :bigint
 #
 # Indexes
 #

--- a/spec/features/web_intake/requested_documents_spec.rb
+++ b/spec/features/web_intake/requested_documents_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.feature "Client uploads a requested document" do
+  scenario "client goes to the follow up documents link provided by their preparer" do
+    silence_omniauth_logging do
+      visit "/documents/requested-documents"
+    end
+    expect(page).to have_selector("h1", text: "Sign in")
+    OmniAuth.config.mock_auth[:idme] = omniauth_idme_success
+    click_on "Sign in with ID.me"
+
+    # TODO: remove this when we can go to the original link after sign in
+    visit "/documents/requested-documents"
+
+    expect(page).to have_selector("h1", text: "Your tax specialist is requesting additional documents")
+    attach_file("document_type_upload_form_document", Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))
+    click_on "Upload"
+
+    expect(page).to have_content("test-pattern.png")
+    expect(page).to have_link("Remove")
+
+    click_on "I'm done for now"
+
+    expect(page).to have_text "Thank you, your documents have been submitted."
+    expect(page).to have_text "Free tax filing, real human support."
+  end
+end

--- a/spec/features/web_intake/sign_out_spec.rb
+++ b/spec/features/web_intake/sign_out_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Online intake user signs out" do
+RSpec.feature "Web Intake user signs out" do
   before do
     allow_any_instance_of(Users::SessionsController).to receive(:idme_request).and_return(
       user_idme_omniauth_callback_path(logout: "success")

--- a/spec/jobs/send_requested_documents_to_zendesk_job_spec.rb
+++ b/spec/jobs/send_requested_documents_to_zendesk_job_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe SendRequestedDocumentsToZendeskJob, type: :job do
+  let(:fake_service) { instance_double(ZendeskFollowUpDocsService) }
+
+  before do
+    allow(ZendeskFollowUpDocsService).to receive(:new).and_return fake_service
+    allow(fake_service).to receive(:send_requested_docs).and_return(true)
+  end
+
+  describe "#perform" do
+    let(:intake) do
+      create :intake
+    end
+
+    before do
+      described_class.perform_now(intake.id)
+    end
+
+    it "sends the intake pdf and all of the docs as comments on the intake ticket" do
+      expect(ZendeskFollowUpDocsService).to have_received(:new).with(intake)
+      expect(fake_service).to have_received(:send_requested_docs)
+    end
+  end
+end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -2,11 +2,12 @@
 #
 # Table name: documents
 #
-#  id            :bigint           not null, primary key
-#  document_type :string           not null
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  intake_id     :bigint
+#  id                :bigint           not null, primary key
+#  document_type     :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  intake_id         :bigint
+#  zendesk_ticket_id :bigint
 #
 # Indexes
 #

--- a/spec/services/zendesk_follow_up_docs_service_spec.rb
+++ b/spec/services/zendesk_follow_up_docs_service_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+describe ZendeskFollowUpDocsService do
+  let(:intake) { create :intake, intake_ticket_id: 34 }
+  let(:service) { described_class.new(intake) }
+
+  describe "#send_requested_docs" do
+    let!(:requested_docs) do
+      [
+        create(:document, :with_upload, intake: intake, document_type: "Requested"),
+        create(:document, :with_upload, intake: intake, document_type: "Requested")
+      ]
+    end
+    let!(:other_doc) do
+      create(:document, :with_upload, intake: intake, document_type: "Other")
+    end
+    let!(:older_doc) do
+      create :document, :with_upload, intake: intake, document_type: "Requested", zendesk_ticket_id: 1234
+    end
+    let(:output) { true }
+
+    before { allow(service).to receive(:append_multiple_files_to_ticket).and_return(output) }
+
+    it "appends each requested doc to the ticket" do
+      result = service.send_requested_docs
+
+      expect(result).to eq true
+
+      expect(service).to have_received(:append_multiple_files_to_ticket).with(
+        ticket_id: 34,
+        file_list: [
+          { filename: "picture_id.jpg", file: instance_of(Tempfile) },
+          { filename: "picture_id.jpg", file: instance_of(Tempfile) },
+        ],
+        comment: <<~DOCS
+          The client added requested follow-up documents:
+          * #{requested_docs[0].upload.filename}
+          * #{requested_docs[1].upload.filename}
+        DOCS
+      )
+    end
+
+    it "sets the zendesk ticket id on each document that is successfully sent" do
+      service.send_requested_docs
+
+      requested_docs.each do |doc|
+        doc.reload
+        expect(doc.zendesk_ticket_id).to eq 34
+      end
+    end
+  end
+end


### PR DESCRIPTION
Some things to note:
- the page is in the docs navigation list because there's a lot of functionality there that didn't seem worth trying to fill in the gaps for
- the show method just returns false so that it never shows up in the flow
- i added the send_requested_documents controller to the routes by adding it to the list of docs controllers that's iterated over - would like input on whether this is a good way to have done that