### PR TITLE
Stub pdf creation for intakes except when explicitly testing pdf creation [#175675390]

### DIFF
--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -1320,6 +1320,8 @@ describe Intake do
     before do
       example_pdf = Tempfile.new("example.pdf")
       example_pdf.write("example pdf contents")
+      allow(intake).to receive(:create_original_13614c_document).and_call_original
+
       allow(intake).to receive(:pdf).and_return(example_pdf)
     end
     it "should create a new document pdf of original 13614-C answers" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -92,6 +92,8 @@ RSpec.configure do |config|
     # Stub required credentials to prevent need for RAILS_MASTER_KEY in test
     allow(EnvironmentCredentials).to receive(:dig).and_call_original
     allow(EnvironmentCredentials).to receive(:dig).with(:db_encryption_key).and_return('any-32-character-string-here!!!!')
+
+    allow_any_instance_of(Intake).to receive(:create_original_13614c_document)
   end
 
 end


### PR DESCRIPTION
clients_controller_spec before: 
<img width="423" alt="Screen Shot 2020-12-07 at 1 11 26 PM" src="https://user-images.githubusercontent.com/4494389/101396102-7982e680-3890-11eb-8a41-30f82c41f7e1.png">

clients_controller_spec after:
<img width="415" alt="Screen Shot 2020-12-07 at 1 11 49 PM" src="https://user-images.githubusercontent.com/4494389/101396105-7a1b7d00-3890-11eb-8082-9b5d7360ce19.png">
