### PR TITLE
Add a list of exceptions to ignore for Sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -2,4 +2,7 @@ Raven.configure do |config|
   config.dsn = Rails.application.credentials.dig(Rails.env.to_sym, :sentry_dsn)
   config.environments = %w(production staging demo)
   config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+  config.excluded_exceptions = Raven::Configuration::IGNORE_DEFAULT + %w(
+    ActionController::UnknownFormat
+  )
 end


### PR DESCRIPTION
All but `ActionController::UnknownFormat` came from [GCF's sizeable
list][1]. The UnknownFormat error happened because someone tried to
request a JSON version of our homepage.

[1]: https://github.com/codeforamerica/gcf-backend/blob/master/config/initializers/sentry.rb