### PR TITLE
Closing tasks for 10/13

### DIFF
--- a/app/assets/stylesheets/organisms/_flash-messages.scss
+++ b/app/assets/stylesheets/organisms/_flash-messages.scss
@@ -19,3 +19,9 @@
   background-color: $color-yellow-light;
   color: #000;
 }
+
+.flash--offseason-warning {
+  color: #000;
+  background-color: $color-red-light;
+  border: 2px solid $color-red;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -244,8 +244,8 @@ class ApplicationController < ActionController::Base
     Time.use_zone(current_user.timezone) { yield }
   end
 
-  def redirect_home
-    redirect_to root_path
+  def redirect_offseason_intake
+    redirect_to root_path if Rails.env.production?
   end
 
   rescue_from CanCan::AccessDenied do |exception|

--- a/app/controllers/diy/diy_controller.rb
+++ b/app/controllers/diy/diy_controller.rb
@@ -1,7 +1,7 @@
 module Diy
   class DiyController < ApplicationController
     before_action :require_diy_intake
-
+    before_action :redirect_home, if: -> { Rails.env.development? }
     delegate :form_name, to: :class
     delegate :form_class, to: :class
 

--- a/app/controllers/diy/diy_controller.rb
+++ b/app/controllers/diy/diy_controller.rb
@@ -1,7 +1,6 @@
 module Diy
   class DiyController < ApplicationController
-    before_action :require_diy_intake
-    before_action :redirect_home, if: -> { Rails.env.development? }
+    before_action :require_diy_intake, :redirect_offseason_intake
     delegate :form_name, to: :class
     delegate :form_class, to: :class
 

--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -1,7 +1,7 @@
 class PublicPagesController < ApplicationController
 
   skip_before_action :check_maintenance_mode
-  before_action :redirect_home, if: -> { Rails.env.production? }, only: [:diy_home]
+  before_action :redirect_offseason_intake, only: [:diy_home]
   def include_analytics?
     true
   end

--- a/app/controllers/questions/questions_controller.rb
+++ b/app/controllers/questions/questions_controller.rb
@@ -1,7 +1,6 @@
 module Questions
   class QuestionsController < ApplicationController
-    before_action :require_intake
-    before_action :redirect_home, if: -> { Rails.env.production? || Rails.env.demo? }
+    before_action :redirect_offseason_intake, :require_intake
     delegate :form_name, to: :class
     delegate :form_class, to: :class
 

--- a/app/controllers/questions/questions_controller.rb
+++ b/app/controllers/questions/questions_controller.rb
@@ -1,7 +1,7 @@
 module Questions
   class QuestionsController < ApplicationController
     before_action :require_intake
-
+    before_action :redirect_home, if: -> { Rails.env.production? || Rails.env.demo? }
     delegate :form_name, to: :class
     delegate :form_class, to: :class
 

--- a/app/views/public_pages/home.html.erb
+++ b/app/views/public_pages/home.html.erb
@@ -29,7 +29,7 @@
   <div class="slab slab--info-section">
     <div class="grid">
       <div class="grid__item width-one-whole">
-        <h3 class="spacing-below-0"><%= t("views.public_pages.home.stimulus_banner.heading") %></h3>
+        <h3 class="spacing-below-0"><%=t("views.public_pages.home.stimulus_banner.heading")%></h3>
         <p class="spacing-below-0"><%=t("views.public_pages.home.stimulus_banner.subheading") %></p>
       </div>
       <div class="grid__item width-one-whole">

--- a/app/views/shared/_environment_warning.html.erb
+++ b/app/views/shared/_environment_warning.html.erb
@@ -8,3 +8,13 @@
     </div>
   </div>
 <% end %>
+
+<% if Rails.env.production? %>
+  <div class="slab slab--flash flash--offseason-warning">
+    <div class="grid">
+      <div class="grid__item">
+        <%= t("views.shared.environment_warning.off_season")%>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1377,6 +1377,8 @@ en:
         notice_html: Due to COVID-19, a number of VITA sites and all TCE sites are closed for an undetermined period of time. Please call a site before visiting to confirm hours. To get connected with a VITA site online and have a VITA site assist you with your taxes remotely, visit GetYourRefund.org and click "Get Started." You can also visit the %{free_file_link} to find other free online tax preparation tools.
       environment_warning:
         banner: This site is for example purposes only. If you want help with your taxes, go to
+        off_season: GetYourRefund services are closed for this tax season. We look forward to providing our free tax assistance again starting in January.
+
       footer:
         service_description_html: GetYourRefund.org is a non-profit service built by %{cfa_link} in partnership with IRS-certified Volunteer Income Tax Assistance (%{vita_link}) sites nationally.
         volunteer_sign_in: Volunteer sign in

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -788,13 +788,6 @@ es:
           header: Preguntas
           resolve: Haremos todo lo posible para resolver el problema.
         title: Política de Privacidad
-      stimulus_banner:
-        heading: ¿Necesitas ayuda para conseguir tu cheque de estímulo (también conocido como Pago de Impacto Económico)?
-        subheading: La fecha límite para conseguir tu cheque de estímulo a través de la aplicación en línea del IRS se ha extendido hasta el 21 de noviembre.
-        facts_html:
-          - "Revisa el estado de tu cheque de estímulo en <a href='https://www.irs.gov/es/coronavirus/get-my-payment'>IRS Get My Payment website</a>"
-          - "Solicita tu cheque de estímulo directamente a través de <a href='https://www.irs.gov/es/coronavirus/non-filers-enter-payment-info-here'>IRS nonfiler tool website</a>"
-          - "Llama a la Línea Directa de Pago de Impacto Económico 211 (en inglés: 211 Economic Impact Payment); <a href='tel:1-844-322-3639'>+1 (844) 322-3639</a>"
       stimulus_payment:
         faq:
           eip:
@@ -1384,6 +1377,7 @@ es:
         notice_html: Por la pandemia de COVID-19, varios centros de VITA y todos los centros TCE permanecerán cerrados durante un período de tiempo indeterminado. Llame antes de visitar las oficinas para confirmar el horario de atención. Para conectarse con un sitio de VITA en línea y recibir ayuda con su declaración de impuestos de forma remota, visite GetYourRefund.org y haga clic en "Get Started" ("Empezar"). También puede visitar %{free_file_link} para encontrar otras herramientas gratuitas de preparación de impuestos en línea.
       environment_warning:
         banner: 'Este sitio es sólo para fines de ejemplo. Si necesitas ayuda con sus impuestos, visite  '
+        off_season: Los servicios GetYourRefund están cerrados para esta temporada de impuestos. Nos daría mucho gusto poder trabajar con usted el próximo año y ayudarle a declarar sus impuestos absolutamente gratis.
       footer:
         service_description_html: GetYourRefund.org es un servicio sin ánimo de lucro creado por %{cfa_link} en colaboración con los sitios de Asistencia Voluntaria al Contribuyente (%{vita_link}) certificados por el IRS en todo el país.
         volunteer_sign_in: Sesión de voluntarios

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -788,6 +788,13 @@ es:
           header: Preguntas
           resolve: Haremos todo lo posible para resolver el problema.
         title: Política de Privacidad
+      stimulus_banner:
+        heading: ¿Necesitas ayuda para conseguir tu cheque de estímulo (también conocido como Pago de Impacto Económico)?
+        subheading: La fecha límite para conseguir tu cheque de estímulo a través de la aplicación en línea del IRS se ha extendido hasta el 21 de noviembre.
+        facts_html:
+          - "Revisa el estado de tu cheque de estímulo en <a href='https://www.irs.gov/es/coronavirus/get-my-payment'>IRS Get My Payment website</a>"
+          - "Solicita tu cheque de estímulo directamente a través de <a href='https://www.irs.gov/es/coronavirus/non-filers-enter-payment-info-here'>IRS nonfiler tool website</a>"
+          - "Llama a la Línea Directa de Pago de Impacto Económico 211 (en inglés: 211 Economic Impact Payment); <a href='tel:1-844-322-3639'>+1 (844) 322-3639</a>"
       stimulus_payment:
         faq:
           eip:

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -728,7 +728,7 @@ RSpec.describe ApplicationController do
       end
     end
 
-    it_behaves_like :a_ticketed_controller, :index
+    it_behaves_like :a_ticketed_controller, :index, bypass_offseason: true
   end
 
   describe "#set_time_zone" do

--- a/spec/controllers/public_pages_controller_spec.rb
+++ b/spec/controllers/public_pages_controller_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe PublicPagesController do
         expect(response.body).not_to include("https://www.getyourrefund.org")
       end
 
+      it "does show a banner telling users that intakes are closed" do
+        get :home
+        expect(response.body).to include("services are closed for this tax season.")
+      end
+
       it "includes GA script in html" do
         get :home
 
@@ -48,6 +53,8 @@ RSpec.describe PublicPagesController do
         expect(response.body).not_to include "https://www.googletagmanager.com/gtag/js?id=UA-156157414-1"
       end
     end
+
+
 
     context "in development env" do
       before do

--- a/spec/controllers/questions/additional_info_controller_spec.rb
+++ b/spec/controllers/questions/additional_info_controller_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe Questions::AdditionalInfoController do
     allow(subject).to receive(:current_intake).and_return(intake)
   end
 
+  it_behaves_like :an_offseason_intake_page, :edit
+  it_behaves_like :an_offseason_intake_page, :update
+
   describe "#update", active_job: true do
     let(:params) do
       { additional_info_form: { additional_info: "I moved here from Alaska." } }
@@ -31,5 +34,6 @@ RSpec.describe Questions::AdditionalInfoController do
         expect(SendIntakePdfToZendeskJob).not_to have_been_enqueued
       end
     end
+
   end
 end

--- a/spec/controllers/questions/backtaxes_controller_spec.rb
+++ b/spec/controllers/questions/backtaxes_controller_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe Questions::BacktaxesController do
   render_views
 
+  it_behaves_like :an_offseason_intake_page, :edit
+  it_behaves_like :an_offseason_intake_page, :update
   describe "#update" do
     before do
       session[:source] = "source_from_session"

--- a/spec/controllers/questions/bank_details_controller_spec.rb
+++ b/spec/controllers/questions/bank_details_controller_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Questions::BankDetailsController do
+  it_behaves_like :an_offseason_intake_page, :edit
+  it_behaves_like :an_offseason_intake_page, :update
   describe ".show?" do
     let(:refund_method) {nil}
     let(:pay_from_bank) {nil}

--- a/spec/controllers/questions/chat_with_us_controller_spec.rb
+++ b/spec/controllers/questions/chat_with_us_controller_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe Questions::ChatWithUsController do
     allow(subject).to receive(:current_intake).and_return(intake)
   end
 
+  it_behaves_like :an_offseason_intake_page, :edit
+  it_behaves_like :an_offseason_intake_page, :update
+
   describe "#edit" do
     context "with a non-eip intake" do
       context "with an intake with a ZIP code" do

--- a/spec/controllers/questions/consent_controller_spec.rb
+++ b/spec/controllers/questions/consent_controller_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe Questions::ConsentController do
     allow(subject).to receive(:current_intake).and_return(intake)
   end
 
+  it_behaves_like :an_offseason_intake_page, :edit
+  it_behaves_like :an_offseason_intake_page, :update
+
   describe "#update" do
     context "with valid params" do
       let (:params) do

--- a/spec/controllers/questions/divorced_controller_spec.rb
+++ b/spec/controllers/questions/divorced_controller_spec.rb
@@ -10,6 +10,9 @@ RSpec.describe Questions::DivorcedController do
       end
     end
 
+    it_behaves_like :an_offseason_intake_page, :edit
+    it_behaves_like :an_offseason_intake_page, :update
+
     context "with an intake that has not filled out the ever_married column" do
       let!(:intake) { create :intake, ever_married: "unfilled" }
 

--- a/spec/support/shared_examples/a_ticketed_controller.rb
+++ b/spec/support/shared_examples/a_ticketed_controller.rb
@@ -1,4 +1,4 @@
-shared_examples :a_ticketed_controller do |get_action|
+shared_examples :a_ticketed_controller do |get_action, bypass_offseason: false|
   before do
     allow(subject).to receive(:current_intake).and_return(intake)
   end
@@ -49,10 +49,11 @@ shared_examples :a_ticketed_controller do |get_action|
 
       it "redirects to the start of the questions workflow" do
         get get_action
-
-        expect(response).to redirect_to(question_path(:id => QuestionNavigation.first))
+        expected_path = bypass_offseason ? question_path(:id => QuestionNavigation.first) : root_path
+        expect(response).to redirect_to(expected_path)
       end
     end
+
 
     context "in any other environment" do
       before { allow(Rails).to receive(:env).and_return "demo".inquiry }
@@ -73,8 +74,8 @@ shared_examples :a_ticketed_controller do |get_action|
 
       it "redirects to the start of the questions workflow" do
         get get_action
-
-        expect(response).to redirect_to(question_path(:id => QuestionNavigation.first))
+        expected_path = bypass_offseason ? question_path(:id => QuestionNavigation.first) : root_path
+        expect(response).to redirect_to(expected_path)
       end
     end
 

--- a/spec/support/shared_examples/an_offseason_intake_page.rb
+++ b/spec/support/shared_examples/an_offseason_intake_page.rb
@@ -1,0 +1,14 @@
+shared_examples :an_offseason_intake_page do |get_action|
+  before do
+    allow(Rails).to receive(:env).and_return("production".inquiry)
+  end
+
+  context "when we're redirecting because it is the off season" do
+
+    it "redirects to home" do
+      get get_action
+
+      expect(response).to redirect_to root_path
+    end
+  end
+end


### PR DESCRIPTION
Add banner in production,
gate other intake routes back to root

<img width="754" alt="Screen Shot 2020-10-12 at 4 19 13 PM" src="https://user-images.githubusercontent.com/4494389/95801891-ac559780-0cb0-11eb-98d8-7e3563929e53.png">


- I created a shared example for redirects on questions controllers, but only added it to select questions_controller specs because doing it on every single one seemed like overkill?
- there is a spec that tests the require_intake logic directly by creating a fake controller action, so i had to add logic for isolating that test case in the a_ticketed_controller shared example. it made me question the approach i took a little because its a little funky
- I wanted to get this up even though its not total optimal implementation so that the more eastern timezones devs could take a look/pick up on it if they really wanted to!