### PR TITLE
Refactor DocumentNavigation to use an array

### DIFF
--- a/app/controllers/documents/additional_documents_controller.rb
+++ b/app/controllers/documents/additional_documents_controller.rb
@@ -1,4 +1,7 @@
 module Documents
   class AdditionalDocumentsController < DocumentUploadQuestionController
+    def self.document_type
+      "Other"
+    end
   end
 end

--- a/app/controllers/documents/care_provider_statements_controller.rb
+++ b/app/controllers/documents/care_provider_statements_controller.rb
@@ -3,5 +3,9 @@ module Documents
     def self.show?(intake)
       intake.paid_dependent_care_yes?
     end
+
+    def self.document_type
+      "Care Provider Statement"
+    end
   end
 end

--- a/app/controllers/documents/document_upload_question_controller.rb
+++ b/app/controllers/documents/document_upload_question_controller.rb
@@ -6,11 +6,15 @@ module Documents
     helper_method :document_type
 
     def edit
+      return if self.class.document_type.nil?
+
       @documents = current_intake.documents.of_type(document_type)
       @form = form_class.new(document_type, current_intake, form_params)
     end
 
     def update
+      return if self.class.document_type.nil?
+
       @form = form_class.new(document_type, current_intake, form_params)
       if @form.valid?
         form_saved = @form.save
@@ -32,7 +36,7 @@ module Documents
     end
 
     def self.document_type
-      DocumentNavigation.document_type(self)
+      raise NotImplementedError, "#{self.name} must implement document_type or return nil to indicate no document will be uploaded."
     end
 
     def track_document_upload
@@ -46,7 +50,7 @@ module Documents
     end
 
     def next_path(params = {})
-      next_step = form_navigation.next
+      next_step = form_navigation.next_for_intake(current_intake)
       document_path(next_step.to_param, params) if next_step
     end
 

--- a/app/controllers/documents/form1095as_controller.rb
+++ b/app/controllers/documents/form1095as_controller.rb
@@ -3,5 +3,9 @@ module Documents
     def self.show?(intake)
       intake.bought_health_insurance_yes?
     end
+
+    def self.document_type
+      "1095-A"
+    end
   end
 end

--- a/app/controllers/documents/form1098es_controller.rb
+++ b/app/controllers/documents/form1098es_controller.rb
@@ -3,5 +3,9 @@ module Documents
     def self.show?(intake)
       intake.paid_student_loan_interest_yes?
     end
+
+    def self.document_type
+      "1098-E"
+    end
   end
 end

--- a/app/controllers/documents/form1098s_controller.rb
+++ b/app/controllers/documents/form1098s_controller.rb
@@ -3,5 +3,9 @@ module Documents
     def self.show?(intake)
       intake.paid_mortgage_interest_yes? || intake.paid_local_tax_yes?
     end
+
+    def self.document_type
+      "1098"
+    end
   end
 end

--- a/app/controllers/documents/form1098ts_controller.rb
+++ b/app/controllers/documents/form1098ts_controller.rb
@@ -3,5 +3,9 @@ module Documents
     def self.show?(intake)
       intake.had_student_in_family_yes?
     end
+
+    def self.document_type
+      "1098-T"
+    end
   end
 end

--- a/app/controllers/documents/form1099as_controller.rb
+++ b/app/controllers/documents/form1099as_controller.rb
@@ -3,5 +3,9 @@ module Documents
     def self.show?(intake)
       intake.had_debt_forgiven_yes?
     end
+
+    def self.document_type
+      "1099-A"
+    end
   end
 end

--- a/app/controllers/documents/form1099bs_controller.rb
+++ b/app/controllers/documents/form1099bs_controller.rb
@@ -3,5 +3,9 @@ module Documents
     def self.show?(intake)
       intake.had_asset_sale_income_yes?
     end
+
+    def self.document_type
+      "1099-B"
+    end
   end
 end

--- a/app/controllers/documents/form1099cs_controller.rb
+++ b/app/controllers/documents/form1099cs_controller.rb
@@ -3,5 +3,9 @@ module Documents
     def self.show?(intake)
       intake.had_debt_forgiven_yes?
     end
+
+    def self.document_type
+      "1099-C"
+    end
   end
 end

--- a/app/controllers/documents/form1099divs_controller.rb
+++ b/app/controllers/documents/form1099divs_controller.rb
@@ -3,5 +3,9 @@ module Documents
     def self.show?(intake)
       intake.had_interest_income_yes?
     end
