### PR TITLE
WIP non-urgent refactor: Add ClientFilterForm [#175207595]

### DIFF
--- a/app/forms/hub/client_filter_form.rb
+++ b/app/forms/hub/client_filter_form.rb
@@ -1,0 +1,16 @@
+module Hub
+  class ClientFilterForm < Form
+    attr_accessor :sort_column, :sort_order, :_filtered_and_sorted_clients
+
+    def filtered_and_sorted_clients(clients)
+      clients = clients.after_consent
+      clients.delegated_order(sort_column, sort_order)
+    end
+
+    def initialize(*args, **attributes)
+      super(*args, **attributes)
+      self.sort_column = %w[preferred_name updated_at locale].include?(sort_column) ? sort_column : "id"
+      self.sort_order = sort_order == "desc" ? "desc" : "asc"
+    end
+  end
+end

--- a/spec/forms/hub/client_filter_form_spec.rb
+++ b/spec/forms/hub/client_filter_form_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.describe Hub::ClientFilterForm do
+  describe "#sort_column" do
+    context "valid values" do
+      it "permits preferred_name" do
+        expect(described_class.new(sort_column: "preferred_name").sort_column).to eq("preferred_name")
+      end
+
+      it "permits updated_at" do
+        expect(described_class.new(sort_column: "updated_at").sort_column).to eq("updated_at")
+      end
+
+      it "permits locale" do
+        expect(described_class.new(sort_column: "locale").sort_column).to eq("locale")
+      end
+    end
+
+    context "blank or invalid" do
+      it "uses id by default" do
+        expect(described_class.new.sort_column).to eq("id")
+      end
+
+      it "converts invalid values to id" do
+        expect(described_class.new(sort_column: "invalid").sort_column).to eq("id")
+      end
+    end
+  end
+
+  describe "#sort_order" do
+    context "asc by default" do
+      it "uses asc by default" do
+        expect(described_class.new.sort_order).to eq("asc")
+      end
+
+      it "uses asc when given bad values" do
+        expect(described_class.new(sort_order: "bad").sort_order).to eq("asc")
+      end
+    end
+
+    context "desc" do
+      it "uses desc if given" do
+        expect(described_class.new(sort_order: "desc").sort_order).to eq("desc")
+      end
+    end
+  end
+
+  describe "#filtered_and_sorted_clients" do
+    context "filtering for consent" do
+      let(:client_before_consent) { create(:client) }
+      let(:client_after_consent) { create(:client, :with_return) }
+
+      it "filters for only clients that have consented" do
+        expect(subject.filtered_and_sorted_clients(
+          Client.where(id: [client_after_consent.id, client_before_consent.id]))).to eq([client_after_consent])
+      end
+    end
+
+    context "ordering" do
+      let(:clients_query_double) { double }
+
+      before do
+        allow(clients_query_double).to receive(:after_consent).and_return(clients_query_double)
+        allow(clients_query_double).to receive(:delegated_order)
+      end
+
+      it "passes sort_column and sort_order to Client#delegated_order" do
+        subject.filtered_and_sorted_clients(clients_query_double)
+        expect(clients_query_double).to have_received(:delegated_order).with(subject.sort_column, subject.sort_order)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds the start of ClientFilterForm, a `Form` that can centralize our client searching, filtering, and ordering logic.

The reason I began writing it was to work toward being able to TDD adding a new column to order by. I found that tests for the client filtering & sorting & searching logic was spread between the ClientsController and the ClientSortable, so I wanted to unify them somewhere. I found it easier to do this in a new Form than by modifying ClientSortable, based on advice from @bengolder that a form might be a good idea, and based on experience trying to add more tests to ClientSortable with @sniemeyer13 .

This is work in progress toward https://www.pivotaltracker.com/story/show/175207595