### PR TITLE
Attempt to sign user out of ID.me while using spouse auth token

### DIFF
--- a/app/views/spouse_auth_only/show.html.erb
+++ b/app/views/spouse_auth_only/show.html.erb
@@ -26,7 +26,11 @@
       If you have any trouble please e-mail <a href="mailto:hello@getyourrefund.org">hello@getyourrefund.org</a>. We’re here to help!
     </p>
 
-    <%= link_to user_idme_omniauth_authorize_path(spouse: "true"), class: "button button--primary button--wide text--centered", method: :post do %>
+    <%#
+      Log out the current user from ID.me, in case they are accidentally
+      signed in as the primary user (i.e. on a shared computer)
+    %>
+    <%= link_to destroy_idme_session_path, class: "button button--primary button--wide text--centered", method: :delete do %>
       Sign in with
       <span class="sr-only">ID.me</span> <%= image_tag("ID.me.svg", alt: "", class: "button-logo--inline") %>
     <% end %>

--- a/spec/controllers/spouse_auth_only_controller_spec.rb
+++ b/spec/controllers/spouse_auth_only_controller_spec.rb
@@ -27,10 +27,10 @@ RSpec.describe SpouseAuthOnlyController, type: :controller do
         expect(session[:authenticate_spouse_only]).to eq true
       end
 
-      it "displays a link to authorize path with spouse param" do
+      it "displays a link to ID.me logout path" do
         get :show, params: { token: token }
 
-        expect(response.body).to include(user_idme_omniauth_authorize_path(spouse: "true"))
+        expect(response.body).to include(destroy_idme_session_path)
       end
     end
   end

--- a/spec/features/web_intake/new_joint_filer_skip_spouse_auth_spec.rb
+++ b/spec/features/web_intake/new_joint_filer_skip_spouse_auth_spec.rb
@@ -81,6 +81,9 @@ RSpec.feature "Web Intake Joint Filer without spouse present" do
     before do
       create :intake, spouse_auth_token: "t0k3n"
       OmniAuth.config.mock_auth[:idme] = spouse_auth_hash
+      allow_any_instance_of(Users::SessionsController).to receive(:idme_logout).and_return(
+        user_idme_omniauth_callback_path(spouse: "true")
+      )
     end
 
     scenario "spouse authenticates later" do


### PR DESCRIPTION
The current user experience is confusing if a spouse accessing the
`/verify-spouse/[token]` path is using it while they are logged into
ID.me as the primary user.

Of course any time we are touching this code, it is difficult to capture
all the different cases. Here is how I tested this:

Steps taken starting from a totally clean slate (no intakes, no users in
database, and cleared cookies):

1. Go to /questions/identity
1. Sign in with an ID.me account to become a primary user
1. In rails console, run: `Intake.last.update(spouse_auth_token: "123")`
1. Go to /verify-spouse/123
1. Note: We are still signed in as the primary user, in our app and with
   ID.me.
1. Click the "Sign In with ID.me" button

At this point we want to make sure the user is signed out of ID.me. This
commit makes it so that the sign in button does this first. Whereas in
the previous version of the code, the user would have to go through the
following steps:
1. User is taken to ID.me still signed in as the primary user
1. ID.me asks user to verify your phone number
1. User gets the "Oops! It looks like you signed in as your spouse.
   Please sign your spouse in with ID.me so we can verify their
   identity." error
1. User is taken to the /questions/spouse-identity?missing_spouse=true
   page
1. User clicks the "Sign it with ID.me" button
1. User is signed out of ID.me

I verified that the remainder of the behavior is unchanged between this
commit and the previous version:
1. The user signs in with the spouse account
1. User gets the consent page
1. You are sent to the "You did it!" page that sends you back to the
   home page
1. From there, if you click "Get Started" again, you go through the
   questions up to ID.me. When you sign in with ID.me since you are
   still signed in as the spouse. It takes you to
   /questions/spouse-was-student.

One other case I also tested:
1. Using the spouse token page works fine on a different machine (i.e.
   the "log out" path works properly even if the user was not logged in
   to ID.me in the first place)

https://www.pivotaltracker.com/story/show/172137090