### PR TITLE
Ensure clients are linked to VITA partners

### DIFF
--- a/app/controllers/questions/personal_info_controller.rb
+++ b/app/controllers/questions/personal_info_controller.rb
@@ -7,7 +7,10 @@ module Questions
     end
 
     def after_update_success
-      current_intake.assign_vita_partner! unless Client.after_consent.where(intake: current_intake).exists?
+      unless Client.after_consent.where(intake: current_intake).exists?
+        current_intake.assign_vita_partner!
+        current_intake.client.update(vita_partner: current_intake.vita_partner)
+      end
     end
   end
 end

--- a/spec/controllers/questions/personal_info_controller_spec.rb
+++ b/spec/controllers/questions/personal_info_controller_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Questions::PersonalInfoController do
         post :update, params: params
 
         expect(intake.reload.vita_partner).to eq vita_partner
+        expect(intake.client.vita_partner).to eq vita_partner
       end
     end
 
@@ -46,18 +47,21 @@ RSpec.describe Questions::PersonalInfoController do
         post :update, params: params
 
         expect(intake.reload.vita_partner).to eq vita_partner
+        expect(intake.client.vita_partner).to eq vita_partner
       end
     end
 
     context "when intake already has a return with 'In Progress' or later status" do
       let!(:old_vita_partner) { create :vita_partner }
-      let(:intake) { create :intake, vita_partner: old_vita_partner }
+      let(:client) { create :client, vita_partner: old_vita_partner }
+      let(:intake) { create :intake, vita_partner: old_vita_partner, client: client }
       before { create :tax_return, client: intake.client, status: "intake_in_progress" }
 
       it "does not re-assign the vita partner" do
         post :update, params: params
 
         expect(intake.reload.vita_partner).to eq old_vita_partner
+        expect(intake.client.vita_partner).to eq old_vita_partner
       end
     end
   end


### PR DESCRIPTION
I noticed that during the intake process, when we assign intakes to VITA partners, we don't yet link the client to the vita partner. All the code in Ability and elsewhere expects clients to be directly associated to a vita partner. This ensures we do it  during intake. 

I didn't want to interfere with the existing `assign_vita_partner!` method on intake because I think that method is overloaded and in need of refactor. I also didn't want to force that method to rely on the existence of a client record. So instead I kept the logic in the controller.