### PR TITLE
[SPIKE removing anonymous intakes] Excludes anonymous intakes from current_intake except req docs flow

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   helper_method :include_google_analytics?, :current_intake
 
   def current_intake
-    current_user&.intake || Intake.find_by_id(session[:intake_id])
+    current_user&.intake || Intake.where.not(anonymous: true).find_by_id(session[:intake_id])
   end
 
   def include_google_analytics?

--- a/app/controllers/documents/requested_documents_later_controller.rb
+++ b/app/controllers/documents/requested_documents_later_controller.rb
@@ -4,6 +4,10 @@ module Documents
     before_action :current_intake_or_home, only: :update
     skip_before_action :require_intake
 
+    def current_intake
+      current_user&.intake || Intake.find_by_id(session[:intake_id])
+    end
+
     def self.show?(_)
       false
     end

--- a/app/controllers/documents/send_requested_documents_later_controller.rb
+++ b/app/controllers/documents/send_requested_documents_later_controller.rb
@@ -3,6 +3,10 @@ module Documents
     after_action :clear_anonymous_session
     skip_before_action :require_intake
 
+    def current_intake
+      current_user&.intake || Intake.find_by_id(session[:intake_id])
+    end
+
     def edit
       original_intake = find_original_intake
       original_intake.documents << current_intake.documents

--- a/spec/controllers/questions/job_count_controller_spec.rb
+++ b/spec/controllers/questions/job_count_controller_spec.rb
@@ -3,10 +3,6 @@ require "rails_helper"
 RSpec.describe Questions::JobCountController do
   let(:intake) { create :intake }
 
-  before do
-    allow(subject).to receive(:current_intake).and_return(intake)
-  end
-
   describe "#edit" do
     context "when user doesn't have a current intake" do
       before do
@@ -19,9 +15,27 @@ RSpec.describe Questions::JobCountController do
         expect(response).to redirect_to(feelings_questions_path)
       end
     end
+
+    context "when the user has an anonymous intake in their session" do
+      let(:anonymous_intake) { create :intake, anonymous: true }
+
+      before do
+        session[:intake_id] = anonymous_intake
+      end
+
+      it "doesn't return the anonymous intake" do
+        get :edit
+
+        expect(response).to redirect_to(feelings_questions_path)
+      end
+    end
   end
 
   describe "#update" do
+    before do
+      allow(subject).to receive(:current_intake).and_return(intake)
+    end
+
     context "with valid params" do
       let(:params) do
         {

--- a/spec/features/web_intake/requested_documents_token_spec.rb
+++ b/spec/features/web_intake/requested_documents_token_spec.rb
@@ -36,6 +36,16 @@ RSpec.feature "Client uploads a requested document" do
     expect(page).to have_text "Your tax preparer will reach out with updates and any additional questions within 3 business days."
   end
 
+  scenario "client goes to the follow up documents link and does not finish the requested docs flow" do
+    visit "/documents/add/1234ABCDEF"
+
+    expect(page).to have_selector("h1", text: "Your tax specialist is requesting additional documents")
+    expect(page).to have_button("Continue", disabled: true)
+
+    visit "/questions/job-count"
+    expect(current_path).to eq("/questions/feelings")
+  end
+
   # TODO: remove this scenario when login is removed
   xscenario "client goes to the follow up documents token link while logged in", :js do
     silence_omniauth_logging do


### PR DESCRIPTION
- Adds a feature spec for current bug scenario of user trying to access
main intake flow from incomplete requested docs flow

(#172627601) Spike on improving how we handle Anonymous Intakes for
returning sessions