### PR TITLE
Add EIP only flow

### DIFF
--- a/app/controllers/questions/eip_overview_controller.rb
+++ b/app/controllers/questions/eip_overview_controller.rb
@@ -1,0 +1,27 @@
+module Questions
+  class EipOverviewController < QuestionsController
+    def current_intake
+      Intake.new(eip_only: true)
+    end
+
+    def illustration_path
+      "eip-check.svg"
+    end
+
+    def form_params
+      super.merge(
+        source: source,
+        referrer: referrer,
+        locale: I18n.locale,
+      )
+    end
+
+    def after_update_success
+      session[:intake_id] = @form.intake.id
+      stimulus_triage_id = session.delete(:stimulus_triage_id)
+      if stimulus_triage_id.present?
+        current_intake.update(triage_source: StimulusTriage.find(stimulus_triage_id))
+      end
+    end
+  end
+end

--- a/app/controllers/stimulus/filing_might_help_controller.rb
+++ b/app/controllers/stimulus/filing_might_help_controller.rb
@@ -18,8 +18,7 @@ module Stimulus
       if current_stimulus_triage.chose_to_file_yes?
         redirect_to backtaxes_questions_path
       else
-        session.delete(:stimulus_triage_id)
-        redirect_to stimulus_path
+        redirect_to EipOnlyNavigation.first.to_path_helper
       end
     end
 

--- a/app/controllers/stimulus/visit_stimulus_faq_controller.rb
+++ b/app/controllers/stimulus/visit_stimulus_faq_controller.rb
@@ -3,7 +3,6 @@ module Stimulus
     layout 'question'
     after_action :clear_stimulus_triage_session
 
-
     class << self
       def form_class
         Stimulus::NullForm

--- a/app/forms/eip_overview_form.rb
+++ b/app/forms/eip_overview_form.rb
@@ -1,0 +1,7 @@
+class EipOverviewForm < QuestionsForm
+  set_attributes_for :intake, :eip_only, :source, :referrer, :locale
+
+  def save
+    @intake.update(attributes_for(:intake))
+  end
+end

--- a/app/lib/eip_only_navigation.rb
+++ b/app/lib/eip_only_navigation.rb
@@ -53,6 +53,8 @@ class EipOnlyNavigation
     Questions::InterviewSchedulingController,
 
     # Payment info
+    Questions::RefundPaymentController,
+    Questions::BankDetailsController,
     Questions::MailingAddressController,
 
     # Optional Demographic Questions

