### PR TITLE
For 211 EIP tickets, say so in opening comment & tag & custom field

### DIFF
--- a/app/helpers/eitc_zendesk_instance.rb
+++ b/app/helpers/eitc_zendesk_instance.rb
@@ -22,6 +22,8 @@ class EitcZendeskInstance
   LINK_TO_CLIENT_DOCUMENTS = "360042211294"
   CLIENT_ZIP_CODE = "360043811533"
   DOCUMENTS_NEEDED = "360045974133"
+  # REFERRAL_BY_211 is only used by EIP at the moment
+  REFERRAL_BY_211 = "360047499514"
 
   # Form IDs
   EIP_TICKET_FORM = "360004533173"
@@ -47,7 +49,7 @@ class EitcZendeskInstance
     INTAKE_STATUS_WAITING_FOR_INFO => "Waiting For Info",
     INTAKE_STATUS_COMPLETE => "Complete",
     INTAKE_STATUS_NOT_FILING => "Not Filing",
-}
+  }
 
   # Zendesk Ticket Return Statuses
   RETURN_STATUS_UNSTARTED = ""


### PR DESCRIPTION
Resolves https://www.pivotaltracker.com/story/show/174129712

## Unnecessary changes

This PR makes some irrelevant whitespace changes; hopefully you find them acceptable.

The PR also makes one or two methods private.

This seems peaceful to me because they're not directly tested by the test suite. I was motivated to do so because today I read this text:

>Have Few Public Methods
>
>Many Rubyists have two very bad habits: using a public attr_accessor for every instance variable, and declaring all methods public, even if they aren’t part of the class’ actual API. Worse, many Rubyists feel the need to write tests for these private-but-public methods.
>
>This style of coding makes refactoring pretty much impossible, and it also makes it hard to understand how a class is intended to be used. If the intention is that users of your class just call one or two methods, those are the only ones that should be public (and your tests should only use those methods, too).

It was at this URL https://multithreaded.stitchfix.com/blog/2015/06/02/anatomy-of-service-objects-in-rails/ (due to https://opensource.stitchfix.com/tech-radar/radar/index being mentioned on #eng-staff).

The advice nicely matched up with advice in a book I'm reading (Effective Java, not that Ruby and Java are the same), so I figured I'd just go for it.

The advice to make these methods private also matches up with my experience reading other parts of our code, where we do test these helper methods, which makes refactoring harder.