### PR TITLE
Truncate data before adding it to the session [#174371407]

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -65,7 +65,8 @@ class ApplicationController < ActionController::Base
   def set_source
     source_from_params = params[:source] || params[:utm_source] || params[:s]
     if source_from_params.present?
-      session[:source] = source_from_params
+      # Use at most 100 chars in session so we don't overflow it.
+      session[:source] = source_from_params.slice(0, 100)
     elsif request.headers.fetch(:referer, "").include?("google.com")
       session[:source] = "organic_google"
     end
@@ -77,7 +78,8 @@ class ApplicationController < ActionController::Base
 
   def set_referrer
     unless referrer.present?
-      session[:referrer] = request.headers.fetch(:referer, "None")
+      # Use at most 200 chars in the session to avoid overflow.
+      session[:referrer] = request.headers.fetch(:referer, "None").slice(0, 200)
     end
   end
 
@@ -89,7 +91,8 @@ class ApplicationController < ActionController::Base
     return unless params[:utm_state].present?
 
     unless utm_state.present?
-      session[:utm_state] = params[:utm_state]
+      # Valid values are at most 2 characters.
+      session[:utm_state] = params[:utm_state].slice(0, 2)
     end
   end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -345,6 +345,19 @@ RSpec.describe ApplicationController do
 
         expect(session[:source]).to eq "shromps"
       end
+
+      context "when the param is very long" do
+        let(:params) do
+          { source: ("shromps" * 200)}
+        end
+
+        it "truncates it" do
+          get :index, params: params
+
+          expect(session[:source]).to eq ("shromps" * 14 + "sh")
+        end
+      end
+
     end
 
     context "with an 's' param" do
@@ -395,6 +408,16 @@ RSpec.describe ApplicationController do
         end
       end
 
+      context "with a very long HTTP_REFERER header" do
+        before { request.headers["HTTP_REFERER"] = ('!' * 9001) }
+
+        it "sets the referrer to a truncated version" do
+          get :index
+
+          expect(session[:referrer]).to eq ('!' * 200)
+        end
+      end
+
       context "without an HTTP_REFERER header" do
         it "sets the referrer to 'None'" do
           get :index
@@ -424,6 +447,14 @@ RSpec.describe ApplicationController do
           get :index, params: { utm_state: "CA" }
 
           expect(session[:utm_state]).to eq "CA"
+        end
+      end
+
+      context "with a very long utm_state param" do
+        it "truncates to two characters" do
+          get :index, params: { utm_state: ("!" * 9001) }
+
+          expect(session[:utm_state]).to eq "!!"
         end
       end
 


### PR DESCRIPTION
I wasn't sure if it was really important to test all 3 ways `source` data comes into the app in the test suite, so I only tested one. Happy to have feedback.