### PR TITLE
Create memberships

### DIFF
--- a/app/controllers/hub/clients/organizations_controller.rb
+++ b/app/controllers/hub/clients/organizations_controller.rb
@@ -11,6 +11,7 @@ module Hub
       def edit;end
 
       def update
+        authorize!(:edit_organization, @client)
         @client.update(client_params)
         redirect_to hub_client_path(id: @client.id)
       end

--- a/app/controllers/hub/users_controller.rb
+++ b/app/controllers/hub/users_controller.rb
@@ -8,52 +8,34 @@ module Hub
     before_action :authorize_vita_partner_updates, only: :update
     layout "admin"
 
-    def profile;end
+    def profile; end
 
     def index
-      @users = @users.includes(:vita_partner)
+      @users = @users.includes(:memberships)
     end
 
-    def edit
-      @user.vita_partner_id = @user.memberships.find_by(role: "member")&.vita_partner_id
-      @user.supported_organization_ids = @user.memberships.where(role: "lead").pluck(:vita_partner_id)
-    end
+    def edit; end
 
     def update
-      authorize_vita_partner_updates
       return render :edit unless update_user
       redirect_to edit_hub_user_path(id: @user), notice: I18n.t("general.changes_saved")
     end
 
     private
-    # To leave the view as-is but allow the ability to save as memberships, we're doing the simplest thing possible:
-    # blowing away and recreating memberships on every update.
     def update_user
-      ApplicationRecord.transaction do
-        @user.memberships.destroy_all && @user.update!(user_params.merge(memberships_attributes: memberships))
-      end
-
-    rescue ActiveRecord::RecordInvalid
-      logger.info("User update unexpectedly failed. Rolling back transaction.")
-    end
-
-    def memberships
-      supported_org_ids = (params[:user][:supported_organization_ids] || []).reject(&:empty?)
-      memberships = supported_org_ids.map { |so| { user_id: @user.id, vita_partner_id: so, role: "lead"} }
-      memberships.push({user_id: @user.id, vita_partner_id: params[:user][:vita_partner_id], role: "member"}) if params[:user][:vita_partner_id].present?
-      memberships
+      @user.update(user_params)
     end
 
     def authorize_vita_partner_updates
-      changing_vita_partner_ids = [params[:user][:vita_partner_id], params[:user][:supported_organization_ids]].flatten.select(&:present?)
-      changing_vita_partner_ids.each { |id| authorize!(:manage, @vita_partners.find(id)) }
+      user_params[:memberships_attributes].values.map { |v| authorize!(:manage, VitaPartner.find(v[:vita_partner_id])) }
     end
 
     def user_params
       params.require(:user).permit(
-          *(:is_admin if current_user.is_admin?),
-          :timezone,
-          )
+        *(:is_admin if current_user.is_admin?),
+        :timezone,
+        memberships_attributes: {}
+      )
     end
   end
 end

--- a/app/controllers/hub/users_controller.rb
+++ b/app/controllers/hub/users_controller.rb
@@ -5,35 +5,55 @@ module Hub
     before_action :require_sign_in
     load_and_authorize_resource
     load_and_authorize_resource :vita_partner, collection: [:edit, :update], parent: false
-
+    before_action :authorize_vita_partner_updates, only: :update
     layout "admin"
 
-    def profile
-    end
+    def profile;end
 
     def index
       @users = @users.includes(:vita_partner)
     end
 
     def edit
+      @user.vita_partner_id = @user.memberships.find_by(role: "member")&.vita_partner_id
+      @user.supported_organization_ids = @user.memberships.where(role: "lead").pluck(:vita_partner_id)
     end
 
     def update
-      authorize!(:manage, @vita_partners.find(user_params[:vita_partner_id]))
-      return render :edit unless @user.update(user_params)
-
+      authorize_vita_partner_updates
+      return render :edit unless update_user
       redirect_to edit_hub_user_path(id: @user), notice: I18n.t("general.changes_saved")
     end
 
     private
+    # To leave the view as-is but allow the ability to save as memberships, we're doing the simplest thing possible:
+    # blowing away and recreating memberships on every update.
+    def update_user
+      ApplicationRecord.transaction do
+        @user.memberships.destroy_all && @user.update!(user_params.merge(memberships_attributes: memberships))
+      end
+
+    rescue ActiveRecord::RecordInvalid
+      logger.info("User update unexpectedly failed. Rolling back transaction.")
+    end
+
+    def memberships
+      supported_org_ids = (params[:user][:supported_organization_ids] || []).reject(&:empty?)
+      memberships = supported_org_ids.map { |so| { user_id: @user.id, vita_partner_id: so, role: "lead"} }
+      memberships.push({user_id: @user.id, vita_partner_id: params[:user][:vita_partner_id], role: "member"}) if params[:user][:vita_partner_id].present?
+      memberships
+    end
+
+    def authorize_vita_partner_updates
+      changing_vita_partner_ids = [params[:user][:vita_partner_id], params[:user][:supported_organization_ids]].flatten.select(&:present?)
+      changing_vita_partner_ids.each { |id| authorize!(:manage, @vita_partners.find(id)) }
+    end
 
     def user_params
       params.require(:user).permit(
-        *(:is_admin if current_user.is_admin?),
-        :vita_partner_id,
-        :timezone,
-        current_user.is_admin ? { supported_organization_ids: [] } : {},
-      )
+          *(:is_admin if current_user.is_admin?),
+          :timezone,
+          )
     end
   end
 end

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -21,8 +21,7 @@ class Users::InvitationsController < Devise::InvitationsController
   def create
     authorize!(:manage, @vita_partners.find(invite_params[:vita_partner_id]))
     super do |invited_user|
-      # set default values
-      invited_user.update(role: invited_user.role || "agent")
+      invited_user.memberships.create(vita_partner_id: invite_params[:vita_partner_id])
     end
   end
 

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -5,12 +5,20 @@ class Ability
     return unless user.present?
 
     accessible_organizations = user.accessible_organizations
+    alias_action :response_needed, :update_take_action, :edit_take_action, to: :update
+    alias_action :read, :create, :update, :destroy, to: :crud
 
     if user.is_admin?
       can :manage, :all
     else
       can :manage, [VitaPartner], id: accessible_organizations.pluck(:id)
-      can :manage, [Client, User], vita_partner: accessible_organizations
+      can :manage, User, memberships: { vita_partner: accessible_organizations }
+
+      can :crud, Client, vita_partner: accessible_organizations
+      can :edit_organization, Client do |client|
+        user.can_lead?(client.vita_partner)
+      end
+
       can :manage, [
         IncomingTextMessage,
         OutgoingTextMessage,

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -24,4 +24,13 @@ class Membership < ApplicationRecord
   belongs_to :vita_partner
 
   enum role: { member: 1, lead: 2 }
+
+  default_scope -> { includes(:vita_partner) }
+
+  def specific_role
+    return :member if read_attribute(:role) == "member"
+    return :site_coordinator if vita_partner.is_site?
+    # return :coalition_coordinator if vita_partner.is_coalition_lead?
+    :organization_coordinator
+  end
 end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: memberships
+#
+#  id              :bigint           not null, primary key
+#  role            :integer          default("member"), not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  user_id         :bigint           not null
+#  vita_partner_id :bigint           not null
+#
+# Indexes
+#
+#  index_memberships_on_user_id          (user_id)
+#  index_memberships_on_vita_partner_id  (vita_partner_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#  fk_rails_...  (vita_partner_id => vita_partners.id)
+#
+class Membership < ApplicationRecord
+  belongs_to :user
+  belongs_to :vita_partner
+
+  enum role: { member: 1, lead: 2 }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,11 +79,23 @@ class User < ApplicationRecord
     }).exists?
   end
 
-  # returns organizations a user is a member of, and their children (if any).
+  # Returns a role specific to the vita_partner provided, so that we can scope behaviors and hide/show things on
+  # a specific client page (based on their organization) to users
+  # @param [VitaPartner || Int] vita_partner
+  def role_for(vita_partner)
+    memberships.find_by(vita_partner: vita_partner)&.specific_role
+  end
+
+  # returns organizations a user is a member of, and their children if any.
+  # Also includes coalition member organizations if a user has a lead role in a coalition.
   def accessible_organizations
     return VitaPartner.all if is_admin?
 
-    VitaPartner.where("id IN (?) OR parent_organization_id IN (?)", vita_partner_ids, vita_partner_ids)
+    ids = vita_partner_ids
+    # coalition_leads = memberships.joins(:vita_partner).where(role: "lead", "vita_partners.coalition_lead": true)
+    # coalition_leads.each { |org| ids << org.coalition.member_organization_ids }
+
+    VitaPartner.where("id IN (?) OR parent_organization_id IN (?)", ids, ids)
   end
 end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,21 +56,41 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :lockable, :validatable, :timeoutable, :trackable, :invitable, :recoverable
 
-  belongs_to :vita_partner, optional: true
   has_many :assigned_tax_returns, class_name: "TaxReturn", foreign_key: :assigned_user_id
+
+  #
+  belongs_to :vita_partner, optional: true
   has_and_belongs_to_many :supported_organizations,
            join_table: "users_vita_partners",
            class_name: "VitaPartner"
+  #
+
+  has_many :memberships
+  accepts_nested_attributes_for :memberships
 
   attr_encrypted :access_token, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }
 
   validates_presence_of :name
   validates_inclusion_of :timezone, in: ActiveSupport::TimeZone.country_zones("us").map { |tz| tz.tzinfo.name }
 
+  # returns true if the user has role "lead" for organization or its parents.
+  # @param keyword [Boolean] exclude_ancestors
+  def can_lead?(vita_partner, exclude_ancestors: false)
+    memberships.where({
+        role: "lead",
+        vita_partner_id: [
+          vita_partner.id,
+          *(vita_partner.ancestors unless exclude_ancestors)
+        ].compact
+    }).exists?
+  end
+
+  # returns organizations a user is a member of, and their children (if any).
   def accessible_organizations
-    accessible_organization_ids = [vita_partner_id] + supported_organizations.pluck(:id)
-    VitaPartner.where(id: accessible_organization_ids).or(
-      VitaPartner.where(parent_organization_id: accessible_organization_ids)
+    member_org_ids = memberships.pluck(:vita_partner_id)
+    VitaPartner.where(id: member_org_ids).or(
+      VitaPartner.where(parent_organization_id: member_org_ids)
     )
   end
 end
+

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,15 +58,9 @@ class User < ApplicationRecord
 
   has_many :assigned_tax_returns, class_name: "TaxReturn", foreign_key: :assigned_user_id
 
-  #
-  belongs_to :vita_partner, optional: true
-  has_and_belongs_to_many :supported_organizations,
-           join_table: "users_vita_partners",
-           class_name: "VitaPartner"
-  #
-
   has_many :memberships
-  accepts_nested_attributes_for :memberships
+  accepts_nested_attributes_for :memberships, allow_destroy: true
+  has_many :vita_partners, through: :memberships
 
   attr_encrypted :access_token, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }
 
