### PR TITLE
Limits visible vita partners to ones users can access

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -13,12 +13,13 @@ class Users::InvitationsController < Devise::InvitationsController
     # If an anonymous user tries to send an invitation, send them to the invitation page after sign-in.
     require_sign_in(redirect_after_login: new_user_invitation_path)
   end
-  before_action :load_vita_partners, only: [:new]
+  before_action :load_vita_partners, only: [:new, :create]
 
   authorize_resource :user, only: [:new, :create]
   before_action :require_valid_invitation_token, only: [:edit, :update]
 
   def create
+    authorize!(:manage, @vita_partners.find(invite_params[:vita_partner_id]))
     super do |invited_user|
       # set default values
       invited_user.update(role: invited_user.role || "agent")

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -13,6 +13,7 @@ class Users::InvitationsController < Devise::InvitationsController
     # If an anonymous user tries to send an invitation, send them to the invitation page after sign-in.
     require_sign_in(redirect_after_login: new_user_invitation_path)
   end
+  before_action :load_vita_partners, only: [:new]
 
   authorize_resource :user, only: [:new, :create]
   before_action :require_valid_invitation_token, only: [:edit, :update]
@@ -20,11 +21,15 @@ class Users::InvitationsController < Devise::InvitationsController
   def create
     super do |invited_user|
       # set default values
-      invited_user.update(role: invited_user.role || "agent" )
+      invited_user.update(role: invited_user.role || "agent")
     end
   end
 
   private
+
+  def load_vita_partners
+    @vita_partners = VitaPartner.accessible_by(Ability.new(current_user))
+  end
 
   # Override superclass method for default params for newly created invites, allowing us to add attributes
   def invite_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,6 +18,7 @@ class UsersController < ApplicationController
   end
 
   def update
+    authorize!(:manage, @vita_partners.find(user_params[:vita_partner_id]))
     return render :edit unless @user.update(user_params)
 
     redirect_to edit_user_path(id: @user), notice: I18n.t("general.changes_saved")

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,7 @@ class UsersController < ApplicationController
 
   before_action :require_sign_in
   load_and_authorize_resource
+  load_and_authorize_resource :vita_partner, collection: [:edit, :update], parent: false
 
   layout "admin"
 

--- a/app/helpers/vita_partner_helper.rb
+++ b/app/helpers/vita_partner_helper.rb
@@ -1,6 +1,6 @@
 module VitaPartnerHelper
   def grouped_organization_options
-    VitaPartner.top_level.collect do |partner|
+    @vita_partners.top_level.collect do |partner|
       [partner.name, [[partner.name, partner.id], *partner.sub_organizations.collect { |v| [v.name, v.id] }]]
     end
   end

--- a/app/views/invitations/index.html.erb
+++ b/app/views/invitations/index.html.erb
@@ -14,6 +14,7 @@
           <%= invitation.name %> &lt;<%= invitation.email %>&gt; <%= invitation.vita_partner&.name %> (<%= t(".invitation.sent_at", datetime: invitation.invitation_sent_at) %>)
           <%= form_with(model: invitation, url: user_invitation_path, method: :post, local: true) do |f| %>
             <%= f.hidden_field :email %>
+            <%= f.hidden_field :vita_partner_id %>
             <%= f.submit value: t(".invitation.create"), class: "button button--small" %>
           <% end %>
         </li>

--- a/spec/controllers/users/invitations_controller_spec.rb
+++ b/spec/controllers/users/invitations_controller_spec.rb
@@ -3,13 +3,22 @@ require "rails_helper"
 RSpec.describe Users::InvitationsController do
   let(:raw_invitation_token) { "exampleToken" }
   let(:user) { create :user_with_org }
-  let(:vita_partner) { create :vita_partner }
+  let(:vita_partner) { user.vita_partner }
   before do
     @request.env["devise.mapping"] = Devise.mappings[:user]
   end
 
   describe "#new" do
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :new
+
+    let!(:inaccessible_vita_partner) { create(:vita_partner) }
+
+    it "sets @vita_partners so the template can render a list of partners the user has access to" do
+      sign_in user
+      get :new
+      expect(assigns(:vita_partners)).to include(vita_partner)
+      expect(assigns(:vita_partners)).not_to include(inaccessible_vita_partner)
+    end
   end
 
   describe "#create" do

