### PR TITLE
Use same form param in template & controller

### DIFF
--- a/app/controllers/case_management/tax_returns_controller.rb
+++ b/app/controllers/case_management/tax_returns_controller.rb
@@ -58,9 +58,9 @@ module CaseManagement
           end
         end
 
-        if @take_action_form.internal_note.present?
+        if @take_action_form.internal_note_body.present?
           Note.create!(
-            body: @take_action_form.internal_note,
+            body: @take_action_form.internal_note_body,
             client: @client,
             user: current_user
           )
@@ -115,7 +115,7 @@ module CaseManagement
     end
 
     def take_action_form_params
-      params.require(:case_management_take_action_form).permit(:status, :locale, :message_body, :contact_method, :internal_note)
+      params.require(:case_management_take_action_form).permit(:status, :locale, :message_body, :contact_method, :internal_note_body)
     end
   end
 end

--- a/app/forms/case_management/take_action_form.rb
+++ b/app/forms/case_management/take_action_form.rb
@@ -1,6 +1,6 @@
 module CaseManagement
   class TakeActionForm < Form
-    attr_accessor :status, :locale, :message_body, :contact_method, :internal_note
+    attr_accessor :status, :locale, :message_body, :contact_method, :internal_note_body
 
     def initialize(client, *args, **attributes)
       @client = client

--- a/app/views/case_management/tax_returns/edit_status.html.erb
+++ b/app/views/case_management/tax_returns/edit_status.html.erb
@@ -38,8 +38,8 @@
         )%>
 
     <%= f.cfa_textarea(
-            :note_body,
-            t(".note_body_label"),
+            :internal_note_body,
+            t(".internal_note_body_label"),
             options: {rows: 8}
         )%>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,7 +72,7 @@ en:
         title: Assign %{client_name}'s %{tax_year} tax return
       edit_status:
         contact_method_label: Contact method
-        note_body_label: Add an internal note
+        internal_note_body_label: Add an internal note
         language_mismatch: This client requested %{interview_language} for their interview
         prefers_one_contact_method: This client prefers %{preferred} instead of %{other_method}
         send_clarifier: By clicking send, you will also update status, send a team note, and update followers.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -72,7 +72,7 @@ es:
         title: Asignar la declaración de impuestos %{tax_year} de %{client_name}
       edit_status:
         contact_method_label: Método de contacto
-        note_body_label: Crear una nota interna
+        internal_note_body_label: Crear una nota interna
         language_mismatch: Este cliente prefiere ser entrevistado en %{interview_language}
         prefers_one_contact_method: Este cliente prefiere %{preferred} en vez de %{other_method}
         send_clarifier: Al hacer clic en enviar, también actualizará el estado, enviará una nota al equipo y actualizará los seguidores.

--- a/spec/controllers/case_management/tax_returns_controller_spec.rb
+++ b/spec/controllers/case_management/tax_returns_controller_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe CaseManagement::TaxReturnsController, type: :controller do
     let(:tax_return) { create :tax_return, status: "intake_in_progress", client: client }
     let(:status) { "review_complete_signature_requested"}
     let(:locale) { "en" }
-    let(:internal_note) { "" }
+    let(:internal_note_body) { "" }
     let(:message_body) { "" }
     let(:contact_method) { "email" }
     let(:params) do
@@ -198,7 +198,7 @@ RSpec.describe CaseManagement::TaxReturnsController, type: :controller do
         id: tax_return.id,
         case_management_take_action_form: {
           status: status,
-          internal_note: internal_note,
+          internal_note_body: internal_note_body,
           locale: locale,
           message_body: message_body,
           contact_method: contact_method,
@@ -241,7 +241,7 @@ RSpec.describe CaseManagement::TaxReturnsController, type: :controller do
       end
 
       context "there is content in the note field" do
-        let(:internal_note) { "Lorem ipsum note about client tax return" }
+        let(:internal_note_body) { "Lorem ipsum note about client tax return" }
 
         it "saves a note" do
           expect do
@@ -250,7 +250,7 @@ RSpec.describe CaseManagement::TaxReturnsController, type: :controller do
 
           note = Note.last
           expect(note.client).to eq tax_return.client
-          expect(note.body).to eq internal_note
+          expect(note.body).to eq internal_note_body
           expect(note.user).to eq user
 
           expect(flash[:notice]).to match "added internal note"
@@ -258,7 +258,7 @@ RSpec.describe CaseManagement::TaxReturnsController, type: :controller do
       end
 
       context "when the note field is blank" do
-        let(:internal_note) { " \n" }
+        let(:internal_note_body) { " \n" }
 
         it "does not save a note" do
           expect do
@@ -315,7 +315,7 @@ RSpec.describe CaseManagement::TaxReturnsController, type: :controller do
       context "when status is changed, message body is present, and internal note is present" do
         let(:status) { "review_in_review" }
         let(:message_body) { "hi" }
-        let(:internal_note) { "wyd" }
+        let(:internal_note_body) { "wyd" }
         before { allow(subject).to receive(:send_email) }
 
         it "adds a flash success message listing all the actions taken" do


### PR DESCRIPTION
This fixes a bug in the take action form: internal notes were not being saved.

Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>
Co-authored-by: Ben Golder <bgolder@codeforamerica.org>