### PR TITLE
Add GYR Volunteer roles to Import Script

### DIFF
--- a/app/cli/zendesk_cli/import_users.rb
+++ b/app/cli/zendesk_cli/import_users.rb
@@ -14,7 +14,9 @@ class ZendeskCli
       "Customer Support Advocate" => "VITA Staff",
       "Quality Reviewer" => "VITA Staff",
       "Limited Volunteer" => "VITA Staff (assigned tickets only)",
-    }
+      "Partner Support - Explore Dashboard" => "Partner Support - Explore Dashboard",
+      "Brigade - All Client Access" => "Brigade - All Client Access",
+    }.freeze
 
     def self.from_csv(csv_path)
       rows = CSV.open(Rails.root.join(csv_path), 'r', headers: :first_row)


### PR DESCRIPTION
These roles have existed in Zendesk for a while now, and we've defined
processes for volunteers to get these levels of access. This is
documented in the [Access Matrix for GYR Volunteers][1].

[1]: https://docs.google.com/spreadsheets/d/1MySYITwcOmye2mLzusNV8TGArGPyrjoXasGGQlFxYPQ/edit#gid=0