### PR TITLE
Coalitions, orgs, and sites

### DIFF
--- a/app/controllers/hub/organizations_controller.rb
+++ b/app/controllers/hub/organizations_controller.rb
@@ -1,0 +1,34 @@
+module Hub
+  class OrganizationsController < ApplicationController
+    include AccessControllable
+    before_action :require_sign_in
+    load_and_authorize_resource :vita_partner, parent: false
+
+    layout "admin"
+
+    def new
+      @coalitions = Coalition.all
+    end
+
+    def create
+      render :new unless @vita_partner.save!
+
+      redirect_to hub_organizations_path
+    end
+
+    def index
+      @coalitions = Coalition.includes(:organizations)
+      @organizations = @vita_partners.organizations
+      @independent_organizations = @vita_partners.organizations.where(coalition: nil)
+    end
+
+    private
+
+    def vita_partner_params
+      params.require(:vita_partner).permit(:name, :coalition_id).merge(
+        zendesk_group_id: "unused",
+        zendesk_instance_domain: "unused"
+      )
+    end
+  end
+end

--- a/app/controllers/hub/organizations_controller.rb
+++ b/app/controllers/hub/organizations_controller.rb
@@ -11,15 +11,29 @@ module Hub
     end
 
     def create
-      render :new unless @vita_partner.save!
-
-      redirect_to hub_organizations_path
+      @coalitions = Coalition.all
+      if @vita_partner.save
+        redirect_to hub_organizations_path
+      else
+        render :new
+      end
     end
 
     def index
       @coalitions = Coalition.includes(:organizations)
       @organizations = @vita_partners.organizations
       @independent_organizations = @vita_partners.organizations.where(coalition: nil)
+    end
+
+    def edit
+      @coalitions = Coalition.all
+      @organization = @vita_partner
+    end
+
+    def update
+      render :edit unless @vita_partner.update(vita_partner_params)
+
+      redirect_to hub_organizations_path
     end
 
     private

--- a/app/controllers/hub/organizations_controller.rb
+++ b/app/controllers/hub/organizations_controller.rb
@@ -8,13 +8,14 @@ module Hub
 
     def new
       @coalitions = Coalition.all
+      @organization = @vita_partner
     end
 
     def create
-      @coalitions = Coalition.all
       if @vita_partner.save
         redirect_to hub_organizations_path
       else
+        @coalitions = Coalition.all
         render :new
       end
     end

--- a/app/controllers/hub/sites_controller.rb
+++ b/app/controllers/hub/sites_controller.rb
@@ -1,0 +1,47 @@
+module Hub
+  class SitesController < ApplicationController
+    include AccessControllable
+    before_action :require_sign_in
+    before_action :load_organizations, only: [:new, :edit]
+
+    load_and_authorize_resource :vita_partner, parent: false
+
+    layout "admin"
+
+    def new
+      @site = VitaPartner.new(parent_organization_id: params[:parent_organization_id])
+    end
+
+    def create
+      @site = VitaPartner.new(vita_partner_params)
+      if @site.save
+        redirect_to edit_hub_organization_path(id: @site.parent_organization)
+      else
+        render :new
+      end
+    end
+
+    def edit
+      @site = @vita_partner
+    end
+
+    def update
+      render :edit unless @vita_partner.update(vita_partner_params)
+
+      redirect_to edit_hub_organization_path(id: @vita_partner.parent_organization_id)
+    end
+
+    private
+
+    def load_organizations
+      @organizations = VitaPartner.accessible_by(current_ability).organizations
+    end
+
+    def vita_partner_params
+      params.require(:vita_partner).permit(:name, :parent_organization_id).merge(
+        zendesk_instance_domain: "unused",
+        zendesk_group_id: "unused",
+      )
+    end
+  end
+end

--- a/app/models/coalition.rb
+++ b/app/models/coalition.rb
@@ -13,6 +13,6 @@
 #
 class Coalition < ApplicationRecord
   validates :name, uniqueness: true
-  # A coalition has many Organizations. We use the VitaPartner.organizations scope to ensure we only find Organizations, not Sites.
+  # Use the VitaPartner.organizations scope to ensure we only find Organizations, not Sites.
   has_many :organizations, -> { organizations }, class_name: "VitaPartner", foreign_key: "coalition_id"
 end

--- a/app/models/coalition.rb
+++ b/app/models/coalition.rb
@@ -13,4 +13,6 @@
 #
 class Coalition < ApplicationRecord
   validates :name, uniqueness: true
+  # A coalition has many Organizations. We use the VitaPartner.organizations scope to ensure we only find Organizations, not Sites.
+  has_many :organizations, -> { organizations }, class_name: "VitaPartner", foreign_key: "coalition_id"
 end

--- a/app/models/vita_partner.rb
+++ b/app/models/vita_partner.rb
@@ -45,6 +45,9 @@ class VitaPartner < ApplicationRecord
   scope :top_level, -> { where(parent_organization: nil).order(:display_name).order(:name) }
   scope :organizations, -> { where(parent_organization: nil) }
   scope :sites, -> { where.not(parent_organization: nil) }
