### PR TITLE
Require document upload on ID, selfie, and SSN/ITIN pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ group :development, :test do
   gem 'axe-matchers'
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '>= 2.15'
-  gem 'webdrivers', '~> 4.0'
+  gem 'webdrivers'
   gem 'factory_bot_rails'
   gem 'rspec-rails'
   gem 'rails-controller-testing'
@@ -73,7 +73,6 @@ end
 
 group :test do
   # Easy installation and use of chromedriver to run system tests with Chrome
-  gem 'chromedriver-helper'
   gem 'rspec_junit_formatter'
   gem 'webmock'
   gem 'simplecov', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,8 +74,6 @@ GEM
     annotate (3.1.1)
       activerecord (>= 3.2, < 7.0)
       rake (>= 10.4, < 14.0)
-    archive-zip (0.12.0)
-      io-like (~> 0.3.0)
     ast (2.4.0)
     attr_encrypted (3.1.0)
       encryptor (~> 3.0.0)
@@ -121,9 +119,6 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
-    chromedriver-helper (2.1.1)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     cliver (0.3.2)
     coderay (1.1.2)
     coercible (1.0.0)
@@ -187,7 +182,6 @@ GEM
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     inflection (1.0.0)
-    io-like (0.3.1)
     jaro_winkler (1.5.4)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
@@ -418,7 +412,7 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (4.2.0)
+    webdrivers (4.3.0)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (>= 3.0, < 4.0)
@@ -453,7 +447,6 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   cfa-styleguide!
-  chromedriver-helper
   delayed_job_active_record
   device_detector
   devise
@@ -490,7 +483,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
-  webdrivers (~> 4.0)
+  webdrivers
   webmock
   will_paginate
   zendesk_api

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -32,4 +32,16 @@ module DocumentsHelper
   def any_must_have_docs?(doc_types)
     doc_types.any? { |type| must_have?(type) }
   end
+
+  def required_document_next_path
+    if @documents.empty?
+      current_path(submitted_with_no_docs: true)
+    else
+      next_path
+    end
+  end
+
+  def display_validation_error?
+    params[:submitted_with_no_docs]
+  end
 end

--- a/app/lib/document_navigation.rb
+++ b/app/lib/document_navigation.rb
@@ -41,6 +41,11 @@ class DocumentNavigation
     Documents::SendRequestedDocumentsLaterController,
   ].freeze
 
+  REQUIRED_DOCUMENT_TYPES = [
+    Documents::IdsController,
+    Documents::SelfiesController,
+    Documents::SsnItinsController,
+  ].map(&:document_type)
   DOCUMENT_TYPES = FLOW.map(&:document_type).compact
   CONTROLLER_BY_DOCUMENT_TYPE = FLOW
     .find_all(&:document_type)

--- a/app/views/documents/ids/edit.html.erb
+++ b/app/views/documents/ids/edit.html.erb
@@ -3,6 +3,9 @@
 <% content_for :form_help_content do %>
   <p>
     <%= @help_text %>
+  <p/>
+  <p>
+    We will use your ID card to verify and protect your identity in accordance with IRS guidelines. It is ok if your ID is expired or if you have a temporary drivers license as long as we can clearly view your name and photo.
   </p>
 
   <div class="text--bold">

--- a/app/views/layouts/document_upload.html.erb
+++ b/app/views/layouts/document_upload.html.erb
@@ -59,14 +59,27 @@
             <% end %>
           <% end %>
 
