### PR TITLE
Use valid_email2 gem for a bit stricter email validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ gem 'delayed_job_active_record'
 gem 'attr_encrypted'
 gem 'lograge'
 gem 'fix-db-schema-conflicts'
+gem 'valid_email2'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -407,6 +407,9 @@ GEM
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.7.0)
+    valid_email2 (3.2.2)
+      activemodel (>= 3.2)
+      mail (~> 2.5)
     virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
@@ -492,6 +495,7 @@ DEPENDENCIES
   strip_attributes
   tzinfo-data
   uglifier (>= 1.3.0)
+  valid_email2
   web-console (>= 3.3.0)
   webdrivers
   webmock

--- a/app/forms/email_address_form.rb
+++ b/app/forms/email_address_form.rb
@@ -1,9 +1,6 @@
 class EmailAddressForm < QuestionsForm
   set_attributes_for :intake, :email_address, :email_address_confirmation
-  validates :email_address, format: {
-    with: URI::MailTo::EMAIL_REGEXP,
-    message: "Please enter a valid email address.",
-  }
+  validates :email_address, 'valid_email_2/email': { message: "Please enter a valid email address." }
   validates :email_address, confirmation: { message: "Please double check that the email addresses match." }
   validates :email_address_confirmation, presence: true
 

--- a/spec/forms/email_address_form_spec.rb
+++ b/spec/forms/email_address_form_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe EmailAddressForm do
+  let(:intake) { create :intake }
+
+  describe "validations" do
+    context "when the email is valid" do
+      it "is valid" do
+
+        form = EmailAddressForm.new(
+          intake,
+          {
+            email_address: "stuff@things.net",
+            email_address_confirmation: "stuff@things.net"
+          }
+        )
+
+        expect(form).to be_valid
+      end
+    end
+
+    context "when the email does not have a top level domain" do
+      it "is not valid" do
+
+        form = EmailAddressForm.new(
+          intake,
+          {
+            email_address: "stuff@things",
+            email_address_confirmation: "stuff@things"
+          }
+        )
+
+        expect(form).not_to be_valid
+        expect(form.errors[:email_address]).to be_present
+      end
+    end
+  end
+end


### PR DESCRIPTION
- (#172627155) Fix email validation

Note: There are lots of email address validation options out there. [valid_email2](https://github.com/micke/valid_email2) is relatively new and might be a bit heavier but the regex does validate that there is a top level domain and was easy to use. The [basic specs](https://github.com/micke/valid_email2/blob/master/spec/valid_email2_spec.rb#L45-L114) seem to match our current requirements. 