### PR TITLE
Link users to partners

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -27,7 +27,7 @@ class Users::InvitationsController < Devise::InvitationsController
 
   # Override superclass method for default params for newly created invites, allowing us to add attributes
   def invite_params
-    params.require(:user).permit(:name, :email)
+    params.require(:user).permit(:name, :email, :vita_partner_id)
   end
 
   # Override superclass method for accepted invite params, allowing us to add attributes

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,7 @@ class UsersController < ApplicationController
   end
 
   def index
-    @users = User.all
+    @users = User.includes(:vita_partner)
   end
 
   def edit
@@ -29,6 +29,6 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:is_beta_tester)
+    params.require(:user).permit(:is_beta_tester, :vita_partner_id)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,7 @@
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  invited_by_id             :bigint
+#  vita_partner_id           :bigint
 #  zendesk_user_id           :bigint
 #
 # Indexes
@@ -44,14 +45,18 @@
 #  index_users_on_invitations_count     (invitations_count)
 #  index_users_on_invited_by_id         (invited_by_id)
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_vita_partner_id       (vita_partner_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (invited_by_id => users.id)
+#  fk_rails_...  (vita_partner_id => vita_partners.id)
 #
 class User < ApplicationRecord
   devise :database_authenticatable, :lockable, :validatable, :timeoutable, :trackable, :invitable, :recoverable,
          :omniauthable, omniauth_providers: [:zendesk]
+  
+  belongs_to :vita_partner, optional: true
 
   attr_encrypted :access_token, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }
 

--- a/app/models/vita_partner.rb
+++ b/app/models/vita_partner.rb
@@ -21,8 +21,13 @@ class VitaPartner < ApplicationRecord
   has_many :intakes
   has_and_belongs_to_many :states, association_foreign_key: :state_abbreviation
   has_many :source_parameters
+  has_many :users
 
   after_initialize :defaults
+
+  def self.select_input_options
+    all.collect { |v| [v.name, v.id] }
+  end
 
   def at_capacity?
     actionable_intakes_this_week.count >= weekly_capacity_limit

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -5,6 +5,7 @@
   <%= form_for(resource, as: resource_name, url: invitation_path(resource_name), method: :put, local: true, builder: VitaMinFormBuilder) do |f| %>
     <h1><%= @main_heading %></h1>
 
+    <h2 class="form-question"><%= t("general.organization") %>: <%= resource.vita_partner.name %></h2>
     <h2 class="form-question"><%= t(".email_label") %>: <%= resource.email %></h2>
     <%= f.hidden_field :invitation_token, readonly: true %>
     <%= f.cfa_input_field(:name, t(".name_label")) %>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -9,6 +9,7 @@
 
     <%= f.cfa_input_field(:name, t(".name_label")) %>
     <%= f.cfa_input_field(:email, t(".email_label"), type: 'email', classes: ['form-width--email']) %>
+    <%= f.cfa_select(:vita_partner_id, t(".vita_partner_label"), VitaPartner.select_input_options, include_blank: true) %>
 
     <%= f.submit t(".submit"), class: "button button--primary" %>
   <% end %>

--- a/app/views/invitations/index.html.erb
+++ b/app/views/invitations/index.html.erb
@@ -11,7 +11,7 @@
     <ul class="invitations list--bulleted">
       <% @unaccepted_invitations.each do |invitation| %>
         <li id="invitation-<%= invitation.id %>" class="invitation">
-          <%= invitation.name %> &lt;<%= invitation.email %>&gt; (<%= t(".invitation.sent_at", datetime: invitation.invitation_sent_at) %>)
+          <%= invitation.name %> &lt;<%= invitation.email %>&gt; <%= invitation.vita_partner.name %> (<%= t(".invitation.sent_at", datetime: invitation.invitation_sent_at) %>)
           <%= form_with(model: invitation, url: user_invitation_path, method: :post, local: true) do |f| %>
             <%= f.hidden_field :email %>
             <%= f.submit value: t(".invitation.create"), class: "button button--small" %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -10,6 +10,7 @@
     </p>
 
     <%= f.cfa_checkbox(:is_beta_tester, t(".is_beta_tester_label"), options: { classes: ["form-width--long"] }) %>
+    <%= f.cfa_select(:vita_partner_id, t("general.organization"), VitaPartner.select_input_options, include_blank: true) %>
 
     <button class="button" type="submit">
       <%=t("general.save") %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -10,6 +10,7 @@
       <tr class="index-table__row">
         <th scope="col" class="index-table__header"><%= t("general.name") %></th>
         <th scope="col" class="index-table__header"><%= t("general.role") %></th>
+        <th scope="col" class="index-table__header"><%= t("general.organization") %></th>
       </tr>
     </thead>
 
