### PR TITLE
Add ajaxMixpanelEvents to track link clicks

### DIFF
--- a/app/assets/javascripts/ajax_mixpanel_events.js
+++ b/app/assets/javascripts/ajax_mixpanel_events.js
@@ -1,0 +1,35 @@
+var ajaxMixpanelEvents = (function() {
+  var init = function() {
+    $("[data-track-click]").on("click", function (e, options = {}) {
+      if (options.trackedEvent === true) {
+        return;
+      }
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      var clickedElement = $(e.target);
+      var eventData = {
+        event_name: "clicked_link",
+        controller_action: window.mixpanelData.controller_action,
+        full_path: window.mixpanelData.full_path,
+        data: {
+          link_text: clickedElement.text().trim(),
+        }
+      };
+
+      $.ajax({
+        type: "POST",
+        url: "/ajax_mixpanel_events",
+        timeout: 200,
+        data: eventData,
+      })
+      .then(() => clickedElement.trigger("click", {trackedEvent: true}))
+      .fail(() => clickedElement.trigger("click", {trackedEvent: true}));
+    });
+  };
+
+  return {
+    init: init
+  }
+})();

--- a/app/assets/javascripts/ajax_mixpanel_events.js
+++ b/app/assets/javascripts/ajax_mixpanel_events.js
@@ -9,19 +9,20 @@ var ajaxMixpanelEvents = (function() {
       e.stopPropagation();
 
       var clickedElement = $(e.target);
+      var elementText = clickedElement.text().trim();
+      var eventName = "click_" + clickedElement.attr("data-track-click");
       var eventData = {
-        event_name: "clicked_link",
+        event_name: eventName,
         controller_action: window.mixpanelData.controller_action,
         full_path: window.mixpanelData.full_path,
         data: {
-          link_text: clickedElement.text().trim(),
+          call_to_action: elementText,
         }
       };
 
       $.ajax({
         type: "POST",
         url: "/ajax_mixpanel_events",
-        timeout: 200,
         data: eventData,
       })
       .then(() => clickedElement.trigger("click", {trackedEvent: true}))

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -36,6 +36,6 @@ var immediateUpload = (function() {
   }
 })();
 
-// $(document).ready(function() {
-//   immediateUpload.init();
-// });
+$(document).ready(function() {
+  ajaxMixpanelEvents.init();
+});

--- a/app/controllers/ajax_mixpanel_events_controller.rb
+++ b/app/controllers/ajax_mixpanel_events_controller.rb
@@ -1,0 +1,34 @@
+class AjaxMixpanelEventsController < ApplicationController
+  def create
+    return head :bad_request unless all_required_params_present?
+
+    event_data = controller_and_path_data
+    event_data = event_data.merge(event_params[:data]) if event_params[:data].present?
+
+    send_mixpanel_event(
+      event_name: event_params[:event_name],
+      data: event_data
+    )
+  end
+
+  private
+
+  def event_params
+    params.permit(:event_name, :full_path, :controller_action, data: {})
+  end
+
+  def all_required_params_present?
+    [:event_name, :full_path, :controller_action].all? { |key| event_params[key].present? }
+  end
+
+  def controller_and_path_data
+    controller, action = event_params[:controller_action].split("#", 2)
+    {
+      full_path: event_params[:full_path],
+      path: URI(event_params[:full_path]).path,
+      controller_action: event_params[:controller_action],
+      controller_action_name: action,
+      controller_name: controller.sub("Controller", ""),
+    }
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,6 +22,12 @@
     <%= javascript_include_tag 'application' %>
 
     <%= favicon_link_tag image_path('checkbox-logo--black.png'), :type=>'image/png', :sizes => '57x57' %>
+    <script>
+      window.mixpanelData = JSON.parse(<%= JSON.generate(
+        controller_action: "#{controller.class.name}##{action_name}",
+        full_path: request.fullpath
+      ).inspect.html_safe %>);
+    </script>
   </head>
 
   <body <% if content_for :body_class %>class="<%= content_for :body_class %>"<% end %>>

--- a/app/views/questions/identity/edit.html.erb
+++ b/app/views/questions/identity/edit.html.erb
@@ -13,7 +13,7 @@
               <%= image_tag("questions/#{illustration_path}", alt: "") %>
             </div>
 
-            <%= link_to user_idme_omniauth_authorize_path(after_login: params[:after_login]), class: "button button--primary button--wide text--centered", method: :post, data: { track_click: true } do %>
+            <%= link_to user_idme_omniauth_authorize_path(after_login: params[:after_login]), class: "button button--primary button--wide text--centered", method: :post, data: { track_click: "idme_sign_in" } do %>
               Sign in with <span class="sr-only">ID.me</span> <%= image_tag("ID.me.svg", alt: "", class: "button-logo--inline") %>
             <% end %>
 

--- a/app/views/questions/identity/edit.html.erb
+++ b/app/views/questions/identity/edit.html.erb
@@ -13,7 +13,7 @@
               <%= image_tag("questions/#{illustration_path}", alt: "") %>
             </div>
 
-            <%= link_to user_idme_omniauth_authorize_path(after_login: params[:after_login]), class: "button button--primary button--wide text--centered", method: :post do %>
+            <%= link_to user_idme_omniauth_authorize_path(after_login: params[:after_login]), class: "button button--primary button--wide text--centered", method: :post, data: { track_click: true } do %>
               Sign in with <span class="sr-only">ID.me</span> <%= image_tag("ID.me.svg", alt: "", class: "button-logo--inline") %>
             <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
 
   resources :dependents, only: [:index, :new, :create, :edit, :update, :destroy]
   resources :documents, only: [:destroy]
+  resources :ajax_mixpanel_events, only: [:create]
 
   get "/:organization/drop-off", to: "intake_site_drop_offs#new", as: :new_drop_off
   post "/:organization/drop-offs", to: "intake_site_drop_offs#create", as: :create_drop_off

--- a/spec/controllers/ajax_mixpanel_events_controller_spec.rb
+++ b/spec/controllers/ajax_mixpanel_events_controller_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+RSpec.describe AjaxMixpanelEventsController, type: :controller do
+  before { allow(subject).to receive(:send_mixpanel_event) }
+
+  context "with valid params" do
+    let(:valid_params) do
+      {
+        event_name: "clicked_link",
+        full_path: "/page?key=value",
+        controller_action: "Questions::TestQuestionController#edit",
+        data: {
+          link_text: "Sign in with ID.me",
+        }
+      }
+    end
+
+    it "sends an event to mixpanel" do
+      post :create,  params: valid_params
+
+      expect(subject).to have_received(:send_mixpanel_event).with(
+        event_name: "clicked_link",
+        data: {
+          path: "/page",
+          full_path: "/page?key=value",
+          controller_action: "Questions::TestQuestionController#edit",
+          controller_action_name: "edit",
+          controller_name: "Questions::TestQuestion",
+          "link_text" => "Sign in with ID.me",
+        }
+      )
+    end
+
+    context "with no custom data" do
+      let(:valid_params) do
+        {
+          event_name: "clicked_link",
+          full_path: "/page?key=value",
+          controller_action: "Questions::TestQuestionController#edit",
+        }
+      end
+
+      it "sends an event to mixpanel" do
+        post :create,  params: valid_params
+
+        expect(subject).to have_received(:send_mixpanel_event).with(
+          event_name: "clicked_link",
+          data: {
+            path: "/page",
+            full_path: "/page?key=value",
+            controller_action: "Questions::TestQuestionController#edit",
+            controller_action_name: "edit",
+            controller_name: "Questions::TestQuestion",
+          }
+        )
+      end
+    end
+  end
+
+  context "with invalid params" do
+    let(:invalid_params) do
+      {
+        data: {
+          some_key: "some_value",
+        }
+      }
+    end
+
+    it "returns an error and doesn't send to mixpanel" do
+      post :create,  params: invalid_params
+
+      expect(response.status).to eq(400)
+      expect(subject).not_to have_received(:send_mixpanel_event)
+    end
+  end
+end


### PR DESCRIPTION
Any link with a `data-track-click` property will have its click events
intercepted by this handler, which will send an AJAX POST to a new
controller action that sends the event to Mixpanel.

Of particular note is that the click handler will allow the user to continue regardless of whether the AJAX request succeeds, fails, or hits a 200ms timeout. (I chose 200ms to be as imperceptible as possible.)

### `AjaxMixpanelEventsController`
This controller's single action, `#create` will accept a valid POST and then send a Mixpanel event in response.

### `window.MixpanelData`
On every page, we add some data about the page to the Javascript `window` object. it looks like this:
```javascript
{controller_action: "Questions::IdentityController#edit", full_path: "/questions/identity?spouse=true"}
```
### `ajaxMixpanelEvents` function

On page load, we look for any elements with the `data-track-click` property. When they are clicked, we use the value of `data-track-click` to send a POST to the `AjaxMixpanelEventsController`.

```html
<!-- sends a "click_whatever" event to Mixpanel -->
<a href="/whatever" data-track-click="whatever">Click meee!</a>
```
