### PR TITLE
Add Zendesk CLI to list "inactive" users and remove users 

### DIFF
--- a/app/cli/zendesk_cli.rb
+++ b/app/cli/zendesk_cli.rb
@@ -18,4 +18,20 @@ class ZendeskCli < Thor
       .from_csv(options[:csv_path])
       .import_all
   end
+
+  desc "list_inactive_users", "Outputs a list of inactive users from the Zendesk API"
+  option :csv_path, description: "Output to CSV.", required: true
+  def list_inactive_users
+    ZendeskCli::ListInactiveUsers
+      .new
+      .list_inactive_users(output_path: options[:csv_path])
+  end
+
+  desc "remove_users", "Removes a list of users from Zendesk via API"
+  option :csv_path, description: "Input CSV of users to remove.", required: true
+  def remove_users
+    ZendeskCli::RemoveUsers
+      .new(csv_path: options[:csv_path])
+      .remove_all
+  end
 end

--- a/app/cli/zendesk_cli/list_inactive_users.rb
+++ b/app/cli/zendesk_cli/list_inactive_users.rb
@@ -35,8 +35,7 @@ class ZendeskCli
 
     def inactive_agents
       @inactive_agents ||= agents.find_all do |agent|
-        agent.last_login_at.present? &&
-          agent.last_login_at < INACTIVE_THRESHOLD.ago &&
+        (agent.last_login_at.nil? || agent.last_login_at < INACTIVE_THRESHOLD.ago) &&
           agent.created_at < GRACE_PERIOD.ago &&
           !SKIP_EMAIL_REGEX.match(agent.email)
       end

--- a/app/cli/zendesk_cli/list_inactive_users.rb
+++ b/app/cli/zendesk_cli/list_inactive_users.rb
@@ -1,0 +1,62 @@
+require 'csv'
+
+class ZendeskCli
+  class ListInactiveUsers
+    include Thor::Shell
+
+    # A user is "inactive" if they don't log in for this amount of time
+    INACTIVE_THRESHOLD = 60.days
+
+    # An "inactive" user will NOT be removed if their account is less than
+    # this old:
+    GRACE_PERIOD = 60.days
+
+    # "Inactive" users will NOT be removed that are likely system users
+    SKIP_EMAIL_REGEX = /getyourrefund\.org|codeforamerica\.org/.freeze
+
+    # Headers for the CSV to export
+    CSV_HEADERS = %w[id email name last_login_at default_group_id created_at].freeze
+
+    def initialize; end
+
+    def list_inactive_users(output_path: nil)
+      say "Loading agents..."
+      say "  Loaded #{agents.length} Zendesk users."
+      say "Exporting to #{output_path}..." if output_path.present?
+
+      CSV.open(output_path, "w", write_headers: true, headers: CSV_HEADERS) do |csv|
+        inactive_agents.each do |agent|
+          csv << agent.values_at(*CSV_HEADERS)
+        end
+      end
+
+      say "  Exported #{inactive_agents.length} Zendesk users to remove."
+    end
+
+    def inactive_agents
+      @inactive_agents ||= agents.find_all do |agent|
+        agent.last_login_at.present? &&
+          agent.last_login_at < INACTIVE_THRESHOLD.ago &&
+          agent.created_at < GRACE_PERIOD.ago &&
+          !SKIP_EMAIL_REGEX.match(agent.email)
+      end
+    end
+
+    private
+
+    def agents
+      @agents ||= []
+      return @agents if @agents.any?
+
+      client.users.search(query: "role:agent").all! do |user|
+        @agents << user
+      end
+
+      @agents
+    end
+
+    def client
+      @client ||= EitcZendeskInstance.client
+    end
+  end
+end

--- a/app/cli/zendesk_cli/remove_users.rb
+++ b/app/cli/zendesk_cli/remove_users.rb
@@ -1,0 +1,41 @@
+require 'csv'
+
+class ZendeskCli
+  class RemoveUsers
+    include Thor::Shell
+
+    def initialize(csv_path:)
+      @csv_path = csv_path
+    end
+
+    def remove_all
+      say "Loading agents..."
+      agents = parse_csv(@csv_path)
+
+      if yes?("  Delete #{agents.length} agents? [y/N]: ")
+        agents.each do |agent_to_delete|
+          begin
+            say "Deleting #{agent_to_delete["email"]}..."
+            agent = client.users.find(id: agent_to_delete["id"])
+            if agent.destroy!
+              say "  Deleted!"
+            end
+          rescue ZendeskAPI::Error::RecordInvalid => e
+            say "  Could not delete #{agent_to_delete["email"]}: #{e.message}"
+          end
+        end
+      end
+    end
+
+    def parse_csv(csv_path)
+      contents = File.read(csv_path)
+      CSV.parse(contents, headers: :first_row)
+    end
+
+    private
+
+    def client
+      @client ||= EitcZendeskInstance.client
+    end
+  end
+end