-          <%= link_to next_path, class: "button button--wide button--icon button--cta", "data-track-click": "done_for_now", "data-track-attribute-document_type": "#{document_type}" do %>
-            <%= image_tag "checkmark--white.svg", alt: "" %>
-            I'm done for now
+          <% if DocumentNavigation::REQUIRED_DOCUMENT_TYPES.include?(document_type) %>
+            <% if display_validation_error? %>
+              <p class="text--error">
+                <i class="icon-warning"></i>
+                This document is required.
+              </p>
+            <% end %>
+            <%= link_to required_document_next_path, class: "button button--cta" do %>
+              Continue
+            <% end %>
+          <% else %>
+            <%= link_to next_path, class: "button button--wide button--icon button--cta", "data-track-click": "done_for_now", "data-track-attribute-document_type": "#{document_type}" do %>
+              <%= image_tag "checkmark--white.svg", alt: "" %>
+              I'm done for now
+            <% end %>
+            <%= link_to next_path, class: "button button--wide button--icon", "data-track-click": "dont_have_doc", "data-track-attribute-document_type": "#{document_type}" do %>
+              <%= image_tag "crossmark--black.svg", alt: "" %>
+              I don't have this document
+            <% end %>
           <% end %>
-          <%= link_to next_path, class: "button button--wide button--icon", "data-track-click": "dont_have_doc", "data-track-attribute-document_type": "#{document_type}" do %>
-            <%= image_tag "crossmark--black.svg", alt: "" %>
-            I don't have this document
-          <% end %>
+
         </main>
       </div>
     </div>

--- a/spec/controllers/documents/ids_controller_spec.rb
+++ b/spec/controllers/documents/ids_controller_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe Documents::IdsController do
   end
 
   describe "#edit" do
+    it_behaves_like "required documents controllers"
+
     context "when they are filing jointly" do
       let(:attributes) { { filing_joint: "yes" } }
 

--- a/spec/controllers/documents/selfies_controller_spec.rb
+++ b/spec/controllers/documents/selfies_controller_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe Documents::SelfiesController do
   end
 
   describe "#edit" do
+    it_behaves_like "required documents controllers"
+
     context "when they do not have a spouse" do
       let(:filing_joint) { "no" }
 

--- a/spec/controllers/documents/ssn_itins_controller_spec.rb
+++ b/spec/controllers/documents/ssn_itins_controller_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe Documents::SsnItinsController do
   end
 
   describe "#edit" do
+    it_behaves_like "required documents controllers"
+
     context "when they do not have a spouse" do
       let(:filing_joint) { "no" }
 

--- a/spec/features/web_intake/new_joint_filers_spec.rb
+++ b/spec/features/web_intake/new_joint_filers_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature "Web Intake Joint Filers" do
     )
   end
 
-  scenario "new client filing joint taxes with spouse and dependents" do
+  scenario "new client filing joint taxes with spouse and dependents", :js do
     # Feelings
     visit "/questions/feelings"
     expect(page).to have_selector("h1", text: "How are you feeling about your taxes?")
@@ -304,18 +304,20 @@ RSpec.feature "Web Intake Joint Filers" do
     click_on "Continue"
 
     expect(page).to have_selector("h1", text: "Attach photos of ID cards")