@@ -22,7 +23,8 @@
               <%= user.name %><%= user.is_beta_tester? ? " (beta-tester)" : "" %>
             <% end %>
           </th>
-          <td class="index-table__cell"><%= user.role.capitalize %></td>
+          <td class="index-table__cell"><%= user.role&.capitalize %></td>
+          <td class="index-table__cell"><%= user.vita_partner&.name || t("general.none") %></td>
         </tr>
       <% end %>
 

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -5,7 +5,10 @@
     <strong><%= t("general.email") %></strong> <%= current_user.email %>
   </p>
   <p>
-    <strong>Role:</strong> <%= current_user.role.capitalize %>
+    <strong><%= t("general.role") %>></strong> <%= current_user.role&.capitalize %>
+  </p>
+  <p>
+    <strong><%= t("general.organization") %>></strong> <%= current_user.vita_partner&.name || t("general.none") %>
   </p>
 
   <ul class="actions">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,7 @@ en:
         name_label: What is their name?
         submit: Send invitation email
         title: Send a new invitation
+        vita_partner_label: Which organization?
       not_found:
         check_your_email: 'Try searching your email for messages with the subject: "%{subject}"'
         contact_support: If you're stuck, you can contact support at support@getyourrefund.org
@@ -176,11 +177,13 @@ en:
     name: Name
     negative: 'No'
     next: Next
+    none: None
     none_of_the_above: None of the above
     not_at_all: Not at all
     not_well: Not well
     oops: Oops!
     open: Open
+    organization: Organization
     other_options: Try another free tax filing option
     partner: Partner
     password: Password

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -37,6 +37,7 @@ es:
         name_label: "¿Cúal es el nombre del invitado?"
         submit: Enviar email de invitación
         title: Envíe una nueva invitación
+        vita_partner_label: ¿Cúal organización?
       not_found:
         check_your_email: 'Intente buscar en su correo electrónico mensajes con el asunto: "%{subject}"'
         contact_support: Si está atascado, puede ponerse en contacto con el soporte en support@getyourrefund.org
@@ -176,11 +177,13 @@ es:
     name: Nombre
     negative: 'No'
     next: Próximo
+    none: Ninguna
     none_of_the_above: Ninguna de las anteriores
     not_at_all: De ningún modo
     not_well: No muy bein
     oops: "¡Oye!"
     open: Abrir
+    organization: Organización
     other_options: Intente otra opción de declaración gratis
     partner: Socio
     password: Contraseña

--- a/db/migrate/20200926201736_add_vita_partner_to_user.rb
+++ b/db/migrate/20200926201736_add_vita_partner_to_user.rb
@@ -1,0 +1,5 @@
+class AddVitaPartnerToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :users, :vita_partner, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_24_061736) do
+ActiveRecord::Schema.define(version: 2020_09_26_201736) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -502,12 +502,14 @@ ActiveRecord::Schema.define(version: 2020_09_24_061736) do
     t.string "uid"
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "verified"
+    t.bigint "vita_partner_id"
     t.bigint "zendesk_user_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invitations_count"], name: "index_users_on_invitations_count"
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["vita_partner_id"], name: "index_users_on_vita_partner_id"
   end
 
   create_table "vita_partners", force: :cascade do |t|
@@ -556,5 +558,6 @@ ActiveRecord::Schema.define(version: 2020_09_24_061736) do
   add_foreign_key "states_vita_partners", "vita_partners"
   add_foreign_key "ticket_statuses", "intakes"
   add_foreign_key "users", "users", column: "invited_by_id"
+  add_foreign_key "users", "vita_partners"
   add_foreign_key "vita_providers", "provider_scrapes", column: "last_scrape_id"
 end

--- a/spec/controllers/users/invitations_controller_spec.rb
+++ b/spec/controllers/users/invitations_controller_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe Users::InvitationsController do
   let(:raw_invitation_token) { "exampleToken" }
   let(:beta_user) { create :beta_tester }
+  let(:vita_partner) { create :vita_partner }
   before do
     @request.env["devise.mapping"] = Devise.mappings[:user]
   end
@@ -17,7 +18,8 @@ RSpec.describe Users::InvitationsController do
       {
         user: {
           name: "Cher Cherimoya",
-          email: "cherry@example.com"
+          email: "cherry@example.com",
+          vita_partner_id: vita_partner.id
         }
       }
     end
@@ -40,6 +42,7 @@ RSpec.describe Users::InvitationsController do
         expect(invited_user.invitation_token).to be_present
         expect(invited_user.invited_by).to eq beta_user
         expect(invited_user.role).to eq "agent"
+        expect(invited_user.vita_partner).to eq vita_partner
         expect(response).to redirect_to invitations_path
       end
 
