### PR TITLE
Link clients to vita partners

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -9,8 +9,18 @@
 #  sms_phone_number :string
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
+#  vita_partner_id  :bigint
+#
+# Indexes
+#
+#  index_clients_on_vita_partner_id  (vita_partner_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (vita_partner_id => vita_partners.id)
 #
 class Client < ApplicationRecord
+  belongs_to :vita_partner, optional: true
   has_many :intakes
   has_many :outgoing_text_messages
   has_many :outgoing_emails
@@ -23,6 +33,7 @@ class Client < ApplicationRecord
       email_address: intake.email_address,
       phone_number: intake.phone_number,
       sms_phone_number: intake.sms_phone_number,
+      vita_partner: intake.vita_partner,
     )
   end
 end

--- a/app/models/vita_partner.rb
+++ b/app/models/vita_partner.rb
@@ -18,6 +18,7 @@
 class VitaPartner < ApplicationRecord
   DEFAULT_CAPACITY_LIMIT = 300
 
+  has_many :clients
   has_many :intakes
   has_and_belongs_to_many :states, association_foreign_key: :state_abbreviation
   has_many :source_parameters

--- a/db/migrate/20200926213358_add_vita_partner_to_clients.rb
+++ b/db/migrate/20200926213358_add_vita_partner_to_clients.rb
@@ -1,0 +1,5 @@
+class AddVitaPartnerToClients < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :clients, :vita_partner, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_26_201736) do
+ActiveRecord::Schema.define(version: 2020_09_26_213358) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,6 +58,8 @@ ActiveRecord::Schema.define(version: 2020_09_26_201736) do
     t.string "preferred_name"
     t.string "sms_phone_number"
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "vita_partner_id"
+    t.index ["vita_partner_id"], name: "index_clients_on_vita_partner_id"
   end
 
   create_table "delayed_jobs", force: :cascade do |t|
@@ -544,6 +546,7 @@ ActiveRecord::Schema.define(version: 2020_09_26_201736) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "clients", "vita_partners"
   add_foreign_key "documents", "documents_requests"
   add_foreign_key "documents_requests", "intakes"
   add_foreign_key "idme_users", "intakes"

--- a/spec/factories/clients.rb
+++ b/spec/factories/clients.rb
@@ -9,6 +9,15 @@
 #  sms_phone_number :string
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
+#  vita_partner_id  :bigint
+#
+# Indexes
+#
+#  index_clients_on_vita_partner_id  (vita_partner_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (vita_partner_id => vita_partners.id)
 #
 FactoryBot.define do
   factory :client do


### PR DESCRIPTION
This simply adds a foreign key from a client to a vita_partner.
When a client is created from an intake, the intake's vita_partner_id is copied over to the client.