+  has_many :child_sites, -> { order(:id) }, class_name: "VitaPartner", foreign_key: "parent_organization_id"
+
+  default_scope { includes(:child_sites) }
 
   after_initialize :defaults
 

--- a/app/views/hub/organizations/_edit_organization.html.erb
+++ b/app/views/hub/organizations/_edit_organization.html.erb
@@ -1,0 +1,2 @@
+<%= f.cfa_input_field :name, t("general.name") %>
+<%= f.cfa_select :coalition_id, t("general.coalition"), @coalitions.map { |c| [c.name, c.id] }, include_blank: true %>

--- a/app/views/hub/organizations/_listing.html.erb
+++ b/app/views/hub/organizations/_listing.html.erb
@@ -1,0 +1,3 @@
+<h3>
+  <%= link_to "#{organization.name} (#{t(".site_count", count: organization.child_sites.count)})", edit_hub_organization_path(id: organization) %>
+</h3>

--- a/app/views/hub/organizations/edit.html.erb
+++ b/app/views/hub/organizations/edit.html.erb
@@ -2,6 +2,8 @@
 <% content_for :page_title, @title %>
 <% content_for :card do %>
   <div class="hub-form">
+    <%= link_to t("general.all_organizations"), hub_organizations_path, class: "button button--small" %>
+
     <%= form_with model: @organization, url: hub_organizations_path, method: :post, local: true, builder: VitaMinFormBuilder do |f| %>
       <h1 class="form-card__title">
         <%= @title %>
@@ -14,10 +16,12 @@
         <%= t("general.save") %>
       </button>
 
+      <h2><%= t("general.sites") %></h2>
+      <%= link_to t("hub.sites.new.title"), new_hub_site_path(parent_organization_id: @organization), class: "button button--cta" %>
+
       <% if @organization.child_sites.exists? %>
-        <h2><%= t("general.sites") %></h2>
         <% @organization.child_sites.map do |site| %>
-          <h3><%= site.name %></h3>
+          <h3><%= link_to site.name, edit_hub_site_path(parent_organization_id: @organization, id: site) %></h3>
         <% end %>
       <% else %>
         <%= t(".no_sites") %>

--- a/app/views/hub/organizations/edit.html.erb
+++ b/app/views/hub/organizations/edit.html.erb
@@ -1,0 +1,27 @@
+<% @title = @organization.name %>
+<% content_for :page_title, @title %>
+<% content_for :card do %>
+  <div class="hub-form">
+    <%= form_with model: @organization, url: hub_organizations_path, method: :post, local: true, builder: VitaMinFormBuilder do |f| %>
+      <h1 class="form-card__title">
+        <%= @title %>
+      </h1>
+
+      <%= f.cfa_input_field :name, t("general.name") %>
+      <%= f.cfa_select :coalition_id, t("general.coalition"), @coalitions.map { |c| [c.name, c.id] }, include_blank: true %>
+
+      <button class="button button--primary button--wide" type="submit">
+        <%= t("general.save") %>
+      </button>
+
+      <% if @organization.child_sites.exists? %>
+        <h2><%= t("general.sites") %></h2>
+        <% @organization.child_sites.map do |site| %>
+          <h3><%= site.name %></h3>
+        <% end %>
+      <% else %>
+        <%= t(".no_sites") %>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/hub/organizations/edit.html.erb
+++ b/app/views/hub/organizations/edit.html.erb
@@ -9,8 +9,7 @@
         <%= @title %>
       </h1>
 
-      <%= f.cfa_input_field :name, t("general.name") %>
-      <%= f.cfa_select :coalition_id, t("general.coalition"), @coalitions.map { |c| [c.name, c.id] }, include_blank: true %>
+      <%= render "hub/organizations/edit_organization", f: f %>
 
       <button class="button button--primary button--wide" type="submit">
         <%= t("general.save") %>

--- a/app/views/hub/organizations/index.html.erb
+++ b/app/views/hub/organizations/index.html.erb
@@ -3,7 +3,6 @@
 <% content_for :card do %>
   <h1><%= @title %></h1>
 
-
   <p><%= t(".organizations_by_coalition") %></p>
 
   <%= link_to t("hub.organizations.new.title"), new_hub_organization_path, class: "button button--cta"%>

