### PR TITLE
Stop redirecting to zendesk sign in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -241,7 +241,7 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(_user)
-    case_management_root_path
+    @after_login_path || case_management_root_path
   end
 
   def set_time_zone

--- a/app/controllers/concerns/access_controllable.rb
+++ b/app/controllers/concerns/access_controllable.rb
@@ -4,7 +4,7 @@ module AccessControllable
   def require_sign_in(redirect_after_login: nil )
     unless current_user.present?
       session[:after_login_path] = redirect_after_login || request.path
-      redirect_to zendesk_sign_in_path
+      redirect_to new_user_session_path
     end
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -11,4 +11,9 @@ class Users::SessionsController < Devise::SessionsController
       end
     end
   end
+
+  def create
+    @after_login_path = session.delete("after_login_path")
+    super
+  end
 end

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -28,4 +28,34 @@ RSpec.describe Users::SessionsController do
       end
     end
   end
+
+  describe "#create" do
+    let!(:user) { create :user, email: "user@example.com", password: "p455w0rd" }
+    let(:params) do
+      {
+        user: {
+          email: "user@example.com",
+          password: "p455w0rd"
+        }
+      }
+    end
+
+    it "signs in the user and redirects to hub root path by default" do
+      expect do
+        post :create, params: params
+      end.to change(subject, :current_user).from(nil).to(user)
+
+      expect(response).to redirect_to case_management_root_path
+    end
+
+    context "with 'after_login_path' set in the session" do
+      before { session[:after_login_path] = case_management_clients_path }
+
+      it "redirects to 'after_login_path'" do
+        post :create, params: params
+
+        expect(response).to redirect_to case_management_clients_path
+      end
+    end
+  end
 end

--- a/spec/support/shared_examples/access_controllable.rb
+++ b/spec/support/shared_examples/access_controllable.rb
@@ -23,7 +23,7 @@ shared_examples :a_get_action_for_authenticated_users_only do |action:|
     it "saves the current path to the session and redirects to the zendesk login path" do
       get action, params: params
 
-      expect(response).to redirect_to zendesk_sign_in_path
+      expect(response).to redirect_to new_user_session_path
       expect(session[:after_login_path]).to be_present
     end
   end
@@ -36,7 +36,7 @@ shared_examples :a_post_action_for_authenticated_users_only do |action:|
     it "saves the current path to the session and redirects to the zendesk login path" do
       post action, params: params
 
-      expect(response).to redirect_to zendesk_sign_in_path
+      expect(response).to redirect_to new_user_session_path
       expect(session[:after_login_path]).to be_present
     end
   end


### PR DESCRIPTION
This redirects to our new homemade sign in instead of the zendesk OAuth sign in.