### PR TITLE
Remove state-based routing

### DIFF
--- a/app/lib/vita_partner_importer.rb
+++ b/app/lib/vita_partner_importer.rb
@@ -36,9 +36,6 @@ class VitaPartnerImporter < CliScriptBase
     db_partner.source_parameters.destroy(db_partner.source_parameters)
     yaml_partner["source_parameters"].each { |code| db_partner.source_parameters.create!(code: code.downcase) } if yaml_partner["source_parameters"].present?
 
-    db_partner.states.clear
-    yaml_partner["states"].each { |st| db_partner.states << State.find_by!(abbreviation: st.upcase) } if yaml_partner["states"].present?
-
     db_partner.save!
   end
 
@@ -48,7 +45,6 @@ class VitaPartnerImporter < CliScriptBase
       # This removes the source parameter. If you need a list of all historically-used source parameters, do a query
       # against Intake objects.
       db_partner.source_parameters.destroy(db_partner.source_parameters)
-      db_partner.states.clear
     end
   end
 end

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -482,7 +482,7 @@ class Intake < ApplicationRecord
 
   def assign_vita_partner!
     # this is a RouteOptions struct, defined below
-    route_options = partner_for_eip_only || partner_for_source || partner_for_state || partner_for_overflow
+    route_options = partner_for_eip_only || partner_for_source || partner_for_overflow
 
     raise "Unable to route to any partner" unless route_options&.partner # this shouldn't happen unless the data is horked!
 
@@ -628,14 +628,6 @@ class Intake < ApplicationRecord
     return nil unless partner.present?
 
     RouteOptions.new(partner, "source_parameter", source)
-  end
-
-  def partner_for_state
-    state = State.find_by(abbreviation: state_of_residence&.upcase || state&.upcase)
-    partner = state.vita_partners.first if state.present? && !state.vita_partners.empty?
-    return nil unless partner.present?
-
-    RouteOptions.new(partner, "state", state_of_residence)
   end
 
   def partner_for_overflow

--- a/app/models/state.rb
+++ b/app/models/state.rb
@@ -10,8 +10,6 @@
 #  index_states_on_name  (name)
 #
 class State < ApplicationRecord
-  has_and_belongs_to_many :vita_partners, foreign_key: :state_abbreviation
-
   validates_presence_of :name
   validates_presence_of :abbreviation
 end

--- a/app/models/vita_partner.rb
+++ b/app/models/vita_partner.rb
@@ -25,7 +25,6 @@ class VitaPartner < ApplicationRecord
 
   has_many :clients
   has_many :intakes
-  has_and_belongs_to_many :states, association_foreign_key: :state_abbreviation
   has_many :source_parameters
   has_many :users
   belongs_to :parent_organization, class_name: "VitaPartner", optional: true

--- a/db/migrate/20201211222519_drop_states_vita_partner_table.rb
+++ b/db/migrate/20201211222519_drop_states_vita_partner_table.rb
@@ -1,0 +1,5 @@
+class DropStatesVitaPartnerTable < ActiveRecord::Migration[6.0]
+  def change
+    drop_table :states_vita_partners
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_10_232524) do
+ActiveRecord::Schema.define(version: 2020_12_11_222519) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -417,13 +417,6 @@ ActiveRecord::Schema.define(version: 2020_12_10_232524) do
     t.index ["name"], name: "index_states_on_name"
   end
 
-  create_table "states_vita_partners", id: false, force: :cascade do |t|
-    t.string "state_abbreviation"
-    t.bigint "vita_partner_id"
-    t.index ["state_abbreviation"], name: "index_states_vita_partners_on_state_abbreviation"
-    t.index ["vita_partner_id"], name: "index_states_vita_partners_on_vita_partner_id"
-  end
-
   create_table "stimulus_triages", force: :cascade do |t|
     t.integer "chose_to_file", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
@@ -561,7 +554,6 @@ ActiveRecord::Schema.define(version: 2020_12_10_232524) do
   add_foreign_key "outgoing_text_messages", "clients"
   add_foreign_key "outgoing_text_messages", "users"
   add_foreign_key "source_parameters", "vita_partners"
