### PR TITLE
Allow vita partner association to be overwritten with assign_vita_partner!

### DIFF
--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -435,11 +435,13 @@ class Intake < ApplicationRecord
   end
 
   def assign_vita_partner!
-    return if vita_partner.present?
-
-    if get_or_create_zendesk_group_id
-      partner = VitaPartner.find_by(zendesk_group_id: zendesk_group_id)
-      raise "unable to determine VITA Partner from zendesk group id: [#{zendesk_group_id}]" unless partner.present?
+    # this should only be called before get_or_create_zendesk_group_id has ever been called
+    # because we want users to be able to change which group they are routed to up until the ZD ticket has been created,
+    # we don't call get_or_create_zendesk_group_id, we only check whether it has been persisted, and do not save it
+    group_id = zendesk_group_id || determine_zendesk_group_id
+    if group_id
+      partner = VitaPartner.find_by(zendesk_group_id: group_id)
+      raise "unable to determine VITA Partner from zendesk group id: [#{group_id}]" unless partner.present?
       update(vita_partner_id: partner.id, vita_partner_name: partner.name)
     end
   end

--- a/spec/controllers/questions/personal_info_controller_spec.rb
+++ b/spec/controllers/questions/personal_info_controller_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe Questions::PersonalInfoController do
+  let!(:vita_partner) { create :vita_partner, zendesk_group_id: "123" }
+
+  before do
+    allow(subject).to receive(:current_intake).and_return(intake)
+    allow(intake).to receive(:determine_zendesk_group_id).and_return("123")
+  end
+
+  describe "#update" do
+    let(:params) do
+      {
+        personal_info_form: {
+          state_of_residence: "co",
+          preferred_name: "Shep"
+        }
+      }
+    end
+
+    context "when intake does not have a zendesk ticket id" do
+      let(:intake) { create :intake }
+
+      it "re-assigns the vita partner" do
+        post :update, params: params
+
+        expect(intake.reload.vita_partner).to eq vita_partner
+      end
+    end
+
+    context "when intake already has a zendesk ticket id" do
+      let!(:old_vita_partner) { create :vita_partner, zendesk_group_id: "345" }
+      let(:intake) { create :intake, zendesk_group_id: "345", vita_partner: old_vita_partner }
+
+      it "does not re-assign the vita partner" do
+        post :update, params: params
+
+        expect(intake.reload.vita_partner).to eq old_vita_partner
+      end
+    end
+  end
+end
+

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -566,6 +566,7 @@ describe Intake do
 
     it "returns the expected hash" do
       intake.assign_vita_partner!
+      intake.get_or_create_zendesk_group_id
       expect(intake.mixpanel_data).to eq({
         intake_source: "beep",
         intake_referrer: "http://boop.horse/mane",


### PR DESCRIPTION
- users should be able to go back and change their state