### PR TITLE
Temporarily load documents through intake to make documents request uploads reflect in ui

### DIFF
--- a/app/controllers/case_management/clients_controller.rb
+++ b/app/controllers/case_management/clients_controller.rb
@@ -8,7 +8,7 @@ module CaseManagement
     layout "admin"
 
     def index
-      @clients = @clients.includes(intakes: :vita_partner)
+      @clients = @clients.includes(intake: :vita_partner)
     end
 
     def create

--- a/app/controllers/case_management/documents_controller.rb
+++ b/app/controllers/case_management/documents_controller.rb
@@ -19,8 +19,7 @@ module CaseManagement
       render_active_storage_attachment @document.upload
     end
 
-    def edit
-    end
+    def edit; end
 
     def update
       @form = CaseManagement::DocumentForm.new(@document, document_params)

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -24,19 +24,17 @@
 #
 class Client < ApplicationRecord
   belongs_to :vita_partner, optional: true
-  has_many :intakes
+  has_one :intake
+  # has_many :documents
   has_many :outgoing_text_messages
   has_many :outgoing_emails
   has_many :incoming_text_messages
   has_many :incoming_emails
-  has_many :documents
   has_many :notes
   has_many :tax_returns
 
-  def intake
-    intakes && intakes.first
-  end
-
+  delegate :documents, to: :intake
+  
   def legal_name
     return unless intake&.primary_first_name? && intake&.primary_last_name?
 
@@ -50,8 +48,8 @@ class Client < ApplicationRecord
       phone_number: intake.phone_number,
       sms_phone_number: intake.sms_phone_number,
       vita_partner: intake.vita_partner,
-      documents: intake.documents,
-      intakes: [intake]
+      # documents: intake.documents,
+      intake: intake
     )
   end
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -38,7 +38,11 @@ class Document < ApplicationRecord
   has_one_attached :upload
 
   before_save :set_display_name
-  after_create :record_incoming_interaction
+  after_create do
+    client.present? ? record_incoming_interaction : intake&.record_incoming_interaction
+  end
+
+
 
   def set_display_name
     return if display_name

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -195,7 +195,7 @@ class Intake < ApplicationRecord
   include InteractionTracking
 
   has_many :users, foreign_key: "intake_id", class_name: "IdmeUser"
-  has_many :documents, -> { order(created_at: :asc) }
+  has_many :documents
   has_many :dependents, -> { order(created_at: :asc) }
   has_many :ticket_statuses, -> { order(created_at: :asc) }
   belongs_to :client, optional: true

--- a/spec/controllers/case_management/clients_controller_spec.rb
+++ b/spec/controllers/case_management/clients_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe CaseManagement::ClientsController do
             expect(client.phone_number).to eq "14155537865"
             expect(client.preferred_name).to eq "Casey"
             expect(client.documents.first).to eq(document)
-            expect(client.intakes).to include(intake)
+            expect(client.intake).to eq(intake)
             expect(intake.reload.client).to eq client
             expect(response).to redirect_to case_management_client_path(id: client.id)
           end
@@ -131,9 +131,9 @@ RSpec.describe CaseManagement::ClientsController do
       render_views
 
       before { sign_in create(:beta_tester) }
-      let!(:george_sr) { create :client, preferred_name: "George Sr.", intakes: [create(:intake, :filled_out, needs_help_2019: "yes", needs_help_2018: "yes", locale: "en")] }
-      let!(:michael) { create :client, preferred_name: "Michael", intakes: [create(:intake, :filled_out, needs_help_2019: "yes", needs_help_2017: "yes") ] }
-      let!(:tobias) { create :client, preferred_name: "Tobias", intakes: [create(:intake, :filled_out, needs_help_2018: "yes", locale: "es")] }
+      let!(:george_sr) { create :client, preferred_name: "George Sr.", intake: create(:intake, :filled_out, needs_help_2019: "yes", needs_help_2018: "yes", locale: "en") }
+      let!(:michael) { create :client, preferred_name: "Michael", intake: create(:intake, :filled_out, needs_help_2019: "yes", needs_help_2017: "yes") }
+      let!(:tobias) { create :client, preferred_name: "Tobias", intake: create(:intake, :filled_out, needs_help_2018: "yes", locale: "es") }
       let(:assigned_user) { create :user, name: "Lindsay" }
       let!(:tobias_2019_return) { create :tax_return, client: tobias, year: 2019, assigned_user: assigned_user }
       let!(:tobias_2018_return) { create :tax_return, client: tobias, year: 2018, assigned_user: assigned_user }
