### PR TITLE
Add lograge gem for JSON logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ gem 'omniauth-rails_csrf_protection', '~> 0.1'
 gem 'sendgrid-ruby'
 gem 'delayed_job_active_record'
 gem 'attr_encrypted'
+gem 'lograge'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,6 +182,11 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
+    lograge (0.11.2)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.4.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -279,6 +284,8 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (1.7.0)
+    request_store (1.5.0)
+      rack (>= 1.4)
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -403,6 +410,7 @@ DEPENDENCIES
   git-pair
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
+  lograge
   mini_magick (~> 4.8)
   mini_racer
   mixpanel-ruby

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  before_action :redirect_to_getyourrefund, :set_visitor_id, :set_source, :set_referrer, :set_utm_state
+  before_action :redirect_to_getyourrefund, :set_visitor_id, :set_source, :set_referrer, :set_utm_state, :set_sentry_context
   after_action :track_page_view
   helper_method :include_google_analytics?
 
@@ -130,6 +130,11 @@ class ApplicationController < ActionController::Base
       referrer: referrer,
       ip: request.remote_ip
     }
+  end
+
+  def set_sentry_context
+    Raven.user_context id: current_user&.id, intake_id: current_intake&.id
+    Raven.extra_context visitor_id: visitor_id, is_bot: user_agent.bot?
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -117,6 +117,21 @@ class ApplicationController < ActionController::Base
     )
   end
 
+  def append_info_to_payload(payload)
+    super
+    payload[:request_details] = {
+      user_id: current_user&.id,
+      intake_id: current_intake&.id,
+      device_type: user_agent.device_type,
+      browser_name: user_agent.name,
+      os_name: user_agent.os_name,
+      request_id: request.request_id,
+      visitor_id: visitor_id,
+      referrer: referrer,
+      ip: request.remote_ip
+    }
+  end
+
   private
 
   def require_sign_in

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,0 +1,21 @@
+Rails.application.configure do
+  # Lograge config
+  config.lograge.enabled = true
+
+  # This specifies to log in JSON format
+  config.lograge.formatter = Lograge::Formatters::Json.new
+
+  ## Disables log coloration
+  config.colorize_logging = false
+
+  # Log to the same place as Rails logs
+  config.lograge.logger = Rails.logger
+
+  # This is useful if you want to log query parameters
+  config.lograge.custom_options = lambda do |event|
+    {
+      params: event.payload[:params].reject { |k| %w(controller action).include? k },
+      request_details: event.payload[:request_details],
+    }
+  end
+end


### PR DESCRIPTION
This is a start of JSON logging -- initially to output one JSON line per
request. We add a hash of additional info to aid in debugging based off
the logs.

We mostly followed this guide:
https://docs.datadoghq.com/logs/log_collection/ruby/

We also discovered that Raven allows us to add extra context to our error
events, so we'll send some non-PII that will help us debugging.

https://www.pivotaltracker.com/story/show/172084932