--- a/app/views/hub/organizations/index.html.erb
+++ b/app/views/hub/organizations/index.html.erb
@@ -1,0 +1,29 @@
+<% @title = t("general.organizations") %>
+<% content_for :page_title, @title %>
+<% content_for :card do %>
+  <h1><%= @title %></h1>
+
+
+  <p><%= t(".organizations_by_coalition") %></p>
+
+  <%= link_to t("hub.organizations.new.title"), new_hub_organization_path, class: "button button--cta"%>
+
+  <% @coalitions.each do |coalition| %>
+    <h2><%= coalition.name %></h2>
+
+    <% if coalition.organizations.present? %>
+      <% coalition.organizations.each do |organization| %>
+        <h3><%= organization.name %></h3>
+      <% end %>
+    <% else %>
+      <%= t('.no_organizations') %>
+    <% end %>
+  <% end %>
+
+  <% if @independent_organizations.present? %>
+    <h2><%= t(".independent_organizations") %></h2>
+    <% @independent_organizations.each do |organization| %>
+      <h3><%= organization.name %></h3>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/hub/organizations/index.html.erb
+++ b/app/views/hub/organizations/index.html.erb
@@ -13,7 +13,9 @@
 
     <% if coalition.organizations.present? %>
       <% coalition.organizations.each do |organization| %>
-        <h3><%= organization.name %></h3>
+        <h3>
+          <%= link_to organization.name, edit_hub_organization_path(id: organization) %>
+        </h3>
       <% end %>
     <% else %>
       <%= t('.no_organizations') %>
@@ -23,7 +25,9 @@
   <% if @independent_organizations.present? %>
     <h2><%= t(".independent_organizations") %></h2>
     <% @independent_organizations.each do |organization| %>
-      <h3><%= organization.name %></h3>
+      <h3>
+        <%= link_to organization.name, edit_hub_organization_path(id: organization) %>
+      </h3>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/hub/organizations/index.html.erb
+++ b/app/views/hub/organizations/index.html.erb
@@ -13,9 +13,7 @@
 
     <% if coalition.organizations.present? %>
       <% coalition.organizations.each do |organization| %>
-        <h3>
-          <%= link_to organization.name, edit_hub_organization_path(id: organization) %>
-        </h3>
+        <%= render "hub/organizations/listing", organization: organization %>
       <% end %>
     <% else %>
       <%= t('.no_organizations') %>
@@ -25,9 +23,7 @@
   <% if @independent_organizations.present? %>
     <h2><%= t(".independent_organizations") %></h2>
     <% @independent_organizations.each do |organization| %>
-      <h3>
-        <%= link_to organization.name, edit_hub_organization_path(id: organization) %>
-      </h3>
+      <%= render "hub/organizations/listing", organization: organization %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/hub/organizations/new.html.erb
+++ b/app/views/hub/organizations/new.html.erb
@@ -1,0 +1,18 @@
+<% @title = t(".title") %>
+<% content_for :page_title, @title %>
+<% content_for :card do %>
+  <div class="hub-form">
+    <%= form_with model: @vita_partner, url: hub_organizations_path, method: :post, local: true, builder: VitaMinFormBuilder do |f| %>
+      <h1 class="form-card__title">
+        <%= @title %>
+      </h1>
+
+      <%= f.cfa_input_field :name, t("general.name") %>
+      <%= f.cfa_select :coalition_id, t("general.coalition"), @coalitions.map { |c| [c.name, c.id] }, include_blank: true %>
+
+      <button class="button button--primary button--wide" type="submit">
+        <%= t("general.save") %>
+      </button>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/hub/organizations/new.html.erb
+++ b/app/views/hub/organizations/new.html.erb
@@ -2,13 +2,12 @@
 <% content_for :page_title, @title %>
 <% content_for :card do %>
   <div class="hub-form">
-    <%= form_with model: @vita_partner, url: hub_organizations_path, method: :post, local: true, builder: VitaMinFormBuilder do |f| %>
+    <%= form_with model: @organization, url: hub_organizations_path, method: :post, local: true, builder: VitaMinFormBuilder do |f| %>
       <h1 class="form-card__title">
         <%= @title %>
       </h1>
 
-      <%= f.cfa_input_field :name, t("general.name") %>
-      <%= f.cfa_select :coalition_id, t("general.coalition"), @coalitions.map { |c| [c.name, c.id] }, include_blank: true %>
+      <%= render "hub/organizations/edit_organization", f: f %>
 
       <button class="button button--primary button--wide" type="submit">
         <%= t("general.save") %>

--- a/app/views/hub/sites/_form.html.erb
+++ b/app/views/hub/sites/_form.html.erb
@@ -1,0 +1,14 @@
+<div class="hub-form">
+  <%= form_with model: @site, url: url, method: http_method, local: true, builder: VitaMinFormBuilder do |f| %>
+    <h1 class="form-card__title">
+      <%= @title %>
+    </h1>
+
+    <%= f.cfa_input_field :name, t("general.name") %>
+    <%= f.cfa_select :parent_organization_id, t("general.organization"), @organizations.map { |c| [c.name, c.id] } %>
+
+    <button class="button button--primary button--wide" type="submit">
+      <%= t("general.save") %>
+    </button>
+  <% end %>
+</div>

--- a/app/views/hub/sites/edit.html.erb
+++ b/app/views/hub/sites/edit.html.erb
@@ -1,0 +1,5 @@
+<% @title = @site.name %>
+<% content_for :page_title, @site %>
+<% content_for :card do %>
+  <%= render "form", url: hub_site_path(organization_id: @organization, id: @site), http_method: :put %>
+<% end %>

