### PR TITLE
Attempt to fix phone number validation

### DIFF
--- a/app/forms/phone_number_form.rb
+++ b/app/forms/phone_number_form.rb
@@ -1,21 +1,26 @@
 class PhoneNumberForm < QuestionsForm
   set_attributes_for :intake, :phone_number, :phone_number_confirmation, :phone_number_can_receive_texts
+  before_validation :parse_phone_numbers
+
   validates :phone_number, phone: { message: "Please enter a valid phone number." }
   validates :phone_number, confirmation: { message: "Please double check that the phone numbers match." }
   validates :phone_number_confirmation, presence: true
 
-  # def phone_number=(value)
-  #   if value.present? && value.is_a?(String)
-  #     unless value[0] == "1" || value[0..1] == "+1"
-  #       value = "1#{value}" # add USA country code
-  #     end
-  #     # what goes here?
-  #     @intake.assign_attributes(phone_number: Phonelib.parse(value).sanitized) if @intake
-  #   else
-  #     # what goes here?
-  #     @intake.assign_attributes(phone_number: value) if @intake
-  #   end
-  # end
+  def parse_phone_numbers
+    if phone_number.present?
+      unless phone_number[0] == "1" || phone_number[0..1] == "+1"
+        self.phone_number = "1#{phone_number}"
+      end
+      self.phone_number = Phonelib.parse(phone_number).sanitized
+    end
+
+    if phone_number_confirmation.present?
+      unless phone_number_confirmation[0] == "1" || phone_number_confirmation[0..1] == "+1"
+        self.phone_number_confirmation = "1#{phone_number_confirmation}"
+      end
+      self.phone_number_confirmation = Phonelib.parse(phone_number_confirmation).sanitized
+    end
+  end
 
   def save
     @intake.update(attributes_for(:intake).except(:phone_number_confirmation))

--- a/app/forms/phone_number_form.rb
+++ b/app/forms/phone_number_form.rb
@@ -9,8 +9,10 @@ class PhoneNumberForm < QuestionsForm
   #     unless value[0] == "1" || value[0..1] == "+1"
   #       value = "1#{value}" # add USA country code
   #     end
+  #     # what goes here?
   #     @intake.assign_attributes(phone_number: Phonelib.parse(value).sanitized) if @intake
   #   else
+  #     # what goes here?
   #     @intake.assign_attributes(phone_number: value) if @intake
   #   end
   # end

--- a/app/forms/phone_number_form.rb
+++ b/app/forms/phone_number_form.rb
@@ -4,6 +4,17 @@ class PhoneNumberForm < QuestionsForm
   validates :phone_number, confirmation: { message: "Please double check that the phone numbers match." }
   validates :phone_number_confirmation, presence: true
 
+  # def phone_number=(value)
+  #   if value.present? && value.is_a?(String)
+  #     unless value[0] == "1" || value[0..1] == "+1"
+  #       value = "1#{value}" # add USA country code
+  #     end
+  #     @intake.assign_attributes(phone_number: Phonelib.parse(value).sanitized) if @intake
+  #   else
+  #     @intake.assign_attributes(phone_number: value) if @intake
+  #   end
+  # end
+
   def save
     @intake.update(attributes_for(:intake).except(:phone_number_confirmation))
   end

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -201,18 +201,7 @@ class Intake < ApplicationRecord
   enum was_full_time_student: { unfilled: 0, yes: 1, no: 2 }, _prefix: :was_full_time_student
   enum was_on_visa: { unfilled: 0, yes: 1, no: 2 }, _prefix: :was_on_visa
   enum widowed: { unfilled: 0, yes: 1, no: 2 }, _prefix: :widowed
-
-  def phone_number=(value)
-    if value.present? && value.is_a?(String)
-      unless value[0] == "1" || value[0..1] == "+1"
-        value = "1#{value}" # add USA country code
-      end
-      self[:phone_number] = Phonelib.parse(value).sanitized
-    else
-      self[:phone_number] = value
-    end
-  end
-
+  
   def sms_phone_number=(value)
     if value.present? && value.is_a?(String)
       unless value[0] == "1" || value[0..1] == "+1"

--- a/spec/controllers/questions/phone_number_controller_spec.rb
+++ b/spec/controllers/questions/phone_number_controller_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Questions::PhoneNumberController do
 
   before do
     allow(subject).to receive(:current_user).and_return(user)
