### PR TITLE
Overwrite full intake in session at start

### DIFF
--- a/app/controllers/questions/backtaxes_controller.rb
+++ b/app/controllers/questions/backtaxes_controller.rb
@@ -5,7 +5,7 @@ module Questions
     layout "question"
 
     def current_intake
-      super || Intake.new
+      Intake.new
     end
 
     private
@@ -19,20 +19,22 @@ module Questions
       end
     end
 
+    ##
+    # sets new intake id in session and associates triage source to that intake
     def after_update_success
-      session[:intake_id] = @form.intake.id
-      assign_triage_source
+      new_intake = @form.intake
+      session[:intake_id] = new_intake.id
+      assign_triage_source(new_intake)
     end
 
     ##
-    # after creating an intake, looks for a triage source and attaches
-    # to intake
-    def assign_triage_source
+    # looks for a triage source and attaches to intake
+    def assign_triage_source(intake)
       return unless session.key?(:triage_source_id) && session.key?(:triage_source_type)
 
       triage_type = session.delete(:triage_source_type).constantize
       triage_source = triage_type.find(session.delete(:triage_source_id))
-      current_intake.update_attribute(:triage_source, triage_source)
+      intake.update_attribute(:triage_source, triage_source)
     end
 
     def form_params
@@ -40,7 +42,7 @@ module Questions
         source: current_intake.source || source,
         referrer: current_intake.referrer || referrer,
         locale: I18n.locale,
-        )
+      )
     end
   end
 end

--- a/app/controllers/questions/file_with_help_controller.rb
+++ b/app/controllers/questions/file_with_help_controller.rb
@@ -3,6 +3,10 @@ module Questions
     skip_before_action :require_intake
     layout "question"
 
+    def next_path
+      backtaxes_questions_path
+    end
+
     private
 
     def self.form_class

--- a/spec/controllers/questions/backtaxes_controller_spec.rb
+++ b/spec/controllers/questions/backtaxes_controller_spec.rb
@@ -20,19 +20,36 @@ RSpec.describe Questions::BacktaxesController do
         }
       end
 
-      it "creates new intake backtaxes answers" do
-        expect {
-          post :update, params: params
-        }.to change(Intake, :count).by(1)
+      context "without an intake in the session" do
+        it "creates new intake backtaxes answers" do
+          expect {
+            post :update, params: params
+          }.to change(Intake, :count).by(1)
 
-        intake = Intake.last
+          intake = Intake.last
 
-        expect(intake.source).to eq "source_from_session"
-        expect(intake.referrer).to eq "referrer_from_session"
-        expect(intake.locale).to eq "en"
-        expect(intake.needs_help_2017).to eq "no"
-        expect(intake.needs_help_2018).to eq "yes"
-        expect(intake.needs_help_2019).to eq "yes"
+          expect(intake.source).to eq "source_from_session"
+          expect(intake.referrer).to eq "referrer_from_session"
+          expect(intake.locale).to eq "en"
+          expect(intake.needs_help_2017).to eq "no"
+          expect(intake.needs_help_2018).to eq "yes"
+          expect(intake.needs_help_2019).to eq "yes"
+        end
+      end
+
+      context "with an existing intake in the session" do
+        let(:intake) { create :intake, :eip_only }
+
+        before { session[:intake_id] = intake.id }
+
+        it "creates a new intake and overwrites the one in the session" do
+          expect {
+            post :update, params: params
+          }.to change(Intake, :count).by(1)
+
+          created_intake = Intake.last
+          expect(session[:intake_id]).to eq created_intake.id
+        end
       end
     end
 
@@ -60,11 +77,11 @@ RSpec.describe Questions::BacktaxesController do
       let(:stimulus_triage) { create :stimulus_triage }
       let(:params) do
         {
-            backtaxes_form: {
-                needs_help_2017: "yes",
-                needs_help_2018: "no",
-                needs_help_2019: "no",
-            }
+          backtaxes_form: {
+            needs_help_2017: "yes",
+            needs_help_2018: "no",
+            needs_help_2019: "no",
+          }
         }
       end
 

--- a/spec/controllers/questions/file_with_help_controller_spec.rb
+++ b/spec/controllers/questions/file_with_help_controller_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe Questions::FileWithHelpController do
+  describe "#next_path" do
+    context "without an intake in the session" do
+      it "returns the backtaxes controller" do
+        expect(subject.next_path).to eq backtaxes_questions_path
+      end
+    end
+
+    context "with an eip intake in the session" do
+      let(:intake) { create :intake, :eip_only }
+
+      before do
+        session[:intake_id] = intake.id
+      end
+
+      it "returns the backtaxes controller" do
+        expect(subject.next_path).to eq backtaxes_questions_path
+      end
+    end
+  end
+end

--- a/spec/features/web_intake/multiple_intake_paths_filer_spec.rb
+++ b/spec/features/web_intake/multiple_intake_paths_filer_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.feature "Web Intake Filer Tries Multiple Intake Paths" do
+  scenario "new client goes back to beginning of intake in same session before submitting" do
+    # Skip to EIP overview
+    visit "/questions/eip-overview"
+
+    expect(page).to have_selector("h1", text: "Great! Let's help you collect your stimulus.")
+    click_on "Continue"
+
+    # Intake with eip_only: true has been created
+
+    # Skip to welcome page with options (DIY, full service, etc.)
+    visit "/questions/welcome"
+    expect(page).to have_selector("h1", text: "Welcome! How can we help you?")
+    click_on "File taxes with help"
+
+    expect(page).to have_selector("h1", text: "File with the help of a tax expert!")
+    click_on "Continue"
+
+    # Doesn't get stuck trying to do full service flow
+    expect(page).to have_selector("h1", text: "What years do you need to file for?")
+
+    check "2017"
+    check "2019"
+    click_on "Continue"
+
+    # Non-production environment warning
+    expect(page).to have_selector("h1", text: "Thanks for visiting the GetYourRefund demo application!")
+    click_on "Continue to example"
+  end
+end


### PR DESCRIPTION
- fixes bug where client starts EIP and continues to full intake and gets stuck
- hard code file with help next_path
- create new intake every time full intake is started (backtaxes controller)

Co-authored-by: Dimitri DeFigueiredo <ddefigueiredo@codeforamerica.org>