### PR TITLE
Set names for both edit and update

### DIFF
--- a/app/controllers/documents/document_upload_question_controller.rb
+++ b/app/controllers/documents/document_upload_question_controller.rb
@@ -72,5 +72,12 @@ module Documents
     def form_navigation
       @form_navigation ||= DocumentNavigation.new(self)
     end
+
+    def set_filer_names
+      @names = [current_intake.primary_full_name]
+      if current_intake.filing_joint_yes?
+        @names << current_intake.spouse_name_or_placeholder
+      end
+    end
   end
 end

--- a/app/controllers/documents/ids_controller.rb
+++ b/app/controllers/documents/ids_controller.rb
@@ -1,12 +1,6 @@
 module Documents
   class IdsController < DocumentUploadQuestionController
-    def edit
-      @names = [current_intake.primary_full_name]
-      if current_intake.filing_joint_yes?
-        @names << current_intake.spouse_name_or_placeholder
-      end
-      super
-    end
+    before_action :set_filer_names, only: [:edit, :update]
 
     def self.document_type
       "ID"

--- a/app/controllers/documents/selfies_controller.rb
+++ b/app/controllers/documents/selfies_controller.rb
@@ -1,12 +1,6 @@
 module Documents
   class SelfiesController < DocumentUploadQuestionController
-    def edit
-      @names = [current_intake.primary_full_name]
-      if current_intake.filing_joint_yes?
-        @names << current_intake.spouse_name_or_placeholder
-      end
-      super
-    end
+    before_action :set_filer_names, only: [:edit, :update]
 
     def self.document_type
       "Selfie"

--- a/app/controllers/documents/ssn_itins_controller.rb
+++ b/app/controllers/documents/ssn_itins_controller.rb
@@ -1,6 +1,14 @@
 module Documents
   class SsnItinsController < DocumentUploadQuestionController
-    def edit
+    before_action :set_household_names, only: [:edit, :update]
+
+    def self.document_type
+      "SSN or ITIN"
+    end
+
+    private
+
+    def set_household_names
       @names = [current_intake.primary_full_name]
       if current_intake.filing_joint_yes?
         @names << current_intake.spouse_name_or_placeholder
@@ -8,11 +16,6 @@ module Documents
       if current_intake.dependents.present?
         @names += current_intake.dependents.map(&:full_name)
       end
-      super
-    end
-
-    def self.document_type
-      "SSN or ITIN"
     end
   end
 end

--- a/app/controllers/documents/student_account_statements_controller.rb
+++ b/app/controllers/documents/student_account_statements_controller.rb
@@ -1,16 +1,19 @@
 module Documents
   class StudentAccountStatementsController < DocumentUploadQuestionController
+    before_action :set_student_names, only: [:edit, :update]
+
     def self.show?(intake)
       intake.any_students?
     end
 
-    def edit
-      @student_names = current_intake.student_names
-      super
-    end
-
     def self.document_type
       "Student Account Statement"
+    end
+
+    private
+
+    def set_student_names
+      @student_names = current_intake.student_names
     end
   end
 end

--- a/spec/controllers/documents/ids_controller_spec.rb
+++ b/spec/controllers/documents/ids_controller_spec.rb
@@ -56,5 +56,26 @@ RSpec.describe Documents::IdsController do
       end
     end
   end
+
+  describe "#update" do
+    context "with an invalid file upload" do
+      render_views
+
+      let(:params) do
+        {
+          document_type_upload_form: {
+            document: fixture_file_upload("attachments/test-pattern.html")
+          }
+        }
+      end
+
+      it "renders edit with validation errors" do
+        post :update, params: params
+
+        expect(response).to render_template :edit
+        expect(response.body).to include "Please upload a valid document type."
+      end
+    end
+  end
 end
 


### PR DESCRIPTION
This resolves the (currently live!) bug on 
https://www.pivotaltracker.com/story/show/173943188

In short, we weren't setting names on document upload templates for the update method. Consequently, when we tried to render :edit, the template would choke on the nil value for the `@names` instance attribute.

Co-authored-by: Dimitri DeFigueiredo <ddefigueiredo@codeforamerica.org>