### PR TITLE
Sends mixpanel event when TicketStatus created from Zendesk Webhook

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -80,13 +80,37 @@ class ApplicationController < ActionController::Base
     send_mixpanel_event(event_name: "validation_error", data: tracking_data)
   end
 
-  def send_mixpanel_event(event_name:, data: {}, intake: current_intake, user_data: true, unique_id: visitor_id)
+  def send_mixpanel_event(event_name:, data: {})
     return if user_agent.bot?
-    default_data = mixpanel_routing_data
-    default_data.merge!(mixpanel_user_data) if user_data
-    default_data.merge!(intake.mixpanel_data) if intake.present?
+    major_browser_version = user_agent.full_version.try { |v| v.partition('.').first }
+    default_data = {
+      source: source,
+      referrer: referrer,
+      utm_state: utm_state,
+      referrer_domain: URI.parse(referrer).host || "None",
+      full_user_agent: request.user_agent,
+      browser_name: user_agent.name,
+      browser_full_version: user_agent.full_version,
+      browser_major_version: major_browser_version,
+      os_name: user_agent.os_name,
+      os_full_version: user_agent.os_full_version,
+      os_major_version: user_agent.os_full_version.try { |v| v.partition('.').first },
+      is_bot: user_agent.bot?,
+      bot_name: user_agent.bot_name,
+      device_brand: user_agent.device_brand,
+      device_name: user_agent.device_name,
+      device_type: user_agent.device_type,
+      device_browser_version: "#{user_agent.os_name} #{user_agent.device_type} #{user_agent.name} #{major_browser_version}",
+      locale: I18n.locale.to_s,
+      path: request.path,
+      full_path: request.fullpath,
+      controller_name: self.class.name.sub("Controller", ""),
+      controller_action: "#{self.class.name}##{action_name}",
+      controller_action_name: action_name,
+    }
+    default_data.merge!(current_intake.mixpanel_data) if current_intake.present?
     MixpanelService.instance.run(
-      unique_id: unique_id,
+      unique_id: visitor_id,
       event_name: event_name,
       data: default_data.merge(data),
     )
@@ -118,43 +142,6 @@ class ApplicationController < ActionController::Base
   # redirect to the beginning of question navigation
   def require_ticket
     redirect_to_beginning_of_intake unless current_intake&.intake_ticket_id
-  end
-
-  def major_browser_version
-    user_agent.full_version.try { |v| v.partition('.').first }
-  end
-
-  def mixpanel_routing_data
-    {
-      path: request.path,
-      full_path: request.fullpath,
-      controller_name: self.class.name.sub("Controller", ""),
-      controller_action: "#{self.class.name}##{action_name}",
-      controller_action_name: action_name,
-    }
-  end
-
-  def mixpanel_user_data
-    {
-      source: source,
-      referrer: referrer,
-      utm_state: utm_state,
-      referrer_domain: URI.parse(referrer).host || "None",
-      full_user_agent: request.user_agent,
-      browser_name: user_agent.name,
-      browser_full_version: user_agent.full_version,
-      browser_major_version: major_browser_version,
-      os_name: user_agent.os_name,
-      os_full_version: user_agent.os_full_version,
-      os_major_version: user_agent.os_full_version.try { |v| v.partition('.').first },
-      is_bot: user_agent.bot?,
-      bot_name: user_agent.bot_name,
-      device_brand: user_agent.device_brand,
-      device_name: user_agent.device_name,
-      device_type: user_agent.device_type,
-      device_browser_version: "#{user_agent.os_name} #{user_agent.device_type} #{user_agent.name} #{major_browser_version}",
-      locale: I18n.locale.to_s,
-    }
   end
 
   def require_intake

--- a/app/controllers/zendesk_webhook_controller.rb
+++ b/app/controllers/zendesk_webhook_controller.rb
@@ -43,18 +43,22 @@ class ZendeskWebhookController < ApplicationController
       end
 
       if new_status.present?
-        send_mixpanel_event(
-          event_name: "ticket_status_change",
-          data: new_status.mixpanel_data,
-          user_data: false,
-          intake: intake,
-          unique_id: intake.visitor_id
-        )
+        new_status.send_mixpanel_event(mixpanel_routing_data)
       end
     end
   end
 
   private
+
+  def mixpanel_routing_data
+    {
+      path: request.path,
+      full_path: request.fullpath,
+      controller_name: self.class.name.sub("Controller", ""),
+      controller_action: "#{self.class.name}##{action_name}",
+      controller_action_name: action_name,
+    }
+  end
 
   def intakes_for_ticket
     @intakes_for_ticket ||= Intake.where(intake_ticket_id: json_payload[:ticket_id])

--- a/app/helpers/eitc_zendesk_instance.rb
+++ b/app/helpers/eitc_zendesk_instance.rb
@@ -82,6 +82,7 @@ class EitcZendeskInstance
   INTAKE_SOURCE = "360040933734"
 
   # Digital Intake Status value tags