+    allow(subject).to receive(:current_intake).and_return(intake)
     allow(subject).to receive(:send_mixpanel_event)
   end
 
@@ -25,8 +26,8 @@ RSpec.describe Questions::PhoneNumberController do
       let(:params) do
         {
           phone_number_form: {
-            phone_number: "555-867-5309",
-            phone_number_confirmation: "555-867-5309",
+            phone_number: "5558675309",
+            phone_number_confirmation: "5558675309",
             phone_number_can_receive_texts: "yes",
           }
         }

--- a/spec/controllers/questions/phone_number_controller_spec.rb
+++ b/spec/controllers/questions/phone_number_controller_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe Questions::PhoneNumberController do
       let(:params) do
         {
           phone_number_form: {
-            phone_number: "5558675309",
-            phone_number_confirmation: "5558675309",
+            phone_number: "(415) 553-7865",
+            phone_number_confirmation: "(415) 553-7865",
             phone_number_can_receive_texts: "yes",
           }
         }
@@ -38,7 +38,7 @@ RSpec.describe Questions::PhoneNumberController do
           post :update, params: params
         end.to change { intake.reload.phone_number }
           .from(nil)
-          .to("15558675309")
+          .to("14155537865")
       end
 
       it "sends an event to mixpanel without the phone number data" do
@@ -55,8 +55,8 @@ RSpec.describe Questions::PhoneNumberController do
       let(:params) do
         {
           phone_number_form: {
-            phone_number: "555-867-5309",
-            phone_number_confirmation: "555-555-1234",
+            phone_number: "415-553-7865",
+            phone_number_confirmation: "415-553-1234",
             phone_number_can_receive_texts: "yes",
           }
         }

--- a/spec/features/web_intake/new_joint_filers_spec.rb
+++ b/spec/features/web_intake/new_joint_filers_spec.rb
@@ -78,8 +78,8 @@ RSpec.feature "Web Intake Joint Filers" do
 
     # Phone number
     expect(page).to have_selector("h1", text: "Please share your contact number.")
-    fill_in "Phone number", with: "555-231-1234"
-    fill_in "Confirm phone number", with: "555-231-1234"
+    fill_in "Phone number", with: "(415) 553-7865"
+    fill_in "Confirm phone number", with: "(415) 553-7865"
     click_on "Continue"
 
     # Email

--- a/spec/features/web_intake/new_single_filer_spec.rb
+++ b/spec/features/web_intake/new_single_filer_spec.rb
@@ -46,8 +46,8 @@ RSpec.feature "Web Intake Single Filer" do
 
     # Phone number
     expect(page).to have_selector("h1", text: "Please share your contact number.")
-    fill_in "Phone number", with: "555-231-1234"
-    fill_in "Confirm phone number", with: "555-231-1234"
+    fill_in "Phone number", with: "(415) 553-7865"
+    fill_in "Confirm phone number", with: "(415) 553-7865"
     check "This number can receive text messages"
     click_on "Continue"
 

--- a/spec/forms/phone_number_form_spec.rb
+++ b/spec/forms/phone_number_form_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe PhoneNumberForm do
+  let(:intake) { create :intake }
+
+  describe "validations" do
+    context "when all params are valid" do
+      it "is valid" do
+        form = PhoneNumberForm.new(
+          intake,
+          {
+            phone_number: "15558675309",
+            phone_number_confirmation: "15558675309",
+            phone_number_can_receive_texts: "no",
+          }
+        )
+
+        expect(form).to be_valid
+      end
+
+      context "when phone number excludes country code" do
+        it "adds one in the setter and is still valid" do
+          form = PhoneNumberForm.new(
+            intake,
+            {
+              phone_number: "5558675309",
+              phone_number_confirmation: "5558675309",
+              phone_number_can_receive_texts: "no",
+            }
+          )
+
+          expect(form).to be_valid
+        end
+      end
+    end
+
+    context "when phone number is not valid" do
+      it "adds an error" do
+        form = PhoneNumberForm.new(
+          nil,
+          {
+            phone_number: "555",
+            phone_number_confirmation: "555",
+            phone_number_can_receive_texts: "no",
+          }
+        )
+
+        expect(form).not_to be_valid
+        expect(form.errors[:phone_number]).to be_present
+      end
+    end
+
+    context "when phone number confirmation does not match phone number" do
+      it "adds an error" do
+        form = PhoneNumberForm.new(
+          nil,
+          {
+            phone_number: "5558675309",
+            phone_number_confirmation: "5558884444",
+            phone_number_can_receive_texts: "no",
+          }
+        )
+
+        expect(form).not_to be_valid
+        expect(form.errors[:phone_number_confirmation]).to be_present
+      end
+    end
+  end
+end

