### PR TITLE
Deploy to Aptible one at a time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,7 @@ jobs:
       - run: echo $APTIBLE_PUBLIC_KEY >> ~/.ssh/known_hosts
       - run: git fetch --depth=1000000
       - run: git push git@beta.aptible.com:vita-min-demo/vita-min-demo.git $CIRCLE_SHA1:master
+    parallelism: 1
   deploy_to_aptible--production:
     executor: rails_executor
     steps:
@@ -63,6 +64,7 @@ jobs:
       - run: echo $APTIBLE_PUBLIC_KEY >> ~/.ssh/known_hosts
       - run: git fetch --depth=1000000
       - run: git push git@beta.aptible.com:vita-min-prod/vita-min-prod.git $CIRCLE_SHA1:master
+    parallelism: 1
 workflows:
   version: 2
   build:


### PR DESCRIPTION
Co-authored-by: Sarah Niemeyer <sniemeyer@vmware.com>

This intends to avoid a problem where Aptible rejects a `git push` because they are processing a different deploy. That is my hypothesis about why we got this error:

![image](https://user-images.githubusercontent.com/67708639/95624401-abf89a80-0a2b-11eb-953d-f162ee147398.png)
