### PR TITLE
 Allow VitaPartnerImporter to move source params between partners

### DIFF
--- a/app/lib/vita_partner_importer.rb
+++ b/app/lib/vita_partner_importer.rb
@@ -16,6 +16,7 @@ module VitaPartnerImporter
 
     partners = YAML.load_file(yml)['vita_partners']
     VitaPartner.transaction do
+      SourceParameter.destroy_all
       partners.each do |datum|
         states = datum.delete('states')
         sources = datum.delete('source_parameters')
@@ -29,7 +30,6 @@ module VitaPartnerImporter
   end
 
   def refresh_partner_sources(partner, codes)
-    partner.source_parameters.destroy_all
     return unless codes.present?
 
     say "  -> updating #{partner.name} source codes"

--- a/spec/factories/source_parameters.rb
+++ b/spec/factories/source_parameters.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: source_codes
+# Table name: source_parameters
 #
 #  id              :bigint           not null, primary key
 #  code            :string
@@ -10,8 +10,8 @@
 #
 # Indexes
 #
-#  index_source_codes_on_code             (code)
-#  index_source_codes_on_vita_partner_id  (vita_partner_id)
+#  index_source_parameters_on_code             (code) UNIQUE
+#  index_source_parameters_on_vita_partner_id  (vita_partner_id)
 #
 # Foreign Keys
 #

--- a/spec/lib/vita_partner_importer_spec.rb
+++ b/spec/lib/vita_partner_importer_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+class TestImporter
+  class << self
+    include VitaPartnerImporter
+  end
+end
+
+RSpec.describe VitaPartnerImporter do
+  describe "#upsert_vita_partners" do
+    let(:zendesk_group_id) { "360000000000" }
+    let(:fake_partners_yaml) do
+      {
+        "vita_partners" => [{
+          "name" => "Tax Help Colorado",
+          "zendesk_instance_domain" => "eitc",
+          "zendesk_group_id" => zendesk_group_id,
+          "display_name" => "Tax Help Colorado",
+          "source_parameters" => ["test-source"],
+          "states" => ["CO"],
+          "logo_path" => "",
+        }],
+      }
+    end
+
+    before do
+      allow(YAML).to receive(:load_file).and_call_original
+      allow(YAML).to receive(:load_file)
+        .with(VitaPartnerImporter::VITA_PARTNERS_YAML)
+        .and_return(fake_partners_yaml)
+    end
+
+    it "inserts a new partner" do
+      expect do
+        TestImporter.upsert_vita_partners
+      end.to change(VitaPartner, :count).by(1)
+
+      created = VitaPartner.last
+      expect(created.name).to eq("Tax Help Colorado")
+      expect(created.zendesk_group_id).to eq(zendesk_group_id)
+      expect(created.source_parameters.length).to eq(1)
+      expect(created.source_parameters.first.code).to eq("test-source")
+      expect(created.states.length).to eq(1)
+      expect(created.states.first.abbreviation).to eq("CO")
+    end
+
+    context "when a partner exists with that group ID" do
+      let!(:existing_partner) do
+        create(:vita_partner, name: "Old Name", zendesk_group_id: zendesk_group_id)
+      end
+
+      it "updates the existing partner" do
+        expect do
+          TestImporter.upsert_vita_partners
+        end.to change { existing_partner.reload.name }
+          .from("Old Name").to("Tax Help Colorado")
+      end
+    end
+  end
+end


### PR DESCRIPTION
We just hit a situation which broke the script: moving the "uwba" source
code between partners. Due to the ordering in the file, the uniqueness
constraint prevented the new partner with uwba (which appeared first in
the array) from being created.

We can solve this by moving up the deletion of SourceParameter objects,
which we do anyway inside the loop. This should be safe because we don't
want any SourceParameters to exist outside those specified within
vita_partners.yml.