### PR TITLE
Store instance #172461634

### DIFF
--- a/app/lib/intake_instance_domain_and_group_id_backfill.rb
+++ b/app/lib/intake_instance_domain_and_group_id_backfill.rb
@@ -1,0 +1,34 @@
+# Backfills Zendesk phone numbers on intake tickets. This can be
+# removed once it is run once in a production console.
+#
+# Usage (in rails console):
+# > ZendeskPhoneNumberBackfill.update_zendesk!
+#
+class IntakeInstanceDomainAndGroupIdBackfill
+  def self.backfill_instance_domains!
+    Intake.find_each do |intake|
+      populate_instance_domain(intake)
+    end
+  end
+
+  def self.backfill_group_ids!
+    Intake.where(zendesk_group_id: nil).each do |intake|
+      populate_group_id(intake)
+    end
+    nil
+  end
+
+  private
+  
+  def self.populate_instance_domain(intake)
+    puts "#######"
+    puts "populating instance domain for Intake with id: #{intake.id}"
+    intake.get_or_create_zendesk_instance_domain
+  end
+
+  def self.populate_group_id(intake)
+    puts "#######"
+    puts "populating group id for Intake with id: #{intake.id}"
+    intake.get_or_create_zendesk_group_id
+  end
+end

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -350,14 +350,6 @@ class Intake < ApplicationRecord
   def get_or_create_requested_docs_token
     return requested_docs_token if requested_docs_token.present?
 
-    new_token = SecureRandom.urlsafe_base64(8)
-    update(requested_docs_token: new_token, requested_docs_token_created_at: Time.now)
-    new_token
-  end
-
-  def get_or_create_requested_docs_token
-    return requested_docs_token if requested_docs_token.present?
-
     new_token = SecureRandom.urlsafe_base64(10)
     update(requested_docs_token: new_token, requested_docs_token_created_at: Time.now)
     new_token
@@ -421,7 +413,7 @@ class Intake < ApplicationRecord
   end
 
   def zendesk_instance
-    if state.nil? || EitcZendeskInstance::ALL_EITC_GROUP_IDS.include?(zendesk_group_id)
+    if get_or_create_zendesk_instance_domain == EitcZendeskInstance::DOMAIN
       EitcZendeskInstance
     else
       UwtsaZendeskInstance
@@ -460,7 +452,7 @@ class Intake < ApplicationRecord
   end
 
   def determine_zendesk_instance_domain
-    if state.nil? || EitcZendeskInstance::ALL_EITC_GROUP_IDS.include?(get_or_create_zendesk_group_id)
+    if state_of_residence.nil? || EitcZendeskInstance::ALL_EITC_GROUP_IDS.include?(get_or_create_zendesk_group_id)
       EitcZendeskInstance::DOMAIN
     else
       UwtsaZendeskInstance::DOMAIN

--- a/app/services/zendesk_intake_service.rb
+++ b/app/services/zendesk_intake_service.rb
@@ -54,7 +54,7 @@ class ZendeskIntakeService
       subject: @intake.primary_full_name,
       requester_id: @intake.intake_ticket_requester_id,
       external_id: @intake.external_id,
-      group_id: @intake.zendesk_group_id,
+      group_id: @intake.get_or_create_zendesk_group_id,
       body: new_ticket_body,
       fields: new_ticket_fields
     )

--- a/db/migrate/20200422181839_add_instance_and_group_to_intake.rb
+++ b/db/migrate/20200422181839_add_instance_and_group_to_intake.rb
@@ -1,0 +1,6 @@
+class AddInstanceAndGroupToIntake < ActiveRecord::Migration[6.0]
+  def change
+    add_column :intakes, :zendesk_instance_domain, :string
+    add_column :intakes, :zendesk_group_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_21_213952) do
+ActiveRecord::Schema.define(version: 2020_04_22_181839) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -235,6 +235,8 @@ ActiveRecord::Schema.define(version: 2020_04_21_213952) do
     t.integer "was_on_visa", default: 0, null: false
     t.integer "widowed", default: 0, null: false
     t.string "widowed_year"
+    t.string "zendesk_group_id"
+    t.string "zendesk_instance_domain"
     t.string "zip_code"
   end
 

