### PR TITLE
Don't send mailing addresses to Mixpanel

### DIFF
--- a/app/controllers/questions/mailing_address_controller.rb
+++ b/app/controllers/questions/mailing_address_controller.rb
@@ -1,4 +1,7 @@
 module Questions
   class MailingAddressController < QuestionsController
+    def tracking_data
+      {}
+    end
   end
 end


### PR DESCRIPTION
The default implementation of `tracking_data` is to send the params to
Mixpanel, however we want to override it with an empty hash to avoid
sending any sensitive data, or data that will not be useful to us.