### PR TITLE
Remove document_bundle from drop off model

### DIFF
--- a/app/controllers/intake_site_drop_offs_controller.rb
+++ b/app/controllers/intake_site_drop_offs_controller.rb
@@ -81,7 +81,6 @@ class IntakeSiteDropOffsController < ApplicationController
       :state,
       :signature_method,
       :pickup_date_string,
-      :document_bundle,
       :certification_level,
       :hsa,
       :additional_info,

--- a/app/models/intake_site_drop_off.rb
+++ b/app/models/intake_site_drop_off.rb
@@ -108,7 +108,6 @@ class IntakeSiteDropOff < ApplicationRecord
   validates :phone_number, allow_blank: true, phone: true
   validate :has_valid_pickup_date?
 
-  has_one_attached :document_bundle
   belongs_to :prior_drop_off, class_name: self.name, optional: true
 
   def phone_number=(value)

--- a/app/models/intake_site_drop_off.rb
+++ b/app/models/intake_site_drop_off.rb
@@ -106,17 +106,10 @@ class IntakeSiteDropOff < ApplicationRecord
   validates :certification_level, allow_blank: true, inclusion: { in: CERTIFICATION_LEVELS }
   validates :email, allow_blank: true, 'valid_email_2/email': true
   validates :phone_number, allow_blank: true, phone: true
-  validate :has_document_bundle?
   validate :has_valid_pickup_date?
 
   has_one_attached :document_bundle
   belongs_to :prior_drop_off, class_name: self.name, optional: true
-
-  def has_document_bundle?
-    doc_is_attached = document_bundle.attached?
-    errors.add(:document_bundle, I18n.t("models.intake_site_drop_off.errors.choose_file")) unless doc_is_attached
-    doc_is_attached
-  end
 
   def phone_number=(value)
     if value.present? && value.is_a?(String)

--- a/app/views/intake_site_drop_offs/new.html.erb
+++ b/app/views/intake_site_drop_offs/new.html.erb
@@ -35,7 +35,6 @@
                                         classes: ["form-width--phone"]
                     }
                 ) %>
-            <%= f.cfa_file_field(:document_bundle, t("views.intake_site_drop_offs.new.document_bundle")) %>
             <%= f.cfa_select(:state, t("views.intake_site_drop_offs.new.state.label"), States.name_value_pairs, help_text: t("views.intake_site_drop_offs.new.state.help_text")) %>
             <%= f.cfa_radio_set(
                     :certification_level,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -441,7 +441,6 @@ en:
       your_spouse: Your spouse
     intake_site_drop_off:
       errors:
-        choose_file: Please choose a file.
         valid_pickup_date: Please enter a valid month and day (M/D).
   signups:
     flash_notice: Thank you! You will receive a notification when we open in January 2021.
@@ -658,7 +657,6 @@ en:
       new:
         additional_info: Additional information
         certification_level: Certification level
-        document_bundle: Documents bundle
         email: Client email
         hsa: HSA
         intake_site: Intake Site

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -441,7 +441,6 @@ es:
       your_spouse: Su cónyuge
     intake_site_drop_off:
       errors:
-        choose_file: Por favor, elija un archivo.
         valid_pickup_date: Por favor, introduzca un mes y día válido (M/D).
   signups:
     flash_notice: "¡Gracias! Recibirá una notificación cuando abramos en enero de 2021."
@@ -658,7 +657,6 @@ es:
       new:
         additional_info: Información adicional
         certification_level: Nivel de certificación
-        document_bundle: Paquete de documentos
         email: Correo electrónico del cliente
         hsa: HSA (cuenta de ahorros para gastos médicos)
         intake_site: Sitio de admisión

--- a/spec/controllers/intake_site_drop_offs_controller_spec.rb
+++ b/spec/controllers/intake_site_drop_offs_controller_spec.rb
@@ -101,7 +101,6 @@ RSpec.describe IntakeSiteDropOffsController do
               certification_level: "Advanced",
               hsa: "1",
               additional_info: "Needs to double check if they have another W-2",
-              document_bundle: fixture_file_upload("attachments/document_bundle.pdf"),
               timezone: "America/Juneau",
             }
           }
