### PR TITLE
Fixes copy mistake on vita provider page and adds cron job to scrape providers once a week

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1262,7 +1262,7 @@ en:
         no_hours_listed: Sorry, no hours listed.
         no_phone_number_listed: Sorry, no phone number listed.
         phone_number_title: Call %{provider_name}
-        search_radius: Within %{distance} miles of %{zip} (%{zip_name}) %>
+        search_radius: Within %{distance} miles of %{zip} (%{zip_name})
     zendesk:
       extracts:
         filename: Filename

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1262,7 +1262,7 @@ es:
         no_hours_listed: Disculpe, no hay horario de apertura.
         no_phone_number_listed: Disculpe, no hay número de teléfono.
         phone_number_title: Llame a %{provider_name}
-        search_radius: Dentro de %{distance} millas de %{zip} (%{zip_name}) %>
+        search_radius: Dentro de %{distance} millas de %{zip} (%{zip_name})
     zendesk:
       extracts:
         filename: Nombre de archivo

--- a/crontab
+++ b/crontab
@@ -1,1 +1,2 @@
 */30 * * * * bundle exec rake documents:notify_unsent
+0 0 * * 0 bundle exec rake vita_providers:scrape_vita_providers

--- a/lib/tasks/scrape_vita_providers.rake
+++ b/lib/tasks/scrape_vita_providers.rake
@@ -1,0 +1,7 @@
+namespace :vita_providers do
+  desc 'scrapes vita providers from IRS website'
+  task scrape_vita_providers: [:environment] do
+    service = ScrapeVitaProvidersJob.new
+    service.perform_now
+  end
+end


### PR DESCRIPTION
I was on a wild goose chase related to a sentry error when I bumped into a small copy mistake (probably the result of copy pasting)

Also discovered while trying to hunt down a missing delimiter was the fact that when I scraped providers locally I could not find the one that was in the URL for the Sentry error. I couldn't remember or find whether we have some way to regularly scrape providers so I made this weekly cron job.