### PR TITLE
Use a hash in order() call

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -38,7 +38,7 @@ class Client < ApplicationRecord
   scope :delegated_order, ->(column, direction) do
     raise ArgumentError, "column and direction are required" if !column || !direction
 
-    order("#{delegated_query_column(column)} #{direction}")
+    order(Hash[delegated_query_column(column), direction])
   end
 
   def legal_name


### PR DESCRIPTION
By using a hash, we mollify the (overeager? not sure) SQL injection detection of Hakiri in e.g. https://hakiri.io/github/codeforamerica/vita-min/master/4a7bee5a17fede89ab51e73beb74cef2f139aeb5/warnings?filter=code

This implementation approach relies on two things that may not be obvious. In Ruby, keyword arguments can be passed by passing a hash to the method. Second, the `Hash[expression1, expression2]` syntax evaluates the expressions, then creates a Hash with them.

If you like this, feel free to merge it!