### PR TITLE
Changes default link colors

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,6 +15,7 @@
 @import "cfa_styleguide_main";
 @import "atoms/variables";
 @import "atoms/form-elements";
+@import "atoms/typography";
 @import "organisms/document-overview";
 @import "organisms/flash-messages";
 @import "molecules/accordion";

--- a/app/assets/stylesheets/atoms/_typography.scss
+++ b/app/assets/stylesheets/atoms/_typography.scss
@@ -1,16 +1,16 @@
 a {
-  color: $color-default-link;
+  color: $color-link-default;
   &:hover {
-    color: $color-hover-link;
+    color: $color-link-hover;
   }
   &:visited {
-    color: $color-visited-link;
+    color: $color-link-visited;
   }
-  &:focus {
-    color: $color-focused-link;
-    background-color: $color-focused-link-background;
-  }
+  //&:focus {
+  //  color: $color-focused-link;
+  //  background-color: $color-focused-link-background;
+  //}
   &:active {
-    color: $color-active-link;
+    color: $color-link-active;
   }
 }

--- a/app/assets/stylesheets/atoms/_typography.scss
+++ b/app/assets/stylesheets/atoms/_typography.scss
@@ -6,10 +6,6 @@ a {
   &:visited {
     color: $color-link-visited;
   }
-  //&:focus {
-  //  color: $color-focused-link;
-  //  background-color: $color-focused-link-background;
-  //}
   &:active {
     color: $color-link-active;
   }

--- a/app/assets/stylesheets/atoms/_typography.scss
+++ b/app/assets/stylesheets/atoms/_typography.scss
@@ -1,0 +1,16 @@
+a {
+  color: $color-default-link;
+  &:hover {
+    color: $color-hover-link;
+  }
+  &:visited {
+    color: $color-visited-link;
+  }
+  &:focus {
+    color: $color-focused-link;
+    background-color: $color-focused-link-background;
+  }
+  &:active {
+    color: $color-active-link;
+  }
+}

--- a/app/assets/stylesheets/atoms/_variables.scss
+++ b/app/assets/stylesheets/atoms/_variables.scss
@@ -12,9 +12,9 @@ $color-gold-accent: #FF9214;
 $color-purple: #3D3DE1;
 $color-default-purple: #4C2C92;
 
-$color-default-link: #0358A2;
-$color-hover-link: #0358A1;
-$color-active-link: #1D70B8;
-$color-visited-link: #4C2C92;
+$color-link-default: #0358A2;
+$color-link-hover: #0358A1;
+$color-link-active: #1D70B8;
+$color-link-visited: #4C2C92;
 $color-focused-link-background: #F9C802;
 $color-focused-link: #000000;

--- a/app/assets/stylesheets/atoms/_variables.scss
+++ b/app/assets/stylesheets/atoms/_variables.scss
@@ -11,3 +11,10 @@ $color-orange-dark: #D73D02;
 $color-gold-accent: #FF9214;
 $color-purple: #3D3DE1;
 $color-default-purple: #4C2C92;
+
+$color-default-link: #0358A2;
+$color-hover-link: #0358A1;
+$color-active-link: #1D70B8;
+$color-visited-link: #4C2C92;
+$color-focused-link-background: #F9C802;
+$color-focused-link: #000000;

--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -1,6 +1,12 @@
 .button {
   box-shadow: none;
   border-width: 3px;
+  &:active {
+    color: $color-grey-darkest;
+  }
+  &:visited {
+    color: $color-grey-darkest;
+  }
 }
 
 .button--inline-action {
@@ -20,10 +26,15 @@
   &:hover {
     background-color: #303030;
     border-color: #303030;
+    color: white;
+  }
+  &:visited {
+    color: white;
   }
   &:active {
     background-color: #303030;
     border-color: #303030;
+    color: white;
   }
 }
 
@@ -31,6 +42,10 @@
   background-color: #008060;
   color: white;
   border: none;
+
+  &:visited {
+    color: white;
+  }
   &:active {
     background-color: #034E46;
     color: white;
@@ -52,6 +67,10 @@
 
   &:hover {
     background-color: #F7F5F4;
+    color: #D70A40;
+  }
+
+  &:visited {
     color: #D70A40;
   }
 }
@@ -80,7 +99,6 @@
     border-color: #F3B9C9;
     color: #F3B9C9;
   }
-
 }
 
 .button--wide {


### PR DESCRIPTION
Non-button links are currently styleguide colors but we want them to be:
![image](https://user-images.githubusercontent.com/43800769/84959808-f210a380-b0b4-11ea-9216-b5dd07972898.png)

We were going to address this by adding variables to the [styleguide](https://github.com/codeforamerica/honeycrisp-gem/pull/188) but that is currently blocked on review, as we are working out a way to make it more useful to other teams.

Context for why we are overriding button styles is [here](https://github.com/codeforamerica/honeycrisp-gem/pull/188#issuecomment-645579758)

Here's an example of an affected page:
![image](https://user-images.githubusercontent.com/43800769/84959866-19677080-b0b5-11ea-99ec-769f6e5eede9.png)