### PR TITLE
Adjust scope of progress bar

### DIFF
--- a/app/assets/stylesheets/components/_progress-indicator.scss
+++ b/app/assets/stylesheets/components/_progress-indicator.scss
@@ -17,7 +17,7 @@
 }
 
 .progress-indicator__percentage {
-  color: #A0A0A0;
+  color: $color-grey-dark;
   font-size: 16px;
   font-weight: bold;
   margin: 0 auto;

--- a/app/controllers/questions/questions_controller.rb
+++ b/app/controllers/questions/questions_controller.rb
@@ -51,7 +51,7 @@ module Questions
     end
 
     def show_progress?
-      true
+      IntakeProgressCalculator.show_progress?(self.class)
     end
 
     private

--- a/app/services/intake_progress_calculator.rb
+++ b/app/services/intake_progress_calculator.rb
@@ -1,9 +1,12 @@
 class IntakeProgressCalculator
 
-  starting_index = QuestionNavigation::FLOW.index(Questions::BacktaxesController)
-  question_steps = QuestionNavigation::FLOW[starting_index..-1]
-  doc_overview_index = question_steps.index(Questions::OverviewDocumentsController)
-  POSSIBLE_STEPS = question_steps.insert(doc_overview_index + 1, *DocumentNavigation::FLOW)
+  starting_index = QuestionNavigation::FLOW.index(Questions::WasStudentController)
+  ending_index = QuestionNavigation::FLOW.index(Questions::AdditionalInfoController)
+  POSSIBLE_STEPS = QuestionNavigation::FLOW[starting_index..ending_index]
+
+  def self.show_progress?(controller_class)
+    POSSIBLE_STEPS.include? controller_class
+  end
 
   def self.get_progress(controller, intake)
     return 0 if controller == POSSIBLE_STEPS.first

--- a/app/views/documents/id_guidance/edit.html.erb
+++ b/app/views/documents/id_guidance/edit.html.erb
@@ -4,7 +4,6 @@
   <section class="slab slab--white">
     <div class="grid">
       <div class="grid__item width-three-fourths shift-one-eighth">
-        <%= render "shared/progress_bar" %>
         <main role="main">
           <div class="question__illustration spacing-above-0">
             <%= image_tag("questions/#{illustration_path}", alt: "") %>

--- a/app/views/documents/intro/edit.html.erb
+++ b/app/views/documents/intro/edit.html.erb
@@ -4,7 +4,6 @@
   <section class="slab slab--white">
     <div class="grid">
       <div class="grid__item width-three-fourths shift-one-eighth">
-        <%= render "shared/progress_bar" %>
         <main role="main">
           <h1 class="form-question">
             <%= content_for(:page_title) %>

--- a/app/views/documents/overview/edit.html.erb
+++ b/app/views/documents/overview/edit.html.erb
@@ -4,7 +4,6 @@
   <section class="slab slab--white">
     <div class="grid">
       <div class="grid__item width-three-fourths shift-one-eighth">
-        <%= render "shared/progress_bar" %>
         <main role="main">
           <h1 class="form-question">
             <%= content_for(:page_title) %>

--- a/app/views/documents/selfie_instructions/edit.html.erb
+++ b/app/views/documents/selfie_instructions/edit.html.erb
@@ -4,7 +4,6 @@
   <section class="slab slab--white">
     <div class="grid">
       <div class="grid__item width-three-fourths shift-one-eighth">
-        <%= render "shared/progress_bar" %>
         <main role="main">
           <h1 class="form-question">
             <%=t("views.documents.selfie_instructions.header") %>

--- a/app/views/layouts/document_upload.html.erb
+++ b/app/views/layouts/document_upload.html.erb
@@ -3,7 +3,6 @@
   <section class="slab slab--white">
     <div class="grid">
       <div class="grid__item width-three-fourths shift-one-eighth">
-        <%= render "shared/progress_bar" %>
         <main role="main">
           <h1 class="form-question">
             <%= yield :form_question %>

--- a/app/views/questions/consent/edit.html.erb
+++ b/app/views/questions/consent/edit.html.erb
@@ -8,7 +8,6 @@
     <div class="grid">
       <div class="grid__item width-three-fourths shift-one-eighth">
         <%= yield :notices %>
-        <%= render "shared/progress_bar" %>
         <main role="main">
           <%= form_with model: @form, url: current_path, local: true, method: "put", builder: VitaMinFormBuilder, html: { class: "form-card form-card--long" } do |f| %>
             <%= render "shared/consent_agreement" %>

--- a/app/views/questions/overview/edit.html.erb
+++ b/app/views/questions/overview/edit.html.erb
@@ -5,7 +5,6 @@
   <section class="slab slab--white">
     <div class="grid">
       <div class="grid__item width-three-fourths shift-one-eighth">
-        <%= render "shared/progress_bar" %>
         <main role="main">
           <h1 class="form-question"><%= @main_heading %></h1>
           <p class="spacing-below-35">

--- a/app/views/questions/overview_documents/edit.html.erb
+++ b/app/views/questions/overview_documents/edit.html.erb
@@ -5,7 +5,6 @@
   <section class="slab slab--white">
     <div class="grid">
       <div class="grid__item width-three-fourths shift-one-eighth">
-        <%= render "shared/progress_bar" %>
         <main role="main">
           <div class="form-card">
             <h1 class="form-question">

--- a/spec/features/web_intake/new_single_filer_spec.rb
+++ b/spec/features/web_intake/new_single_filer_spec.rb
@@ -24,7 +24,6 @@ RSpec.feature "Web Intake Single Filer" do
 
     # Ask about backtaxes
     expect(page).to have_selector("h1", text: "What years do you need to file for?")
-    expect(track_progress).to eq(0)
 
     check "2017"
     check "2019"
@@ -39,7 +38,6 @@ RSpec.feature "Web Intake Single Filer" do
 
     # VITA eligibility checks
     expect(page).to have_selector("h1", text: "Let’s check a few things.")
-    expect{ track_progress }.to change { @current_progress }.by_at_least(1)
 
     check "None of the above"
     click_on "Continue"
@@ -93,9 +91,13 @@ RSpec.feature "Web Intake Single Filer" do
 
     # Primary filer personal information
     expect(page).to have_selector("h1", text: "Were you a full-time student in 2019?")
+    expect(track_progress).to eq(0)
     click_on "No"
+
     expect(page).to have_selector("h1", text: "In 2019, were you in the United States on a Visa?")
+    expect{ track_progress }.to change { @current_progress }.by_at_least(1)
     click_on "No"
+
     expect(page).to have_selector("h1", text: "In 2019, did you have a permanent disability?")
     click_on "Yes"
     expect(page).to have_selector("h1", text: "In 2019, were you legally blind?")
@@ -209,6 +211,7 @@ RSpec.feature "Web Intake Single Filer" do
 
     # Additional Information
     fill_in "Is there any more information you think we should know?", with: "One of my kids moved away for college, should I include them as a dependent?"
+    expect{ track_progress }.to change { @current_progress }.to(100)
     click_on "Next"
 
     # Overview: Documents
@@ -220,7 +223,6 @@ RSpec.feature "Web Intake Single Filer" do
     click_on "Continue"
 
     expect(page).to have_selector("h1", text: "Attach a photo of your ID card")
-    expect(track_progress).to be_present
     attach_file("document_type_upload_form_document", Rails.root.join("spec", "fixtures", "attachments", "picture_id.jpg"))
     click_on "Upload"
     click_on "Continue"
@@ -355,7 +357,6 @@ RSpec.feature "Web Intake Single Filer" do
     click_on "Submit"
 
     expect(page).to have_selector("h1", text: "Success! Your tax information has been submitted.")
-    expect{ track_progress }.to change { @current_progress }.to(100)
     expect(page).to have_text("Your confirmation number is: #{ticket_id}")
 
     # reloading the success page works without trying to show the progress bar

--- a/spec/services/intake_progress_calculator_spec.rb
+++ b/spec/services/intake_progress_calculator_spec.rb
@@ -1,27 +1,16 @@
 require "rails_helper"
 
 describe IntakeProgressCalculator do
-  describe "::POSSIBLE_STEPS" do
-    it "inserts the document flow into the question flow after document overview" do
-      expect(IntakeProgressCalculator::POSSIBLE_STEPS.index(Questions::OverviewDocumentsController))
-        .to eq(IntakeProgressCalculator::POSSIBLE_STEPS.index(DocumentNavigation::FLOW.first) - 1)
-    end
-
-    it "starts with the backtaxes controller" do
-      expect(IntakeProgressCalculator::POSSIBLE_STEPS.first).to eq Questions::BacktaxesController
-    end
-  end
-
   describe "#get_progress" do
     let (:intake) { create :intake }
     it "returns 0 for the progress of the starting controller and intake" do
-      progress = IntakeProgressCalculator.get_progress(Questions::BacktaxesController, intake)
+      progress = IntakeProgressCalculator.get_progress(Questions::WasStudentController, intake)
 
       expect(progress).to eq 0
     end
 
     it "returns 100 for the progress of the final controller and intake" do
-      progress = IntakeProgressCalculator.get_progress(Questions::SuccessfullySubmittedController, intake)
+      progress = IntakeProgressCalculator.get_progress(Questions::AdditionalInfoController, intake)
 
       expect(progress).to eq 100
     end
@@ -31,12 +20,13 @@ describe IntakeProgressCalculator do
     end
 
     it "includes all possible future steps until you reach the question" do
-      intake_survey_yes = Intake.new(demographic_questions_opt_in: :yes)
-      intake_survey_no = Intake.new(demographic_questions_opt_in: :no)
-      intake_survey_unfilled = Intake.new
+      ever_married_yes = Intake.new(ever_married: :yes)
+      ever_married_no = Intake.new(ever_married: :no)
+      ever_married_unfilled = Intake.new
+      controller_before_question = Questions::IssuedIdentityPinController
 
-      expect(IntakeProgressCalculator.get_progress(Questions::MailingAddressController, intake_survey_yes)).to eq IntakeProgressCalculator.get_progress(Questions::MailingAddressController, intake_survey_no)
-      expect(IntakeProgressCalculator.get_progress(Questions::MailingAddressController, intake_survey_yes)).to eq IntakeProgressCalculator.get_progress(Questions::MailingAddressController, intake_survey_unfilled)
+      expect(IntakeProgressCalculator.get_progress(controller_before_question, ever_married_yes)).to eq IntakeProgressCalculator.get_progress(controller_before_question, ever_married_no)
+      expect(IntakeProgressCalculator.get_progress(controller_before_question, ever_married_yes)).to eq IntakeProgressCalculator.get_progress(controller_before_question, ever_married_unfilled)
     end
   end
 end


### PR DESCRIPTION
Start the progress bar on "Was student?" and end it on "additional info" 
Also makes the text a little darker for accessibility standards.

https://www.pivotaltracker.com/story/show/173505665