### PR TITLE
Reroutes all MA source codes to "Online Intake (w/Boston Tax Help)"

### DIFF
--- a/db/vita_partners.yml
+++ b/db/vita_partners.yml
@@ -190,10 +190,6 @@ vita_partners:
   zendesk_group_id: '360009807434'
   display_name: Tax Help New Mexico
   logo_path: partner-logos/th-nm.png
-  source_parameters:
-  - uwcnm
-  states:
-  - NM
   weekly_capacity_limit: 0
 - name: United Way of Greater Newark
   zendesk_instance_domain: eitc

--- a/db/vita_partners.yml
+++ b/db/vita_partners.yml
@@ -235,6 +235,14 @@ vita_partners:
   zendesk_group_id: '360011044474'
   display_name: Massachusetts Association for Community Action (MASSCAP) and Boston
     Tax Help
+  source_parameters:
+  - MC-SP
+  - MC-CAPV
+  - MC-NS
+  - MC-LEO
+  - MC-SSSC
+  - MC-SOUTH
+  - MC-WOR
   states:
   - MA
   logo_path: ''
@@ -242,38 +250,26 @@ vita_partners:
   zendesk_instance_domain: eitc
   zendesk_group_id: '360010417234'
   display_name: Massachusetts Association for Community Action (MASSCAP)
-  source_parameters:
-  - MC-SSSC
-  - MC-SOUTH
   logo_path: ''
 - name: "[MA/BTH] North Shore"
   zendesk_instance_domain: eitc
   zendesk_group_id: '360010417254'
   display_name: Massachusetts Association for Community Action (MASSCAP)
-  source_parameters:
-  - MC-NS
-  - MC-LEO
   logo_path: ''
 - name: "[MA/BTH] Springfield"
   zendesk_instance_domain: eitc
   zendesk_group_id: '360010417334'
   display_name: Massachusetts Association for Community Action (MASSCAP)
-  source_parameters:
-  - MC-SP
   logo_path: ''
 - name: "[MA/BTH] Community Action of Pioneer Valley"
   zendesk_instance_domain: eitc
   zendesk_group_id: '360010417354'
   display_name: Massachusetts Association for Community Action (MASSCAP)
-  source_parameters:
-  - MC-CAPV
   logo_path: ''
 - name: "[MA/BTH] Worcester"
   zendesk_instance_domain: eitc
   zendesk_group_id: '360010415253'
   display_name: Massachusetts Association for Community Action (MASSCAP)
-  source_parameters:
-  - MC-WOR
   logo_path: ''
 - name: "[MA/BTH] ABCD"
   zendesk_instance_domain: eitc

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -796,7 +796,6 @@ describe Intake do
       it_behaves_like "state-level routing", "AZ", "United Way of Tucson and Southern Arizona", "eitc"
       it_behaves_like "state-level routing", "VA", "United Way of Greater Richmond and Petersburg", "eitc"
       it_behaves_like "state-level routing", "FL", "Tax Help Colorado (Piton Foundation)", "eitc"
-      it_behaves_like "state-level routing", "NM", "Tax Help New Mexico", "eitc"
       it_behaves_like "state-level routing", "MD", "CASH Campaign of MD", "eitc"
       it_behaves_like "state-level routing", "NY", "Urban Upbound (NY)", "eitc"
       it_behaves_like "state-level routing", "TN", "United Way of Greater Nashville", "eitc"


### PR DESCRIPTION
- Shuts down Tax Help New Mexico by removing state and source

[#173806492] URGENT - Reroute MA clients
[#173806679] Partner Capacity Updates
