### PR TITLE
Use the image_processing gem as suggested in warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'jbuilder', '~> 2.5'
 # gem 'bcrypt', '~> 3.1.7'
 
 # Use ActiveStorage variant
-gem 'mini_magick', '~> 4.8'
+gem 'image_processing'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,6 +181,9 @@ GEM
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
+    image_processing (1.10.3)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     inflection (1.0.0)
     jaro_winkler (1.5.4)
     jbuilder (2.10.0)
@@ -349,6 +352,8 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
     ruby-progressbar (1.10.1)
+    ruby-vips (2.0.17)
+      ffi (~> 1.9)
     ruby_dep (1.5.0)
     ruby_http_client (3.5.0)
     rubyzip (2.3.0)
@@ -452,10 +457,10 @@ DEPENDENCIES
   fix-db-schema-conflicts
   git-pair
   guard-rspec
+  image_processing
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   lograge
-  mini_magick (~> 4.8)
   mini_racer
   mixpanel-ruby
   nokogiri (>= 1.10.8)


### PR DESCRIPTION
- Seems to be new default for variants and includes mini-magick as a
dependency
- Hint: use `gem uninstall json` to get rid of extra JSON constant
warnings when running rspec

(#172512982) Remove unhelpful test output