@@ -87,10 +81,9 @@ class User < ApplicationRecord
 
   # returns organizations a user is a member of, and their children (if any).
   def accessible_organizations
-    member_org_ids = memberships.pluck(:vita_partner_id)
-    VitaPartner.where(id: member_org_ids).or(
-      VitaPartner.where(parent_organization_id: member_org_ids)
-    )
+    return VitaPartner.all if is_admin?
+
+    VitaPartner.where("id IN (?) OR parent_organization_id IN (?)", vita_partner_ids, vita_partner_ids)
   end
 end
 

--- a/app/models/users_vita_partner.rb
+++ b/app/models/users_vita_partner.rb
@@ -1,0 +1,16 @@
+# == Schema Information
+#
+# Table name: users_vita_partners
+#
+#  user_id         :bigint           not null
+#  vita_partner_id :bigint           not null
+#
+# Indexes
+#
+#  index_users_vita_partners_on_user_id          (user_id)
+#  index_users_vita_partners_on_vita_partner_id  (vita_partner_id)
+#
+class UsersVitaPartner < ApplicationRecord
+  belongs_to :user
+  belongs_to :vita_partner
+end

--- a/app/models/vita_partner.rb
+++ b/app/models/vita_partner.rb
@@ -33,6 +33,7 @@ class VitaPartner < ApplicationRecord
   accepts_nested_attributes_for :memberships
 
   belongs_to :parent_organization, class_name: "VitaPartner", optional: true
+  belongs_to :coalition, optional: true
   has_many :sub_organizations, -> { order(:id) }, class_name: "VitaPartner", foreign_key: "parent_organization_id"
   validate :one_level_of_depth
 
@@ -40,14 +41,27 @@ class VitaPartner < ApplicationRecord
 
   after_initialize :defaults
 
+  # would require a coalition model that indicates a coalition lead organization
   # organization + coalition
   def ancestors
-    [parent_organization, parent_organization&.parent_organization].compact
+    [
+      parent_organization,
+      # coalition,
+      # parent_organization&.coalition
+    ].compact
   end
 
   def at_capacity?
     actionable_intakes_this_week.count >= weekly_capacity_limit
   end
+
+  def is_site?
+    parent_organization.present?
+  end
+
+  # def is_coalition_lead?
+  #   coalition.present? && coalition_lead?
+  # end
 
   def has_capacity_for?(intake)
     if intake.vita_partner.name == "Urban Upbound (NY)"

--- a/app/models/vita_partner.rb
+++ b/app/models/vita_partner.rb
@@ -35,7 +35,6 @@ class VitaPartner < ApplicationRecord
   belongs_to :parent_organization, class_name: "VitaPartner", optional: true
   has_many :sub_organizations, -> { order(:id) }, class_name: "VitaPartner", foreign_key: "parent_organization_id"
   validate :one_level_of_depth
-  # attribute :user_vita_partner
 
   scope :top_level, -> { where(parent_organization: nil).order(:display_name).order(:name) }
 

--- a/app/models/vita_partner.rb
+++ b/app/models/vita_partner.rb
@@ -27,14 +27,24 @@ class VitaPartner < ApplicationRecord
   has_many :intakes
   has_and_belongs_to_many :states, association_foreign_key: :state_abbreviation
   has_many :source_parameters
-  has_many :users
+
+  has_many :memberships
+  has_many :users, through: :memberships
+  accepts_nested_attributes_for :memberships
+
   belongs_to :parent_organization, class_name: "VitaPartner", optional: true
   has_many :sub_organizations, -> { order(:id) }, class_name: "VitaPartner", foreign_key: "parent_organization_id"
   validate :one_level_of_depth
+  # attribute :user_vita_partner
 
   scope :top_level, -> { where(parent_organization: nil).order(:display_name).order(:name) }
 
   after_initialize :defaults
+
+  # organization + coalition
+  def ancestors
+    [parent_organization, parent_organization&.parent_organization].compact
+  end
 
   def at_capacity?
     actionable_intakes_this_week.count >= weekly_capacity_limit
@@ -74,3 +84,5 @@ class VitaPartner < ApplicationRecord
     self.weekly_capacity_limit ||= DEFAULT_CAPACITY_LIMIT
   end
 end
+
+

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -5,7 +5,9 @@
   <%= form_for(resource, as: resource_name, url: invitation_path(resource_name), method: :put, local: true, builder: VitaMinFormBuilder) do |f| %>
     <h1><%= @main_heading %></h1>
 
-    <h2 class="form-question"><%= t("general.organization") %>: <%= resource.vita_partner.name %></h2>
+    <h2 class="form-question"><%= t("general.organization") %>: <%= resource.memberships&.first.vita_partner.name %></h2>
+    <h2 class="form-question"><%= t("general.role") %>: <%= resource.memberships&.first.role&.capitalize %></h2>
+
     <h2 class="form-question"><%= t(".email_label") %>: <%= resource.email %></h2>
     <%= f.hidden_field :invitation_token, readonly: true %>
     <%= f.cfa_input_field(:name, t(".name_label")) %>

--- a/app/views/hub/clients/_client_header.html.erb
+++ b/app/views/hub/clients/_client_header.html.erb
@@ -8,7 +8,7 @@
     </div>
     <div class="client-header__organization">
       <h2 class="h3"><%= @client.vita_partner&.name %></h2>
-      <div><%= link_to "Edit", edit_organization_hub_client_path(id: @client.id), class: "button button--inline-action" if current_user.is_admin? %></div>
+      <div><%= link_to "Edit", edit_organization_hub_client_path(id: @client.id), class: "button button--inline-action" if can?(:edit_organization, @client) %></div>
     </div>
     <h2 class="h4">Client Id: #<%= @client.id %></h2>
     <%= form_for [:hub, @client], method: :patch, url: response_needed_hub_client_path(id: @client.id) do |f| %>

--- a/app/views/hub/users/_memberships.html.erb
+++ b/app/views/hub/users/_memberships.html.erb
@@ -1,0 +1,7 @@
+<div class="membership client-edit__row align-center">
+  <%= f.hidden_field :id %>
+  <%= f.cfa_select(:vita_partner_id, t("general.organization"), grouped_organization_options, include_blank: "") %>
+  <%= f.cfa_select(:role, t("general.role"), %w[member lead]) %>
+  <%= f.hidden_field :_destroy %>
+  <%= link_to_remove_fields "Remove", ".membership", {class: "button button--inline-action"} %>
+</div>

--- a/app/views/hub/users/edit.html.erb
+++ b/app/views/hub/users/edit.html.erb
@@ -1,38 +1,28 @@
 <% content_for :page_title, @user.name %>
 <% content_for :card do %>
-  <%= form_with model: [:hub, @user], method: :put, local: true, builder: VitaMinFormBuilder, html: { class: 'form-card form-card--long' } do |f| %>
-    <h1><%= @user.name %></h1>
-    <p>
-      <strong><%= t("general.email") %>:</strong> <%= @user.email %>
-    </p>
+  <div class="client-edit">
+    <%= form_with model: [:hub, @user], method: :put, local: true, builder: VitaMinFormBuilder, html: { class: 'form-card form-card--long' } do |f| %>
+      <h1><%= @user.name %></h1>
+      <p>
+        <strong><%= t("general.email") %>:</strong> <%= @user.email %>
+      </p>
 
-    <%= f.cfa_select(:timezone, t("general.timezone"), timezone_select_options) %>
-    <%= f.cfa_select(:vita_partner_id, t("general.organization"), grouped_organization_options, include_blank: t("general.none")) %>
+      <%= f.cfa_select(:timezone, t("general.timezone"), timezone_select_options) %>
 
-    <h2><%= t("general.role") %></h2>
+      <h2><%= "Organization Memberships" %></h2>
+      <%= f.fields_for :memberships do |ff| %>
+        <% render "memberships", f: ff %>
+      <% end %>
 
-    <%= f.cfa_checkbox(:is_admin, t(".is_admin_label"), options: {classes: ["form-width--long"], disabled: !current_user.is_admin }) %>
-    <% if current_user.is_admin %>
-      <div class="reveal">
-        <p><a href="#" class="reveal__link">Select supported organizations</a></p>
-        <div class="reveal__content">
-          <% VitaPartner.all.map do |vita_partner| %>
-            <%= f.cfa_checkbox(
-                  :supported_organization_ids,
-                  vita_partner.display_name,
-                  options: {
-                    checked_value: vita_partner.id,
-                    unchecked_value: "",
-                    multiple: true,
-                  }
-              ) %>
-          <% end %>
-        </div>
-      </div>
+      <%= link_to_add_fields("Add membership", f, :memberships, { class: "button button--small" }, partial: "hub/users/memberships") %>
+
+      <h2><%= t("general.role") %></h2>
+
+      <%= f.cfa_checkbox(:is_admin, t(".is_admin_label"), options: {classes: ["form-width--long"], disabled: !current_user.is_admin }) %>
+
+      <button class="button" type="submit">
+        <%=t("general.save") %>
+      </button>
     <% end %>
-
-    <button class="button" type="submit">
-      <%=t("general.save") %>
-    </button>
-  <% end %>
+  </div>
 <% end %>

--- a/app/views/hub/users/index.html.erb
+++ b/app/views/hub/users/index.html.erb
@@ -22,7 +22,9 @@
             <%= link_to user.name, edit_hub_user_path(id: user) %>
           </th>
           <td class="index-table__cell"><%= user_roles(user) %></td>
-          <td class="index-table__cell"><%= user.vita_partner&.name || t("general.none") %></td>
+          <td class="index-table__cell">
+            <%= user.memberships ? user.memberships.map { |m| m.vita_partner&.name }.join(", ") : t("general.none") %>
+          </td>
         </tr>
       <% end %>
 

--- a/app/views/hub/users/profile.html.erb
+++ b/app/views/hub/users/profile.html.erb
@@ -4,12 +4,23 @@
   <p>
     <strong><%= t("general.email") %></strong> <%= current_user.email %>
   </p>
-  <p>
-    <strong><%= t("general.role") %>></strong> <%= current_user.role&.capitalize %>
-  </p>
-  <p>
-    <strong><%= t("general.organization") %>></strong> <%= current_user.vita_partner&.name || t("general.none") %>
-  </p>
+
+  <% if current_user.is_admin?  %>
+    <p>
+      <strong><%= t("general.role") %></strong> <%= t("general.admin") %>
+    </p>
+  <% else %>
+    <p>
+      <strong><%= t("general.organization") %></strong>
+      <br />
+      <%=  t("general.none") unless current_user.memberships.present? %>
+      <ul>
+        <% current_user.memberships.each do |membership| %>
+          <li><%= membership.vita_partner.name %>: <%= membership.role&.capitalize %></li>
+        <% end %>
+      <ul>
+    </p>
+  <% end %>
 
   <ul class="actions">
     <li class="user-action-link">

