### PR TITLE
Stop attaching drop off documents to zendesk ticket, show in doc portal instead

### DIFF
--- a/app/controllers/intake_site_drop_offs_controller.rb
+++ b/app/controllers/intake_site_drop_offs_controller.rb
@@ -27,7 +27,7 @@ class IntakeSiteDropOffsController < ApplicationController
         ZendeskDropOffService.new(@drop_off).append_to_existing_ticket
         track_append_to_drop_off
       else
-        zendesk_ticket_id = ZendeskDropOffService.new(@drop_off).create_ticket_and_attach_file
+        zendesk_ticket_id = ZendeskDropOffService.new(@drop_off).create_ticket
         @drop_off.update(zendesk_ticket_id: zendesk_ticket_id)
         track_create_drop_off
       end

--- a/app/controllers/zendesk/drop_offs_controller.rb
+++ b/app/controllers/zendesk/drop_offs_controller.rb
@@ -1,0 +1,22 @@
+module Zendesk
+  class DropOffsController < ApplicationController
+    include ZendeskAuthenticationControllerHelper
+    include FileResponseControllerHelper
+
+    before_action :require_zendesk_user, :set_drop_off, :require_ticket_access
+
+    def show
+      render_active_storage_attachment @drop_off.document_bundle
+    end
+
+    private
+
+    def set_drop_off
+      @drop_off = IntakeSiteDropOff.find(params[:id])
+    end
+
+    def zendesk_ticket_id
+      @drop_off.zendesk_ticket_id
+    end
+  end
+end

--- a/app/controllers/zendesk/tickets_controller.rb
+++ b/app/controllers/zendesk/tickets_controller.rb
@@ -3,6 +3,7 @@ module Zendesk
     include ZendeskAuthenticationControllerHelper
 
     before_action :require_zendesk_user, :require_ticket_access
+    helper_method :drop_off_upload_date
 
     layout "admin"
 
@@ -13,9 +14,15 @@ module Zendesk
         zendesk_instance_domain: EitcZendeskInstance::DOMAIN
       )
       @document_groups = DocumentPresenter.grouped_documents(@intakes)
+
+      @drop_offs = IntakeSiteDropOff.where(zendesk_ticket_id: zendesk_ticket_id)
     end
 
     private
+
+    def drop_off_upload_date(drop_off)
+      "#{ActionController::Base.helpers.time_ago_in_words(drop_off.created_at)} ago"
+    end
 
     def zendesk_ticket_id
       params[:id]

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -48,5 +48,4 @@ class DocumentPresenter < BasePresenter
   def byte_size
     upload.byte_size
   end
-
 end

--- a/app/services/zendesk_drop_off_service.rb
+++ b/app/services/zendesk_drop_off_service.rb
@@ -38,14 +38,10 @@ class ZendeskDropOffService
           EitcZendeskInstance::SIGNATURE_METHOD => @drop_off.signature_method
       }
     )
-    success = ticket.save
-    raise ZendeskServiceHelper::ZendeskAPIError.new("Error creating drop off ticket: #{ticket.errors}") unless success
+    ticket.save!
 
     ticket.fields = { EitcZendeskInstance::LINK_TO_CLIENT_DOCUMENTS => zendesk_ticket_url(id: ticket.id) }
-    update_success = ticket.save
-    raise ZendeskServiceHelper::ZendeskAPIError.new(
-      "Error updating drop off ticket document link: #{ticket.errors}"
-    ) unless update_success
+    ticket.save!
 
     return ticket.id
   end
@@ -54,9 +50,7 @@ class ZendeskDropOffService
     ticket = ZendeskAPI::Ticket.find(client, id: @drop_off.zendesk_ticket_id)
     ticket.comment = { body: comment_body }
 
-    success = ticket.save
-    raise ZendeskServiceHelper::ZendeskAPIError.new("Error updating drop off ticket: #{ticket.errors}") unless success
-
+    success = ticket.save!
     success
   end
 

--- a/app/views/zendesk/tickets/show.html.erb
+++ b/app/views/zendesk/tickets/show.html.erb
@@ -92,6 +92,20 @@
           <td></td>
         </tr>
       <% end %>
