### PR TITLE
Replaces anonymous intakes with DocumentsRequests

### DIFF
--- a/app/controllers/documents/document_upload_question_controller.rb
+++ b/app/controllers/documents/document_upload_question_controller.rb
@@ -4,6 +4,7 @@ module Documents
 
     delegate :document_type, to: :class
     helper_method :document_type
+    helper_method :destroy_document_path
 
     def edit
       return if self.class.document_type.nil?
@@ -26,6 +27,10 @@ module Documents
     end
 
     private
+
+    def destroy_document_path(document)
+      document_path(document)
+    end
 
     def form_name
       "document_type_upload_form"

--- a/app/forms/requested_document_upload_form.rb
+++ b/app/forms/requested_document_upload_form.rb
@@ -1,0 +1,16 @@
+class RequestedDocumentUploadForm < QuestionsForm
+  set_attributes_for :documents_request, :document
+
+  def initialize(documents_request, *args, **kwargs)
+    @documents_request = documents_request
+    super(nil, *args, **kwargs)
+  end
+
+  def save
+    document_file_upload = attributes_for(:documents_request)[:document]
+    if document_file_upload.present?
+      document = @documents_request.documents.create(document_type: "Requested Later")
+      document.upload.attach(document_file_upload)
+    end
+  end
+end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -2,24 +2,31 @@
 #
 # Table name: documents
 #
-#  id                :bigint           not null, primary key
-#  document_type     :string           not null
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  intake_id         :bigint
-#  zendesk_ticket_id :bigint
+#  id                   :bigint           not null, primary key
+#  document_type        :string           not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  documents_request_id :bigint
+#  intake_id            :bigint
+#  zendesk_ticket_id    :bigint
 #
 # Indexes
 #
-#  index_documents_on_intake_id  (intake_id)
+#  index_documents_on_documents_request_id  (documents_request_id)
+#  index_documents_on_intake_id             (intake_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (documents_request_id => documents_requests.id)
 #
 
 class Document < ApplicationRecord
   validates :document_type, inclusion: { in: DocumentNavigation::DOCUMENT_TYPES }
-  validates :intake, presence: true
+  validates :intake, presence: { unless: :documents_request_id }
 
   scope :of_type, ->(type) { where(document_type: type) }
 
-  belongs_to :intake
+  belongs_to :intake, optional: true
+  belongs_to :documents_request, optional: true
   has_one_attached :upload
 end

--- a/app/models/documents_request.rb
+++ b/app/models/documents_request.rb
@@ -1,0 +1,6 @@
+class DocumentsRequest < ApplicationRecord
+  belongs_to :intake
+  has_many :documents
+
+  validates :intake, presence: true
+end

--- a/app/views/layouts/document_upload.html.erb
+++ b/app/views/layouts/document_upload.html.erb
@@ -28,7 +28,7 @@
                   </div>
                   <div class="doc-preview__info">
                     <h2 class="h3 doc-preview__filename"><%= document.upload.filename %></h2>
-                    <%= link_to(document_path(document), method: :delete, class: "link--delete", data: { confirm: "Are you sure you want to remove \"#{document.upload.filename}\"?" }) do %>
+                    <%= link_to(destroy_document_path(document), method: :delete, class: "link--delete", data: { confirm: "Are you sure you want to remove \"#{document.upload.filename}\"?" }) do %>
                       Remove
                     <% end %>
                   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Rails.application.routes.draw do
     end
   end
   namespace :documents do
+    delete "/requested-documents-later/remove", to: "requested_documents_later#destroy", as: :remove_requested_document
     get "/requested-documents-later/not-found", to: "requested_documents_later#not_found", as: :requested_docs_not_found
     get "/add/success", to: "send_requested_documents_later#success", as: :requested_documents_success
     get "/add/:token", to: "requested_documents_later#edit", as: :add_requested_documents

--- a/db/migrate/20200513160951_create_documents_request.rb
+++ b/db/migrate/20200513160951_create_documents_request.rb
@@ -1,0 +1,10 @@
+class CreateDocumentsRequest < ActiveRecord::Migration[6.0]
+  def change
+    create_table :documents_requests do |t|
+      t.belongs_to :intake, foreign_key: true
+      t.timestamps
+    end
+
+    add_reference :documents, :documents_request, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_12_205301) do
+ActiveRecord::Schema.define(version: 2020_05_13_160951) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,10 +72,19 @@ ActiveRecord::Schema.define(version: 2020_05_12_205301) do
   create_table "documents", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "document_type", null: false
