### PR TITLE
SQL script to copy anonymized data

### DIFF
--- a/db/copy_anonymized_data.md
+++ b/db/copy_anonymized_data.md
@@ -1,0 +1,26 @@
+# Overview
+The included script
+1. Creates an `anon` schema to house the anonymized data separately from "production"
+   data, which lives in the `public` schema
+1. Copies of certain tables (including data) from the `public` schema to the `anon` schema
+1. Replaces personally identifiable information (PII) with anonymized values
+
+## Running the script
+1. Open ssh tunnel to the Aptible database. For example, `demo`:
+    ```shell
+    aptible db:tunnel vita-min-demo --type postgresql
+    ```
+1. Run the SQL script against the desired database. For example, `demo`:
+    ```shell
+    aptible db:execute vita-min-demo db/copy_anonymized_data.sql
+    ```
+1. Verify the data:
+    ```postgresql
+    -- Confirm that the "anon" schema is created
+    select schema_name from information_schema.schemata where schema_name = 'anon';
+
+    -- Confirm that the expected tables appear in the "anon" schema
+    select table_name from information_schema.tables where table_schema = 'anon';
+
+   -- Run some "select" queries against the data in the above tables to verify that everything appears as expected.
+    ```

--- a/db/copy_anonymized_data.sql
+++ b/db/copy_anonymized_data.sql
@@ -1,0 +1,62 @@
+create schema if not exists anon;
+
+-- intake_site_drop_offs
+drop table if exists anon.intake_site_drop_offs;
+create table anon.intake_site_drop_offs as (select * from intake_site_drop_offs);
+update anon.intake_site_drop_offs set additional_info = 'ANONYMIZED';
+update anon.intake_site_drop_offs set name = 'ANONYMIZED';
+update anon.intake_site_drop_offs set phone_number = 'ANONYMIZED';
+update anon.intake_site_drop_offs set email = 'ANONYMIZED';
+
+-- diy_intakes
+drop table if exists anon.diy_intakes;
+create table anon.diy_intakes as (select * from diy_intakes);
+update anon.diy_intakes set email_address = 'ANONYMIZED';
+update anon.diy_intakes set preferred_name = 'ANONYMIZED';
+
+-- dependents
+drop table if exists anon.dependents;
+create table anon.dependents as (select * from dependents);
+-- Anonymize birthday day and month
+update anon.dependents set birth_date = to_date(concat('1/1/', extract(year from birth_date)), 'MM/DD/YYYY');
+update anon.dependents set first_name = 'ANONYMIZED';
+update anon.dependents set last_name = 'ANONYMIZED';
+
+-- intakes
+drop table if exists anon.intakes;
+create table anon.intakes as (select * from intakes);
+update anon.intakes set additional_info = 'ANONYMIZED';
+update anon.intakes set email_address = 'ANONYMIZED';
+update anon.intakes set encrypted_bank_account_number = 'ANONYMIZED';
+update anon.intakes set encrypted_bank_account_number_iv = 'ANONYMIZED';
+update anon.intakes set encrypted_bank_name = 'ANONYMIZED';
+update anon.intakes set encrypted_bank_name_iv = 'ANONYMIZED';
+update anon.intakes set encrypted_bank_routing_number = 'ANONYMIZED';
+update anon.intakes set encrypted_bank_routing_number_iv = 'ANONYMIZED';
+update anon.intakes set encrypted_primary_last_four_ssn = 'ANONYMIZED';
+update anon.intakes set encrypted_primary_last_four_ssn_iv = 'ANONYMIZED';
+update anon.intakes set encrypted_spouse_last_four_ssn = 'ANONYMIZED';
+update anon.intakes set encrypted_spouse_last_four_ssn_iv = 'ANONYMIZED';
+update anon.intakes set feedback = 'ANONYMIZED';
+update anon.intakes set final_info = 'ANONYMIZED';
+update anon.intakes set interview_timing_preference = 'ANONYMIZED';
+update anon.intakes set other_income_types = 'ANONYMIZED';
+update anon.intakes set phone_number = 'ANONYMIZED';
+update anon.intakes set preferred_name = 'ANONYMIZED';
+update anon.intakes set primary_birth_date = to_date(concat('1/1/', extract(year from primary_birth_date)), 'MM/DD/YYYY');
+update anon.intakes set primary_consented_to_service_ip = '127.0.0.1';
+update anon.intakes set primary_first_name = 'ANONYMIZED';
+update anon.intakes set primary_last_name = 'ANONYMIZED';
+update anon.intakes set sms_phone_number = 'ANONYMIZED';
+update anon.intakes set spouse_birth_date = to_date(concat('1/1/', extract(year from spouse_birth_date)), 'MM/DD/YYYY');
+update anon.intakes set spouse_consented_to_service_ip = '127.0.0.1';
+update anon.intakes set spouse_email_address = 'ANONYMIZED';
+update anon.intakes set spouse_first_name = 'ANONYMIZED';
+update anon.intakes set spouse_last_name = 'ANONYMIZED';
+update anon.intakes set street_address = 'ANONYMIZED';
+update anon.intakes set zip_code = 'ANONYMIZED';
+
+-- documents
+drop table if exists anon.documents;
+create table anon.documents as (select * from documents);
+update anon.documents set display_name = 'ANONYMIZED';


### PR DESCRIPTION
The included script
1. Creates an `anon` schema to house the anonymized data separately from "production"
   data, which lives in the `public` schema
1. Copies of certain tables (including data) from the `public` schema to the `anon` schema
1. Replaces personally identifiable information (PII) with anonymized values

Rest of the documentation can be found in [the readme](https://github.com/codeforamerica/vita-min/blob/b4b8a79f603597483fecf73c214bd2c0f6177d04/db/copy_anonymized_data.md).