--- a/app/views/hub/sites/new.html.erb
+++ b/app/views/hub/sites/new.html.erb
@@ -1,0 +1,5 @@
+<% @title = t(".title") %>
+<% content_for :page_title, @title %>
+<% content_for :card do %>
+  <%= render "hub/sites/form", url: hub_sites_path(parent_organization_id: @organization), http_method: :post %>
+<% end %>

--- a/app/views/hub/users/profile.html.erb
+++ b/app/views/hub/users/profile.html.erb
@@ -46,6 +46,14 @@
           <%= t(".vita_partners_link") %>
         <% end %>
       </li>
+
+      <% if can? :manage, VitaPartner %>
+        <li class="user-action-link">
+          <%= link_to hub_organizations_path, class: "button button--small" do %>
+            <%= t("general.organizations") %>
+          <% end %>
+        </li>
+      <% end %>
     </ul>
   </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -195,6 +195,13 @@ en:
       add_site: Add site
       index:
         title: VITA partners
+    organizations:
+      new:
+        title: "New Organization"
+      index:
+        independent_organizations: "Independent Organizations"
+        no_organizations: "No organizations"
+        organizations_by_coalition: "Organizations grouped by coalition:"
   controllers:
     application_controller:
       maintenance: GetYourRefund.org will be down for scheduled maintenance tonight at 11:00 p.m. Eastern (8:00 p.m. Pacific) until 3:00 a.m. Eastern (12:00 a.m. Pacific). We recommend that you answer all questions by this time or start a new session tomorrow.
@@ -340,6 +347,7 @@ en:
     changes_saved: Changes saved
     chat_with_us: Chat with us
     city: City
+    coalition: Coalition
     confirm: Confirm
     continue: Continue
     continue_example: Continue to example
@@ -411,6 +419,7 @@ en:
     opt_in_email: Opt into email notifications
     opt_in_sms: Opt into sms notifications
     organization: Organization
+    organizations: Organizations
     other_options: Try another free tax filing option
     partner: Partner
     password: Password

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -198,6 +198,8 @@ en:
     organizations:
       new:
         title: "New Organization"
+      edit:
+        no_sites: "No sites"
       index:
         independent_organizations: "Independent Organizations"
         no_organizations: "No organizations"
@@ -447,6 +449,7 @@ en:
     sign_out: Sign out
     sign_up: Sign up
     single: Single
+    sites: Sites
     skip_question: Skip question
     skip_questions: Skip questions
     sorry: We're sorry!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -200,10 +200,17 @@ en:
         title: "New Organization"
       edit:
         no_sites: "No sites"
+      listing:
+        site_count:
+          one: "%{count} site"
+          other: "%{count} sites"
       index:
         independent_organizations: "Independent Organizations"
         no_organizations: "No organizations"
         organizations_by_coalition: "Organizations grouped by coalition:"
+    sites:
+      new:
+        title: "Add site"
   controllers:
     application_controller:
       maintenance: GetYourRefund.org will be down for scheduled maintenance tonight at 11:00 p.m. Eastern (8:00 p.m. Pacific) until 3:00 a.m. Eastern (12:00 a.m. Pacific). We recommend that you answer all questions by this time or start a new session tomorrow.
@@ -338,6 +345,7 @@ en:
         certification_level: certification level
       general: Please fix indicated errors before continuing.
   general:
+    all_organizations: "All organizations"
     at_time: at %{time}
     NA: N/A
     address: Address

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -195,6 +195,13 @@ es:
       add_site: Agregar sitio
       index:
         title: Socios de VITA
+    organizations:
+      new:
+        title: "Nueva Organización"
+      index:
+        independent_organizations: "Organizaciones Independientes"
+        no_organizations: "Sin organizaciones"
+        organizations_by_coalition: "Organizaciones por coalición:"
   controllers:
     application_controller:
       maintenance: GetYourRefund.org estará fuera de servicio esta noche debido a un mantenimiento programado entre las 11:00 p.m. hora del Este (8:00 p.m. hora del Pacífico) hasta las 3:00 a.m. hora del Este (12:00 a.m. hora del Pacífico). Le recomendamos que responda  todas las preguntas antes de estos horarios o que comience una nueva sesión mañana.
@@ -340,6 +347,7 @@ es:
     changes_saved: Cambios guardados
     chat_with_us: Hable con nosotros por el chat
     city: Ciudad
+    coalition: Coalición
     confirm: Confirmar
     continue: Continuar
     continue_example: Continúe para ver un ejemplo
@@ -411,6 +419,7 @@ es:
     opt_in_email: Ha optado por recibir notificaciones por email
     opt_in_sms: Ha optado por recibir notificaciones por SMS
     organization: Organización
+    organizations: Organizaciones
     other_options: Intente otra opción de declaración gratis
     partner: Socio
     password: Contraseña

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -204,6 +204,13 @@ es:
         independent_organizations: "Organizaciones Independientes"
         no_organizations: "Sin organizaciones"
         organizations_by_coalition: "Organizaciones por coalición:"
