### PR TITLE
Set "sms_opt_in" / "email_opt_in" on Zendesk tickets

### DIFF
--- a/app/helpers/eitc_zendesk_instance.rb
+++ b/app/helpers/eitc_zendesk_instance.rb
@@ -23,6 +23,7 @@ class EitcZendeskInstance
   LINKED_TICKET = "360033135434"
   NEEDS_RESPONSE = "360035388874"
   FILING_YEARS = "360037221113"
+  COMMUNICATION_PREFERENCES = "360037409074"
 
   # Digital Intake Status value tags
   INTAKE_STATUS_IN_PROGRESS = "1._new_online_submission"

--- a/app/helpers/uwtsa_zendesk_instance.rb
+++ b/app/helpers/uwtsa_zendesk_instance.rb
@@ -11,6 +11,7 @@ class UwtsaZendeskInstance
   LINKED_TICKET = "360035942494"
   NEEDS_RESPONSE = "360035847233"
   FILING_YEARS = "360037476894"
+  COMMUNICATION_PREFERENCES = "360037477054"
 
   # Digital Intake Status value tags
   INTAKE_STATUS_IN_PROGRESS = "1._new_online_submission"

--- a/app/services/zendesk_intake_service.rb
+++ b/app/services/zendesk_intake_service.rb
@@ -93,12 +93,18 @@ class ZendeskIntakeService
   end
 
   def new_ticket_fields
+    notification_opt_ins = [
+      ("sms_opt_in" if @intake.primary_user.sms_notification_opt_in_yes?),
+      ("email_opt_in" if @intake.primary_user.email_notification_opt_in_yes?),
+    ].compact
+
     if instance_eitc?
       {
         EitcZendeskInstance::INTAKE_SITE => "online_intake",
         EitcZendeskInstance::INTAKE_STATUS => EitcZendeskInstance::INTAKE_STATUS_IN_PROGRESS,
         EitcZendeskInstance::STATE => @intake.state,
         EitcZendeskInstance::FILING_YEARS => @intake.filing_years,
+        EitcZendeskInstance::COMMUNICATION_PREFERENCES => notification_opt_ins,
       }
     else
       {
@@ -106,6 +112,7 @@ class ZendeskIntakeService
         UwtsaZendeskInstance::INTAKE_STATUS => UwtsaZendeskInstance::INTAKE_STATUS_IN_PROGRESS,
         UwtsaZendeskInstance::STATE => @intake.state,
         UwtsaZendeskInstance::FILING_YEARS => @intake.filing_years,
+        UwtsaZendeskInstance::COMMUNICATION_PREFERENCES => notification_opt_ins,
       }
     end
   end

--- a/spec/services/zendesk_intake_service_spec.rb
+++ b/spec/services/zendesk_intake_service_spec.rb
@@ -176,7 +176,8 @@ describe ZendeskIntakeService do
             EitcZendeskInstance::INTAKE_SITE => "online_intake",
             EitcZendeskInstance::INTAKE_STATUS => EitcZendeskInstance::INTAKE_STATUS_IN_PROGRESS,
             EitcZendeskInstance::STATE => "co",
-            EitcZendeskInstance::FILING_YEARS => ["2019", "2017"]
+            EitcZendeskInstance::FILING_YEARS => ["2019", "2017"],
+            EitcZendeskInstance::COMMUNICATION_PREFERENCES => ["sms_opt_in", "email_opt_in"],
           }
         )
       end
@@ -198,9 +199,22 @@ describe ZendeskIntakeService do
             UwtsaZendeskInstance::INTAKE_SITE => "online_intake",
             UwtsaZendeskInstance::INTAKE_STATUS => UwtsaZendeskInstance::INTAKE_STATUS_IN_PROGRESS,
             UwtsaZendeskInstance::STATE => "az",
-            UwtsaZendeskInstance::FILING_YEARS => ["2019", "2017"]
+            UwtsaZendeskInstance::FILING_YEARS => ["2019", "2017"],
+            UwtsaZendeskInstance::COMMUNICATION_PREFERENCES => ["sms_opt_in", "email_opt_in"]
           }
         )
+      end
+    end
+
+    context "when the user opts out of sms notifications" do
+      let(:sms_opt_in) { "no" }
+      let(:email_opt_in) { "no" }
+
+      it "does not send the 'sms_opt_in'" do
+        result = service.create_intake_ticket
+        expect(service)
+          .to have_received(:create_ticket)
+          .with(include(fields: include(EitcZendeskInstance::COMMUNICATION_PREFERENCES => [])))
       end
     end
 


### PR DESCRIPTION
This will be helpful for filtering notification triggers in Zendesk so
we don't try to send notifications to users where we didn't put their
contact information in Zendesk.

Sample test ticket from development:
https://eitc.zendesk.com/agent/tickets/2867
<img width="275" alt="image" src="https://user-images.githubusercontent.com/129120/78187815-fcab8d00-7423-11ea-8672-fa51817fc8cb.png">
