### PR TITLE
Upload multiple files for a client

### DIFF
--- a/app/controllers/hub/documents_controller.rb
+++ b/app/controllers/hub/documents_controller.rb
@@ -13,6 +13,7 @@ module Hub
       @sort_order = sort_order
       @sort_column = sort_column
       @documents = @documents.except(:order).order({ @sort_column => @sort_order })
+      @document = Document.new # used for form to upload documents
     end
 
     def show
@@ -20,6 +21,18 @@ module Hub
     end
 
     def edit; end
+
+    def create
+      document_params[:upload].each do |file_upload|
+        Document.create!(
+          client: @client,
+          intake: @client.intake,
+          document_type: DocumentTypes::Other,
+          upload: file_upload
+        )
+      end
+      redirect_to(hub_client_documents_path(client_id: @client))
+    end
 
     def update
       @form = Hub::DocumentForm.new(@document, document_params)
@@ -35,7 +48,7 @@ module Hub
     private
 
     def document_params
-      params.require(:document).permit(:display_name)
+      params.require(:document).permit(:display_name, upload: [])
     end
 
     def sort_column

--- a/app/views/hub/documents/index.html.erb
+++ b/app/views/hub/documents/index.html.erb
@@ -40,5 +40,38 @@
     </tbody>
   </table>
 
+  <%= form_with model: @document, url: [:hub, @client, :documents], local: true, method: "post", builder: VitaMinFormBuilder, id: "file-upload-form" do |f| %>
+    <div class="document-upload">
+      <div class="file-upload">
+        <%= f.file_field(:upload, multiple: "multiple", class: "form__documentuploader file-input", data: { "upload-immediately" => true}) %>
+        <%= f.label(:upload, class: "button button--wide button--icon js-only", style: "display: none !important;") do %>
+          <span class="is-tablet-hidden--inline">
+            <%= image_tag "upload.svg", alt: "" %>
+            <%=t("general.select_files") %>
+          </span>
+          <span class="is-desktop-hidden--inline">
+            <%= image_tag "camera.svg", alt: "" %>
+            <%=t("general.take_picture") %>
+          </span>
+        <% end %>
+      </div>
+    </div>
+
+    <% if @document.errors[:upload].any? %>
+      <div class="form-group form-group--error">
+        <% @document.errors.values.flatten.each do |error_message| %>
+          <p class="text--error"><i class="icon-warning"></i>
+            <%= error_message %>
+          </p>
+        <% end %>
+      </div>
+    <% end %>
+
+    <%= f.button class: "button button--primary button--wide" do %>
+      <%=t("general.upload") %>
+    <% end %>
+  <% end %>
+
+
   <%= render "hub/clients/client_take_action_footer" %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -438,6 +438,8 @@ en:
       basic: "BAS"
     hsa: "HSA"
     drop_off: Drop Off
+    select_files: Select files
+    take_picture: Take picture
   helpers:
     birth_date_helper:
       valid_birth_date: Please select a valid date

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -438,6 +438,8 @@ es:
       basic: "BAS"
     hsa: "HSA"
     drop_off: Entrega
+    select_files: Seleccionar archivos
+    take_picture: Sacar foto
   helpers:
     birth_date_helper:
       valid_birth_date: Por favor, seleccione una fecha válida

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -118,7 +118,7 @@ Rails.application.routes.draw do
       resources :clients, only: [:index, :show, :create, :edit, :update] do
         get "/organization", to: "clients/organizations#edit", on: :member, as: :edit_organization
         patch "/organization", to: "clients/organizations#update", on: :member, as: :organization
-        resources :documents, only: [:index, :edit, :update, :show]
+        resources :documents, only: [:index, :edit, :update, :show, :create]
         resources :notes, only: [:create, :index]
         resources :messages, only: [:index]
         resources :outgoing_text_messages, only: [:create]

--- a/spec/features/hub/documents_spec.rb
+++ b/spec/features/hub/documents_spec.rb
@@ -47,5 +47,18 @@ RSpec.feature "View and edit documents for a client" do
 
       expect(page).to have_selector("#document_display_name__errors", text: "Can't be blank.")
     end
+
+    scenario "uploading a document to a client's documents page" do
+      visit hub_client_documents_path(client_id: client.id)
+
+      attach_file "document_upload", [
+        Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"),
+        Rails.root.join("spec", "fixtures", "attachments", "document_bundle.pdf"),
+      ]
+      click_on "Upload"
+
+      expect(page).to have_content("test-pattern.png")
+      expect(page).to have_content("document_bundle.pdf")
+    end
   end
 end


### PR DESCRIPTION
This completes the story: [Upload documents in the Documents tab](https://www.pivotaltracker.com/story/show/175675757)

A logged in user on the documents tab can upload new documents to the list of client documents

![Screen Shot 2020-12-01 at 3 22 13 PM](https://user-images.githubusercontent.com/451510/100808442-063d2880-33e9-11eb-852a-b96ce0beffe1.png)
