### PR TITLE
[SPIKE removing anonymous intakes] Create new model to replace intake while docs are being uploaded

### DIFF
--- a/app/controllers/documents/document_upload_question_controller.rb
+++ b/app/controllers/documents/document_upload_question_controller.rb
@@ -4,6 +4,7 @@ module Documents
 
     delegate :document_type, to: :class
     helper_method :document_type
+    helper_method :destroy_document_path
 
     def edit
       return if self.class.document_type.nil?
@@ -37,6 +38,10 @@ module Documents
 
     def self.document_type
       raise NotImplementedError, "#{self.name} must implement document_type or return nil to indicate no document will be uploaded."
+    end
+
+    def destroy_document_path(document)
+      document_path(document)
     end
 
     def track_document_upload

--- a/app/controllers/documents/send_requested_documents_later_controller.rb
+++ b/app/controllers/documents/send_requested_documents_later_controller.rb
@@ -1,11 +1,12 @@
 module Documents
   class SendRequestedDocumentsLaterController < DocumentUploadQuestionController
-    after_action :clear_anonymous_session
+    append_after_action :reset_session, :track_page_view, only: :success
     skip_before_action :require_intake
 
     def edit
-      original_intake = find_original_intake
-      original_intake.documents << current_intake.documents
+      documents_request = DocumentsRequest.find(session[:documents_request_id])
+      original_intake = documents_request.intake
+      documents_request.documents.update_all(intake_id: original_intake.id)
       SendRequestedDocumentsToZendeskJob.perform_later(original_intake.id)
       redirect_to documents_requested_documents_success_path
     end
@@ -21,25 +22,5 @@ module Documents
     def self.document_type
       nil
     end
-
-    private
-
-    def clear_anonymous_session
-      if session[:anonymous_session]
-        intake = Intake.anonymous.find_by(id: session[:intake_id])
-        intake.destroy if intake
-        session[:anonymous_session] = false
-        session[:intake_id] = nil
-      end
-    end
-
-    def find_original_intake
-      if session[:anonymous_session]
-        Intake.find_original_intake(current_intake)
-      else
-        current_intake
-      end
-    end
   end
 end
-

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,5 +1,5 @@
 class DocumentsController < ApplicationController
-  before_action :require_intake
+  before_action :require_intake, only: :destroy
 
   def destroy
     document = current_intake.documents.find_by(id: params[:id])
@@ -11,5 +11,12 @@ class DocumentsController < ApplicationController
     else
       redirect_to overview_documents_path
     end
+  end
+
+  def destroy_requested
+    document = Document.find_by(id: params[:id])
+
+    document.destroy
+    redirect_to helpers.edit_document_path(document.document_type)
   end
 end

--- a/app/forms/requested_document_upload_form.rb
+++ b/app/forms/requested_document_upload_form.rb
@@ -1,0 +1,16 @@
+class RequestedDocumentUploadForm < QuestionsForm
+  set_attributes_for :documents_request, :document
+
+  def initialize(documents_request, *args, **kwargs)
+    @documents_request = documents_request
+    super(nil, *args, **kwargs)
+  end
+
+  def save
+    document_file_upload = attributes_for(:documents_request)[:document]
+    if document_file_upload.present?
+      document = @documents_request.documents.create(document_type: "Requested Later")
+      document.upload.attach(document_file_upload)
+    end
+  end
+end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -2,24 +2,30 @@
 #
 # Table name: documents
 #
-#  id                :bigint           not null, primary key
-#  document_type     :string           not null
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  intake_id         :bigint
-#  zendesk_ticket_id :bigint
+#  id                   :bigint           not null, primary key
+#  document_type        :string           not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  documents_request_id :bigint
+#  intake_id            :bigint
+#  zendesk_ticket_id    :bigint
 #
 # Indexes
 #
