### PR TITLE
Add job for running anonymized diy intake csv service

### DIFF
--- a/app/jobs/anonymized_diy_intake_csv_job.rb
+++ b/app/jobs/anonymized_diy_intake_csv_job.rb
@@ -1,0 +1,7 @@
+class AnonymizedDiyIntakeCsvJob < ApplicationJob
+  queue_as :default
+
+  def perform(diy_intake_ids=nil)
+    AnonymizedDiyIntakeCsvService.new(diy_intake_ids).store_csv
+  end
+end

--- a/app/services/anonymized_diy_intake_csv_service.rb
+++ b/app/services/anonymized_diy_intake_csv_service.rb
@@ -22,7 +22,7 @@ class AnonymizedDiyIntakeCsvService
     if @ids
       DiyIntake.where(id: @ids)
     else
-      DiyIntake.all
+      DiyIntake.where.not(ticket_id: nil)
     end
   end
 

--- a/spec/jobs/anonymized_diy_intake_csv_job_spec.rb
+++ b/spec/jobs/anonymized_diy_intake_csv_job_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe AnonymizedDiyIntakeCsvJob, type: :job do
+  let(:diy_intakes) { create_list(:diy_intake, 3) }
+  let(:fake_service) { double(AnonymizedDiyIntakeCsvService) }
+  let(:diy_intake_ids) { diy_intakes.map(&:id) }
+
+  before do
+    allow(AnonymizedDiyIntakeCsvService).to receive(:new).with(diy_intake_ids).and_return(fake_service)
+    allow(fake_service).to receive(:store_csv)
+  end
+
+  describe "#perform" do
+    context "when diy intake ids passed in" do
+      before do
+        described_class.perform_now(diy_intake_ids)
+      end
+
+      it "calls the service" do
+        expect(AnonymizedDiyIntakeCsvService).to have_received(:new).with(diy_intake_ids)
+        expect(fake_service).to have_received(:store_csv)
+      end
+    end
+
+    context "when no intake ids passed in" do
+      let(:diy_intake_ids) { nil }
+
+      before do
+        described_class.perform_now
+      end
+
+      it "calls the service" do
+        expect(AnonymizedDiyIntakeCsvService).to have_received(:new).with(nil)
+        expect(fake_service).to have_received(:store_csv)
+      end
+    end
+  end
+end
+

--- a/spec/services/anonymized_diy_intake_csv_service_spec.rb
+++ b/spec/services/anonymized_diy_intake_csv_service_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe AnonymizedDiyIntakeCsvService do
     context "when there are no diy_intake ids passed in" do
       let(:ids) { nil }
 
-      it "returns all records" do
-        expect(subject.records).to contain_exactly(filled_diy_intake, unfilled_diy_intake, filled_diy_intake_2)
+      it "returns all records with a ticket id" do
+        expect(subject.records).to contain_exactly(filled_diy_intake, filled_diy_intake_2)
       end
     end
   end


### PR DESCRIPTION
Re: canceling the job if it causes a problem - my research so far has not yielded many promising results. It doesn't look like ActiveJob gives you an easy way to stop a running job, but there are a number of gems that may. See [this thread (from 2014 - not ideal)](https://github.com/rails/rails/issues/17054) and this [stack overflow question about Resque](https://stackoverflow.com/questions/20097568/resque-jobs-how-to-stop-running-job)