### PR TITLE
Sort documents by date

### DIFF
--- a/app/controllers/case_management/documents_controller.rb
+++ b/app/controllers/case_management/documents_controller.rb
@@ -12,7 +12,7 @@ module CaseManagement
     def index
       @sort_order = sort_order
       @sort_column = sort_column
-      @documents = @documents.order({ @sort_column => @sort_order })
+      @documents = @documents.except(:order).order({ @sort_column => @sort_order })
     end
 
     def show

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -33,6 +33,8 @@ class Document < ApplicationRecord
   validates :document_type, inclusion: { in: DocumentTypes::ALL_TYPES.map(&:key) + ["Requested"] }
   validates :intake, presence: { unless: :documents_request_id }
 
+  default_scope { order(created_at: :asc) }
+
   scope :of_type, ->(type) { where(document_type: type) }
 
   belongs_to :intake, optional: true


### PR DESCRIPTION
When explicitly sorting documents, call `except(:order)` to skip this behavior.

For reviewers: The main reason to do this is to get the tests to always return the documents in the same order. We had a few flaky test runs recently that this would fix, I believe.

- https://app.circleci.com/pipelines/github/codeforamerica/vita-min/2762/workflows/2b3b30a6-c972-427c-82cb-7906abd87d68/jobs/9217
- https://app.circleci.com/pipelines/github/codeforamerica/vita-min/2771/workflows/5833ce08-0519-41f2-b617-df9a4277a801/jobs/9230