-    attach_file("document_type_upload_form_document", Rails.root.join("spec", "fixtures", "attachments", "picture_id.jpg"))
-    attach_file("document_type_upload_form_document", Rails.root.join("spec", "fixtures", "attachments", "picture_id.jpg"))
-    click_on "I'm done for now"
+    attach("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "attachments", "picture_id.jpg"))
+    attach("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "attachments", "picture_id.jpg"))
+    click_on "Continue"
 
     expect(page).to have_selector("h1", text: "Confirm your identity with a selfie")
     click_on "Submit a selfie"
 
     expect(page).to have_selector("h1", text: "Share a selfie with your ID card")
-    click_on "I'm done for now"
+    attach("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "attachments", "picture_id.jpg"))
+    click_on "Continue"
 
     expect(page).to have_selector("h1", text: "Attach photos of Social Security Card or ITIN")
-    click_on "I'm done for now"
+    attach("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "attachments", "picture_id.jpg"))
+    click_on "Continue"
 
     # Documents: Intro
     expect(page).to have_selector("h1", text: "All right, let's collect your documents!")
@@ -323,14 +325,12 @@ RSpec.feature "Web Intake Joint Filers" do
 
 
     expect(page).to have_selector("h1", text: "Attach your W-2's")
-    attach_file("document_type_upload_form_document", Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))
-    click_on "Upload"
+    attach("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))
 
     expect(page).to have_content("test-pattern.png")
     expect(page).to have_link("Remove")
 
-    attach_file("document_type_upload_form_document", Rails.root.join("spec", "fixtures", "attachments", "picture_id.jpg"))
-    click_on "Upload"
+    attach("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "attachments", "picture_id.jpg"))
 
     expect(page).to have_content("test-pattern.png")
     expect(page).to have_content("picture_id.jpg")
@@ -409,8 +409,7 @@ RSpec.feature "Web Intake Joint Filers" do
     click_on "I'm done for now"
 
     expect(page).to have_selector("h1", text: "Do you have any additional documents?")
-    attach_file("document_type_upload_form_document", Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))
-    click_on "Upload"
+    attach("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))
     expect(page).to have_content("test-pattern.png")
     click_on "I'm done for now"
 

--- a/spec/features/web_intake/new_single_filer_spec.rb
+++ b/spec/features/web_intake/new_single_filer_spec.rb
@@ -200,16 +200,21 @@ RSpec.feature "Web Intake Single Filer" do
 
     expect(page).to have_selector("h1", text: "Attach a photo of your ID card")
     attach_file("document_type_upload_form_document", Rails.root.join("spec", "fixtures", "attachments", "picture_id.jpg"))
-    click_on "I'm done for now"
+    click_on "Upload"
+    click_on "Continue"
 
     expect(page).to have_selector("h1", text: "Confirm your identity with a selfie")
     click_on "Submit a selfie"
 
     expect(page).to have_selector("h1", text: "Share a selfie with your ID card")
-    click_on "I'm done for now"
+    attach_file("document_type_upload_form_document", Rails.root.join("spec", "fixtures", "attachments", "picture_id.jpg"))
+    click_on "Upload"
+    click_on "Continue"
 
     expect(page).to have_selector("h1", text: "Attach photos of Social Security Card or ITIN")
-    click_on "I'm done for now"
+    attach_file("document_type_upload_form_document", Rails.root.join("spec", "fixtures", "attachments", "picture_id.jpg"))
+    click_on "Upload"
+    click_on "Continue"
 
     # Documents: Intro
     expect(page).to have_selector("h1", text: "All right, let's collect your documents!")

--- a/spec/features/web_intake/requested_documents_spec.rb
+++ b/spec/features/web_intake/requested_documents_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Client uploads a requested document" do
     visit "/documents/requested-documents"
 
     expect(page).to have_selector("h1", text: "Your tax specialist is requesting additional documents")
-    attach_file("document_type_upload_form_document", Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))
+    attach("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))
     click_on "Upload"
 
     expect(page).to have_content("test-pattern.png")

--- a/spec/features/web_intake/requested_documents_token_spec.rb
+++ b/spec/features/web_intake/requested_documents_token_spec.rb
@@ -2,12 +2,11 @@ require "rails_helper"
 
 RSpec.feature "Client uploads a requested document" do
   let!(:intake) { create :intake, requested_docs_token: "1234ABCDEF" }
-  scenario "client goes to the follow up documents token link without logging in" do
+  scenario "client goes to the follow up documents token link without logging in", :js do
     visit "/documents/add/1234ABCDEF"
 
     expect(page).to have_selector("h1", text: "Your tax specialist is requesting additional documents")
-    attach_file("document_type_upload_form_document", Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))
-    click_on "Upload"
+    attach("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))
 
     expect(page).to have_content("test-pattern.png")
     expect(page).to have_link("Remove")
@@ -24,8 +23,7 @@ RSpec.feature "Client uploads a requested document" do
     expect(page).not_to have_content("test-pattern.png")
     expect(page).not_to have_link("Remove")
 
-    attach_file("document_type_upload_form_document", Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))
-    click_on "Upload"
+    attach("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))
 
     expect(page).to have_content("test-pattern.png")
     expect(page).to have_link("Remove")
@@ -37,7 +35,7 @@ RSpec.feature "Client uploads a requested document" do
   end
 
   # TODO: remove this scenario when login is removed
-  xscenario "client goes to the follow up documents token link while logged in" do
+  xscenario "client goes to the follow up documents token link while logged in", :js do
     silence_omniauth_logging do
       visit "/documents/requested-documents"
     end
@@ -49,8 +47,7 @@ RSpec.feature "Client uploads a requested document" do
     visit "/documents/requested-documents"
 
     expect(page).to have_selector("h1", text: "Your tax specialist is requesting additional documents")
-    attach_file("document_type_upload_form_document", Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))
-    click_on "Upload"
+    attach("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))
 
     expect(page).to have_content("test-pattern.png")
     expect(page).to have_link("Remove")
@@ -69,8 +66,7 @@ RSpec.feature "Client uploads a requested document" do
     expect(page).not_to have_selector("h2", text: "test-pattern.png")
 
     # Check that file can be added
-    attach_file("document_type_upload_form_document", Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))
-    click_on "Upload"
+    attach("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))
 
     expect(page).to have_selector("h2", text: "test-pattern.png", count: 1)
 
@@ -84,8 +80,7 @@ RSpec.feature "Client uploads a requested document" do
     expect(page).to have_link("Remove")
 
     # Check that another file can be added
-    attach_file("document_type_upload_form_document", Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))
-    click_on "Upload"
+    attach("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))
 
     expect(page).to have_selector("h2", text: "test-pattern.png", count: 2)
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,7 @@ require "selenium/webdriver"
 require "webdrivers"
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 Dir[Rails.root.join("lib/strategies/**/*.rb")].each { |f| require f }
+Capybara.javascript_driver = :selenium_chrome_headless
 
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -1,0 +1,5 @@
+def attach(selector, path)
+  script = "$(\"[name='#{selector}']\").css({opacity: 100, display: 'block', position: 'relative', left: ''});"
+  page.execute_script(script)
+  attach_file selector, path
+end

--- a/spec/support/shared_examples/required_document_controllers.rb
+++ b/spec/support/shared_examples/required_document_controllers.rb
@@ -1,0 +1,21 @@
+shared_examples "required documents controllers" do
+  context "requiring an upload" do
+    render_views
+
+    context "when they first arrive on the page" do
+      it "does not render a validation error" do
+        get :edit
+
+        expect(response.body).not_to include("This document is required.")
+      end
+    end
+
+    context "when they tried to continue with no documents" do
+      it "renders a validation error" do
+        get :edit, params: { submitted_with_no_docs: true }
+
+        expect(response.body).to include("This document is required.")
+      end
+    end
+  end
+end

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,4 +1,5 @@
 require 'webmock/rspec'
 
-WebMock.disable_net_connect!(allow_localhost: true)
+driver_urls = Webdrivers::Common.subclasses.map(&:base_url)
 
+WebMock.disable_net_connect!(allow_localhost: true, allow: driver_urls)


### PR DESCRIPTION
There are some wild shenanigans happening here with capybara

Basically, the feature specs where we were attaching a file didn't seem to actually be attaching a file and as a result we couldn't get past the pages where we now require a document upload. Jonathan had this javascript snippet from another project that appears to work for attaching documents. We also replaced geckodriver with chromedriver because the former wasn't playing nice with stubbed requests.

This all works locally but appears to break on circleci :(

This might be a good candidate for a group discussion! Some pretty big changes might be required

Co-authored-by: Jonathan Greenberg <jgreenberg@codeforamerica.org>