+  INTAKE_STATUS_UNSTARTED = ""
   INTAKE_STATUS_IN_PROGRESS = "1._new_online_submission"
   INTAKE_STATUS_GATHERING_DOCUMENTS = "online_intake_gathering_documents"
   INTAKE_STATUS_READY_FOR_REVIEW = "online_intake_ready_for_review"
@@ -90,6 +91,18 @@ class EitcZendeskInstance
   INTAKE_STATUS_WAITING_FOR_INFO = "online_intake_waiting_for_info"
   INTAKE_STATUS_COMPLETE = "3._ready_for_prep"
   INTAKE_STATUS_NOT_FILING = "online_intake_not_filing"
+
+  INTAKE_STATUS_LABELS = {
+    INTAKE_STATUS_UNSTARTED => "Unstarted",
+    INTAKE_STATUS_IN_PROGRESS => "Online Submission",
+    INTAKE_STATUS_GATHERING_DOCUMENTS => "Gathering Documents",
+    INTAKE_STATUS_READY_FOR_REVIEW => "Ready For Review",
+    INTAKE_STATUS_IN_REVIEW => "In Review",
+    INTAKE_STATUS_READY_FOR_INTAKE_INTERVIEW => "Readu For Intake Interview",
+    INTAKE_STATUS_WAITING_FOR_INFO => "Waiting For Info",
+    INTAKE_STATUS_COMPLETE => "Complete",
+    INTAKE_STATUS_NOT_FILING => "Not Filing",
+}
 
   # Zendesk Ticket Return Statuses
   RETURN_STATUS_UNSTARTED = ""
@@ -101,6 +114,18 @@ class EitcZendeskInstance
   RETURN_STATUS_COMPLETED_RETURNS = "5._completed_returns"
   RETURN_STATUS_DO_NOT_FILE = "6._do_not_file"
   RETURN_STATUS_FOREIGN_STUDENT = "7._foreign_student"
+
+  RETURN_STATUS_LABELS = {
+    RETURN_STATUS_UNSTARTED => "Unstarted",
+    RETURN_STATUS_IN_PROGRESS => "In Progress",
+    RETURN_STATUS_READY_FOR_QUALITY_REVIEW => "Ready For Quality Review",
+    RETURN_STATUS_READY_FOR_SIGNATURE_ESIGN => "Ready For Signaure ESign",
+    RETURN_STATUS_READY_FOR_SIGNATURE_PICKUP	=> "Ready For Signature Pick-Up",
+    RETURN_STATUS_READY_FOR_EFILE => "Ready For E-File",
+    RETURN_STATUS_COMPLETED_RETURNS => "Completed Returns",
+    RETURN_STATUS_DO_NOT_FILE => "Do Not File",
+    RETURN_STATUS_FOREIGN_STUDENT => "Foreign Student",
+  }
 
   # partner group ids for drop offs
   TAX_HELP_COLORADO = "360007047214"

--- a/app/models/ticket_status.rb
+++ b/app/models/ticket_status.rb
@@ -30,9 +30,28 @@ class TicketStatus < ApplicationRecord
     {
       verified_change: verified_change,
       ticket_id: ticket_id,
-      intake_status: intake_status,
-      return_status: return_status,
+      intake_status: intake_status_label,
+      return_status: return_status_label,
       created_at: created_at.utc.iso8601,
     }
+  end
+
+  def send_mixpanel_event(context = {})
+    data = context.merge(intake.mixpanel_data).merge(mixpanel_data)
+    MixpanelService.instance.run(
+      unique_id: intake.visitor_id,
+      event_name: "ticket_status_change",
+      data: data
+    )
+  end
+
+  private
+
+  def intake_status_label
+    EitcZendeskInstance::INTAKE_STATUS_LABELS[intake_status]
+  end
+
+  def return_status_label
+    EitcZendeskInstance::RETURN_STATUS_LABELS[return_status]
   end
 end

--- a/app/models/ticket_status.rb
+++ b/app/models/ticket_status.rb
@@ -25,4 +25,14 @@ class TicketStatus < ApplicationRecord
   def status_changed?(intake_status:, return_status:)
     self.intake_status != intake_status || self.return_status != return_status
   end
+
+  def mixpanel_data
+    {
+      verified_change: verified_change,
+      ticket_id: ticket_id,
+      intake_status: intake_status,
+      return_status: return_status,
+      created_at: created_at.utc.iso8601,
+    }
+  end
 end

--- a/app/services/zendesk_intake_service.rb
+++ b/app/services/zendesk_intake_service.rb
@@ -75,12 +75,13 @@ class ZendeskIntakeService
         body: new_ticket_body,
         fields: new_ticket_fields
       )
