### PR TITLE
Add beta testers

### DIFF
--- a/app/controllers/concerns/access_controllable.rb
+++ b/app/controllers/concerns/access_controllable.rb
@@ -11,4 +11,8 @@ module AccessControllable
   def require_admin
     head 403 unless current_user&.role == "admin"
   end
+
+  def require_beta_tester
+    head 403 unless current_user&.is_beta_tester?
+  end
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -2,7 +2,7 @@ class InvitationsController < ApplicationController
   include AccessControllable
 
   before_action :require_sign_in
-  before_action :require_admin
+  before_action :require_beta_tester
 
   layout "admin"
 

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -13,14 +13,21 @@ class Users::InvitationsController < Devise::InvitationsController
     # If an anonymous user tries to send an invitation, send them to the invitation page after sign-in.
     require_sign_in(redirect_after_login: new_user_invitation_path)
   end
-  before_action :require_admin, only: [:new, :create]
+  before_action :require_beta_tester, only: [:new, :create]
   before_action :require_valid_invitation_token, only: [:edit, :update]
+
+  def create
+    super do |invited_user|
+      # set default values
+      invited_user.update(is_beta_tester: true, role: invited_user.role || "agent" )
+    end
+  end
 
   private
 
   # Override superclass method for default params for newly created invites, allowing us to add attributes
   def invite_params
-    params.require(:user).permit(:name, :email).merge(role: "agent")
+    params.require(:user).permit(:name, :email)
   end
 
   # Override superclass method for accepted invite params, allowing us to add attributes

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,7 @@ class UsersController < ApplicationController
   include AccessControllable
 
   before_action :require_sign_in
+  before_action :require_beta_tester
 
   layout "admin"
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,7 @@
 #  invitation_sent_at        :datetime
 #  invitation_token          :string
 #  invitations_count         :integer          default(0)
+#  is_beta_tester            :boolean          default(FALSE), not null
 #  last_sign_in_at           :datetime
 #  last_sign_in_ip           :string
 #  locked_at                 :datetime

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -1,5 +1,5 @@
 <% content_for :toolbar_right do %>
-  <% if current_user.role == "admin" %>
+  <% if current_user.is_beta_tester? %>
     <%= link_to user_profile_path, class: "toolbar__item" do %>
       <%=t("views.layouts.admin.welcome_user_html", :name => current_user.name) %>
     <% end %>

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -9,7 +9,7 @@
   </p>
 
   <ul class="actions">
-    <% if current_user.role == "admin" %>
+    <% if current_user.is_beta_tester? %>
       <li class="user-action-link">
         <%= link_to invitations_path do %>
           <%= t("general.invitations") %>

--- a/db/migrate/20200924042414_add_is_beta_tester_to_users.rb
+++ b/db/migrate/20200924042414_add_is_beta_tester_to_users.rb
@@ -1,0 +1,5 @@
+class AddIsBetaTesterToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :is_beta_tester, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_24_041919) do
+ActiveRecord::Schema.define(version: 2020_09_24_042414) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -485,6 +485,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_041919) do
     t.string "invitation_token"
     t.integer "invitations_count", default: 0
     t.bigint "invited_by_id"
+    t.boolean "is_beta_tester", default: false, null: false
     t.datetime "last_sign_in_at"
     t.string "last_sign_in_ip"
     t.datetime "locked_at"

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -3,10 +3,10 @@ require "rails_helper"
 RSpec.describe InvitationsController do
   describe "#index" do
     it_behaves_like :a_get_action_that_redirects_anonymous_users_to_sign_in, action: :index
-    it_behaves_like :a_get_action_forbidden_to_non_admin_users, action: :index
+    it_behaves_like :a_get_action_for_beta_testers_only, action: :index
 
-    context "with an admin user who has prior invites" do
-      let(:user) { create :admin_user }
+    context "with an beta user who has prior invites" do
+      let(:user) { create :beta_tester }
       let!(:unaccepted_invite) { create :invited_user, invited_by: user }
       let!(:someone_elses_unaccepted_invite) { create :invited_user }
       let!(:accepted_invite) { create :accepted_invite_user, invited_by: user }

