### PR TITLE
Ignore agent replies to SMS threads

### DIFF
--- a/spec/controllers/email_controller_spec.rb
+++ b/spec/controllers/email_controller_spec.rb
@@ -115,11 +115,24 @@ RSpec.describe EmailController, type: :controller do
         end
       end
 
+      context "when it's an agent replying to a client in the SMS thread" do
+        let(:subject) { "Update to SMS Ticket - 4324" }
+        let(:text) { "We received your documents, thank you!" }
+
+        it "returns ok" do
+          post :create, params: params
+
+          expect(response).to be_ok
+        end
+      end
+
       context "when it's from any other type of sender", active_job: true do
         let(:from) { "Another Person not a client" }
 
         it "does nothing" do
-          post :create, params: params
+          expect do
+            post :create, params: params
+          end.to raise_error(StandardError)
 
           expect(ZendeskInboundSmsJob).not_to have_been_enqueued
         end


### PR DESCRIPTION
This should quiet down the Sentry errors we were receiving from being unable to parse incoming messages.

https://www.pivotaltracker.com/story/show/172153973

It was blowing up whenever a Zendesk agent replied to an SMS thread. Now it should ignore that situation, but still raise an error if it gets something unexpected.