### PR TITLE
Delete a client and all associated records

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -62,4 +62,21 @@ class Client < ApplicationRecord
   def needs_response?
     response_needed_since.present?
   end
+
+  def destroy_completely
+    intake.ticket_statuses.destroy_all
+    intake.dependents.destroy_all
+    DocumentsRequest.where(intake: intake).destroy_all
+    documents.destroy_all
+    intake.documents.destroy_all
+    incoming_emails.destroy_all
+    incoming_text_messages.destroy_all
+    outgoing_emails.destroy_all
+    outgoing_text_messages.destroy_all
+    notes.destroy_all
+    system_notes.destroy_all
+    tax_returns.destroy_all
+    intake.destroy
+    destroy
+  end
 end


### PR DESCRIPTION
This adds a `Client#destroy_completely` method that will destroy a client and all associated records.

I know that it's possible to set up deletion conditions on the relationships (such as `cascade`, but I wasn't sure I wanted deletion to implicitly cascade if, for example, someone tried to delete an intake that still had a client and the system went ahead and deleted everything associated with the intake, but left all data associated with the client. 
My hope was that this reinforces the idea of the Client as the top-level record that is the only clear gate for deleting everything.

If others would prefer that we just add explicit `dependent: :destroy` or other explicit `dependent:` values on associations, I'd be happy to implement that as an alternative. Django raises an error if such things are left undefined or implicit, and requires all relationships to state what they will do in the case of a deletion.