+      listing:
+        site_count:
+          one: "%{count} sitio"
+          other: "%{count} sitios"
+    sites:
+      new:
+        title: "Agregar sitio"
   controllers:
     application_controller:
       maintenance: GetYourRefund.org estará fuera de servicio esta noche debido a un mantenimiento programado entre las 11:00 p.m. hora del Este (8:00 p.m. hora del Pacífico) hasta las 3:00 a.m. hora del Este (12:00 a.m. hora del Pacífico). Le recomendamos que responda  todas las preguntas antes de estos horarios o que comience una nueva sesión mañana.
@@ -343,6 +350,7 @@ es:
     address: Dirección
     admin: Admin
     affirmative: Sí
+    all_organizations: "Todas organizaciones"
     assign: Asignar
     assignee: Asignada a
     attachment: Adjunto

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -198,6 +198,8 @@ es:
     organizations:
       new:
         title: "Nueva Organización"
+      edit:
+        no_sites: "Ningunos sitios"
       index:
         independent_organizations: "Organizaciones Independientes"
         no_organizations: "Sin organizaciones"
@@ -447,6 +449,7 @@ es:
     sign_out: Cerrar sesión
     sign_up: Regístrate
     single: Soltera
+    sites: "Sitios"
     skip_question: Saltar pregunta
     skip_questions: Saltar preguntas
     sorry: "¡Ay, no! ¡Lo sentimos!"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -136,6 +136,7 @@ Rails.application.routes.draw do
         patch "update_certification", to: "tax_returns/certifications#update", on: :member
       end
       resources :organizations, only: [:index, :create, :new, :edit, :update]
+      resources :sites, only: [:new, :create, :edit, :update]
       resources :sub_organizations, only: [:edit, :update]
       resources :vita_partners, only: [:index, :edit, :update, :show]
       resources :anonymized_intake_csv_extracts, only: [:index, :show], path: "/csv-extracts", as: :csv_extracts

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -135,6 +135,7 @@ Rails.application.routes.draw do
       resources :tax_returns, only: [] do
         patch "update_certification", to: "tax_returns/certifications#update", on: :member
       end
+      resources :organizations, only: [:index, :create, :new]
       resources :sub_organizations, only: [:edit, :update]
       resources :vita_partners, only: [:index, :edit, :update, :show]
       resources :anonymized_intake_csv_extracts, only: [:index, :show], path: "/csv-extracts", as: :csv_extracts

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -135,7 +135,7 @@ Rails.application.routes.draw do
       resources :tax_returns, only: [] do
         patch "update_certification", to: "tax_returns/certifications#update", on: :member
       end