--- a/app/views/invitations/index.html.erb
+++ b/app/views/invitations/index.html.erb
@@ -11,7 +11,7 @@
     <ul class="invitations list--bulleted">
       <% @unaccepted_invitations.each do |invitation| %>
         <li id="invitation-<%= invitation.id %>" class="invitation">
-          <%= invitation.name %> &lt;<%= invitation.email %>&gt; <%= invitation.vita_partner&.name %> (<%= t(".invitation.sent_at", datetime: invitation.invitation_sent_at) %>)
+          <%= invitation.name %> &lt;<%= invitation.email %>&gt; <%= invitation.memberships.first.vita_partner&.name %> (<%= t(".invitation.sent_at", datetime: invitation.invitation_sent_at) %>)
           <%= form_with(model: invitation, url: user_invitation_path, method: :post, local: true) do |f| %>
             <%= f.hidden_field :email %>
             <%= f.hidden_field :vita_partner_id %>

--- a/db/migrate/20201116190659_create_memberships.rb
+++ b/db/migrate/20201116190659_create_memberships.rb
@@ -18,7 +18,10 @@ class CreateMemberships < ActiveRecord::Migration[6.0]
   def migrate_data
     User.all.each do |user|
       user.memberships.create(vita_partner_id: user.vita_partner_id)
-      user.supported_organizations.map { |so| user.memberships.create(vita_partner_id: so.id, role: "lead")}
+      # Since supported orgs was trying to create a loose coalition per user and product wants them to be more
+      # concrete, copying them over could create more trouble than help, unless this concept is actively being
+      # used on demo to support loose coalitions (would also allow us to delete supported organizations and UVP table in this PR).
+      # user.supported_organizations.map { |so| user.memberships.create(vita_partner_id: so.id, role: "lead")}
     end
   end
 end

--- a/db/migrate/20201116190659_create_memberships.rb
+++ b/db/migrate/20201116190659_create_memberships.rb
@@ -1,0 +1,24 @@
+class CreateMemberships < ActiveRecord::Migration[6.0]
+  def up
+    create_table :memberships do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :vita_partner, null: false, foreign_key: true
+      t.integer :role, default: 1, null: false
+
+      t.timestamps
+    end
+
+    migrate_data
+  end
+
+  def down
+    drop_table :memberships
+  end
+
+  def migrate_data
+    User.all.each do |user|
+      user.memberships.create(vita_partner_id: user.vita_partner_id)
+      user.supported_organizations.map { |so| user.memberships.create(vita_partner_id: so.id, role: "lead")}
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2020_11_23_144557) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -398,6 +397,16 @@ ActiveRecord::Schema.define(version: 2020_11_23_144557) do
     t.index ["vita_partner_id"], name: "index_intakes_on_vita_partner_id"
   end
 
+  create_table "memberships", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.integer "role", default: 1, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id", null: false
+    t.bigint "vita_partner_id", null: false
+    t.index ["user_id"], name: "index_memberships_on_user_id"
+    t.index ["vita_partner_id"], name: "index_memberships_on_vita_partner_id"
+  end
+
   create_table "notes", force: :cascade do |t|
     t.text "body"
     t.bigint "client_id", null: false
@@ -615,6 +624,8 @@ ActiveRecord::Schema.define(version: 2020_11_23_144557) do
   add_foreign_key "incoming_text_messages", "clients"
   add_foreign_key "intake_site_drop_offs", "intake_site_drop_offs", column: "prior_drop_off_id"
   add_foreign_key "intakes", "vita_partners"
+  add_foreign_key "memberships", "users"
+  add_foreign_key "memberships", "vita_partners"
   add_foreign_key "notes", "clients"
   add_foreign_key "notes", "users"
   add_foreign_key "outgoing_emails", "clients"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2020_11_23_144557) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"

--- a/spec/channels/client_channel_spec.rb
+++ b/spec/channels/client_channel_spec.rb
@@ -1,8 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe ClientChannel, type: :channel do
-  let(:client) { create :client }
-  let(:user) { create :user_with_org }
+  let(:user) { create :user_with_membership }
+  let(:vita_partner) { user.memberships.first.vita_partner }
+  let(:client) { create :client, vita_partner: vita_partner }
+
   let(:params) { { id: client.id } }
 
   context "as an unauthenticated user" do
@@ -29,8 +31,6 @@ RSpec.describe ClientChannel, type: :channel do
     end
 
     context 'with valid params' do
-      let(:client) { create(:client, vita_partner: user.vita_partner) }
-
       it 'subscribes to a client' do
         subscribe params
 

--- a/spec/controllers/hub/assigned_clients_controller_spec.rb
+++ b/spec/controllers/hub/assigned_clients_controller_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Hub::AssignedClientsController do
   end
 
   context "as an authenticated user" do
-    let(:vita_partner) { create(:vita_partner) }
-    let(:user) { create(:user_with_org, vita_partner: vita_partner) }
+    let(:user) { create(:user_with_membership) }
+    let(:vita_partner) { user.memberships.first.vita_partner }
 
     before { sign_in user}
     let!(:assigned_to_me) { create :client, vita_partner: vita_partner, intake: (create :intake), tax_returns: [(create :tax_return, assigned_user: user, status: "intake_in_progress")] }
@@ -83,7 +83,7 @@ RSpec.describe Hub::AssignedClientsController do
       end
 
       context "filtering by needs response" do
-        let!(:needs_response) { create :client, response_needed_since: DateTime.now, vita_partner: user.vita_partner, tax_returns: [(create :tax_return, assigned_user: user)] }
+        let!(:needs_response) { create :client, response_needed_since: DateTime.now, vita_partner: user.memberships.first.vita_partner, tax_returns: [(create :tax_return, assigned_user: user)] }
         it "filters in" do
           get :index, params: { needs_response: true }
           expect(assigns(:clients)).to include needs_response
@@ -91,7 +91,7 @@ RSpec.describe Hub::AssignedClientsController do
       end
 
       context "filtering and sorting" do
-        let!(:starts_with_a_assigned) { create :client, intake: (create :intake, preferred_name: "Aardvark Alan"), vita_partner: user.vita_partner, tax_returns: [(create :tax_return, status: "intake_in_progress", assigned_user: user)] }
+        let!(:starts_with_a_assigned) { create :client, intake: (create :intake, preferred_name: "Aardvark Alan"), vita_partner: vita_partner, tax_returns: [(create :tax_return, status: "intake_in_progress", assigned_user: user)] }
 
         it "preferred_name, asc" do
           get :index, params: { status: "intake_in_progress", column: "preferred_name", order: "asc" }

--- a/spec/controllers/hub/clients/organizations_controller_spec.rb
+++ b/spec/controllers/hub/clients/organizations_controller_spec.rb
@@ -9,8 +9,15 @@ RSpec.describe Hub::Clients::OrganizationsController, type: :controller do
     it_behaves_like :a_post_action_for_authenticated_users_only, action: :update
 
     context "as a logged in user with access to the clients organization" do
