### PR TITLE
Don't install test or development gems in docker instances

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN curl -fsSLO "$SUPERCRONIC_URL" \
 ADD Gemfile /app/
 ADD Gemfile.lock /app/
 WORKDIR /app
-RUN bundle install
+RUN bundle install --without test development
 
 ADD . /app
 ADD crontab /app/crontab


### PR DESCRIPTION
In order to prevent test and development gems from being installed in our docker containers, we can add the --without flag to our bundle install. If these gems are not installed, they won't affect our rails console setup, meaning that the FATAL error from the Listen gem (used by Spring preloader) trying to index all of the files should stop affecting us.

See screenshots that show that show that Spring is no longer loading after the change.
<img width="768" alt="Screen Shot 2020-10-28 at 8 44 07 AM" src="https://user-images.githubusercontent.com/4494389/97474512-6718a300-1909-11eb-8c05-da681468a4d9.png">
<img width="856" alt="Screen Shot 2020-10-28 at 10 32 17 AM" src="https://user-images.githubusercontent.com/4494389/97474515-68e26680-1909-11eb-92c8-3d87daf0f82e.png">
<img width="1402" alt="Screen Shot 2020-10-28 at 10 32 58 AM" src="https://user-images.githubusercontent.com/4494389/97474518-697afd00-1909-11eb-8d79-9e60e7cffd9f.png">

Co-authored-by: Alex Sartan <asartan@vmware.com>