### PR TITLE
Set Delayed::Job to not retry failed jobs

### DIFF
--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,0 +1,2 @@
+Delayed::Worker.destroy_failed_jobs = false
+Delayed::Worker.max_attempts = 1


### PR DESCRIPTION
Most of our jobs are currently likely to re-fail for the same reason
they initially failed. To prevent side effects in Zendesk and elsewhere,
let's set the `max_attempts` to 1, so they are not retried.

We will then have to manually re-run them, which can be accomplished
with this console command:

```
> job = Delayed::Job.last
> Delayed::Worker.new.run(job)
```

Using this method, instead of Delayed::Job.last.invoke_job, also has the
benefit of clearing the job from the database if successful.