### PR TITLE
Invite users only to orgs you can manage

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -20,7 +20,7 @@ class Users::InvitationsController < Devise::InvitationsController
   def create
     super do |invited_user|
       # set default values
-      invited_user.update(role: invited_user.role || "agent" )
+      invited_user.update(role: invited_user.role || "agent")
     end
   end
 
@@ -28,7 +28,11 @@ class Users::InvitationsController < Devise::InvitationsController
 
   # Override superclass method for default params for newly created invites, allowing us to add attributes
   def invite_params
-    params.require(:user).permit(:name, :email, :vita_partner_id)
+    vita_partner_id = params.require(:user).require(:vita_partner_id)
+    vita_partner = VitaPartner.find(vita_partner_id)
+    if Ability.new(current_user).can?(:manage, vita_partner)
+      params.require(:user).permit(:name, :email, :vita_partner_id)
+    end
   end
 
   # Override superclass method for accepted invite params, allowing us to add attributes

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -15,7 +15,16 @@ class Users::InvitationsController < Devise::InvitationsController
   end
 
   authorize_resource :user, only: [:new, :create]
+  # This line does not do what i would like it to do :(
+  # was hoping to get a @vita_partners that matched the current user's organization (to be used in vita_partner_helper)
+  # load_and_authorize_resource :vita_partner, through: :user
   before_action :require_valid_invitation_token, only: [:edit, :update]
+
+  # maybe this is the way instead?
+  # def new
+  #   @vita_partners = current_user.accessible_organizations
+  #   super
+  # end
 
   def create
     super do |invited_user|
@@ -30,7 +39,7 @@ class Users::InvitationsController < Devise::InvitationsController
   def invite_params
     vita_partner_id = params.require(:user).require(:vita_partner_id)
     vita_partner = VitaPartner.find(vita_partner_id)
-    if Ability.new(current_user).can?(:manage, vita_partner)
+    if current_ability.can?(:manage, vita_partner)
       params.require(:user).permit(:name, :email, :vita_partner_id)
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -27,7 +27,7 @@ class UsersController < ApplicationController
   def user_params
     vita_partner_id = params.require(:user).require(:vita_partner_id)
     vita_partner = VitaPartner.find(vita_partner_id)
