### PR TITLE
Cron job for unsent docs #173063073

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:2.6.5
 
 # System prerequisites
 RUN apt-get update \
- && apt-get -y install build-essential libpq-dev pdftk ghostscript poppler-utils \
+ && apt-get -y install build-essential libpq-dev pdftk ghostscript poppler-utils curl \
  && rm -rf /var/lib/apt/lists/*
 
 # If you require additional OS dependencies, install them here:
@@ -10,12 +10,23 @@ RUN apt-get update \
 #  && apt-get -y install imagemagick nodejs \
 #  && rm -rf /var/lib/apt/lists/*
 
+ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.9/supercronic-linux-amd64 \
+    SUPERCRONIC=supercronic-linux-amd64 \
+    SUPERCRONIC_SHA1SUM=5ddf8ea26b56d4a7ff6faecdd8966610d5cb9d85
+
+RUN curl -fsSLO "$SUPERCRONIC_URL" \
+ && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
+ && chmod +x "$SUPERCRONIC" \
+ && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
+ && ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic
+
 ADD Gemfile /app/
 ADD Gemfile.lock /app/
 WORKDIR /app
 RUN bundle install
 
 ADD . /app
+ADD crontab /app/crontab
 
 # Collect assets. This approach is not fully production-ready, but
 # will help you experiment with Aptible Deploy before bothering with assets.

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 cmd: bundle exec rails s -b 0.0.0.0 -p 3000
 worker: bundle exec rails jobs:work
+cron: exec supercronic /app/crontab

--- a/app/services/unsent_documents_service.rb
+++ b/app/services/unsent_documents_service.rb
@@ -1,5 +1,3 @@
-
-
 class UnsentDocumentsService
   include ZendeskServiceHelper
   include Rails.application.routes.url_helpers
@@ -9,6 +7,7 @@ class UnsentDocumentsService
   end
 
   def detect_unsent_docs_and_notify
+    tickets_updated = 0
     Intake.where.not(intake_ticket_id: nil).find_each(batch_size: 100) do |intake|
       unsent_docs = intake.documents.where(zendesk_ticket_id: nil).where("created_at < ?", 15.minutes.ago)
       if unsent_docs.present?
@@ -23,7 +22,11 @@ class UnsentDocumentsService
           comment: comment_body
         )
         unsent_docs.each {|d| d.update(zendesk_ticket_id: intake.intake_ticket_id)}
+        tickets_updated += 1
+        DatadogApi.gauge("zendesk.ticket.docs.unsent.ticket_updated.document_count", unsent_docs.length)
       end
     end
+    DatadogApi.gauge("zendesk.ticket.docs.unsent.tickets_updated", tickets_updated)
+    DatadogApi.increment("cronjob.documents.unsent.detect_and_notify")
   end
 end

--- a/app/services/unsent_documents_service.rb
+++ b/app/services/unsent_documents_service.rb
@@ -1,0 +1,29 @@
+
+
+class UnsentDocumentsService
+  include ZendeskServiceHelper
+  include Rails.application.routes.url_helpers
+
+  def instance
+    @instance ||= EitcZendeskInstance
+  end
+
+  def detect_unsent_docs_and_notify
+    Intake.where.not(intake_ticket_id: nil).find_each(batch_size: 100) do |intake|
+      unsent_docs = intake.documents.where(zendesk_ticket_id: nil).where("created_at < ?", 15.minutes.ago)
+      if unsent_docs.present?
+        comment_body = <<~BODY
+          New client documents are available to view: #{zendesk_ticket_url(id: intake.intake_ticket_id)}
+          Files uploaded:
+          #{unsent_docs.map {|d| "* #{d.upload.filename} (#{d.document_type})"}.join("\n")}
+        BODY
+
+        append_comment_to_ticket(
+          ticket_id: intake.intake_ticket_id,
+          comment: comment_body
+        )
+        unsent_docs.each {|d| d.update(zendesk_ticket_id: intake.intake_ticket_id)}
+      end
+    end
+  end
+end

--- a/crontab
+++ b/crontab
@@ -1,1 +1,1 @@
-*/30 * * * * bundle exec rake some:task
+*/30 * * * * bundle exec rake documents:notify_unsent

--- a/crontab
+++ b/crontab
@@ -1,0 +1,1 @@
+*/30 * * * * bundle exec rake some:task

--- a/lib/tasks/notify_unsent_documents.rake
+++ b/lib/tasks/notify_unsent_documents.rake
@@ -1,0 +1,7 @@
+namespace :documents do
+  desc 'sends Zendesk comments for all Intakes with unsent documents'
+  task notify_unsent: [:environment] do
+    service = UnsentDocumentsService.new
+    service.detect_unsent_docs_and_notify
+  end
+end

--- a/spec/lib/datadog_api_spec.rb
+++ b/spec/lib/datadog_api_spec.rb
@@ -7,6 +7,10 @@ describe DatadogApi do
     allow(Dogapi::Client).to receive(:new).and_return(mock_dogapi)
   end
 
+  after do
+    DatadogApi.instance_variable_set("@dogapi_client", nil)
+  end
+
   it 'initializes and calls Dogapi::Client when enabled' do
     DatadogApi.configure do |c|
       c.enabled = true

--- a/spec/services/unsent_documents_service_spec.rb
+++ b/spec/services/unsent_documents_service_spec.rb
@@ -1,9 +1,10 @@
 require "rails_helper"
 
 describe UnsentDocumentsService do
