### PR TITLE
Adds source, referrer, visitor_id to diy_intake

### DIFF
--- a/app/controllers/diy/diy_controller.rb
+++ b/app/controllers/diy/diy_controller.rb
@@ -10,8 +10,8 @@ module Diy
 
     layout "question"
 
-    def current_diy_intake
-      DiyIntake.find_by_id(session[:diy_intake_id])
+    def visitor_record
+      current_diy_intake
     end
 
     def edit

--- a/app/controllers/diy/personal_info_controller.rb
+++ b/app/controllers/diy/personal_info_controller.rb
@@ -17,5 +17,12 @@ module Diy
     def after_update_success
       session[:diy_intake_id] = @form.diy_intake.id
     end
+
+    def form_params
+      super.merge(
+        source: current_diy_intake.source || source,
+        referrer: current_diy_intake.referrer || referrer,
+      )
+    end
   end
 end

--- a/app/forms/diy_personal_info_form.rb
+++ b/app/forms/diy_personal_info_form.rb
@@ -1,5 +1,5 @@
 class DiyPersonalInfoForm < DiyForm
-  set_attributes_for :diy_intake, :state_of_residence, :preferred_name
+  set_attributes_for :diy_intake, :state_of_residence, :preferred_name, :source, :referrer
 
   validates :state_of_residence, inclusion: { in: States.keys, message: "Please select a state from the list." }
   validates :preferred_name, presence: { message: "Please enter your preferred name." }

--- a/app/models/diy_intake.rb
+++ b/app/models/diy_intake.rb
@@ -5,12 +5,15 @@
 #  id                 :bigint           not null, primary key
 #  email_address      :string
 #  preferred_name     :string
+#  referrer           :string
+#  source             :string
 #  state_of_residence :string
 #  token              :string
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  requester_id       :bigint
 #  ticket_id          :bigint
+#  visitor_id         :string
 #
 # Indexes
 #

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -411,7 +411,7 @@ class Intake < ApplicationRecord
         had_dependents_under_6: dependents_under_6 ? "yes" : "no",
         filing_joint: filing_joint,
         had_earned_income: had_earned_income ? "yes" : "no",
-        state: state,
+        state: state_of_residence,
         zip_code: zip_code,
         needs_help_2019: needs_help_2019,
         needs_help_2018: needs_help_2018,

--- a/db/migrate/20200526164047_add_columns_to_diy_intake.rb
+++ b/db/migrate/20200526164047_add_columns_to_diy_intake.rb
@@ -1,0 +1,7 @@
+class AddColumnsToDiyIntake < ActiveRecord::Migration[6.0]
+  def change
+    add_column :diy_intakes, :visitor_id, :string
+    add_column :diy_intakes, :source, :string
+    add_column :diy_intakes, :referrer, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_22_093842) do
+ActiveRecord::Schema.define(version: 2020_05_26_164047) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,11 +73,14 @@ ActiveRecord::Schema.define(version: 2020_05_22_093842) do
     t.datetime "created_at", precision: 6, null: false
     t.string "email_address"
     t.string "preferred_name"
+    t.string "referrer"
     t.bigint "requester_id"
+    t.string "source"
     t.string "state_of_residence"
     t.bigint "ticket_id"
     t.string "token"
     t.datetime "updated_at", precision: 6, null: false
+    t.string "visitor_id"
     t.index ["token"], name: "index_diy_intakes_on_token", unique: true
   end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -457,9 +457,11 @@ RSpec.describe ApplicationController do
 
     let(:fake_payload) { {} }
     let(:intake) { nil }
+    let(:diy_intake) { nil }
 
     before do
       allow(controller).to receive(:current_intake).and_return(intake)
+      allow(controller).to receive(:current_diy_intake).and_return(diy_intake)
     end
 
     context "for any user" do
@@ -475,6 +477,15 @@ RSpec.describe ApplicationController do
       it "includes an intake_id" do
         controller.append_info_to_payload(fake_payload)
         expect(fake_payload).to include(request_details: include(intake_id: intake.id))
+      end
+    end
+
+    context "for a user with a diy intake" do
+      let(:diy_intake) { create(:diy_intake) }
+
+      it "includes an diy_intake_id" do
+        controller.append_info_to_payload(fake_payload)
+        expect(fake_payload).to include(request_details: include(diy_intake_id: diy_intake.id))
       end
     end
   end

--- a/spec/controllers/diy/email_address_controller_spec.rb
+++ b/spec/controllers/diy/email_address_controller_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe Diy::EmailAddressController do
       get :edit
       expect(response).to be_successful
     end
+
+    it "sets a new visitor_id on the diy intake" do
+      get :edit
+
+      expect(diy_intake.visitor_id).to be_present
+    end
   end
 
 

--- a/spec/controllers/diy/personal_info_controller_spec.rb
+++ b/spec/controllers/diy/personal_info_controller_spec.rb
@@ -4,6 +4,11 @@ RSpec.describe Diy::PersonalInfoController do
   render_views
 
   describe "#update" do
+    before do
+      session[:source] = "source_from_session"
+      session[:referrer] = "referrer_from_session"
+    end
+
     context "with valid params" do
       let(:params) do
         {
@@ -22,6 +27,8 @@ RSpec.describe Diy::PersonalInfoController do
         diy_intake = DiyIntake.last
         expect(diy_intake.state_of_residence).to eq "CO"
         expect(diy_intake.preferred_name).to eq "Shep"
+        expect(diy_intake.source).to eq "source_from_session"
+        expect(diy_intake.referrer).to eq "referrer_from_session"
       end
     end
   end

--- a/spec/factories/diy_intakes.rb
+++ b/spec/factories/diy_intakes.rb
@@ -5,12 +5,15 @@
 #  id                 :bigint           not null, primary key
 #  email_address      :string
 #  preferred_name     :string
+#  referrer           :string
+#  source             :string
 #  state_of_residence :string
 #  token              :string
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  requester_id       :bigint
 #  ticket_id          :bigint
+#  visitor_id         :string
 #
 # Indexes
 #

--- a/spec/models/diy_intake_spec.rb
+++ b/spec/models/diy_intake_spec.rb
@@ -5,12 +5,15 @@
 #  id                 :bigint           not null, primary key
 #  email_address      :string
 #  preferred_name     :string
+#  referrer           :string
+#  source             :string
 #  state_of_residence :string
 #  token              :string
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  requester_id       :bigint
 #  ticket_id          :bigint
+#  visitor_id         :string
 #
 # Indexes
 #

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -561,7 +561,6 @@ describe Intake do
         referrer: "http://boop.horse/mane",
         filing_joint: "no",
         had_wages: "yes",
-        state: state_of_residence,
         state_of_residence: state_of_residence,
         zip_code: "94609",
         intake_ticket_id: 9876,


### PR DESCRIPTION
- fixes state tracking on intake to read from state_of_residence
- adds diy_intake_id to request_details for logs

[#173016392] Track request info on DIY intake and DIY intake id on request details
Co-authored-by: Jonathan Greenberg <jgreenberg@codeforamerica.org>