### PR TITLE
Add more details to outgoing text message display

### DIFF
--- a/app/assets/stylesheets/components/_contact-record.scss
+++ b/app/assets/stylesheets/components/_contact-record.scss
@@ -11,6 +11,8 @@
    margin-left: 3rem;
     .contact-record__heading {
       padding-left: 3rem;
+      display: flex;
+      justify-content: space-between;
     }
     .contact-record__name {
       font-weight: bold;

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -36,4 +36,9 @@ class Client < ApplicationRecord
       vita_partner: intake.vita_partner,
     )
   end
+
+  # Returns the phone number formatted for user display, e.g.: "(510) 555-1234"
+  def formatted_phone_number
+    Phonelib.parse(phone_number).local_number
+  end
 end

--- a/app/models/concerns/contact_record.rb
+++ b/app/models/concerns/contact_record.rb
@@ -4,4 +4,8 @@ module ContactRecord
   def contact_record_type
     self.class.name.underscore.to_sym
   end
+
+  def formatted_time
+    datetime.strftime("%l:%M %p #{datetime.zone}").strip
+  end
 end

--- a/app/views/clients/show.html.erb
+++ b/app/views/clients/show.html.erb
@@ -16,25 +16,32 @@
       <% @contact_history.each do |contact_record| %>
         <li class="contact-record contact-record--<%= contact_record.contact_record_type %>">
           <div class="contact-record__heading">
-
-            <span class="contact-record__name">
-              <%= contact_record.author %>
-            </span>
-            <span class="contact-record__time">
-            <%= contact_record.datetime %>
-            </span>
-
-            <% if contact_record.contact_record_type == :outgoing_text_message %>
-              <span class="contact-record__status">
-                <%= contact_record.twilio_status || "sending..." %>
+            <div>
+              <span class="contact-record__name">
+                <%= contact_record.author %>
               </span>
-            <% end %>
 
-            <% if contact_record.contact_record_type.to_s.include? "email" %>
-              <div class="contact-record__subject">
-                <%= contact_record.subject %>
-              </div>
-            <% end %>
+                <% if contact_record.contact_record_type == :outgoing_text_message %>
+                <span class="contact-record__phone_number">
+                  Text to <%= contact_record.client.formatted_phone_number %>
+                </span>
+                  <span class="contact-record__status">
+                  <%= contact_record.twilio_status || "sending..." %>
+                </span>
+                <% end %>
+
+                <% if contact_record.contact_record_type.to_s.include? "email" %>
+                  <div class="contact-record__subject">
+                    <%= contact_record.subject %>
+                  </div>
+              <% end %>
+            </div>
+
+            <div>
+              <span class="contact-record__time">
+                <%= contact_record.formatted_time %>
+              </span>
+            </div>
           </div>
 
           <div class="contact-record__body">

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -1,0 +1,32 @@
+# == Schema Information
+#
+# Table name: clients
+#
+#  id               :bigint           not null, primary key
+#  email_address    :string
+#  phone_number     :string
+#  preferred_name   :string
+#  sms_phone_number :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  vita_partner_id  :bigint
+#
+# Indexes
+#
+#  index_clients_on_vita_partner_id  (vita_partner_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (vita_partner_id => vita_partners.id)
+#
+require "rails_helper"
+
+RSpec.describe Client, type: :model do
+  describe "#formatted_phone_number" do
+    let(:client) { build :client, phone_number: "14158161286" }
+
+    it "returns a locally formatted phone number" do
+      expect(client.formatted_phone_number).to eq "(415) 816-1286"
+    end
+  end
+end

--- a/spec/models/outgoing_text_message_spec.rb
+++ b/spec/models/outgoing_text_message_spec.rb
@@ -54,4 +54,12 @@ RSpec.describe OutgoingTextMessage, type: :model do
       end
     end
   end
+
+  describe "#formatted_time" do
+    let(:message) { create :outgoing_text_message, sent_at: DateTime.new(2020, 2, 1, 2, 45, 1) }
+
+    it "returns a human readable time" do
+      expect(message.formatted_time).to eq "2:45 AM UTC"
+    end
+  end
 end


### PR DESCRIPTION
- adds method for formatted phone number
- adds method for formatted timestamp
- adds empty test contexts for other message types (incoming text, outgoing & incoming email)

![image](https://user-images.githubusercontent.com/43800769/94498816-f4a09000-01af-11eb-8ce2-c44ec15ae10b.png)