+      <% if @drop_offs.present? %>
+        <% @drop_offs.each do |drop_off| %>
+          <tr>
+            <td><%=t("views.zendesk.tickets.show.chart.drop_off_document_bundle") %></td>
+            <td>
+              <%= link_to drop_off.document_bundle.filename,
+                zendesk_drop_off_path(id: drop_off.id),
+                target: "_blank" %>
+            </td>
+            <td><%= drop_off_upload_date(drop_off) %></td>
+            <td></td>
+          </tr>
+        <% end %>
+      <% end %>
     </tbody>
   </table>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1296,3 +1296,4 @@ en:
             link: Link
             notes: Notes
             upload_date: Upload Date
+            drop_off_document_bundle: Document Bundle

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1296,3 +1296,4 @@ es:
             link: Vínculo
             notes: Apuntes
             upload_date: Fecha de carga
+            drop_off_document_bundle: Paquete de documentos

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,6 +91,7 @@ Rails.application.routes.draw do
     namespace :zendesk do
       resources :tickets, only: [:show]
       resources :documents, only: [:show]
+      resources :drop_offs, only: [:show]
       resources :intakes, only: [:pdf, :consent_pdf] do
         get "13614c/:filename", to: "intakes#intake_pdf", on: :member, as: :pdf
         get "consent/:filename", to: "intakes#consent_pdf", on: :member, as: :consent_pdf

--- a/spec/controllers/intake_site_drop_offs_controller_spec.rb
+++ b/spec/controllers/intake_site_drop_offs_controller_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe IntakeSiteDropOffsController do
   let(:ticket_id) { '23' }
   let(:zendesk_drop_off_service_spy) do
-    instance_double(ZendeskDropOffService, create_ticket_and_attach_file: ticket_id, append_to_existing_ticket: true)
+    instance_double(ZendeskDropOffService, create_ticket: ticket_id, append_to_existing_ticket: true)
   end
 
   before do
@@ -142,7 +142,7 @@ RSpec.describe IntakeSiteDropOffsController do
             drop_off = IntakeSiteDropOff.last
 
             expect(ZendeskDropOffService).to have_received(:new).with(drop_off)
-            expect(zendesk_drop_off_service_spy).to have_received(:create_ticket_and_attach_file)
+            expect(zendesk_drop_off_service_spy).to have_received(:create_ticket)
             expect(drop_off.zendesk_ticket_id).to eq ticket_id
             expect(response).to redirect_to show_drop_off_path(id: drop_off.id, organization: "thc")
           end
@@ -221,7 +221,7 @@ RSpec.describe IntakeSiteDropOffsController do
             drop_off = IntakeSiteDropOff.last
 
             expect(ZendeskDropOffService).to have_received(:new).with(drop_off)
-            expect(zendesk_drop_off_service_spy).to have_received(:create_ticket_and_attach_file)
+            expect(zendesk_drop_off_service_spy).to have_received(:create_ticket)
             expect(drop_off.zendesk_ticket_id).to eq ticket_id
             expect(response).to redirect_to show_drop_off_path(id: drop_off.id, organization: "thc")
           end

--- a/spec/controllers/zendesk/drop_offs_controller_spec.rb
+++ b/spec/controllers/zendesk/drop_offs_controller_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe Zendesk::DropOffsController do
+  describe "#show" do
+    let!(:drop_off) { create :intake_site_drop_off }
+    let(:user) { create :user, provider: "zendesk" }
+
+    it_behaves_like :a_protected_zendesk_ticket_page do
+      let(:valid_params) do
+        { id: drop_off.id }
+      end
+    end
+
+    context "as an authenticated zendesk user with ticket access" do
+      let(:ticket) { instance_double(ZendeskAPI::Ticket) }
+
+      before do
+        allow(subject).to receive(:current_user).and_return(user)
+        allow(subject).to receive(:current_ticket).and_return(ticket)
+      end
+
+      it "renders the document" do
+        get :show, params: { id: drop_off.id }
+
+        expect(response).to be_ok
+        expect(response.headers["Content-Type"]).to eq("application/pdf")
+      end
+    end
+
+    context "as an authenticated user without ticket access" do
+      before do
+        allow(subject).to receive(:current_user).and_return(user)
+      end
+
+      it "returns 404 with a not found page" do
+        get :show, params: { id: drop_off.id }
+
+        expect(response.status).to eq 404
+        expect(response).to render_template "public_pages/page_not_found"
+      end
+    end
+  end
+end