--- a/app/lib/eip_only_navigation.rb
+++ b/app/lib/eip_only_navigation.rb
@@ -1,11 +1,9 @@
 class EipOnlyNavigation
   FLOW = [
-    # Triage
-    Questions::EipOnlyController, # create new Intake with eip_only: true
-    Questions::EnvironmentWarningController,
-
     # Overview
-    Questions::OverviewController,
+    Questions::EipOverviewController,
+
+    Questions::EnvironmentWarningController,
 
     # EIP Eligibility
     Questions::EipEligibilityController,

--- a/app/views/questions/eip_overview/edit.html.erb
+++ b/app/views/questions/eip_overview/edit.html.erb
@@ -1,0 +1,37 @@
+<% @main_heading = t("views.questions.eip_overview.title") %>
+<% content_for :page_title, @main_heading %>
+
+<% content_for :form_card do %>
+  <%= form_with model: @form, url: current_path, local: true, method: "put", builder: VitaMinFormBuilder, html: { class: "form-card" } do |f| %>
+    <h1 class="form-question"><%= @main_heading %></h1>
+    <p>
+      <%= t("views.questions.eip_overview.info_html") %>
+    </p>
+    <ul class="checkmark-list">
+      <li>
+        <%= render "shared/svg/checkmark", fill_class: "venice-blue" %>
+        <span><%=t("views.questions.eip_overview.received_ssdi") %></span>
+      </li>
+      <li>
+        <%= render "shared/svg/checkmark", fill_class: "venice-blue" %>
+        <span><%=t("views.questions.eip_overview.received_rrb") %></span>
+      </li>
+      <li>
+        <%= render "shared/svg/checkmark", fill_class: "venice-blue" %>
+        <span><%=t("views.questions.eip_overview.received_ssi") %></span>
+      </li>
+      <li>
+        <%= render "shared/svg/checkmark", fill_class: "venice-blue" %>
+        <span><%=t("views.questions.eip_overview.received_va") %></span>
+      </li>
+    </ul>
+
+    <button class="button button--primary button--wide text--centered spacing-above-60" name="eip_overview_form[eip_only]" value="true" type="submit">
+      <%=t("general.continue") %>
+    </button>
+
+    <%= link_to root_path, class: "button button--wide text--centered" do %>
+      <%=t("general.return_home") %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/stimulus/filing_might_help/edit.html.erb
+++ b/app/views/stimulus/filing_might_help/edit.html.erb
@@ -3,7 +3,6 @@
 <% content_for :form_card do %>
   <div class="form-card">
     <%= form_with model: @form, url: current_path, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
-
       <h1 class="form-question">
         <%= content_for(:page_title) %>
       </h1>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -842,6 +842,13 @@ en:
       eip_maybe_ineligible:
         title: Unfortunately, you don't qualify for our assistance.
         info: Based on your previous answers, we cannot help you collect your stimulus. If you have additional questions, chat with us or visit our stimulus FAQ page.
+      eip_overview:
+        title: Great! Let's help you collect your stimulus.
+        info_html: "Heads up: You should get the payment automatically and <strong>do not need to fill out this form</strong> if you received:"
+        received_ssdi: Social Security retirement, survivor, or disability benefits (SSDI)
+        received_rrb: Railroad Retirement benefits
+        received_ssi: Supplemental Security Income (SSI)
+        received_va: VA Compensation and Pension (C&P)
       eligibility:
         info: We have a few additional questions to determine if you qualify for our services.
         situations:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -842,6 +842,13 @@ es:
       eip_maybe_ineligible:
         title: Desafortunadamente, no califica para nuestra ayuda.
         info: "Según sus respuestas, no podemos ayudarlo a recibir su estímulo. Si tiene preguntas, \"Chat\" con nosotros o visita nuestra página de preguntas frecuentes de estímulo."
+      eip_overview:
+        title: ¡Excelente! Nos vamos a trabajar juntos para asugara que usted puede recibir tu pago de estimulo.
+        info_html: "Tenga en cuenta: Si recibió lo siguiente, el pago debería llegarle automáticamente y <strong>no es necesario que complete el formulario</strong>:"
+        received_ssdi: Sobreviviente o discapacidad del Seguro Social (SSDI)
+        received_rrb: Beneficios de Jubilación Ferroviaria
+        received_ssi: Seguridad de Ingreso suplementario (SSI)
+        received_va: Beneficios de Asuntos de Veteranos (C&P)
       eligibility:
         info: Tenemos algunas preguntas adicionales para determinar si califica para nuestros servicios.
         situations:

--- a/spec/controllers/questions/eip_overview_controller_spec.rb
+++ b/spec/controllers/questions/eip_overview_controller_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.describe Questions::EipOverviewController do
+  render_views
+
+  describe "#edit" do
+    context "without an intake in the session" do
+      it "renders successfully" do
+        get :edit
+
+        expect(response).to be_ok
+      end
+    end
+  end
+
+  describe "#update" do
+    let(:valid_params) do
+      {
+        eip_overview_form: {
+          eip_only: "true"
+        }
+      }
+    end
+
+    before do
+      session[:source] = "source_from_session"
+      session[:referrer] = "referrer_from_session"
+    end
+
+    it "creates an eip only intake" do
+      expect {
+        put :update, params: valid_params
+      }.to change(Intake, :count).by(1)
+
+      intake = Intake.last
+      expect(intake.eip_only).to eq true
+    end
+
+    it "creates an intake with basic information" do
+      expect {
+        put :update, params: valid_params
+      }.to change(Intake, :count).by(1)
+
+      intake = Intake.last
+      expect(intake.source).to eq "source_from_session"
+      expect(intake.referrer).to eq "referrer_from_session"
+      expect(intake.locale).to eq "en"
+    end
+
+    it "updates the intake in the session" do
+      put :update, params: valid_params
+
+      intake = Intake.last
+      expect(session[:intake_id]).to eq intake.id
+    end
+
+    context "with an existing intake in the session" do
+      let(:intake) { create :intake }
+      before { session[:intake_id] = intake.id }
+
+      it "replaces the existing intake with a new one in the session" do
+        put :update, params: valid_params
+
+        expect(session[:intake_id]).to be_present
+        expect(session[:intake_id]).not_to eq intake.id
+      end
+    end
+
+    context "with existing stimulus triage id in session" do
+      let(:stimulus_triage) { create :stimulus_triage }
+      before { session[:stimulus_triage_id] = stimulus_triage.id }
+
+      it "links it to the new intake and deletes it from the session" do
+        put :update, params: valid_params
+
+        intake = Intake.last
+        expect(intake.triage_source).to eq stimulus_triage
+        expect(session[:stimulus_triage_id]).to be_nil
+      end
+    end
+  end
+end

--- a/spec/controllers/stimulus/filing_might_help_controller_spec.rb
+++ b/spec/controllers/stimulus/filing_might_help_controller_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Stimulus::FilingMightHelpController do
   end
 
   describe ".show?" do
-
     context "when client does not need to file" do
       let(:stimulus_triage) do
         create(:stimulus_triage,
@@ -108,11 +107,10 @@ RSpec.describe Stimulus::FilingMightHelpController do
         expect(stimulus_triage.chose_to_file).to eq('no')
       end
 
-      it 'clears the session and redirects to the stimulus FAQ' do
+      it 'redirects to the beginning of EIP only intake' do
         post :update, params: params
 
-        expect(session[:stimulus_triage_id].blank?).to eq(true)
-        expect(response).to redirect_to(stimulus_path)
+        expect(response).to redirect_to(eip_overview_questions_path)
       end
     end
   end

--- a/spec/features/stimulus/new_stimulus_client_spec.rb
+++ b/spec/features/stimulus/new_stimulus_client_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Stimulus Triage Flow" do
     click_on("No")
     expect(page).to have_selector("h1", text: "We can help increase your cash support, by filing your taxes in addition to the stimulus")
     click_on("No. I only want my stimulus.")
-    expect(page).to have_selector("h1", text: "Get your Stimulus Payment (EIP)")
+    expect(page).to have_selector("h1", text: "Great! Let's help you collect your stimulus.")
   end
 
   scenario "new stimulus triage client visits the stimulus FAQ" do

--- a/spec/features/web_intake/new_eip_only_filer_spec.rb
+++ b/spec/features/web_intake/new_eip_only_filer_spec.rb
@@ -172,6 +172,18 @@ RSpec.feature "Web Intake EIP Only Filer" do
     select("Spanish", from: "What is your preferred language for the review?")
     click_on "Continue"
 
+    # Payment info
+    expect(page).to have_selector("h1", text: "If due a refund, how would like to receive it?")
+    choose "Direct deposit (fastest)"
+    click_on "Continue"
+    # Bank Details
+    expect(page).to have_selector("h1", text: "Great, please provide your bank details below!")
+    fill_in "Bank name", with: "First Savings Bank"
+    fill_in "Routing number", with: "123456"
+    fill_in "Account number", with: "987654321"
+    choose "Checking"
+    click_on "Continue"
+
     # Contact information
     expect(page).to have_text("What is your mailing address?")
     fill_in "Street address", with: "123 Main St."

--- a/spec/features/web_intake/new_eip_only_filer_spec.rb
+++ b/spec/features/web_intake/new_eip_only_filer_spec.rb
@@ -9,17 +9,34 @@ RSpec.feature "Web Intake EIP Only Filer" do
   end
 
   scenario "new EIP-only client filing joint with a dependent" do
-    #placeholder page
-    visit "/questions/eip-only"
-    click_on "Go"
+    # Home
+    visit "/"
+    find("#firstCta").click
+
+    # Welcome
+    expect(page).to have_selector("h1", text: "Welcome! How can we help you?")
+    expect(page).to have_selector("h2", text: "Get your Stimulus")
+    click_on("Get your Stimulus")
+
+    expect(page).to have_selector("h1", text: "Have you already filed for 2018 and 2019?")
+    click_on("Yes")
+
+    expect(page).to have_selector("h1", text: "Do you need to correct your 2019 taxes?")
+    click_on("No")
+
+    expect(page).to have_selector("h1", text: "Have you already filed for 2017?")
+    click_on("No")
+
+    expect(page).to have_selector("h1", text: "We can help increase your cash support, by filing your taxes in addition to the stimulus")
+    click_on("No. I only want my stimulus.")
+
+    # Overview
+    expect(page).to have_selector("h1", text: "Great! Let's help you collect your stimulus.")
+    click_on "Continue"
 
     #Non-production environment warning
     expect(page).to have_selector("h1", text: "Thanks for visiting the GetYourRefund demo application!")
     click_on "Continue to example"
-
-    # Overview
-    expect(page).to have_selector("h1", text: "Just a few simple steps to file!")
-    click_on "Continue"
 
     # Eligibility Page
     expect(page).to have_selector("h1", text: "Before we start, let's make sure you qualify for our help!")
@@ -210,18 +227,14 @@ RSpec.feature "Web Intake EIP Only Filer" do
     expect(page).to have_selector("h1", text: "Welcome! How can we help you?")
   end
 
-  xscenario "ineligible for EIP" do
-    #placeholder page
-    visit "/questions/eip-only"
-    click_on "Go"
+  scenario "ineligible for EIP" do
+    visit "/questions/eip-overview"
+    expect(page).to have_selector("h1", text: "Great! Let's help you collect your stimulus.")
+    click_on "Continue"
 
     # Non-production environment warning
     expect(page).to have_selector("h1", text: "Thanks for visiting the GetYourRefund demo application!")
     click_on "Continue to example"
-
-    # Overview
-    expect(page).to have_selector("h1", text: "Great! Let's help you collect your stimulus.")
-    click_on "Continue"
 
     # Eligibility Page
     expect(page).to have_selector("h1", text: "Before we start, let's make sure you qualify for our help!")


### PR DESCRIPTION
- add EIP overview page at beginning of streamlined EIP
- redirect to EIP overview page from filing might help page

Co-authored-by: Ben Golder <bgolder@codeforamerica.org>