### PR TITLE
Skip intakes with no user in Zendesk phone backfill

### DIFF
--- a/app/lib/zendesk_remove_duplicate_phones_backfill.rb
+++ b/app/lib/zendesk_remove_duplicate_phones_backfill.rb
@@ -21,7 +21,7 @@ class ZendeskRemoveDuplicatePhonesBackfill
   private
 
   def self.backfill_intake(intake)
-    return unless intake.intake_ticket_requester_id.present?
+    return unless intake.intake_ticket_requester_id.present? && intake.primary_user.present?
 
     service = ZendeskIntakeService.new(intake)
     user = service.get_end_user(user_id: intake.intake_ticket_requester_id)


### PR DESCRIPTION
Intakes don't have users if they are in progress and before the user has
authenticated with ID.me.