### PR TITLE
Move FL routing to City of Miami

### DIFF
--- a/db/vita_partners.yml
+++ b/db/vita_partners.yml
@@ -186,8 +186,6 @@ vita_partners:
   display_name: RefundDay
   source_parameters:
   - RefundDay
-  states:
-  - FL
   logo_path: ''
 - name: Tax Help New Mexico
   zendesk_instance_domain: eitc
@@ -336,6 +334,8 @@ vita_partners:
   display_name: the City of Miami
   source_parameters:
   - cityofmiami
+  states:
+  - FL
   logo_path: partner-logos/city-of-miami.png
 - name: Desert Financial and Tax Services
   zendesk_instance_domain: eitc

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -882,7 +882,7 @@ describe Intake do
       it_behaves_like "state-level routing", "TX", "Foundation Communities", "eitc"
       it_behaves_like "state-level routing", "AZ", "United Way of Tuscon and Southern Arizona", "eitc"
       it_behaves_like "state-level routing", "VA", "United Way of Greater Richmond and Petersburg", "eitc"
-      it_behaves_like "state-level routing", "FL", "RefundDay", "eitc"
+      it_behaves_like "state-level routing", "FL", "[RefundDay] City of Miami", "eitc"
       it_behaves_like "state-level routing", "NM", "Tax Help New Mexico", "eitc"
       it_behaves_like "state-level routing", "MD", "CASH Campaign of MD", "eitc"
       it_behaves_like "state-level routing", "MA", "[MASSCAP] Online Intake (w/Boston Tax Help)", "eitc"


### PR DESCRIPTION
Per Gregory, our new City of Miami partner will become the new default
recipient of all Florida returns.

Please hold off on merging this until I am able to double-check with Gregory about it, but I think we should be good here.