### PR TITLE
make "none of the above" checkboxes clear other options

### DIFF
--- a/app/views/questions/eip_eligibility/edit.html.erb
+++ b/app/views/questions/eip_eligibility/edit.html.erb
@@ -12,7 +12,7 @@
       <%= f.cfa_checkbox(:claimed_by_another, t("views.questions.eip_eligibility.claimed"), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox(:already_applied_for_stimulus, t("views.questions.eip_eligibility.already_applied"), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox(:no_ssn, t("views.questions.eip_eligibility.no_ssn", :year => current_intake.most_recent_filing_year), options: { checked_value: "yes", unchecked_value: "no" }) %>
-      <%= f.cfa_checkbox(:no_eligibility_checks_apply, t("general.none_of_the_above"), options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <%= f.cfa_checkbox(:no_eligibility_checks_apply, t("general.none_of_the_above"), options: { id: "none__checkbox", checked_value: "yes", unchecked_value: "no" }) %>
     </div>
 
     <button class="button button--primary button--wide" type="submit">

--- a/app/views/questions/eligibility/edit.html.erb
+++ b/app/views/questions/eligibility/edit.html.erb
@@ -15,7 +15,7 @@
       <%= f.cfa_checkbox(:had_rental_income, t("views.questions.eligibility.situations.had_rental_income"), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox(:had_farm_income, t("views.questions.eligibility.situations.had_farm_income"), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox(:income_over_limit, t("views.questions.eligibility.situations.income_over_limit", :year => current_intake.most_recent_filing_year), options: { checked_value: "yes", unchecked_value: "no" }) %>
-      <%= f.cfa_checkbox(:no_eligibility_checks_apply, t("general.none_of_the_above"), options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <%= f.cfa_checkbox(:no_eligibility_checks_apply, t("general.none_of_the_above"), options: { id: "none__checkbox", checked_value: "yes", unchecked_value: "no" }) %>
     </div>
 
     <button class="button button--primary button--wide" type="submit">

--- a/app/views/questions/life_situations/edit.html.erb
+++ b/app/views/questions/life_situations/edit.html.erb
@@ -13,7 +13,7 @@
       <%= f.cfa_checkbox(:was_blind, t('views.questions.life_situations.options.was_blind'), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox(:was_full_time_student, t('views.questions.life_situations.options.was_full_time_student'), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox(:was_on_visa, t('views.questions.life_situations.options.was_on_visa'), options: { checked_value: "yes", unchecked_value: "no" }) %>
-      <%= f.cfa_checkbox(:no_life_situations_apply, t("general.none_of_the_above"), options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <%= f.cfa_checkbox(:no_life_situations_apply, t("general.none_of_the_above"), options: { id: "none__checkbox", checked_value: "yes", unchecked_value: "no" }) %>
     </div>
 
     <button class="button button--primary button--wide" type="submit">

--- a/app/views/questions/spouse_life_situations/edit.html.erb
+++ b/app/views/questions/spouse_life_situations/edit.html.erb
@@ -13,7 +13,7 @@
       <%= f.cfa_checkbox(:spouse_was_blind, t('views.questions.spouse_life_situations.options.was_blind'), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox(:spouse_was_full_time_student, t('views.questions.spouse_life_situations.options.was_full_time_student'), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox(:spouse_was_on_visa, t('views.questions.spouse_life_situations.options.was_on_visa'), options: { checked_value: "yes", unchecked_value: "no" }) %>
-      <%= f.cfa_checkbox(:no_life_situations_apply, t("general.none_of_the_above"), options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <%= f.cfa_checkbox(:no_life_situations_apply, t("general.none_of_the_above"), options: { id: "none__checkbox", checked_value: "yes", unchecked_value: "no" }) %>
     </div>
 
     <button class="button button--primary button--wide" type="submit">


### PR DESCRIPTION
Turns out honeycrisp already supported the feature requested [here](https://www.pivotaltracker.com/story/show/174612760) so just adding the "none__checkbox" id to the appropriate checkbox ensures that other checkboxes are deselected automatically when it is chosen and it is deselected when others are chosen 