--- a/spec/controllers/users/invitations_controller_spec.rb
+++ b/spec/controllers/users/invitations_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Users::InvitationsController do
       context "if the invited user already exists and is an admin" do
         let!(:invited_user) { create :admin_user, email: "cherry@example.com" }
 
-        it "doesn't change the users role" do
+        it "doesn't change the user's role" do
           post :create, params: params
           invited_user.reload
           expect(invited_user.is_beta_tester?).to eq true

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -3,37 +3,19 @@ require "rails_helper"
 RSpec.describe UsersController do
   describe "#profile" do
     it_behaves_like :a_get_action_that_redirects_anonymous_users_to_sign_in, action: :profile
+    it_behaves_like :a_get_action_for_beta_testers_only, action: :profile
 
-    context "with an authenticated user" do
+    context "with an authenticated beta tester" do
       render_views
-      let(:user) { create :agent_user, name: "Adam Avocado" }
+      let(:user) { create :beta_tester, role: "agent", name: "Adam Avocado" }
       before { sign_in user }
 
-      it "renders information about the current user" do
+      it "renders information about the current user with an invitations link" do
         get :profile
 
         expect(response).to be_ok
         expect(response.body).to have_content "Adam Avocado"
-      end
-
-      context "who is an admin" do
-        let(:user) { create :admin_user }
-
-        it "shows an invitations link" do
-          get :profile
-
-          expect(response.body).to include invitations_path
-        end
-      end
-
-      context "who is just an agent" do
-        let(:user) { create :agent_user }
-
-        it "does not show an invitations link" do
-          get :profile
-
-          expect(response.body).not_to include invitations_path
-        end
+        expect(response.body).to include invitations_path
       end
     end
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -64,6 +64,10 @@ FactoryBot.define do
       role { "agent" }
     end
 
+    factory :beta_tester do
+      is_beta_tester { true }
+    end
+
     factory :invited_user do
       association :invited_by, factory: :admin_user
       invitation_created_at { 1.day.ago - 1.minute }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -17,6 +17,7 @@
 #  invitation_sent_at        :datetime
 #  invitation_token          :string
 #  invitations_count         :integer          default(0)
+#  is_beta_tester            :boolean          default(FALSE), not null
 #  last_sign_in_at           :datetime
 #  last_sign_in_ip           :string
 #  locked_at                 :datetime

--- a/spec/features/authenticate_spec.rb
+++ b/spec/features/authenticate_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.feature "Logging in and out to the volunteer portal" do
-  # Making these users admins because profile page is admin only for now
-  let!(:user) { create(:user, name: "German Geranium", email: "german@flowers.orange", password: "goodPassword", role: "admin") }
+  # Making these users beta testers because profile page is beta tester only for now
+  let!(:user) { create(:beta_tester, name: "German Geranium", email: "german@flowers.orange", password: "goodPassword", role: "agent") }
 
   scenario "logging in and out" do
     # go to password-based sign in page
@@ -15,7 +15,7 @@ RSpec.feature "Logging in and out to the volunteer portal" do
 
     # Expect to be redirected to user profile page
     expect(page).to have_text "German Geranium"
-    expect(page).to have_text "Admin"
+    expect(page).to have_text "Agent"
 
     click_on "Sign out"
     # Should be redirected to home page
@@ -44,7 +44,7 @@ RSpec.feature "Logging in and out to the volunteer portal" do
     click_on "Sign in"
     # Expect to be redirected to user profile page
     expect(page).to have_text "German Geranium"
-    expect(page).to have_text "Admin"
+    expect(page).to have_text "Agent"
   end
 
   scenario "resetting password" do

--- a/spec/features/invitations_spec.rb
+++ b/spec/features/invitations_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.feature "Sending and accepting invitations" do
   context "As an admin user" do
-    let(:admin_user) { create :admin_user }
+    let(:beta_tester) { create :beta_tester, role: "agent" }
     before do
-      login_as admin_user
+      login_as beta_tester
     end
 
     scenario "I can send, review, and revoke invitations" do
