### PR TITLE
Fix Datadog warnings when the app loads

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem 'activerecord-postgis-adapter'
 gem 'will_paginate'
 gem 'sentry-raven'
 gem 'pdf-forms'
-gem 'aws-sdk-s3', require: false
+gem 'aws-sdk-s3'
 gem 'device_detector'
 gem 'mixpanel-ruby'
 gem 'devise'

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -3,7 +3,6 @@ Datadog.configure do |c|
   c.env = Rails.env
   c.use :rails
   c.use :aws
-  c.use :sequel
   c.use :delayed_job
   c.tracer.enabled = Rails.env.staging? || Rails.env.demo? || Rails.env.production?
   c.tracer hostname: Rails.application.credentials.dig(Rails.env.to_sym, :datadog_agent_host)


### PR DESCRIPTION
* We don't use Sequel (it's an alternate ORM to ActiveRecord)
* We do use AWS, but don't load it by default. So let's load it by
  default so datadog can instrument it.