### PR TITLE
Create Zendesk ticket after consent

### DIFF
--- a/app/controllers/questions/consent_controller.rb
+++ b/app/controllers/questions/consent_controller.rb
@@ -7,5 +7,9 @@ module Questions
         primary_consented_to_service_ip: request.remote_ip,
       )
     end
+
+    def after_update_success
+      CreateZendeskIntakeTicketJob.perform_later(current_intake.id) if current_intake.intake_ticket_id.blank?
+    end
   end
 end

--- a/app/controllers/questions/notification_preference_controller.rb
+++ b/app/controllers/questions/notification_preference_controller.rb
@@ -2,10 +2,6 @@ module Questions
   class NotificationPreferenceController < QuestionsController
     private
 
-    def after_update_success
-      CreateZendeskIntakeTicketJob.perform_later(current_intake.id) if current_intake.intake_ticket_id.blank?
-    end
-
     def tracking_data
       @form.attributes_for(:intake).reject { |k, _| k == :sms_phone_number }
     end

--- a/app/lib/question_navigation.rb
+++ b/app/lib/question_navigation.rb
@@ -16,10 +16,10 @@ class QuestionNavigation
     Questions::ChatWithUsController,
     Questions::PhoneNumberController,
     Questions::EmailAddressController,
-    Questions::NotificationPreferenceController, # creates initial Zendesk ticket
+    Questions::NotificationPreferenceController,
 
     # Consent
-    Questions::ConsentController,
+    Questions::ConsentController, # create Zendesk ticket
 
     # Primary filer personal information
     Questions::WasStudentController,
@@ -120,7 +120,7 @@ class QuestionNavigation
     Questions::EnergyEfficientPurchasesController,
 
     # Additional Information
-    Questions::AdditionalInfoController, # appends 13614-C to Zendesk ticket
+    Questions::AdditionalInfoController, # appends 13614-C & consent PDF to Zendesk ticket
 
     # Documents --> See DocumentNavigation
     Questions::OverviewDocumentsController,

--- a/app/services/zendesk_intake_service.rb
+++ b/app/services/zendesk_intake_service.rb
@@ -39,7 +39,7 @@ class ZendeskIntakeService
     # returns the Zendesk ID of the created user
     contact_info = @intake.contact_info_filtered_by_preferences
     find_or_create_end_user(
-      @intake.primary_full_name,
+      @intake.preferred_name,
       contact_info[:email],
       contact_info[:phone_number],
       exact_match: true
@@ -64,7 +64,9 @@ class ZendeskIntakeService
     <<~BODY
       #{new_ticket_body_header}
 
-      Name: #{@intake.primary_full_name}
+      Preferred name: #{@intake.preferred_name}
+      Legal first name: #{@intake.primary_first_name}
+      Legal last name: #{@intake.primary_last_name}
       Phone number: #{@intake.formatted_phone_number}
       Email: #{@intake.email_address}
       State of residence: #{@intake.state_of_residence_name}

--- a/spec/controllers/questions/notification_preference_controller_spec.rb
+++ b/spec/controllers/questions/notification_preference_controller_spec.rb
@@ -3,8 +3,7 @@ require "rails_helper"
 RSpec.describe Questions::NotificationPreferenceController do
   render_views
 
-  let(:zendesk_ticket_id) { nil }
-  let(:intake) { create :intake, intake_ticket_id: zendesk_ticket_id }
+  let(:intake) { create :intake }
   let(:user) { create :user, intake: intake }
 
   before do
@@ -82,26 +81,6 @@ RSpec.describe Questions::NotificationPreferenceController do
             sms_notification_opt_in: "no",
           }
         )
-      end
-
-      context "making a new Zendesk ticket", active_job: true do
-        before { post :update, params: params }
-
-        context "without a ticket id" do
-          let(:zendesk_ticket_id) { nil }
-
-          it "enqueues a job to make a zendesk ticket" do
-            expect(CreateZendeskIntakeTicketJob).to have_been_enqueued
-          end
-        end
-
-        context "with a ticket id" do
-          let(:zendesk_ticket_id) { 32 }
-
-          it "does not enqueue a job to make a zendesk ticket" do
-            expect(CreateZendeskIntakeTicketJob).not_to have_been_enqueued
-          end
-        end
       end
     end
   end

--- a/spec/services/zendesk_intake_service_spec.rb
+++ b/spec/services/zendesk_intake_service_spec.rb
@@ -25,6 +25,7 @@ describe ZendeskIntakeService do
            phone_number: "14155551234",
            primary_first_name: "Cher",
            primary_last_name: "Cherimoya",
+           preferred_name: "Cherry",
            email_notification_opt_in: email_opt_in,
            sms_notification_opt_in: sms_opt_in
   end
@@ -84,7 +85,7 @@ describe ZendeskIntakeService do
       it "returns the end user ID based on all contact info" do
         expect(service.create_intake_ticket_requester).to eq 1
         expect(service).to have_received(:find_or_create_end_user).with(
-          "Cher Cherimoya", "cash@raining.money", "+14155551234", exact_match: true
+          "Cherry", "cash@raining.money", "+14155551234", exact_match: true
         )
       end
     end
@@ -96,7 +97,7 @@ describe ZendeskIntakeService do
       it "returns the end user ID based on just the name" do
         expect(service.create_intake_ticket_requester).to eq 1
         expect(service).to have_received(:find_or_create_end_user).with(
-          "Cher Cherimoya", nil, nil, exact_match: true
+          "Cherry", nil, nil, exact_match: true
         )
       end
     end
@@ -183,7 +184,9 @@ describe ZendeskIntakeService do
       <<~BODY
         New Online Intake Started
 
-        Name: Cher Cherimoya
+        Preferred name: Cherry
+        Legal first name: Cher
+        Legal last name: Cherimoya
         Phone number: (415) 555-1234
         Email: cash@raining.money
         State of residence: Nebraska


### PR DESCRIPTION
This moves the zendesk ticket creation job so that it occurs after the consent page rather than after the notification preferences page.

It also adds the preferred name to the new ticket comment body, and creates the ticket requester using the preferred name. By creating the requester with the preferred name, outgoing message macros that use the requester name should end up using the preferred name, instead the legal first name.

Ticket subject will be legal first name and legal last name.