@@ -31,7 +31,7 @@ RSpec.feature "Sending and accepting invitations" do
         expect(page).to have_text "Colleen Cauliflower"
         expect(page).to have_text "colleague@cauliflower.org"
       end
-      invited_user = User.where(invited_by: admin_user).last
+      invited_user = User.where(invited_by: beta_tester).last
       expect(invited_user).to be_present
       within("#invitation-#{invited_user.id}") do
         click_on "Resend invitation email"
@@ -39,7 +39,7 @@ RSpec.feature "Sending and accepting invitations" do
       within(".flash--notice") do
         expect(page).to have_text "We sent an email invitation to colleague@cauliflower.org"
       end
-      invited_user = User.where(invited_by: admin_user).last
+      invited_user = User.where(invited_by: beta_tester).last
       expect(invited_user.invitation_token).to be_present
 
       logout
@@ -51,7 +51,7 @@ RSpec.feature "Sending and accepting invitations" do
       expect(mail.subject).to eq "You've been invited to GetYourRefund"
       expect(accept_invite_url).to be_present
       expect(mail.body.encoded).to have_text "Hello,"
-      expect(mail.body.encoded).to have_text "#{admin_user.name} (#{admin_user.email}) has invited #{invited_user.name} to create an account on GetYourRefund"
+      expect(mail.body.encoded).to have_text "#{beta_tester.name} (#{beta_tester.email}) has invited #{invited_user.name} to create an account on GetYourRefund"
       expect(mail.body.encoded).to have_text "If you don't want to accept the invitation, please ignore this email."
 
       # Sign up page

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,6 +17,7 @@
 #  invitation_sent_at        :datetime
 #  invitation_token          :string
 #  invitations_count         :integer          default(0)
+#  is_beta_tester            :boolean          default(FALSE), not null
 #  last_sign_in_at           :datetime
 #  last_sign_in_ip           :string
 #  locked_at                 :datetime

--- a/spec/support/shared_examples/access_controllable.rb
+++ b/spec/support/shared_examples/access_controllable.rb
@@ -76,7 +76,7 @@ shared_examples :a_get_action_for_beta_testers_only do |action:|
   context "with a non-admin user" do
     before { sign_in( create :user, is_beta_tester: false ) }
 
-    it "saves the current path to the session and redirects to the zendesk login path" do
+    it "responds with status forbidden" do
       get action, params: params
 
       expect(response.status).to eq 403
@@ -90,7 +90,7 @@ shared_examples :a_post_action_for_beta_testers_only do |action:|
   context "with a non-admin user" do
     before { sign_in( create :user, is_beta_tester: false ) }
 
-    it "saves the current path to the session and redirects to the zendesk login path" do
+    it "responds with status forbidden" do
       post action, params: params
 
       expect(response.status).to eq 403

--- a/spec/support/shared_examples/access_controllable.rb
+++ b/spec/support/shared_examples/access_controllable.rb
@@ -69,3 +69,31 @@ shared_examples :a_post_action_forbidden_to_non_admin_users do |action:|
     end
   end
 end
+
+shared_examples :a_get_action_for_beta_testers_only do |action:|
+  let(:params) { {} } unless method_defined?(:params)
+
+  context "with a non-admin user" do
+    before { sign_in( create :user, is_beta_tester: false ) }
+
+    it "saves the current path to the session and redirects to the zendesk login path" do
+      get action, params: params
+
+      expect(response.status).to eq 403
+    end
+  end
+end
+
+shared_examples :a_post_action_for_beta_testers_only do |action:|
+  let(:params) { {} } unless method_defined?(:params)
+
+  context "with a non-admin user" do
+    before { sign_in( create :user, is_beta_tester: false ) }
+
+    it "saves the current path to the session and redirects to the zendesk login path" do
+      post action, params: params
+
+      expect(response.status).to eq 403
+    end
+  end
+end


### PR DESCRIPTION
Replaces all the admin-only restrictions with beta tester only restrictions.

Any users invited through the new interface will be marked as beta testers, including existing users.