### PR TITLE
Turns on locale switching for English/Spanish translations

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -153,19 +153,18 @@ class ApplicationController < ActionController::Base
   end
 
   def switch_locale(&action)
-    # Set the locale in order of priority
-    # 1) Language picker: query param 'new_locale'
-    # 2) Previously set locale: query param 'locale' (added by default_url_options once I18n.locale is set)
-    # 3) Browser settings: accept-header is examined if no params are set
-    # 4) Default Fallback: from I18n.default_locale (we set it to :en)
-    # TODO: uncomment to include browser settings when we unlock spanish translation
-    # locale = params[:new_locale] || params[:locale] || http_accept_language.compatible_language_from(I18n.available_locales) || I18n.default_locale
-    locale = params[:new_locale] || params[:locale] || I18n.default_locale
+    locale = available_locale(params[:new_locale]) ||
+      available_locale(params[:locale]) ||
+      http_accept_language.compatible_language_from(I18n.available_locales) ||
+      I18n.default_locale
     I18n.with_locale(locale, &action)
   end
 
-
   private
+
+  def available_locale(locale)
+    locale if I18n.available_locales.map(&:to_sym).include?(locale&.to_sym)
+  end
 
   ##
   # when the session's current intake doesn't have a ticket, this will

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,4 +14,22 @@ module ApplicationHelper
     (meters / five_miles_in_meters).ceil * 5
   end
 
+  def link_to_locale(locale, label, additional_attributes = {})
+    link_to(label,
+            "?" + request.query_parameters.merge("new_locale" => locale).to_query,
+            lang: locale,
+            "data-track-click": "intake-language-changed",
+            "data-track-attributes-to_locale": locale,
+            "data-track-attributes_from_locale": I18n.locale,
+            **additional_attributes).html_safe
+  end
+
+  def link_to_spanish(additional_attributes={})
+    link_to_locale('es', 'Español', additional_attributes)
+  end
+
+  def link_to_english(additional_attributes={})
+    link_to_locale('en', 'English', additional_attributes)
+  end
+
 end

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -13,12 +13,16 @@
       </div>
 
       <ul class="grid__item width-one-fourth footer-links">
-        <%# if I18n.locale != :en %>
-<!--          <li><%#= link_to("English", "?" + request.query_parameters.merge("new_locale" => "en").to_query, lang: 'en') %></li>-->
-        <%# end %>
-        <%# if I18n.locale != :es %>
-<!--          <li><%#= link_to "Español", "?" + request.query_parameters.merge("new_locale" => "es").to_query, lang: 'es' %></li>-->
-        <%# end %>
+        <% if I18n.locale != :en %>
+          <li>
+            <%= link_to_english() %>
+          </li>
+        <% end %>
+        <% if I18n.locale != :es %>
+          <li>
+            <%= link_to_spanish() %>
+          </li>
+        <% end %>
         <li>
           <%= link_to about_us_path do %>
             <%=t("views.public_pages.about_us.title") %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -8,12 +8,12 @@
       </div>
     </div>
     <div class="toolbar__right">
-      <%# if I18n.locale != :en %>
-        <%#= link_to("English", "?" + request.query_parameters.merge("new_locale" => "en").to_query, lang: 'en', class: "toolbar__item text--small") %>
-      <%# end %>
-      <%# if I18n.locale != :es %>
-        <%#= link_to "Español", "?" + request.query_parameters.merge("new_locale" => "es").to_query, lang: 'es', class: "toolbar__item text--small" %>
-      <%# end %>
+      <% if I18n.locale != :en %>
+        <%= link_to_english(class: "toolbar__item text--small") %>
+      <% end %>
+      <% if I18n.locale != :es %>
+        <%= link_to_spanish(class: "toolbar__item text--small") %>
+      <% end %>
       <%= yield :toolbar_right %>
     </div>
   </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,6 +26,7 @@ module VitaMin
 
     config.i18n.default_locale = :en
     config.i18n.fallbacks = [I18n.default_locale]
+    config.i18n.available_locales = [:en, :es]
 
     config.active_job.queue_adapter = :delayed_job
     # Settings in config/environments/* take precedence over those specified here.

--- a/config/environments/demo.rb
+++ b/config/environments/demo.rb
@@ -1,7 +1,6 @@
 require_relative "./shared_deployment_config"
 
 Rails.application.configure do
-  config.i18n.available_locales = [:en]
   config.active_storage.service = :s3_demo
 
   config.action_mailer.default_url_options = { host: 'demo.getyourrefund.org' }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,7 +1,6 @@
 require_relative "./shared_deployment_config"
 
 Rails.application.configure do
-  config.i18n.available_locales = [:en]
   config.active_storage.service = :s3_prod
 
   config.action_mailer.default_url_options = { host: 'www.getyourrefund.org' }

--- a/config/environments/shared_deployment_config.rb
+++ b/config/environments/shared_deployment_config.rb
@@ -95,5 +95,4 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
-  config.i18n.available_locales = [:en, :es]
 end

--- a/config/environments/shared_deployment_config.rb
+++ b/config/environments/shared_deployment_config.rb
@@ -95,4 +95,5 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+  config.i18n.available_locales = [:en, :es]
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,7 +1,6 @@
 require_relative "./shared_deployment_config"
 
 Rails.application.configure do
-  config.i18n.available_locales = [:en, :es]
   config.active_storage.service = :s3_staging
 
   config.action_mailer.default_url_options = { host: 'staging.getyourrefund.org' }

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -467,7 +467,7 @@ es:
         filing_deadline_banner:
           body: No tiene que presentar un formulario adicional ni llamar al IRS para pedir una extensión. Le recomendamos que declare sus impuestos hoy mismo, ya que puede recibir un reembolso que puede ayudar a mantener su hogar.
           title: 'Nota: La fecha límite para presentar la declaración del impuesto federal ha sido extendida hasta el 15 de julio de 2020.'
-        header: 'Personas reales, proporcionando apoyo gratuito para su declaración de impuestos '
+        header: 'Personas reales, proporcionando apoyo gratuito para su declaración de impuestos'
         partners:
           header: Colaboramos con organizaciones de confianza
           learn_more_html: Obtenga más información sobre nosotros &rsaquo;

--- a/spec/features/switching_locale_spec.rb
+++ b/spec/features/switching_locale_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.feature "Switching Locale" do
+
+  scenario "client switches between Spanish and English versions of website using the footer link" do
+    visit root_path
+
+    within(".footer") do
+      click_on "Español"
+    end
+    expect(page).to have_content(I18n.t("views.public_pages.home.header", locale: :es))
+
+    within(".footer") do
+      click_on "English"
+    end
+    expect(page).to have_content(I18n.t("views.public_pages.home.header", locale: :en))
+  end
+
+  scenario "client switches between Spanish and English versions of website using the header link" do
+    visit root_path
+
+    within(".main-header") do
+      click_on "Español"
+    end
+    expect(page).to have_content(I18n.t("views.public_pages.home.header", locale: :es))
+
+    within(".main-header") do
+      click_on "English"
+    end
+    expect(page).to have_content(I18n.t("views.public_pages.home.header", locale: :en))
+  end
+end
+


### PR DESCRIPTION
- ensures that locale and new_locale params are an available locale
- refactors language links to helper methods
- adds specs for ApplicationController#switch_locale
- adds mixpanel tracking for to_locale and from_locale with switching
locales

[#173111774] Turn on Spanish translations