### PR TITLE
Less updates for ZD SMS Tickets

### DIFF
--- a/app/helpers/zendesk_service_helper.rb
+++ b/app/helpers/zendesk_service_helper.rb
@@ -130,11 +130,12 @@ module ZendeskServiceHelper
     success
   end
 
-  def append_comment_to_ticket(ticket_id:, comment:, fields: {}, public: false)
+  def append_comment_to_ticket(ticket_id:, comment:, fields: {}, public: false, group_id: nil)
     raise MissingTicketIdError if ticket_id.blank?
 
     ticket = ZendeskAPI::Ticket.find(client, id: ticket_id)
     ticket.fields = fields if fields.present?
+    ticket.group_id = group_id if group_id.present?
     ticket.comment = { body: comment, public: public }
     success = ticket.save
 

--- a/app/services/zendesk_sms_service.rb
+++ b/app/services/zendesk_sms_service.rb
@@ -57,6 +57,9 @@ class ZendeskSmsService
       )
     end
 
+    # assign sms ticket to same group as most recently updated related ticket
+    most_recently_updated_ticket = related_tickets.sort_by(&:updated_at).last
+
     # comment on sms ticket with related ticket id's
     # update linked ticket field with related ticket id's
     ticket_urls = related_ticket_ids.map { |id| ticket_url(id) }
@@ -64,14 +67,11 @@ class ZendeskSmsService
     append_comment_to_ticket(
       ticket_id: sms_ticket_id,
       comment: comment_body,
+      group_id: most_recently_updated_ticket.group_id,
       fields: {
         EitcZendeskInstance::LINKED_TICKET => ticket_urls.join(",")
-      }
+      },
     )
-
-    # assign sms ticket to same group as most recently updated related ticket
-    most_recently_updated_ticket = related_tickets.sort_by(&:updated_at).last
-    assign_ticket_to_group(ticket_id: sms_ticket_id, group_id: most_recently_updated_ticket.group_id)
   end
 
   private

--- a/spec/services/zendesk_sms_service_spec.rb
+++ b/spec/services/zendesk_sms_service_spec.rb
@@ -86,25 +86,11 @@ describe ZendeskSmsService do
         expect(service).to have_received(:append_comment_to_ticket).with(
           ticket_id: sms_ticket_id,
           comment: expected_comment_body,
+          group_id: "1004",
           fields: {
             EitcZendeskInstance::LINKED_TICKET => "https://eitc.zendesk.com/agent/tickets/1,https://eitc.zendesk.com/agent/tickets/2,https://eitc.zendesk.com/agent/tickets/3,https://eitc.zendesk.com/agent/tickets/4"
           },
         )
-      end
-
-      context "with existing tickets that have different group ids" do
-        it "updates the sms ticket with the group id of the most recently updated related ticket" do
-          service.handle_inbound_sms(
-            phone_number: phone_number,
-            sms_ticket_id: sms_ticket_id,
-            message_body: sms_message_body
-          )
-
-          expect(service).to have_received(:assign_ticket_to_group).with(
-            ticket_id: sms_ticket_id,
-            group_id: "1004"
-          )
-        end
       end
 
       it "updates each related ticket to link it and flag it" do


### PR DESCRIPTION
- This sets the group of an SMS ticket while making other updates, in
order to prevent duplicate triggers.