### PR TITLE
Changes content and tweaks styling for selfie pages

### DIFF
--- a/app/views/documents/selfie_instructions/edit.html.erb
+++ b/app/views/documents/selfie_instructions/edit.html.erb
@@ -6,7 +6,7 @@
       <div class="grid__item width-three-fourths shift-one-eighth">
         <main role="main">
           <h1 class="form-question">
-            Confirm your identity with a selfie
+            Confirm your identity with a photo of yourself
           </h1>
           <div class="text--centered with-padding-med">
             <%= image_tag("selfie-illustration.svg", alt: "") %>
@@ -19,12 +19,13 @@
           <div class="selfie-instructions-list with-padding-large">
             <div class="text--centered">
               <span class="emoji emoji--small emoji--star"></span>
-              <p class="text--bold">
-                Helpful tips for taking a selfie:
-              </p>
             </div>
 
-            <ul>
+            <p class="text--bold">
+              Read through the following steps before continuing
+            </p>
+
+            <ul class="list--bulleted">
               <li>Make sure your face is clearly visible</li>
               <li>Make sure you aren't covering up your ID</li>
               <li>Face the camera directly and include from your shoulders to the top of your head, similar to your ID photo</li>
@@ -33,11 +34,10 @@
             </ul>
           </div>
 
-
         </main>
         <div class="text--centered">
           <%= link_to selfies_documents_path, class: "button button--wide button--primary button--centered" do %>
-            Submit a selfie
+            Submit a photo
           <% end %>
         </div>
       </div>

--- a/app/views/documents/selfies/edit.html.erb
+++ b/app/views/documents/selfies/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :form_question, "Share a selfie with your ID card" %>
+<% content_for :form_question, "Share a photo of yourself holding your ID card" %>
 
 <% content_for :form_help_content do %>
   <p>
@@ -7,7 +7,7 @@
 
   <div class="text--bold">
     <p class="spacing-below-10">
-      We will need to see a selfie with ID for:
+      We will need to see a <u>photo with ID</u> for:
     </p>
 
     <ul class="list--bulleted spacing-above-0 spacing-below-35">

--- a/spec/features/web_intake/new_joint_filers_spec.rb
+++ b/spec/features/web_intake/new_joint_filers_spec.rb
@@ -309,10 +309,10 @@ RSpec.feature "Web Intake Joint Filers" do
     attach("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "attachments", "picture_id.jpg"))
     click_on "Continue"
 
-    expect(page).to have_selector("h1", text: "Confirm your identity with a selfie")
-    click_on "Submit a selfie"
+    expect(page).to have_selector("h1", text: "Confirm your identity with a photo of yourself")
+    click_on "Submit a photo"
 
-    expect(page).to have_selector("h1", text: "Share a selfie with your ID card")
+    expect(page).to have_selector("h1", text: "Share a photo of yourself holding your ID card")
     attach("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "attachments", "picture_id.jpg"))
     click_on "Continue"
 

--- a/spec/features/web_intake/new_single_filer_spec.rb
+++ b/spec/features/web_intake/new_single_filer_spec.rb
@@ -205,10 +205,10 @@ RSpec.feature "Web Intake Single Filer" do
     click_on "Upload"
     click_on "Continue"
 
-    expect(page).to have_selector("h1", text: "Confirm your identity with a selfie")
-    click_on "Submit a selfie"
+    expect(page).to have_selector("h1", text: "Confirm your identity with a photo of yourself")
+    click_on "Submit a photo"
 
-    expect(page).to have_selector("h1", text: "Share a selfie with your ID card")
+    expect(page).to have_selector("h1", text: "Share a photo of yourself holding your ID card")
     attach_file("document_type_upload_form_document", Rails.root.join("spec", "fixtures", "attachments", "picture_id.jpg"))
     click_on "Upload"
     click_on "Continue"


### PR DESCRIPTION
- Changes "selfies" to "photo of yourself" on instructions and upload page
- Removes centered text for "Helpful tips.." and makes list bulleted

(#172567615) Update selfie/ ID upload page to clarify requirements

![screencapture-localhost-3000-documents-selfie-instructions-1588952791043](https://user-images.githubusercontent.com/3073/81422970-c26b9480-9121-11ea-844e-43d459b281c4.png)
![screencapture-localhost-3000-documents-selfies-1588952943577](https://user-images.githubusercontent.com/3073/81423136-09f22080-9122-11ea-8ec4-00e5139b5b8e.png)
