### PR TITLE
Upload requested docs to correct ZD instance

### DIFF
--- a/app/helpers/zendesk_service_helper.rb
+++ b/app/helpers/zendesk_service_helper.rb
@@ -36,7 +36,7 @@ module ZendeskServiceHelper
   end
 
   def instance
-    EitcZendeskInstance
+    raise NotImplementedError, "You must define #instance in #{self.class.name}"
   end
 
   def get_ticket(ticket_id:)

--- a/app/services/zendesk_drop_off_service.rb
+++ b/app/services/zendesk_drop_off_service.rb
@@ -12,6 +12,10 @@ class ZendeskDropOffService
     @drop_off = drop_off
   end
 
+  def instance
+    EitcZendeskInstance
+  end
+
   def create_ticket_and_attach_file
     zendesk_user_id = find_or_create_end_user(@drop_off.name, @drop_off.email, @drop_off.phone_number)
     ticket = build_ticket(

--- a/app/services/zendesk_follow_up_docs_service.rb
+++ b/app/services/zendesk_follow_up_docs_service.rb
@@ -6,6 +6,10 @@ class ZendeskFollowUpDocsService
     @intake = intake
   end
 
+  def instance
+    @instake.zendesk_instance
+  end
+
   def send_requested_docs
     return if @intake.documents.none?
 

--- a/app/services/zendesk_sms_service.rb
+++ b/app/services/zendesk_sms_service.rb
@@ -5,6 +5,10 @@ class ZendeskSmsService
 
   def initialize; end
 
+  def instance
+    EitcZendeskInstance
+  end
+
   def handle_inbound_sms(phone_number:, sms_ticket_id:, message_body:)
     users = User.where(phone_number: phone_number)
     drop_offs = IntakeSiteDropOff.where(phone_number: phone_number)

--- a/spec/helpers/zendesk_service_helper_spec.rb
+++ b/spec/helpers/zendesk_service_helper_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe ZendeskServiceHelper do
   let(:service) do
     class SampleService
       include ZendeskServiceHelper
+
+      def instance
+        EitcZendeskInstance
+      end
     end
 
     SampleService.new


### PR DESCRIPTION
Because we were including `ZendeskServiceHelper` (which defaulted to
routing to EitcZendeskInstance) in `ZendeskFollowUpDocsService`, all
requested docs were being uploaded to our instance. But by implementing
the `instance` method in `ZendeskFollowUpDocsService`, we can use the
routing based on the intake.

This commit makes it an error to rely on the default `instance` method
in `ZendeskServiceHelper`. So any services that use it must implement
routing by implementing an `instance` method.

https://www.pivotaltracker.com/story/show/172248534

Co-Authored-By: Jenny Heath <jheath@codeforamerica.org>