### PR TITLE
bdt eip campaign support

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,11 @@ Rails.application.routes.draw do
     get "/422", to: "public_pages#internal_server_error"
     get "/404", to: "public_pages#page_not_found"
 
+    # Routes to support a simple URL for mailings from Benefits Data Trust (BDT) to their clients
+    # This will points people to the EIP landing page with the proper source tracking
+    get "/bdt", to: "public_pages#eip_home", defaults: {"s": "bdt"}
+    get "/BDT", to: "public_pages#eip_home", defaults: {"s": "bdt"}
+
     # Zendesk Admin routes
     get "/zendesk/sign-in", to: "zendesk#sign_in", as: :zendesk_sign_in
     namespace :zendesk do


### PR DESCRIPTION
added routes to support GetYourRefund.org/BDT or getyourrefund.org/bdt. Benefits Data Trust will be putting these in a mailing going out to their clients. the routes point to the EIP landing page and set the proper source param. can be pointed to other content after 10/15 and ultimately removed, so i separated them from other routes with a comment as @bengolder suggested.