### PR TITLE
Handles case where ticket is not found in Zendesk

### DIFF
--- a/app/services/zendesk/duplicate_intake_matcher.rb
+++ b/app/services/zendesk/duplicate_intake_matcher.rb
@@ -20,6 +20,8 @@ module Zendesk
         :needs_help_2018,
         :needs_help_2017,
         :needs_help_2016
+      ).where(
+        zendesk_instance_domain: EitcZendeskInstance::DOMAIN
       ).group(
         :lower_name,
         :lower_email,

--- a/app/services/zendesk/ticket_merging_service.rb
+++ b/app/services/zendesk/ticket_merging_service.rb
@@ -44,26 +44,29 @@ module Zendesk
       Rails.logger.info("#{logging_prefix}: Identified primary ticket #{primary_ticket.id} during duplicate merging")
 
       duplicate_ticket_ids = ticket_ids - [primary_ticket.id]
-      duplicate_tickets = duplicate_ticket_ids.map{ |id| get_ticket(ticket_id: id) }
+      if duplicate_ticket_ids.present?
+        duplicate_tickets = duplicate_ticket_ids.map{ |id| get_ticket(ticket_id: id) }
 
-      primary_intake = Intake.where(intake_ticket_id: primary_ticket.id).first
+        primary_intake = Intake.where(intake_ticket_id: primary_ticket.id).first
 
-      # Update duplicate intakes with primary ticket id
-      Intake.find(intake_ids).each do |intake|
-        unless intake.id == primary_intake.id
-          intake.update(intake_ticket_id: primary_ticket.id, primary_intake_id: primary_intake.id)
+        # Update duplicate intakes with primary ticket id
 
-          Rails.logger.info("#{logging_prefix}: Updated duplicate intake #{intake.id} during duplicate merging")
+        Intake.find(intake_ids).each do |intake|
+          unless intake.id == primary_intake.id
+            intake.update(intake_ticket_id: primary_ticket.id, primary_intake_id: primary_intake.id)
+
+            Rails.logger.info("#{logging_prefix}: Updated duplicate intake #{intake.id} during duplicate merging")
+          end
         end
-      end
 
-      # Comment on primary ticket with links to duplicates
-      update_primary_ticket(primary_ticket, duplicate_tickets)
+        # Comment on primary ticket with links to duplicates
+        update_primary_ticket(primary_ticket, duplicate_tickets)
 
-      # Mark duplicate tickets as not filing and leave comments
-      duplicate_tickets.each do |duplicate_ticket|
-        unless duplicate_ticket.status == "closed"
-          update_duplicate_ticket(duplicate_ticket, primary_ticket)
+        # Mark duplicate tickets as not filing and leave comments
+        duplicate_tickets.each do |duplicate_ticket|
+          unless duplicate_ticket.status == "closed"
+            update_duplicate_ticket(duplicate_ticket, primary_ticket)
+          end
         end
       end
 

--- a/spec/services/zendesk/duplicate_intake_matcher_spec.rb
+++ b/spec/services/zendesk/duplicate_intake_matcher_spec.rb
@@ -8,7 +8,8 @@ describe Zendesk::DuplicateIntakeMatcher do
       phone_number: "1234567890",
       intake_ticket_id: 12345,
       needs_help_2018: "yes",
-      needs_help_2019: "yes")
+      needs_help_2019: "yes",
+      zendesk_instance_domain: EitcZendeskInstance::DOMAIN)
   end
   let!(:duplicate_intake) do
     create(:intake,
@@ -17,10 +18,16 @@ describe Zendesk::DuplicateIntakeMatcher do
       phone_number: " 1234567890",
       intake_ticket_id: 23456,
       needs_help_2018: "yes",
-      needs_help_2019: "yes")
+      needs_help_2019: "yes",
+      zendesk_instance_domain: EitcZendeskInstance::DOMAIN)
     end
   let!(:_other_year_intake) do
     create(:intake, original_intake.attributes.except("id").merge(needs_help_2018: "no"))
+  end
+  let!(:_uwtsa_intake) do
+    create(:intake,
+      original_intake.attributes.except("id")
+        .merge(zendesk_instance_domain: UwtsaZendeskInstance))
   end
   let!(:_other_name_intake) do
     create(:intake,
@@ -77,13 +84,14 @@ describe Zendesk::DuplicateIntakeMatcher do
         end
       end
     end
+
     context "when primary ticket is not identified (e.g. all tickets are closed)" do
       before do
         allow(merging_service).to receive(:find_primary_ticket)
           .and_return(nil)
       end
       it "does not blow up" do
-        expect { subject.run(false) }.not_to raise_error(NoMethodError)
+        expect { subject.run(false) }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
- skips merging and commenting of tickets when no duplicates are
identified

[#173280533] run merging service on all strong matches