### PR TITLE
Create external ID for linking to Zendesk & Qualtrics

### DIFF
--- a/app/helpers/zendesk_service_helper.rb
+++ b/app/helpers/zendesk_service_helper.rb
@@ -85,22 +85,24 @@ module ZendeskServiceHelper
     result.id if result.present?
   end
 
-  def build_ticket(subject:, requester_id:, group_id:, body:, fields: {})
+  def build_ticket(subject:, requester_id:, group_id:, external_id: nil, body:, fields: {})
     ZendeskAPI::Ticket.new(
       client,
       subject: subject,
       requester_id: requester_id,
       group_id: group_id,
+      external_id: external_id,
       comment: { body: body },
       fields: [fields]
     )
   end
 
-  def create_ticket(subject:, requester_id:, group_id:, body:, fields: {})
+  def create_ticket(subject:, requester_id:, group_id:, external_id: nil, body:, fields: {})
     ticket = build_ticket(
       subject: subject,
       requester_id: requester_id,
       group_id: group_id,
+      external_id: external_id,
       body: body,
       fields: fields
     )

--- a/app/lib/zendesk_external_id_backfill.rb
+++ b/app/lib/zendesk_external_id_backfill.rb
@@ -1,0 +1,27 @@
+# Backfills Zendesk `external_id`s on Drop off and Intakes. This can be removed
+# once it is run once in a production console.
+#
+# Usage (in rails console):
+# > ZendeskExternalIdBackfill.run
+#
+class ZendeskExternalIdBackfill
+  class << self
+    include ZendeskServiceHelper
+
+    def run
+      IntakeSiteDropOff.find_each do |drop_off|
+        ticket = get_ticket(ticket_id: drop_off.zendesk_ticket_id)
+        next unless ticket
+        ticket.external_id = drop_off.external_id
+        ticket.save
+      end
+
+      Intake.find_each do |drop_off|
+        ticket = get_ticket(ticket_id: drop_off.intake_ticket_id)
+        next unless ticket
+        ticket.external_id = drop_off.external_id
+        ticket.save
+      end
+    end
+  end
+end

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -249,4 +249,10 @@ class Intake < ApplicationRecord
     names += dependents.where(was_student: "yes").map(&:full_name)
     names
   end
+
+  def external_id
+    return unless id.present?
+
+    ["intake", id].join("-")
+  end
 end

--- a/app/models/intake_site_drop_off.rb
+++ b/app/models/intake_site_drop_off.rb
@@ -161,6 +161,12 @@ class IntakeSiteDropOff < ApplicationRecord
     States.name_for_key(state)
   end
 
+  def external_id
+    return unless id.present?
+
+    ["drop-off", id].join("-")
+  end
+
   def self.intake_sites
     INTAKE_SITES
   end

--- a/app/services/zendesk_drop_off_service.rb
+++ b/app/services/zendesk_drop_off_service.rb
@@ -19,6 +19,7 @@ class ZendeskDropOffService
       subject: @drop_off.name,
       requester_id: zendesk_user_id,
       group_id: group_id,
+      external_id: @drop_off.external_id,
       body: comment_body,
       fields: {
           EitcZendeskInstance::CERTIFICATION_LEVEL => @drop_off.certification_level,

--- a/app/services/zendesk_intake_service.rb
+++ b/app/services/zendesk_intake_service.rb
@@ -48,6 +48,7 @@ class ZendeskIntakeService
     create_ticket(
       subject: @intake.primary_user.full_name,
       requester_id: @intake.intake_ticket_requester_id,
+      external_id: @intake.external_id,
       group_id: new_ticket_group_id,
       body: new_ticket_body,
       fields: new_ticket_fields

--- a/spec/helpers/zendesk_service_helper_spec.rb
+++ b/spec/helpers/zendesk_service_helper_spec.rb
@@ -162,6 +162,7 @@ RSpec.describe ZendeskServiceHelper do
           subject: "wyd",
           requester_id: 4,
           group_id: "123409218",
+          external_id: nil,
           comment: {
             body: "What's up?",
           },
@@ -179,6 +180,7 @@ RSpec.describe ZendeskServiceHelper do
         subject: "wyd",
         requester_id: 4,
         group_id: "123409218",
+        external_id: "some-object-123",
         body: "What's up?",
         fields: {
           "09182374" => "not_busy"

--- a/spec/models/intake_site_drop_off_spec.rb
+++ b/spec/models/intake_site_drop_off_spec.rb
@@ -308,4 +308,22 @@ describe IntakeSiteDropOff do
       end
     end
   end
+
+  describe "#external_id" do
+    let(:drop_off) { build :intake_site_drop_off }
+
+    context "when unsaved" do
+      it "is nil" do
+        expect(drop_off.external_id).to eq(nil)
+      end
+    end
+
+    context "when saved" do
+      it "is in the intended format" do
+        drop_off.save
+        drop_off.reload
+        expect(drop_off.external_id).to eq("drop-off-#{drop_off.id}")
+      end
+    end
+  end
 end

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -374,4 +374,22 @@ describe Intake do
       end
     end
   end
+
+  describe "#external_id" do
+    let(:intake) { build :intake }
+
+    context "when unsaved" do
+      it "is nil" do
+        expect(intake.external_id).to eq(nil)
+      end
+    end
+
+    context "when saved" do
+      it "is in the intended format" do
+        intake.save
+        intake.reload
+        expect(intake.external_id).to eq("intake-#{intake.id}")
+      end
+    end
+  end
 end

--- a/spec/services/zendesk_drop_off_service_spec.rb
+++ b/spec/services/zendesk_drop_off_service_spec.rb
@@ -45,6 +45,7 @@ describe ZendeskDropOffService do
           subject: drop_off.name,
           requester_id: fake_zendesk_user.id,
           group_id: EitcZendeskInstance::TAX_HELP_COLORADO,
+          external_id: "drop-off-#{drop_off.id}",
           comment: {
             body: comment_body,
           },
@@ -92,6 +93,7 @@ describe ZendeskDropOffService do
             subject: drop_off.name,
             requester_id: fake_zendesk_user.id,
             group_id: EitcZendeskInstance::GOODWILL_SOUTHERN_RIVERS,
+            external_id: "drop-off-#{drop_off.id}",
             comment: {
               body: comment_body,
             },

--- a/spec/services/zendesk_intake_service_spec.rb
+++ b/spec/services/zendesk_intake_service_spec.rb
@@ -111,6 +111,7 @@ describe ZendeskIntakeService do
           subject: "Cher Cherimoya",
           requester_id: 987,
           group_id: EitcZendeskInstance::ONLINE_INTAKE_THC_UWBA,
+          external_id: "intake-#{intake.id}",
           body: "Body text",
           fields: {
             EitcZendeskInstance::INTAKE_SITE => "online_intake",
@@ -130,6 +131,7 @@ describe ZendeskIntakeService do
           subject: "Cher Cherimoya",
           requester_id: 987,
           group_id: nil,
+          external_id: intake.external_id,
           body: "Body text",
           fields: {
             UwtsaZendeskInstance::INTAKE_SITE => "online_intake",


### PR DESCRIPTION
* Add a simple external_id field to intakes (e.g. `intake-123`) and drop offs (e.g. `drop-off-123`)
* Set the external_id in Zendesk upon ticket creation
* Add a script to backfill existing tickets with the external IDs