### PR TITLE
Don't send_requested_docs if there aren't any

### DIFF
--- a/app/services/zendesk_follow_up_docs_service.rb
+++ b/app/services/zendesk_follow_up_docs_service.rb
@@ -7,6 +7,8 @@ class ZendeskFollowUpDocsService
   end
 
   def send_requested_docs
+    return if @intake.documents.none?
+
     new_requested_docs = @intake.documents.where(document_type: "Requested", zendesk_ticket_id: nil)
     file_list = new_requested_docs.map do |document|
       @document_blob = document.upload
@@ -26,7 +28,9 @@ class ZendeskFollowUpDocsService
     new_requested_docs.each { |doc| doc.update(zendesk_ticket_id: @intake.intake_ticket_id) }
     output
   ensure
-    file_list.each { |entry| entry[:file].close! }
+    if file_list.present?
+      file_list.each { |entry| entry[:file].close! }
+    end
   end
 
   def blob

--- a/spec/services/zendesk_follow_up_docs_service_spec.rb
+++ b/spec/services/zendesk_follow_up_docs_service_spec.rb
@@ -48,5 +48,17 @@ describe ZendeskFollowUpDocsService do
         expect(doc.zendesk_ticket_id).to eq 34
       end
     end
+
+    context "when the user has not uploaded any documents" do
+      before do
+        intake.documents.destroy_all
+      end
+
+      it "does not update zendesk" do
+        result = service.send_requested_docs
+
+        expect(service).not_to have_received(:append_multiple_files_to_ticket)
+      end
+    end
   end
 end


### PR DESCRIPTION
This is a stopgap to prevent confusion in Zendesk, to, at the bare
minimum, don't create empty Zendesk comments giving the appearance a
user uploaded files.

A subsequent story will handle improving the user experience.