@@ -66,7 +69,8 @@ RSpec.describe Users::InvitationsController do
         name: "Cherry Cherimoya",
         email: "cherry@example.com",
         invitation_token: Devise.token_generator.digest(User, :invitation_token, raw_invitation_token),
-        invited_by: beta_user
+        invited_by: beta_user,
+        vita_partner: vita_partner
       )
     end
 
@@ -74,6 +78,7 @@ RSpec.describe Users::InvitationsController do
       get :edit, params: params
 
       expect(response.body).to have_content "cherry@example.com"
+      expect(response.body).to have_content vita_partner.name
       expect(assigns(:user).name).to eq "Cherry Cherimoya"
     end
 
@@ -104,7 +109,8 @@ RSpec.describe Users::InvitationsController do
         :invited_user,
         name: "Cherry Cherimoya",
         invitation_token: Devise.token_generator.digest(User, :invitation_token, raw_invitation_token),
-        invited_by: beta_user
+        invited_by: beta_user,
+        vita_partner: vita_partner
       )
     end
 
@@ -126,6 +132,7 @@ RSpec.describe Users::InvitationsController do
         end.to change{ controller.current_user }.from(nil).to(invited_user)
         invited_user.reload
         expect(invited_user.name).to eq "Cher Cherimoya"
+        expect(invited_user.vita_partner).to eq vita_partner
         expect(response).to redirect_to user_profile_path
       end
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -35,6 +35,7 @@
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  invited_by_id             :bigint
+#  vita_partner_id           :bigint
 #  zendesk_user_id           :bigint
 #
 # Indexes
@@ -44,10 +45,12 @@
 #  index_users_on_invitations_count     (invitations_count)
 #  index_users_on_invited_by_id         (invited_by_id)
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_vita_partner_id       (vita_partner_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (invited_by_id => users.id)
+#  fk_rails_...  (vita_partner_id => vita_partners.id)
 #
 FactoryBot.define do
   factory :user do

--- a/spec/features/invitations_spec.rb
+++ b/spec/features/invitations_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.feature "Sending and accepting invitations" do
   context "As an admin user" do
     let(:beta_tester) { create :beta_tester, role: "agent" }
+    let!(:vita_partner) { create :vita_partner, name: "Brassica Asset Builders" }
     before do
       login_as beta_tester
     end
@@ -21,6 +22,7 @@ RSpec.feature "Sending and accepting invitations" do
       expect(page).to have_text "Send a new invitation"
       fill_in "What is their name?", with: "Colleen Cauliflower"
       fill_in "What is their email?", with: "colleague@cauliflower.org"
+      select "Brassica Asset Builders", from: "Which organization?"
       click_on "Send invitation email"
 
       # back on the invitations page
@@ -30,6 +32,7 @@ RSpec.feature "Sending and accepting invitations" do
       within(".invitations") do
         expect(page).to have_text "Colleen Cauliflower"
         expect(page).to have_text "colleague@cauliflower.org"
+        expect(page).to have_text "Brassica Asset Builders"
       end
       invited_user = User.where(invited_by: beta_tester).last
       expect(invited_user).to be_present
@@ -58,6 +61,7 @@ RSpec.feature "Sending and accepting invitations" do
       visit accept_invite_url
       expect(page).to have_text "Thank you for signing up to help!"
       expect(page).to have_text "colleague@cauliflower.org"
+      expect(page).to have_text "Brassica Asset Builders"
       expect(find_field("What is your name?").value).to eq "Colleen Cauliflower"
       fill_in "Please choose a strong password", with: "c0v3rt-c4ul1fl0wer"
       fill_in "Enter your new password again", with: "c0v3rt-c4ul1fl0wer"
@@ -66,6 +70,7 @@ RSpec.feature "Sending and accepting invitations" do
       expect(page).to have_text "You're all set and ready to go! You've joined an amazing team!"
       expect(page).to have_text "Colleen Cauliflower"
       expect(page).to have_text "Agent"
+      expect(page).to have_text "Brassica Asset Builders"
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -35,6 +35,7 @@
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  invited_by_id             :bigint
+#  vita_partner_id           :bigint
 #  zendesk_user_id           :bigint
 #
 # Indexes
@@ -44,10 +45,12 @@
 #  index_users_on_invitations_count     (invitations_count)
 #  index_users_on_invited_by_id         (invited_by_id)
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_vita_partner_id       (vita_partner_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (invited_by_id => users.id)
+#  fk_rails_...  (vita_partner_id => vita_partners.id)
 #
 require "rails_helper"
 


### PR DESCRIPTION
This PR makes it so that a given User can belong to a VitaPartner.

- You can set an organization when inviting a user (they can't change it when they accept)
- You can edit an existing user's organization
- It lists the user's organization on the user index page.