-#  index_documents_on_intake_id  (intake_id)
+#  index_documents_on_documents_request_id  (documents_request_id)
+#  index_documents_on_intake_id             (intake_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (documents_request_id => documents_requests.id)
 #
 
 class Document < ApplicationRecord
   validates :document_type, inclusion: { in: DocumentNavigation::DOCUMENT_TYPES }
-  validates :intake, presence: true
+  validates :intake, presence: { unless: :documents_request_id }
 
   scope :of_type, ->(type) { where(document_type: type) }
 
-  belongs_to :intake
+  belongs_to :intake, optional: true
   has_one_attached :upload
 end

--- a/app/models/documents_request.rb
+++ b/app/models/documents_request.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: documents_requests
+#
+#  id                   :bigint           not null, primary key
+#  requested_docs_token :string
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  intake_id            :bigint
+#
+# Indexes
+#
+#  index_documents_requests_on_intake_id  (intake_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (intake_id => intakes.id)
+#
+class DocumentsRequest < ApplicationRecord
+  belongs_to :intake
+  has_many :documents
+
+  validates :intake, presence: true
+end

--- a/app/views/layouts/document_upload.html.erb
+++ b/app/views/layouts/document_upload.html.erb
@@ -28,7 +28,7 @@
                   </div>
                   <div class="doc-preview__info">
                     <h2 class="h3 doc-preview__filename"><%= document.upload.filename %></h2>
-                    <%= link_to(document_path(document), method: :delete, class: "link--delete", data: { confirm: "Are you sure you want to remove \"#{document.upload.filename}\"?" }) do %>
+                    <%= link_to(destroy_document_path(document), method: :delete, class: "link--delete", data: { confirm: "Are you sure you want to remove \"#{document.upload.filename}\"?" }) do %>
                       Remove
                     <% end %>
                   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,11 @@ Rails.application.routes.draw do
   end
 
   resources :dependents, only: [:index, :new, :create, :edit, :update, :destroy]
-  resources :documents, only: [:destroy]
+  resources :documents, only: [:destroy] do
+    member do
+      delete :destroy_requested
+    end
+  end
   resources :ajax_mixpanel_events, only: [:create]
 
   get "/:organization/drop-off", to: "intake_site_drop_offs#new", as: :new_drop_off

--- a/db/migrate/20200507202939_create_documents_request.rb
+++ b/db/migrate/20200507202939_create_documents_request.rb
@@ -1,0 +1,11 @@
+class CreateDocumentsRequest < ActiveRecord::Migration[6.0]
+  def change
+    create_table :documents_requests do |t|
+      t.string :requested_docs_token
+      t.belongs_to :intake, foreign_key: true
+      t.timestamps
+    end
+
+    add_reference :documents, :documents_request, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_06_005451) do
+ActiveRecord::Schema.define(version: 2020_05_07_202939) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,10 +72,20 @@ ActiveRecord::Schema.define(version: 2020_05_06_005451) do
   create_table "documents", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "document_type", null: false
+    t.bigint "documents_request_id"
     t.bigint "intake_id"
     t.datetime "updated_at", null: false
     t.bigint "zendesk_ticket_id"
+    t.index ["documents_request_id"], name: "index_documents_on_documents_request_id"
     t.index ["intake_id"], name: "index_documents_on_intake_id"
+  end
+
+  create_table "documents_requests", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.bigint "intake_id"
+    t.string "requested_docs_token"
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["intake_id"], name: "index_documents_requests_on_intake_id"
   end
 
   create_table "intake_site_drop_offs", force: :cascade do |t|
@@ -318,6 +328,8 @@ ActiveRecord::Schema.define(version: 2020_05_06_005451) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "documents", "documents_requests"
+  add_foreign_key "documents_requests", "intakes"
   add_foreign_key "intake_site_drop_offs", "intake_site_drop_offs", column: "prior_drop_off_id"
   add_foreign_key "intakes", "vita_partners"
   add_foreign_key "users", "intakes"

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -2,16 +2,22 @@
 #
 # Table name: documents
 #
