### PR TITLE
Route all overflow to UUNY with capacity limit

### DIFF
--- a/app/controllers/questions/at_capacity_controller.rb
+++ b/app/controllers/questions/at_capacity_controller.rb
@@ -15,7 +15,7 @@ module Questions
       def show?(intake)
         return false unless intake.vita_partner
 
-        intake.vita_partner.at_capacity?
+        intake.might_encounter_delayed_service?
       end
     end
   end

--- a/app/lib/vita_partner_importer.rb
+++ b/app/lib/vita_partner_importer.rb
@@ -14,7 +14,8 @@ module VitaPartnerImporter
   def upsert_vita_partners(yml = VITA_PARTNERS_YAML)
     say "beginning partner upsert using environment: #{Rails.env}"
 
-    partners = YAML.load_file(yml)['vita_partners']
+    yaml_file = YAML.load_file(yml)
+    partners = yaml_file['vita_partners']
     VitaPartner.transaction do
       SourceParameter.destroy_all
       partners.each do |datum|

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -438,7 +438,7 @@ class Intake < ApplicationRecord
     # this is a RouteOptions struct, defined below
     route_options = partner_for_source || partner_for_state || partner_for_overflow
 
-    raise "partner not found!" unless route_options.partner # this shouldn't happen unless the data is horked!
+    raise "partner not found!" unless route_options&.partner # this shouldn't happen unless the data is horked!
 
     update(
       vita_partner_id: route_options.partner.id,
@@ -448,6 +448,10 @@ class Intake < ApplicationRecord
       routing_criteria: route_options.routing_criteria,
       routing_value: route_options.routing_value,
     )
+  end
+
+  def might_encounter_delayed_service?
+    !vita_partner.has_capacity_for?(self)
   end
 
   def zendesk_instance

--- a/db/vita_partners.yml
+++ b/db/vita_partners.yml
@@ -69,7 +69,7 @@ vita_partners:
   - fc
   states:
   - TX
-  accepts_overflow: true
+  accepts_overflow: false
   logo_path: ''
   weekly_capacity_limit: 0
 - name: United Way of Central Ohio
@@ -95,7 +95,7 @@ vita_partners:
   zendesk_group_id: '360009581934'
   display_name: United Way of Tucson and Southern Arizona
   logo_path: ''
-  accepts_overflow: true
+  accepts_overflow: false
   states:
   - AZ
   weekly_capacity_limit: 0
@@ -228,6 +228,7 @@ vita_partners:
   - VT
   logo_path: ''
   weekly_capacity_limit: 500
+  accepts_overflow: true
 - name: "[MA/BTH] Online Intake (w/Boston Tax Help)"
   zendesk_instance_domain: eitc
   zendesk_group_id: '360011044474'

--- a/spec/controllers/questions/at_capacity_controller_spec.rb
+++ b/spec/controllers/questions/at_capacity_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Questions::AtCapacityController do
   describe ".show?" do
     context "when vita partner is at capacity" do
       before do
-        allow(vita_partner).to receive(:at_capacity?).and_return true
+        allow(intake).to receive(:might_encounter_delayed_service?).and_return true
       end
 
       it "returns true" do
@@ -22,7 +22,7 @@ RSpec.describe Questions::AtCapacityController do
 
     context "when vita partner is not yet at capacity" do
       before do
-        allow(vita_partner).to receive(:at_capacity?).and_return false
+        allow(intake).to receive(:might_encounter_delayed_service?).and_return false
       end
 
       it "returns false" do

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -935,6 +935,20 @@ describe Intake do
     end
   end
 
+  describe "#might_encounter_delayed_service?" do
+    let(:vita_partner) { create :vita_partner }
+    let(:intake) { build :intake, vita_partner: vita_partner }
+
+    before do
+      allow(vita_partner).to receive(:has_capacity_for?).with(intake).and_return(true)
+    end
+
+    it "returns true if the partner does not have capacity for this intake" do
+      expect(intake.might_encounter_delayed_service?).to eq false
+      expect(vita_partner).to have_received(:has_capacity_for?).with(intake)
+    end
+  end
+
   describe "#contact_info_filtered_by_preferences" do
     let(:intake) do
       build :intake,

--- a/spec/models/vita_partner_spec.rb
+++ b/spec/models/vita_partner_spec.rb
@@ -17,82 +17,153 @@
 require "rails_helper"
 
 describe VitaPartner do
-  describe "#at_capacity?" do
-    let(:vita_partner) { create(:vita_partner, weekly_capacity_limit: 10) }
+  context "capacity" do
+    let(:routing_criteria) { "source_parameter" }
+    let(:recent_intake_count) { 0 }
 
     before do
-      recent_intake_count.times do |n|
-        create(
-          :intake,
-          primary_consented_to_service_at: 1.minute.since((n % 7).days.ago),
-          intake_ticket_id: 1000 + n,
-          vita_partner: vita_partner
-        )
-      end
+      create_list(
+        :intake,
+        recent_intake_count,
+        vita_partner: vita_partner,
+        primary_consented_to_service_at: rand(1...6).days.ago,
+        intake_ticket_id: 12345,
+        routing_criteria: routing_criteria,
+      )
     end
 