+    t.bigint "documents_request_id"
     t.bigint "intake_id"
     t.datetime "updated_at", null: false
     t.bigint "zendesk_ticket_id"
+    t.index ["documents_request_id"], name: "index_documents_on_documents_request_id"
     t.index ["intake_id"], name: "index_documents_on_intake_id"
+  end
+
+  create_table "documents_requests", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.bigint "intake_id"
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["intake_id"], name: "index_documents_requests_on_intake_id"
   end
 
   create_table "intake_site_drop_offs", force: :cascade do |t|
@@ -329,6 +338,8 @@ ActiveRecord::Schema.define(version: 2020_05_12_205301) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "documents", "documents_requests"
+  add_foreign_key "documents_requests", "intakes"
   add_foreign_key "intake_site_drop_offs", "intake_site_drop_offs", column: "prior_drop_off_id"
   add_foreign_key "intakes", "vita_partners"
   add_foreign_key "ticket_statuses", "intakes"

--- a/spec/controllers/documents/send_requested_documents_later_controller_spec.rb
+++ b/spec/controllers/documents/send_requested_documents_later_controller_spec.rb
@@ -3,15 +3,14 @@ require "rails_helper"
 RSpec.describe Documents::SendRequestedDocumentsLaterController, type: :controller do
   render_views
   let!(:original_intake) { create :intake, intake_ticket_id: 123, created_at: 3.days.ago }
-  let!(:anonymous_intake) { create :anonymous_intake, intake_ticket_id: 123, created_at: 5.minutes.ago }
+  let!(:documents_request) { create :documents_request, intake: original_intake }
 
   describe "#edit" do
-    context "when the session is anonymous" do
-      let!(:document) { create :document, :with_upload, document_type: "Requested Later", intake: anonymous_intake }
+    context "with a documents request in the session" do
+      let!(:document) { create :document, :with_upload, document_type: "Requested Later", documents_request: documents_request }
 
       before do
-        session[:intake_id] = anonymous_intake.id
-        session[:anonymous_session] = true
+        session[:documents_request_id] = documents_request.id
       end
 
       it "adds the document upload job to the queue" do
@@ -26,46 +25,18 @@ RSpec.describe Documents::SendRequestedDocumentsLaterController, type: :controll
 
         expect(original_intake.reload.documents).to include(document)
       end
+    end
+  end
 
-      it "sets anonymous_session to false" do
-        get :edit
-
-        expect(session[:anonymous_session]).to eq false
-      end
-
-      it "destroys the anonymous intake" do
-        expect {
-          get :edit
-        }.to change(Intake, :count).by(-1)
-      end
+  describe "#success" do
+    before do
+      session[:documents_request_id] = documents_request.id
     end
 
-    context "when the session is NOT anonymous" do
-      let!(:document) { create :document, :with_upload, document_type: "Requested Later", intake: original_intake }
+    it "clears the session" do
+      get :success
 
-      before do
-        session[:intake_id] = original_intake.id
-        session[:anonymous_session] = false
-      end
-
-      it "adds the document upload job to the queue" do
-        get :edit
-
-        expect(SendRequestedDocumentsToZendeskJob).to have_been_enqueued.with(original_intake.id)
-        expect(response).to redirect_to documents_requested_documents_success_path
-      end
-
-      it "does not duplicate documents" do
-        get :edit
-
-        expect(original_intake.reload.documents.count).to eq 1
-      end
-
-      it "does NOT destroy the intake on the session" do
-        expect {
-          get :edit
-        }.not_to change(Intake, :count)
-      end
+      expect(session[:documents_request_id]).to be_nil
     end
   end
 end

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -2,16 +2,22 @@
 #
 # Table name: documents
 #
-#  id                :bigint           not null, primary key
-#  document_type     :string           not null
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  intake_id         :bigint
-#  zendesk_ticket_id :bigint
+#  id                   :bigint           not null, primary key
+#  document_type        :string           not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  documents_request_id :bigint
+#  intake_id            :bigint
+#  zendesk_ticket_id    :bigint
 #
 # Indexes
 #
-#  index_documents_on_intake_id  (intake_id)
+#  index_documents_on_documents_request_id  (documents_request_id)
+#  index_documents_on_intake_id             (intake_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (documents_request_id => documents_requests.id)
 #
 
 FactoryBot.define do

