### PR TITLE
Skip oversize uploads #172293223

### DIFF
--- a/app/helpers/eitc_zendesk_instance.rb
+++ b/app/helpers/eitc_zendesk_instance.rb
@@ -1,5 +1,7 @@
 class EitcZendeskInstance
   DOMAIN = "eitc"
+  # ZD "Professional" plan allows uploads up to 20MB
+  MAXIMUM_UPLOAD_SIZE = 20000000
 
   # online intake group ids
   ALL_EITC_GROUP_IDS = [

--- a/app/helpers/uwtsa_zendesk_instance.rb
+++ b/app/helpers/uwtsa_zendesk_instance.rb
@@ -1,5 +1,7 @@
 class UwtsaZendeskInstance
   DOMAIN = "unitedwaytucson"
+  # ZD "Team" plan allows uploads up to 7MB
+  MAXIMUM_UPLOAD_SIZE = 7000000
 
   # custom field id codes
   CERTIFICATION_LEVEL = "114101964473"

--- a/app/helpers/zendesk_service_helper.rb
+++ b/app/helpers/zendesk_service_helper.rb
@@ -31,9 +31,6 @@ module ZendeskServiceHelper
     "Pacific/Honolulu" => "Hawaii",
   }.freeze
 
-  # Zendesk caps uploads at 20MB
-  MAXIMUM_UPLOAD_SIZE = 20000000
-
   def client
     @client ||= instance.client
   end
@@ -173,10 +170,18 @@ module ZendeskServiceHelper
   end
 
   def append_file_or_add_comment(file, ticket, comment)
-    if file[:file].size < MAXIMUM_UPLOAD_SIZE
+    if file[:file].size < file_size_limit
       ticket.comment.uploads << file
     else
-      comment.concat("\n\nThe file #{file[:filename]} could not be uploaded because it exceeds the maximum size of #{MAXIMUM_UPLOAD_SIZE/1000000}MB.")
+      comment.concat("\n\nThe file #{file[:filename]} could not be uploaded because it exceeds the maximum size of #{file_size_limit/1000000}MB.")
+    end
+  end
+
+  def file_size_limit
+    if instance == EitcZendeskInstance
+      EitcZendeskInstance::MAXIMUM_UPLOAD_SIZE
+    else
+      UwtsaZendeskInstance::MAXIMUM_UPLOAD_SIZE
     end
   end
 


### PR DESCRIPTION
If a file is too big, adds the following note to the comment:

"The file [filename] could not be uploaded because it exceeds the maximum size of [file_size_limit]MB."

If multiple files exceed the limit, the message will be repeated for each file name.

The size limit depends on the Zendesk instance for the ticket.