-#  id                :bigint           not null, primary key
-#  document_type     :string           not null
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  intake_id         :bigint
-#  zendesk_ticket_id :bigint
+#  id                   :bigint           not null, primary key
+#  document_type        :string           not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  documents_request_id :bigint
+#  intake_id            :bigint
+#  zendesk_ticket_id    :bigint
 #
 # Indexes
 #
-#  index_documents_on_intake_id  (intake_id)
+#  index_documents_on_documents_request_id  (documents_request_id)
+#  index_documents_on_intake_id             (intake_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (documents_request_id => documents_requests.id)
 #
 
 FactoryBot.define do

--- a/spec/features/web_intake/requested_documents_token_spec.rb
+++ b/spec/features/web_intake/requested_documents_token_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Client uploads a requested document" do
 
     expect(page).to have_selector("h1", text: "Your tax specialist is requesting additional documents")
     expect(page).to have_button("Continue", disabled: true)
-    attach("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))
+    attach("requested_document_upload_form[document]", Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))
 
 
     expect(page).to have_content("test-pattern.png")
@@ -25,7 +25,7 @@ RSpec.feature "Client uploads a requested document" do
     expect(page).not_to have_content("test-pattern.png")
     expect(page).not_to have_link("Remove")
 
-    attach("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))
+    attach("requested_document_upload_form[document]", Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))
 
     expect(page).to have_content("test-pattern.png")
     expect(page).to have_link("Remove")
@@ -34,6 +34,16 @@ RSpec.feature "Client uploads a requested document" do
 
     expect(page).to have_text "Thank you! Your documents have been submitted."
     expect(page).to have_text "Your tax preparer will reach out with updates and any additional questions within 3 business days."
+  end
+
+  scenario "client goes to the follow up documents link and does not finish the requested docs flow" do
+    visit "/documents/add/1234ABCDEF"
+
+    expect(page).to have_selector("h1", text: "Your tax specialist is requesting additional documents")
+    expect(page).to have_button("Continue", disabled: true)
+
+    visit "/questions/job-count"
+    expect(current_path).to eq("/questions/feelings")
   end
 
   # TODO: remove this scenario when login is removed

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -2,16 +2,22 @@
 #
 # Table name: documents
 #
-#  id                :bigint           not null, primary key
-#  document_type     :string           not null
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  intake_id         :bigint
-#  zendesk_ticket_id :bigint
+#  id                   :bigint           not null, primary key
+#  document_type        :string           not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  documents_request_id :bigint
+#  intake_id            :bigint
+#  zendesk_ticket_id    :bigint
 #
 # Indexes
 #
-#  index_documents_on_intake_id  (intake_id)
+#  index_documents_on_documents_request_id  (documents_request_id)
+#  index_documents_on_intake_id             (intake_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (documents_request_id => documents_requests.id)
 #
 
 require "rails_helper"


### PR DESCRIPTION
In this PR, we explore the idea of creating a new type of model to stand in for the intake while we're uploading documents on the requested documents page. The `DocumentsRequest` model `has_many` documents and `belongs_to` an intake. This involved:
- changing the controller methods to handle `documents_request` instead of `intake`
- changing the form for same reason

One case that we thought about but didn't solve for was one where a user starts to upload requested docs, doesn't ever click continue, and later another user tries to upload requested docs on the same device. This may not be a concern, but is worth acknowledging.

Another thing to note is that we thought about making the `document` <-> `intake` and `document` <-> `documents_request` associations into one polymorphic association. We didn't go down that road but as a consequence had to make the intake association optional on document. Either one could work and we can discuss the tradeoffs.

Note: we forgot to save the `requested_docs_token` on the `DocumentsRequest` even though we added the column - it may not be necessary to do this

Co-authored-by: Jonathan Greenberg <jgreenberg@codeforamerica.org>