### PR TITLE
Add another civil rights protection pdf to link [#175724659]

### DIFF
--- a/app/views/shared/_consent_agreement.html.erb
+++ b/app/views/shared/_consent_agreement.html.erb
@@ -11,6 +11,10 @@
 <div class="consent-details">
   <h2 class="h3"><%=t("views.shared.consent_agreement.details.header") %></h2>
   <p>
+    <%= t("views.shared.consent_agreement.details.civil_rights_understanding_html") %>
+  </p>
+
+  <p>
     <%=t("views.shared.consent_agreement.details.provide_required_info") %>
   </p>
   <p>
@@ -42,11 +46,6 @@
   </p>
   <p>
     <%=t("views.shared.consent_agreement.details.responsible") %>
-  </p>
-  <p>
-    <%= t("views.shared.consent_agreement.details.civil_rights_understanding") %>
-    <%= link_to(t("views.shared.consent_agreement.details.civil_rights_link"),
-                "https://www.irs.gov/pub/irs-pdf/p4053csp.pdf") %>
   </p>
   <p>
     <%=t("views.shared.consent_agreement.details.irs") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1525,8 +1525,7 @@ en:
       consent_agreement:
         details:
           cfa: I understand that GetYourRefund.org is a website run by Code for America, a non-profit organization, that will submit your tax information to a VITA preparation site.
-          civil_rights_link: protects my civil rights.
-          civil_rights_understanding: I understand that VITA
+          civil_rights_understanding_html: I understand that VITA is a <a href="https://www.irs.gov/pub/irs-pdf/p4836.pdf">free tax program</a> that <a href="https://www.irs.gov/pub/irs-pdf/p4053csp.pdf">protects my civil rights</a>.
           collects_pii: I understand that this site collects personally identifiable information I provide (social security numbers, Form W-2 and/or 1099, picture identification, and other documents) in order to prepare and quality review my tax return.
           contacted: I understand that I may be contacted for additional information using a contact preference I provide. If the preparer has everything required to prepare the return, I will not be contacted until the return is completed.
           e_signature: I understand that I will need to sign Form 8879, IRS e-file Signature Authorization, through an electronic signature delivered via email after Quality Review is completed in order for a VITA preparation site to e-file my tax return.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1525,8 +1525,7 @@ es:
       consent_agreement:
         details:
           cfa: Entiendo que GetYourRefund.org es un sitio web dirigido por Code for America, una organización sin fines de lucro, que enviará mi información tributaria a un sitio de preparación de VITA.
-          civil_rights_link: protege mis derechos civiles.
-          civil_rights_understanding: Comprendo esta Asistencia Voluntaria al Contribuyente Tributario (VITA).
+          civil_rights_understanding_html: Comprendo esta Asistencia Voluntaria al Contribuyente Tributario (VITA) es una <a href="https://www.irs.gov/pub/irs-pdf/p4836.pdf">Programas de Impuestos Gratuitos Ofrecidos</a> que <a href="https://www.irs.gov/pub/irs-pdf/p4053csp.pdf">protege mis derechos civiles</a>.
           collects_pii: Entiendo que este sitio recopila la información de identificación personal que proporciono (números del Seguro Social, formularios W-2 o 1099, identificación con foto y otros documentos) para preparar mi declaración de impuestos y hacer un control de calidad de ella.
           contacted: Entiendo que alguien podría comunicarse conmigo a través del medio que yo prefiera para obtener más información. Si el preparador tiene todo lo necesario para preparar la declaración, nadie se comunicará conmigo hasta que la declaración esté lista.
           e_signature: Entiendo que tendré que firmar el formulario 8879 (SP), la autorización de firma electrónica del IRS para presentar la declaración por Internet, mediante una firma electrónica que enviaré por correo electrónico, después de completar control de calidad para que un sitio de preparación de VITA pueda presentar mi declaración de impuestos en línea.


### PR DESCRIPTION
Moves the civil rights section to the top, puts full link in one translation string, and adds the new PDF link.