+
+    def self.document_type
+      "1099-DIV"
+    end
   end
 end

--- a/app/controllers/documents/form1099gs_controller.rb
+++ b/app/controllers/documents/form1099gs_controller.rb
@@ -3,5 +3,9 @@ module Documents
     def self.show?(intake)
       intake.had_unemployment_income_yes?
     end
+
+    def self.document_type
+      "1099-G"
+    end
   end
 end

--- a/app/controllers/documents/form1099ints_controller.rb
+++ b/app/controllers/documents/form1099ints_controller.rb
@@ -3,5 +3,9 @@ module Documents
     def self.show?(intake)
       intake.had_interest_income_yes?
     end
+
+    def self.document_type
+      "1099-INT"
+    end
   end
 end

--- a/app/controllers/documents/form1099ks_controller.rb
+++ b/app/controllers/documents/form1099ks_controller.rb
@@ -3,5 +3,9 @@ module Documents
     def self.show?(intake)
       intake.had_self_employment_income_yes?
     end
+
+    def self.document_type
+      "1099-K"
+    end
   end
 end

--- a/app/controllers/documents/form1099miscs_controller.rb
+++ b/app/controllers/documents/form1099miscs_controller.rb
@@ -4,5 +4,9 @@ module Documents
       intake.had_self_employment_income_yes? ||
         intake.had_a_job?
     end
+
+    def self.document_type
+      "1099-MISC"
+    end
   end
 end

--- a/app/controllers/documents/form1099rs_controller.rb
+++ b/app/controllers/documents/form1099rs_controller.rb
@@ -3,5 +3,9 @@ module Documents
     def self.show?(intake)
       intake.had_retirement_income_yes?
     end
+
+    def self.document_type
+      "1099-R"
+    end
   end
 end

--- a/app/controllers/documents/form1099sas_controller.rb
+++ b/app/controllers/documents/form1099sas_controller.rb
@@ -3,5 +3,9 @@ module Documents
     def self.show?(intake)
       intake.had_hsa_yes?
     end
+
+    def self.document_type
+      "1099-SA"
+    end
   end
 end

--- a/app/controllers/documents/form1099ss_controller.rb
+++ b/app/controllers/documents/form1099ss_controller.rb
@@ -3,5 +3,9 @@ module Documents
     def self.show?(intake)
       intake.had_asset_sale_income_yes? || intake.sold_a_home_yes?
     end
+
+    def self.document_type
+      "1099-S"
+    end
   end
 end

--- a/app/controllers/documents/form5498sas_controller.rb
+++ b/app/controllers/documents/form5498sas_controller.rb
@@ -3,5 +3,9 @@ module Documents
     def self.show?(intake)
       intake.had_hsa_yes?
     end
+
+    def self.document_type
+      "5498-SA"
+    end
   end
 end

--- a/app/controllers/documents/id_guidance_controller.rb
+++ b/app/controllers/documents/id_guidance_controller.rb
@@ -3,5 +3,9 @@ module Documents
     layout "application"
 
     def edit; end
+
+    def self.document_type
+      nil
+    end
   end
 end

--- a/app/controllers/documents/ids_controller.rb
+++ b/app/controllers/documents/ids_controller.rb
@@ -11,5 +11,9 @@ module Documents
       end
       super
     end
+
+    def self.document_type
+      "ID"
+    end
   end
 end

--- a/app/controllers/documents/intro_controller.rb
+++ b/app/controllers/documents/intro_controller.rb
@@ -6,10 +6,14 @@ module Documents
 
     def edit; end
 
+    def self.document_type
+      nil
+    end
+
     private
 
     def recommended_document_types
-      DocumentNavigation.new(self).types_for_intake(current_intake)
+      DocumentNavigation.document_types_for_intake(current_intake)
     end
   end
 end

--- a/app/controllers/documents/ira_statements_controller.rb
+++ b/app/controllers/documents/ira_statements_controller.rb
@@ -3,5 +3,9 @@ module Documents
     def self.show?(intake)
       intake.paid_retirement_contributions_yes?
     end
+
+    def self.document_type
+      "IRA Statement"
+    end
   end
 end

--- a/app/controllers/documents/overview_controller.rb
+++ b/app/controllers/documents/overview_controller.rb
@@ -1,5 +1,5 @@
 module Documents
