### PR TITLE
Track clicks to "IRS Free File" (via sendBeacon API)

### DIFF
--- a/app/assets/javascripts/ajax_mixpanel_events.js
+++ b/app/assets/javascripts/ajax_mixpanel_events.js
@@ -1,33 +1,20 @@
+//= require vendor/navigator.sendbeacon.min
+
 var ajaxMixpanelEvents = (function() {
   var init = function() {
     $("[data-track-click]").on("click", function (e, options) {
-      options = options || {};
-      if (options.trackedEvent === true) {
-        return;
-      }
-
-      e.preventDefault();
-      e.stopPropagation();
-
       var clickedElement = $(e.target);
       var elementText = clickedElement.text().trim();
       var eventName = "click_" + clickedElement.attr("data-track-click");
-      var eventData = {
-        event_name: eventName,
-        controller_action: window.mixpanelData.controller_action,
-        full_path: window.mixpanelData.full_path,
-        data: {
-          call_to_action: elementText,
-        }
-      };
 
-      $.ajax({
-        type: "POST",
-        url: "/ajax_mixpanel_events",
-        data: eventData,
-      })
-      .then(function() { clickedElement.trigger("click", {trackedEvent: true}) })
-      .fail(function() { clickedElement.trigger("click", {trackedEvent: true}) });
+      var eventData = new FormData();
+      eventData.append("event[event_name]", eventName);
+      eventData.append("event[controller_action]", window.mixpanelData.controller_action);
+      eventData.append("event[full_path]", window.mixpanelData.full_path);
+      eventData.append("event[data][call_to_action]", elementText);
+      eventData.append(Rails.csrfParam(), Rails.csrfToken());
+
+      navigator.sendBeacon("/ajax_mixpanel_events", eventData);
     });
   };
 

--- a/app/assets/javascripts/vendor/navigator.sendbeacon.min.js
+++ b/app/assets/javascripts/vendor/navigator.sendbeacon.min.js
@@ -1,0 +1,24 @@
+/*
+ * MIT license
+ *
+ * Copyright (C) 2015 Miguel Mota
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+*/
+!function(t,e){"object"==typeof exports&&"undefined"!=typeof module?e():"function"==typeof define&&define.amd?define(e):e()}(0,function(){"use strict";function t(e){return(t="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(t){return typeof t}:function(t){return t&&"function"==typeof Symbol&&t.constructor===Symbol&&t!==Symbol.prototype?"symbol":typeof t})(e)}var e=function(t){return"string"==typeof t},n=function(t){return t instanceof Blob};(function(){"navigator"in this||(this.navigator={});"function"!=typeof this.navigator.sendBeacon&&(this.navigator.sendBeacon=function(t,o){var i=this.event&&this.event.type,r="unload"===i||"beforeunload"===i,f="XMLHttpRequest"in this?new XMLHttpRequest:new ActiveXObject("Microsoft.XMLHTTP");f.open("POST",t,!r),f.withCredentials=!0,f.setRequestHeader("Accept","*/*"),e(o)?(f.setRequestHeader("Content-Type","text/plain;charset=UTF-8"),f.responseType="text"):n(o)&&o.type&&f.setRequestHeader("Content-Type",o.type);try{f.send(o)}catch(t){return!1}return!0}.bind(this))}).call("object"===("undefined"==typeof window?"undefined":t(window))?window:{})});

--- a/app/controllers/ajax_mixpanel_events_controller.rb
+++ b/app/controllers/ajax_mixpanel_events_controller.rb
@@ -14,7 +14,8 @@ class AjaxMixpanelEventsController < ApplicationController
   private
 
   def event_params
-    params.permit(:event_name, :full_path, :controller_action, data: {})
+    params.fetch(:event, {})
+      .permit(:event_name, :full_path, :controller_action, data: {})
   end
 
   def all_required_params_present?

--- a/app/views/public_pages/maybe_ineligible.html.erb
+++ b/app/views/public_pages/maybe_ineligible.html.erb
@@ -24,7 +24,7 @@
               Try another free tax filing option
             </p>
             <p>
-              If you'd like to file your taxes without the assistance of our staff and services, use the <a href="https://apps.irs.gov/app/freeFile/jsp/wizard.jsp" target="_blank">IRS Free File Lookup Tool</a> to find a free way to file your taxes online.
+              If you'd like to file your taxes without the assistance of our staff and services, use the <a href="https://apps.irs.gov/app/freeFile/jsp/wizard.jsp" target="_blank" data-track-click="freefile">IRS Free File Lookup Tool</a> to find a free way to file your taxes online.
             </p>
           </div>
 
@@ -32,7 +32,7 @@
             <%= link_to vita_providers_path, class: "button button--primary button--wide text--centered" do %>
               Find a VITA site near you
             <% end %>
-            <a href="https://apps.irs.gov/app/freeFile/jsp/wizard.jsp" target="_blank" class="button button--wide text--centered">
+            <a href="https://apps.irs.gov/app/freeFile/jsp/wizard.jsp" target="_blank" class="button button--wide text--centered" data-track-click="freefile">
               Visit IRS Free File
             </a>
           </div>

--- a/app/views/public_pages/other_options.html.erb
+++ b/app/views/public_pages/other_options.html.erb
@@ -24,7 +24,7 @@
               Try another free tax filing option
             </p>
             <p>
-              If you'd like to file your taxes without the assistance of our staff and services, use the <a href="https://apps.irs.gov/app/freeFile/jsp/wizard.jsp" target="_blank">IRS Free File Lookup Tool</a> to find an online service that lets you prepare your own taxes for free.
+              If you'd like to file your taxes without the assistance of our staff and services, use the <a href="https://apps.irs.gov/app/freeFile/jsp/wizard.jsp" target="_blank" data-track-click="freefile">IRS Free File Lookup Tool</a> to find an online service that lets you prepare your own taxes for free.
             </p>
           </div>
 
@@ -32,7 +32,7 @@
             <%= link_to vita_providers_path, class: "button button--primary button--wide text--centered" do %>
               Find a VITA site near you
             <% end %>
-            <a href="https://apps.irs.gov/app/freeFile/jsp/wizard.jsp" target="_blank" class="button button--wide text--centered">
+            <a href="https://apps.irs.gov/app/freeFile/jsp/wizard.jsp" target="_blank" class="button button--wide text--centered" data-track-click="freefile">
               Visit IRS Free File
             </a>
           </div>

--- a/app/views/vita_providers/index.html.erb
+++ b/app/views/vita_providers/index.html.erb
@@ -47,7 +47,7 @@
 
           <p>
             You can also prepare your own taxes by using the
-            <%= link_to("https://apps.irs.gov/app/freeFile/jsp/wizard.jsp", target: "_blank") do %>IRS Free File Lookup Tool<% end %>
+            <%= link_to("https://apps.irs.gov/app/freeFile/jsp/wizard.jsp", target: "_blank", data: { track_click: "freefile" }) do %>IRS Free File Lookup Tool<% end %>
             to find a free way to file your taxes online.
           </p>
         <% end %>

--- a/spec/controllers/ajax_mixpanel_events_controller_spec.rb
+++ b/spec/controllers/ajax_mixpanel_events_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe AjaxMixpanelEventsController, type: :controller do
     end
 
     it "sends an event to mixpanel" do
-      post :create,  params: valid_params
+      post :create,  params: { event: valid_params }
 
       expect(subject).to have_received(:send_mixpanel_event).with(
         event_name: "clicked_link",
@@ -41,7 +41,7 @@ RSpec.describe AjaxMixpanelEventsController, type: :controller do
       end
 
       it "sends an event to mixpanel" do
-        post :create,  params: valid_params
+        post :create,  params: { event: valid_params }
 
         expect(subject).to have_received(:send_mixpanel_event).with(
           event_name: "clicked_link",


### PR DESCRIPTION
The original `ajaxMixpanelEvents` approach didn't work for standard <a>
tags due to the fact that browsers do not navigate to a link's
destination when a jQuery click event is programmatically triggered.

This commit updates the implementation to use a [new-ish API called
`sendBeacon`][1] which is made for this purpose: to send analytics
reliably as a user is leaving a page. The API is well-supported except
for Internet Explorer, for which a polyfill has been included. I
verified that the polyfill works on IE11 via Browserstack. (No traffic
to GetYourRefund has been from a version of IE other than 11, according
to Mixpanel.)

The polyfill ([on Github here](https://github.com/miguelmota/Navigator.sendBeacon)) was downloaded using this command, and I manually added the
license to the header of the file:

```
wget -O app/assets/javascripts/vendor/navigator.sendbeacon.min.js \
  https://raw.githubusercontent.com/miguelmota/Navigator.sendBeacon/master/dist/navigator.sendbeacon.min.js
```

Finally, worth mentioning, the `sendBeacon` API requires a `FormData()`
javascript object instead of using jQuery's AJAX. So I included the CSRF
`authenticity_token` param manually, and as such decided to scope all
the Mixpanel event params under a top-level `event` key so we could not
have to worry about the extra `authenticity_token` param while
processing the form params.

[1]: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon