### PR TITLE
Only install default and Rails.env groups of gems 

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -17,7 +17,8 @@ require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
-Bundler.require(*Rails.groups)
+# Bundler.require(*Rails.groups)
+Bundler.require(:default, Rails.env)
 
 module VitaMin
   class Application < Rails::Application


### PR DESCRIPTION
I _think_ we can avoid some of the issues where Listen gem and Spring is trying to load in demo rails console and causing errors by scoping the bundle installed gems to the :default group and the Rails.env group.