-    context "recently consented intakes with Zendesk ticket count is at capacity limit" do
-      let(:recent_intake_count) { vita_partner.weekly_capacity_limit }
-      it "returns true" do
-        expect(vita_partner).to be_at_capacity
-      end
-    end
+    describe "#at_capacity?" do
+      let(:vita_partner) { create(:vita_partner, weekly_capacity_limit: 10) }
 
-    context "recently consented intakes with Zendesk ticket count is above capacity limit" do
-      let(:recent_intake_count) { vita_partner.weekly_capacity_limit + 1}
-      it "returns true" do
-        expect(vita_partner).to be_at_capacity
-      end
-    end
+      context "recently consented intakes with Zendesk ticket count is at capacity limit" do
+        let(:recent_intake_count) { vita_partner.weekly_capacity_limit }
 
-    context "recently consented intakes with Zendesk ticket count is less than capacity limit" do
-      let(:recent_intake_count) do
-        vita_partner.weekly_capacity_limit - 1
-      end
-      it "returns false" do
-        expect(vita_partner).not_to be_at_capacity
+        it "returns true" do
+          expect(vita_partner).to be_at_capacity
+        end
       end
 
-      context "when there are partner intakes consented more than a week ago" do
-        before do
-          create(
-            :intake,
-            primary_consented_to_service_at: 7.days.ago,
-            vita_partner: vita_partner
-          )
+      context "recently consented intakes with Zendesk ticket count is above capacity limit" do
+        let(:recent_intake_count) { vita_partner.weekly_capacity_limit + 1}
+
+        it "returns true" do
+          expect(vita_partner).to be_at_capacity
+        end
+      end
+
+      context "recently consented intakes with Zendesk ticket count is less than capacity limit" do
+        let(:recent_intake_count) do
+          vita_partner.weekly_capacity_limit - 1
         end
 
         it "returns false" do
           expect(vita_partner).not_to be_at_capacity
         end
-      end
 
-      context "when there are recently consented partner intakes without tickets" do
-        before do
+        context "when there are partner intakes consented more than a week ago" do
+          before do
+            create(
+              :intake,
+              primary_consented_to_service_at: 7.days.ago,
+              vita_partner: vita_partner
+            )
+          end
+
+          it "returns false" do
+            expect(vita_partner).not_to be_at_capacity
+          end
+        end
+
+        context "when there are recently consented partner intakes without tickets" do
+          before do
+            create(
+              :intake,
+              primary_consented_to_service_at: 1.days.ago,
+              vita_partner: vita_partner
+            )
+          end
+
+          it "returns false" do
+            expect(vita_partner).not_to be_at_capacity
+          end
+        end
+
+        context "when there are partner intakes that have not been consented to" do
+          before do
+            create(
+              :intake,
+              primary_consented_to_service_at: nil,
+              intake_ticket_id: 123,
+              vita_partner: vita_partner
+            )
+          end
+
+          it "returns false" do
+            expect(vita_partner).not_to be_at_capacity
+          end
+        end
+      end
+    end
+
+    describe "#has_capacity_for?" do
+      let(:intake) { create :intake, vita_partner: vita_partner, routing_criteria: routing_criteria }
+
+      context "for the special situation of Urban Upbound" do
+        let(:vita_partner) do
           create(
-            :intake,
-            primary_consented_to_service_at: 1.days.ago,
-            vita_partner: vita_partner
+            :vita_partner,
+            name: "Urban Upbound (NY)",
+            zendesk_group_id: "360010243314",
           )
         end
 
-        it "returns false" do
-          expect(vita_partner).not_to be_at_capacity
+        context "with an intake referred by source parameter" do
+          let(:routing_criteria) { "source_parameter" }
+
+          it "always has capacity" do
+            expect(vita_partner.has_capacity_for?(intake)).to eq true
+          end
+        end
+
+        context "with an intake in UUNY's list of states" do
+          let(:routing_criteria) { "state" }
+
+          it "always has capacity" do
+            expect(vita_partner.has_capacity_for?(intake)).to eq true
+          end
+        end
+
+        context "with an overflow intake" do
+          let(:routing_criteria) { "overflow" }
+
+          context "under 50 overflow intakes this week" do
+            let(:recent_intake_count) { 5 }
+
+            it "has capacity for the intake" do
+              expect(vita_partner.has_capacity_for?(intake)).to eq true
+            end
+          end
+
+          context "more than 50 overflow intakes this week" do
+            let(:recent_intake_count) { 51 }
+
+            it "does not have capacity for this intake" do
+              expect(vita_partner.has_capacity_for?(intake)).to eq false
+            end
+          end
         end
       end
 
-      context "when there are partner intakes that have not been consented to" do
+      context "in all other cases" do
+        let(:vita_partner) { create :vita_partner }
+
         before do
-          create(
-            :intake,
-            primary_consented_to_service_at: nil,
-            intake_ticket_id: 123,
-            vita_partner: vita_partner
-          )
+          allow(vita_partner).to receive(:at_capacity?).and_return(false)
         end
 
-        it "returns false" do
-          expect(vita_partner).not_to be_at_capacity
+        it "just checks for the partner's default capacity" do
+          expect(vita_partner.has_capacity_for?(intake)).to eq true
+          expect(vita_partner).to have_received(:at_capacity?)
         end
       end
     end


### PR DESCRIPTION
- only limits UUNY capacity for overflow intakes, allows unlimited state and source routed intakes

Co-authored-by: Jenny Heath <jheath@codeforamerica.org>