--- a/spec/cli/zendesk_cli/list_inactive_users_spec.rb
+++ b/spec/cli/zendesk_cli/list_inactive_users_spec.rb
@@ -25,11 +25,27 @@ RSpec.describe ZendeskCli::ListInactiveUsers do
       end
     end
 
+    context "with an inactive user that has never logged in" do
+      let(:agent_last_login) { nil }
+
+      it "includes the user" do
+        expect(instance.inactive_agents).to include(agent)
+      end
+    end
+
     context "with a user that was recently created" do
       let(:agent_created_at) { described_class::GRACE_PERIOD.ago + 1.day }
 
       it "does not include that agent" do
         expect(instance.inactive_agents).to be_empty
+      end
+
+      context "when that user has never logged in" do
+        let(:agent_last_login) { nil }
+
+        it "does not include that agent" do
+          expect(instance.inactive_agents).to be_empty
+        end
       end
     end
 

--- a/spec/cli/zendesk_cli/list_inactive_users_spec.rb
+++ b/spec/cli/zendesk_cli/list_inactive_users_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe ZendeskCli::ListInactiveUsers do
+  describe "#inactive_agents" do
+    let(:agent) do
+      ZendeskAPI::User.new(
+        nil,
+        last_login_at: agent_last_login,
+        created_at: agent_created_at,
+        email: agent_email,
+      )
+    end
+    let(:agent_email) { "vita-volunteer@example.org" }
+    let(:agent_created_at) { described_class::GRACE_PERIOD.ago - 1.day }
+    let(:agent_last_login) { described_class::INACTIVE_THRESHOLD.ago - 1.day }
+    let(:instance) { described_class.new }
+
+    before do
+      allow(instance).to receive(:agents).and_return([agent])
+    end
+
+    context "with an inactive user" do
+      it "includes that agent" do
+        expect(instance.inactive_agents).to include(agent)
+      end
+    end
+
+    context "with a user that was recently created" do
+      let(:agent_created_at) { described_class::GRACE_PERIOD.ago + 1.day }
+
+      it "does not include that agent" do
+        expect(instance.inactive_agents).to be_empty
+      end
+    end
+
+    context "with a user matching the SKIP_EMAIL_REGEX" do
+      let(:agent_email) { "zendesk-sms@hooks.getyourrefund.org" }
+
+      it "does not include that agent" do
+        expect(instance.inactive_agents).to be_empty
+      end
+    end
+
+    context "given an agent has logged in recently" do
+      let(:agent_last_login) { described_class::INACTIVE_THRESHOLD.ago + 1.day }
+
+      it "does not include that agent" do
+        expect(instance.inactive_agents).to be_empty
+      end
+    end
+  end
+end

--- a/spec/cli/zendesk_cli/remove_users_spec.rb
+++ b/spec/cli/zendesk_cli/remove_users_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ZendeskCli::RemoveUsers do
+  let(:fake_csv_path) { "/tmp/test-file.csv" }
+  let(:instance) { described_class.new(csv_path: fake_csv_path) }
+
+  describe "#parse_csv" do
+    let(:valid_csv) { <<~CSV }
+      id,email,name,last_login_at,default_group_id,created_at
+      400000000000,tomatio@example.com,Tom A Tio,2020-04-24 17:03:44 UTC,360000000000,2020-04-23 22:41:46 UTC
+    CSV
+
+    before do
+      allow(File).to receive(:read).with(fake_csv_path).and_return(valid_csv)
+    end
+
+    context "given a valid CSV" do
+      it "returns a list of agents" do
+        results = instance.parse_csv(fake_csv_path)
+        expect(results.length).to eq(1)
+        expect(results.first["id"]).to eq("400000000000")
+        expect(results.first["email"]).to eq("tomatio@example.com")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a Zendesk CLI tool to remove "inactive" Zendesk users.
"Inactive" users are defined as users that match all of these criteria:

* were created 2 or more months ago
* have not logged in in 2 or more months, and
* do not have a `@codeforamerica.org` or `@getyourrefund.org` email
  address.

To remove them, it is a two step process:

1. `bin/zendesk list_inactive_users --csv-path inactive-users.csv`
    This will create a list of inactive users according to the criteria
    above. This will be helpful for auditing the list and verifying that
    all these users are expected to be removed.
2. `bin/zendesk remove_users --csv-path inactive-users.csv`
    This will actually do the user-by-user removal.

The two step process is designed for auditing purposes and to add some
flexibility down the line (if we want to remove other lists of users,
for example).