### PR TITLE
Update intake onto document on creation so that we can trip our needs response logic.

### DIFF
--- a/app/controllers/case_management/clients_controller.rb
+++ b/app/controllers/case_management/clients_controller.rb
@@ -25,12 +25,6 @@ module CaseManagement
 
     def show; end
 
-    def response_needed
-      @client.clear_response_needed if params.fetch(:client, {})[:action] == "clear"
-      @client.touch(:response_needed_since) if params.fetch(:client, {})[:action] == "set"
-      redirect_to case_management_client_path(id: @client.id)
-    end
-
     def edit
       @form = ClientIntakeForm.new(@client.intake)
     end
@@ -43,6 +37,12 @@ module CaseManagement
       else
         render :edit
       end
+    end
+
+    def response_needed
+      @client.clear_response_needed if params.fetch(:client, {})[:action] == "clear"
+      @client.touch(:response_needed_since) if params.fetch(:client, {})[:action] == "set"
+      redirect_back(fallback_location: case_management_client_path(id: @client.id))
     end
 
     private

--- a/app/controllers/documents/send_requested_documents_later_controller.rb
+++ b/app/controllers/documents/send_requested_documents_later_controller.rb
@@ -10,7 +10,6 @@ module Documents
         @flash_warning = t("controllers.send_requested_documents_later_controller.not_found")
       else
         intake = documents_request.intake
-        documents_request.documents.update_all(intake_id: intake.id)
         SendRequestedDocumentsToZendeskJob.perform_later(intake.id)
         @flash_notice = t("controllers.send_requested_documents_later_controller.success")
       end

--- a/app/forms/requested_document_upload_form.rb
+++ b/app/forms/requested_document_upload_form.rb
@@ -10,7 +10,7 @@ class RequestedDocumentUploadForm < QuestionsForm
   def save
     document_file_upload = attributes_for(:documents_request)[:document]
     if document_file_upload.present?
-      document = @documents_request.documents.create(document_type: "Requested Later")
+      document = @documents_request.documents.create(document_type: "Requested Later", intake_id: @documents_request.intake.id)
       document.upload.attach(document_file_upload)
     end
   end

--- a/spec/controllers/documents/requested_documents_later_controller_spec.rb
+++ b/spec/controllers/documents/requested_documents_later_controller_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe Documents::RequestedDocumentsLaterController, type: :controller d
           latest_doc = documents_request.documents.last
           expect(latest_doc.document_type).to eq "Requested Later"
           expect(latest_doc.upload.filename).to eq "test-pattern.png"
-
+          expect(latest_doc.intake_id).to eq documents_request.intake.id
           expect(response).to redirect_to requested_documents_later_documents_path
         end
       end

--- a/spec/controllers/documents/send_requested_documents_later_controller_spec.rb
+++ b/spec/controllers/documents/send_requested_documents_later_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Documents::SendRequestedDocumentsLaterController, type: :controll
 
   describe "#edit" do
     context "with a documents request in the session" do
-      let!(:document) { create :document, :with_upload, document_type: "Requested Later", documents_request: documents_request }
+      let!(:document) { create :document, :with_upload, document_type: "Requested Later", intake: original_intake, documents_request: documents_request }
 
       before do
         session[:documents_request_id] = documents_request.id
@@ -28,12 +28,6 @@ RSpec.describe Documents::SendRequestedDocumentsLaterController, type: :controll
 
         expect(SendRequestedDocumentsToZendeskJob).to have_been_enqueued.with(original_intake.id)
         expect(response).to redirect_to(root_path)
-      end
-
-      it "adds the documents to the original intake" do
-        get :edit
-
-        expect(original_intake.reload.documents).to include(document)
       end
 
       it "clears the session" do


### PR DESCRIPTION
@jenny-heath et al: can you take a look at this and let me know whether this is okay to do? Right now we are assigning the intake id AFTER creation in the controller action where we enqueue the zendesk background job, but we already have the intake_id on the document_request so I was hoping this would be okay... I'm thinking some of this code had to do with anonymous intakes which I thought you said we weren't using anymore, so again hope this is all good but can also find another approach if we need to.

Co-authored-by: Sarah Niemeyer <sniemeyer@vmware.com>