@@ -125,7 +124,6 @@ RSpec.describe IntakeSiteDropOffsController do
           expect(drop_off.certification_level).to eq "Advanced"
           expect(drop_off.hsa).to eq true
           expect(drop_off.additional_info).to eq "Needs to double check if they have another W-2"
-          expect(drop_off.document_bundle).to be_attached
           expect(drop_off.timezone).to eq "America/Juneau"
 
           expect(response).to redirect_to show_drop_off_path(id: drop_off.id, organization: "thc")
@@ -251,7 +249,7 @@ RSpec.describe IntakeSiteDropOffsController do
           }.not_to change(IntakeSiteDropOff, :count)
 
           expect(assigns(:drop_off)).not_to be_valid
-          expect(assigns(:drop_off).errors).to include(:document_bundle)
+          expect(assigns(:drop_off).errors).to include(:phone_number)
           expect(response).to render_template(:new)
         end
 
@@ -262,7 +260,6 @@ RSpec.describe IntakeSiteDropOffsController do
             organization: "thc",
             intake_site: "Denver Main Library",
             state: nil,
-            invalid_document_bundle: true,
             invalid_signature_method: true,
             invalid_phone_number: true,
             invalid_intake_site: true,

--- a/spec/factories/intake_site_drop_offs.rb
+++ b/spec/factories/intake_site_drop_offs.rb
@@ -36,7 +36,6 @@ FactoryBot.define do
     organization { "thc" }
     state { "CO" }
     signature_method { :e_signature }
-    document_bundle { Rack::Test::UploadedFile.new("spec/fixtures/attachments/document_bundle.pdf", "application/pdf") }
 
     trait :optional_fields do
       email { "gguava@example.com" }

--- a/spec/features/new_in_person_intake_spec.rb
+++ b/spec/features/new_in_person_intake_spec.rb
@@ -15,7 +15,6 @@ RSpec.feature "Add a new intake case from an in-person drop-off site" do
     choose "In-person"
     expect(page).to have_text "M/D"
     fill_in "Pick-up date", with: "2/20"
-    attach_file("Documents bundle", "spec/fixtures/attachments/document_bundle.pdf")
     choose "Advanced"
     check "HSA"
     fill_in "Additional information", with: "Needs to double check if they have another W-2"
@@ -44,7 +43,6 @@ RSpec.feature "Add a new intake case from an in-person drop-off site" do
     choose "In-person"
     expect(page).to have_text "M/D"
     fill_in "Pick-up date", with: "2/20"
-    attach_file("Documents bundle", "spec/fixtures/attachments/document_bundle.pdf")
     fill_in "Additional information", with: "Needs to double check if they have another W-2"
 
     click_on "Send for prep"

--- a/spec/models/intake_site_drop_off_spec.rb
+++ b/spec/models/intake_site_drop_off_spec.rb
@@ -58,10 +58,8 @@ describe IntakeSiteDropOff do
       expect(invalid_drop_off.errors).to include(:name)
       expect(invalid_drop_off.errors).to include(:intake_site)
       expect(invalid_drop_off.errors).to include(:signature_method)
-      expect(invalid_drop_off.errors).to include(:document_bundle)
       expect(invalid_drop_off.errors).to include(:organization)
       expect(invalid_drop_off.errors).to include(:state)
-      expect(invalid_drop_off.errors.messages[:document_bundle]).to include "Please choose a file."
     end
 
     describe "#signature_method" do
@@ -142,16 +140,6 @@ describe IntakeSiteDropOff do
 
         expect(drop_off.error_summary).to eq "Errors: Please enter a valid phone number. Please enter a valid month and day (M/D)."
       end
-    end
-  end
-
-
-  describe "#document_bundle" do
-    it "can attach a document bundle" do
-      drop_off.save
-      drop_off.document_bundle.attach(io: File.open('spec/fixtures/attachments/document_bundle.pdf'), filename: 'document_bundle.pdf')
-
-      expect(drop_off.document_bundle).to be_an_instance_of(ActiveStorage::Attached::One)
     end
   end
 


### PR DESCRIPTION
While working on [Manually add client](https://www.pivotaltracker.com/story/show/175466221), @jenny-heath and I noticed that we don't need `document_bundle` on drop-offs anymore, since we'll be creating `Document` records. This removes the property and related validation & tests.