--- a/spec/factories/intakes.rb
+++ b/spec/factories/intakes.rb
@@ -134,12 +134,14 @@
 #  was_on_visa                                          :integer          default("unfilled"), not null
 #  widowed                                              :integer          default("unfilled"), not null
 #  widowed_year                                         :string
+#  zendesk_instance_domain                              :string
 #  zip_code                                             :string
 #  created_at                                           :datetime
 #  updated_at                                           :datetime
 #  intake_ticket_id                                     :bigint
 #  intake_ticket_requester_id                           :bigint
 #  visitor_id                                           :string
+#  zendesk_group_id                                     :string
 #
 
 FactoryBot.define do

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -637,7 +637,7 @@ describe Intake do
       end
 
       context "when the group id is NOT an EITC group id" do
-        let(:intake) { create :intake, state: "ny", source: nil }
+        let(:intake) { create :intake, state_of_residence: "ny", source: nil }
 
         it "returns the uwtsa instance and saves the domain on the intake" do
           expect(intake.zendesk_instance).to eq (UwtsaZendeskInstance)

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -657,7 +657,8 @@ describe Intake do
         let(:state) { "ne" }
 
         it "uses the state to route" do
-          expect(intake.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_THC
+          expect(intake.get_or_create_zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_THC
+          expect(intake.reload.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_THC
           expect(intake.zendesk_instance).to eq EitcZendeskInstance
         end
       end
@@ -667,7 +668,8 @@ describe Intake do
         let(:state) { "ne" }
 
         it "matches the correct group id" do
-          expect(intake.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_KING_COUNTY
+          expect(intake.get_or_create_zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_KING_COUNTY
+          expect(intake.reload.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_KING_COUNTY
           expect(intake.zendesk_instance).to eq EitcZendeskInstance
         end
       end
@@ -677,7 +679,8 @@ describe Intake do
         let(:state) { "oh" }
 
         it "matches the correct group and the correct instance" do
-          expect(intake.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_CENTRAL_OHIO
+          expect(intake.get_or_create_zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_CENTRAL_OHIO
+          expect(intake.reload.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_CENTRAL_OHIO
           expect(intake.zendesk_instance).to eq EitcZendeskInstance
         end
       end
@@ -687,7 +690,8 @@ describe Intake do
         let(:state) { "ne" }
 
         it "assigns to the UWKC group" do
-          expect(intake.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_KING_COUNTY
+          expect(intake.get_or_create_zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_KING_COUNTY
+          expect(intake.reload.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_KING_COUNTY
           expect(intake.zendesk_instance).to eq EitcZendeskInstance
         end
       end
@@ -697,7 +701,8 @@ describe Intake do
         let(:state) { "ne" }
 
         it "assigns to the UWVP group" do
-          expect(intake.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_VIRGINIA
+          expect(intake.get_or_create_zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_VIRGINIA
+          expect(intake.reload.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_VIRGINIA
           expect(intake.zendesk_instance).to eq EitcZendeskInstance
         end
       end
@@ -707,7 +712,8 @@ describe Intake do
       let(:state) { "co" }
 
       it "assigns to the shared Tax Help Colorado / UWBA online intake group" do
-        expect(intake.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_THC
+        expect(intake.get_or_create_zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_THC
+        expect(intake.reload.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_THC
         expect(intake.zendesk_instance).to eq EitcZendeskInstance
       end
     end
@@ -716,7 +722,8 @@ describe Intake do
       let(:state) { "ca" }
 
       it "assigns to the Online Intake - California group" do
-        expect(intake.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UWBA
+        expect(intake.get_or_create_zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UWBA
+        expect(intake.reload.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UWBA
         expect(intake.zendesk_instance).to eq EitcZendeskInstance
       end
     end
@@ -724,7 +731,8 @@ describe Intake do
     context "with a GWISR state" do
       let(:state) { "ga" }
       it "assigns to the Goodwill online intake" do
-        expect(intake.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_GWISR
+        expect(intake.get_or_create_zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_GWISR
+        expect(intake.reload.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_GWISR
         expect(intake.zendesk_instance).to eq EitcZendeskInstance
       end
     end
@@ -732,7 +740,8 @@ describe Intake do
     context "with Washington state" do
       let(:state) { "wa" }
       it "assigns to United Way King County" do
-        expect(intake.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_KING_COUNTY
+        expect(intake.get_or_create_zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_KING_COUNTY
+        expect(intake.reload.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_KING_COUNTY
         expect(intake.zendesk_instance).to eq EitcZendeskInstance
       end
     end
@@ -740,7 +749,8 @@ describe Intake do
     context "with Pennsylvania" do
       let(:state) { "pa" }
       it "assigns to Campaign for Working Families" do
-        expect(intake.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_WORKING_FAMILIES
+        expect(intake.get_or_create_zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_WORKING_FAMILIES
+        expect(intake.reload.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_WORKING_FAMILIES
         expect(intake.zendesk_instance).to eq EitcZendeskInstance
       end
     end
@@ -748,7 +758,8 @@ describe Intake do
     context "with Ohio" do
       let(:state) { "oh" }
       it "assigns to UW Central Ohio" do
-        expect(intake.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_CENTRAL_OHIO
+        expect(intake.get_or_create_zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_CENTRAL_OHIO
+        expect(intake.reload.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_CENTRAL_OHIO
         expect(intake.zendesk_instance).to eq EitcZendeskInstance
       end
     end
@@ -756,7 +767,8 @@ describe Intake do
     context "with New Jersey" do
       let(:state) { "nj" }
       it "assigns to Campaign for Working Families" do
-        expect(intake.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_WORKING_FAMILIES
+        expect(intake.get_or_create_zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_WORKING_FAMILIES
+        expect(intake.reload.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_WORKING_FAMILIES
         expect(intake.zendesk_instance).to eq EitcZendeskInstance
       end
     end
@@ -764,7 +776,8 @@ describe Intake do
     context "with South Carolina" do
       let(:state) { "sc" }
       it "assigns to Impact America - South Carolina" do
-        expect(intake.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_IA_SC
+        expect(intake.get_or_create_zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_IA_SC
+        expect(intake.reload.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_IA_SC
         expect(intake.zendesk_instance).to eq EitcZendeskInstance
       end
     end
@@ -772,7 +785,8 @@ describe Intake do
     context "with Tennessee" do
       let(:state) { "tn" }
       it "assigns to Impact America - Alabama" do
-        expect(intake.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_IA_AL
+        expect(intake.get_or_create_zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_IA_AL
+        expect(intake.reload.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_IA_AL
         expect(intake.zendesk_instance).to eq EitcZendeskInstance
       end
     end
@@ -780,7 +794,8 @@ describe Intake do
     context "with Nevada" do
       let(:state) { "nv" }
       it "assigns to Nevada Free Tax Coalition" do
-        expect(intake.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_NV_FTC
+        expect(intake.get_or_create_zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_NV_FTC
+        expect(intake.reload.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_NV_FTC
         expect(intake.zendesk_instance).to eq EitcZendeskInstance
       end
     end
@@ -788,7 +803,8 @@ describe Intake do
     context "with Texas" do
       let(:state) { "tx" }
       it "assigns to Foundation Communities" do
-        expect(intake.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_FC
+        expect(intake.get_or_create_zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_FC
+        expect(intake.reload.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_FC
         expect(intake.zendesk_instance).to eq EitcZendeskInstance
       end
     end
@@ -797,7 +813,8 @@ describe Intake do
       let(:state) { "ny" }
 
       it "assigns to the UW Tucson instance" do
-        expect(intake.zendesk_group_id).to be_nil
+        expect(intake.get_or_create_zendesk_group_id).to be_nil
+        expect(intake.reload.zendesk_group_id).to be_nil
         expect(intake.zendesk_instance).to eq UwtsaZendeskInstance
       end
     end


### PR DESCRIPTION
Adds columns for `zendesk_instance_domain` and `zendesk_group_id` on Intake, and saves values to those columns the first time we calculate the value.

Includes script to backfill these values for all existing Intakes.
`IntakeInstanceDomainAndGroupIdBackfill.backfill_instance_domains!`
`IntakeInstanceDomainAndGroupIdBackfill.backfill_group_ids!`