### PR TITLE
Generate fake clients with tax returns for a user on demo only

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,10 @@ gem 'devise_invitable', '~> 2.0.0'
 gem 'cancancan'
 gem 'webpacker'
 
+group :demo, :development, :test do
+  gem 'factory_bot_rails' # added to demo for creating fake data
+end
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
@@ -65,7 +69,6 @@ group :development, :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '>= 2.15'
   gem 'webdrivers'
-  gem 'factory_bot_rails'
   gem 'rspec-rails'
   gem 'rails-controller-testing'
   gem 'pry-byebug'

--- a/app/lib/beta_test_data_generator.rb
+++ b/app/lib/beta_test_data_generator.rb
@@ -1,0 +1,98 @@
+# This is used by the beta_test_client factory to create fake clients on demo for beta testing
+
+class BetaTestDataGenerator
+  FIRST_NAMES = [
+    "Logan", "Justin", "Gabriel", "Jose", "Austin", "Kevin", "Elijah", "Caleb", "Robert", "Thomas", "Jordan",
+    "Cameron", "Jack", "Hunter", "Jackson", "Angel", "Isaiah", "Evan", "Isaac", "Luke", "Mason", "Jayden", "Jason", "Gavin",
+    "Aaron", "Connor", "Aiden", "Aidan", "Kyle", "Juan", "Charles", "Luis", "Adam", "Lucas", "Brian", "Eric", "Adrian",
+    "Nathaniel", "Sean", "Alex", "Carlos", "Bryan", "Ian", "Owen", "Jesus", "Landon", "Julian", "Chase", "Cole", "Diego",
+    "Jeremiah", "Steven", "Sebastian", "Xavier", "Timothy", "Carter", "Wyatt", "Brayden", "Blake", "Hayden", "Devin",
+    "Cody", "Richard", "Seth", "Dominic", "Jaden", "Antonio", "Miguel", "Liam", "Patrick", "Carson", "Jesse", "Tristan",
+    "Alejandro", "Henry", "Victor", "Trevor", "Bryce", "Jake", "Riley", "Colin", "Jared", "Jeremy", "Mark", "Caden",
+    "Garrett", "Parker", "Marcus", "Vincent", "Kaleb", "Kaden", "Brady", "Colton", "Kenneth", "Joel", "Oscar", "Josiah",
+    "Jorge", "Ashton", "Cooper", "Tanner", "Eduardo", "Paul", "Edward", "Ivan", "Preston", "Maxwell", "Alan", "Levi",
+    "Stephen", "Grant", "Nicolas", "Dakota", "Omar", "Alexis", "George", "Eli", "Collin", "Spencer", "Gage", "Max", "Ricardo",
+    "Cristian", "Derek", "Micah", "Brody", "Francisco", "Nolan", "Ayden", "Dalton", "Shane", "Peter", "Damian", "Jeffrey",
+    "Brendan", "Travis", "Fernando", "Peyton", "Conner", "Andres", "Javier", "Giovanni", "Shawn", "Braden", "Jonah",
+    "Bradley", "Cesar", "Emmanuel", "Manuel", "Edgar", "Mario", "Erik", "Edwin", "Johnathan", "Devon", "Erick", "Wesley",
+    "Oliver", "Trenton", "Hector", "Malachi", "Jalen", "Raymond", "Gregory", "Abraham", "Elias", "Leonardo", "Sergio",
+    "Donovan", "Colby", "Marco", "Bryson", "Martin", "Emily", "Madison", "Emma", "Olivia", "Hannah", "Abigail", "Isabella",
+    "Samantha", "Elizabeth", "Ashley", "Alexis", "Sarah", "Sophia", "Alyssa", "Grace", "Ava", "Taylor", "Brianna", "Lauren",
+    "Chloe", "Natalie", "Kayla", "Jessica", "Anna", "Victoria", "Mia", "Hailey", "Sydney", "Jasmine", "Julia", "Morgan",
+    "Destiny", "Rachel", "Ella", "Kaitlyn", "Megan", "Katherine", "Savannah", "Jennifer", "Alexandra", "Allison",
+    "Haley", "Maria", "Kaylee", "Lily", "Makayla", "Brooke", "Nicole", "Mackenzie", "Addison", "Stephanie", "Lillian",
+    "Andrea", "Faith", "Zoe", "Kimberly", "Madeline", "Alexa", "Katelyn", "Gabriella", "Gabrielle", "Trinity", "Amanda",
+    "Kylie", "Mary", "Paige", "Riley", "Leah", "Jenna", "Sara", "Rebecca", "Michelle", "Sofia", "Vanessa", "Jordan",
+    "Angelina", "Caroline", "Avery", "Audrey", "Evelyn", "Maya", "Claire", "Autumn", "Jocelyn", "Ariana", "Nevaeh",
+    "Arianna", "Jada", "Bailey", "Brooklyn", "Aaliyah", "Amber", "Isabel", "Mariah", "Danielle", "Melanie", "Sierra",
+    "Erin", "Amelia", "Molly", "Isabelle", "Madelyn", "Melissa", "Jacqueline", "Marissa", "Angela", "Shelby", "Leslie",
+    "Katie", "Jade", "Catherine", "Diana", "Aubrey", "Mya", "Amy", "Briana", "Sophie", "Gabriela", "Breanna", "Gianna",
+    "Kennedy", "Gracie", "Peyton", "Adriana", "Christina", "Courtney", "Daniela", "Lydia", "Kathryn", "Valeria", "Layla",
+    "Alexandria", "Natalia", "Angel", "Laura", "Charlotte", "Margaret", "Cheyenne", "Miranda", "Mikayla", "Naomi",
+    "Kelsey", "Payton", "Ana", "Alicia", "Jillian", "Daisy", "Ashlyn", "Sabrina", "Caitlin", "Summer",
+    "Ruby", "Rylee", "Valerie", "Skylar", "Lindsey", "Kelly", "Genesis", "Zoey", "Eva", "Sadie", "Alexia", "Cassidy",
+    "Kylee", "Kendall", "Jordyn", "Kate", "Jayla", "Karen", "Tiffany", "Cassandra", "Juliana", "Reagan", "Caitlyn",
+    "Giselle", "Serenity", "Alondra", "Lucy", "Bianca", "Kiara", "Crystal", "Erica", "Angelica", "Hope", "Chelsea",
+    "Alana", "Liliana", "Brittany", "Camila", "Makenzie", "Lilly", "Veronica", "Abby", "Jazmin", "Adrianna", "Delaney",
+    "Karina", "Ellie", "Jasmin"]
+
+  LAST_NAMES = [
+    "Alfalfa", "Apple", "Apricot", "Artichoke", "Asparagus", "Avocado", "Almond",
+    "Banana", "Bean", "Beans", "Beets", "Blackberry", "Blueberry", "Boysenberry", "Broccoli", "Basil",
+    "Cabbage", "Cantaloupe", "Carrots", "Cassava", "Cauliflower", "Celery", "Chayote", "Cherimoya", "Cherry", "Coconut", "Collards", "Corn", "Cranberry", "Cucumber",
+    "Date", "Dill", "Daikon", "Dandelion Greens", "Delicata", "Dragonfruit",
+    "Eggplant", "Escarole", "Endive", "Epazote",
+    "Fennel", "Fig", "Fenugreek",
+    "Garlic", "Gooseberry", "Grapefruit", "Grape", "Green Bean", "Green Onion", "Guava", "Galangal", "Ginger",
+    "Honeydew", "Habanero", "Hazelnut", "Hibiscus", "Horseradish",
+    "Ilama", "Imbé", "Icaco",
+    "Jicama", "Jujube", "Jalapeño", "Jitomate",
+    "Kale", "Kiwi", "Kohlrabi", "Kumquat",
+    "Leek", "Lemons", "Lettuce", "Lima Bean", "Lime", "Longan", "Loquat", "Lychee", "Lemongrass",
+    "Mandarin", "Mango", "Mulberry", "Mushroom", "Mangosteen", "Marjoram", "Maple", "Matcha", "Mustard", "Mustard-Greens", "Mint",
+    "Nectarines", "Nopales", "Nutmeg", "Nigella",
+    "Okra", "Onion", "Orange", "Oregano",
+    "Papaya", "Parsnip", "Passionfruit", "Peach", "Pear", "Pea", "Peas", "Pepper", "Persimmon", "Pineapple", "Plantain", "Plum", "Pomegranate", "Potato", "Prickly Pear", "Prune", "Pomelo", "Pumpkin", "Prickly Pear",
+    "Quince",
+    "Radicchio", "Radish", "Raisin", "Raspberry", "Rhubarb", "Romaine", "Rutabaga", "Rosemary",
+    "Shallot", "Snow-Pea", "Spinach", "Sprouts", "Squash", "Strawberry", "String Bean", "Sweet-Potato", "Serrano", "Sesame",
+    "Tangelo", "Tangerine", "Tomatillo", "Tomato", "Turnip", "Thyme", "Tea", "Tamarind",
+    "Ube", "Uva",
+    "Vidalia", "Verdolaga", "Vanilla",
+    "Water Chestnut", "Watercress", "Watermelon", "Waxed Bean", "Wasabi", "Walnut",
+    "Xocota", "Ximenia",
+    "Yam", "Yucca",
+    "Zucchini",
+  ]
+
+  STATUSES_AFTER_OPEN = TaxReturnStatus::STATUSES.select do |_, value|
+    value >= TaxReturnStatus::STATUSES[:intake_open]
+  end.keys.freeze
+
+  def self.get_name
+    first_name = FIRST_NAMES.sample
+    last_name = LAST_NAMES.select { |last| last[0] == first_name[0] }.sample
+    return [first_name, last_name]
+  end
+
+  def self.get_status_open_or_later
+
+  end
+
+  def self.make_clients_for_user(user, all_possible_assignees)
+    clients = FactoryBot.create_list :beta_test_client, rand(3..12), vita_partner: user.vita_partner
+    clients.each do |client|
+      client.tax_returns.each do |tax_return|
+        tax_return.status = STATUSES_AFTER_OPEN.sample
+        case rand(10)
+        when 0..4
+          tax_return.assigned_user = user
+        when 5
+          # assign to a random other user
+          tax_return.assigned_user = all_possible_assignees.order(Arel.sql("RANDOM()")).first
+        end
+        tax_return.save
+      end
+    end
+  end
+end