-  let(:service) { described_class.new }
+  let(:service) {described_class.new}
 
   describe "#detect_unsent_docs_and_notify" do
+    let(:fake_dogapi) {instance_double(Dogapi::Client, emit_point: nil)}
     let!(:intake_docs_sent) {create :intake, intake_ticket_id: 1}
     let!(:intake_docs_not_sent) {create :intake, intake_ticket_id: 2}
     let!(:intake_new_doc) {create :intake, intake_ticket_id: 3}
@@ -14,6 +15,16 @@ describe UnsentDocumentsService do
 
     before do
       allow(service).to receive(:append_comment_to_ticket)
+
+      DatadogApi.configure do |c|
+        c.enabled = true
+        c.namespace = "test.dogapi"
+      end
+      allow(Dogapi::Client).to receive(:new).and_return(fake_dogapi)
+    end
+
+    after do
+      DatadogApi.instance_variable_set("@dogapi_client", nil)
     end
 
     it "checks each intake for unsent documents and notifies Zendesk if any are found" do
@@ -44,6 +55,11 @@ describe UnsentDocumentsService do
 
       expect(document2.reload.zendesk_ticket_id).to eq intake_docs_not_sent.intake_ticket_id
       expect(document3.reload.zendesk_ticket_id).to eq intake_docs_not_sent.intake_ticket_id
+
+      expect(Dogapi::Client).to have_received(:new).once
+      expect(fake_dogapi).to have_received(:emit_point).once.with('test.dogapi.cronjob.documents.unsent.detect_and_notify', 1, {:tags => ["env:" + Rails.env], :type => "count"})
+      expect(fake_dogapi).to have_received(:emit_point).once.with('test.dogapi.zendesk.ticket.docs.unsent.tickets_updated', 1, {:tags => ["env:" + Rails.env], :type => "gauge"})
+      expect(fake_dogapi).to have_received(:emit_point).once.with('test.dogapi.zendesk.ticket.docs.unsent.ticket_updated.document_count', 2, {:tags => ["env:" + Rails.env], :type => "gauge"})
     end
 
     it "does not notify about or update unsent docs that are less than 15 minutes old" do

--- a/spec/services/unsent_documents_service_spec.rb
+++ b/spec/services/unsent_documents_service_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+describe UnsentDocumentsService do
+  let(:service) { described_class.new }
+
+  describe "#detect_unsent_docs_and_notify" do
+    let!(:intake_docs_sent) {create :intake, intake_ticket_id: 1}
+    let!(:intake_docs_not_sent) {create :intake, intake_ticket_id: 2}
+    let!(:intake_new_doc) {create :intake, intake_ticket_id: 3}
+    let!(:document1) {create :document, :with_upload, intake: intake_docs_sent, zendesk_ticket_id: 1234, created_at: 2.hours.ago}
+    let!(:document2) {create :document, :with_upload, intake: intake_docs_not_sent, zendesk_ticket_id: nil, created_at: 2.hours.ago}
+    let!(:document3) {create :document, :with_upload, intake: intake_docs_not_sent, zendesk_ticket_id: nil, created_at: 2.hours.ago}
+    let!(:document4) {create :document, :with_upload, intake: intake_new_doc, zendesk_ticket_id: nil, created_at: 3.minutes.ago}
+
+    before do
+      allow(service).to receive(:append_comment_to_ticket)
+    end
+
+    it "checks each intake for unsent documents and notifies Zendesk if any are found" do
+      service.detect_unsent_docs_and_notify
+
+      comment = <<~BODY
+        New client documents are available to view: #{zendesk_ticket_url(id: intake_docs_not_sent.intake_ticket_id)}
+        Files uploaded:
+        * picture_id.jpg (W-2)
+        * picture_id.jpg (W-2)
+      BODY
+
+      expect(service).to have_received(:append_comment_to_ticket).with(
+        ticket_id: intake_docs_not_sent.intake_ticket_id,
+        comment: comment
+      )
+
+      comment_not_sent = <<~BODY
+        New client documents are available to view: #{zendesk_ticket_url(id: intake_docs_sent.intake_ticket_id)}
+        Files uploaded:
+        * picture_id.jpg (W-2)
+      BODY
+
+      expect(service).not_to have_received(:append_comment_to_ticket).with(
+        ticket_id: intake_docs_sent.intake_ticket_id,
+        comment: comment_not_sent
+      )
+
+      expect(document2.reload.zendesk_ticket_id).to eq intake_docs_not_sent.intake_ticket_id
+      expect(document3.reload.zendesk_ticket_id).to eq intake_docs_not_sent.intake_ticket_id
+    end
+
+    it "does not notify about or update unsent docs that are less than 15 minutes old" do
+      service.detect_unsent_docs_and_notify
+
+      comment_not_sent = <<~BODY
+        New client documents are available to view: #{zendesk_ticket_url(id: intake_new_doc.intake_ticket_id)}
+        Files uploaded:
+        * picture_id.jpg (W-2)
+      BODY
+
+      expect(service).not_to have_received(:append_comment_to_ticket).with(
+        ticket_id: intake_new_doc.intake_ticket_id,
+        comment: comment_not_sent
+      )
+
+      expect(document4.reload.zendesk_ticket_id).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Creates a cron job to run a task that checks for unsent documents and adds comments to tickets when unsent documents are found.