### PR TITLE
Send event when "sign in with ID.me" clicked

### DIFF
--- a/app/controllers/questions/identity_controller.rb
+++ b/app/controllers/questions/identity_controller.rb
@@ -8,6 +8,5 @@ module Questions
     end
 
     def edit; end
-
   end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,6 +1,11 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   include IdmeAuthenticatable
 
+  def idme_sign_in(after_login: nil)
+    send_mixpanel_event(event_name: "click_sign_in")
+    redirect_to idme_authorize(after_login: after_login)
+  end
+
   def idme
     has_spouse_param = params["spouse"] == "true"
     has_after_login_param = params["after_login"].present?

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -71,6 +71,8 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def failure
     error_type = request.env["omniauth.error.type"]
     error = request.env["omniauth.error"]
+    send_mixpanel_event(event_name: "authentication_failure", data: { error: error, error_type: error_type })
+
     if error_type == :access_denied
       # the user did not grant permission to view their info
       redirect_to identity_needed_path

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,9 +1,9 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   include IdmeAuthenticatable
 
-  def idme_sign_in(after_login: nil)
+  def idme_sign_in
     send_mixpanel_event(event_name: "click_sign_in")
-    redirect_to idme_authorize(after_login: after_login)
+    redirect_to idme_authorize(after_login: params[:after_login])
   end
 
   def idme

--- a/app/views/questions/identity/edit.html.erb
+++ b/app/views/questions/identity/edit.html.erb
@@ -13,7 +13,7 @@
               <%= image_tag("questions/#{illustration_path}", alt: "") %>
             </div>
 
-            <%= link_to user_idme_omniauth_authorize_path(after_login: params[:after_login]), class: "button button--primary button--wide text--centered", method: :post do %>
+            <%= link_to idme_sign_in_path(after_login: params[:after_login]), class: "button button--primary button--wide text--centered", method: :post do %>
               Sign in with <span class="sr-only">ID.me</span> <%= image_tag("ID.me.svg", alt: "", class: "button-logo--inline") %>
             <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
     get "sign_in", :to => "devise/sessions#new", as: :new_user_session
     delete "sign_out", :to => "users/sessions#destroy", as: :destroy_user_session
     delete "idme_sign_out", :to => "users/sessions#logout_primary_from_idme", as: :destroy_idme_session
+    post "idme_sign_in", to: "users/omniauth_callbacks#idme_sign_in", as: :idme_sign_in
   end
 
   mount Cfa::Styleguide::Engine => "/cfa"

--- a/lib/strategies/idme.rb
+++ b/lib/strategies/idme.rb
@@ -11,11 +11,6 @@ module OmniAuth
         :token_url => "https://#{DOMAIN}/oauth/token"
       }
 
-      def request_phase
-        puts 'BLOOP!!'
-        super
-      end
-
       def raw_info
         access_token.options[:mode] = :query
         @raw_info ||= access_token.get("api/public/v3/attributes.json").parsed

--- a/lib/strategies/idme.rb
+++ b/lib/strategies/idme.rb
@@ -11,6 +11,11 @@ module OmniAuth
         :token_url => "https://#{DOMAIN}/oauth/token"
       }
 
+      def request_phase
+        puts 'BLOOP!!'
+        super
+      end
+
       def raw_info
         access_token.options[:mode] = :query
         @raw_info ||= access_token.get("api/public/v3/attributes.json").parsed

--- a/spec/controllers/questions/identity_controller_spec.rb
+++ b/spec/controllers/questions/identity_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Questions::IdentityController do
       it "links to the omniauth callback with that URL" do
         get :edit, params: params
         
-        expect(response.body).to include(user_idme_omniauth_authorize_path(after_login: "/foo-bar"))
+        expect(response.body).to include(idme_sign_in_path(after_login: "/foo-bar"))
       end
     end
   end


### PR DESCRIPTION
Things I've tried:

**Overwrite the controller action**
- the link on the 'Sign in with ID.me' button is `user_idme_omniauth_authorize_path` which according to the routes maps to `users/omniauth_callbacks#passthru`
- `passthru` is defined on `Devise::OmniauthCallbacksController` which is what our `Users::OmniauthCallbacksController` inherits from
- i tried overwriting `passthru` in our callbacks controller:
```
def passthru
  puts 'BLOOP'
  super
end
```
it did not appear to work

**Overwrite the `request_phase`**
- i cannot honestly say i remember what the request phase is
- all i know is that it gets called when we do the ID.me sign in
- i overwrote it in the strategy:
```
def request_phase
  puts 'BLOOP!!'
  super
end
```
- this appears to work but now that i'm not in a controller i don't know how to access `send_mixpanel_event`

**next steps**
my next thought was to have the button link to another method which could send the even and then redirect to `idme_authorize` (as happens in `Users::OmniauthCallbacksController#failure`) but then i remembered that the sign in button's method is 'post', which seems to mean that i should not do this. however. i have a question. why can we redirect to `idme_authorize` for the spouse? another question. what is the plural of 'spouse'? 'spice'?

**UPDATE**
i have done what i outlined in the 'next steps'. there are still failing specs. i haven't figured out why they are failing.