### PR TITLE
Add UX improvements to DIY confirmation email page

### DIFF
--- a/app/controllers/diy/check_email_controller.rb
+++ b/app/controllers/diy/check_email_controller.rb
@@ -1,6 +1,7 @@
 module Diy
   class CheckEmailController < DiyController
     layout "application"
+    skip_before_action :require_diy_intake
     append_after_action :reset_session, :track_page_view
 
     def form_class

--- a/app/views/diy/check_email/edit.html.erb
+++ b/app/views/diy/check_email/edit.html.erb
@@ -16,9 +16,6 @@
             <p><%=t("views.diy.check_email.edit.sent_secure_link") %></p>
             <p><%=t("views.diy.check_email.edit.questions_html", :email_link => link_to("hello@getyourrefund.org", "mailto:hello@getyourrefund.org", class: "text--black")) %></p>
           </div>
-          <div class="buttons--vertical-stack">
-            <%= link_to t("general.return_home"), root_path, class: "button button--primary button--wide text--centered spacing-above-60" %>
-          </div>
         </main>
       </div>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -286,8 +286,8 @@ en:
       check_email:
         edit:
           questions_html: If you have questions you should email %{email_link}.
-          sent_secure_link: We just sent you a secure link for our DIY service.
-          title: Please check your e-mail for a confirmation link.
+          sent_secure_link: We just sent you a secure link for our DIY tax service operated by our partner, TaxSlayer.
+          title: Please check your email to log into TaxSlayer.
       email_address:
         edit:
           confirm_email_address: Confirm e-mail address

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -286,13 +286,13 @@ es:
       check_email:
         edit:
           questions_html: Si tiene alguna pregunta, envíe un correo electrónico a %{email_link}.
-          sent_secure_link: Acabamos de enviarle un enlace seguro de nuestro servicio DIY.
+          sent_secure_link: Acabamos de enviarle un enlace seguro de nuestro servicio DIY operado por nuestro socio comercial, TaxSlayer.
           title: Por favor, compruebe si ha recibido un enlace de confirmación por correo electrónico.
       email_address:
         edit:
           confirm_email_address: Confirme la dirección de correo electrónico
           email_address: Dirección de correo electrónico
-          title: Por favor, informe su dirección de correo electrónico.
+          title: Por favor, informe su dirección de correo electrónico para iniciar sesion de TaxSlayer.
           will_send_secure_link: Le enviaremos un enlace seguro a su correo electrónico para que pueda hacer la declaración.
       file_yourself:
         edit:

--- a/spec/controllers/diy/check_email_controller_spec.rb
+++ b/spec/controllers/diy/check_email_controller_spec.rb
@@ -14,5 +14,13 @@ RSpec.describe Diy::CheckEmailController, type: :controller do
 
       expect(session[:diy_intake_id]).to be_nil
     end
+
+    it "does not redirect on reload" do
+      2.times do
+        get :edit
+      end
+
+      expect(response.status).to eq 200
+    end
   end
 end

--- a/spec/features/diy_intake/new_diy_client_spec.rb
+++ b/spec/features/diy_intake/new_diy_client_spec.rb
@@ -22,11 +22,7 @@ RSpec.feature "Web Intake New Client wants to file on their own" do
     fill_in "E-mail address", with: "do.it@your.self"
     click_on "Continue"
 
-    # Remove this when next page is created
-    expect(page).to have_selector("h1", text: "Please check your e-mail for a confirmation link.")
-    click_on "Return to home"
-
-    expect(current_path).to eq(root_path)
+    expect(page).to have_selector("h1", text: "Please check your email to log into TaxSlayer.")
   end
 
   scenario "new client start DIY flow from dedicated DIY landing page" do
@@ -34,30 +30,6 @@ RSpec.feature "Web Intake New Client wants to file on their own" do
     click_on "Send me a link"
 
     expect(page).to have_selector("h1", text: "File your taxes yourself!")
-  end
-
-  scenario "client tries to go back and change their information" do
-    visit "/questions/welcome"
-    click_on "File taxes myself"
-
-    expect(page).to have_selector("h1", text: "File your taxes yourself!")
-    click_on "Continue"
-
-    expect(page).to have_selector("h1", text: "First, let's get some basic information.")
-    fill_in "Preferred name", with: "Gary"
-    select "California", from: "State of residence"
-    click_on "Continue"
-
-    expect(page).to have_selector("h1", text: "Please share your e-mail address.")
-    fill_in "E-mail address", with: "do.it@your.self"
-    fill_in "Confirm e-mail address", with: "do.it@your.self"
-    click_on "Continue"
-
-    # Remove this when next page is created
-    expect(page).to have_selector("h1", text: "Please check your e-mail for a confirmation link.")
-    visit(diy_email_address_path)
-
-    expect(current_path).to eq(diy_file_yourself_path)
   end
 end
 


### PR DESCRIPTION
We removed one feature test as the behavior is covered in the check_email_controller_spec