--- a/spec/controllers/zendesk/tickets_controller_spec.rb
+++ b/spec/controllers/zendesk/tickets_controller_spec.rb
@@ -4,9 +4,6 @@ RSpec.describe Zendesk::TicketsController do
   let(:ticket_id) { 123 }
   let(:user) { create :user, provider: "zendesk" }
   let(:ticket) { double("ZendeskAPI::Ticket", id: ticket_id, subject: "Oswald Orange") }
-  let!(:intake) { create :intake, intake_ticket_id: ticket_id, zendesk_instance_domain: "eitc" }
-  let!(:id_document) { create :document, :with_upload, intake: intake, document_type: "ID" }
-  let!(:w2_document) { create :document, :with_upload, intake: intake, document_type: "W-2" }
 
   describe "#show" do
     it_behaves_like :a_protected_zendesk_ticket_page do
@@ -23,61 +20,97 @@ RSpec.describe Zendesk::TicketsController do
         allow(subject).to receive(:current_ticket).and_return(ticket)
       end
 
-      context "with one intake" do
-        it "shows all documents for the intake based on ticket id" do
-          get :show, params: { id: ticket_id }
+      context "with intakes" do
+        let!(:intake) { create :intake, intake_ticket_id: ticket_id, zendesk_instance_domain: "eitc" }
+        let!(:id_document) { create :document, :with_upload, intake: intake, document_type: "ID" }
+        let!(:w2_document) { create :document, :with_upload, intake: intake, document_type: "W-2" }
 
-          expect(assigns(:ticket)).to eq ticket
-          expect(assigns(:intakes)).to contain_exactly(intake)
-          expect(assigns(:document_groups).values.map(&:first).map(&:original_object))
-            .to contain_exactly(id_document, w2_document)
-          expect(response.body).to include(pdf_zendesk_intake_path(id: intake.id, filename: intake.intake_pdf_filename))
-          expect(response.body).to include(consent_pdf_zendesk_intake_path(
-                                             id: intake.id, filename: intake.consent_pdf_filename))
-          expect(response.body).to include(zendesk_document_path(id: id_document.id))
-          expect(response.body).to include(zendesk_document_path(id: w2_document.id))
+        context "with one intake" do
+          it "shows all documents for the intake based on ticket id" do
+            get :show, params: { id: ticket_id }
+
+            expect(assigns(:ticket)).to eq ticket
+            expect(assigns(:intakes)).to contain_exactly(intake)
+            expect(assigns(:document_groups).values.map(&:first).map(&:original_object))
+              .to contain_exactly(id_document, w2_document)
+            expect(response.body).to include(pdf_zendesk_intake_path(id: intake.id, filename: intake.intake_pdf_filename))
+            expect(response.body).to include(consent_pdf_zendesk_intake_path(
+                                               id: intake.id, filename: intake.consent_pdf_filename))
+            expect(response.body).to include(zendesk_document_path(id: id_document.id))
+            expect(response.body).to include(zendesk_document_path(id: w2_document.id))
+          end
+        end
+
+        context "with duplicate linked intakes" do
+          let!(:duplicate_intake) { create :intake, intake_ticket_id: ticket_id, zendesk_instance_domain: "eitc" }
+          let!(:duplicate_id_document) { create :document, :with_upload, intake: intake, document_type: "ID" }
+          let!(:duplicate_w2_document) { create :document, :with_upload, intake: intake, document_type: "W-2" }
+
+          it "shows all documents for all intakes with that ticket id" do
+            get :show, params: { id: ticket_id }
+
+            expect(assigns(:ticket)).to eq ticket
+            expect(assigns(:intakes)).to contain_exactly(intake, duplicate_intake)
+            contain_exactly(id_document, duplicate_id_document, w2_document, duplicate_w2_document)
+
+            expect(response.body).to include(pdf_zendesk_intake_path(id: intake.id, filename: intake.intake_pdf_filename))
+            expect(response.body).to include(consent_pdf_zendesk_intake_path(
+                                               id: intake.id, filename: intake.consent_pdf_filename))
+            expect(response.body).to include(zendesk_document_path(id: id_document.id))
+            expect(response.body).to include(zendesk_document_path(id: w2_document.id))
+
+            expect(response.body).to include(pdf_zendesk_intake_path(id: duplicate_intake.id, filename: duplicate_intake.intake_pdf_filename))
+            expect(response.body).to include(consent_pdf_zendesk_intake_path(
+                                               id: duplicate_intake.id, filename: duplicate_intake.consent_pdf_filename))
+            expect(response.body).to include(zendesk_document_path(id: duplicate_id_document.id))
+            expect(response.body).to include(zendesk_document_path(id: duplicate_w2_document.id))
+          end
+
+          context "with a UnitedWayTucson intake that coincidentally has the same ticket id" do
+            let!(:coincidental_uwtsa_intake) { create :intake, intake_ticket_id: ticket_id, zendesk_instance_domain: "unitedwaytucson" }
+
+            it "does not include information from the UWTSA intake" do
+              get :show, params: { id: ticket_id }
+
+
+              expect(assigns(:intakes)).not_to include(coincidental_uwtsa_intake)
+              expect(response.body).not_to include(
+                 pdf_zendesk_intake_path(
+                   id: coincidental_uwtsa_intake.id,
+                   filename: coincidental_uwtsa_intake.intake_pdf_filename
+                 )
+               )
+            end
+          end
         end
       end
 
