### PR TITLE
appends '(Fake User)' to users created/searched in demo and staging

### DIFF
--- a/app/helpers/zendesk_service_helper.rb
+++ b/app/helpers/zendesk_service_helper.rb
@@ -63,7 +63,7 @@ module ZendeskServiceHelper
     end
 
     search_string = ""
-    search_string += "name:\"#{name}\" " if name.present?
+    search_string += "name:\"#{qualify_user_name(name)}\" " if name.present?
     search_string += "phone:#{phone}" if phone.present?
     results = search_zendesk_users(search_string)
     if exact_match
@@ -84,7 +84,7 @@ module ZendeskServiceHelper
   def create_end_user(name:, **attributes)
     # for a list of possible valid attributes, see:
     #   https://developer.zendesk.com/rest_api/docs/support/users#json-format-for-end-user-requests
-    client.users.create(name: name, verified: true, **attributes)
+    client.users.create(name: qualify_user_name(name), verified: true, **attributes)
   end
 
   def find_or_create_end_user(name, email, phone, exact_match: false, time_zone: nil)
@@ -96,6 +96,10 @@ module ZendeskServiceHelper
 
     result = create_end_user(name: name, email: email, phone: phone, time_zone: time_zone)
     result.id if result.present?
+  end
+
+  def qualify_user_name(name)
+    (Rails.env.demo? || Rails.env.staging?) ? "#{name} (Fake User)" : name
   end
 
   def build_ticket(subject:, requester_id:, group_id:, external_id: nil, body:, fields: {})

--- a/app/helpers/zendesk_service_helper.rb
+++ b/app/helpers/zendesk_service_helper.rb
@@ -98,8 +98,12 @@ module ZendeskServiceHelper
     result.id if result.present?
   end
 
+  def qualified_environments
+    %w[development demo staging]
+  end
+
   def qualify_user_name(name)
-    (Rails.env.demo? || Rails.env.staging?) ? "#{name} (Fake User)" : name
+    qualified_environments.include?(Rails.env) ? "#{name} (Fake User)" : name
   end
 
   def build_ticket(subject:, requester_id:, group_id:, external_id: nil, body:, fields: {})

--- a/spec/helpers/zendesk_service_helper_spec.rb
+++ b/spec/helpers/zendesk_service_helper_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe ZendeskServiceHelper do
 
     SampleService.new
   end
+  let(:qualified_environments) { service.qualified_environments }
+  let(:unqualified_environments) { %w[test production] }
 
   before do
     allow(ZendeskAPI::Client).to receive(:new).and_return fake_zendesk_client
@@ -124,8 +126,6 @@ RSpec.describe ZendeskServiceHelper do
     end
 
     context "in name-qualified environments" do
-      let(:qualified_environments) { %w[demo staging] }
-
       before do
         allow(service).to receive(:search_zendesk_users).with(include("(Fake User)")).and_return([])
       end
@@ -197,7 +197,6 @@ RSpec.describe ZendeskServiceHelper do
       end
 
       context "in a name-qualified environment" do
-        let(:qualified_environments) { %w[demo staging] }
         let(:fake_zendesk_user_list) { double("ZD Users") }
         let(:fake_zendesk_client) { double("ZD Client") }
         let(:name) { "Percy Plum" }
@@ -513,8 +512,6 @@ RSpec.describe ZendeskServiceHelper do
 
   describe "#qualify_user_name" do
     let(:name) { "Some Name" }
-    let(:qualified_environments) { %w[demo staging] }
-    let(:unqualified_environments) { %w[test production] }
 
     it "appends a qualifier in staging, demo environment" do
       qualified_environments.each do |e|

--- a/spec/support/with_environment.rb
+++ b/spec/support/with_environment.rb
@@ -1,0 +1,11 @@
+##
+# temporarily changes the Rails environment
+def with_environment(env_name)
+  prev = Rails.env
+  Rails.env = env_name
+
+  yield
+
+ensure
+  Rails.env = prev
+end


### PR DESCRIPTION
PT inception: https://www.pivotaltracker.com/story/show/172570012

- list of environments in ZendeskServiceHelper
- specs added for support function and environments
- helper method `with_environment` added to prevent duplication