### PR TITLE
Update state routing for FL, NY

### DIFF
--- a/db/vita_partners.yml
+++ b/db/vita_partners.yml
@@ -12,6 +12,7 @@ vita_partners:
   - WY
   - KS
   - NE
+  - FL
   logo_path: ''
 - name: Goodwill Industries of the Southern Rivers
   zendesk_instance_domain: eitc
@@ -178,8 +179,6 @@ vita_partners:
   display_name: RefundDay
   source_parameters:
   - RefundDay
-  states:
-  - FL
   logo_path: ''
 - name: Tax Help New Mexico
   zendesk_instance_domain: eitc
@@ -219,6 +218,8 @@ vita_partners:
   display_name: Urban Upbound (NY)
   source_parameters:
   - uuny
+  states:
+  - NY
   logo_path: ''
 - name: "[MA/BTH] Online Intake (w/Boston Tax Help)"
   zendesk_instance_domain: eitc

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -789,9 +789,10 @@ describe Intake do
       it_behaves_like "state-level routing", "TX", "Foundation Communities", "eitc"
       it_behaves_like "state-level routing", "AZ", "United Way of Tuscon and Southern Arizona", "eitc"
       it_behaves_like "state-level routing", "VA", "United Way of Greater Richmond and Petersburg", "eitc"
-      it_behaves_like "state-level routing", "FL", "RefundDay", "eitc"
+      it_behaves_like "state-level routing", "FL", "Tax Help Colorado (Piton Foundation)", "eitc"
       it_behaves_like "state-level routing", "NM", "Tax Help New Mexico", "eitc"
       it_behaves_like "state-level routing", "MD", "CASH Campaign of MD", "eitc"
+      it_behaves_like "state-level routing", "NY", "Urban Upbound (NY)", "eitc"
       it_behaves_like "state-level routing", "MA", "[MA/BTH] Online Intake (w/Boston Tax Help)", "eitc"
     end
 


### PR DESCRIPTION
* Florida will temporarily be handled by THC until we can get some more
  Florida partners onboard.
* Urban Upbound is ready to go for NY.