-    if Ability.new(current_user).can?(:manage, vita_partner)
+    if current_ability.can?(:manage, vita_partner)
       params.require(:user).permit(
         :vita_partner_id,
         *(:is_admin if current_user.is_admin?),

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,11 +25,15 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(
-      *(:is_admin if current_user.is_admin?),
-      :vita_partner_id,
-      :timezone,
-      current_user.is_admin ? { supported_organization_ids: [] } : {},
-    )
+    vita_partner_id = params.require(:user).require(:vita_partner_id)
+    vita_partner = VitaPartner.find(vita_partner_id)
+    if Ability.new(current_user).can?(:manage, vita_partner)
+      params.require(:user).permit(
+        :vita_partner_id,
+        *(:is_admin if current_user.is_admin?),
+        :timezone,
+        current_user.is_admin ? { supported_organization_ids: [] } : {}
+      )
+    end
   end
 end

--- a/app/helpers/vita_partner_helper.rb
+++ b/app/helpers/vita_partner_helper.rb
@@ -1,6 +1,6 @@
 module VitaPartnerHelper
   def grouped_organization_options
-    VitaPartner.top_level.collect do |partner|
+    VitaPartner.accessible_by(Ability.new(current_user)).top_level.collect do |partner|
       [partner.name, [[partner.name, partner.id], *partner.sub_organizations.collect { |v| [v.name, v.id] }]]
     end
   end

--- a/app/helpers/vita_partner_helper.rb
+++ b/app/helpers/vita_partner_helper.rb
@@ -1,6 +1,6 @@
 module VitaPartnerHelper
   def grouped_organization_options
-    VitaPartner.accessible_by(Ability.new(current_user)).top_level.collect do |partner|
+    VitaPartner.accessible_by(current_ability).top_level.collect do |partner|
       [partner.name, [[partner.name, partner.id], *partner.sub_organizations.collect { |v| [v.name, v.id] }]]
     end
   end

--- a/app/views/invitations/index.html.erb
+++ b/app/views/invitations/index.html.erb
@@ -14,6 +14,7 @@
           <%= invitation.name %> &lt;<%= invitation.email %>&gt; <%= invitation.vita_partner&.name %> (<%= t(".invitation.sent_at", datetime: invitation.invitation_sent_at) %>)
           <%= form_with(model: invitation, url: user_invitation_path, method: :post, local: true) do |f| %>
             <%= f.hidden_field :email %>
+            <%= f.hidden_field :vita_partner_id %>
             <%= f.submit value: t(".invitation.create"), class: "button button--small" %>
           <% end %>
         </li>

--- a/spec/controllers/users/invitations_controller_spec.rb
+++ b/spec/controllers/users/invitations_controller_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Users::InvitationsController do
   let(:raw_invitation_token) { "exampleToken" }
   let(:user) { create :user_with_org }
-  let(:vita_partner) { create :vita_partner }
+  let(:vita_partner) { user.vita_partner }
   before do
     @request.env["devise.mapping"] = Devise.mappings[:user]
   end
@@ -50,6 +50,25 @@ RSpec.describe Users::InvitationsController do
           post :create, params: params
           invited_user.reload
           expect(invited_user.role).to eq "admin"
+        end
+      end
+
+      context "when inviting a user to an organization that we do not have access to" do
+        let(:inaccessible_vita_partner) { create :vita_partner }
+        let(:params) do
+          {
+            user: {
+              name: "Cher Cherimoya",
+              email: "cherry@example.com",
+              vita_partner_id: inaccessible_vita_partner.id
+            }
+          }
+        end
+
+        it "doesn't create a new user" do
+          expect {
+            post :create, params: params
+          }.not_to change(User, :count)
         end
       end
     end

--- a/spec/controllers/users/invitations_controller_spec.rb
+++ b/spec/controllers/users/invitations_controller_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe Users::InvitationsController do
 
   describe "#new" do
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :new
+
+  #  TODO: write test that checks what is shown in dropdown
   end
 
   describe "#create" do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -102,6 +102,14 @@ RSpec.describe UsersController do
         end
       end
 
+      context "when trying to change a user's vita_partner to an org we may not access" do
+        it "rejects the change" do
+          expect {
+            post :update, params: { id: user.id, user: { vita_partner_id: create(:vita_partner).id } }
+          }.not_to change { user.reload.vita_partner }
+        end
+      end
+
       context "when editing user fields that require admin powers" do
         before do
           params[:user][:supported_organizations] = [create(:vita_partner).id]

--- a/spec/features/case_management/invitations_spec.rb
+++ b/spec/features/case_management/invitations_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.feature "Sending and accepting invitations" do
   context "As an authenticated user" do
-    let(:user) { create :user_with_org, role: "agent" }
-    let!(:vita_partner) { create :vita_partner, name: "Brassica Asset Builders" }
+    let(:vita_partner) { create :vita_partner, name: "Brassica Asset Builders" }
+    let(:user) { create :user, role: "agent", vita_partner: vita_partner }
     before do
       login_as user
     end

--- a/spec/helpers/vita_partner_helper_spec.rb
+++ b/spec/helpers/vita_partner_helper_spec.rb
@@ -8,17 +8,25 @@ describe VitaPartnerHelper do
     let(:sub_org1) { create(:vita_partner, parent_organization_id: parent_org1.id, name: "The First Child Org") }
     let(:sub_org2) { create(:vita_partner, parent_organization_id: parent_org1.id, name: "The Second Child Org") }
     let(:sub_org3) { create(:vita_partner, parent_organization_id: parent_org2.id, name: "The Third Child Org") }
+    let!(:inaccessible_org) { create(:vita_partner, name: "User Cannot Access It") }
 
-    it "returns array grouped by parent org" do
-      expected =
-        [
-          ["First Parent Org", [["First Parent Org", parent_org1.id], ["The First Child Org", sub_org1.id], ["The Second Child Org",  sub_org2.id]]],
-          ["Second Parent Org", [["Second Parent Org", parent_org2.id], ["The Third Child Org", sub_org3.id]]],
-          ["No Child Org", [["No Child Org", parent_org3.id]]]
-        ]
+    let(:user) { create(:user, vita_partner: parent_org1, supported_organizations: [parent_org2, parent_org3]) }
 
-      expect(helper.grouped_organization_options).to eq(expected)
+    context "with a logged-in user" do
+      before do
+        allow(controller).to receive(:current_user).and_return(user)
+      end
+
+      it "returns an array of VitaPartners, grouped by parent org, that this user can access" do
+        expected =
+          [
+            ["First Parent Org", [["First Parent Org", parent_org1.id], ["The First Child Org", sub_org1.id], ["The Second Child Org",  sub_org2.id]]],
+            ["Second Parent Org", [["Second Parent Org", parent_org2.id], ["The Third Child Org", sub_org3.id]]],
+            ["No Child Org", [["No Child Org", parent_org3.id]]]
+          ]
+
+        expect(helper.grouped_organization_options).to eq(expected)
+      end
     end
-
   end
 end


### PR DESCRIPTION
This does 3 things.

- Limit the orgs you can see in the dropdown to those you can edit (there are more orgs than the ones listed below, but the list now only shows the ones that this user can access)

<img width="1515" alt="Screen Shot 2020-11-11 at 1 06 10 PM" src="https://user-images.githubusercontent.com/67708639/98847715-ade4bd80-241e-11eb-9aa0-576a9ed6d7b0.png">

- Add backend validation that you can only change a user's org to ones you can `:manage` when editing a user.

- Add backend validation that you can only set a new user's org to ones you can `:manage` when inviting a user.

Feedback request specifically on the repeated use of `Ability.new(current_user)` -- is there a pattern that would avoid creating this object? Should I not worry about it? It seems ugly to me to imperatively create it, but I'm OK with it, but I wanted to ask @bytheway875 and/or @bengolder since you have more cancancan experience than Jenny & I do.

https://www.pivotaltracker.com/story/show/175618733

Co-authored-by: Jenny Heath <jheath@codeforamerica.org>