@@ -145,7 +145,7 @@ RSpec.describe CaseManagement::ClientsController do
         html = Nokogiri::HTML.parse(response.body)
         expect(html).to have_text("Updated At")
         expect(html.at_css("#client-#{george_sr.id}")).to have_text("George Sr.")
-        expect(html.at_css("#client-#{george_sr.id}")).to have_text(george_sr.intakes.first.vita_partner.display_name)
+        expect(html.at_css("#client-#{george_sr.id}")).to have_text(george_sr.intake.vita_partner.display_name)
         expect(html.at_css("#client-#{george_sr.id} a")["href"]).to eq case_management_client_path(id: george_sr)
         expect(html.at_css("#client-#{george_sr.id}")).to have_text("English")
         expect(html.at_css("#client-#{tobias.id}")).to have_text("Spanish")

--- a/spec/controllers/case_management/documents_controller_spec.rb
+++ b/spec/controllers/case_management/documents_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe CaseManagement::DocumentsController, type: :controller do
   describe "#index" do
-    let(:client) { create :client }
+    let(:client) { create :client, intake: create(:intake) }
     let(:params) { { client_id: client.id } }
 
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :index
@@ -20,14 +20,16 @@ RSpec.describe CaseManagement::DocumentsController, type: :controller do
                  display_name: "some_file.jpg",
                  document_type: "ID",
                  created_at: 2.days.ago,
-                 client: client
+                 client: client,
+                 intake: client.intake
         }
         let!(:second_document) {
           create :document,
                  display_name: "another_file.pdf",
                  document_type: "W-2",
                  created_at: 3.hours.ago,
-                 client: client
+                 client: client,
+                 intake: client.intake
         }
 
         it "displays all the documents for the client" do
@@ -48,8 +50,8 @@ RSpec.describe CaseManagement::DocumentsController, type: :controller do
       context "sorting and ordering" do
         context "with a sort param" do
           let(:params) { { client_id: client.id, sort: "created_at", order: "desc" } }
-          let!(:earlier_document) { create :document, display_name: "Alligator doc", created_at: 1.hour.ago, client: client }
-          let!(:later_document) { create :document, display_name: "Zebra doc", created_at: 1.minute.ago, client: client }
+          let!(:earlier_document) { create :document, display_name: "Alligator doc", created_at: 1.hour.ago, client: client, intake: client.intake }
+          let!(:later_document) { create :document, display_name: "Zebra doc", created_at: 1.minute.ago, client: client, intake: client.intake }
 
           it "orders documents by that column" do
             get :index, params: params
@@ -62,8 +64,8 @@ RSpec.describe CaseManagement::DocumentsController, type: :controller do
 
         context "with no params" do
           let(:params) { { client_id: client.id } }
-          let!(:identity_document) { create :document, client: client, document_type: DocumentTypes::Identity.key, display_name: "alligator doc" }
-          let!(:employment_document) { create :document, client: client, document_type: DocumentTypes::Employment.key, display_name: "zebra doc" }
+          let!(:identity_document) { create :document, client: client, intake: client.intake, document_type: DocumentTypes::Identity.key, display_name: "alligator doc" }
+          let!(:employment_document) { create :document, client: client, intake: client.intake, document_type: DocumentTypes::Employment.key, display_name: "zebra doc" }
 
           it "defaults to sorting by document_type" do
             get :index, params: params
@@ -74,8 +76,8 @@ RSpec.describe CaseManagement::DocumentsController, type: :controller do
         end
 
         context "with bad sort param" do