-      let!(:user) { create :user, vita_partner: client.vita_partner }
-      before { sign_in user }
+      let!(:user) { create :user }
+
+      before do
+        sign_in user
+        allow_any_instance_of(Ability).to receive(:can?).with(:update, VitaPartner).and_return(true)
+        allow_any_instance_of(Ability).to receive(:can?).with(:update, Client).and_return(true)
+        allow_any_instance_of(Ability).to receive(:can?).with(:edit_organization, Client).and_return(true)
+
+      end
 
       it "can change the associated organization on a client" do
         expect {
@@ -34,7 +41,7 @@ RSpec.describe Hub::Clients::OrganizationsController, type: :controller do
 
     describe "#edit" do
       let!(:client) { create :client, vita_partner: (create :vita_partner) }
-      let!(:new_vita_partner) { create :vita_partner}
+      let!(:new_vita_partner) { create :vita_partner }
       let(:params) { {id: client.id, client: { vita_partner_id: new_vita_partner.id}} }
 
       it_behaves_like :a_get_action_for_authenticated_users_only, action: :edit

--- a/spec/controllers/hub/clients/organizations_controller_spec.rb
+++ b/spec/controllers/hub/clients/organizations_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Hub::Clients::OrganizationsController, type: :controller do
     end
 
     context "as a logged in user without access to the clients organization" do
-      let!(:user) { create :user, vita_partner: (create :vita_partner) }
+      let!(:user) { create :user_with_membership }
       before { sign_in user }
 
       it "does not allow user to update" do
@@ -42,7 +42,7 @@ RSpec.describe Hub::Clients::OrganizationsController, type: :controller do
     describe "#edit" do
       let!(:client) { create :client, vita_partner: (create :vita_partner) }
       let!(:new_vita_partner) { create :vita_partner }
-      let(:params) { {id: client.id, client: { vita_partner_id: new_vita_partner.id}} }
+      let(:params) { { id: client.id, client: { vita_partner_id: new_vita_partner.id }} }
 
       it_behaves_like :a_get_action_for_authenticated_users_only, action: :edit
 

--- a/spec/controllers/hub/clients_controller_spec.rb
+++ b/spec/controllers/hub/clients_controller_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe Hub::ClientsController do
         let!(:michael) { create :client, vita_partner: vita_partner, intake: create(:intake, :filled_out, preferred_name: "Michael", needs_help_2019: "yes", needs_help_2017: "yes") }
         let!(:michael_2019_return) { create :tax_return, client: michael, year: 2019, assigned_user: assigned_user, status: "intake_in_progress" }
         let!(:tobias) { create :client, vita_partner: vita_partner, intake: create(:intake, :filled_out, preferred_name: "Tobias", needs_help_2018: "yes", locale: "es") }
-        let(:assigned_user) { create :user, name: "Lindsay", vita_partner: vita_partner }
+        let(:assigned_user) { create :user, name: "Lindsay", memberships: [build(:membership, vita_partner: vita_partner)] }
         let!(:tobias_2019_return) { create :tax_return, client: tobias, year: 2019, assigned_user: assigned_user, status: "intake_in_progress" }
         let!(:tobias_2018_return) { create :tax_return, client: tobias, year: 2018, assigned_user: assigned_user }
         let!(:lucille) { create :client, vita_partner: vita_partner, intake: create(:intake, preferred_name: "Lucille") }

--- a/spec/controllers/hub/documents_controller_spec.rb
+++ b/spec/controllers/hub/documents_controller_spec.rb
@@ -2,14 +2,14 @@ require 'rails_helper'
 
 RSpec.describe Hub::DocumentsController, type: :controller do
   describe "#index" do
-    let(:vita_partner) { create :vita_partner }
-    let(:client) { create :client, vita_partner: vita_partner, intake: create(:intake, vita_partner: vita_partner) }
+    let(:user) { create :user_with_membership }
+    let(:vita_partner) { user.memberships.first.vita_partner }
+    let(:client) { create :client, vita_partner: vita_partner, intake: create(:intake) }
     let(:params) { { client_id: client.id } }
 
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :index
 
     context "as an authenticated user" do
-      let(:user) { create :user, vita_partner: vita_partner }
       before { sign_in(user) }
 
       context "with some existing documents" do
@@ -104,15 +104,15 @@ RSpec.describe Hub::DocumentsController, type: :controller do
   end
 
   describe "#edit" do
-    let(:vita_partner) { create :vita_partner }
-    let(:client) { create :client, vita_partner: vita_partner, intake: create(:intake, vita_partner: vita_partner) }
+    let(:user) { create :user_with_membership }
+    let(:vita_partner) { user.memberships.first.vita_partner }
+    let(:client) { create :client, vita_partner: vita_partner, intake: create(:intake) }
     let(:document) { create :document, :with_upload, client: client }
     let(:params) { { id: document.id, client_id: client.id }}
 
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :edit
 
     context "with an authenticated user" do
-      let(:user) { create :user, vita_partner: vita_partner }
       before { sign_in(user) }
 
       it "renders edit for the document" do
@@ -125,16 +125,16 @@ RSpec.describe Hub::DocumentsController, type: :controller do
   end
 
   describe "#update" do
+    let(:user) { create :user_with_membership }
     let(:new_display_name) { "New Display Name"}
-    let(:vita_partner) { create :vita_partner }
-    let(:client) { create :client, vita_partner: vita_partner, intake: create(:intake, vita_partner: vita_partner) }
+    let(:vita_partner) { user.memberships.first.vita_partner }
+    let(:client) { create :client, vita_partner: vita_partner, intake: create(:intake) }
     let(:document) { create :document, :with_upload, client: client }
     let(:params) { { client_id: client.id, id: document.id, document: { display_name: new_display_name} } }
 
     it_behaves_like :a_post_action_for_authenticated_users_only, action: :update
 
     context "with an authenticated user" do
-      let(:user) { create :user, vita_partner: vita_partner }
       before { sign_in(user) }
       context "with valid params" do
         it "updates the display name attribute on the document" do
@@ -162,7 +162,8 @@ RSpec.describe Hub::DocumentsController, type: :controller do
   end
 
   describe "#show" do
-    let(:vita_partner) { create :vita_partner }
+    let(:user) { create :user_with_membership }
+    let(:vita_partner) { user.memberships.first.vita_partner }
     let(:client) { create :client, vita_partner: vita_partner, intake: create(:intake, vita_partner: vita_partner) }
     let(:document) { create :document, :with_upload, client: client }
     let(:params) { { client_id: client.id, id: document.id }}
@@ -170,7 +171,6 @@ RSpec.describe Hub::DocumentsController, type: :controller do
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :show
 
     context "with a signed in user" do
-      let(:user) { create :user, vita_partner: vita_partner }
       before { sign_in(user) }
 
       it "shows the document" do

--- a/spec/controllers/hub/messages_controller_spec.rb
+++ b/spec/controllers/hub/messages_controller_spec.rb
@@ -1,13 +1,13 @@
 require "rails_helper"
 
 RSpec.describe Hub::MessagesController do
-  let(:vita_partner) { create :vita_partner }
-  let(:client) { create :client, vita_partner: vita_partner }
   let!(:intake) { create :intake, client: client }
   let(:params) do
     { client_id: client.id }
   end
-  let(:user) { create :user, vita_partner: vita_partner }
+  let(:user) { create :user_with_membership }
+  let(:vita_partner) { user.memberships.first.vita_partner }
+  let(:client) { create :client, vita_partner: vita_partner }
 
   describe "#index" do
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :index
@@ -19,7 +19,7 @@ RSpec.describe Hub::MessagesController do
         render_views
 
         let(:twilio_status) { nil }
-        let(:client) { create :client, vita_partner: vita_partner, intake: create(:intake, preferred_name: "George Sr.", phone_number: "4155551233", email_address: "money@banana.stand")  }
+        let(:client) { create :client, vita_partner: user.memberships.first.vita_partner, intake: create(:intake, preferred_name: "George Sr.", phone_number: "4155551233", email_address: "money@banana.stand")  }
         let!(:expected_contact_history) do
           [
             create(:incoming_email, body_plain: "Me too! Happy to get every notification", received_at: DateTime.new(2020, 1, 1, 18, 0, 4), client: client, from: "Georgie <money@banana.stand>" ),
@@ -107,7 +107,7 @@ RSpec.describe Hub::MessagesController do
         end
 
         context "with messages from different days" do
-          let(:user) { create :user, timezone: "America/Los_Angeles" , vita_partner: vita_partner}
+          let(:user) { create :user_with_membership, timezone: "America/Los_Angeles" }
 
           before do
             create(:outgoing_email, sent_at: DateTime.new(2019, 10, 4, 14), client: client)

--- a/spec/controllers/hub/notes_controller_spec.rb
+++ b/spec/controllers/hub/notes_controller_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Hub::NotesController, type: :controller do
-  let(:vita_partner) { create :vita_partner }
+  let(:user) { create :user_with_membership }
+  let(:vita_partner) { user.memberships.first.vita_partner }
   let(:client) { create :client, vita_partner: vita_partner }
   let!(:intake) { create :intake, client: client }
 
@@ -18,9 +19,8 @@ RSpec.describe Hub::NotesController, type: :controller do
     it_behaves_like :a_post_action_for_authenticated_users_only, action: :create
 
     context "as an authenticated user" do
-      let(:current_user) { create :user, vita_partner: vita_partner }
       before do
-        sign_in current_user
+        sign_in user
       end
 
       it "creates a new note" do
@@ -29,7 +29,7 @@ RSpec.describe Hub::NotesController, type: :controller do
         note = Note.last
         expect(note.body).to eq "Note body"
         expect(note.client).to eq client
-        expect(note.user).to eq current_user
+        expect(note.user).to eq user
         expect(response).to redirect_to hub_client_notes_path(client_id: client.id)
       end
 
@@ -58,7 +58,6 @@ RSpec.describe Hub::NotesController, type: :controller do
   describe "#index" do
     let(:client) { create :client, vita_partner: vita_partner }
     let(:params) { { client_id: client.id } }
-    let(:user) { create :user, vita_partner: vita_partner }
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :index
 
     context "as a logged in user loading a clients notes" do
@@ -95,7 +94,7 @@ RSpec.describe Hub::NotesController, type: :controller do
       end
 
       context "with notes from different days" do
-        let(:user) { create :user, timezone: "America/Los_Angeles" , vita_partner: vita_partner}
+        let(:user) { create :user_with_membership, timezone: "America/Los_Angeles" }
 
         it "correctly groups notes by day created" do
           day1_client_note = create :note, client: client, created_at: DateTime.new(2019, 10, 5, 8) # UTC

--- a/spec/controllers/hub/outgoing_emails_controller_spec.rb
+++ b/spec/controllers/hub/outgoing_emails_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Hub::OutgoingEmailsController do
     it_behaves_like :a_post_action_for_authenticated_users_only, action: :create
 
     context "as an authenticated admin user" do
-      let(:user) { create :user, vita_partner: vita_partner }
+      let(:user) { create :user, memberships: [build(:membership, vita_partner: vita_partner)] }
       before do
         sign_in user
         allow(subject).to receive(:send_email)

--- a/spec/controllers/hub/outgoing_text_messages_controller_spec.rb
+++ b/spec/controllers/hub/outgoing_text_messages_controller_spec.rb
@@ -2,48 +2,42 @@ require "rails_helper"
 
 RSpec.describe Hub::OutgoingTextMessagesController do
   describe "#create" do
-    let(:vita_partner) { create :vita_partner }
+    let(:user) { create :user_with_membership }
+    let(:vita_partner) { user.memberships.first.vita_partner }
     let(:client) { create :client, vita_partner: vita_partner, intake: create(:intake, sms_phone_number: "+15105551234", phone_number: "+15105551777") }
     let(:params) do
       {
-        client_id: client.id,
-        outgoing_text_message: {
-          body: "This is an outgoing text"
-        }
+          client_id: client.id,
+          outgoing_text_message: {
+              body: "This is an outgoing text"
+          }
       }
     end
-
-    before { allow(subject).to receive(:send_text_message) }
 
     it_behaves_like :a_post_action_for_authenticated_users_only, action: :create
 
     context "as an authenticated user" do
-      let(:user) { create :user, vita_partner: vita_partner }
-      before { sign_in user }
+      before do
+        sign_in user
+        allow(ClientChannel).to receive(:broadcast_contact_record)
+      end
 
-      it "calls send_text_message with the right arguments and redirects to messages" do
-        post :create, params: params
+      it "sends a text", active_job: true do
+        expect {
+          post :create, params: params
+        }.to change(OutgoingTextMessage, :count).from(0).to(1)
 
-        expect(subject).to have_received(:send_text_message).with("This is an outgoing text")
+        outgoing_text_message = OutgoingTextMessage.last
+        expect(outgoing_text_message.body).to eq "This is an outgoing text"
+        expect(outgoing_text_message.to_phone_number).to eq client.sms_phone_number
+        expect(outgoing_text_message.client).to eq client
+        expect(SendOutgoingTextMessageJob).to have_been_enqueued.with(outgoing_text_message.id)
         expect(response).to redirect_to(hub_client_messages_path(client_id: client.id))
       end
 
-      context "with a blank body" do
-        let(:params) do
-          {
-            client_id: client.id,
-            outgoing_text_message: {
-              body: " \n\t"
-            }
-          }
-        end
-
-        it "doesn't call send_text_message but still redirects to messages" do
-          post :create, params: params
-
-          expect(subject).not_to have_received(:send_text_message)
-          expect(response).to redirect_to(hub_client_messages_path(client_id: client.id))
-        end
+      it "sends a real-time update to anyone on this client's page" do
+        post :create, params: params
+        expect(ClientChannel).to have_received(:broadcast_contact_record).with(OutgoingTextMessage.last)
       end
     end
   end

--- a/spec/controllers/hub/sub_organizations_controller_spec.rb
+++ b/spec/controllers/hub/sub_organizations_controller_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Hub::SubOrganizationsController, type: :controller do
   describe "#update" do
-    let!(:vita_partner) { create :vita_partner }
-    let(:user) { create :user, vita_partner: vita_partner }
+    let(:user) { create :user_with_membership }
+    let!(:vita_partner) { user.memberships.first.vita_partner }
     let(:params) { { id: vita_partner } }
 
     it_behaves_like :a_post_action_for_authenticated_users_only, action: :update
@@ -64,8 +64,8 @@ RSpec.describe Hub::SubOrganizationsController, type: :controller do
   end
 
   describe "#edit" do
-    let!(:vita_partner) { create :vita_partner }
-    let(:user) { create :user, vita_partner: vita_partner }
+    let(:user) { create :user_with_membership }
+    let!(:vita_partner) { user.memberships.first.vita_partner }
     let(:params) { { id: vita_partner } }
 
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :edit

--- a/spec/controllers/hub/tax_returns/certifications_controller_spec.rb
+++ b/spec/controllers/hub/tax_returns/certifications_controller_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 
 RSpec.describe Hub::TaxReturns::CertificationsController do
   describe "#update" do
-    let(:vita_partner) { create(:vita_partner) }
-    let(:user) { create(:user_with_org, vita_partner: vita_partner) }
-    let(:tax_return) { create :tax_return, client: (create :client, vita_partner: vita_partner)}
+    let(:user) { create(:user_with_membership) }
+    let(:vita_partner) { user.memberships.first.vita_partner }
+    let(:tax_return) { create :tax_return, client: (create :client, vita_partner: vita_partner) }
     let(:next_path) { "/next/path" }
-    let(:params) { { id: tax_return.id, certification_level: "advanced", is_hsa: true, next: next_path }}
+    let(:params) { { id: tax_return.id, certification_level: "advanced", is_hsa: true, next: next_path } }
 
     it_behaves_like :a_post_action_for_authenticated_users_only, action: :update
 

--- a/spec/controllers/hub/tax_returns_controller_spec.rb
+++ b/spec/controllers/hub/tax_returns_controller_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe Hub::TaxReturnsController, type: :controller do
 
     context "as an authenticated user" do
       render_views
-      let(:user) { create :user, vita_partner: vita_partner }
-      let!(:other_user) { create :user, vita_partner: vita_partner }
+      let(:user) { create :user, memberships: [build(:membership, vita_partner: vita_partner)] }
+      let!(:other_user) { create :user, memberships: [build(:membership, vita_partner: vita_partner)]  }
       let!(:outside_org_user) { create :user }
       before { sign_in user }
 
@@ -43,9 +43,9 @@ RSpec.describe Hub::TaxReturnsController, type: :controller do
     end
 
     context "as an admin user" do
-      let(:admin) { create :admin_user, vita_partner: create(:vita_partner) }
-      let!(:other_user) { create :user, vita_partner: vita_partner }
-      let!(:outside_org_user) { create :user, vita_partner: admin.vita_partner }
+      let(:admin) { create :admin_user }
+      let!(:other_user) { create :user, memberships: [build(:membership, vita_partner: vita_partner)] }
+      let!(:outside_org_user) { create :user, memberships: [build(:membership, vita_partner: create(:vita_partner))] }
       before { sign_in admin }
 
       it "offers a list of users based on client's partner, not admin's org" do
@@ -56,7 +56,8 @@ RSpec.describe Hub::TaxReturnsController, type: :controller do
   end
 
   describe "#update" do
-    let(:assigned_user) { create :user, name: "Buster" }
+    let(:vita_partner) { create :vita_partner }
+    let(:assigned_user) { create :user, memberships: [build(:membership, vita_partner: vita_partner)], name: "Buster" }
     let(:params) {
       {
         client_id: client.id,
@@ -68,7 +69,7 @@ RSpec.describe Hub::TaxReturnsController, type: :controller do
     it_behaves_like :a_post_action_for_authenticated_users_only, action: :update
 
     context "as an authenticated user" do
-      let(:user) { create :user, vita_partner: vita_partner }
+      let(:user) { create :user, memberships: [build(:membership, vita_partner: vita_partner )] }
       before { sign_in user }
 
       it "assigns the user to the tax return" do

--- a/spec/controllers/hub/users_controller_spec.rb
+++ b/spec/controllers/hub/users_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Hub::UsersController do
 
     context "with an authenticated user" do
       render_views
-      let(:user) { create :user_with_org, role: "agent", name: "Adam Avocado", vita_partner: vita_partner}
+      let(:user) { create :user_with_lead_membership, name: "Adam Avocado" }
       before { sign_in user }
 
       it "renders information about the current user with helpful links" do
@@ -29,34 +29,36 @@ RSpec.describe Hub::UsersController do
 
     context "with an authenticated user" do
       render_views
+      let(:vita_partner) { user.memberships.first.vita_partner }
+      let(:user) { create :user_with_lead_membership }
+      let!(:leslie) { create :user, name: "Leslie", memberships: [build(:membership, vita_partner: vita_partner)] }
+      let!(:ben) { create :user, name: "Ben", memberships: [build(:membership, vita_partner: vita_partner)] }
 
-      before { sign_in(create :user_with_org, vita_partner: vita_partner ) }
-      let(:vita_partner) { create :vita_partner, name: "Pawnee Preparers" }
-      let!(:leslie) { create :zendesk_admin_user, name: "Leslie", vita_partner: vita_partner }
-      let!(:ben) { create :agent_user, name: "Ben", vita_partner: vita_partner }
+      before { sign_in user }
 
       it "displays a list of all users in the org and certain key attributes" do
         get :index
-
         expect(assigns(:users).count).to eq 3
         html = Nokogiri::HTML.parse(response.body)
         expect(html.at_css("#user-#{leslie.id}")).to have_text("Leslie")
-        expect(html.at_css("#user-#{leslie.id}")).to have_text("Pawnee Preparers")
+        expect(html.at_css("#user-#{leslie.id}")).to have_text(vita_partner.name)
         expect(html.at_css("#user-#{leslie.id} a")["href"]).to eq edit_hub_user_path(id: leslie)
       end
     end
   end
 
   describe "#edit" do
-    let(:vita_partner) { create :vita_partner }
-    let!(:user) { create :agent_user, name: "Anne", vita_partner: vita_partner }
-    let(:params) { { id: user.id } }
+    let(:user) { create :user_with_membership }
+    let(:vita_partner) { user.memberships.first.vita_partner }
+    let!(:other_user) { create :user, name: "Anne", memberships: [build(:membership, vita_partner: vita_partner)] }
+    let(:params) { { id: other_user.id } }
+
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :edit
 
     context "as an authenticated user" do
       render_views
 
-      before { sign_in(create :user_with_org, vita_partner: vita_partner) }
+      before { sign_in(user) }
 
       it "shows a form prefilled with data about the user" do
         get :edit, params: params
@@ -69,12 +71,17 @@ RSpec.describe Hub::UsersController do
 
         expect(response.body).to have_text("Eastern Time (US & Canada)")
       end
+
+      it "assigns user vita_partner id to the member membership vita_partner_id" do
+        get :edit, params: params
+        expect(assigns(:user).vita_partner_id).to eq vita_partner.id
+      end
     end
   end
 
   describe "#update" do
     let!(:vita_partner) { create :vita_partner, name: "Avonlea Tax Aid" }
-    let!(:user) { create :agent_user, name: "Anne", vita_partner: vita_partner }
+    let!(:user) { create :user, name: "Anne", memberships: [build(:membership, vita_partner: vita_partner)]}
     let(:params) do
       {
         id: user.id,
@@ -89,14 +96,14 @@ RSpec.describe Hub::UsersController do
     context "as an authenticated user" do
       render_views
 
-      before { sign_in(create :user_with_org, vita_partner: vita_partner) }
+      before { sign_in(create :user, memberships: [build(:membership, vita_partner: vita_partner)]) }
 
       context "when editing user fields that any user can edit" do
         it "updates the user and redirects to edit" do
           post :update, params: params
 
           user.reload
-          expect(user.vita_partner).to eq vita_partner
+          expect(user.memberships.first.vita_partner).to eq vita_partner
           expect(user.timezone).to eq "America/Chicago"
           expect(response).to redirect_to edit_hub_user_path(id: user)
         end
@@ -129,6 +136,20 @@ RSpec.describe Hub::UsersController do
           expect(user.reload).to eq user
         end
       end
+
+      context "when creating lead memberships to inaccessible organization" do
+        before do
+          params[:user][:vita_partner_id] = vita_partner.id
+          params[:user][:supported_organization_ids] = [create(:vita_partner).id, create(:vita_partner).id]
+        end
+
+        it "raises an exception and does not change the user" do
+          expect do
+            post :update, params: params
+          end.to raise_error(ActiveRecord::RecordNotFound)
+          expect(user.reload).to eq user
+        end
+      end
     end
 
     context "as an admin" do
@@ -137,9 +158,11 @@ RSpec.describe Hub::UsersController do
       let(:supported_vita_partner_1) { create(:vita_partner) }
       let(:supported_vita_partner_2) { create(:vita_partner) }
 
-      before { sign_in(create(:admin_user, supported_organizations: [supported_vita_partner_1, supported_vita_partner_2])) }
+      before { sign_in(create(:admin_user)) }
 
-      it "can add admin role & supported organizations" do
+      it "can add admin role & organization memberships" do
+        expect(user.memberships.count).to eq 1
+
         params = {
           id: user.id,
           user: {
@@ -157,7 +180,178 @@ RSpec.describe Hub::UsersController do
 
         user.reload
         expect(user.is_admin?).to eq true
-        expect(user.supported_organization_ids.sort).to eq [supported_vita_partner_1.id, supported_vita_partner_2.id]
+        expect(user.memberships.count).to eq 3
+        expect(user.memberships).to include(have_attributes(vita_partner_id: vita_partner.id, role: "member"))
+        expect(user.memberships).to include(have_attributes(vita_partner_id: supported_vita_partner_1.id, role: "lead"))
+        expect(user.memberships).to include(have_attributes(vita_partner_id: supported_vita_partner_2.id, role: "lead"))
+      end
+
+      it "can remove memberships" do
+        user.memberships.create(vita_partner: supported_vita_partner_2, role: "lead")
+        expect(user.memberships.count).to eq 2
+
+        params = {
+          id: user.id,
+          user: {
+            is_admin: true,
+            vita_partner_id: vita_partner.id,
+            timezone: "America/Chicago",
+            supported_organization_ids: []
+          }
+        }
+
+        post :update, params: params
+
+        user.reload
+        expect(user.is_admin?).to eq true
+        expect(user.memberships.count).to eq 1
+        expect(user.memberships).to include(have_attributes(vita_partner_id: vita_partner.id, role: "member"))
+      end
+
+      it "can change supported organizations" do
+        old_vita_partner = create(:vita_partner)
+        new_vita_partner = create(:vita_partner)
+        user.memberships.create(vita_partner: old_vita_partner, role: "lead")
+
+        expect(user.memberships.count).to eq 2
+        expect(user.memberships).to include(have_attributes(vita_partner_id: vita_partner.id, role: "member"))
+        expect(user.memberships).to include(have_attributes(vita_partner_id: old_vita_partner.id, role: "lead"))
+
+        params = {
+          id: user.id,
+          user: {
+            is_admin: true,
+            vita_partner_id: vita_partner.id,
+            timezone: "America/Chicago",
+            supported_organization_ids: [new_vita_partner.id]
+          }
+        }
+
+        post :update, params: params
+
+        user.reload
+        expect(user.memberships.count).to eq 2
+        expect(user.memberships).to include(have_attributes(vita_partner_id: vita_partner.id, role: "member"))
+        expect(user.memberships).to include(have_attributes(vita_partner_id: new_vita_partner.id, role: "lead"))
+      end
+
+      it "omits bad supported organization ids" do
+        user = create :user, memberships: [build(:membership, vita_partner: vita_partner)]
+        params = { id: user.id, user: { vita_partner_id: vita_partner.id, supported_organization_ids: ["", nil] } }
+
+        put :update, params: params
+
+        user.reload
+        expect(user.memberships.length).to eq 1
+        expect(user.memberships).to include(have_attributes(vita_partner_id: vita_partner.id, role: "member"))
+      end
+
+      it "does not persist vita_partner_id to user" do
+        new_vita_partner = create(:vita_partner)
+        params = { id: user.id, user: { vita_partner_id: new_vita_partner.id } }
+        expect {
+          put :update, params: params
+          user.reload
+        }.not_to change(user, :vita_partner_id)
+      end
+
+      it "does not persist supported_organization_ids to user" do
+        new_vita_partner = create(:vita_partner)
+        params = { id: user.id, user: { supported_organization_ids: [new_vita_partner.id] } }
+        expect {
+          put :update, params: params
+          user.reload
+        }.not_to change(user.supported_organizations, :count)
+
+        expect(user.memberships).to include(have_attributes(vita_partner_id: new_vita_partner.id, role: "lead"))
+      end
+
+      it "can change primary vita partner membership" do
+        new_vita_partner = create(:vita_partner)
+        params = { id: user.id, user: { vita_partner_id: new_vita_partner.id } }
+        put :update, params: params
+        user.reload
+
+        expect(user.memberships.length).to eq 1
+        expect(user.memberships).to include(have_attributes(vita_partner_id: new_vita_partner.id, role: "member"))
+      end
+
+
+      it "can set primary vita partner membership" do
+        new_vita_partner = create(:vita_partner)
+        user = create :user, memberships: []
+        params = { id: user.id, user: { vita_partner_id: new_vita_partner.id, supported_organization_ids: [] } }
+
+        put :update, params: params
+
+        user.reload
+        expect(user.memberships.length).to eq 1
+        expect(user.memberships).to include(have_attributes(vita_partner_id: new_vita_partner.id, role: "member"))
+      end
+
+      it "can set supported organization without vita_partner_id" do
+        new_vita_partner = create(:vita_partner)
+        user = create :user, memberships: []
+        params = { id: user.id, user: { supported_organization_ids: [new_vita_partner.id] } }
+
+        put :update, params: params
+
+        user.reload
+        expect(user.memberships.length).to eq 1
+        expect(user.memberships).to include(have_attributes(vita_partner_id: new_vita_partner.id, role: "lead"))
+      end
+
+      it "can set supported organization with nil" do
+        new_vita_partner = create(:vita_partner)
+        user = create :user, memberships: []
+        params = { id: user.id, user: {vita_partner_id: nil, supported_organization_ids: [new_vita_partner.id] } }
+
+        put :update, params: params
+
+        user.reload
+        expect(user.memberships.length).to eq 1
+        expect(user.memberships).to include(have_attributes(vita_partner_id: new_vita_partner.id, role: "lead"))
+      end
+
+      it "can set supported organization with empty vita_partner_id" do
+        new_vita_partner = create(:vita_partner)
+        user = create :user, memberships: []
+        params = { id: user.id, user: { vita_partner_id: "", supported_organization_ids: [new_vita_partner.id] } }
+
+        put :update, params: params
+
+        user.reload
+        expect(user.memberships.length).to eq 1
+        expect(user.memberships).to include(have_attributes(vita_partner_id: new_vita_partner.id, role: "lead"))
+      end
+
+      it "can remove primary vita partner membership" do
+        new_vita_partner = create(:vita_partner)
+        user = create :user, memberships: [build(:membership, vita_partner: create(:vita_partner))]
+        params = { id: user.id, user: { vita_partner_id: new_vita_partner.id } }
+
+        put :update, params: params
+
+        user.reload
+        expect(user.memberships.length).to eq 1
+        expect(user.memberships).to include(have_attributes(vita_partner_id: new_vita_partner.id, role: "member"))
+      end
+
+      context "when the user does not successfully update" do
+        before do
+          allow_any_instance_of(User).to receive(:update!).and_raise(ActiveRecord::RecordInvalid)
+        end
+
+        it "should rollback transaction and not destroy the existing memberships" do
+          new_vita_partner = create(:vita_partner)
+          user = create :user, memberships: [build(:membership, vita_partner: vita_partner)]
+          params = { id: user.id, user: { vita_partner_id: new_vita_partner.id } }
+          put :update, params: params
+
+          user.reload
+          expect(user.memberships.length).to eq 1
+          expect(user.memberships).to include(have_attributes(vita_partner_id: vita_partner.id, role: "member"))
+        end
       end
     end
   end

--- a/spec/controllers/hub/vita_partners_controller_spec.rb
+++ b/spec/controllers/hub/vita_partners_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Hub::VitaPartnersController, type: :controller do
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :index
 
     context "for orgs with sub-organizations, i.e., sites" do
-      let(:user) { create(:admin_user, vita_partner: vita_partner1) }
+      let(:user) { create(:admin_user) }
       let!(:vita_partner1) { create(:vita_partner, display_name: "Vita Partner 1") }
       let!(:vita_partner1_site) { create(:vita_partner, display_name: "Library Tax Help of Vita Partner 1", parent_organization: vita_partner1) }
       let!(:vita_partner2) { create(:vita_partner, display_name: "Vita Partner 2") }
@@ -26,12 +26,13 @@ RSpec.describe Hub::VitaPartnersController, type: :controller do
 
   describe "#show" do
     let(:vita_partner) { create :vita_partner }
-    let(:params) { {id: vita_partner} }
+    let(:params) { { id: vita_partner } }
+    let(:params) { { id: vita_partner } }
 
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :show
 
     context "sub-organizations" do
-      let(:user) { create(:admin_user, vita_partner: vita_partner)}
+      let(:user) { create :admin_user}
       let!(:vita_partner_site) { create(:vita_partner, display_name: "Library Tax Help of Vita Partner", parent_organization: vita_partner) }
 
       before do
@@ -47,8 +48,9 @@ RSpec.describe Hub::VitaPartnersController, type: :controller do
     end
 
     context "as an authenticated user who is not an admin" do
-      let(:user) { create :user, vita_partner: vita_partner }
-      let(:other_vita_partner) { create :vita_partner}
+      let(:user) { create :user_with_membership }
+      let(:vita_partner) { user.memberships.first.vita_partner }
+      let(:other_vita_partner) { create :vita_partner }
       before { sign_in(user) }
 
       it "can access if user has matching vita partner" do

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe InvitationsController do
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :index
 
     context "with a user who has prior invites" do
-      let(:user) { create :user_with_org }
+      let(:user) { create :user_with_membership }
       let!(:unaccepted_invite) { create :invited_user, invited_by: user }
       let!(:someone_elses_unaccepted_invite) { create :invited_user }
       let!(:accepted_invite) { create :accepted_invite_user, invited_by: user }

--- a/spec/factories/memberships.rb
+++ b/spec/factories/memberships.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: memberships
+#
+#  id              :bigint           not null, primary key
+#  role            :integer          default("member"), not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  user_id         :bigint           not null
+#  vita_partner_id :bigint           not null
+#
+# Indexes
+#
+#  index_memberships_on_user_id          (user_id)
+#  index_memberships_on_vita_partner_id  (vita_partner_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#  fk_rails_...  (vita_partner_id => vita_partners.id)
+#
+FactoryBot.define do
+  factory :membership do
+    vita_partner
+  end
+
+  factory :lead_membership, parent: :membership do
+    role { "lead" }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -68,8 +68,12 @@ FactoryBot.define do
       role { "agent" }
     end
 
-    factory :user_with_org do
-      vita_partner
+    factory :user_with_membership, parent: :user do |user|
+      memberships { build_list :membership, 1 }
+    end
+
+    factory :user_with_lead_membership, parent: :user do |user|
+      memberships { build_list :lead_membership, 1 }
     end
 
     factory :admin_user do
@@ -77,7 +81,7 @@ FactoryBot.define do
     end
 
     factory :invited_user do
-      association :invited_by, factory: :user_with_org
+      association :invited_by, factory: :user_with_membership
       invitation_created_at { 1.day.ago - 1.minute }
       invitation_sent_at { 1.day.ago }
       vita_partner { invited_by.vita_partner }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -84,7 +84,7 @@ FactoryBot.define do
       association :invited_by, factory: :user_with_membership
       invitation_created_at { 1.day.ago - 1.minute }
       invitation_sent_at { 1.day.ago }
-      vita_partner { invited_by.vita_partner }
+      memberships { [build(:membership, vita_partner: invited_by.memberships.first.vita_partner)] }
       sequence(:invitation_token) do |n|
         Devise.token_generator.digest(User, :invitation_token, "InvitationToken#{n}")
       end

--- a/spec/features/hub/add_sub_organization_spec.rb
+++ b/spec/features/hub/add_sub_organization_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Create a sub-organization" do
   context "as a non-admin user" do
     let(:vita_partner) { create :vita_partner, name: "Example Partner", display_name: "Example Partner" }
-    let(:current_user) { create :user, vita_partner: vita_partner }
+    let(:current_user) { create :user, memberships: [build(:membership, vita_partner: vita_partner)] }
     before { login_as current_user }
 
     scenario "create a sub-org of your own org" do

--- a/spec/features/hub/assignments_spec.rb
+++ b/spec/features/hub/assignments_spec.rb
@@ -2,15 +2,15 @@ require "rails_helper"
 
 RSpec.feature "Assign a user to a tax return" do
   context "As an authenticated user" do
-    let(:vita_partner) { create :vita_partner}
-    let(:logged_in_user) { create :user, vita_partner: vita_partner }
-    let!(:user_to_assign) { create :user, name: "Lucille 2", vita_partner: vita_partner }
+    let(:user) { create :user_with_membership }
+    let(:vita_partner) { user.memberships.first.vita_partner }
+    let!(:user_to_assign) { create :user, name: "Lucille 2", memberships: [build(:membership, vita_partner: vita_partner)] }
     let(:client) { create :client, vita_partner: vita_partner }
     let!(:intake) { create :intake, client: client }
     let!(:tax_return_to_assign) { create :tax_return, status: "intake_open", year: 2019, client: client }
 
     before do
-      login_as logged_in_user
+      login_as user
     end
 
     scenario "logged in user can assign another user to a tax return" do

--- a/spec/features/hub/authenticate_spec.rb
+++ b/spec/features/hub/authenticate_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Logging in and out to the volunteer portal" do
-  let!(:user) { create(:user_with_org, name: "German Geranium", email: "german@flowers.orange", password: "goodPassword", role: "agent") }
+  let!(:user) { create(:user_with_membership, name: "German Geranium", email: "german@flowers.orange", password: "goodPassword", role: "agent") }
 
   scenario "logging in and out" do
     # go to password-based sign in page

--- a/spec/features/hub/clients_sorting_and_filtering_spec.rb
+++ b/spec/features/hub/clients_sorting_and_filtering_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "sorting and filtering clients" do
   context "as an admin user" do
-    let(:user) { create :admin_user, vita_partner: create(:vita_partner) }
+    let(:user) { create :admin_user }
 
     before { login_as user }
 

--- a/spec/features/hub/documents_spec.rb
+++ b/spec/features/hub/documents_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.feature "View and edit documents for a client" do
   context "As an authenticated user" do
-    let(:vita_partner) { create :vita_partner }
-    let(:user) { create :user, vita_partner: vita_partner }
+    let(:user) { create :user_with_membership }
+    let(:vita_partner) { user.memberships.first.vita_partner }
     let(:client) { create :client, vita_partner: vita_partner, intake: create(:intake, preferred_name: "Bart Simpson") }
     let!(:document_1) { create :document, display_name: "ID.jpg", client: client, intake: client.intake }
     let!(:document_2) { create :document, display_name: "W-2.pdf", client: client, intake: client.intake }

--- a/spec/features/hub/edit_client_intake_spec.rb
+++ b/spec/features/hub/edit_client_intake_spec.rb
@@ -2,10 +2,10 @@ require "rails_helper"
 
 RSpec.describe "a user editing a clients intake fields" do
   context "as an admin user" do
-    let(:user) { create :admin_user, vita_partner: create(:vita_partner) }
+    let(:user) { create :admin_user }
     let(:client) {
       create :client,
-             vita_partner: user.vita_partner,
+             vita_partner: create(:vita_partner),
              intake: create(:intake, primary_first_name: "Colleen", primary_last_name: "Cauliflower", dependents: [
                create(:dependent, first_name: "Lara", last_name: "Legume", birth_date: "2007-03-06"),
              ])

--- a/spec/features/hub/edit_user_spec.rb
+++ b/spec/features/hub/edit_user_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe "a user editing a user" do
       let!(:denver_org) { create :vita_partner, parent_organization: colorado_org, name: "Denver", display_name: "Denver" }
       let!(:california_org) { create :vita_partner, name: "California", display_name: "California" }
       let!(:san_fran_org) { create :vita_partner, parent_organization: california_org, name: "San Francisco", display_name: "San Francisco" }
-      let(:current_user) { create :admin_user, vita_partner: colorado_org }
-      let(:user_to_edit) { create :user, vita_partner: colorado_org }
+      let(:current_user) { create :admin_user }
+      let(:user_to_edit) { create :user, memberships: [build(:membership, vita_partner: colorado_org)] }
       before { login_as current_user }
 
       scenario "update all fields" do
@@ -27,7 +27,14 @@ RSpec.describe "a user editing a user" do
           expect(page).to have_selector("option", text: "San Francisco")
         end
 
-        expect(find_field("user_vita_partner_id").value).to eq user_to_edit.vita_partner.id.to_s
+        expect(find_field("user_vita_partner_id").value).to eq colorado_org.id.to_s
+
+        select "California", from: "Organization"
+
+        click_on "Save"
+
+        expect(find_field("user_vita_partner_id").value).to eq california_org.id.to_s
+
 
         check "Admin"
 

--- a/spec/features/hub/edit_user_spec.rb
+++ b/spec/features/hub/edit_user_spec.rb
@@ -35,12 +35,7 @@ RSpec.describe "a user editing a user" do
 
         expect(find_field("user_vita_partner_id").value).to eq california_org.id.to_s
 
-
         check "Admin"
-
-        click_on "Select supported organizations"
-        check "Colorado"
-        check "Denver"
 
         click_on "Save"
         expect(page).to have_text "Changes saved"

--- a/spec/features/hub/invitations_spec.rb
+++ b/spec/features/hub/invitations_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.feature "Sending and accepting invitations" do
   context "As an authenticated user" do
-    let(:user) { create :user, role: "agent", vita_partner: vita_partner }
     let!(:vita_partner) { create :vita_partner, name: "Brassica Asset Builders" }
+    let(:user) { create :user, role: "agent", memberships: [build(:membership, vita_partner: vita_partner)] }
     before do
       login_as user
     end
@@ -69,7 +69,7 @@ RSpec.feature "Sending and accepting invitations" do
 
       expect(page).to have_text "You're all set and ready to go! You've joined an amazing team!"
       expect(page).to have_text "Colleen Cauliflower"
-      expect(page).to have_text "Agent"
+      expect(page).to have_text "Member"
       expect(page).to have_text "Brassica Asset Builders"
     end
   end

--- a/spec/features/hub/notes_spec.rb
+++ b/spec/features/hub/notes_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.feature "View and add internal notes for a client" do
   context "As an authenticated user" do
-    let(:vita_partner) { create :vita_partner }
-    let(:user) { create :user, vita_partner: vita_partner }
+    let(:user) { create :user_with_membership}
+    let(:vita_partner) { user.memberships.first.vita_partner }
     let(:client) { create :client, vita_partner: vita_partner, intake: create(:intake, preferred_name: "Bart Simpson") }
     before do
       login_as user

--- a/spec/features/hub/send_messages_spec.rb
+++ b/spec/features/hub/send_messages_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.feature "Read and send messages to a client", js: true do
   context "As an authenticated user" do
-    let(:vita_partner) { create :vita_partner }
-    let(:user) { create :user, vita_partner: vita_partner }
+    let(:user) { create :user_with_membership }
+    let(:vita_partner) { user.memberships.first.vita_partner }
     let(:client) do
       create(
         :client,

--- a/spec/features/hub/show_client_spec.rb
+++ b/spec/features/hub/show_client_spec.rb
@@ -47,8 +47,13 @@ RSpec.describe "a user viewing a client" do
 
   context "user without admin access" do
     let!(:client) { create :client, vita_partner: (create :vita_partner), intake: create(:intake, :with_contact_info) }
+    let!(:user) {
+      create :user, memberships: [
+        build(:membership, vita_partner_id: client.vita_partner_id),
+        build(:membership)
+      ]
+    }
 
-    let!(:user) { create :user, vita_partner_id: client.vita_partner_id }
     before { login_as user }
 
     scenario "can view and cannot update organization" do
@@ -60,10 +65,13 @@ RSpec.describe "a user viewing a client" do
     end
   end
 
-  skip "user without admin access, but is coalition lead for client organization" do
-    let(:user) { create :user, supported_organizations: [client.vita_partner, other_vita_partner] }
+  context "user without admin access, but is coalition lead for client organization" do
+    let(:user) { 
+      create :user, memberships: [
+      build(:membership, vita_partner: client.vita_partner, role: "lead"),
+      build(:membership, vita_partner: create(:vita_partner, name: "Tax Helpers"), role: "lead")
+    ] }
     let(:client) { create :client, vita_partner: (create :vita_partner), intake: create(:intake, :with_contact_info) }
-    let!(:other_vita_partner) { create :vita_partner }
     before { login_as user }
 
     scenario "can view and update client organization" do
@@ -74,10 +82,27 @@ RSpec.describe "a user viewing a client" do
       end
       expect(page.current_path).to eq edit_organization_hub_client_path(id: client.id)
       expect(page).to have_text "Edit Organization for #{client.preferred_name}"
-      select other_vita_partner.display_name, from: "Organization"
+      select "Tax Helpers", from: "Organization"
       click_on "Save"
       within ".client-header" do
-        expect(page).to have_text other_vita_partner.display_name
+        expect(page).to have_text "Tax Helpers"
+      end
+    end
+  end
+
+  context "user with only volunteer access to clients organization" do
+    let(:user) { 
+      create :user, memberships: [
+      build(:membership, vita_partner: client.vita_partner),
+    ] }
+    let(:client) { create :client, vita_partner: (create :vita_partner), intake: create(:intake, :with_contact_info) }
+    before { login_as user }
+
+    scenario "can view and update client organization" do
+      visit hub_client_path(id: client.id)
+      within ".client-header" do
+        expect(page).to have_text client.vita_partner.display_name
+        expect(page).not_to have_text "Edit"
       end
     end
   end

--- a/spec/features/hub/take_action_spec.rb
+++ b/spec/features/hub/take_action_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.feature "Change tax return status on a client" do
   context "As a beta tester" do
-    let(:vita_partner) { create :vita_partner }
-    let(:user) { create :user, name: "Example Preparer", vita_partner: vita_partner }
+    let(:user) { create :user_with_membership, name: "Example Preparer" }
+    let(:vita_partner) { user.memberships.first.vita_partner }
     let(:client) { create :client, vita_partner: vita_partner }
     let!(:intake) { create :intake, client: client, locale: "en", email_address: "client@example.com", phone_number: "+14155551212", sms_phone_number: "+14155551212", email_notification_opt_in: "yes", sms_notification_opt_in: "yes" }
     let!(:tax_return) { create :tax_return, year: 2019, client: client, status: "intake_in_progress" }

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -23,7 +23,7 @@ describe Ability do
   end
 
   context "a user and client without an organization" do
-    let(:user) { create(:user_with_org, vita_partner: nil) }
+    let(:user) { create(:user_with_membership, vita_partner: nil) }
     let(:client) { create(:client, vita_partner: nil) }
     let(:intake) { create(:intake, vita_partner: nil, client: client) }
 
@@ -41,19 +41,21 @@ describe Ability do
   end
 
   context "a user who is a member of a parent organization" do
-    let(:child_org) { create :vita_partner }
-    let(:parent_org) { create :vita_partner, sub_organizations: [child_org] }
-    let(:user) { create :user_with_org, vita_partner: parent_org }
-    let(:intake) { create(:intake, vita_partner: child_org, client: (create :client, vita_partner: child_org)) }
-    let(:client) { intake.client }
+    let!(:child_org) { create :vita_partner, parent_organization_id: parent_org.id, name: "Child Organization" }
+    let!(:parent_org) { create :vita_partner, name: "Parent Organization"}
+    let(:user) { create :user, memberships: [build(:membership, vita_partner: parent_org, role: "lead")] }
+    let(:managed_user) { create :user, memberships: [build(:membership, vita_partner: child_org)] }
+    let(:client) { create :client, vita_partner: child_org }
+    let(:intake) { create(:intake, vita_partner: child_org, client: client) }
 
     it "can manage data in child organizations" do
-      expect(subject.can?(:manage, client)).to eq true
+      expect(subject.can?(:crud, client)).to eq true
+      expect(subject.can?(:edit_organization, client)).to eq true
       expect(subject.can?(:manage, IncomingTextMessage.new(client: client))).to eq true
       expect(subject.can?(:manage, OutgoingTextMessage.new(client: client))).to eq true
       expect(subject.can?(:manage, OutgoingEmail.new(client: client))).to eq true
       expect(subject.can?(:manage, IncomingEmail.new(client: client))).to eq true
-      expect(subject.can?(:manage, User.new(vita_partner: child_org))).to eq true
+      expect(subject.can?(:manage, managed_user)).to eq true
       expect(subject.can?(:manage, Note.new(client: client))).to eq true
       expect(subject.can?(:manage, child_org)).to eq true
       expect(subject.can?(:manage, VitaPartner.new)).to eq false
@@ -62,39 +64,42 @@ describe Ability do
   end
 
   context "a user who is a member of an organization without child organizations" do
-    let(:user) { create :user_with_org, vita_partner: create(:vita_partner) }
-    let(:accessible_client) { create(:client, vita_partner: user.vita_partner) }
-    let(:accessible_intake) { create(:intake, vita_partner: user.vita_partner) }
+    let(:vita_partner) { create(:vita_partner) }
+    let(:user) { create :user, memberships: [build(:membership, role: "lead", vita_partner: vita_partner)] }
+    let(:managed_user) { create :user, memberships: [build(:membership, vita_partner: vita_partner)] }
+    let(:accessible_client) { create(:client, vita_partner: vita_partner) }
+    let(:accessible_intake) { create(:intake, vita_partner: vita_partner) }
     let(:other_vita_partner_client) { create(:client, vita_partner: create(:vita_partner)) }
     let(:nil_vita_partner_client) { create(:client, vita_partner: nil) }
 
     it "can manage data from their own organization" do
-      expect(subject.can?(:manage, accessible_client)).to eq true
+      expect(subject.can?(:crud, accessible_client)).to eq true
+      expect(subject.can?(:edit_organization, accessible_client)).to eq true
       expect(subject.can?(:manage, IncomingTextMessage.new(client: accessible_client))).to eq true
       expect(subject.can?(:manage, OutgoingTextMessage.new(client: accessible_client))).to eq true
       expect(subject.can?(:manage, OutgoingEmail.new(client: accessible_client))).to eq true
       expect(subject.can?(:manage, IncomingEmail.new(client: accessible_client))).to eq true
       expect(subject.can?(:manage, Document.new(client: accessible_client))).to eq true
-      expect(subject.can?(:manage, User.new(vita_partner: user.vita_partner))).to eq true
+      expect(subject.can?(:manage, managed_user)).to eq true
       expect(subject.can?(:manage, Note.new(client: accessible_client))).to eq true
       expect(subject.can?(:manage, SystemNote.new(client: accessible_client))).to eq true
-      expect(subject.can?(:manage, user.vita_partner)).to eq true
+      expect(subject.can?(:manage, vita_partner)).to eq true
     end
 
     it "cannot manage data which lack an organization" do
-      expect(subject.can?(:manage, nil_vita_partner_client)).to eq false
+      expect(subject.can?(:crud, nil_vita_partner_client)).to eq false
       expect(subject.can?(:manage, IncomingTextMessage.new(client: nil_vita_partner_client))).to eq false
       expect(subject.can?(:manage, OutgoingTextMessage.new(client: nil_vita_partner_client))).to eq false
       expect(subject.can?(:manage, OutgoingEmail.new(client: nil_vita_partner_client))).to eq false
       expect(subject.can?(:manage, IncomingEmail.new(client: nil_vita_partner_client))).to eq false
       expect(subject.can?(:manage, Document.new(client: nil_vita_partner_client))).to eq false
-      expect(subject.can?(:manage, User.new(vita_partner: nil))).to eq false
+      expect(subject.can?(:manage, User.new(memberships: []))).to eq false
       expect(subject.can?(:manage, Note.new(client: nil_vita_partner_client))).to eq false
       expect(subject.can?(:manage, SystemNote.new(client: nil_vita_partner_client))).to eq false
     end
 
     it "cannot manage data from another organization" do
-      expect(subject.can?(:manage, other_vita_partner_client)).to eq false
+      expect(subject.can?(:crud, other_vita_partner_client)).to eq false
       expect(subject.can?(:manage, IncomingTextMessage.new(client: other_vita_partner_client))).to eq false
       expect(subject.can?(:manage, OutgoingTextMessage.new(client: other_vita_partner_client))).to eq false
       expect(subject.can?(:manage, OutgoingEmail.new(client: other_vita_partner_client))).to eq false
@@ -103,24 +108,28 @@ describe Ability do
       expect(subject.can?(:manage, User.new(vita_partner: other_vita_partner_client.vita_partner))).to eq false
       expect(subject.can?(:manage, Note.new(client: other_vita_partner_client))).to eq false
       expect(subject.can?(:manage, SystemNote.new(client: other_vita_partner_client))).to eq false
-      expect(subject.can?(:manage, other_vita_partner_client.vita_partner)).to eq false
+      expect(subject.can?(:crud, other_vita_partner_client.vita_partner)).to eq false
     end
   end
 
   context "a coalition lead" do
     let(:coalition_member_organization) { create(:vita_partner) }
     let(:intake) { create(:intake, vita_partner: coalition_member_organization) }
-    let(:user) { create :user_with_org, vita_partner: create(:vita_partner), supported_organizations: [coalition_member_organization] }
+    let(:user) { create :user, memberships: [
+      build(:membership, vita_partner: create(:vita_partner), role: "lead"),
+      build(:membership, vita_partner: coalition_member_organization, role: "lead")
+    ] }
+    let(:managed_user) { create :user, memberships: [build(:membership, vita_partner: coalition_member_client.vita_partner)] }
     let(:coalition_member_client) { create(:client, intake: intake, vita_partner: coalition_member_organization) }
 
     it "can manage data from the coalition member organization" do
-      expect(subject.can?(:manage, coalition_member_client)).to eq true
+      expect(subject.can?(:crud, coalition_member_client)).to eq true
       expect(subject.can?(:manage, IncomingTextMessage.new(client: coalition_member_client))).to eq true
       expect(subject.can?(:manage, OutgoingTextMessage.new(client: coalition_member_client))).to eq true
       expect(subject.can?(:manage, OutgoingEmail.new(client: coalition_member_client))).to eq true
       expect(subject.can?(:manage, IncomingEmail.new(client: coalition_member_client))).to eq true
       expect(subject.can?(:manage, Document.new(client: coalition_member_client))).to eq true
-      expect(subject.can?(:manage, User.new(vita_partner: coalition_member_client.vita_partner))).to eq true
+      expect(subject.can?(:manage, managed_user)).to eq true
       expect(subject.can?(:manage, Note.new(client: coalition_member_client))).to eq true
       expect(subject.can?(:manage, SystemNote.new(client: coalition_member_client))).to eq true
     end
@@ -141,6 +150,7 @@ describe Ability do
       expect(subject.can?(:manage, Note.new(client: client))).to eq true
       expect(subject.can?(:manage, VitaPartner.new)).to eq true
       expect(subject.can?(:manage, SystemNote.new)).to eq true
+      expect(subject.can?(:edit_organization, client)).to eq true
     end
   end
 end

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -15,7 +15,7 @@ describe Ability do
       expect(subject.can?(:manage, OutgoingTextMessage.new(client: client))).to eq false
       expect(subject.can?(:manage, OutgoingEmail.new(client: client))).to eq false
       expect(subject.can?(:manage, IncomingEmail.new(client: client))).to eq false
-      expect(subject.can?(:manage, User.new(vita_partner: vita_partner))).to eq false
+      expect(subject.can?(:manage, User.new(memberships: [build(:membership, vita_partner: vita_partner)]))).to eq false
       expect(subject.can?(:manage, Note.new(client: client))).to eq false
       expect(subject.can?(:manage, VitaPartner.new)).to eq false
       expect(subject.can?(:manage, SystemNote.new)).to eq false
@@ -23,7 +23,7 @@ describe Ability do
   end
 
   context "a user and client without an organization" do
-    let(:user) { create(:user_with_membership, vita_partner: nil) }
+    let(:user) { create(:user) }
     let(:client) { create(:client, vita_partner: nil) }
     let(:intake) { create(:intake, vita_partner: nil, client: client) }
 
@@ -33,7 +33,7 @@ describe Ability do
       expect(subject.can?(:manage, OutgoingTextMessage.new(client: client))).to eq false
       expect(subject.can?(:manage, OutgoingEmail.new(client: client))).to eq false
       expect(subject.can?(:manage, IncomingEmail.new(client: client))).to eq false
-      expect(subject.can?(:manage, User.new(vita_partner: nil))).to eq false
+      expect(subject.can?(:manage, User.new)).to eq false
       expect(subject.can?(:manage, Note.new(client: client))).to eq false
       expect(subject.can?(:manage, VitaPartner.new)).to eq false
       expect(subject.can?(:manage, SystemNote.new)).to eq false
@@ -105,7 +105,7 @@ describe Ability do
       expect(subject.can?(:manage, OutgoingEmail.new(client: other_vita_partner_client))).to eq false
       expect(subject.can?(:manage, IncomingEmail.new(client: other_vita_partner_client))).to eq false
       expect(subject.can?(:manage, Document.new(client: other_vita_partner_client))).to eq false
-      expect(subject.can?(:manage, User.new(vita_partner: other_vita_partner_client.vita_partner))).to eq false
+      expect(subject.can?(:manage, User.new(memberships: [build(:membership, vita_partner: other_vita_partner_client.vita_partner)]))).to eq false
       expect(subject.can?(:manage, Note.new(client: other_vita_partner_client))).to eq false
       expect(subject.can?(:manage, SystemNote.new(client: other_vita_partner_client))).to eq false
       expect(subject.can?(:crud, other_vita_partner_client.vita_partner)).to eq false


### PR DESCRIPTION
Creates memberships model to keep track of a users role in relation to an org.

- Accessible organization ids now looks for relationship through memberships
- There is a data migration that will run on the "up" when we release to demo
- We can now limit certain functionality to people with lead role for the client's organization

OUT OF SCOPE:
- For this PR, we decided to shim the existing functionality on the update user page. "supported organizations" are now those for which you have lead roles, and most users have one primary relationship to an org as a member through the drop down. I have some ideas on how we can update this page to add new organizations with specific roles if thats something the user has permission to do, but it seemed out of scope for this PR AND we wanted to show that we could model the data the same on the front end even though there was a fairly significant change on the backend.

Co-authored-by: Shannon Byrne <sbyrne@codeforamerica.org>
Co-authored-by: Jenny Heath <jheath@codeforamerica.org>