### PR TITLE
Make first comment public and add tags if given

### DIFF
--- a/app/helpers/zendesk_service_helper.rb
+++ b/app/helpers/zendesk_service_helper.rb
@@ -146,7 +146,7 @@ module ZendeskServiceHelper
       requester_id: requester_id,
       group_id: group_id,
       external_id: external_id,
-      comment: { body: body, public: false },
+      comment: { body: body, public: true }, # we need the first comment to be public
       fields: [fields],
       **extra_attributes
     )
@@ -170,7 +170,7 @@ module ZendeskServiceHelper
   #                                constructor
   #
   # @return [ZendeskAPI::Ticket] the (persisted) ticket
-  def create_ticket(subject:, requester_id:, group_id:, external_id: nil, body:, fields: {}, **extra_attributes)
+  def create_ticket(subject:, requester_id:, group_id:, external_id: nil, body:, fields: {}, tags: [], **extra_attributes)
     ticket = build_ticket(
       subject: subject,
       requester_id: requester_id,
@@ -180,7 +180,7 @@ module ZendeskServiceHelper
       fields: fields,
       **extra_attributes
     )
-
+    ticket.tags += tags if tags.present?
     ticket.save!
     ticket
   end

--- a/spec/helpers/zendesk_service_helper_spec.rb
+++ b/spec/helpers/zendesk_service_helper_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe ZendeskServiceHelper do
           external_id: nil,
           comment: {
             body: "What's up?",
-            public: false
+            public: true
           },
           fields: [
             "09182374" => "not_busy"

--- a/spec/services/zendesk_drop_off_service_spec.rb
+++ b/spec/services/zendesk_drop_off_service_spec.rb
@@ -55,7 +55,7 @@ describe ZendeskDropOffService do
             external_id: "drop-off-#{drop_off.id}",
             comment: {
               body: comment_body,
-              public: false,
+              public: true,
             },
             fields: [
               {
@@ -109,7 +109,7 @@ describe ZendeskDropOffService do
               external_id: "drop-off-#{drop_off.id}",
               comment: {
                 body: comment_body,
-                public: false,
+                public: true,
               },
               fields: [
                 {


### PR DESCRIPTION
We need the first comment to be public, otherwise all volunteers will see a weird warning when they open a new ticket.
![image (1)](https://user-images.githubusercontent.com/451510/94630185-dacb7f80-0279-11eb-8504-d51baa4c0ed5.png)


We apparently weren't properly setting tags during `create_ticket`, which I only learned while manually checking in development and seeing the result in Zendesk.