### PR TITLE
Allow users to have no role

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -6,7 +6,7 @@
       <strong><%= t("general.email") %>:</strong> <%= @user.email %>
     </p>
     <p>
-      <strong><%= t("general.role") %>:</strong> <%= @user.role.capitalize %>
+      <strong><%= t("general.role") %>:</strong> <%= @user.role&.capitalize || "Role not specified" %>
     </p>
 
     <%= f.cfa_checkbox(:is_beta_tester, t(".is_beta_tester_label"), options: { classes: ["form-width--long"] }) %>


### PR DESCRIPTION
🐞 Bugfix 🐞 in the `.erb`

When visiting the user edit page for a user with a `nil` role value, e.g., those created by `rake db:seed`:

Before this change:

![image](https://user-images.githubusercontent.com/67708639/95511811-cfa8db80-096c-11eb-9375-a2f1eb3e7f49.png)

After this change:

![image](https://user-images.githubusercontent.com/67708639/95511823-d46d8f80-096c-11eb-8f63-a2c64f0e1913.png)
