### PR TITLE
Adjust color & spacing for filing-might-help page

### DIFF
--- a/app/assets/stylesheets/components/_checkmark-list.scss
+++ b/app/assets/stylesheets/components/_checkmark-list.scss
@@ -11,17 +11,20 @@ ul.checkmark-list {
     margin-left: 3.2rem;
   }
   svg.checkmark {
-     position: absolute;
-     top: 7px;
-     margin-right: 1.5rem;
-     &.teal {
-       fill: #02CEAA;
-     }
+    position: absolute;
+    top: 7px;
+    margin-right: 1.5rem;
+    &.teal {
+      fill: #02CEAA;
+    }
 
-     &.purple {
-       fill: $color-purple;
-     }
+    &.purple {
+      fill: $color-purple;
+    }
 
+    &.venice-blue {
+      fill: $color-venice-blue;
+    }
    }
 }
 

--- a/app/views/stimulus/filing_might_help/edit.html.erb
+++ b/app/views/stimulus/filing_might_help/edit.html.erb
@@ -12,15 +12,15 @@
         <%=t("views.stimulus.filing_might_help.info") %>
       </p>
 
-      <div class="text--semibold spacing-below-35">
+      <div class="text--semibold spacing-below-60">
         <p><%=t("views.stimulus.filing_might_help.list.header") %></p>
         <ul class="checkmark-list">
           <li>
-            <%= render "shared/svg/checkmark", fill_class: "purple" %>
+            <%= render "shared/svg/checkmark", fill_class: "venice-blue" %>
             <span><%=t("views.stimulus.filing_might_help.list.item_1") %> </span>
           </li>
           <li>
-            <%= render "shared/svg/checkmark", fill_class: "purple" %>
+            <%= render "shared/svg/checkmark", fill_class: "venice-blue" %>
             <span><%=t("views.stimulus.filing_might_help.list.item_2") %> </span>
           </li>
         </ul>


### PR DESCRIPTION
On `/stimulus/filing-might-help`,
- update the checkmarks to `#03578C` (`$color-venice-blue`)
- ensure 60px spacing above primary CTA button