### PR TITLE
Move requested docs link field population

### DIFF
--- a/app/services/zendesk_intake_service.rb
+++ b/app/services/zendesk_intake_service.rb
@@ -94,6 +94,7 @@ class ZendeskIntakeService
         EitcZendeskInstance::STATE => @intake.state_of_residence,
         EitcZendeskInstance::FILING_YEARS => @intake.filing_years,
         EitcZendeskInstance::COMMUNICATION_PREFERENCES => notification_opt_ins,
+        EitcZendeskInstance::DOCUMENT_REQUEST_LINK => @intake.requested_docs_token_link,
       }
     else
       {
@@ -102,6 +103,7 @@ class ZendeskIntakeService
         UwtsaZendeskInstance::STATE => @intake.state_of_residence,
         UwtsaZendeskInstance::FILING_YEARS => @intake.filing_years,
         UwtsaZendeskInstance::COMMUNICATION_PREFERENCES => notification_opt_ins,
+        UwtsaZendeskInstance::DOCUMENT_REQUEST_LINK => @intake.requested_docs_token_link,
       }
     end
   end
@@ -238,12 +240,10 @@ class ZendeskIntakeService
     if instance_eitc?
       {
         EitcZendeskInstance::INTAKE_STATUS => EitcZendeskInstance::INTAKE_STATUS_READY_FOR_REVIEW,
-        EitcZendeskInstance::DOCUMENT_REQUEST_LINK => @intake.requested_docs_token_link
       }
     else
       {
         UwtsaZendeskInstance::INTAKE_STATUS => UwtsaZendeskInstance::INTAKE_STATUS_READY_FOR_REVIEW,
-        UwtsaZendeskInstance::DOCUMENT_REQUEST_LINK => @intake.requested_docs_token_link
       }
     end
   end

--- a/app/services/zendesk_intake_service.rb
+++ b/app/services/zendesk_intake_service.rb
@@ -228,10 +228,12 @@ class ZendeskIntakeService
     if instance_eitc?
       {
         EitcZendeskInstance::INTAKE_STATUS => EitcZendeskInstance::INTAKE_STATUS_GATHERING_DOCUMENTS,
+        EitcZendeskInstance::DOCUMENT_REQUEST_LINK => @intake.requested_docs_token_link,
       }
     else
       {
         UwtsaZendeskInstance::INTAKE_STATUS => UwtsaZendeskInstance::INTAKE_STATUS_GATHERING_DOCUMENTS,
+        UwtsaZendeskInstance::DOCUMENT_REQUEST_LINK => @intake.requested_docs_token_link,
       }
     end
   end
@@ -240,10 +242,12 @@ class ZendeskIntakeService
     if instance_eitc?
       {
         EitcZendeskInstance::INTAKE_STATUS => EitcZendeskInstance::INTAKE_STATUS_READY_FOR_REVIEW,
+        EitcZendeskInstance::DOCUMENT_REQUEST_LINK => @intake.requested_docs_token_link,
       }
     else
       {
         UwtsaZendeskInstance::INTAKE_STATUS => UwtsaZendeskInstance::INTAKE_STATUS_READY_FOR_REVIEW,
+        UwtsaZendeskInstance::DOCUMENT_REQUEST_LINK => @intake.requested_docs_token_link,
       }
     end
   end

--- a/spec/services/zendesk_intake_service_spec.rb
+++ b/spec/services/zendesk_intake_service_spec.rb
@@ -305,7 +305,8 @@ describe ZendeskIntakeService do
         ],
         comment: expected_comment,
         fields: {
-          EitcZendeskInstance::INTAKE_STATUS => EitcZendeskInstance::INTAKE_STATUS_GATHERING_DOCUMENTS
+          EitcZendeskInstance::INTAKE_STATUS => EitcZendeskInstance::INTAKE_STATUS_GATHERING_DOCUMENTS,
+          EitcZendeskInstance::DOCUMENT_REQUEST_LINK => "http://test.host/documents/add/3456ABCDEF",
         }
       )
     end
