### PR TITLE
Uploading a requested doc without a current_intake redirects to home

### DIFF
--- a/app/controllers/documents/requested_documents_later_controller.rb
+++ b/app/controllers/documents/requested_documents_later_controller.rb
@@ -1,6 +1,7 @@
 module Documents
   class RequestedDocumentsLaterController < DocumentUploadQuestionController
     before_action :handle_session, only: :edit
+    before_action :current_intake_or_home, only: :update
     skip_before_action :require_intake
 
     def self.show?(_)
@@ -20,6 +21,12 @@ module Documents
     end
 
     private
+
+    def current_intake_or_home
+      if session[:intake_id].nil?
+        redirect_to root_path
+      end
+    end
 
     def handle_session
       check_token_and_create_anonymous_session unless session_in_progress?

--- a/app/controllers/documents/send_requested_documents_later_controller.rb
+++ b/app/controllers/documents/send_requested_documents_later_controller.rb
@@ -29,6 +29,7 @@ module Documents
         intake = Intake.anonymous.find_by(id: session[:intake_id])
         intake.destroy if intake
         session[:anonymous_session] = false
+        session[:intake_id] = nil
       end
     end
 

--- a/spec/controllers/documents/requested_documents_later_controller_spec.rb
+++ b/spec/controllers/documents/requested_documents_later_controller_spec.rb
@@ -109,29 +109,40 @@ RSpec.describe Documents::RequestedDocumentsLaterController, type: :controller d
   end
 
   describe "#update" do
-    before do
-      allow(subject).to receive(:current_intake).and_return(anonymous_intake)
+    context "with no intake in the session" do
+      it "redirects to the home page" do
+        get :update
+
+        expect(response).to redirect_to root_path
+      end
     end
 
-    context "with valid params" do
-      let(:valid_params) do
-        {
-          document_type_upload_form: {
-            document: fixture_file_upload("attachments/test-pattern.png")
-          }
-        }
+    context "with an intake in the session" do
+      before do
+        session[:anonymous_session] = true
+        session[:intake_id] = anonymous_intake.id
       end
 
-      it "appends the documents to the intake and rerenders :edit without redirecting" do
-        expect {
-          post :update, params: valid_params
-        }.to change(anonymous_intake.documents, :count).by 1
+      context "with valid params" do
+        let(:valid_params) do
+          {
+            document_type_upload_form: {
+              document: fixture_file_upload("attachments/test-pattern.png")
+            }
+          }
+        end
 
-        latest_doc = anonymous_intake.documents.last
-        expect(latest_doc.document_type).to eq "Requested Later"
-        expect(latest_doc.upload.filename).to eq "test-pattern.png"
+        it "appends the documents to the intake and rerenders :edit without redirecting" do
+          expect {
+            post :update, params: valid_params
+          }.to change(anonymous_intake.documents, :count).by 1
 
-        expect(response).to redirect_to requested_documents_later_documents_path
+          latest_doc = anonymous_intake.documents.last
+          expect(latest_doc.document_type).to eq "Requested Later"
+          expect(latest_doc.upload.filename).to eq "test-pattern.png"
+
+          expect(response).to redirect_to requested_documents_later_documents_path
+        end
       end
     end
   end


### PR DESCRIPTION
This is a fix for the "undefined method documents for nil class" error caused by people trying to go backwards in the requested docs flow.

For detailed explanation: https://www.pivotaltracker.com/story/show/172589704