### PR TITLE
Correctly handle clicking on <a> sub-elements

### DIFF
--- a/app/assets/javascripts/ajax_mixpanel_events.js
+++ b/app/assets/javascripts/ajax_mixpanel_events.js
@@ -3,7 +3,7 @@
 var ajaxMixpanelEvents = (function() {
   var init = function() {
     $("[data-track-click]").on("click", function (e, options) {
-      var clickedElement = $(e.target);
+      var clickedElement = $(e.target).closest("a");
       var elementText = clickedElement.text().trim();
       var eventName = "click_" + clickedElement.attr("data-track-click");
 


### PR DESCRIPTION
There was a bug where if you clicked on the `<img>` tag within the "Sign
in with ID.me" button (the logo of ID.me), then we would attempt to get
the event name from the `<img>` tag instead of the `<a>` tag. This resulted
in a `click_undefined` event being recorded in mixpanel.

https://www.pivotaltracker.com/story/show/172013085