### PR TITLE
Use master branch on Aptible

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - checkout
       - run: echo $APTIBLE_PUBLIC_KEY >> ~/.ssh/known_hosts
       - run: git fetch --depth=1000000
-      - run: git push git@beta.aptible.com:vita-min-demo/vita-min-demo.git $CIRCLE_SHA1:main
+      - run: git push git@beta.aptible.com:vita-min-demo/vita-min-demo.git $CIRCLE_SHA1:master
     parallelism: 1
   deploy_to_aptible--production:
     executor: rails_executor
@@ -63,7 +63,7 @@ jobs:
       - checkout
       - run: echo $APTIBLE_PUBLIC_KEY >> ~/.ssh/known_hosts
       - run: git fetch --depth=1000000
-      - run: git push git@beta.aptible.com:vita-min-prod/vita-min-prod.git $CIRCLE_SHA1:main
+      - run: git push git@beta.aptible.com:vita-min-prod/vita-min-prod.git $CIRCLE_SHA1:master
     parallelism: 1
 workflows:
   version: 2


### PR DESCRIPTION
On Aptible, the main branch is still called master

At the moment, auto deploys fail for this reason: https://app.circleci.com/pipelines/github/codeforamerica/vita-min/3257/workflows/d7c28c93-b6d8-4164-a8e2-069e92ed358b/jobs/9831