-      @intake.ticket_statuses.create(
+      ticket_status = @intake.ticket_statuses.create(
         intake_status: EitcZendeskInstance::INTAKE_STATUS_IN_PROGRESS,
         return_status: EitcZendeskInstance::RETURN_STATUS_UNSTARTED,
         ticket_id: ticket_id
       )
       @intake.update(intake_ticket_id: ticket_id)
+      ticket_status.send_mixpanel_event
       ticket_id
     end
   end

--- a/spec/controllers/zendesk_webhook_controller_spec.rb
+++ b/spec/controllers/zendesk_webhook_controller_spec.rb
@@ -124,7 +124,6 @@ RSpec.describe ZendeskWebhookController, type: :controller do
         it "sends a mixpanel event with ticket status data and without default user data" do
           mixpanel_spy = spy(MixpanelService)
           allow(MixpanelService).to receive(:instance).and_return(mixpanel_spy)
-          expect(subject).to receive(:send_mixpanel_event).and_call_original
           post :incoming, params: params
 
           expected_mixpanel_data = {

--- a/spec/models/ticket_status_spec.rb
+++ b/spec/models/ticket_status_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe TicketStatus, type: :model do
       expect(ticket_status.mixpanel_data).to eq({
         verified_change: true,
         ticket_id: ticket_status.intake.intake_ticket_id,
-        intake_status: EitcZendeskInstance::INTAKE_STATUS_IN_REVIEW,
-        return_status: EitcZendeskInstance::RETURN_STATUS_IN_PROGRESS,
+        intake_status: "In Review",
+        return_status: "In Progress",
         created_at: ticket_status.created_at.utc.iso8601
       })
     end

--- a/spec/models/ticket_status_spec.rb
+++ b/spec/models/ticket_status_spec.rb
@@ -49,4 +49,22 @@ RSpec.describe TicketStatus, type: :model do
       )).to be false
     end
   end
+
+  describe "#mixpanel_data" do
+    let(:ticket_status) do
+      create(:ticket_status,
+        intake_status: EitcZendeskInstance::INTAKE_STATUS_IN_REVIEW,
+        return_status: EitcZendeskInstance::RETURN_STATUS_IN_PROGRESS)
+    end
+
+    it "returns the expected hash" do
+      expect(ticket_status.mixpanel_data).to eq({
+        verified_change: true,
+        ticket_id: ticket_status.intake.intake_ticket_id,
+        intake_status: EitcZendeskInstance::INTAKE_STATUS_IN_REVIEW,
+        return_status: EitcZendeskInstance::RETURN_STATUS_IN_PROGRESS,
+        created_at: ticket_status.created_at.utc.iso8601
+      })
+    end
+  end
 end

--- a/spec/services/zendesk_intake_service_spec.rb
+++ b/spec/services/zendesk_intake_service_spec.rb
@@ -163,6 +163,7 @@ describe ZendeskIntakeService do
     context "in a state for the EITC Zendesk instance" do
       let(:state) { "co" }
       let!(:vita_partner) { create :vita_partner, zendesk_group_id: EitcZendeskInstance::ONLINE_INTAKE_THC }
+      let(:ticket_status) { intake.current_ticket_status }
 
       it "calls create_ticket with the right arguments" do
         result = service.create_intake_ticket
@@ -192,12 +193,23 @@ describe ZendeskIntakeService do
 
       it "creates the initial TicketStatus for the intake" do
         service.create_intake_ticket
-        ticket_status = intake.current_ticket_status
         expect(ticket_status).to be_present
         expect(ticket_status.intake_status).to eq(EitcZendeskInstance::INTAKE_STATUS_IN_PROGRESS)
         expect(ticket_status.return_status).to eq(EitcZendeskInstance::RETURN_STATUS_UNSTARTED)
         expect(ticket_status.verified_change).to eq(true)
         expect(ticket_status.ticket_id).to eq(101)
+      end
+
+      it "sends a mixpanel event" do
+        mixpanel_spy = spy(MixpanelService)
+        allow(MixpanelService).to receive(:instance).and_return(mixpanel_spy)
+        service.create_intake_ticket
+
+        expect(mixpanel_spy).to have_received(:run).with(
+          unique_id: intake.visitor_id,
+          event_name: "ticket_status_change",
+          data: intake.mixpanel_data.merge(ticket_status.mixpanel_data)
+        )
       end
     end
 
@@ -375,7 +387,7 @@ describe ZendeskIntakeService do
 
       expected_comment = <<~COMMENT
         Preliminary 13614-C questions answered.
-  
+
         Primary filer (and spouse, if applicable) consent form attached.
       COMMENT
       expect(result).to eq true
@@ -519,7 +531,7 @@ describe ZendeskIntakeService do
           Online intake form submitted and ready for review. The taxpayer was notified that their information has been submitted. (automated_notification_submit_confirmation)
 
           Client's provided interview preferences: Monday evenings and Wednesday mornings
-          
+
           Additional information from Client: I want my money
         BODY
         expect(service).to have_received(:append_file_to_ticket).with(


### PR DESCRIPTION
- changes signature of ApplicationController.send_mixpanel_event to
allow bypassing sending of user request data and explicitly specify
intake and visitor_id

(#172635778) Send return and digital intake status from Zendesk to
mixpanel