### PR TITLE
Rescue job errors and send explicitly to Sentry with intake_ticket_id

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,8 @@
 class ApplicationJob < ActiveJob::Base
+
+  def with_raven_context(extra)
+    yield
+  rescue => exception
+    Raven.capture_exception(exception, extra: extra)
+  end
 end

--- a/app/jobs/create_zendesk_intake_ticket_job.rb
+++ b/app/jobs/create_zendesk_intake_ticket_job.rb
@@ -3,12 +3,14 @@ class CreateZendeskIntakeTicketJob < ApplicationJob
 
   def perform(intake_id)
     intake = Intake.find(intake_id)
-    if intake.intake_ticket_id.blank?
-      service = ZendeskIntakeService.new(intake)
-      if intake.intake_ticket_requester_id.blank?
-        intake.update(intake_ticket_requester_id: service.create_intake_ticket_requester)
+    with_raven_context({ticket_id: intake.intake_ticket_id}) do
+      if intake.intake_ticket_id.blank?
+        service = ZendeskIntakeService.new(intake)
+        if intake.intake_ticket_requester_id.blank?
+          intake.update(intake_ticket_requester_id: service.create_intake_ticket_requester)
+        end
+        intake.update(intake_ticket_id: service.create_intake_ticket)
       end
-      intake.update(intake_ticket_id: service.create_intake_ticket)
     end
   end
 end

--- a/app/jobs/send_completed_intake_to_zendesk_job.rb
+++ b/app/jobs/send_completed_intake_to_zendesk_job.rb
@@ -3,11 +3,12 @@ class SendCompletedIntakeToZendeskJob < ApplicationJob
 
   def perform(intake_id)
     intake = Intake.find(intake_id)
+    with_raven_context({ticket_id: intake.intake_ticket_id}) do
+      service = ZendeskIntakeService.new(intake)
+      success = service.send_final_intake_pdf &&
+        service.send_all_docs
 
-    service = ZendeskIntakeService.new(intake)
-    success = service.send_final_intake_pdf &&
-      service.send_all_docs
-
-    intake.update(completed_intake_sent_to_zendesk: success)
+      intake.update(completed_intake_sent_to_zendesk: success)
+    end
   end
 end

--- a/app/jobs/send_intake_pdf_to_zendesk_job.rb
+++ b/app/jobs/send_intake_pdf_to_zendesk_job.rb
@@ -3,10 +3,13 @@ class SendIntakePdfToZendeskJob < ApplicationJob
 
   def perform(intake_id)
     intake = Intake.find(intake_id)
-    unless intake.intake_pdf_sent_to_zendesk
-      service = ZendeskIntakeService.new(intake)
-      output = service.send_preliminary_intake_and_consent_pdfs
-      intake.update(intake_pdf_sent_to_zendesk: output)
+    with_raven_context({ticket_id: intake.intake_ticket_id}) do
+      intake = Intake.find(intake_id)
+      unless intake.intake_pdf_sent_to_zendesk
+        service = ZendeskIntakeService.new(intake)
+        output = service.send_preliminary_intake_and_consent_pdfs
+        intake.update(intake_pdf_sent_to_zendesk: output)
+      end
     end
   end
 end

--- a/app/jobs/send_requested_documents_to_zendesk_job.rb
+++ b/app/jobs/send_requested_documents_to_zendesk_job.rb
@@ -2,7 +2,10 @@ class SendRequestedDocumentsToZendeskJob < ApplicationJob
   queue_as :default
 
   def perform(intake_id)
-    service = ZendeskFollowUpDocsService.new(Intake.find(intake_id))
-    service.send_requested_docs
+    intake = Intake.find(intake_id)
+    with_raven_context({ticket_id: intake.intake_ticket_id}) do
+      service = ZendeskFollowUpDocsService.new(intake)
+      service.send_requested_docs
+    end
   end
 end

--- a/app/jobs/send_spouse_auth_docs_to_zendesk_job.rb
+++ b/app/jobs/send_spouse_auth_docs_to_zendesk_job.rb
@@ -4,10 +4,12 @@ class SendSpouseAuthDocsToZendeskJob < ApplicationJob
   def perform(intake_id)
     intake = Intake.find(intake_id)
 
-    if intake.completed_intake_sent_to_zendesk
-      service = ZendeskIntakeService.new(intake)
-      service.send_intake_pdf_with_spouse &&
-        service.send_consent_pdf_with_spouse
+    with_raven_context({ticket_id: intake.intake_ticket_id}) do
+      if intake.completed_intake_sent_to_zendesk
+        service = ZendeskIntakeService.new(intake)
+        service.send_intake_pdf_with_spouse &&
+          service.send_consent_pdf_with_spouse
+      end
     end
   end
 end