-      context "with duplicate linked intakes" do
-        let!(:duplicate_intake) { create :intake, intake_ticket_id: ticket_id, zendesk_instance_domain: "eitc" }
-        let!(:duplicate_id_document) { create :document, :with_upload, intake: intake, document_type: "ID" }
-        let!(:duplicate_w2_document) { create :document, :with_upload, intake: intake, document_type: "W-2" }
+      context "with drop offs" do
+        let!(:drop_off) { create :intake_site_drop_off, zendesk_ticket_id: ticket_id, created_at: 3.days.ago }
 
-        it "shows all documents for all intakes with that ticket id" do
-          get :show, params: { id: ticket_id }
-
-          expect(assigns(:ticket)).to eq ticket
-          expect(assigns(:intakes)).to contain_exactly(intake, duplicate_intake)
-          contain_exactly(id_document, duplicate_id_document, w2_document, duplicate_w2_document)
-
-          expect(response.body).to include(pdf_zendesk_intake_path(id: intake.id, filename: intake.intake_pdf_filename))
-          expect(response.body).to include(consent_pdf_zendesk_intake_path(
-                                             id: intake.id, filename: intake.consent_pdf_filename))
-          expect(response.body).to include(zendesk_document_path(id: id_document.id))
-          expect(response.body).to include(zendesk_document_path(id: w2_document.id))
-
-          expect(response.body).to include(pdf_zendesk_intake_path(id: duplicate_intake.id, filename: duplicate_intake.intake_pdf_filename))
-          expect(response.body).to include(consent_pdf_zendesk_intake_path(
-                                             id: duplicate_intake.id, filename: duplicate_intake.consent_pdf_filename))
-          expect(response.body).to include(zendesk_document_path(id: duplicate_id_document.id))
-          expect(response.body).to include(zendesk_document_path(id: duplicate_w2_document.id))
-        end
-
-        context "with a UnitedWayTucson intake that coincidentally has the same ticket id" do
-          let!(:coincidental_uwtsa_intake) { create :intake, intake_ticket_id: ticket_id, zendesk_instance_domain: "unitedwaytucson" }
-
-          it "does not include information from the UWTSA intake" do
+        context "with one drop off" do
+          it "shows document bundle for drop off based on ticket id" do
             get :show, params: { id: ticket_id }
 
+            expect(assigns(:ticket)).to eq ticket
+            expect(assigns(:drop_offs)).to contain_exactly(drop_off)
+            expect(response.body).to include("Document Bundle")
+            expect(response.body).to include(zendesk_drop_off_path(id: drop_off.id))
+            expect(response.body).to include("document_bundle.pdf")
+            expect(response.body).to include("3 days ago")
+          end
+        end
 
-            expect(assigns(:intakes)).not_to include(coincidental_uwtsa_intake)
-            expect(response.body).not_to include(
-              pdf_zendesk_intake_path(
-                id: coincidental_uwtsa_intake.id,
-                filename: coincidental_uwtsa_intake.intake_pdf_filename
-              )
-            )
+        context "with multiple drop offs" do
+          let!(:second_drop_off) { create :intake_site_drop_off, zendesk_ticket_id: ticket_id }
+
+          it "shows both document bundles based on ticket id" do
+            get :show, params: { id: ticket_id }
+
+            expect(assigns(:ticket)).to eq ticket
+            expect(assigns(:drop_offs)).to contain_exactly(drop_off, second_drop_off)
+            expect(response.body).to include(zendesk_drop_off_path(id: drop_off.id))
+            expect(response.body).to include(zendesk_drop_off_path(id: second_drop_off.id))
           end
         end
       end

