### PR TITLE
fix filing extension banner width

### DIFF
--- a/app/views/public_pages/home.html.erb
+++ b/app/views/public_pages/home.html.erb
@@ -33,9 +33,13 @@
   </div>
 
   <div class="slab banner">
-    <strong>Note: The federal income tax filing deadline has been extended to July 15, 2020.</strong>
-    You do not need to file any additional forms or call the IRS for the extension. We encourage you to file today as
-    you may be due a refund that can help support your household.
+    <div class="grid">
+      <div class="grid__item width-one-whole">
+        <strong>Note: The federal income tax filing deadline has been extended to July 15, 2020.</strong>
+        You do not need to file any additional forms or call the IRS for the extension. We encourage you to file today as
+        you may be due a refund that can help support your household.
+      </div>
+    </div>
   </div>
 
   <div class="slab slab--intro">


### PR DESCRIPTION
wraps the filing extension banner in a grid element so text width is consistent with the rest of the page at >1024px widths