@@ -329,7 +330,8 @@ describe ZendeskIntakeService do
           ],
           comment: expected_comment,
           fields: {
-            UwtsaZendeskInstance::INTAKE_STATUS => UwtsaZendeskInstance::INTAKE_STATUS_GATHERING_DOCUMENTS
+            UwtsaZendeskInstance::INTAKE_STATUS => UwtsaZendeskInstance::INTAKE_STATUS_GATHERING_DOCUMENTS,
+            UwtsaZendeskInstance::DOCUMENT_REQUEST_LINK => "http://test.host/documents/add/3456ABCDEF",
           }
         )
       end
@@ -419,6 +421,7 @@ describe ZendeskIntakeService do
         comment: comment_body,
         fields: {
           EitcZendeskInstance::INTAKE_STATUS => EitcZendeskInstance::INTAKE_STATUS_READY_FOR_REVIEW,
+          EitcZendeskInstance::DOCUMENT_REQUEST_LINK => "http://test.host/documents/add/3456ABCDEF",
         }
       )
     end
@@ -442,6 +445,7 @@ describe ZendeskIntakeService do
           comment: comment_body,
           fields: {
             UwtsaZendeskInstance::INTAKE_STATUS => UwtsaZendeskInstance::INTAKE_STATUS_READY_FOR_REVIEW,
+            UwtsaZendeskInstance::DOCUMENT_REQUEST_LINK => "http://test.host/documents/add/3456ABCDEF",
           }
         )
       end

--- a/spec/services/zendesk_intake_service_spec.rb
+++ b/spec/services/zendesk_intake_service_spec.rb
@@ -128,6 +128,7 @@ describe ZendeskIntakeService do
             EitcZendeskInstance::STATE => "co",
             EitcZendeskInstance::FILING_YEARS => ["2019", "2017"],
             EitcZendeskInstance::COMMUNICATION_PREFERENCES => ["sms_opt_in", "email_opt_in"],
+            EitcZendeskInstance::DOCUMENT_REQUEST_LINK => "http://test.host/documents/add/3456ABCDEF",
           }
         )
       end
@@ -150,7 +151,8 @@ describe ZendeskIntakeService do
             UwtsaZendeskInstance::INTAKE_STATUS => UwtsaZendeskInstance::INTAKE_STATUS_IN_PROGRESS,
             UwtsaZendeskInstance::STATE => "az",
             UwtsaZendeskInstance::FILING_YEARS => ["2019", "2017"],
-            UwtsaZendeskInstance::COMMUNICATION_PREFERENCES => ["sms_opt_in", "email_opt_in"]
+            UwtsaZendeskInstance::COMMUNICATION_PREFERENCES => ["sms_opt_in", "email_opt_in"],
+            UwtsaZendeskInstance::DOCUMENT_REQUEST_LINK => "http://test.host/documents/add/3456ABCDEF"
           }
         )
       end
@@ -417,7 +419,6 @@ describe ZendeskIntakeService do
         comment: comment_body,
         fields: {
           EitcZendeskInstance::INTAKE_STATUS => EitcZendeskInstance::INTAKE_STATUS_READY_FOR_REVIEW,
-          EitcZendeskInstance::DOCUMENT_REQUEST_LINK => "http://test.host/documents/add/3456ABCDEF"
         }
       )
     end
@@ -441,7 +442,6 @@ describe ZendeskIntakeService do
           comment: comment_body,
           fields: {
             UwtsaZendeskInstance::INTAKE_STATUS => UwtsaZendeskInstance::INTAKE_STATUS_READY_FOR_REVIEW,
-            UwtsaZendeskInstance::DOCUMENT_REQUEST_LINK => "http://test.host/documents/add/3456ABCDEF"
           }
         )
       end


### PR DESCRIPTION
this moves the place where we populate the field from the step where we attach the final intake pdf to the step where we create the ticket

it's a small change and does not seem to be urgent so we are waiting to merge it after we've deployed the ID.me removal epic. will probably need a rebase.

Co-authored-by: Jonathan Greenberg <jgreenberg@codeforamerica.org>