### PR TITLE
Remove case where we delete intake from session when newly authenticated user is a new spouse

### DIFF
--- a/spec/controllers/users/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/users/omniauth_callbacks_controller_spec.rb
@@ -175,20 +175,6 @@ RSpec.describe Users::OmniauthCallbacksController do
           get :idme, params: { spouse: "true" }
           expect(spouse_user.reload.intake).to eq primary_user.intake
         end
-
-        context "spouse has intake in session" do
-          let(:intake_from_session) { create :intake }
-
-          before do
-            session[:intake_id] = intake_from_session.id
-          end
-
-          it "clears the intake id from the session and deletes the intake" do
-            get :idme, params: { spouse: "true" }
-            expect(session[:intake_id]).to be_nil
-            expect(Intake.exists?(intake_from_session.id)).to eq false
-          end
-        end
       end
 
       context "when using link to authenticate later" do


### PR DESCRIPTION
not sure why it was there in the first place - hoping it was a mistake and not for good reason 😬