### PR TITLE
Clear session on successfully submitted page

### DIFF
--- a/app/controllers/questions/successfully_submitted_controller.rb
+++ b/app/controllers/questions/successfully_submitted_controller.rb
@@ -1,5 +1,7 @@
 module Questions
   class SuccessfullySubmittedController < QuestionsController
+    append_after_action :reset_session, :track_page_view
+
     def edit
     end
   end

--- a/spec/features/web_intake/new_single_filer_spec.rb
+++ b/spec/features/web_intake/new_single_filer_spec.rb
@@ -315,5 +315,9 @@ RSpec.feature "Web Intake Single Filer" do
     click_on "Submit"
 
     expect(page).to have_selector("h1", text: "Your tax information has been successfully submitted!")
+
+    # going back to another page after submit redirects to beginning
+    visit "/questions/wages"
+    expect(page).to have_selector("h1", text: "How are you feeling about your taxes?")
   end
 end


### PR DESCRIPTION
Some notes:
- we had to do an `append_after_action` because when we clear the source/referrer from the session, it causes an error in `send_mixpanel_event` because it's expecting both to be present
- we made the decision to reset the whole session instead of just the intake_id, assuming that the existence of this story means that we want to treat every device like it could be a public library computer and that means other things like source/referrer that live on the session should be cleared for the next user
- one thing we noticed is that this doesn't touch the `visitor_id` - should it? we're saving visitor id in the permanent cookies and it never gets reset

Co-authored-by: Jonathan Greenberg <jgreenberg@codeforamerica.org>