### PR TITLE
[SPIKE removing anonymous intakes] try keeping requested docs token in session instead of intake id

### DIFF
--- a/app/controllers/concerns/intake_from_token.rb
+++ b/app/controllers/concerns/intake_from_token.rb
@@ -1,0 +1,11 @@
+module IntakeFromToken
+  def current_intake
+    Intake.find_for_requested_docs_token(retrieve_or_store_token)
+  end
+
+  def retrieve_or_store_token
+    token = params[:token] || session[:token]
+    session[:token] = token if session[:token] != token
+    token
+  end
+end

--- a/app/controllers/documents/requested_documents_later_controller.rb
+++ b/app/controllers/documents/requested_documents_later_controller.rb
@@ -1,8 +1,6 @@
 module Documents
   class RequestedDocumentsLaterController < DocumentUploadQuestionController
-    before_action :handle_session, only: :edit
-    before_action :current_intake_or_home, only: :update
-    skip_before_action :require_intake
+    include IntakeFromToken
 
     def self.show?(_)
       false
@@ -20,39 +18,5 @@ module Documents
       "Requested Later"
     end
 
-    private
-
-    def current_intake_or_home
-      if session[:intake_id].nil?
-        redirect_to root_path
-      end
-    end
-
-    def handle_session
-      check_token_and_create_anonymous_session unless session_in_progress?
-    end
-
-    def check_token_and_create_anonymous_session
-      original_intake = Intake.find_for_requested_docs_token(params[:token])
-      if original_intake.present?
-        create_anonymous_intake_session(original_intake)
-      else
-        redirect_to documents_requested_docs_not_found_path
-      end
-    end
-
-    def create_anonymous_intake_session(original_intake)
-      anonymous_intake = Intake.create_anonymous_intake(original_intake)
-      session[:intake_id] = anonymous_intake.id
-      session[:anonymous_session] = true
-    end
-
-    def anonymous_session_in_progress?
-      session[:anonymous_session] && session[:intake_id].present?
-    end
-
-    def session_in_progress?
-      current_user.present? || anonymous_session_in_progress?
-    end
   end
 end

--- a/app/controllers/documents/send_requested_documents_later_controller.rb
+++ b/app/controllers/documents/send_requested_documents_later_controller.rb
@@ -1,12 +1,10 @@
 module Documents
   class SendRequestedDocumentsLaterController < DocumentUploadQuestionController
-    after_action :clear_anonymous_session
-    skip_before_action :require_intake
+    include IntakeFromToken
+    append_after_action :reset_session, :track_page_view, only: :success
 
     def edit
-      original_intake = find_original_intake
-      original_intake.documents << current_intake.documents
-      SendRequestedDocumentsToZendeskJob.perform_later(original_intake.id)
+      SendRequestedDocumentsToZendeskJob.perform_later(current_intake.id)
       redirect_to documents_requested_documents_success_path
     end
 
@@ -22,24 +20,6 @@ module Documents
       nil
     end
 
-    private
-
-    def clear_anonymous_session
-      if session[:anonymous_session]
-        intake = Intake.anonymous.find_by(id: session[:intake_id])
-        intake.destroy if intake
-        session[:anonymous_session] = false
-        session[:intake_id] = nil
-      end
-    end
-
-    def find_original_intake
-      if session[:anonymous_session]
-        Intake.find_original_intake(current_intake)
-      else
-        current_intake
-      end
-    end
   end
 end
 


### PR DESCRIPTION
In this PR, we explore the idea of keeping the requested docs token in the session and overwriting `current_intake` on the requested docs controllers to get the original intake from the token. This avoids the issue of the rest of the flow accessing intake in the same way, and we've removed anonymous intakes entirely.

The remaining issue is that using the original intake exposes all previous "Requested Later" type documents. Here are some possible solutions to that issue:
- we could generate a token when someone visits the link and include it in the `document_type` - this way they would only see the documents they had uploaded during that session, but it would create a bunch of weird looking document types and there's some complicated stuff to figure out with when to generate/clear the token
- we could overwrite `update` and instead of assigning `@documents` to all documents of type "Requested Later" we could assign it to an array and add each document as it's uploaded, and `render :edit` instead of `redirect_to :edit`. One downside of this is that if the person refreshed the page they would lose their documents (they'd be saved but never sent)
- we could do a similar version of the previous solution but save the document id's in the session so that they wouldn't get lost. this may also be similarly complicated to solution 1 in that when we add more things to the session we have to think through when to access/clear them and what different user behaviors could cause an unexpected outcome.

Note: this PR is for socializing some details of a solution but is otherwise incomplete. For example, it does not redirect to no intake found page when the token is bad. It also doesn't have any specs.