### PR TITLE
Fixes bugs related to requested docs

### DIFF
--- a/app/controllers/documents/requested_documents_later_controller.rb
+++ b/app/controllers/documents/requested_documents_later_controller.rb
@@ -62,7 +62,7 @@ module Documents
     private
 
     def destroy_document_path(document)
-      documents_remove_requested_document_path(document)
+      documents_remove_requested_document_path(id: document)
     end
 
     def self.document_type
@@ -87,9 +87,14 @@ module Documents
     end
 
     def handle_session
-      return if session[:documents_request_id].present?
+      return if session[:documents_request_id].present? &&
+        (params[:token].nil? || token_matches_documents_request?)
 
       validate_token_and_create_session
+    end
+
+    def token_matches_documents_request?
+      documents_request&.intake&.requested_docs_token == params[:token]
     end
 
     def create_new_documents_request_session(intake)


### PR DESCRIPTION
- replaces documents_request_id in session when new token param is
requested
- corrects the documents_remove_requested_document_path signature to
pass document id in a hash to generate correct route

[#173504865] Multiple requested docs links leak across session
[#173504893 Removing uploaded requested document throws 404

Signed-off-by: Jenny Heath <jheath@codeforamerica.org>