### PR TITLE
CanCanCan Spike

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ gem 'websocket-extensions', '>= 0.1.5'
 gem 'twilio-ruby', '~> 5.40.1'
 gem 'mailgun-ruby', '~>1.1.6'
 gem 'devise_invitable', '~> 2.0.0'
+gem 'cancancan'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,7 @@ GEM
       thor (~> 0.19)
     builder (3.2.4)
     byebug (11.1.3)
+    cancancan (3.1.0)
     capybara (3.33.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -511,6 +512,7 @@ DEPENDENCIES
   axe-matchers
   bootsnap (>= 1.1.0)
   byebug
+  cancancan
   capybara (>= 2.15)
   cfa-styleguide!
   ddtrace

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -239,4 +239,10 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(_user)
     user_profile_path
   end
+
+  rescue_from CanCan::AccessDenied do |exception|
+    respond_to do |format|
+      format.html { head :forbidden }
+    end
+  end
 end

--- a/app/controllers/case_management/documents_controller.rb
+++ b/app/controllers/case_management/documents_controller.rb
@@ -2,25 +2,24 @@ module CaseManagement
   class DocumentsController < ApplicationController
     include AccessControllable
     include FileResponseControllerHelper
-    before_action :require_sign_in, :require_beta_tester
+
+    before_action :require_sign_in
+    load_and_authorize_resource :client
+    load_and_authorize_resource through: :client
+
     layout "admin"
 
     def index
-      @client = Client.find(params[:client_id])
-      @documents = @client.documents
     end
 
     def show
-      @document = Document.find(params[:id])
       render_active_storage_attachment @document.upload
     end
 
     def edit
-      @document = Document.find(params[:id])
     end
 
     def update
-      @document = Document.find(params[:id])
       @form = CaseManagement::DocumentForm.new(@document, document_params)
       if @form.valid?
         @form.save

--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -2,12 +2,12 @@ class ClientsController < ApplicationController
   include AccessControllable
 
   before_action :require_sign_in
-  before_action :require_beta_tester
+  load_and_authorize_resource
 
   layout "admin"
 
   def index
-    @clients = Client.all.includes(intakes: :vita_partner)
+    @clients = @clients.includes(intakes: :vita_partner)
   end
 
   def create
@@ -23,7 +23,6 @@ class ClientsController < ApplicationController
   end
 
   def show
-    @client = Client.find(params[:id])
     @contact_history = (
       @client.outgoing_text_messages.includes(:user) +
       @client.incoming_text_messages +

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,17 +1,22 @@
 class MessagesController < ApplicationController
   include AccessControllable
 
-  before_action :require_sign_in, :require_beta_tester
+  before_action :require_sign_in
+  load_and_authorize_resource :client
+  load_and_authorize_resource :outgoing_text_message, parent: false, through: :client
+  load_and_authorize_resource :incoming_text_message, parent: false, through: :client
+  load_and_authorize_resource :outgoing_email, parent: false, through: :client
+  load_and_authorize_resource :incoming_email, parent: false, through: :client
+
 
   layout "admin"
 
   def index
-    @client = Client.find(params[:client_id])
     @contact_history = (
-      @client.outgoing_text_messages.includes(:user) +
-      @client.incoming_text_messages +
-      @client.outgoing_emails.includes(:user) +
-      @client.incoming_emails
+      @outgoing_text_messages.includes(:user) +
+      @incoming_text_messages +
+      @outgoing_emails.includes(:user) +
+      @incoming_emails
     ).sort_by(&:datetime)
     @outgoing_text_message = OutgoingTextMessage.new(client: @client)
     @outgoing_email = OutgoingEmail.new(client: @client)

--- a/app/controllers/outgoing_emails_controller.rb
+++ b/app/controllers/outgoing_emails_controller.rb
@@ -1,15 +1,15 @@
 class OutgoingEmailsController < ApplicationController
   include AccessControllable
 
-  before_action :require_sign_in, :require_beta_tester
+  before_action :require_sign_in
+  load_and_authorize_resource
 
   def create
-    email = OutgoingEmail.new(outgoing_email_params)
-    email.to = email.client.email_address
-    if email.save
-      OutgoingEmailMailer.user_message(outgoing_email: email).deliver_later
+    @outgoing_email.to = @outgoing_email.client.email_address
+    if @outgoing_email.save
+      OutgoingEmailMailer.user_message(outgoing_email: @outgoing_email).deliver_later
     end
-    redirect_to client_messages_path(client_id: email.client_id)
+    redirect_to client_messages_path(client_id: @outgoing_email.client_id)
   end
 
   private

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -13,7 +13,8 @@ class Users::InvitationsController < Devise::InvitationsController
     # If an anonymous user tries to send an invitation, send them to the invitation page after sign-in.
     require_sign_in(redirect_after_login: new_user_invitation_path)
   end
-  before_action :require_beta_tester, only: [:new, :create]
+
+  authorize_resource :user, only: [:new, :create]
   before_action :require_valid_invitation_token, only: [:edit, :update]
 
   def create

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -1,0 +1,15 @@
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    can :manage, [
+      IncomingTextMessage,
+      OutgoingTextMessage,
+      OutgoingEmail,
+      IncomingEmail,
+      Client,
+      Document,
+      User
+    ] if user.is_beta_tester?
+  end
+end

--- a/app/views/case_management/documents/edit.html.erb
+++ b/app/views/case_management/documents/edit.html.erb
@@ -1,7 +1,7 @@
 <% @title = t(".title") %>
 <% content_for :page_title, @title %>
 <% content_for :card do %>
-  <%= form_with model: [:case_management, @document], local: true, builder: VitaMinFormBuilder, html: { class: 'form-card form-card--long' } do |f| %>
+  <%= form_with model: @document, url: case_management_client_document_path, local: true, builder: VitaMinFormBuilder, html: { class: 'form-card form-card--long' } do |f| %>
     <h1 class="form-card__title">
       <%= @title %>
     </h1>

--- a/app/views/case_management/documents/index.html.erb
+++ b/app/views/case_management/documents/index.html.erb
@@ -26,7 +26,7 @@
           </td>
           <td><%= t(".uploaded_ago", time: time_ago_in_words(document.created_at)) %></td>
           <td class="edit">
-            <%= link_to t("general.edit"), edit_case_management_document_path(id: document.id) %>
+            <%= link_to t("general.edit"), edit_case_management_client_document_path(client_id: @client.id, id: document.id) %>
           </td>
         </tr>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -123,9 +123,8 @@ Rails.application.routes.draw do
     end
     
     namespace :case_management do
-      resources :documents, only: [:edit, :update, :show]
       resources :clients, controller: '/clients' do
-        resources :documents, only: [:index]
+        resources :documents, only: [:index, :edit, :update, :show]
       end
     end
 

--- a/spec/controllers/case_management/documents_controller_spec.rb
+++ b/spec/controllers/case_management/documents_controller_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe CaseManagement::DocumentsController, type: :controller do
       it "displays all the documents for the client" do
         get :index, params: params
 
+        expect(response).to be_ok
         html = Nokogiri::HTML.parse(response.body)
         first_doc_element = html.at_css("#document-#{first_document.id}")
         expect(first_doc_element).to have_text("ID")
@@ -69,7 +70,7 @@ RSpec.describe CaseManagement::DocumentsController, type: :controller do
     let(:new_display_name) { "New Display Name"}
     let(:client) { create :client }
     let(:document) { create :document, :with_upload, client: client }
-    let(:params) { { id: document.id, document: { display_name: new_display_name} } }
+    let(:params) { { client_id: client.id, id: document.id, document: { display_name: new_display_name} } }
 
     it_behaves_like :a_post_action_for_authenticated_users_only, action: :update
     it_behaves_like :a_post_action_for_beta_testers_only, action: :update
@@ -88,7 +89,7 @@ RSpec.describe CaseManagement::DocumentsController, type: :controller do
       end
 
       context "invalid params" do
-        let(:params) { { id: document.id, document: { display_name: '' } } }
+        let(:params) { { client_id: client.id, id: document.id, document: { display_name: '' } } }
 
         it "renders edit and does not update the document with invalid data" do
           post :update, params: params
@@ -103,8 +104,9 @@ RSpec.describe CaseManagement::DocumentsController, type: :controller do
   end
 
   describe "#show" do
-    let(:document) { create :document, :with_upload }
-    let(:params) { { id: document.id }}
+    let(:client) { create :client }
+    let(:document) { create :document, :with_upload, client: client }
+    let(:params) { { client_id: client.id, id: document.id }}
 
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :show
     it_behaves_like :a_get_action_for_beta_testers_only, action: :show

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -28,6 +28,20 @@ RSpec.describe MessagesController do
           ].reverse
         end
 
+        before do
+          create :outgoing_text_message
+        end
+
+        it "displays all message bodies sorted by date" do
+          get :index, params: params
+
+          expect(assigns(:contact_history)).to eq expected_contact_history
+          expect(response.body).to include("Your tax return is great")
+          expect(response.body).to include("Thx appreciate yr gratitude")
+          expect(response.body).to include("We are really excited to work with you")
+          expect(response.body).to include("Me too! Happy to get every notification")
+        end
+
         context "outgoing text messages" do
           context "with Twilio status" do
             let(:twilio_status) { "queued" }

--- a/spec/controllers/outgoing_emails_controller_spec.rb
+++ b/spec/controllers/outgoing_emails_controller_spec.rb
@@ -3,6 +3,9 @@ require "rails_helper"
 RSpec.describe OutgoingEmailsController do
   describe "#create" do
     let(:client) { create :client }
+    let(:params) do
+      { outgoing_email: { client_id: client.id, body: "hi client" } }
+    end
 
     it_behaves_like :a_post_action_for_authenticated_users_only, action: :create
     it_behaves_like :a_post_action_for_beta_testers_only, action: :create
@@ -13,9 +16,6 @@ RSpec.describe OutgoingEmailsController do
       before { sign_in beta_user }
 
       context "with body & client_id" do
-        let(:params) do
-          { outgoing_email: { client_id: client.id, body: "hi client" } }
-        end
         before { allow(DateTime).to receive(:now).and_return(expected_time) }
 
         it "creates an OutgoingEmail, asks it to deliver itself later, then redirects to client show", active_job: true do

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+describe Ability do
+  let (:subject) { Ability.new(user) }
+  context "as a beta tester" do
+    let(:user) { create :beta_tester }
+    it "can manage clients" do
+      expect(subject.can?(:manage, Client.new)).to eq true
+    end
+  end
+
+  context "as a non-beta tester" do
+    let(:user) { create :user }
+    it "cannot manage clients" do
+      expect(subject.can?(:manage, Client.new)).to eq false
+    end
+  end
+end


### PR DESCRIPTION
# CanCanCan Gem Spike

[Also available on HackMD](https://hackmd.io/jjGatRUBReu-roKyuCnDMg?view)

Resource-based permissions in controllers. It grows well, and keeps access control organized, consistent, and readable.

## Positives

### Centralizes unauthorized access handling. We can ensure that we always log unauthorized access attempts.

```ruby
  rescue_from CanCan::AccessDenied do |exception|
    # "attempted unauthorized access by user 3 to read Client"
    log "attempted unauthorized access by #{current_user} to #{exception.action} #{exception.subject}"
    respond_to do |format|
      format.html { head :forbidden }
    end
  end
```

### Fetches the right scope, by default

```ruby
class DocumentsController
  # checks for access a particular client, sets @client
  load_and_authorize_resource :client
  # checks for access to documents, sets @documents to only those documents user can access that are linked to client
  load_and_authorize_resource through: :client
end
```

- Centralized way to grab currently authorized resources.
- Does routine work in a helpful way, by fetching only resources that are available to the current user.
- Encourages us to scope nested resources under access to the parent model.

### Super flexible and facilitates more complex permissions logic

```ruby
class Ability
  include CanCan::Ability

  def initialize(user)
    can :manage, Client if user.is_super_admin?
    can :manage, Client, organization: user.organization
    # coalition
    can :manage, Client, organization: { parent_organization: { id: user.organization_id } }
    if user.is_greeter? || user.is_client_support?
      # basic greeter or client support check
      can :manage, Client, organization_id: user.supported_organizations
      # greeter supporting a coalition parent
      can :manage, Client, organization: { coalition_parent_id: user.supported_organizations }
    end

    if user.is_site_coordinator?
      can :manage, User, organization: user.organization
    end

    if user.is_coalition_owner?
      can :manage, Organization, coalition_parent_id: user.organization_id
    end
  end
end
```

We can proxy permission to do things through access to a client

```ruby
class MessagesController
  load_and_authorize_resource :client
  load_and_authorize_resource :outgoing_text_message, parent: false, through: :client
  load_and_authorize_resource :incoming_text_message, parent: false, through: :client
  load_and_authorize_resource :outgoing_email, parent: false, through: :client
  load_and_authorize_resource :incoming_email, parent: false, through: :client

  def index
    @contact_history = (
      @outgoing_text_messages.includes(:user) +
      @incoming_text_messages +
      @outgoing_emails.includes(:user) +
      @incoming_emails
    ).sort_by(&:datetime)
  end
end
```
- If we ever want to differentiate the ability to read, write, or delete based on any criteria, this gem would make it much easier to implement.
- If we ever need more complex permissions logic, such as storing permissions in the database or creating custom permissions logic (for example, limiting access to certain spans of time)

## Mixed
- Probably does not eliminate need to write controller specs to affirm correct access control or scope. But shared code for determining access might make access control specs easier to write.
- I don't think it's actually reducing the lines of code.

## Risks
- Always make sure that we check if the user is signed in before checking their abilities.
- If a controller is not clearly tied to a resource, we need to be careful to pin access to something helpful. Not clear how to tie permissions to things other than Models.
- Lack of transparency for querying access carries some risk of bugs or performance issues. But probably less risk than home-cooked code.

## Other notes

### Cascading Ability Sheets
Can statements are executed as a series of `OR` queries. Like CSS, subsequent `can` statements override previous statements.

## Multiple Ability Classes
A common way to implement CanCanCan permissions is to write a single `Ability` class and put all the permission logic inside of the single `initialize` method.
`current_ability` is a method that determines the currently instantiated Ability class. If we want to use multiple Ability classes, we'd have to overwrite `current_ability`.
I think we'd be most likely to separate abilities by _role_. For example, a `SiteCoordinatorAbility` or a `GreeterAbility`.

### Choosing a specific Ability class

```ruby
def current_ability
  @current_ability ||= MyAbility.new(current_user)
end
```

### Merging multiple Ability classes


```ruby
def current_ability
  @current_ability ||= MyAbility.new(current_user).merge(MyOtherAbility.new(current_user))
end
```

### A more complex example of ability structure
```
# file tree
app/
  abilities/
    base_ability.rb
    one_ability.rb  # inherits from base_ability
    other_ability.rb  # inherits from base_ability
    another_ability.rb  # inherits from base_ability
```

```ruby
def current_ability
  # build method can figure out which class to instantiate
  @current_ability ||= Abilities::BaseAbility.build(current_user, request)
end
```

## Further Reading

- [Defining Abilities: Best Practices](https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities:-Best-Practices)
- [Ensuring Authorization is run for a broad set of controllers](https://github.com/CanCanCommunity/cancancan/wiki/Ensure-Authorization)