### PR TITLE
Redirect to transient storage URLs [#176083281]

### DIFF
--- a/app/controllers/concerns/files_concern.rb
+++ b/app/controllers/concerns/files_concern.rb
@@ -1,0 +1,15 @@
+module FilesConcern
+  def transient_storage_url(attachment, disposition: nil)
+    # Create a quickly-expiring URL for a given ActiveStorage attachment.
+    #
+    # Expiration is controlled via `Rails.application.config.active_storage.service_urls_expire_in`
+    #
+    # Use this instead of rails_blob_url because rails_blob_url creates long-lasting URLs which redirect to transient URLs.
+    # We want no long-lasting URLs.
+
+    # ActiveStorage's #service_url requires us to set `host`;  see https://stackoverflow.com/questions/51110789/activestorage-service-url-rails-blob-path-cannot-generate-full-url-when-not-u
+    ActiveStorage::Current.set(host: request.base_url) do
+      attachment.service_url(disposition: disposition || :inline) # :inline is the default for #service_url
+    end
+  end
+end

--- a/app/controllers/concerns/files_concern.rb
+++ b/app/controllers/concerns/files_concern.rb
@@ -1,6 +1,7 @@
 module FilesConcern
   def transient_storage_url(attachment, disposition: nil)
     # Create a quickly-expiring URL for a given ActiveStorage attachment.
+    # When using S3 storage, the URL is not on our domain, protecting users from possible Javascript in the storage object.
     #
     # Expiration is controlled via `Rails.application.config.active_storage.service_urls_expire_in`
     #

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,6 +1,5 @@
 class DocumentsController < ApplicationController
   include AccessControllable
-  include FileResponseControllerHelper
   before_action :require_intake
 
   def destroy

--- a/app/controllers/hub/anonymized_intake_csv_extracts_controller.rb
+++ b/app/controllers/hub/anonymized_intake_csv_extracts_controller.rb
@@ -1,5 +1,6 @@
 module Hub
   class AnonymizedIntakeCsvExtractsController < ApplicationController
+    include FilesConcern
     layout "admin"
 
     load_and_authorize_resource
@@ -9,10 +10,7 @@ module Hub
     end
 
     def show
-      if @anonymized_intake_csv_extract
-        attachment = @anonymized_intake_csv_extract.upload
-        send_data(attachment.download, filename: attachment.filename.to_s, type: attachment.content_type, disposition: "attachment")
-      end
+      redirect_to transient_storage_url(@anonymized_intake_csv_extract.upload.blob, disposition: "attachment")
     end
   end
 end

--- a/app/controllers/hub/documents_controller.rb
+++ b/app/controllers/hub/documents_controller.rb
@@ -1,7 +1,7 @@
 module Hub
   class DocumentsController < ApplicationController
     include AccessControllable
-    include FileResponseControllerHelper
+    include FilesConcern
 
     before_action :require_sign_in
     load_and_authorize_resource :client
@@ -17,7 +17,7 @@ module Hub
     end
 
     def show
-      render_active_storage_attachment @document.upload
+      redirect_to transient_storage_url(@document.upload.blob, disposition: :inline)
     end
 
     def edit; end

--- a/app/controllers/hub/documents_controller.rb
+++ b/app/controllers/hub/documents_controller.rb
@@ -17,7 +17,7 @@ module Hub
     end
 
     def show
-      redirect_to transient_storage_url(@document.upload.blob, disposition: :inline)
+      redirect_to transient_storage_url(@document.upload.blob)
     end
 
     def edit; end

--- a/app/helpers/file_response_controller_helper.rb
+++ b/app/helpers/file_response_controller_helper.rb
@@ -1,9 +1,0 @@
-module FileResponseControllerHelper
-  def render_pdf(pdf_file)
-    send_data(pdf_file.read, type: "application/pdf", disposition: "inline")
-  end
-
-  def render_active_storage_attachment(attachment)
-    send_data(attachment.download, type: attachment.content_type, disposition: "inline")
-  end
-end

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,0 +1,2 @@
+# Expire S3 transient links quickly, nearly immediately
+Rails.application.config.active_storage.service_urls_expire_in = 20.seconds

--- a/spec/controllers/concerns/files_concern_spec.rb
+++ b/spec/controllers/concerns/files_concern_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe FilesConcern, type: :controller do
+
+  controller(ApplicationController) do
+    include FilesConcern
+  end
+
+  let(:attachment) { double }
+
+  describe "#transient_storage_url" do
+    let(:redirect_url) { "https://gyr-demo.s3.amazonaws.com/file.png?sig=whatever&expires=whatever" }
+
+    before do
+      allow(attachment).to receive(:service_url).and_return(redirect_url)
+    end
+
+    it "calls #service_url when given a blob" do
+      expect(subject.transient_storage_url(attachment)).to eq(redirect_url)
+      expect(attachment).to have_received(:service_url).with(disposition: :inline)
+    end
+
+    it "passes the optional disposition parameter" do
+      expect(subject.transient_storage_url(attachment, disposition: "attachment")).to eq(redirect_url)
+      expect(attachment).to have_received(:service_url).with(disposition: "attachment")
+    end
+  end
+end

--- a/spec/controllers/hub/documents_controller_spec.rb
+++ b/spec/controllers/hub/documents_controller_spec.rb
@@ -170,14 +170,18 @@ RSpec.describe Hub::DocumentsController, type: :controller do
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :show
 
     context "with a signed in user" do
+      let(:document_transient_url) { "https://gyr-demo.s3.amazonaws.com/document.pdf?sig=whatever&expires=whatever" }
       let(:user) { create :user, vita_partner: vita_partner }
-      before { sign_in(user) }
+      before do
+        sign_in(user)
+        allow(subject).to receive(:transient_storage_url).and_return(document_transient_url)
+      end
 
       it "shows the document" do
         get :show, params: params
 
-        expect(response).to be_ok
-        expect(response.headers["Content-Type"]).to eq("image/jpeg")
+        expect(response).to redirect_to(document_transient_url)
+        expect(subject).to have_received(:transient_storage_url).with(document.upload.blob, disposition: :inline)
       end
     end
   end
@@ -219,4 +223,3 @@ RSpec.describe Hub::DocumentsController, type: :controller do
     end
   end
 end
-

--- a/spec/controllers/hub/documents_controller_spec.rb
+++ b/spec/controllers/hub/documents_controller_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe Hub::DocumentsController, type: :controller do
         get :show, params: params
 
         expect(response).to redirect_to(document_transient_url)
-        expect(subject).to have_received(:transient_storage_url).with(document.upload.blob, disposition: :inline)
+        expect(subject).to have_received(:transient_storage_url).with(document.upload.blob)
       end
     end
   end


### PR DESCRIPTION
This pull request relies on Rails/ActiveStorage's `#service_url` method, which allows us to redirect to signed URLs in Amazon S3 in dev, staging, and production. This addresses the cross-site scripting issue that arises from our previous use of `#download`.

It configures a 20 second timeout for those URLs per conversation with Dimitri; see e.g. https://www.pivotaltracker.com/story/show/176083281

It also removes a now-unused "helper" that wasn't a template helper anyway. 👊 