--- a/spec/forms/phone_number_form_spec.rb
+++ b/spec/forms/phone_number_form_spec.rb
@@ -5,31 +5,35 @@ RSpec.describe PhoneNumberForm do
 
   describe "validations" do
     context "when all params are valid" do
-      it "is valid" do
-        form = PhoneNumberForm.new(
-          intake,
-          {
-            phone_number: "14155537865",
-            phone_number_confirmation: "14155537865",
-            phone_number_can_receive_texts: "no",
-          }
-        )
-
-        expect(form).to be_valid
-      end
-
-      context "when phone number excludes country code" do
-        it "adds one in the setter and is still valid" do
+      context "when phone number includes the country code" do
+        it "is valid and does not modify the value" do
           form = PhoneNumberForm.new(
             intake,
             {
-              phone_number: "4155537865",
-              phone_number_confirmation: "4155537865",
+              phone_number: "1 (415) 553-7865",
+              phone_number_confirmation: "1 (415) 553-7865",
               phone_number_can_receive_texts: "no",
             }
           )
 
           expect(form).to be_valid
+          expect(form.attributes_for(:intake)[:phone_number]).to eq "14155537865"
+        end
+      end
+
+      context "when phone number excludes country code" do
+        it "is valid and prepends a country code" do
+          form = PhoneNumberForm.new(
+            intake,
+            {
+              phone_number: "415.553.7865",
+              phone_number_confirmation: "415.553.7865",
+              phone_number_can_receive_texts: "no",
+            }
+          )
+
+          expect(form).to be_valid
+          expect(form.attributes_for(:intake)[:phone_number]).to eq "14155537865"
         end
       end
     end
@@ -39,14 +43,15 @@ RSpec.describe PhoneNumberForm do
         form = PhoneNumberForm.new(
           nil,
           {
-            phone_number: "555",
-            phone_number_confirmation: "555",
+            phone_number: "415",
+            phone_number_confirmation: "415",
             phone_number_can_receive_texts: "no",
           }
         )
 
         expect(form).not_to be_valid
         expect(form.errors[:phone_number]).to be_present
+        expect(form.attributes_for(:intake)[:phone_number]).to eq "1415"
       end
     end
 
@@ -55,8 +60,8 @@ RSpec.describe PhoneNumberForm do
         form = PhoneNumberForm.new(
           nil,
           {
-            phone_number: "5558675309",
-            phone_number_confirmation: "5558884444",
+            phone_number: "4155537865",
+            phone_number_confirmation: "4155537811",
             phone_number_can_receive_texts: "no",
           }
         )

--- a/spec/forms/phone_number_form_spec.rb
+++ b/spec/forms/phone_number_form_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe PhoneNumberForm do
         form = PhoneNumberForm.new(
           intake,
           {
-            phone_number: "15558675309",
-            phone_number_confirmation: "15558675309",
+            phone_number: "14155537865",
+            phone_number_confirmation: "14155537865",
             phone_number_can_receive_texts: "no",
           }
         )
@@ -23,8 +23,8 @@ RSpec.describe PhoneNumberForm do
           form = PhoneNumberForm.new(
             intake,
             {
-              phone_number: "5558675309",
-              phone_number_confirmation: "5558675309",
+              phone_number: "4155537865",
+              phone_number_confirmation: "4155537865",
               phone_number_can_receive_texts: "no",
             }
           )


### PR DESCRIPTION
**problem:** our phone number form requires users to enter a country code. this happens because the validation occurs before the setter which appends a country code.

**we want to:** 
- allow users to enter phone numbers without a country code
- make sure that the phone numbers are valid
- save the phone number with a country code so that zendesk doesn't complain

solution: `before_validation` action adds a country code if need be