### PR TITLE
Spike: Search Client Index

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ gem 'mailgun-ruby', '~>1.1.6'
 gem 'devise_invitable', '~> 2.0.0'
 gem 'cancancan'
 gem 'webpacker'
+gem 'pg_search'
 
 group :demo, :development, :test do
   gem 'factory_bot_rails' # added to demo for creating fake data

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,6 +283,9 @@ GEM
       cliver (~> 0.3.2)
       safe_shell (>= 1.0.3, < 2.0)
     pg (1.2.3)
+    pg_search (2.3.5)
+      activerecord (>= 5.2)
+      activesupport (>= 5.2)
     phonelib (0.6.45)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -527,6 +530,7 @@ DEPENDENCIES
   nokogiri (>= 1.10.8)
   pdf-forms
   pg
+  pg_search
   phonelib
   pry-byebug
   puma (>= 4.3.5)

--- a/app/controllers/concerns/client_sortable.rb
+++ b/app/controllers/concerns/client_sortable.rb
@@ -4,6 +4,7 @@ module ClientSortable
     @sort_column = clients_sort_column
     @sort_order = clients_sort_order
     @filters = {
+        search: params[:search],
         status: status_filter,
         stage: stage_filter,
         assigned_to_me: params[:assigned_to_me],
@@ -21,6 +22,10 @@ module ClientSortable
     clients = clients.where(tax_returns: { assigned_user: limited_user_ids }) unless limited_user_ids.empty?
     clients = clients.where(tax_returns: { year: @filters[:year] }) if @filters[:year].present?
     clients = clients.where(tax_returns: { status: @filters[:status] }) if @filters[:status].present?
+    if @filters[:search].present?
+      # I didn't want to search the entire Intake table, so I limited it to the intakes for these clients
+      clients = clients.where(intake: Intake.where(client: clients).search(@filters[:search]))
+    end
     clients
   end
 
@@ -28,6 +33,7 @@ module ClientSortable
 
   # reset the raw parameters for each filter received by the form
   def reset_filter_params
+    params[:search] = nil
     params[:status] = nil
     params[:unassigned] = nil
     params[:assigned_to_me] = nil

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -199,8 +199,12 @@ class Intake < ApplicationRecord
   # afterwards.
   # We could add other custom search scopes, such as :search_messages, that could search the bodies of multiple message models.
   pg_search_scope :search, against: [
-    :preferred_name, :primary_first_name, :primary_last_name, :email_address, :phone_number, :sms_phone_number
-  ]
+    :id, :preferred_name, :primary_first_name, :primary_last_name, :email_address, :phone_number, :sms_phone_number
+  ], using: {
+      tsearch: {
+          prefix: true
+      }
+  }
 
   has_many :users, foreign_key: "intake_id", class_name: "IdmeUser"
   has_many :documents

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -193,6 +193,14 @@
 
 class Intake < ApplicationRecord
   include InteractionTracking
+  include PgSearch::Model
+  # we can add custom search scopes. the symbol given (:search in this case), adds a .search method to the model class
+  # works like a scope we can append to any existing query. It should also return a query we can combine with other scopes
+  # afterwards.
+  # We could add other custom search scopes, such as :search_messages, that could search the bodies of multiple message models.
+  pg_search_scope :search, against: [
+    :preferred_name, :primary_first_name, :primary_last_name, :email_address, :phone_number, :sms_phone_number
+  ]
 
   has_many :users, foreign_key: "intake_id", class_name: "IdmeUser"
   has_many :documents

--- a/app/views/shared/_client_filters.erb
+++ b/app/views/shared/_client_filters.erb
@@ -1,5 +1,14 @@
 <div class="client-filters">
   <%= form_with method: "get", local: true, builder: VitaMinFormBuilder, id: "filter-form" do |f| %>
+    <div class="vita-min-searchbar form-group" role="search">
+      <div class="">
+        <label for="search"><%= t("general.search") %></label>
+        <div>
+          <%= text_field_tag("search", params[:search], id: "search", class: "text-input") %>
+        </div>
+      </div>
+    </div>
+
     <h3>Filters</h3>
     <hr/>
     <div class="filters-wrapper">


### PR DESCRIPTION
This is a spike for _[Add search to client list](https://www.pivotaltracker.com/story/show/175608224)_ that adds just enough to enable a functioning search on:
- preferred_name
- primary_first_name
- primary_last_name
- email_address
- phone_number
- sms_phone_number

It should combine with filters (and doesn't run the search until after scoping down with filters).

It uses the [pg_search](https://github.com/casecommons/pg_search) gem, which was pretty easy to get set up and running, and also can later be enhanced with more complex search indices (fuzzy search, natural language, scoring systems, full text) if we need to further optimize our search functionality.

You can test this out by grabbing the branch, running `bundle`, and then opening the `rails c` console and running
```ruby
FactoryBot.create_list(:beta_test_client, 200)
```

This will give you a list of 200 randomly generate clients that you can search through.

![Kapture 2020-12-01 at 17 44 26](https://user-images.githubusercontent.com/451510/100817390-f0d1f980-33fc-11eb-839b-22a3ebf3e7f3.gif)


### More Background

A quick search gave me [a Thoughtbot article about optimizing full text search in Rails](https://thoughtbot.com/blog/optimizing-full-text-search-with-postgres-tsvector-columns-and-triggers). The article is focused on using tsvector lexemes for optimizing searches of large text columns, which is not something I think we need right now. However, it starts with the use of [a gem called **`pg_search`**](https://github.com/Casecommons/pg_search), which appears to be heavily used and very actively maintained by CaseCommons, _company that maintains a big case management system_.

Other relevant articles:
- [pg_search: How I Learned to Stop Worrying and Love PostgreSQL full-text search](https://tanzu.vmware.com/content/blog/pg-search-how-i-learned-to-stop-worrying-and-love-postgresql-full-text-search). An article about how easy it was to add full text search for a child-welfare-focused web application used by governments and non-profit organizations. Makes the point that PostgreSQL now supports full text search indexing, so there's no need to maintain searching indices with external tools. Uses pg_search.
- [Implementing Full-Text Search in Rails with Postgres](https://www.viget.com/articles/implementing-full-text-search-in-rails-with-postgres/) a short simple example that uses pg_search
- [Implementing Multi-Table Full Text Search with Postgres in Rails](https://thoughtbot.com/blog/implementing-multi-table-full-text-search-with-postgres). Explains the use of the [Textacular gem](https://github.com/textacular/textacular) to search text across multiple models at the same time (for example, if we wanted to search the content of all messages).
- [Simple Full Text Search in Rails](https://dev.to/johnsalzarulo/simple-full-text-search-in-rails-l7n). Shows an example of relying on a simple `LIKE %` query text search, without adding any dependencies.
- [Optimizing Full Text Search with Postgres tsvector Columns and Triggers](https://thoughtbot.com/blog/optimizing-full-text-search-with-postgres-tsvector-columns-and-triggers) mentions pg_search and using tsvector lexemes for optimization.