### PR TITLE
Adds duplicate tag to duplicate tickets when merging

### DIFF
--- a/app/helpers/zendesk_service_helper.rb
+++ b/app/helpers/zendesk_service_helper.rb
@@ -204,11 +204,12 @@ module ZendeskServiceHelper
     success
   end
 
-  def append_comment_to_ticket(ticket_id:, comment:, fields: {}, public: false, group_id: nil)
+  def append_comment_to_ticket(ticket_id:, comment:, fields: {}, tags: [], public: false, group_id: nil)
     raise MissingTicketIdError if ticket_id.blank?
 
     ticket = get_ticket!(ticket_id)
     ticket.fields = fields if fields.present?
+    ticket.tags += tags if tags.present?
     ticket.group_id = group_id if group_id.present?
     ticket.comment = { body: comment, public: public }
     success = ticket.save

--- a/app/services/zendesk/ticket_merging_service.rb
+++ b/app/services/zendesk/ticket_merging_service.rb
@@ -121,7 +121,8 @@ module Zendesk
         fields: {
           EitcZendeskInstance::INTAKE_STATUS => EitcZendeskInstance::INTAKE_STATUS_NOT_FILING,
           EitcZendeskInstance::RETURN_STATUS => EitcZendeskInstance::RETURN_STATUS_DO_NOT_FILE,
-        }
+        },
+        tags: ["duplicate"]
       )
 
       Rails.logger.info("Updated duplicate ticket #{duplicate_ticket.id} during duplicate merging")

--- a/spec/helpers/zendesk_service_helper_spec.rb
+++ b/spec/helpers/zendesk_service_helper_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe ZendeskServiceHelper do
     allow(fake_zendesk_comment_body).to receive(:concat)
     allow(fake_zendesk_ticket).to receive(:comment=)
     allow(fake_zendesk_ticket).to receive(:fields=)
+    allow(fake_zendesk_ticket).to receive(:tags).and_return ["old_tag"]
+    allow(fake_zendesk_ticket).to receive(:tags=)
     allow(fake_zendesk_ticket).to receive(:group_id=)
     allow(fake_zendesk_ticket).to receive(:comment).and_return fake_zendesk_comment
     allow(fake_zendesk_ticket).to receive(:save).and_return true
@@ -448,12 +450,14 @@ RSpec.describe ZendeskServiceHelper do
       result = service.append_comment_to_ticket(
         ticket_id: 1141,
         comment: "hey this is a comment",
-        fields: { "314324132" => "custom_field_value" }
+        fields: { "314324132" => "custom_field_value" },
+        tags: ["some", "tags"],
       )
 
       expect(result).to eq true
       expect(fake_zendesk_ticket).to have_received(:comment=).with({ body: "hey this is a comment", public: false })
       expect(fake_zendesk_ticket).to have_received(:fields=).with({ "314324132" => "custom_field_value" })
+      expect(fake_zendesk_ticket).to have_received(:tags=).with(["old_tag", "some", "tags"])
       expect(fake_zendesk_ticket).to have_received(:save)
     end
   end

--- a/spec/services/zendesk/ticket_merging_service_spec.rb
+++ b/spec/services/zendesk/ticket_merging_service_spec.rb
@@ -111,7 +111,8 @@ describe Zendesk::TicketMergingService do
           fields: {
             EitcZendeskInstance::INTAKE_STATUS => EitcZendeskInstance::INTAKE_STATUS_NOT_FILING,
             EitcZendeskInstance::RETURN_STATUS => EitcZendeskInstance::RETURN_STATUS_DO_NOT_FILE,
-          }
+          },
+          tags: ["duplicate"],
         )
         expect(service).to have_received(:append_comment_to_ticket).with(
           ticket_id: 345,
@@ -120,7 +121,8 @@ describe Zendesk::TicketMergingService do
           fields: {
             EitcZendeskInstance::INTAKE_STATUS => EitcZendeskInstance::INTAKE_STATUS_NOT_FILING,
             EitcZendeskInstance::RETURN_STATUS => EitcZendeskInstance::RETURN_STATUS_DO_NOT_FILE,
-          }
+          },
+          tags: ["duplicate"],
         )
       end
 
@@ -139,7 +141,8 @@ describe Zendesk::TicketMergingService do
           fields: {
             EitcZendeskInstance::INTAKE_STATUS => EitcZendeskInstance::INTAKE_STATUS_NOT_FILING,
             EitcZendeskInstance::RETURN_STATUS => EitcZendeskInstance::RETURN_STATUS_DO_NOT_FILE,
-          }
+          },
+          tags: ["duplicate"]
         )
       end
 
@@ -211,7 +214,8 @@ describe Zendesk::TicketMergingService do
           fields: {
             EitcZendeskInstance::INTAKE_STATUS => EitcZendeskInstance::INTAKE_STATUS_NOT_FILING,
             EitcZendeskInstance::RETURN_STATUS => EitcZendeskInstance::RETURN_STATUS_DO_NOT_FILE,
-          }
+          },
+          tags: ["duplicate"]
         )
       end
     end


### PR DESCRIPTION
- adds tags as argument to append_comment_to_ticket

Co-authored-by: Ben Golder <bgolder@codeforamerica.org>