### PR TITLE
adds united way of tuscon's group id and routes other states

### DIFF
--- a/app/helpers/eitc_zendesk_instance.rb
+++ b/app/helpers/eitc_zendesk_instance.rb
@@ -20,16 +20,16 @@ class EitcZendeskInstance
   ].freeze
 
   GROUP_ID_TO_STATE_LIST_MAPPING = {
-    EitcZendeskInstance::ONLINE_INTAKE_UW_CENTRAL_OHIO => %w(oh).freeze,
-    EitcZendeskInstance::ONLINE_INTAKE_UW_KING_COUNTY => %w(wa).freeze,
-    EitcZendeskInstance::ONLINE_INTAKE_IA_SC => %w(sc).freeze,
-    EitcZendeskInstance::ONLINE_INTAKE_IA_AL => %w(tn).freeze,
-    EitcZendeskInstance::ONLINE_INTAKE_NV_FTC => %w(nv).freeze,
-    EitcZendeskInstance::ONLINE_INTAKE_FC => %w(tx).freeze,
-    EitcZendeskInstance::ONLINE_INTAKE_THC => %w(co sd wy ks nm ne).freeze,
-    EitcZendeskInstance::ONLINE_INTAKE_UWBA => %w(ca ak fl).freeze,
-    EitcZendeskInstance::ONLINE_INTAKE_GWISR => %w(ga al).freeze,
-    EitcZendeskInstance::ONLINE_INTAKE_WORKING_FAMILIES => %w(pa nj).freeze
+    ONLINE_INTAKE_UW_CENTRAL_OHIO => %w(oh).freeze,
+    ONLINE_INTAKE_UW_KING_COUNTY => %w(wa).freeze,
+    ONLINE_INTAKE_IA_SC => %w(sc).freeze,
+    ONLINE_INTAKE_IA_AL => %w(tn).freeze,
+    ONLINE_INTAKE_NV_FTC => %w(nv).freeze,
+    ONLINE_INTAKE_FC => %w(tx).freeze,
+    ONLINE_INTAKE_THC => %w(co sd wy ks nm ne).freeze,
+    ONLINE_INTAKE_UWBA => %w(ca ak fl).freeze,
+    ONLINE_INTAKE_GWISR => %w(ga al).freeze,
+    ONLINE_INTAKE_WORKING_FAMILIES => %w(pa nj).freeze
   }.freeze
 
   # online intake source parameter to group
@@ -43,15 +43,6 @@ class EitcZendeskInstance
     uwco: ONLINE_INTAKE_UW_CENTRAL_OHIO,
   }.freeze
 
-  # states for intake groups
-  ONLINE_INTAKE_THC_STATES = %w(co sd wy ks nm ne).freeze
-  ONLINE_INTAKE_UWBA_STATES = %w(ca ak fl).freeze
-  ONLINE_INTAKE_GWISR_STATES = %w(ga al).freeze
-  ONLINE_INTAKE_UW_KING_COUNTY_STATES = %w(wa).freeze
-  ONLINE_INTAKE_WORKING_FAMILIES_STATES = %w(pa nj).freeze
-  ONLINE_INTAKE_IA_SC_STATES = %w(sc).freeze
-  ONLINE_INTAKE_IA_AL_STATES = %w(tn).freeze
-  ONLINE_INTAKE_UW_TSA_STATES = %w(az).freeze
 
   # custom field id codes
   CERTIFICATION_LEVEL = "360028917234"

--- a/app/helpers/eitc_zendesk_instance.rb
+++ b/app/helpers/eitc_zendesk_instance.rb
@@ -16,7 +16,21 @@ class EitcZendeskInstance
     ONLINE_INTAKE_IA_AL = "360009341853",
     ONLINE_INTAKE_FC = "360009397734",     # Foundation Communities
     ONLINE_INTAKE_NV_FTC = "360009537374", # Nevada Free Tax Coalition
+    ONLINE_INTAKE_UW_TSA = "360009581934", # Nevada Free Tax Coalition
   ].freeze