--- a/lib/tasks/verify_sentry_extra_fields.rake
+++ b/lib/tasks/verify_sentry_extra_fields.rake
@@ -1,0 +1,17 @@
+# use this to verify that sentry is seeing what
+# we want it to see
+
+
+namespace :test do
+  desc "dispatch an exception from a background job"
+  task dispatch_exception: [:environment] do
+    class DoAnExceptionalJob < ApplicationJob
+      def perform(fake_id)
+        with_raven_context({ticket_id: fake_id}) do
+          raise "hell"
+        end
+      end
+    end
+    DoAnExceptionalJob.perform_now('from test:dispatch_exception with love')
+  end
+end

--- a/spec/jobs/create_zendesk_intake_ticket_job_spec.rb
+++ b/spec/jobs/create_zendesk_intake_ticket_job_spec.rb
@@ -13,50 +13,54 @@ RSpec.describe CreateZendeskIntakeTicketJob, type: :job do
   end
 
   describe "#perform" do
-    before do
-      described_class.perform_now(intake.id)
-    end
+    context "without errors" do
+      before do
+        described_class.perform_now(intake.id)
+      end
 
-    context "without a requester or ticket" do
-      let(:zendesk_requester_id) { nil }
-      let(:zendesk_ticket_id) { nil }
+      context "without a requester or ticket" do
+        let(:zendesk_requester_id) { nil }
+        let(:zendesk_ticket_id) { nil }
 
-      it "creates a new intake ticket in Zendesk and saves IDs to the intake" do
-        intake.reload
-        expect(ZendeskIntakeService).to have_received(:new).with(intake)
-        expect(fake_zendesk_intake_service).to have_received(:create_intake_ticket_requester).with(no_args)
-        expect(intake.intake_ticket_requester_id).to eq 23
-        expect(fake_zendesk_intake_service).to have_received(:create_intake_ticket).with(no_args)
-        expect(intake.intake_ticket_id).to eq 5
+        it "creates a new intake ticket in Zendesk and saves IDs to the intake" do
+          intake.reload
+          expect(ZendeskIntakeService).to have_received(:new).with(intake)
+          expect(fake_zendesk_intake_service).to have_received(:create_intake_ticket_requester).with(no_args)
+          expect(intake.intake_ticket_requester_id).to eq 23
+          expect(fake_zendesk_intake_service).to have_received(:create_intake_ticket).with(no_args)
+          expect(intake.intake_ticket_id).to eq 5
+        end
+      end
+
+      context "with a requester but no ticket" do
+        let(:zendesk_requester_id) { 32 }
+        let(:zendesk_ticket_id) { nil }
+
+        it "only creates a ticket" do
+          intake.reload
+          expect(ZendeskIntakeService).to have_received(:new).with(intake)
+          expect(fake_zendesk_intake_service).not_to have_received(:create_intake_ticket_requester)
+          expect(intake.intake_ticket_requester_id).to eq 32
+          expect(fake_zendesk_intake_service).to have_received(:create_intake_ticket).with(no_args)
+          expect(intake.intake_ticket_id).to eq 5
+        end
+      end
+
+      context "with a requester and ticket" do
+        let(:zendesk_requester_id) { 32 }
+        let(:zendesk_ticket_id) { 7 }
+
+        it "does not call the zendesk service" do
+          intake.reload
+          expect(ZendeskIntakeService).not_to have_received(:new)
+          expect(fake_zendesk_intake_service).not_to have_received(:create_intake_ticket_requester)
+          expect(intake.intake_ticket_requester_id).to eq 32
+          expect(fake_zendesk_intake_service).not_to have_received(:create_intake_ticket)
+          expect(intake.intake_ticket_id).to eq 7
+        end
       end
     end
 
-    context "with a requester but no ticket" do
-      let(:zendesk_requester_id) { 32 }
-      let(:zendesk_ticket_id) { nil }
-
-      it "only creates a ticket" do
-        intake.reload
-        expect(ZendeskIntakeService).to have_received(:new).with(intake)
-        expect(fake_zendesk_intake_service).not_to have_received(:create_intake_ticket_requester)
-        expect(intake.intake_ticket_requester_id).to eq 32
-        expect(fake_zendesk_intake_service).to have_received(:create_intake_ticket).with(no_args)
-        expect(intake.intake_ticket_id).to eq 5
-      end
-    end
-
-    context "with a requester and ticket" do
-      let(:zendesk_requester_id) { 32 }
-      let(:zendesk_ticket_id) { 7 }
-
-      it "does not call the zendesk service" do
-        intake.reload
-        expect(ZendeskIntakeService).not_to have_received(:new)
-        expect(fake_zendesk_intake_service).not_to have_received(:create_intake_ticket_requester)
-        expect(intake.intake_ticket_requester_id).to eq 32
-        expect(fake_zendesk_intake_service).not_to have_received(:create_intake_ticket)
-        expect(intake.intake_ticket_id).to eq 7
-      end
-    end
+    it_behaves_like "catches exceptions with raven context", :create_intake_ticket
   end
 end

