### PR TITLE
Mark fake Zendesk tickets on environments other than production or test

### DIFF
--- a/app/services/zendesk_intake_service.rb
+++ b/app/services/zendesk_intake_service.rb
@@ -51,13 +51,18 @@ class ZendeskIntakeService
     raise MissingRequesterIdError if @intake.intake_ticket_requester_id.blank?
 
     create_ticket(
-      subject: @intake.primary_full_name,
+      subject: new_ticket_subject,
       requester_id: @intake.intake_ticket_requester_id,
       external_id: @intake.external_id,
       group_id: @intake.zendesk_group_id,
       body: new_ticket_body,
       fields: new_ticket_fields
     )
+  end
+
+  def new_ticket_subject
+    suffix = (Rails.env.production? || Rails.env.test?) ? "" : " (Test Ticket)"
+    @intake.primary_full_name + suffix
   end
 
   def new_ticket_body

--- a/spec/services/zendesk_intake_service_spec.rb
+++ b/spec/services/zendesk_intake_service_spec.rb
@@ -204,6 +204,38 @@ describe ZendeskIntakeService do
     end
   end
 
+  describe "#new_ticket_subject" do
+    context "in production" do
+      before do
+        allow(Rails).to receive(:env).and_return("production".inquiry)
+      end
+
+      it "returns the primary full name" do
+        expect(service.new_ticket_subject).to eq "Cher Cherimoya"
+      end
+    end
+
+    context "in test" do
+      before do
+        allow(Rails).to receive(:env).and_return("test".inquiry)
+      end
+
+      it "returns the primary full name" do
+        expect(service.new_ticket_subject).to eq "Cher Cherimoya"
+      end
+    end
+
+    context "in demo" do
+      before do
+        allow(Rails).to receive(:env).and_return("demo".inquiry)
+      end
+
+      it "returns the primary full name and marks it as a test ticket" do
+        expect(service.new_ticket_subject).to eq "Cher Cherimoya (Test Ticket)"
+      end
+    end
+  end
+
   describe "#contact_preferences" do
     context "with sms and email" do
       let(:email_opt_in) { "yes" }


### PR DESCRIPTION
Adds ` (Test Ticket)` to the end of the ticket subject on demo, staging, or development.