### PR TITLE
Index ticket id, email, phones on Intakes

### DIFF
--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -177,6 +177,10 @@
 # Indexes
 #
 #  index_intakes_on_client_id                                (client_id)
+#  index_intakes_on_email_address                            (email_address)
+#  index_intakes_on_intake_ticket_id                         (intake_ticket_id)
+#  index_intakes_on_phone_number                             (phone_number)
+#  index_intakes_on_sms_phone_number                         (sms_phone_number)
 #  index_intakes_on_triage_source_type_and_triage_source_id  (triage_source_type,triage_source_id)
 #  index_intakes_on_vita_partner_id                          (vita_partner_id)
 #

--- a/db/migrate/20200924041919_add_indices_to_intake.rb
+++ b/db/migrate/20200924041919_add_indices_to_intake.rb
@@ -1,0 +1,8 @@
+class AddIndicesToIntake < ActiveRecord::Migration[6.0]
+  def change
+    add_index :intakes, :intake_ticket_id
+    add_index :intakes, :email_address
+    add_index :intakes, :phone_number
+    add_index :intakes, :sms_phone_number
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_17_042818) do
+ActiveRecord::Schema.define(version: 2020_09_24_041919) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -381,6 +381,10 @@ ActiveRecord::Schema.define(version: 2020_09_17_042818) do
     t.string "zendesk_instance_domain"
     t.string "zip_code"
     t.index ["client_id"], name: "index_intakes_on_client_id"
+    t.index ["email_address"], name: "index_intakes_on_email_address"
+    t.index ["intake_ticket_id"], name: "index_intakes_on_intake_ticket_id"
+    t.index ["phone_number"], name: "index_intakes_on_phone_number"
+    t.index ["sms_phone_number"], name: "index_intakes_on_sms_phone_number"
     t.index ["triage_source_type", "triage_source_id"], name: "index_intakes_on_triage_source_type_and_triage_source_id"
     t.index ["vita_partner_id"], name: "index_intakes_on_vita_partner_id"
   end

--- a/spec/factories/intakes.rb
+++ b/spec/factories/intakes.rb
@@ -177,6 +177,10 @@
 # Indexes
 #
 #  index_intakes_on_client_id                                (client_id)
+#  index_intakes_on_email_address                            (email_address)
+#  index_intakes_on_intake_ticket_id                         (intake_ticket_id)
+#  index_intakes_on_phone_number                             (phone_number)
+#  index_intakes_on_sms_phone_number                         (sms_phone_number)
 #  index_intakes_on_triage_source_type_and_triage_source_id  (triage_source_type,triage_source_id)
 #  index_intakes_on_vita_partner_id                          (vita_partner_id)
 #

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -177,6 +177,10 @@
 # Indexes
 #
 #  index_intakes_on_client_id                                (client_id)
+#  index_intakes_on_email_address                            (email_address)
+#  index_intakes_on_intake_ticket_id                         (intake_ticket_id)
+#  index_intakes_on_phone_number                             (phone_number)
+#  index_intakes_on_sms_phone_number                         (sms_phone_number)
 #  index_intakes_on_triage_source_type_and_triage_source_id  (triage_source_type,triage_source_id)
 #  index_intakes_on_vita_partner_id                          (vita_partner_id)
 #


### PR DESCRIPTION
Our queries that use up the most time are those that look up intakes based on their zendesk ticket ids, email, or phone numbers.
This should speed up those queries a bit.