### PR TITLE
Updates user phone in zendesk when found user's phone is blank

### DIFF
--- a/spec/services/zendesk_drop_off_service_spec.rb
+++ b/spec/services/zendesk_drop_off_service_spec.rb
@@ -168,7 +168,7 @@ describe ZendeskDropOffService do
           result = service.find_end_user("Barry Banana", "test@example.com", "14155551234")
           expect(service).to have_received(:search_zendesk_users).with("email:test@example.com")
           expect(service).to have_received(:search_zendesk_users).with("name:\"Barry Banana\" phone:14155551234")
-          expect(result).to eq(1)
+          expect(result).to eq(fake_zendesk_user)
         end
       end
     end


### PR DESCRIPTION
- context is when user is created with email only when contacting
through zendesk chat/help widget.

(#172684636) Bugfix: If a user contacts support via email before
submitting an intake, their contact information will not be updated