### PR TITLE
When computing next_path, rely on I18n.locale

### DIFF
--- a/app/controllers/questions/questions_controller.rb
+++ b/app/controllers/questions/questions_controller.rb
@@ -33,9 +33,9 @@ module Questions
       question_path(self.class.to_param, params)
     end
 
-    def next_path(params = {})
+    def next_path
       next_step = form_navigation.next
-      next_step.to_path_helper(params) if next_step
+      next_step.to_path_helper if next_step
     end
 
     def illustration_folder
@@ -91,14 +91,15 @@ module Questions
         controller_name.dasherize
       end
 
-      def to_path_helper(params = {})
+      def to_path_helper
         path_helper_string = [
           controller_name,
           module_parent.name.underscore,
           "path"
         ].join("_") # "controller_name_module_path"
 
-        Rails.application.routes.url_helpers.send(path_helper_string.to_sym, params)
+        # Pass default_url_options (namely, locale) from ApplicationController when computing URL for this controller
+        Rails.application.routes.url_helpers.send(path_helper_string.to_sym, default_url_options)
       end
 
       def form_name

--- a/spec/controllers/questions/questions_controller_spec.rb
+++ b/spec/controllers/questions/questions_controller_spec.rb
@@ -42,7 +42,17 @@ RSpec.describe Questions::QuestionsController do
       let(:controller_class) { Documents::IdsController }
 
       it "returns the correct path helper" do
-        expect(controller_class.to_path_helper(locale: :es)).to eq(ids_documents_path(locale: :es))
+        expect(controller_class.to_path_helper).to eq(ids_documents_path)
+      end
+
+      context "with a specific locale" do
+        before do
+          allow(I18n).to receive(:locale).and_return(:es)
+        end
+
+        it "computes the route appropriate to that locale" do
+          expect(controller_class.to_path_helper).to eq(ids_documents_path(locale: :es))
+        end
       end
     end
   end


### PR DESCRIPTION
Also stop taking (ignored) `params` hash to two methods.