-      resources :organizations, only: [:index, :create, :new]
+      resources :organizations, only: [:index, :create, :new, :edit, :update]
       resources :sub_organizations, only: [:edit, :update]
       resources :vita_partners, only: [:index, :edit, :update, :show]
       resources :anonymized_intake_csv_extracts, only: [:index, :show], path: "/csv-extracts", as: :csv_extracts

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -69,7 +69,7 @@ Intake.create(client: other_client, preferred_name: "Tony", email_address: "tige
 
 married_client = Client.create!(vita_partner: fake_vita_partner)
 
-married_intake = Intake.create(
+married_intake = Intake.create!(
   client: married_client,
   preferred_name: "Lucky",
   sms_phone_number: "+14155551212",
@@ -81,3 +81,5 @@ married_intake = Intake.create(
   spouse_last_name: "Charms",
   spouse_email_address: "justthemarshmallows@example.com",
 )
+
+Coalition.create!(name: "CA")

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,31 +1,30 @@
-fake_vita_partner = VitaPartner.find_or_create_by(
-  name: "Fake Vita Partner",
-  display_name: "Fake Vita Partner Display Name",
-  zendesk_group_id: "foo",
-  zendesk_instance_domain: "eitc"
+koalas = Coalition.find_or_create_by(name: "Koala Koalition")
+Coalition.find_or_create_by(name: "Cola Coalition")
+
+first_org = VitaPartner.find_or_create_by!(
+  name: "Oregano Org",
+  display_name: "Oregano Org",
+  coalition: koalas,
+  zendesk_group_id: "unused",
+  zendesk_instance_domain: "unused",
 )
 
-another_vita_partner = VitaPartner.find_or_create_by(
-  name: "Another Vita Partner",
-  display_name: "Another Vita Partner with Children",
-  zendesk_group_id: "foo",
-  zendesk_instance_domain: "eitc"
+VitaPartner.find_or_create_by!(
+  name: "Orangutan Organization",
+  display_name: "Orangutan Organization",
+  coalition: koalas,
+  zendesk_group_id: "unused",
+  zendesk_instance_domain: "unused",
 )
 
-VitaPartner.find_or_create_by(
-  name: "Child Vita Partner",
-  display_name: "Child of Another Vita Partner",
-  zendesk_group_id: "foo",
-  zendesk_instance_domain: "eitc",
-  parent_organization: another_vita_partner,
-)
+VitaPartner.find_or_create_by(name: "Liberry Site", parent_organization: first_org)
 
 # basic user
 user = User.where(email: "skywalker@example.com").first_or_initialize
 user.update(
   name: "Luke",
   password: "theforcevita",
-  vita_partner: fake_vita_partner
+  vita_partner: first_org
 )
 
 # additional user
@@ -33,18 +32,18 @@ additional_user = User.where(email: "princess@example.com").first_or_initialize
 additional_user.update(
   name: "Lea",
   password: "theforcevita",
-  vita_partner: fake_vita_partner
+  vita_partner: first_org
 )
 
 admin_user = User.where(email: "admin@example.com").first_or_initialize
 admin_user.update(
   name: "The Admin",
   password: "theforcevita",
-  vita_partner: fake_vita_partner,
+  vita_partner: first_org,
   is_admin: true
 )
 
-client = Client.find_or_create_by(vita_partner: fake_vita_partner)
+client = Client.find_or_create_by(vita_partner: first_org)
 
 intake = Intake.create(client: client, preferred_name: "Captain", sms_phone_number: "+14155551212", email_address: "crunch@example.com", sms_notification_opt_in: :yes, email_notification_opt_in: :yes)
 
@@ -64,10 +63,10 @@ Note.create!(client: client, user: user, body: "This is an outgoing note :)", cr
 
 IncomingTextMessage.create!(client: client, body: "What's up with my taxes?", received_at: DateTime.now, from_phone_number: "+14155551212")
 
-other_client = Client.create!(vita_partner: fake_vita_partner)
+other_client = Client.create!(vita_partner: first_org)
 Intake.create(client: other_client, preferred_name: "Tony", email_address: "tiger@example.com", email_notification_opt_in: :yes)
 
-married_client = Client.create!(vita_partner: fake_vita_partner)
+married_client = Client.create!(vita_partner: first_org)
 
 married_intake = Intake.create!(
   client: married_client,
@@ -81,5 +80,3 @@ married_intake = Intake.create!(
   spouse_last_name: "Charms",
   spouse_email_address: "justthemarshmallows@example.com",
 )
-
-Coalition.create!(name: "CA")

--- a/spec/controllers/hub/organizations_controller_spec.rb
+++ b/spec/controllers/hub/organizations_controller_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe Hub::OrganizationsController, type: :controller do
 
     context "as a logged in admin user" do
       before { sign_in admin_user }
+
       let(:organizations) do
         create_list :organization, 5
       end
@@ -61,6 +62,62 @@ RSpec.describe Hub::OrganizationsController, type: :controller do
         get :index
 
         expect(assigns(:organizations)).to eq organizations
+      end
+    end
+  end
+
+  describe "#edit" do
+    let(:organization) { create :organization }
+    let(:params) do
+      { id: organization.id }
+    end
+
+    it_behaves_like :a_get_action_for_admins_only, action: :edit
+
+    context "as an authenticated admin user" do
+      render_views
+
+      before do
+        sign_in admin_user
+
+        create :site, parent_organization: organization, name: "Salmon Site"
+        create :site, parent_organization: organization, name: "Sea Lion Site"
+      end
+
+      it "displays a list of existing sites" do
+        get :edit, params: params
+
+        expect(response.body).to include "Salmon Site"
+        expect(response.body).to include "Sea Lion Site"
+      end
+    end
+  end
+
+  describe "#update" do
+    let(:organization) { create :organization, coalition: parent_coalition }
+    let(:new_coalition) { create :coalition, name: "Carrot Coalition" }
+    let(:params) do
+      {
+        id: organization.id,
+        vita_partner: {
+          coalition_id: new_coalition.id,
+          name: "Oregano Organization",
+        }
+      }
+    end
+
+    it_behaves_like :a_post_action_for_admins_only, action: :update
+
+    context "as a logged in admin" do
+      before { sign_in admin_user }
+
+      it "updates the name and coalition" do
+        post :update, params: params
+
+        organization.reload
+        expect(organization.name).to eq "Oregano Organization"
+        expect(organization.coalition).to eq new_coalition
+        expect(response).to redirect_to(hub_organizations_path)
       end
     end
   end

--- a/spec/controllers/hub/organizations_controller_spec.rb
+++ b/spec/controllers/hub/organizations_controller_spec.rb
@@ -84,11 +84,12 @@ RSpec.describe Hub::OrganizationsController, type: :controller do
         create :site, parent_organization: organization, name: "Sea Lion Site"
       end
 
-      it "displays a list of existing sites" do
+      it "displays a list of existing sites and a link to the site" do
         get :edit, params: params
 
         expect(response.body).to include "Salmon Site"
         expect(response.body).to include "Sea Lion Site"
+        expect(response.body).to include new_hub_site_path(parent_organization_id: organization)
       end
     end
   end

--- a/spec/controllers/hub/organizations_controller_spec.rb
+++ b/spec/controllers/hub/organizations_controller_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.describe Hub::OrganizationsController, type: :controller do
+  let(:parent_coalition) { create :coalition }
+  let(:admin_user) { create :admin_user }
+
+  describe "#new" do
+    it_behaves_like :a_get_action_for_admins_only, action: :new
+
+    context "as an authenticated admin user" do
+      let!(:coalitions) { create_list :coalition, 2 }
+      before { sign_in admin_user }
+
+      it "includes coalitions" do
+        get :new
+
+        expect(assigns(:coalitions)).to eq coalitions
+      end
+    end
+  end
+
+  describe "#create" do
+    let(:params) do
+      {
+        vita_partner: {
+          name: "Orangutan Organization",
+          coalition_id: parent_coalition.id
+        }
+      }
+    end
+
+    it_behaves_like :a_post_action_for_admins_only, action: :create
+
+    context "as a logged in admin user" do
+      before { sign_in admin_user }
+
+      it "saves a new organization" do
+        expect {
+          post :create, params: params
+        }.to change(VitaPartner.organizations, :count).by 1
+
+        organization = VitaPartner.organizations.last
+        expect(organization.name).to eq "Orangutan Organization"
+        expect(organization.coalition).to eq parent_coalition
+        expect(parent_coalition.organizations).to include organization
+        expect(response).to redirect_to(hub_organizations_path)
+      end
+    end
+  end
+
+  describe "#index" do
+    it_behaves_like :a_get_action_for_admins_only, action: :index
+
+    context "as a logged in admin user" do
+      before { sign_in admin_user }
+      let(:organizations) do
+        create_list :organization, 5
+      end
+
+      it "loads all organizations" do
+        get :index
+
+        expect(assigns(:organizations)).to eq organizations
+      end
+    end
+  end
+end

--- a/spec/controllers/hub/sites_controller_spec.rb
+++ b/spec/controllers/hub/sites_controller_spec.rb
@@ -1,0 +1,108 @@
+require "rails_helper"
+
+RSpec.describe Hub::SitesController, type: :controller do
+  let(:organization) { create :organization }
+  let(:admin_user) { create :admin_user }
+
+  describe "#new" do
+    let(:params) do
+      { parent_organization_id: organization.id }
+    end
+
+    it_behaves_like :a_get_action_for_admins_only, action: :new
+
+    context "as an authenticated admin user" do
+      let!(:other_org) { create :organization }
+      before { sign_in admin_user }
+
+      it "has a default organization and a list of organizations" do
+        get :new, params: params
+
+        expect(assigns(:site).parent_organization).to eq organization
+        expect(assigns(:organizations)).to include organization
+        expect(assigns(:organizations)).to include other_org
+      end
+    end
+  end
+
+  describe "#create" do
+    let(:other_organization) { create :organization }
+    let(:params) do
+      {
+        vita_partner: {
+          name: "Library Site",
+          parent_organization_id: other_organization.id
+        }
+      }
+    end
+
+    it_behaves_like :a_post_action_for_admins_only, action: :create
+
+    context "as an authenticated admin user" do
+      before { sign_in admin_user }
+
+      it "creates the site with attributes and redirects to the organization edit page" do
+        expect do
+          post :create, params: params
+        end.to change { VitaPartner.sites.count }.by 1
+
+        site = VitaPartner.sites.last
+        expect(site.name).to eq "Library Site"
+        expect(site.parent_organization).to eq other_organization
+        expect(response).to redirect_to edit_hub_organization_path(id: other_organization)
+      end
+    end
+  end
+
+  describe "#edit" do
+    let!(:other_org) { create :organization }
+    let(:site) { create :site, parent_organization: organization }
+    let(:params) do
+      { parent_organization_id: organization.id, id: site.id }
+    end
+
+    it_behaves_like :a_get_action_for_admins_only, action: :new
+
+    context "as an authenticated admin user" do
+      before { sign_in admin_user }
+
+      it "retrieves the site, a list of organizations, and returns OK" do
+        get :edit, params: params
+
+        expect(assigns(:site)).to eq site
+        expect(assigns(:organizations)).to include organization
+        expect(assigns(:organizations)).to include other_org
+        expect(response).to be_ok
+      end
+    end
+  end
+
+  describe "#update" do
+    let(:site) { create :site, parent_organization: organization }
+    let(:other_organization) { create :organization }
+    let(:params) do
+      {
+        id: site.id,
+        vita_partner: {
+          name: "Silly Site",
+          parent_organization_id: other_organization.id
+        }
+      }
+    end
+
+    it_behaves_like :a_post_action_for_admins_only, action: :update
+
+    context "as an authenticated admin user" do
+      before { sign_in admin_user }
+
+      it "updates the site with the new attributes and redirects to the input organization edit page" do
+        post :update, params: params
+
+        site.reload
+        expect(site.name).to eq "Silly Site"
+        expect(site.parent_organization).to eq other_organization
+        expect(response).to redirect_to edit_hub_organization_path(id: other_organization)
+      end
+    end
+  end
+end

--- a/spec/features/hub/create_organization_hierarchy_spec.rb
+++ b/spec/features/hub/create_organization_hierarchy_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "create VITA organization hierarchy" do
     let(:admin_user) { create :admin_user }
     before { login_as admin_user }
     let(:coalition) { create :coalition, name: "Koala Koalition" }
+    let!(:other_coalition) { create :coalition, name: "Coati Coalition" } # https://en.wikipedia.org/wiki/Coati
     let!(:organization) { create :organization, name: "Orangutan Organization", coalition: coalition }
 
     scenario "create a new organization" do
@@ -15,9 +16,19 @@ RSpec.describe "create VITA organization hierarchy" do
       expect(page).to have_selector("h2", text: "Koala Koalition")
       expect(page).to have_selector("h3", text: "Orangutan Organization")
 
+      # create a new organization
       click_on "New Organization"
       fill_in "Name", with: "Origami Organization"
       select "Koala Koalition", from: "Coalition"
+      click_on "Save"
+
+      # update the organization
+      # update the organization
+      click_on "Origami Organization"
+      expect(page).to have_text("No sites")
+
+      fill_in "Name", with: "Oregano Org"
+      select "Coati Coalition", from: "Coalition"
       click_on "Save"
 
       expect(page).to have_selector("h3", text: "Origami Organization")

--- a/spec/features/hub/create_organization_hierarchy_spec.rb
+++ b/spec/features/hub/create_organization_hierarchy_spec.rb
@@ -32,6 +32,28 @@ RSpec.describe "create VITA organization hierarchy" do
       click_on "Save"
 
       expect(page).to have_selector("h3", text: "Origami Organization")
+
+      # Add a site to an organization
+      click_on "Oregano Org"
+      click_on "Add site"
+      fill_in "Name", with: "Llama Library"
+      click_on "Save"
+
+      expect(page).to have_selector("h1", text: "Oregano Org")
+      expect(page).to have_text("Llama Library")
+
+      # Update a site
+      click_on "Llama Library"
+      fill_in "Name", with: "Lima Bean Library"
+      click_on "Save"
+
+      expect(page).to have_selector("h1", text: "Oregano Org")
+      expect(page).to have_text("Lima Bean Library")
+
+      # Go back to organization index
+      click_on "All organizations"
+
+      expect(page).to have_text("Oregano Org (1 site)")
     end
   end
 end

--- a/spec/features/hub/create_organization_hierarchy_spec.rb
+++ b/spec/features/hub/create_organization_hierarchy_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe "create VITA organization hierarchy" do
       click_on "Save"
 
       # update the organization
-      # update the organization
       click_on "Origami Organization"
       expect(page).to have_text("No sites")
 

--- a/spec/features/hub/create_organization_hierarchy_spec.rb
+++ b/spec/features/hub/create_organization_hierarchy_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe "create VITA organization hierarchy" do
+  context "as an admin user" do
+    let(:admin_user) { create :admin_user }
+    before { login_as admin_user }
+    let(:coalition) { create :coalition, name: "Koala Koalition" }
+    let!(:organization) { create :organization, name: "Orangutan Organization", coalition: coalition }
+
+    scenario "create a new organization" do
+      visit hub_user_profile_path
+      click_on "Organizations"
+
+      expect(page).to have_selector("h1", text: "Organizations")
+      expect(page).to have_selector("h2", text: "Koala Koalition")
+      expect(page).to have_selector("h3", text: "Orangutan Organization")
+
+      click_on "New Organization"
+      fill_in "Name", with: "Origami Organization"
+      select "Koala Koalition", from: "Coalition"
+      click_on "Save"
+
+      expect(page).to have_selector("h3", text: "Origami Organization")
+    end
+  end
+end

--- a/spec/models/vita_partner_spec.rb
+++ b/spec/models/vita_partner_spec.rb
@@ -223,6 +223,16 @@ describe VitaPartner do
         new_org = build(:organization, coalition: coalition, name: "Oregano Org")
         expect(new_org).not_to be_valid
       end
+
+      describe "#child_sites" do
+        before do
+          create_list(:site, 3, parent_organization: organization)
+        end
+
+        it "includes the sites an org has" do
+          expect(organization.child_sites.count).to eq(3)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This is a bit of a large pull request.

It takes the work done in https://github.com/codeforamerica/vita-min/pull/642/commits/8b51d5177baabcbd45be06b83ab91c93befe30b0 and migrates it to a model where a `VitaPartner` object can be either an Organization or a Site. The `VitaPartner.organizations` and `VitaPartner.sites` scopes allow picking just the right ones.

This completes the story in theory, but I will probably take some time to delete `.display_name`, `.zendesk_group_id`, and `.zendesk_instance_domain` from `VitaPartner` before picking up the next story.

After merging this PR, I will remove the "VITA Partners" button from the profile page, too.