### PR TITLE
Docs requested later bug 175501662

### DIFF
--- a/app/forms/requested_document_upload_form.rb
+++ b/app/forms/requested_document_upload_form.rb
@@ -12,7 +12,8 @@ class RequestedDocumentUploadForm < QuestionsForm
     if document_file_upload.present?
       document = @documents_request.documents.create(
         document_type: "Requested Later",
-        intake_id: @documents_request.intake.id
+        intake_id: @documents_request.intake.id,
+        client_id: @documents_request.intake&.client_id
       )
       document.upload.attach(document_file_upload)
     end

--- a/app/forms/requested_document_upload_form.rb
+++ b/app/forms/requested_document_upload_form.rb
@@ -13,7 +13,7 @@ class RequestedDocumentUploadForm < QuestionsForm
       document = @documents_request.documents.create(
         document_type: "Requested Later",
         intake_id: @documents_request.intake.id,
-        client_id: @documents_request.intake&.client_id
+        client_id: @documents_request.intake.client_id
       )
       document.upload.attach(document_file_upload)
     end

--- a/spec/controllers/documents/requested_documents_later_controller_spec.rb
+++ b/spec/controllers/documents/requested_documents_later_controller_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Documents::RequestedDocumentsLaterController, type: :controller do
   render_views
   let(:token) {"t0k3nN0tbr0k3n?"}
-  let!(:original_intake) { create :intake, requested_docs_token: token, intake_ticket_id: 123 }
+  let!(:original_intake) { create :intake, requested_docs_token: token, intake_ticket_id: 123, client: (create :client) }
   let!(:documents_request) { create :documents_request, intake: original_intake }
   before do
     # everything should still work in the offseason
@@ -199,6 +199,7 @@ RSpec.describe Documents::RequestedDocumentsLaterController, type: :controller d
           expect(latest_doc.document_type).to eq "Requested Later"
           expect(latest_doc.upload.filename).to eq "test-pattern.png"
           expect(latest_doc.intake_id).to eq documents_request.intake.id
+          expect(latest_doc.client_id).to eq documents_request.intake.client.id
           expect(response).to redirect_to requested_documents_later_documents_path
         end
       end

--- a/spec/controllers/questions/final_info_controller_spec.rb
+++ b/spec/controllers/questions/final_info_controller_spec.rb
@@ -15,24 +15,15 @@ RSpec.describe Questions::FinalInfoController do
         example_pdf = Tempfile.new("example.pdf")
         example_pdf.write("example pdf contents")
         allow(intake).to receive(:pdf).and_return(example_pdf)
+        allow(intake).to receive(:create_original_13614c_document)
       end
 
       let(:intake) { create :intake, intake_ticket_id: 1234 }
       let(:client) { intake.client }
 
-      it "adds the initial 13614-C PDF as a Document", active_job: true do
-        # TODO: test that this calls the "after save trigger" that creates the doc
-        expect { post :update, params: params }.to change(Document, :count).by(1)
-        expect(intake).to have_received(:pdf)
-
-        doc = Document.last
-        expect(doc.intake).to eq(intake)
-        expect(doc.client).to eq(client)
-        expect(doc.document_type).to eq("Original 13614-C")
-        blob = doc.upload.blob
-        expect(blob.content_type).to eq("application/pdf")
-        expect(blob.download).to eq("example pdf contents")
-        expect(blob.filename).to eq("Original 13614-C.pdf")
+      it "should trigger the creation of the 13614c document" do
+        post :update, params: params
+        expect(intake).to have_received(:create_original_13614c_document)
       end
     end
 


### PR DESCRIPTION
Associate client and document on documents requested later form. 

Refactor after_save tests for document creation on intake completion.