-  class OverviewController < Questions::QuestionsController
+  class OverviewController < DocumentUploadQuestionController
     layout "application"
 
     helper_method :recommended_document_types
@@ -8,10 +8,14 @@ module Documents
       @documents = current_intake.documents
     end
 
+    def self.document_type
+      nil
+    end
+
     private
 
     def recommended_document_types
-      document_types = DocumentNavigation.new(self).types_for_intake(current_intake)
+      document_types = DocumentNavigation.document_types_for_intake(current_intake)
       include_requested_documents = @documents.where(document_type: "Requested").exists?
       document_types += ["Requested"] if include_requested_documents
       document_types

--- a/app/controllers/documents/prior_tax_returns_controller.rb
+++ b/app/controllers/documents/prior_tax_returns_controller.rb
@@ -3,5 +3,9 @@ module Documents
     def self.show?(intake)
       intake.had_local_tax_refund_yes? || intake.reported_asset_sale_loss_yes?
     end
+
+    def self.document_type
+      "2018 Tax Return"
+    end
   end
 end

--- a/app/controllers/documents/property_tax_statements_controller.rb
+++ b/app/controllers/documents/property_tax_statements_controller.rb
@@ -3,5 +3,9 @@ module Documents
     def self.show?(intake)
       intake.paid_local_tax_yes?
     end
+
+    def self.document_type
+      "Property Tax Statement"
+    end
   end
 end

--- a/app/controllers/documents/requested_documents_controller.rb
+++ b/app/controllers/documents/requested_documents_controller.rb
@@ -7,5 +7,9 @@ module Documents
     def next_path(params = {})
       send_requested_documents_documents_path
     end
+
+    def self.document_type
+      "Requested"
+    end
   end
 end

--- a/app/controllers/documents/requested_documents_later_controller.rb
+++ b/app/controllers/documents/requested_documents_later_controller.rb
@@ -15,6 +15,10 @@ module Documents
       render layout: "application"
     end
 
+    def self.document_type
+      "Requested Later"
+    end
+
     private
 
     def handle_session

--- a/app/controllers/documents/rrb1099s_controller.rb
+++ b/app/controllers/documents/rrb1099s_controller.rb
@@ -3,5 +3,9 @@ module Documents
     def self.show?(intake)
       intake.had_social_security_income_yes?
     end
+
+    def self.document_type
+      "RRB-1099"
+    end
   end
 end

--- a/app/controllers/documents/selfie_instructions_controller.rb
+++ b/app/controllers/documents/selfie_instructions_controller.rb
@@ -1,5 +1,9 @@
 module Documents
   class SelfieInstructionsController < DocumentUploadQuestionController
     layout "application"
+
+    def self.document_type
+      nil
+    end
   end
 end

--- a/app/controllers/documents/selfies_controller.rb
+++ b/app/controllers/documents/selfies_controller.rb
@@ -7,5 +7,9 @@ module Documents
         @names << current_intake.spouse_name_or_placeholder
       end
     end
+
+    def self.document_type
+      "Selfie"
+    end
   end
 end

--- a/app/controllers/documents/send_requested_documents_controller.rb
+++ b/app/controllers/documents/send_requested_documents_controller.rb
@@ -5,12 +5,12 @@ module Documents
       redirect_to documents_requested_documents_success_path
     end
 
-    def self.show?
+    def self.show?(_)
       false
     end
 
-    def self.form_class
-      NullForm
+    def self.document_type
+      nil
     end
   end
 end

--- a/app/controllers/documents/send_requested_documents_later_controller.rb
+++ b/app/controllers/documents/send_requested_documents_later_controller.rb
@@ -18,8 +18,8 @@ module Documents
       false
     end
 
-    def self.form_class
-      NullForm
+    def self.document_type
+      nil
     end
 
     private

--- a/app/controllers/documents/ssa1099s_controller.rb
+++ b/app/controllers/documents/ssa1099s_controller.rb
@@ -3,5 +3,9 @@ module Documents
     def self.show?(intake)
       intake.had_social_security_income_yes?
     end
+
+    def self.document_type
+      "SSA-1099"
+    end
   end
 end

--- a/app/controllers/documents/ssn_itins_controller.rb
+++ b/app/controllers/documents/ssn_itins_controller.rb
@@ -14,5 +14,9 @@ module Documents
     def next_path
       return selfie_instructions_documents_path
     end