--- a/spec/jobs/send_intake_pdf_to_zendesk_job_spec.rb
+++ b/spec/jobs/send_intake_pdf_to_zendesk_job_spec.rb
@@ -13,27 +13,34 @@ RSpec.describe SendIntakePdfToZendeskJob, type: :job do
       create :intake, intake_pdf_sent_to_zendesk: intake_pdf_sent_to_zendesk
     end
 
-    before do
-      described_class.perform_now(intake.id)
-    end
+    context "without errors" do
+      before do
+        described_class.perform_now(intake.id)
+      end
 
-    context "when pdf has already been sent" do
-      let(:intake_pdf_sent_to_zendesk) { true }
+      context "when pdf has already been sent" do
+        let(:intake_pdf_sent_to_zendesk) { true }
 
-      it "does not send it again" do
-        expect(ZendeskIntakeService).not_to have_received(:new)
+        it "does not send it again" do
+          expect(ZendeskIntakeService).not_to have_received(:new)
+        end
+      end
+
+      context "when pdf has not been sent" do
+        let(:intake_pdf_sent_to_zendesk) { false }
+
+        it "sends the intake pdf and the consent pdf to the intake ticket" do
+          expect(ZendeskIntakeService).to have_received(:new).with(intake)
+          expect(fake_zendesk_intake_service).to have_received(:send_preliminary_intake_and_consent_pdfs)
+          intake.reload
+          expect(intake.intake_pdf_sent_to_zendesk).to eq true
+        end
       end
     end
 
-    context "when pdf has not been sent" do
-      let(:intake_pdf_sent_to_zendesk) { false }
-
-      it "sends the intake pdf and the consent pdf to the intake ticket" do
-        expect(ZendeskIntakeService).to have_received(:new).with(intake)
-        expect(fake_zendesk_intake_service).to have_received(:send_preliminary_intake_and_consent_pdfs)
-        intake.reload
-        expect(intake.intake_pdf_sent_to_zendesk).to eq true
-      end
+    it_behaves_like "catches exceptions with raven context", :send_preliminary_intake_and_consent_pdfs do
+        let(:intake_pdf_sent_to_zendesk) { false }
     end
+
   end
 end

--- a/spec/jobs/send_requested_documents_to_zendesk_job_spec.rb
+++ b/spec/jobs/send_requested_documents_to_zendesk_job_spec.rb
@@ -13,13 +13,20 @@ RSpec.describe SendRequestedDocumentsToZendeskJob, type: :job do
       create :intake
     end
 
-    before do
-      described_class.perform_now(intake.id)
+    context "without errors" do
+      before do
+        described_class.perform_now(intake.id)
+      end
+
+      it "sends the intake pdf and all of the docs as comments on the intake ticket" do
+        expect(ZendeskFollowUpDocsService).to have_received(:new).with(intake)
+        expect(fake_service).to have_received(:send_requested_docs)
+      end
     end
 
-    it "sends the intake pdf and all of the docs as comments on the intake ticket" do
-      expect(ZendeskFollowUpDocsService).to have_received(:new).with(intake)
-      expect(fake_service).to have_received(:send_requested_docs)
+    it_behaves_like "catches exceptions with raven context", :send_requested_docs do
+      let(:fake_zendesk_intake_service) { fake_service }
     end
+
   end
 end

--- a/spec/support/shared_examples/exceptions_with_raven_context.rb
+++ b/spec/support/shared_examples/exceptions_with_raven_context.rb
@@ -1,0 +1,13 @@
+shared_examples "catches exceptions with raven context" do |action|
+  context "when error occurs" do
+    it "sends the intake ticket_id to Sentry" do
+      allow(fake_zendesk_intake_service).to receive(action)
+        .and_raise("Test Error")
+      expect(Raven).to receive(:capture_exception)
+        .with(instance_of(RuntimeError), extra: {ticket_id: intake.intake_ticket_id })
+      described_class.perform_now(intake.id)
+    end
+  end
+end
+
+


### PR DESCRIPTION
- Create with_raven_context ApplicationJob helper for catching and
sending errors to Sentry with extra context
- Use shared examples for testing background jobs with errors in specs

(#172583987) Improve Sentry error reporting context to include zendesk
ticket ID