-          let!(:identity_document) { create :document, client: client, document_type: DocumentTypes::Identity.key, display_name: "alligator doc" }
-          let!(:employment_document) { create :document, client: client, document_type: DocumentTypes::Employment.key, display_name: "zebra doc" }
+          let!(:identity_document) { create :document, client: client, intake: client.intake, document_type: DocumentTypes::Identity.key, display_name: "alligator doc" }
+          let!(:employment_document) { create :document, client: client, intake: client.intake, document_type: DocumentTypes::Employment.key, display_name: "zebra doc" }
           let(:params) { { client_id: client.id, sort: "bad_param", order: "nonsensical_order" } }
 
           it "defaults to sorting by document_type" do
@@ -91,8 +93,8 @@ RSpec.describe CaseManagement::DocumentsController, type: :controller do
   end
 
   describe "#edit" do
-    let(:client) { create :client }
-    let(:document) { create :document, :with_upload, client: client }
+    let(:client) { create :client, intake: create(:intake) }
+    let(:document) { create :document, :with_upload, client: client, intake: client.intake }
     let(:params) { { id: document.id, client_id: client.id }}
 
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :edit
@@ -113,8 +115,8 @@ RSpec.describe CaseManagement::DocumentsController, type: :controller do
 
   describe "#update" do
     let(:new_display_name) { "New Display Name"}
-    let(:client) { create :client }
-    let(:document) { create :document, :with_upload, client: client }
+    let(:client) { create :client, intake: create(:intake) }
+    let(:document) { create :document, :with_upload, client: client, intake: client.intake }
     let(:params) { { client_id: client.id, id: document.id, document: { display_name: new_display_name} } }
 
     it_behaves_like :a_post_action_for_authenticated_users_only, action: :update
@@ -149,8 +151,8 @@ RSpec.describe CaseManagement::DocumentsController, type: :controller do
   end
 
   describe "#show" do
-    let(:client) { create :client }
-    let(:document) { create :document, :with_upload, client: client }
+    let(:client) { create :client, intake: create(:intake) }
+    let(:document) { create :document, :with_upload, client: client, intake: client.intake }
     let(:params) { { client_id: client.id, id: document.id }}
 
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :show

--- a/spec/features/case_management/documents_spec.rb
+++ b/spec/features/case_management/documents_spec.rb
@@ -3,9 +3,9 @@ require "rails_helper"
 RSpec.feature "View and edit documents for a client" do
   context "As a beta tester" do
     let(:beta_tester) { create :beta_tester }
-    let(:client) { create :client, preferred_name: "Bart Simpson" }
-    let!(:document_1) { create :document, display_name: "ID.jpg", client: client }
-    let!(:document_2) { create :document, display_name: "W-2.pdf", client: client }
+    let(:client) { create :client, preferred_name: "Bart Simpson", intake: create(:intake) }
+    let!(:document_1) { create :document, display_name: "ID.jpg", client: client, intake: client.intake }
+    let!(:document_2) { create :document, display_name: "W-2.pdf", client: client, intake: client.intake }
     before do
       login_as beta_tester
     end

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -45,7 +45,7 @@ describe Client do
     end
 
     context "when clients intake was completed" do
-      let!(:client) { create :client, intakes: [create(:intake)] }
+      let!(:client) { create :client, intake: create(:intake) }
 
       it "needs attention" do
         client.intake.update(completed_at: Time.now)
@@ -184,6 +184,13 @@ describe Client do
 
       it "updates client response_needed_since" do
         expect { create :document, client: client}.to change(client, :response_needed_since)
+      end
+
+      context "without an explicit relationship to client but an intake that has a client id" do
+        let(:client) { create :client, intake: create(:intake) }
+        it "still should update the associated client" do
+          expect { create :document, intake: client.intake }.to change(client, :response_needed_since)
+        end
       end
     end
 


### PR DESCRIPTION
This is a quick and dirty approach to making documents accessible through client but still stored on the intake to prevent a huge refactor but open up acceptance on new document upload tickets.

The client association was creating ONE copy of documents at the time the client was created, but we need to see documents uploaded by the user later reflected in the UI. 

If we want the relationship to be from client -> documents, we should eventually (hopefully in the shor term) work on this more to make it "right", but wanted to get a stop gap in so that the testers can see new uploads reflected in their documents list.