### PR TITLE
Require upload on all Documents [#175366339]

### DIFF
--- a/app/controllers/twilio_webhooks_controller.rb
+++ b/app/controllers/twilio_webhooks_controller.rb
@@ -29,16 +29,15 @@ class TwilioWebhooksController < ActionController::Base
 
     attachments = TwilioService.new(params).parse_attachments
     attachments.each do |attachment|
-      document = client.documents.create!(
-          document_type: DocumentTypes::TextMessageAttachment.key,
-          contact_record: contact_record
-      )
-
-      document.upload.attach(
+      client.documents.create!(
+        document_type: DocumentTypes::TextMessageAttachment.key,
+        contact_record: contact_record,
+        upload: {
           io: StringIO.new(attachment[:body]),
           filename: attachment[:filename],
           content_type: attachment[:content_type],
           identify: false
+        }
       )
     end
 

--- a/app/forms/additional_documents_form.rb
+++ b/app/forms/additional_documents_form.rb
@@ -4,8 +4,7 @@ class AdditionalDocumentsForm < QuestionsForm
   def save
     document_file_upload = attributes_for(:intake)[:document]
     if document_file_upload.present?
-      document = @intake.documents.create(document_type: "Other")
-      document.upload.attach(document_file_upload)
+      @intake.documents.create(document_type: "Other", upload: document_file_upload)
     end
   end
 end

--- a/app/forms/childcare_statements_form.rb
+++ b/app/forms/childcare_statements_form.rb
@@ -5,7 +5,6 @@ class FormChildcareStatementsForm < QuestionsForm
     document_file_upload = attributes_for(:intake)[:document]
     return unless document_file_upload.present?
 
-    document = @intake.documents.create(document_type: "childcare_statement")
-    document.upload.attach(document_file_upload)
+    @intake.documents.create(document_type: "childcare_statement", upload: document_file_upload)
   end
 end

--- a/app/forms/document_type_upload_form.rb
+++ b/app/forms/document_type_upload_form.rb
@@ -10,8 +10,7 @@ class DocumentTypeUploadForm < QuestionsForm
   def save
     document_file_upload = attributes_for(:intake)[:document]
     if document_file_upload.present?
-      document = @intake.documents.create(document_type: @document_type, client: @intake.client)
-      document.upload.attach(document_file_upload)
+      @intake.documents.create(document_type: @document_type, client: @intake.client, upload: document_file_upload)
     end
   end
 end

--- a/app/forms/requested_document_upload_form.rb
+++ b/app/forms/requested_document_upload_form.rb
@@ -10,12 +10,12 @@ class RequestedDocumentUploadForm < QuestionsForm
   def save
     document_file_upload = attributes_for(:documents_request)[:document]
     if document_file_upload.present?
-      document = @documents_request.documents.create(
+      @documents_request.documents.create(
         document_type: "Requested Later",
         intake_id: @documents_request.intake.id,
-        client_id: @documents_request.intake.client_id
+        client_id: @documents_request.intake.client_id,
+        upload: document_file_upload,
       )
-      document.upload.attach(document_file_upload)
     end
   end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -42,6 +42,7 @@ class Document < ApplicationRecord
   belongs_to :documents_request, optional: true
   belongs_to :contact_record, polymorphic: true, optional: true
   has_one_attached :upload
+  validates :upload, presence: true
 
   before_save :set_display_name
 
@@ -56,10 +57,6 @@ class Document < ApplicationRecord
   def set_display_name
     return if display_name
 
-    if upload.present?
-      self.display_name = upload.attachment.filename
-    else
-      self.display_name = "Untitled"
-    end
+    self.display_name = upload.attachment.filename
   end
 end

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -611,15 +611,14 @@ class Intake < ApplicationRecord
   private
 
   def create_original_13614c_document
-    pdf_doc = client.documents.create!(document_type: DocumentTypes::Original13614C.key, intake: self)
     pdf_tempfile = pdf
     pdf_tempfile.seek(0)
-    pdf_doc.upload.attach(
+    client.documents.create!(document_type: DocumentTypes::Original13614C.key, intake: self, upload: {
       io: pdf_tempfile,
       filename: "Original 13614-C.pdf",
       content_type: "application/pdf",
       identify: false
-    )
+    })
   end
 
   def partner_for_eip_only

--- a/spec/controllers/documents/additional_documents_controller_spec.rb
+++ b/spec/controllers/documents/additional_documents_controller_spec.rb
@@ -48,8 +48,8 @@ RSpec.describe Documents::AdditionalDocumentsController do
 
     context "with existing document uploads" do
       it "assigns the documents to the form" do
-        doc = create :document, :with_upload, document_type: "Other", intake: intake
-        w2_doc = create :document, :with_upload, document_type: "Employment", intake: intake
+        doc = create :document, document_type: "Other", intake: intake
+        w2_doc = create :document, document_type: "Employment", intake: intake
 
         get :edit
 
@@ -62,7 +62,7 @@ RSpec.describe Documents::AdditionalDocumentsController do
       let(:document_path) { Rails.root.join("spec", "fixtures", "attachments", "document_bundle.pdf") }
 
       it "renders the thumbnails" do
-        doc = create :document, :with_upload, document_type: "Other", intake: intake,
+        create :document, document_type: "Other", intake: intake,
           upload_path: document_path
 
         expect { get :edit }.not_to raise_error

--- a/spec/controllers/documents/employment_controller_spec.rb
+++ b/spec/controllers/documents/employment_controller_spec.rb
@@ -85,8 +85,8 @@ RSpec.describe Documents::EmploymentController, type: :controller do
     context "with existing employment-related uploads" do
       it "assigns the documents to the form" do
         # Doc type for the EmploymentController
-        employment_doc = create :document, :with_upload, document_type: "Employment", intake: intake
-        _other_doc = create :document, :with_upload, document_type: "Other", intake: intake
+        employment_doc = create :document, document_type: "Employment", intake: intake
+        _other_doc = create :document, document_type: "Other", intake: intake
 
         get :edit
 
@@ -98,7 +98,7 @@ RSpec.describe Documents::EmploymentController, type: :controller do
       let(:document_path) { Rails.root.join("spec", "fixtures", "attachments", "document_bundle.pdf") }
 
       it "renders the thumbnails" do
-        w2_doc = create :document, :with_upload, document_type: "Employment", intake: intake,
+        create :document, document_type: "Employment", intake: intake,
                         upload_path: document_path
 
         expect { get :edit }.not_to raise_error

--- a/spec/controllers/documents/overview_controller_spec.rb
+++ b/spec/controllers/documents/overview_controller_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe Documents::OverviewController do
       let(:attributes) { { had_wages: "yes" } }
       let(:documents) do
         [
-          create(:document, :with_upload, intake: intake, document_type: "Employment"),
-          create(:document, :with_upload, intake: intake, document_type: "Other"),
+          create(:document, intake: intake, document_type: "Employment"),
+          create(:document, intake: intake, document_type: "Other"),
         ]
       end
 

--- a/spec/controllers/documents/requested_documents_later_controller_spec.rb
+++ b/spec/controllers/documents/requested_documents_later_controller_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Documents::RequestedDocumentsLaterController, type: :controller d
 
           context "when they have uploaded one document" do
             before do
-              create :document, :with_upload, documents_request: documents_request, document_type: controller.document_type_key
+              create :document, documents_request: documents_request, document_type: controller.document_type_key
             end
 
             it "renders a link to the next path" do
@@ -118,8 +118,8 @@ RSpec.describe Documents::RequestedDocumentsLaterController, type: :controller d
       end
 
       context "with existing requested document uploads" do
-        let!(:old_document) {create :document, :with_upload, document_type: "Requested Later", intake: original_intake}
-        let!(:new_document) {create :document, :with_upload, document_type: "Requested Later", documents_request: documents_request}
+        let!(:old_document) {create :document, document_type: "Requested Later", intake: original_intake}
+        let!(:new_document) {create :document, document_type: "Requested Later", documents_request: documents_request}
 
         it "does not show documents on the original intake" do
           get :edit, params: {token: token}

--- a/spec/controllers/documents/send_requested_documents_later_controller_spec.rb
+++ b/spec/controllers/documents/send_requested_documents_later_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Documents::SendRequestedDocumentsLaterController, type: :controll
 
   describe "#edit" do
     context "with a documents request in the session" do
-      let!(:document) { create :document, :with_upload, document_type: "Requested Later", intake: original_intake, documents_request: documents_request }
+      let!(:document) { create :document, document_type: "Requested Later", intake: original_intake, documents_request: documents_request }
 
       before do
         session[:documents_request_id] = documents_request.id

--- a/spec/controllers/hub/documents_controller_spec.rb
+++ b/spec/controllers/hub/documents_controller_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Hub::DocumentsController, type: :controller do
   describe "#edit" do
     let(:vita_partner) { create :vita_partner }
     let(:client) { create :client, vita_partner: vita_partner, intake: create(:intake, vita_partner: vita_partner) }
-    let(:document) { create :document, :with_upload, client: client }
+    let(:document) { create :document, client: client }
     let(:params) { { id: document.id, client_id: client.id }}
 
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :edit
@@ -128,7 +128,7 @@ RSpec.describe Hub::DocumentsController, type: :controller do
     let(:new_display_name) { "New Display Name"}
     let(:vita_partner) { create :vita_partner }
     let(:client) { create :client, vita_partner: vita_partner, intake: create(:intake, vita_partner: vita_partner) }
-    let(:document) { create :document, :with_upload, client: client }
+    let(:document) { create :document, client: client }
     let(:params) { { client_id: client.id, id: document.id, document: { display_name: new_display_name} } }
 
     it_behaves_like :a_post_action_for_authenticated_users_only, action: :update
@@ -164,7 +164,7 @@ RSpec.describe Hub::DocumentsController, type: :controller do
   describe "#show" do
     let(:vita_partner) { create :vita_partner }
     let(:client) { create :client, vita_partner: vita_partner, intake: create(:intake, vita_partner: vita_partner) }
-    let(:document) { create :document, :with_upload, client: client }
+    let(:document) { create :document, client: client }
     let(:params) { { client_id: client.id, id: document.id }}
 
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :show

--- a/spec/controllers/hub/messages_controller_spec.rb
+++ b/spec/controllers/hub/messages_controller_spec.rb
@@ -134,12 +134,12 @@ RSpec.describe Hub::MessagesController do
           )
 
           create(:incoming_email, client: client, documents: [
-            create(:document, :with_upload, upload_path: (Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))),
-            create(:document, :with_upload, upload_path: (Rails.root.join("spec", "fixtures", "attachments", "test-pdf.pdf")))
+            create(:document, upload_path: (Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))),
+            create(:document, upload_path: (Rails.root.join("spec", "fixtures", "attachments", "test-pdf.pdf")))
           ])
 
           create(:incoming_text_message, client: client, documents: [
-            create(:document, :with_upload, upload_path: (Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png")))
+            create(:document, upload_path: (Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png")))
           ])
         end
 

--- a/spec/factories/beta_test_clients.rb
+++ b/spec/factories/beta_test_clients.rb
@@ -25,9 +25,9 @@ FactoryBot.define do
         zip_code: "94103",
       )
 
-      create(:document, :with_upload, document_type: DocumentTypes::Identity, intake: intake, client: client)
-      create(:document, :with_upload, document_type: DocumentTypes::Selfie, intake: intake, client: client)
-      create(:document, :with_upload, document_type: DocumentTypes::SsnItin, intake: intake, client: client)
+      create(:document, document_type: DocumentTypes::Identity, intake: intake, client: client)
+      create(:document, document_type: DocumentTypes::Selfie, intake: intake, client: client)
+      create(:document, document_type: DocumentTypes::SsnItin, intake: intake, client: client)
 
       [2017, 2018, 2019, 2020].sample(rand(1..4)).each do |year|
         create(:tax_return, year: year, client: client, status: "intake_open")

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -34,17 +34,15 @@ FactoryBot.define do
     upload { nil }
     document_type { DocumentTypes::Employment.key }
 
-    trait :with_upload do
-      transient do
-        upload_path { Rails.root.join("spec", "fixtures", "attachments", "picture_id.jpg") }
-      end
+    transient do
+      upload_path { Rails.root.join("spec", "fixtures", "attachments", "picture_id.jpg") }
+    end
 
-      after(:build) do |document, evaluator|
-        document.upload.attach(
-          io: File.open(evaluator.upload_path),
-          filename: File.basename(evaluator.upload_path)
-        )
-      end
+    after(:build) do |document, evaluator|
+      document.upload.attach(
+        io: File.open(evaluator.upload_path),
+        filename: File.basename(evaluator.upload_path)
+      )
     end
   end
 end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -38,6 +38,7 @@ describe Document do
 
       expect(document).to_not be_valid
       expect(document.errors).to include :document_type
+      expect(document.errors).to include :upload
     end
 
     describe "#document_type" do
@@ -50,7 +51,7 @@ describe Document do
   end
 
   describe "before_save" do
-    context "when there is already a display name" do
+    context "when created with a display_name and attachment" do
       let(:document) { build :document, display_name: "HumanReadable.jpg" }
 
       it "keeps the given display name" do
@@ -61,22 +62,12 @@ describe Document do
     end
 
     context "when there is no display name and there is an attachment" do
-      let(:document) { build :document, :with_upload, upload_path: Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png") }
+      let(:document) { build :document, upload_path: Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png") }
 
       it "sets the default display name to the attachment filename" do
         document.save
 
         expect(document.display_name).to eq "test-pattern.png"
-      end
-    end
-
-    context "when there is no display name and no attachment" do
-      let(:document) { build :document }
-
-      it "sets the default display name to Untitled" do
-        document.save
-
-        expect(document.display_name).to eq "Untitled"
       end
     end
   end

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -1317,13 +1317,15 @@ describe Intake do
   describe "#create_original_13614c_document" do
     let(:client) { create :client }
     let(:intake) { create(:intake, client: client) }
+
     before do
       example_pdf = Tempfile.new("example.pdf")
       example_pdf.write("example pdf contents")
-      allow(intake).to receive(:create_original_13614c_document).and_call_original
 
+      allow(intake).to receive(:create_original_13614c_document).and_call_original
       allow(intake).to receive(:pdf).and_return(example_pdf)
     end
+
     it "should create a new document pdf of original 13614-C answers" do
       expect {
         intake.send :create_original_13614c_document

--- a/spec/presenters/document_presenter_spec.rb
+++ b/spec/presenters/document_presenter_spec.rb
@@ -5,19 +5,19 @@ describe DocumentPresenter do
     let(:intake) { create(:intake) }
     let(:duplicate_intake) { create(:intake) }
     let!(:employment_document_a) do
-      create :document, :with_upload,
+      create :document,
         document_type: "Employment",
         created_at: 2.day.ago,
         intake: intake
     end
     let!(:employment_document_b) do
-      create :document, :with_upload,
+      create :document,
         document_type: "Employment",
         created_at: 1.day.ago,
         intake: duplicate_intake
     end
     let!(:ssn_document) do
-      create :document, :with_upload,
+      create :document,
         document_type: "SSN or ITIN",
         created_at: 1.day.ago,
         intake: duplicate_intake

--- a/spec/support/shared_examples/required_document_controllers.rb
+++ b/spec/support/shared_examples/required_document_controllers.rb
@@ -13,7 +13,7 @@ shared_examples :a_required_document_controller do
 
     context "when they have uploaded one document" do
       before do
-        create :document, :with_upload, intake: intake, document_type: controller.document_type_key
+        create :document, intake: intake, document_type: controller.document_type_key
       end
 
       it "renders a link to the next path" do


### PR DESCRIPTION
Shannon and I implemented this as part of https://www.pivotaltracker.com/story/show/175366339 because in that story, we're going to be showing the document display_name in one new place in the hub, and we think now is a good time to make sure documents always have an appropriate `.display_name`.

This fixes a bug where all `Document` records had a `.display_name` of `Untitled`. The cause of the bug was that we generally add the `.upload` field _after the first time a `Document` is saved._ This meant that the `before_save` hook wasn't able to find the document, so it wrote `Untitled` into the `.display_name`.

This pull request makes `Document` require a `upload` -- i.e., all documents in the database expect to to have a file as part of them. This ensures we have a `upload` at the time the `before_save` hook is called. It also removes the `:with_upload` factory, migrating that behavior into the default Document factory.

(No `Co-authored-by` b/c Shannon and I are on different schedules today, so when I finished it, I was solo-ing.)

