### PR TITLE
Capture Zendesk API errors explicitly

### DIFF
--- a/app/services/zendesk_drop_off_service.rb
+++ b/app/services/zendesk_drop_off_service.rb
@@ -65,7 +65,13 @@ class ZendeskDropOffService
   def attach_file_and_save_ticket(ticket)
     download_blob_to_tempfile do |file|
       ticket.comment.uploads << {file: file, filename: file_upload_name}
-      ticket.save
+      success = ticket.save
+
+      unless success
+        raise ZendeskServiceHelper::ZendeskAPIError.new("Error attaching file: #{ticket.errors}")
+      end
+
+      success
     end
   end
 

--- a/spec/services/zendesk_drop_off_service_spec.rb
+++ b/spec/services/zendesk_drop_off_service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe ZendeskDropOffService do
   let(:fake_zendesk_client) { double(ZendeskAPI::Client) }
-  let(:fake_zendesk_ticket) { double(ZendeskAPI::Ticket, id: 2) }
+  let(:fake_zendesk_ticket) { double(ZendeskAPI::Ticket, id: 2, errors: nil) }
   let(:fake_zendesk_user) { double(ZendeskAPI::User, id: 1) }
   let(:comment_uploads) { [] }
   let(:comment_body) do
@@ -30,7 +30,7 @@ describe ZendeskDropOffService do
 
     allow(fake_zendesk_ticket).to receive(:comment=)
     allow(fake_zendesk_ticket).to receive_message_chain(:comment, :uploads).and_return(comment_uploads)
-    allow(fake_zendesk_ticket).to receive(:save)
+    allow(fake_zendesk_ticket).to receive(:save).and_return(true)
   end
 
   describe "#create_ticket_and_attach_file" do
@@ -73,7 +73,7 @@ describe ZendeskDropOffService do
       let(:comment_body) do
         <<~BODY
           New Dropoff at GoodwillSR Columbus Intake
-    
+
           Certification Level: Basic and HSA
           Name: Gary Guava
           Phone number: (415) 816-1286


### PR DESCRIPTION
There was a bug where if you clicked on the <img> tag within the "Sign
in with ID.me" button (the logo of ID.me), then we would attempt to get
the event name from the <img> tag instead of the <a> tag. This resulted
in a `click_undefined` event being recorded in mixpanel.

https://www.pivotaltracker.com/story/show/172013085