+
+  GROUP_ID_TO_STATE_LIST_MAPPING = {
+    EitcZendeskInstance::ONLINE_INTAKE_UW_CENTRAL_OHIO => %w(oh).freeze,
+    EitcZendeskInstance::ONLINE_INTAKE_UW_KING_COUNTY => %w(wa).freeze,
+    EitcZendeskInstance::ONLINE_INTAKE_IA_SC => %w(sc).freeze,
+    EitcZendeskInstance::ONLINE_INTAKE_IA_AL => %w(tn).freeze,
+    EitcZendeskInstance::ONLINE_INTAKE_NV_FTC => %w(nv).freeze,
+    EitcZendeskInstance::ONLINE_INTAKE_FC => %w(tx).freeze,
+    EitcZendeskInstance::ONLINE_INTAKE_THC => %w(co sd wy ks nm ne).freeze,
+    EitcZendeskInstance::ONLINE_INTAKE_UWBA => %w(ca ak fl).freeze,
+    EitcZendeskInstance::ONLINE_INTAKE_GWISR => %w(ga al).freeze,
+    EitcZendeskInstance::ONLINE_INTAKE_WORKING_FAMILIES => %w(pa nj).freeze
+  }.freeze
 
   # online intake source parameter to group
   ORGANIZATION_SOURCE_PARAMETERS = {
@@ -37,6 +51,7 @@ class EitcZendeskInstance
   ONLINE_INTAKE_WORKING_FAMILIES_STATES = %w(pa nj).freeze
   ONLINE_INTAKE_IA_SC_STATES = %w(sc).freeze
   ONLINE_INTAKE_IA_AL_STATES = %w(tn).freeze
+  ONLINE_INTAKE_UW_TSA_STATES = %w(az).freeze
 
   # custom field id codes
   CERTIFICATION_LEVEL = "360028917234"

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -405,10 +405,10 @@ class Intake < ApplicationRecord
   end
 
   def determine_zendesk_group_id
-    if source.present? && group_by_source.present?
-      group_by_source
+    if source.present? && group_id_for_source.present?
+      group_id_for_source
     else
-      group_by_state
+      group_id_for_state
     end
   end
 
@@ -452,16 +452,12 @@ class Intake < ApplicationRecord
   end
 
   def determine_zendesk_instance_domain
-    if state_of_residence.nil? || EitcZendeskInstance::ALL_EITC_GROUP_IDS.include?(get_or_create_zendesk_group_id)
-      EitcZendeskInstance::DOMAIN
-    else
-      UwtsaZendeskInstance::DOMAIN
-    end
+    EitcZendeskInstance::DOMAIN
   end
 
   private
 
-  def group_by_source
+  def group_id_for_source
     EitcZendeskInstance::ORGANIZATION_SOURCE_PARAMETERS.each do |key, value|
       if source.downcase.starts_with?(key.to_s)
         return value
@@ -470,30 +466,11 @@ class Intake < ApplicationRecord
     nil
   end
 
-  def group_by_state
-    if state_of_residence == "wa"
-      EitcZendeskInstance::ONLINE_INTAKE_UW_KING_COUNTY
-    elsif state_of_residence == "oh"
-      EitcZendeskInstance::ONLINE_INTAKE_UW_CENTRAL_OHIO
-    elsif state_of_residence == "sc"
-      EitcZendeskInstance::ONLINE_INTAKE_IA_SC
-    elsif state_of_residence == "tn"
-      EitcZendeskInstance::ONLINE_INTAKE_IA_AL
-    elsif state_of_residence == "nv"
-      EitcZendeskInstance::ONLINE_INTAKE_NV_FTC
-    elsif state_of_residence == "tx"
-      EitcZendeskInstance::ONLINE_INTAKE_FC
-    elsif EitcZendeskInstance::ONLINE_INTAKE_THC_STATES.include? state_of_residence
-      EitcZendeskInstance::ONLINE_INTAKE_THC
-    elsif EitcZendeskInstance::ONLINE_INTAKE_UWBA_STATES.include? state_of_residence
-      EitcZendeskInstance::ONLINE_INTAKE_UWBA
-    elsif EitcZendeskInstance::ONLINE_INTAKE_GWISR_STATES.include? state_of_residence
-      EitcZendeskInstance::ONLINE_INTAKE_GWISR
-    elsif EitcZendeskInstance::ONLINE_INTAKE_WORKING_FAMILIES_STATES.include? state_of_residence
-      EitcZendeskInstance::ONLINE_INTAKE_WORKING_FAMILIES
-    else
-      # we do not yet have group ids for UWTSA Zendesk instance
-      nil
+  def group_id_for_state
+    EitcZendeskInstance::GROUP_ID_TO_STATE_LIST_MAPPING.each do |group_id, state_list|
+      return group_id if state_list.include? state_of_residence
     end
+
+    EitcZendeskInstance::ONLINE_INTAKE_UW_TSA
   end
 end

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -405,6 +405,9 @@ class Intake < ApplicationRecord
   end
 
   def determine_zendesk_group_id
+    # TODO: this should be refactored into a business logic / referral component
+    # (or removed entirely once all UW/TSA Zendesk tickets have been closed)
+    return nil if zendesk_instance == UwtsaZendeskInstance
     if source.present? && group_id_for_source.present?
       group_id_for_source
     else

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -639,9 +639,9 @@ describe Intake do
       context "when the group id is NOT an EITC group id" do
         let(:intake) { create :intake, state_of_residence: "ny", source: nil }
 
-        it "returns the uwtsa instance and saves the domain on the intake" do
-          expect(intake.zendesk_instance).to eq (UwtsaZendeskInstance)
-          expect(intake.reload.zendesk_instance_domain).to eq ("unitedwaytucson")
+        it "returns the EITC instance and saves the domain on the intake" do
+          expect(intake.zendesk_instance).to eq (EitcZendeskInstance)
+          expect(intake.reload.zendesk_instance_domain).to eq ("eitc")
         end
       end
     end
@@ -809,13 +809,23 @@ describe Intake do
       end
     end
 
+    context "with Arizona" do
+      let(:state) { "az" }
+
+      it "assigns to the UW Tucson group" do
+        expect(intake.get_or_create_zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_TSA
+        expect(intake.reload.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_TSA
+        expect(intake.zendesk_instance).to eq EitcZendeskInstance
+      end
+    end
+
     context "with any other state" do
       let(:state) { "ny" }
 
       it "assigns to the UW Tucson instance" do
-        expect(intake.get_or_create_zendesk_group_id).to be_nil
-        expect(intake.reload.zendesk_group_id).to be_nil
-        expect(intake.zendesk_instance).to eq UwtsaZendeskInstance
+        expect(intake.get_or_create_zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_TSA
+        expect(intake.reload.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_TSA
+        expect(intake.zendesk_instance).to eq EitcZendeskInstance
       end
     end
   end

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -651,6 +651,16 @@ describe Intake do
     let(:source) { nil }
     let(:intake) { build :intake, state_of_residence: state, source: source }
 
+    context "when the zendesk instance domain has been saved as UWTSA instance" do
+      let(:uwtsa_instance_intake) { create :intake, state_of_residence: "az", zendesk_instance_domain: UwtsaZendeskInstance::DOMAIN}
+
+      it "assigns to the UWTSA instance and nil group id" do
+        expect(uwtsa_instance_intake.get_or_create_zendesk_group_id).to eq nil
+        expect(uwtsa_instance_intake.reload.zendesk_group_id).to eq nil
+        expect(uwtsa_instance_intake.zendesk_instance).to eq UwtsaZendeskInstance
+      end
+    end
+
     context "when there is a source parameter" do
       context "when there is a source parameter that does not match an organization" do
         let(:source) { "propel" }

--- a/spec/services/zendesk_intake_service_spec.rb
+++ b/spec/services/zendesk_intake_service_spec.rb
@@ -62,15 +62,6 @@ describe ZendeskIntakeService do
         expect(EitcZendeskInstance).to have_received(:client)
       end
     end
-
-    context "in a state for the UW Tucson zendesk instance" do
-      let(:state) { "az" }
-
-      it "returns a client for the UW Tucson zendesk instance" do
-        expect(service.client).to eq fake_uwtsa_zendesk_client
-        expect(UwtsaZendeskInstance).to have_received(:client)
-      end
-    end
   end
 
   describe "#create_intake_ticket_requester" do
@@ -134,7 +125,7 @@ describe ZendeskIntakeService do
       end
     end
 
-    context "in a state for the UWTSA Zendesk instance" do
+    context "in a state for the UWTSA Group" do
       let(:state) { "az" }
 
       it "excludes intake site, and intake status and sends a nil group_id" do
@@ -143,16 +134,16 @@ describe ZendeskIntakeService do
         expect(service).to have_received(:create_ticket).with(
           subject: "Cher Cherimoya",
           requester_id: 987,
-          group_id: nil,
+          group_id: EitcZendeskInstance::ONLINE_INTAKE_UW_TSA,
           external_id: intake.external_id,
           body: "Body text",
           fields: {
-            UwtsaZendeskInstance::INTAKE_SITE => "online_intake",
-            UwtsaZendeskInstance::INTAKE_STATUS => UwtsaZendeskInstance::INTAKE_STATUS_IN_PROGRESS,
-            UwtsaZendeskInstance::STATE => "az",
-            UwtsaZendeskInstance::FILING_YEARS => ["2019", "2017"],
-            UwtsaZendeskInstance::COMMUNICATION_PREFERENCES => ["sms_opt_in", "email_opt_in"],
-            UwtsaZendeskInstance::DOCUMENT_REQUEST_LINK => "http://test.host/documents/add/3456ABCDEF"
+            EitcZendeskInstance::INTAKE_SITE => "online_intake",
+            EitcZendeskInstance::INTAKE_STATUS => EitcZendeskInstance::INTAKE_STATUS_IN_PROGRESS,
+            EitcZendeskInstance::STATE => "az",
+            EitcZendeskInstance::FILING_YEARS => ["2019", "2017"],
+            EitcZendeskInstance::COMMUNICATION_PREFERENCES => ["sms_opt_in", "email_opt_in"],
+            EitcZendeskInstance::DOCUMENT_REQUEST_LINK => "http://test.host/documents/add/3456ABCDEF"
           }
         )
       end
@@ -312,8 +303,11 @@ describe ZendeskIntakeService do
     end
 
     context "for UWTSA instance" do
-      let(:state) { "az" }
+      # let(:state) { "az" }
+
       it "appends the intake pdf to the ticket" do
+        intake.zendesk_instance_domain = UwtsaZendeskInstance::DOMAIN
+
         result = service.send_preliminary_intake_and_consent_pdfs
 
         expected_comment = <<~COMMENT
@@ -427,8 +421,10 @@ describe ZendeskIntakeService do
     end
 
     context "with UWTSA ZD instance" do
-      let(:state) { "az" }
+      # let(:state) { "az" }
       it "appends the intake pdf to the ticket with updated status and interview preferences" do
+        intake.zendesk_instance_domain = UwtsaZendeskInstance::DOMAIN
+
         result = service.send_final_intake_pdf
         expect(result).to eq true
         comment_body = <<~BODY
@@ -444,8 +440,8 @@ describe ZendeskIntakeService do
           file: fake_file,
           comment: comment_body,
           fields: {
-            UwtsaZendeskInstance::INTAKE_STATUS => UwtsaZendeskInstance::INTAKE_STATUS_READY_FOR_REVIEW,
-            UwtsaZendeskInstance::DOCUMENT_REQUEST_LINK => "http://test.host/documents/add/3456ABCDEF",
+              UwtsaZendeskInstance::INTAKE_STATUS => UwtsaZendeskInstance::INTAKE_STATUS_READY_FOR_REVIEW,
+              UwtsaZendeskInstance::DOCUMENT_REQUEST_LINK => "http://test.host/documents/add/3456ABCDEF",
           }
         )
       end

--- a/spec/services/zendesk_intake_service_spec.rb
+++ b/spec/services/zendesk_intake_service_spec.rb
@@ -303,8 +303,6 @@ describe ZendeskIntakeService do
     end
 
     context "for UWTSA instance" do
-      # let(:state) { "az" }
-
       it "appends the intake pdf to the ticket" do
         intake.zendesk_instance_domain = UwtsaZendeskInstance::DOMAIN
 
@@ -421,7 +419,6 @@ describe ZendeskIntakeService do
     end
 
     context "with UWTSA ZD instance" do
-      # let(:state) { "az" }
       it "appends the intake pdf to the ticket with updated status and interview preferences" do
         intake.zendesk_instance_domain = UwtsaZendeskInstance::DOMAIN
 


### PR DESCRIPTION
* the united way of tuscon's group id is added to the
  EitcZenDeskInstance
* `Intake#group_by_source` cleaned up and refactored
* new Intakes route to UWTSA if no other state is appropriate
* specs adjusted/removed where needed