-  add_foreign_key "states_vita_partners", "vita_partners"
   add_foreign_key "system_notes", "clients"
   add_foreign_key "system_notes", "users"
   add_foreign_key "tax_returns", "clients"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,7 +2,8 @@ fake_vita_partner = VitaPartner.find_or_create_by(
   name: "Fake Vita Partner",
   display_name: "Fake Vita Partner Display Name",
   zendesk_group_id: "foo",
-  zendesk_instance_domain: "eitc"
+  zendesk_instance_domain: "eitc",
+  accepts_overflow: true
 )
 
 another_vita_partner = VitaPartner.find_or_create_by(

--- a/spec/controllers/questions/personal_info_controller_spec.rb
+++ b/spec/controllers/questions/personal_info_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Questions::PersonalInfoController do
     end
 
     let!(:vita_partner) do
-      create :vita_partner, states: [State.find_by(abbreviation: state.upcase)]
+      create :vita_partner, accepts_overflow: true
     end
 
     it "sets the timezone on the intake" do

--- a/spec/factories/intakes.rb
+++ b/spec/factories/intakes.rb
@@ -266,8 +266,8 @@ FactoryBot.define do
       zendesk_instance_domain { "eitc" }
       vita_partner_group_id { vita_partner.zendesk_group_id }
       vita_partner_name { vita_partner.name }
-      routing_value { vita_partner.states.first&.abbreviation || "az" }
-      routing_criteria { "state" }
+      routing_value { "az" }
+      routing_criteria { "overflow" }
       job_count { [1, 2, 3].sample }
       preferred_interview_language { ["en", "es"].sample }
       primary_consented_to_service_at { 2.weeks.ago }

--- a/spec/features/web_intake/new_joint_filers_spec.rb
+++ b/spec/features/web_intake/new_joint_filers_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Web Intake Joint Filers" do
   let(:ticket_id) { 9876 }
 
   before do
-    create :vita_partner, display_name: "Virginia Partner", zendesk_group_id: "123", states: [State.find_by(abbreviation: "VA")]
+    create :vita_partner, display_name: "Virginia Partner", zendesk_group_id: "123", accepts_overflow: true
     # see note below about skipping redirects
   end
 

--- a/spec/features/web_intake/new_single_filer_spec.rb
+++ b/spec/features/web_intake/new_single_filer_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Web Intake Single Filer" do
   let(:ticket_id) { 9876 }
 
   before do
-    create :vita_partner, display_name: "Virginia Partner", zendesk_group_id: "123", states: [State.find_by(abbreviation: "VA")]
+    create :vita_partner, display_name: "Virginia Partner", zendesk_group_id: "123", accepts_overflow: true
   end
 
   scenario "new client filing single without dependents" do

--- a/spec/lib/vita_partner_importer_spec.rb
+++ b/spec/lib/vita_partner_importer_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe VitaPartnerImporter do
             "zendesk_group_id" => zendesk_group_id,
             "display_name" => "Tax Help Colorado",
             "source_parameters" => ["test-source"],
-            "states" => ["CO"],
             "logo_path" => "",
             "weekly_capacity_limit" => 500,
             "accepts_overflow" => true,
@@ -38,8 +37,6 @@ RSpec.describe VitaPartnerImporter do
         expect(created.zendesk_group_id).to eq(zendesk_group_id)
         expect(created.source_parameters.length).to eq(1)
         expect(created.source_parameters.first.code).to eq("test-source")
-        expect(created.states.length).to eq(1)
-        expect(created.states.first.abbreviation).to eq("CO")
         expect(created.weekly_capacity_limit).to eq(500)
         expect(created.accepts_overflow).to be(true)
       end
@@ -108,14 +105,13 @@ RSpec.describe VitaPartnerImporter do
         end
       end
 
-      context "when a source code and state are removed" do
+      context "when a source code is removed" do
         before do
           partner = create(
             :vita_partner,
             name: "Fake Name",
             zendesk_instance_domain: "eitc",
             zendesk_group_id: zendesk_group_id,
-            states: [create(:state)],
           )
           create :source_parameter, code: "hello", vita_partner: partner
         end
@@ -140,7 +136,6 @@ RSpec.describe VitaPartnerImporter do
 
           modified_partner = VitaPartner.find_by(zendesk_group_id: zendesk_group_id)
           expect(modified_partner.source_parameters.count).to eq 0
-          expect(modified_partner.states.count).to eq 0
         end
       end
     end
@@ -153,7 +148,6 @@ RSpec.describe VitaPartnerImporter do
           zendesk_instance_domain: "eitc",
           zendesk_group_id: zendesk_group_id,
           weekly_capacity_limit: 1,
-          states: [create(:state, abbreviation: "XYZ")],
           logo_path: "partner-logos/ia.png",
         )
         create :source_parameter, code: "hello", vita_partner: partner
@@ -176,7 +170,6 @@ RSpec.describe VitaPartnerImporter do
         expect(archived_partner.logo_path).to eq("partner-logos/ia.png")
         # Remove routing-related data
         expect(archived_partner.source_parameters.count).to eq 0
-        expect(archived_partner.states.count).to eq 0
         # Mark archived
         expect(archived_partner.archived).to be(true)
       end


### PR DESCRIPTION
This makes it easier to rename the VitaPartners model to VitaGroup.

It also paves the way toward dropping reliance on the vita_partners.yml file. We're going to have to stop relying on that file when admins edit organizations in the interface.

Note the reliance on `accepts_overflow: true` to ensure routing continues to operate.

On demo, it would be sensible to mark **California Online Intake Group** as `accepts_overflow: true`.

Please don't merge without asking me; I am hoping to sequence this with other work. Review is welcome.