--- a/spec/controllers/users/invitations_controller_spec.rb
+++ b/spec/controllers/users/invitations_controller_spec.rb
@@ -62,6 +62,15 @@ RSpec.describe Users::InvitationsController do
           expect(invited_user.role).to eq "admin"
         end
       end
+
+      context "if the invited user's organization is inaccessible by the current user" do
+        it "raises an exception and does not create a new user" do
+          expect do
+            post :create, params: { user: { name: "Cher Cherimoya", email: "cherry@example.com", vita_partner_id: create(:vita_partner).id } }
+          end.to raise_error(ActiveRecord::RecordNotFound)
+          expect(User.where(email: "cherry@example.com").count).to eq(0)
+        end
+      end
     end
   end
 

--- a/spec/controllers/users/invitations_controller_spec.rb
+++ b/spec/controllers/users/invitations_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Users::InvitationsController do
   let(:raw_invitation_token) { "exampleToken" }
-  let(:user) { create :user_with_org }
+  let(:user) { create :user_with_org, supported_organizations: [create(:vita_partner)] }
   let(:vita_partner) { user.vita_partner }
   before do
     @request.env["devise.mapping"] = Devise.mappings[:user]
@@ -17,6 +17,7 @@ RSpec.describe Users::InvitationsController do
       sign_in user
       get :new
       expect(assigns(:vita_partners)).to include(vita_partner)
+      expect(assigns(:vita_partners)).to include(user.supported_organizations.first)
       expect(assigns(:vita_partners)).not_to include(inaccessible_vita_partner)
     end
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -116,6 +116,19 @@ RSpec.describe UsersController do
           expect(user.supported_organization_ids).to be_empty
         end
       end
+
+      context "when assigning the user to an organization inaccessible to the current user" do
+        before do
+          params[:user][:vita_partner_id] = create(:vita_partner).id
+        end
+
+        it "raises an exception and does not change the user" do
+          expect do
+            post :update, params: params
+          end.to raise_error(ActiveRecord::RecordNotFound)
+          expect(user.reload).to eq user
+        end
+      end
     end
 
     context "as an admin" do

--- a/spec/features/case_management/invitations_spec.rb
+++ b/spec/features/case_management/invitations_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Sending and accepting invitations" do
   context "As an authenticated user" do
-    let(:user) { create :user_with_org, role: "agent" }
+    let(:user) { create :user, role: "agent", vita_partner: vita_partner }
     let!(:vita_partner) { create :vita_partner, name: "Brassica Asset Builders" }
     before do
       login_as user

--- a/spec/helpers/vita_partner_helper_spec.rb
+++ b/spec/helpers/vita_partner_helper_spec.rb
@@ -10,6 +10,7 @@ describe VitaPartnerHelper do
     let(:sub_org3) { create(:vita_partner, parent_organization_id: parent_org2.id, name: "The Third Child Org") }
 
     it "returns array grouped by parent org" do
+      @vita_partners = VitaPartner.all
       expected =
         [
           ["First Parent Org", [["First Parent Org", parent_org1.id], ["The First Child Org", sub_org1.id], ["The Second Child Org",  sub_org2.id]]],


### PR DESCRIPTION
🔥  Requesting review from @bengolder especially! 🔥 

This now limits what is visible **and** what the backend accepts, resolving [Adjust invitations so users can only invite people to orgs they can manage](https://www.pivotaltracker.com/story/show/175618733)

This screenshot shows that the set of vita partners is smallish. What isn't evident in the screenshot is that there are other VITA partners now removed from the set that is listed!

![image](https://user-images.githubusercontent.com/67708639/98873039-a71d7100-2445-11eb-8c5b-0725db82d1e7.png)

Co-authored-by: Em Barnard-Shao <ebarnard@codeforamerica.org>