--- a/spec/factories/beta_test_clients.rb
+++ b/spec/factories/beta_test_clients.rb
@@ -1,0 +1,39 @@
+FactoryBot.define do
+  factory :beta_test_client, class: "Client" do
+    vita_partner { VitaPartner.where(name: "[United Way California] Online Intake").first }
+    after(:create) do |client|
+      first_name, last_name = BetaTestDataGenerator.get_name
+      is_married = ["yes", "no"].sample
+      intake = create(
+        :intake,
+        client: client,
+        email_address: "gyr-test-client+#{client.id}@codeforamerica.org",
+        phone_number: "+15005550006", # Valid Twilio number for testing https://www.twilio.com/docs/iam/test-credentials
+        sms_phone_number: "+15005550006",
+        preferred_name: "#{first_name} #{last_name}",
+        primary_first_name: first_name,
+        primary_last_name: last_name,
+        email_notification_opt_in: "yes",
+        sms_notification_opt_in: "no",
+        locale: ["en", "es"].sample,
+        preferred_interview_language: ["de", "en", "es", "fa", "fr", "ru", "zh"].sample,
+        married: is_married,
+        filing_joint: is_married == "yes" ? ["yes", "no"].sample : "no",
+        street_address: "972 Mission St.",
+        city: "San Francisco",
+        state: "CA",
+        zip_code: "94103",
+      )
+
+      create(:document, :with_upload, document_type: DocumentTypes::Identity, intake: intake, client: client)
+      create(:document, :with_upload, document_type: DocumentTypes::Selfie, intake: intake, client: client)
+      create(:document, :with_upload, document_type: DocumentTypes::SsnItin, intake: intake, client: client)
+
+      [2017, 2018, 2019, 2020].sample(rand(1..4)).each do |year|
+        create(:tax_return, year: year, client: client, status: "intake_open")
+      end
+    end
+  end
+end
+
+


### PR DESCRIPTION
Usage so far:

```ruby
# get a user
user = User.last

BetaTestDataGenerator.make_clients_for_user(user, all_possible_assignees: User.all)
```
This will make a bunch of clients, based on the criteria set out in the [pivotal tracker story](https://www.pivotaltracker.com/story/show/175487284).

This code is only intended to be run manually and rarely on demo. I've run it locally and reviewed results. But didn't think it made sense to write specs for it.