### PR TITLE
Simplify date format per product guidance

### DIFF
--- a/app/helpers/time_helper.rb
+++ b/app/helpers/time_helper.rb
@@ -13,6 +13,6 @@ module TimeHelper
   end
 
   def formatted_datetime(datetime)
-    datetime.strftime("%b %-d, %Y %l:%M %p %Z").strip
+    datetime.strftime("%b %d %-l:%M %p")
   end
 end

--- a/spec/helpers/time_helper_spec.rb
+++ b/spec/helpers/time_helper_spec.rb
@@ -10,9 +10,8 @@ describe TimeHelper do
   describe "#formatted_datetime" do
     it "returns a string formatted to show the date and the time with zone" do
       Time.use_zone("America/Los_Angeles") do
-        # in_time_zone coerces from -0800 -> PST
-        test_date = Time.zone.local(2004, 11, 24, 01, 04, 44).in_time_zone("America/Los_Angeles")
-        expect(helper.formatted_datetime(test_date)).to include("Nov 24, 2004  1:04 AM PST")
+        test_date = DateTime.new(2004, 11, 24, 01, 04, 44)
+        expect(helper.formatted_datetime(test_date)).to include("Nov 24 1:04 AM")
       end
     end
   end


### PR DESCRIPTION
Remove timezone and year from date formatter per Kelly.