### PR TITLE
Use Raven.extra_context api to add details to exception

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,8 +1,10 @@
 class ApplicationJob < ActiveJob::Base
 
-  def with_raven_context(extra)
+  def with_raven_context(extra_context={})
     yield
   rescue => exception
-    Raven.capture_exception(exception, extra: extra)
+    Raven.extra_context(extra_context)
+    raise exception
   end
+
 end

--- a/app/jobs/failing_job.rb
+++ b/app/jobs/failing_job.rb
@@ -1,0 +1,9 @@
+class FailingJob < ApplicationJob
+  queue_as :default
+
+  def perform(test_data)
+    with_raven_context(test_data: test_data) do
+      raise "forced test exception with context"
+    end
+  end
+end

--- a/spec/support/shared_examples/exceptions_with_raven_context.rb
+++ b/spec/support/shared_examples/exceptions_with_raven_context.rb
@@ -3,9 +3,10 @@ shared_examples "catches exceptions with raven context" do |action|
     it "sends the intake ticket_id to Sentry" do
       allow(fake_zendesk_intake_service).to receive(action)
         .and_raise("Test Error")
-      expect(Raven).to receive(:capture_exception)
-        .with(instance_of(RuntimeError), extra: {ticket_id: intake.intake_ticket_id })
-      described_class.perform_now(intake.id)
+      expect(Raven).to receive(:extra_context)
+        .with({ticket_id: intake.intake_ticket_id })
+      expect { described_class.perform_now(intake.id) }
+        .to raise_error("Test Error")
     end
   end
 end


### PR DESCRIPTION
- Adds FailingJob for testing purposes

(#172583987) Improve Sentry error reporting context to include zendesk
ticket ID