--- a/spec/features/new_in_person_intake_spec.rb
+++ b/spec/features/new_in_person_intake_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Add a new intake case from an in-person drop-off site" do
   before do
-    zendesk_service_spy = instance_double(ZendeskDropOffService, create_ticket_and_attach_file: 23, append_to_existing_ticket: true)
+    zendesk_service_spy = instance_double(ZendeskDropOffService, create_ticket: 23, append_to_existing_ticket: true)
     allow(ZendeskDropOffService).to receive(:new).and_return(zendesk_service_spy)
   end
 

--- a/spec/presenters/document_presenter_spec.rb
+++ b/spec/presenters/document_presenter_spec.rb
@@ -1,11 +1,9 @@
 require "rails_helper"
 
 describe DocumentPresenter do
-
   describe ".grouped_documents" do
     let(:intake) { create(:intake) }
     let(:duplicate_intake) { create(:intake) }
-
     let!(:w2_document_a) do
       create :document, :with_upload,
         document_type: "W-2",

--- a/spec/services/zendesk_drop_off_service_spec.rb
+++ b/spec/services/zendesk_drop_off_service_spec.rb
@@ -31,7 +31,7 @@ describe ZendeskDropOffService do
 
     allow(fake_zendesk_ticket).to receive(:comment=)
     allow(fake_zendesk_ticket).to receive_message_chain(:comment, :uploads).and_return(comment_uploads)
-    allow(fake_zendesk_ticket).to receive(:save).and_return(true)
+    allow(fake_zendesk_ticket).to receive(:save!).and_return(true)
     allow(fake_zendesk_ticket).to receive(:fields=)
   end
 
@@ -69,7 +69,7 @@ describe ZendeskDropOffService do
         expect(fake_zendesk_ticket).to have_received(:fields=).with({
           EitcZendeskInstance::LINK_TO_CLIENT_DOCUMENTS => zendesk_ticket_url(id: 2)
         })
-        expect(fake_zendesk_ticket).to have_received(:save).twice
+        expect(fake_zendesk_ticket).to have_received(:save!).twice
       end
 
       context "from Goodwill Industries of the Southern Rivers" do
@@ -118,25 +118,13 @@ describe ZendeskDropOffService do
         end
       end
     end
-
-    context "failure creating ticket" do
-      before do
-        allow(fake_zendesk_ticket).to receive(:save).and_return(false)
-      end
-
-      it "raises an error" do
-        expect {
-          ZendeskDropOffService.new(drop_off).create_ticket
-        }.to raise_error(ZendeskServiceHelper::ZendeskAPIError)
-      end
-    end
   end
 
   describe "#append_to_existing_ticket" do
     let(:drop_off) { create :full_drop_off, zendesk_ticket_id: "48", state: "NV" }
 
     before do
-      allow(fake_zendesk_ticket).to receive(:save).and_return(true)
+      allow(fake_zendesk_ticket).to receive(:save!).and_return(true)
     end
 
     it "appends a comment and document to the ticket" do
@@ -144,20 +132,8 @@ describe ZendeskDropOffService do
 
       expect(ZendeskAPI::Ticket).to have_received(:find).with(fake_zendesk_client, id: "48")
       expect(fake_zendesk_ticket).to have_received(:comment=).with({body: comment_body})
-      expect(fake_zendesk_ticket).to have_received(:save)
+      expect(fake_zendesk_ticket).to have_received(:save!)
       expect(result).to eq true
-    end
-
-    context "failure updating ticket" do
-      before do
-        allow(fake_zendesk_ticket).to receive(:save).and_return(false)
-      end
-
-      it "raises an error" do
-        expect {
-          ZendeskDropOffService.new(drop_off).append_to_existing_ticket
-        }.to raise_error(ZendeskServiceHelper::ZendeskAPIError)
-      end
     end
   end
 


### PR DESCRIPTION
Co-authored-by: Dimitri DeFigueiredo <ddefigueiredo@codeforamerica.org>