### PR TITLE
Refactor download_attachments_to_tmp to take attachments

### DIFF
--- a/app/helpers/attachments_helper.rb
+++ b/app/helpers/attachments_helper.rb
@@ -1,12 +1,13 @@
 module AttachmentsHelper
-  def download_attachments_to_tmp(documents, file_list: [], &block)
-    if documents.blank?
+  # @param [Array<ActiveStorage::Attached>] attachments Array of attachment objects, e.g. @intake.documents.map(&:upload)
+  def download_attachments_to_tmp(attachments, file_list: [], &block)
+    if attachments.blank?
       yield file_list
     else
-      documents.first.upload.open(tmpdir: Dir.tmpdir) do |f|
+      attachments.first.open(tmpdir: Dir.tmpdir) do |f|
         download_attachments_to_tmp(
-          documents[1..-1],
-          file_list: file_list.push({file: f, filename: documents.first.upload.filename.to_s}),
+          attachments[1..-1],
+          file_list: file_list.push({ file: f, filename: attachments.first.filename.to_s }),
           &block
         )
       end

--- a/app/services/zendesk_follow_up_docs_service.rb
+++ b/app/services/zendesk_follow_up_docs_service.rb
@@ -10,7 +10,7 @@ class ZendeskFollowUpDocsService
     return if @intake.documents.none?
 
     new_requested_docs = @intake.documents.where(document_type: "Requested", zendesk_ticket_id: nil)
-    download_attachments_to_tmp(new_requested_docs) do |file_list|
+    download_attachments_to_tmp(new_requested_docs.map(&:upload)) do |file_list|
 
       output = append_multiple_files_to_ticket(
         ticket_id: @intake.intake_ticket_id,

--- a/app/services/zendesk_intake_service.rb
+++ b/app/services/zendesk_intake_service.rb
@@ -272,7 +272,7 @@ class ZendeskIntakeService
   end
 
   def send_all_docs
-    download_attachments_to_tmp(@intake.documents) do |file_list|
+    download_attachments_to_tmp(@intake.documents.map(&:upload)) do |file_list|
 
       output = append_multiple_files_to_ticket(
         ticket_id: @intake.intake_ticket_id,


### PR DESCRIPTION
As opposed to being specific to the `Document` model (which has an
`upload` attachment), we'll pass in the attachments themselves so it can
be re-used with other models.

Co-Authored-By: Molly T-M <mollyt@codeforamerica.org>