### PR TITLE
Don't use TaggedLogging in deployment environments

### DIFF
--- a/config/environments/shared_deployment_config.rb
+++ b/config/environments/shared_deployment_config.rb
@@ -45,13 +45,6 @@ Rails.application.configure do
   # when problems arise.
   config.log_level = :info
 
-  # Prepend all log lines with the following tags.
-  config.log_tags = [
-    :request_id,
-    :ip,
-    lambda { |r| "Referrer=\"#{r.headers["HTTP_REFERER"]}\"" },
-  ]
-
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
@@ -72,17 +65,12 @@ Rails.application.configure do
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
 
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
-
   # Use a different logger for distributed setups.
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+    config.logger = ActiveSupport::Logger.new(STDOUT)
   end
 
   # Do not dump schema after migrations.


### PR DESCRIPTION
We want to use JSON based logs, so we need to remove the
ActiveSupport::TaggedLogging wrapper so the line is output as full JSON.

Example log line before:

    I, [2020-04-07T00:05:57.908012 #5]  INFO -- : [...] [...] [...] {"method":"GET","path":"/"...

After:

    {"method":"GET","path":"/","format":"html","controller":"PublicPagesController...