### PR TITLE
Redirect to Rails storage URLs [#176083281]

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,6 +1,5 @@
 class DocumentsController < ApplicationController
   include AccessControllable
-  include FileResponseControllerHelper
   before_action :require_intake
 
   def destroy

--- a/app/controllers/hub/anonymized_intake_csv_extracts_controller.rb
+++ b/app/controllers/hub/anonymized_intake_csv_extracts_controller.rb
@@ -9,10 +9,7 @@ module Hub
     end
 
     def show
-      if @anonymized_intake_csv_extract
-        attachment = @anonymized_intake_csv_extract.upload
-        send_data(attachment.download, filename: attachment.filename.to_s, type: attachment.content_type, disposition: "attachment")
-      end
+      redirect_to rails_blob_path(@anonymized_intake_csv_extract.upload.blob, disposition: "attachment")
     end
   end
 end

--- a/app/controllers/hub/documents_controller.rb
+++ b/app/controllers/hub/documents_controller.rb
@@ -1,7 +1,6 @@
 module Hub
   class DocumentsController < ApplicationController
     include AccessControllable
-    include FileResponseControllerHelper
 
     before_action :require_sign_in
     load_and_authorize_resource :client
@@ -17,7 +16,7 @@ module Hub
     end
 
     def show
-      render_active_storage_attachment @document.upload
+      redirect_to rails_blob_url(@document.upload, disposition: :inline)
     end
 
     def edit; end

--- a/app/helpers/file_response_controller_helper.rb
+++ b/app/helpers/file_response_controller_helper.rb
@@ -1,9 +1,0 @@
-module FileResponseControllerHelper
-  def render_pdf(pdf_file)
-    send_data(pdf_file.read, type: "application/pdf", disposition: "inline")
-  end
-
-  def render_active_storage_attachment(attachment)
-    send_data(attachment.download, type: attachment.content_type, disposition: "inline")
-  end
-end

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,0 +1,1 @@
+Rails.application.config.active_storage.service_urls_expire_in = 20.seconds

--- a/spec/controllers/hub/anonymized_intake_csv_extracts_controller_spec.rb
+++ b/spec/controllers/hub/anonymized_intake_csv_extracts_controller_spec.rb
@@ -35,8 +35,7 @@ RSpec.describe Hub::AnonymizedIntakeCsvExtractsController do
       it "sends the csv file as a download attachment" do
         get :show, params: { id: extract.id }
 
-        expect(response.headers["Content-Type"]).to eq("text/csv")
-        expect(response.headers["Content-Disposition"]).to include("attachment")
+        expect(response).to redirect_to(Rails.application.routes.url_helpers.rails_blob_url(extract.upload, disposition: "attachment"))
       end
     end
   end

--- a/spec/controllers/hub/documents_controller_spec.rb
+++ b/spec/controllers/hub/documents_controller_spec.rb
@@ -176,8 +176,7 @@ RSpec.describe Hub::DocumentsController, type: :controller do
       it "shows the document" do
         get :show, params: params
 
-        expect(response).to be_ok
-        expect(response.headers["Content-Type"]).to eq("image/jpeg")
+        expect(response).to redirect_to(Rails.application.routes.url_helpers.rails_blob_path(document.upload, disposition: :inline))
       end
     end
   end
@@ -219,4 +218,3 @@ RSpec.describe Hub::DocumentsController, type: :controller do
     end
   end
 end
-


### PR DESCRIPTION
This pull request relies on Rails/ActiveStorage's `#rails_blob_url` method, which allows us to redirect to signed URLs in Amazon S3 in dev, staging, and production. This addresses the cross-site scripting issue that arises from our previous use of `#download`.

It configures a 20 second timeout for those URLs per conversation with Dimitri; see e.g. https://www.pivotaltracker.com/story/show/176083281

It also removes a now-unused "helper" that wasn't a template helper anyway. 👊 