+
+    def self.document_type
+      "SSN or ITIN"
+    end
   end
 end

--- a/app/controllers/documents/student_account_statements_controller.rb
+++ b/app/controllers/documents/student_account_statements_controller.rb
@@ -8,5 +8,9 @@ module Documents
       @student_names = current_intake.student_names
       super
     end
+
+    def self.document_type
+      "Student Account Statement"
+    end
   end
 end

--- a/app/controllers/documents/w2gs_controller.rb
+++ b/app/controllers/documents/w2gs_controller.rb
@@ -3,5 +3,9 @@ module Documents
     def self.show?(intake)
       intake.had_gambling_income_yes?
     end
+
+    def self.document_type
+      "W-2G"
+    end
   end
 end

--- a/app/controllers/documents/w2s_controller.rb
+++ b/app/controllers/documents/w2s_controller.rb
@@ -5,5 +5,9 @@ module Documents
         intake.had_disability_income_yes? ||
         intake.had_a_job?
     end
+
+    def self.document_type
+      "W-2"
+    end
   end
 end

--- a/app/controllers/questions/additional_info_controller.rb
+++ b/app/controllers/questions/additional_info_controller.rb
@@ -7,7 +7,7 @@ module Questions
     end
 
     def next_path
-      next_step = DocumentNavigation.new(self).all_controllers.first
+      next_step = DocumentNavigation.first_for_intake(current_intake)
       document_path(next_step.to_param)
     end
 

--- a/app/helpers/documents_overview_helper.rb
+++ b/app/helpers/documents_overview_helper.rb
@@ -1,9 +1,9 @@
 module DocumentsOverviewHelper
   def edit_document_path(document_type)
-    document_controller = DocumentNavigation::DOCUMENT_CONTROLLERS[document_type]
+    document_controller = DocumentNavigation.document_controller_for_type(document_type)
 
     unless document_controller
-      raise "Missing document type `#{document_type}` from Document::DOCUMENT_CONTROLLERS"
+      raise "Missing DocumentNavigation::FLOW controller that returns `#{document_type}` from `self.document_type`"
     end
 
     document_path(document_controller)

--- a/app/lib/document_navigation.rb
+++ b/app/lib/document_navigation.rb
@@ -1,107 +1,81 @@
 # frozen_string_literal: true
 
 class DocumentNavigation
