### PR TITLE
collect all group pages in ZD cli

### DIFF
--- a/app/cli/zendesk_cli/import_users.rb
+++ b/app/cli/zendesk_cli/import_users.rb
@@ -188,7 +188,9 @@ class ZendeskCli
     # Load a cache of all Zendesk groups so we can easily search for a given
     # group by name.
     def zendesk_groups
-      @zendesk_groups ||= client.groups.to_a
+      groups = []
+      client.groups.all! { |group| groups << group }
+      @zendesk_groups ||= groups.to_a
     end
 
     # Load a cache of all Zendesk custom roles so we can easily find a role by

--- a/app/cli/zendesk_cli/import_users.rb
+++ b/app/cli/zendesk_cli/import_users.rb
@@ -188,6 +188,8 @@ class ZendeskCli
     # Load a cache of all Zendesk groups so we can easily search for a given
     # group by name.
     def zendesk_groups
+      return @zendesk_groups if @zendesk_groups.present?
+
       groups = []
       client.groups.all! { |group| groups << group }
       @zendesk_groups ||= groups.to_a


### PR DESCRIPTION
No idea what I'm doing or how ruby syntax really works, but I adapted some of your code @tdooner and it was able to find the second page of groups!

Feel free to tear it up if my ham-fisted implementation raises any other concerns or breaks any style conventions etc.