### PR TITLE
Add `request_id` to Sentry context

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -134,7 +134,7 @@ class ApplicationController < ActionController::Base
 
   def set_sentry_context
     Raven.user_context id: current_user&.id, intake_id: current_intake&.id
-    Raven.extra_context visitor_id: visitor_id, is_bot: user_agent.bot?
+    Raven.extra_context visitor_id: visitor_id, is_bot: user_agent.bot?, request_id: request.request_id
   end
 
   private


### PR DESCRIPTION
This will help us find errors that happened and correlate between Kibana
and Sentry.