-  DOCUMENT_CONTROLLERS = {
-    "ID" => Documents::IdsController,
-    "SSN or ITIN" => Documents::SsnItinsController,
-    "Selfie" => Documents::SelfiesController,
-    "W-2" => Documents::W2sController,
-    "1095-A" => Documents::Form1095asController,
-    "1098" => Documents::Form1098sController,
-    "1098-E" => Documents::Form1098esController,
-    "1098-T" => Documents::Form1098tsController,
-    "1099-A" => Documents::Form1099asController,
-    "1099-B" => Documents::Form1099bsController,
-    "1099-C" => Documents::Form1099csController,
-    "1099-DIV" => Documents::Form1099divsController,
-    "1099-INT" => Documents::Form1099intsController,
-    "1099-K" => Documents::Form1099ksController,
-    "1099-MISC" => Documents::Form1099miscsController,
-    "1099-R" => Documents::Form1099rsController,
-    "1099-S" => Documents::Form1099ssController,
-    "1099-SA" => Documents::Form1099sasController,
-    "1099-G" => Documents::Form1099gsController,
-    "5498-SA" => Documents::Form5498sasController,
-    "IRA Statement" => Documents::IraStatementsController,
-    "Property Tax Statement" => Documents::PropertyTaxStatementsController,
-    "RRB-1099" => Documents::Rrb1099sController,
-    "SSA-1099" => Documents::Ssa1099sController,
-    "Student Account Statement" => Documents::StudentAccountStatementsController,
-    "Care Provider Statement" => Documents::CareProviderStatementsController,
-    "W-2G" => Documents::W2gsController,
-    "2018 Tax Return" => Documents::PriorTaxReturnsController,
-    "Other" => Documents::AdditionalDocumentsController,
-    "Requested" => Documents::RequestedDocumentsController,
-    "Requested Later" => Documents::RequestedDocumentsLaterController,
-  }.freeze
-  BEFORE_CONTROLLERS = [
+  FLOW = [
     Documents::IntroController,
     Documents::IdGuidanceController,
-  ].freeze
-  AFTER_CONTROLLERS = [
+    Documents::IdsController,
+    Documents::SsnItinsController,
+    Documents::SelfiesController,
+    Documents::W2sController,
+    Documents::Form1095asController,
+    Documents::Form1098sController,
+    Documents::Form1098esController,
+    Documents::Form1098tsController,
+    Documents::Form1099asController,
+    Documents::Form1099bsController,
+    Documents::Form1099csController,
+    Documents::Form1099divsController,
+    Documents::Form1099intsController,
+    Documents::Form1099ksController,
+    Documents::Form1099miscsController,
+    Documents::Form1099rsController,
+    Documents::Form1099ssController,
+    Documents::Form1099sasController,
+    Documents::Form1099gsController,
+    Documents::Form5498sasController,
+    Documents::IraStatementsController,
+    Documents::PropertyTaxStatementsController,
+    Documents::Rrb1099sController,
+    Documents::Ssa1099sController,
+    Documents::StudentAccountStatementsController,
+    Documents::CareProviderStatementsController,
+    Documents::W2gsController,
+    Documents::PriorTaxReturnsController,
+    Documents::AdditionalDocumentsController,
+    Documents::RequestedDocumentsController,
+    Documents::RequestedDocumentsLaterController,
     Documents::OverviewController,
     Documents::SelfieInstructionsController,
     Documents::SendRequestedDocumentsController,
     Documents::SendRequestedDocumentsLaterController,
   ].freeze
-  DOCUMENT_TYPES = DOCUMENT_CONTROLLERS.keys.freeze
+
+  DOCUMENT_TYPES = FLOW.map(&:document_type).compact
 
   class << self
     delegate :first, to: :controllers
 
     def controllers
-      DOCUMENT_CONTROLLERS.values
+      FLOW
     end
 
-    def all_controllers
-      BEFORE_CONTROLLERS + controllers + AFTER_CONTROLLERS
+    def first_for_intake(intake)
+      controllers.find { |c| c.show?(intake) }
     end
 
-    def document_type(controller_class)
-      DOCUMENT_CONTROLLERS.key(controller_class)
+    def document_types_for_intake(intake)
+      controllers
+        .find_all { |c| c.show?(intake) }
+        .map(&:document_type)
+        .compact
+    end
+
+    def document_controller_for_type(document_type)
+      controllers.find { |c| c.document_type == document_type }
     end
   end
 
   delegate :controllers, to: :class
-  delegate :all_controllers, to: :class
-  delegate :document_type, to: :class
 
   def initialize(current_controller)
     @current_controller = current_controller
   end
 
-  def next
-    return unless index
+  def next_for_intake(intake)
+    current_index = controllers.index(@current_controller.class)
+    return if current_index.nil?
 
-    controllers_until_end = all_controllers[(index + 1)..-1]
-    seek(controllers_until_end)
-  end
-
-  def first_for_intake(intake)
-    select(intake).first
-  end
-
-  def select(intake)
-    controllers.select do |controller_class|
-      controller_class.show?(intake)
-    end
-  end
-
-  def types_for_intake(intake)
-    select(intake).map do |controller_class|
-      document_type(controller_class)
-    end
-  end
-
-  private
-
-  def index
-    all_controllers.index(@current_controller.class)
-  end
-
-  def seek(list)
-    list.detect do |controller_class|
-      controller_class.show?(@current_controller.current_intake)
-    end
+    controllers[(current_index + 1)..-1].find { |c| c.show?(intake) }
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,7 @@ Rails.application.routes.draw do
 
   resources :documents, controller: :documents do
     collection do
-      DocumentNavigation.all_controllers.uniq.each do |controller_class|
+      DocumentNavigation.controllers.uniq.each do |controller_class|
         { get: :edit, put: :update }.each do |method, action|
           match "/#{controller_class.to_param}",
                 action: action,

--- a/spec/helpers/documents_overview_helper_spec.rb
+++ b/spec/helpers/documents_overview_helper_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe DocumentsOverviewHelper do
 
     it "raises an error" do
       expect { helper.edit_document_path(document_type) }
-        .to raise_error(/Missing document type/)
+        .to raise_error(/Missing/)
     end
   end
 end


### PR DESCRIPTION
This flattens the objects in DocumentNavigation back into one big array,
and moves the responsibility for determining document type onto the
subclass controllers. Overview pages (which don't upload documents) can
return `nil`.