### PR TITLE
Re-enable skipped helper spec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
       - run: dockerize -wait tcp://localhost:5432 -timeout 1m
       - run: bundle exec rake db:create
       - run: bundle exec rake db:schema:load
-      - run: bundle exec rake db:insert_states db:upsert_vita_partners
+      - run: bundle exec rake db:insert_states
       - run: mkdir ~/test-results && mkdir ~/test-results/rspec && mkdir ~/test-results/jest
       - run: |
           bundle exec rspec \

--- a/app/lib/vita_partner_importer.rb
+++ b/app/lib/vita_partner_importer.rb
@@ -8,10 +8,8 @@ class VitaPartnerImporter < CliScriptBase
 
     yaml_partners = YAML.load_file(yml)['vita_partners']
     yaml_zendesk_group_ids = yaml_partners.map { |partner| partner["zendesk_group_id"] }
-    VitaPartner.transaction do
-      yaml_partners.each do |yaml_partner|
-        upsert_vita_partner(yaml_partner)
-      end
+    yaml_partners.each do |yaml_partner|
+      upsert_vita_partner(yaml_partner)
     end
     archive_absent_partners(VitaPartner.where.not(zendesk_group_id: yaml_zendesk_group_ids))
     report_progress "  => done"

--- a/lib/tasks/upsert_vita_partners.rake
+++ b/lib/tasks/upsert_vita_partners.rake
@@ -3,6 +3,8 @@
 namespace :db do
   desc 'loads new vita partners, updates existing partners'
   task upsert_vita_partners: [:environment, :insert_states] do
-    VitaPartnerImporter.upsert_vita_partners
+    VitaPartner.transaction do
+      VitaPartnerImporter.upsert_vita_partners
+    end
   end
 end

--- a/spec/helpers/vita_partner_helper_spec.rb
+++ b/spec/helpers/vita_partner_helper_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe VitaPartnerHelper do
-  skip "#grouped_organization_options" do
+  describe "#grouped_organization_options" do
     let(:parent_org1) { create(:vita_partner, name: "First Parent Org") }
     let(:parent_org2) { create(:vita_partner, name: "Second Parent Org") }
     let(:parent_org3) { create(:vita_partner, name: "No Child Org") }

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -743,21 +743,8 @@ describe Intake do
     let(:source) { nil }
     let(:intake) { create :intake, state_of_residence: state, source: source }
 
-    before(:all) do
-      # Per https://relishapp.com/rspec/rspec-rails/docs/transactions,
-      # before(:all) has to manage data clearing explicitly.
-      @transaction_manager = ActiveRecord::Base.connection.transaction_manager
-      @transaction_manager.begin_transaction
-
+    before do
       VitaPartnerImporter.upsert_vita_partners
-    end
-
-    after(:all) do
-      # Use transaction rollback to speed up some of the data clearing. Some data still leaks through,
-      # so also call destroy_all.
-      @transaction_manager.rollback_transaction
-      SourceParameter.destroy_all
-      VitaPartner.destroy_all
     end
 
     context "when the zendesk instance domain has been saved as UWTSA instance" do


### PR DESCRIPTION
Also:

- Do not add production VITA partners in CI test execution

- Use transaction in Rake task, not upsert_vita_partners method