### PR TITLE
Add source mapping for UWCCR, Branches, and Hispanic Unity

### DIFF
--- a/app/helpers/eitc_zendesk_instance.rb
+++ b/app/helpers/eitc_zendesk_instance.rb
@@ -17,6 +17,9 @@ class EitcZendeskInstance
     ONLINE_INTAKE_FC = "360009397734",     # Foundation Communities
     ONLINE_INTAKE_NV_FTC = "360009537374", # Nevada Free Tax Coalition
     ONLINE_INTAKE_UW_TSA = "360009581934", # Nevada Free Tax Coalition
+    ONLINE_INTAKE_UWCCR = "360009708193", # "United Way California Capital Region
+    ONLINE_INTAKE_BRANCHES_FL = "360009704234", # Branches (FL)
+    ONLINE_INTAKE_HU_FL = "360009704314", # Hispanic Unity (FL)
   ].freeze
 
   GROUP_ID_TO_STATE_LIST_MAPPING = {
@@ -41,6 +44,11 @@ class EitcZendeskInstance
     goodwillsr: ONLINE_INTAKE_GWISR,
     fc: ONLINE_INTAKE_FC,
     uwco: ONLINE_INTAKE_UW_CENTRAL_OHIO,
+    uwccr: ONLINE_INTAKE_UWCCR,
+    "refundday-b" => ONLINE_INTAKE_BRANCHES_FL,
+    branchesfl: ONLINE_INTAKE_BRANCHES_FL,
+    "refundday-h" => ONLINE_INTAKE_HU_FL,
+    hispanicunity: ONLINE_INTAKE_HU_FL,
   }.freeze
 
 

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -662,6 +662,50 @@ describe Intake do
     end
 
     context "when there is a source parameter" do
+      shared_examples "source group matching" do |src, instance|
+        let(:state) { "ne" }
+        context "when source param starts with a organization's source parameter" do
+          let(:source) { "#{src}-something" }
+
+          it "matches the correct group id" do
+            expect(intake.get_or_create_zendesk_group_id).to eq instance
+            expect(intake.reload.zendesk_group_id).to eq instance
+            expect(intake.zendesk_instance).to eq EitcZendeskInstance
+          end
+        end
+
+        context "source matches an organization" do
+          let(:source) { src }
+
+          it "assigns to the correct group" do
+            expect(intake.get_or_create_zendesk_group_id).to eq instance
+            expect(intake.reload.zendesk_group_id).to eq instance
+            expect(intake.zendesk_instance).to eq EitcZendeskInstance
+          end
+        end
+
+        context "source matches a key but is weirdly cased" do
+          let(:source) do
+            src.chars.map { |c| [true, false].sample ? c.downcase : c.upcase }.join
+          end
+
+          it "assigns to the correct group" do
+            expect(intake.get_or_create_zendesk_group_id).to eq instance
+            expect(intake.reload.zendesk_group_id).to eq instance
+            expect(intake.zendesk_instance).to eq EitcZendeskInstance
+          end
+        end
+      end
+
+      it_behaves_like "source group matching", "uwkc", "360009173713"
+      it_behaves_like "source group matching", "uwco", "360009440374"
+      it_behaves_like "source group matching", "uwvp", "360009267673"
+      it_behaves_like "source group matching", "uwccr", "360009708193"
+      it_behaves_like "source group matching", "RefundDay-B", "360009704234"
+      it_behaves_like "source group matching", "branchesfl", "360009704234"
+      it_behaves_like "source group matching", "RefundDay-H", "360009704314"
+      it_behaves_like "source group matching", "hispanicunity", "360009704314"
+
       context "when there is a source parameter that does not match an organization" do
         let(:source) { "propel" }
         let(:state) { "ne" }
@@ -673,17 +717,6 @@ describe Intake do
         end
       end
 
-      context "when source param starts with a organization's source parameter" do
-        let(:source) { "uwkc-something" }
-        let(:state) { "ne" }
-
-        it "matches the correct group id" do
-          expect(intake.get_or_create_zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_KING_COUNTY
-          expect(intake.reload.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_KING_COUNTY
-          expect(intake.zendesk_instance).to eq EitcZendeskInstance
-        end
-      end
-
       context "when source param is for an organization in an otherwise UWTSA state" do
         let(:source) { "uwco" }
         let(:state) { "oh" }
@@ -691,28 +724,6 @@ describe Intake do
         it "matches the correct group and the correct instance" do
           expect(intake.get_or_create_zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_CENTRAL_OHIO
           expect(intake.reload.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_CENTRAL_OHIO
-          expect(intake.zendesk_instance).to eq EitcZendeskInstance
-        end
-      end
-
-      context "source matches an organization" do
-        let(:source) { "uwkc" }
-        let(:state) { "ne" }
-
-        it "assigns to the UWKC group" do
-          expect(intake.get_or_create_zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_KING_COUNTY
-          expect(intake.reload.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_KING_COUNTY
-          expect(intake.zendesk_instance).to eq EitcZendeskInstance
-        end
-      end
-
-      context "source matches a key but is weirdly cased" do
-        let(:source) { "UwVp" }
-        let(:state) { "ne" }
-
-        it "assigns to the UWVP group" do
-          expect(intake.get_or_create_zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_VIRGINIA
-          expect(intake.reload.zendesk_group_id).to eq EitcZendeskInstance::ONLINE_INTAKE_UW_VIRGINIA
           expect(intake.zendesk_instance).to eq EitcZendeskInstance
         end
       end


### PR DESCRIPTION
- Move specs to shared examples for easier testing using actual group id
for a bit better verification with ids from Pivotal Tracker
- Possibly more idiomatic use of find/detect instead of each for
matching group_id
- enable focused running of specs

(#172511772) [Tuesday 4/28] Enable routing for UWCCR, Branches, and
Hispanic Unity