### PR TITLE
fix locale tracking in mixpanel

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,8 +2,8 @@ class ApplicationController < ActionController::Base
   include ConsolidatedTraceHelper
 
   before_action :redirect_to_getyourrefund, :set_visitor_id, :set_source, :set_referrer, :set_utm_state, :set_sentry_context, :check_maintenance_mode
-  after_action :track_page_view
   around_action :switch_locale
+  after_action :track_page_view
   helper_method :include_analytics?, :current_intake, :show_progress?
 
   # This needs to be a class method for the devise controller to have access to it

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -572,6 +572,18 @@ RSpec.describe ApplicationController do
         )
       end
     end
+
+    context "with a new locale" do
+      it "sends the new locale" do
+        get :index, params: { locale: 'es' }
+
+        expect(mixpanel_spy).to have_received(:run).with(
+            unique_id: "123",
+            event_name: "page_view",
+            data: hash_including(locale: "es")
+        )
+      end
+    end
   end
 
   describe "#track_page_view" do


### PR DESCRIPTION
i verified the new test failed before the change and passed with the change, also stepped through it in the debugger.

filters were out of order, resulting in locale always being "en" in mixpanel