### PR TITLE
add GA on successfully submitted page so we can track conversions

### DIFF
--- a/app/controllers/questions/successfully_submitted_controller.rb
+++ b/app/controllers/questions/successfully_submitted_controller.rb
@@ -5,5 +5,9 @@ module Questions
 
     def edit
     end
+
+    def include_google_analytics?
+      true
+    end
   end
 end

--- a/spec/controllers/questions/successfully_submitted_controller_spec.rb
+++ b/spec/controllers/questions/successfully_submitted_controller_spec.rb
@@ -3,6 +3,12 @@ require 'rails_helper'
 RSpec.describe Questions::SuccessfullySubmittedController, type: :controller do
   render_views
 
+  describe "#include_google_analytics?" do
+    it "returns true" do
+      expect(subject.include_google_analytics?).to eq true
+    end
+  end
+
   describe "#edit" do
     let(:intake) { create :intake, intake_ticket_id: 1234 }
 


### PR DESCRIPTION
i assume GA is not included everywhere for privacy reasons, but i think there's nothing to fear exposing on this page and we need this to be tracked in GA if we ever want to run ads and optimize for conversions.