--- a/spec/factories/documents_requests.rb
+++ b/spec/factories/documents_requests.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :documents_request do
+    intake
+  end
+end

--- a/spec/features/web_intake/requested_documents_token_spec.rb
+++ b/spec/features/web_intake/requested_documents_token_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Client uploads a requested document" do
 
     expect(page).to have_selector("h1", text: "Your tax specialist is requesting additional documents")
     expect(page).to have_button("Continue", disabled: true)
-    attach("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))
+    attach("requested_document_upload_form[document]", Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))
 
 
     expect(page).to have_content("test-pattern.png")
@@ -25,7 +25,7 @@ RSpec.feature "Client uploads a requested document" do
     expect(page).not_to have_content("test-pattern.png")
     expect(page).not_to have_link("Remove")
 
-    attach("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))
+    attach("requested_document_upload_form[document]", Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))
 
     expect(page).to have_content("test-pattern.png")
     expect(page).to have_link("Remove")
@@ -36,59 +36,13 @@ RSpec.feature "Client uploads a requested document" do
     expect(page).to have_text "Your tax preparer will reach out with updates and any additional questions within 3 business days."
   end
 
-  # TODO: remove this scenario when login is removed
-  xscenario "client goes to the follow up documents token link while logged in", :js do
-    silence_omniauth_logging do
-      visit "/documents/requested-documents"
-    end
-    expect(page).to have_selector("h1", text: "First, let’s get some basic information.")
-    OmniAuth.config.mock_auth[:idme] = omniauth_idme_success
-    click_on "Sign in with ID.me"
-
-    # Upload a follow up document using logged-in flow
-    visit "/documents/requested-documents"
-
-    expect(page).to have_selector("h1", text: "Your tax specialist is requesting additional documents")
-    attach("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))
-
-    expect(page).to have_content("test-pattern.png")
-    expect(page).to have_link("Remove")
-
-    click_on "I'm done for now"
-
-    expect(page).to have_text "Thank you! Your documents have been submitted."
-    expect(page).to have_text "Your tax preparer will reach out with updates and any additional questions within 3 business days."
-
-    # Visit token-based upload page
+  scenario "client goes to the follow up documents link and does not finish the requested docs flow" do
     visit "/documents/add/1234ABCDEF"
 
     expect(page).to have_selector("h1", text: "Your tax specialist is requesting additional documents")
+    expect(page).to have_button("Continue", disabled: true)
 
-    # Check that doc uploaded with non-token flow is not shown
-    expect(page).not_to have_selector("h2", text: "test-pattern.png")
-
-    # Check that file can be added
-    attach("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))
-
-    expect(page).to have_selector("h2", text: "test-pattern.png", count: 1)
-
-    click_on "I'm done for now"
-
-    # Visit token-based upload page again
-    visit "/documents/add/1234ABCDEF"
-
-    # Check that doc uploaded with token flow while logged in IS shown if still logged in
-    expect(page).to have_selector("h2", text: "test-pattern.png", count: 1)
-    expect(page).to have_link("Remove")
-
-    # Check that another file can be added
-    attach("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))
-
-    expect(page).to have_selector("h2", text: "test-pattern.png", count: 2)
-
-    click_on "I'm done for now"
-
-    expect(page).to have_text "Thank you! Your documents have been submitted."
-    expect(page).to have_text "Your tax preparer will reach out with updates and any additional questions within 3 business days."
+    visit "/questions/job-count"
+    expect(current_path).to eq("/questions/feelings")
   end
 end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -2,16 +2,22 @@
 #
 # Table name: documents
 #
-#  id                :bigint           not null, primary key
-#  document_type     :string           not null
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  intake_id         :bigint
-#  zendesk_ticket_id :bigint
+#  id                   :bigint           not null, primary key
+#  document_type        :string           not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  documents_request_id :bigint
+#  intake_id            :bigint
+#  zendesk_ticket_id    :bigint
 #
 # Indexes
 #
-#  index_documents_on_intake_id  (intake_id)
+#  index_documents_on_documents_request_id  (documents_request_id)
+#  index_documents_on_intake_id             (intake_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (documents_request_id => documents_requests.id)
 #
 
 require "rails_helper"


### PR DESCRIPTION
- requested docs flow now creates DocumentsRequest to attach uploaded docs to
- adds feature spec to ensure no session jumping with anonymous intakes

Co-authored-by: Molly T-M <mollyt@codeforamerica.org>