### PR TITLE
Redirect Impact America routing to FC and UWGC

### DIFF
--- a/db/vita_partners.yml
+++ b/db/vita_partners.yml
@@ -65,9 +65,6 @@ vita_partners:
   - fc
   states:
   - TX
-  - TN
-  - AR
-  - MS
   accepts_overflow: true
   logo_path: ''
 - name: United Way of Central Ohio

--- a/db/vita_partners.yml
+++ b/db/vita_partners.yml
@@ -46,24 +46,16 @@ vita_partners:
   zendesk_instance_domain: eitc
   zendesk_group_id: '360009341853'
   display_name: Save First
-  source_parameters:
-  - ia
   logo_path: partner-logos/ia.png
 - name: Impact America (Save First) Mississippi River States
   zendesk_instance_domain: eitc
   zendesk_group_id: '360009830214'
   display_name: Save First
-  states:
-  - TN
-  - AR
-  - MS
   logo_path: partner-logos/ia.png
 - name: Impact America (Save First) South Carolina
   zendesk_instance_domain: eitc
   zendesk_group_id: '360009341873'
   display_name: Save First
-  states:
-  - SC
   logo_path: partner-logos/ia.png
 - name: Foundation Communities
   zendesk_instance_domain: eitc
@@ -73,6 +65,9 @@ vita_partners:
   - fc
   states:
   - TX
+  - TN
+  - AR
+  - MS
   accepts_overflow: true
   logo_path: ''
 - name: United Way of Central Ohio
@@ -220,6 +215,8 @@ vita_partners:
   display_name: United Way of Greenville County
   source_parameters:
   - uwgc
+  states:
+  - SC
   logo_path: ''
 - name: Urban Upbound (NY)
   zendesk_instance_domain: eitc


### PR DESCRIPTION
Per Annelise's request in https://eitc.zendesk.com/agent/tickets/34253:

1. SC state routing - move to UW Greenville (I wrote him to confirm this is ok, but if you don't hear from me by Monday, please go ahead and make the change)
2. Deactivate source code routing for Impact America (clients will then be routed by state) - https://www.getyourrefund.org/?s=IA
3. Send TN, MS, AR to Foundation Communities/ the national site pool (not sure how you have that working)