### PR TITLE
Permit `Requested` as a valid document_type in the database

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -21,7 +21,8 @@
 #
 
 class Document < ApplicationRecord
-  validates :document_type, inclusion: { in: DocumentTypes::ALL_TYPES.map(&:key) }
+  # Permit all existing document types, plus "Requested", which is superseded by "Requested Later" (but the DB has both)
+  validates :document_type, inclusion: { in: DocumentTypes::ALL_TYPES.map(&:key) + ["Requested"] }
   validates :intake, presence: { unless: :documents_request_id }
 
   scope :of_type, ->(type) { where(document_type: type) }

--- a/spec/services/unsent_documents_service_spec.rb
+++ b/spec/services/unsent_documents_service_spec.rb
@@ -11,7 +11,7 @@ describe UnsentDocumentsService do
     let!(:intake_new_doc) {create :intake, intake_ticket_id: 3}
     let!(:document1) {create :document, :with_upload, intake: intake_docs_sent, zendesk_ticket_id: 1234, created_at: 2.hours.ago}
     let!(:document2) {create :document, :with_upload, intake: intake_docs_not_sent, zendesk_ticket_id: nil, created_at: 2.hours.ago}
-    let!(:document3) {create :document, :with_upload, intake: intake_docs_not_sent, zendesk_ticket_id: nil, created_at: 2.hours.ago}
+    let!(:document3) {create :document, :with_upload, document_type: "Requested", intake: intake_docs_not_sent, zendesk_ticket_id: nil, created_at: 2.hours.ago}
     let!(:document4) {create :document, :with_upload, intake: intake_new_doc, zendesk_ticket_id: nil, created_at: 3.minutes.ago}
 
     before do
@@ -41,7 +41,7 @@ describe UnsentDocumentsService do
           New client documents are available to view: #{zendesk_ticket_url(id: intake_docs_not_sent.intake_ticket_id)}
           Files uploaded:
           * picture_id.jpg (W-2)
-          * picture_id.jpg (W-2)
+          * picture_id.jpg (Requested)
         BODY
 
         expect(fake_zendesk_service).to have_received(:append_comment_to_ticket).with(


### PR DESCRIPTION
This allows documents to be `save()`'d when they have that string.
It is the only document type not represented in DocumentType::ALL_KEYS,
per this query on prod and demo:

```
Document.select(:document_type).distinct.pluck(:document_type).reject { |document_type| DocumentTypes::ALL_TYPES.map(&:key).include?(document_type) }
```

Co-authored-by: Jenny Heath <jheath@codeforamerica.org>