### PR TITLE
Remove VitaPartner.display_name and unused Zendesk columns

### DIFF
--- a/app/controllers/hub/organizations_controller.rb
+++ b/app/controllers/hub/organizations_controller.rb
@@ -40,10 +40,7 @@ module Hub
     private
 
     def vita_partner_params
-      params.require(:vita_partner).permit(:name, :coalition_id).merge(
-        zendesk_group_id: "unused",
-        zendesk_instance_domain: "unused"
-      )
+      params.require(:vita_partner).permit(:name, :coalition_id)
     end
   end
 end

--- a/app/controllers/hub/sites_controller.rb
+++ b/app/controllers/hub/sites_controller.rb
@@ -38,10 +38,7 @@ module Hub
     end
 
     def vita_partner_params
-      params.require(:vita_partner).permit(:name, :parent_organization_id).merge(
-        zendesk_instance_domain: "unused",
-        zendesk_group_id: "unused",
-      )
+      params.require(:vita_partner).permit(:name, :parent_organization_id)
     end
   end
 end

--- a/app/forms/hub/sub_organization_form.rb
+++ b/app/forms/hub/sub_organization_form.rb
@@ -1,7 +1,7 @@
 module Hub
   class SubOrganizationForm < Form
     include FormAttributes
-    set_attributes_for :vita_partner, :display_name, :parent_organization_id, :name
+    set_attributes_for :vita_partner, :parent_organization_id, :name
     validates :name, presence: true, allow_blank: false
 
     def initialize(vita_partner, params = {})
@@ -11,10 +11,7 @@ module Hub
 
     def save
       VitaPartner.create!(name: name,
-                          display_name: display_name.presence || name,
-                          parent_organization_id: parent_organization_id,
-                          zendesk_instance_domain: "required-field-but-value-unused",
-                          zendesk_group_id: "required-field-but-value-unused")
+                          parent_organization_id: parent_organization_id)
     end
   end
 end

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -165,7 +165,6 @@
 #  was_on_visa                                          :integer          default("unfilled"), not null
 #  widowed                                              :integer          default("unfilled"), not null
 #  widowed_year                                         :string
-#  zendesk_instance_domain                              :string
 #  zip_code                                             :string
 #  created_at                                           :datetime
 #  updated_at                                           :datetime
@@ -175,7 +174,6 @@
 #  primary_intake_id                                    :integer
 #  triage_source_id                                     :bigint
 #  visitor_id                                           :string
-#  vita_partner_group_id                                :string
 #  vita_partner_id                                      :bigint
 #
 # Indexes

--- a/app/models/vita_partner.rb
+++ b/app/models/vita_partner.rb
@@ -2,20 +2,17 @@
 #
 # Table name: vita_partners
 #
-#  id                      :bigint           not null, primary key
-#  accepts_overflow        :boolean          default(FALSE)
-#  archived                :boolean          default(FALSE)
-#  display_name            :string
-#  logo_path               :string
-#  name                    :string           not null
-#  source_parameter        :string
-#  weekly_capacity_limit   :integer
-#  zendesk_instance_domain :string           not null
-#  created_at              :datetime         not null
-#  updated_at              :datetime         not null
-#  coalition_id            :bigint
-#  parent_organization_id  :bigint
-#  zendesk_group_id        :string           not null
+#  id                     :bigint           not null, primary key
+#  accepts_overflow       :boolean          default(FALSE)
+#  archived               :boolean          default(FALSE)
+#  logo_path              :string
+#  name                   :string           not null
+#  source_parameter       :string
+#  weekly_capacity_limit  :integer
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  coalition_id           :bigint
+#  parent_organization_id :bigint
 #
 # Indexes
 #
@@ -42,7 +39,7 @@ class VitaPartner < ApplicationRecord
   validate :no_coalitions_for_sites
   validates :name, uniqueness: { scope: [:coalition, :parent_organization] }
 
-  scope :top_level, -> { where(parent_organization: nil).order(:display_name).order(:name) }
+  scope :top_level, -> { where(parent_organization: nil).order(:name) }
   scope :organizations, -> { where(parent_organization: nil) }
   scope :sites, -> { where.not(parent_organization: nil) }
   has_many :child_sites, -> { order(:id) }, class_name: "VitaPartner", foreign_key: "parent_organization_id"

--- a/app/services/anonymized_intake_csv_service.rb
+++ b/app/services/anonymized_intake_csv_service.rb
@@ -17,8 +17,6 @@ class AnonymizedIntakeCsvService
     zip_code
     city
     needs_help_with_backtaxes?
-    zendesk_instance_domain
-    vita_partner_group_id
     vita_partner_name
     routing_criteria
     routing_value

--- a/app/services/mixpanel_service.rb
+++ b/app/services/mixpanel_service.rb
@@ -211,8 +211,6 @@ class MixpanelService
         needs_help_2017: intake.needs_help_2017,
         needs_help_2016: intake.needs_help_2016,
         needs_help_backtaxes: intake.needs_help_with_backtaxes? ? "yes" : "no",
-        zendesk_instance_domain: intake.vita_partner&.zendesk_instance_domain,
-        vita_partner_group_id: intake.vita_partner&.zendesk_group_id,
         vita_partner_name: intake.vita_partner&.name,
         triaged_from_stimulus: intake.triaged_from_stimulus? ? "yes" : "no",
         timezone: intake.timezone,

--- a/app/views/hub/clients/index.html.erb
+++ b/app/views/hub/clients/index.html.erb
@@ -52,7 +52,7 @@
               <% end %>
             </th>
             <td class="index-table__cell" align="center"><%= client.id %></td>
-            <td class="index-table__cell"><%= client.vita_partner&.display_name || t("general.none")  %></td>
+            <td class="index-table__cell"><%= client.vita_partner&.name || t("general.none")  %></td>
             <td class="index-table__cell"><%= client.intake&.locale ? t("general.language_options.#{client.intake&.locale}") : t('general.NA') %></td>
             <td class="index-table__cell" align="center"><%= formatted_datetime_with_break(client.updated_at) %></td>
             <td class="index-table__cell" align="center"><%= formatted_datetime_with_break(client.intake.primary_consented_to_service_at) || "-"%> </td>

--- a/app/views/hub/sub_organizations/edit.html.erb
+++ b/app/views/hub/sub_organizations/edit.html.erb
@@ -1,10 +1,9 @@
-<% content_for :page_title, t(".title", name: @vita_partner.display_name) %>
+<% content_for :page_title, t(".title", name: @vita_partner.name) %>
 
 <% content_for :card do %>
   <%= form_with(model: @form, url: hub_sub_organization_path, builder: VitaMinFormBuilder, method: :put, local: true) do |f| %>
-    <h1 class="h2"><%=t(".title", name: @vita_partner.display_name)%></h1>
+    <h1 class="h2"><%=t(".title", name: @vita_partner.name)%></h1>
     <%= f.cfa_input_field(:name, t("general.name"), classes: ["form-width--long"]) %>
-    <%= f.cfa_input_field(:display_name, t(".display_name"), classes: ["form-width--long"]) %>
     <button type="submit" class="button">
       Save
     </button>

--- a/app/views/hub/users/edit.html.erb
+++ b/app/views/hub/users/edit.html.erb
@@ -19,7 +19,7 @@
           <% VitaPartner.all.map do |vita_partner| %>
             <%= f.cfa_checkbox(
                   :supported_organization_ids,
-                  vita_partner.display_name,
+                  vita_partner.name,
                   options: {
                     checked_value: vita_partner.id,
                     unchecked_value: "",

--- a/app/views/hub/vita_partners/show.html.erb
+++ b/app/views/hub/vita_partners/show.html.erb
@@ -1,12 +1,12 @@
-<% content_for :page_title, "#{@vita_partner.display_name} ##{@vita_partner.id}" %>
+<% content_for :page_title, "#{@vita_partner.name} ##{@vita_partner.id}" %>
 
 <% content_for :card do %>
-  <h1 class="h2"><%= @vita_partner.display_name %></h1>
+  <h1 class="h2"><%= @vita_partner.name %></h1>
   <h2 class="h3">Sites</h2>
   <% if @sub_organizations.present? %>
     <ul class="list--bulleted">
     <% @sub_organizations.each do |sub_organization| %>
-        <li><%= sub_organization.display_name %></li>
+        <li><%= sub_organization.name %></li>
       <% end %>
     </ul>
   <% else %>

--- a/app/views/questions/chat_with_us/edit.html.erb
+++ b/app/views/questions/chat_with_us/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :body_class, "partner-page" %>
 
-<% content_for :page_title, t("views.questions.chat_with_us.title", :partner_name => current_intake.vita_partner&.display_name) %>
+<% content_for :page_title, t("views.questions.chat_with_us.title", :partner_name => current_intake.vita_partner&.name) %>
 
 <% content_for :form_card do %>
   <div class="form-card">
@@ -17,7 +17,7 @@
     <% else %>
 
       <% if current_intake.zip_code %>
-        <p><%= t("views.questions.chat_with_us.partner_info_html", :partner_name => current_intake.vita_partner&.display_name, :zip => current_intake.zip_code, :zip_name => @zip_name) %></p>
+        <p><%= t("views.questions.chat_with_us.partner_info_html", :partner_name => current_intake.vita_partner&.name, :zip => current_intake.zip_code, :zip_name => @zip_name) %></p>
       <% end %>
 
       <p>

--- a/app/views/questions/successfully_submitted/edit.html.erb
+++ b/app/views/questions/successfully_submitted/edit.html.erb
@@ -21,14 +21,14 @@
     </li>
     <li>
       <% if current_intake&.vita_partner.present? %>
-        <%=t("views.questions.successfully_submitted.next_steps.partner_review", :partner_name => current_intake.vita_partner.display_name) %>
+        <%=t("views.questions.successfully_submitted.next_steps.partner_review", :partner_name => current_intake.vita_partner.name) %>
       <% else %>
         <%=t("views.questions.successfully_submitted.next_steps.review") %>
       <% end %>
     </li>
     <li>
       <% if current_intake&.vita_partner.present? %>
-        <%=t("views.questions.successfully_submitted.next_steps.partner_timing", :partner_name => current_intake.vita_partner.display_name) %>
+        <%=t("views.questions.successfully_submitted.next_steps.partner_timing", :partner_name => current_intake.vita_partner.name) %>
       <% else %>
         <%=t("views.questions.successfully_submitted.next_steps.timing") %>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -190,7 +190,6 @@ en:
     sub_organizations:
       edit:
         title: Create sub-organization of %{name}
-        display_name: Client-facing display name (if different)
     vita_partners:
       add_site: Add site
       index:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -190,7 +190,6 @@ es:
     sub_organizations:
       edit:
         title: Crear una sub-organización de %{name}
-        display_name: Orientado al cliente nombre (si es diferente)
     vita_partners:
       add_site: Agregar sitio
       index:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_14_184717) do
+ActiveRecord::Schema.define(version: 2020_12_16_012857) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -337,7 +337,6 @@ ActiveRecord::Schema.define(version: 2020_12_14_184717) do
     t.datetime "updated_at"
     t.boolean "viewed_at_capacity", default: false
     t.string "visitor_id"
-    t.string "vita_partner_group_id"
     t.bigint "vita_partner_id"
     t.string "vita_partner_name"
     t.integer "was_blind", default: 0, null: false
@@ -345,7 +344,6 @@ ActiveRecord::Schema.define(version: 2020_12_14_184717) do
     t.integer "was_on_visa", default: 0, null: false
     t.integer "widowed", default: 0, null: false
     t.string "widowed_year"
-    t.string "zendesk_instance_domain"
     t.string "zip_code"
     t.index ["client_id"], name: "index_intakes_on_client_id"
     t.index ["email_address"], name: "index_intakes_on_email_address"
@@ -526,15 +524,12 @@ ActiveRecord::Schema.define(version: 2020_12_14_184717) do
     t.boolean "archived", default: false
     t.bigint "coalition_id"
     t.datetime "created_at", precision: 6, null: false
-    t.string "display_name"
     t.string "logo_path"
     t.string "name", null: false
     t.bigint "parent_organization_id"
     t.string "source_parameter"
     t.datetime "updated_at", precision: 6, null: false
     t.integer "weekly_capacity_limit"
-    t.string "zendesk_group_id", null: false
-    t.string "zendesk_instance_domain", null: false
     t.index ["coalition_id"], name: "index_vita_partners_on_coalition_id"
     t.index ["parent_organization_id", "name", "coalition_id"], name: "index_vita_partners_on_parent_name_and_coalition", unique: true
     t.index ["parent_organization_id"], name: "index_vita_partners_on_parent_organization_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,18 +3,12 @@ Coalition.find_or_create_by(name: "Cola Coalition")
 
 first_org = VitaPartner.find_or_create_by!(
   name: "Oregano Org",
-  display_name: "Oregano Org",
-  coalition: koalas,
-  zendesk_group_id: "unused",
-  zendesk_instance_domain: "unused",
+  coalition: koalas
 )
 
 VitaPartner.find_or_create_by!(
   name: "Orangutan Organization",
-  display_name: "Orangutan Organization",
   coalition: koalas,
-  zendesk_group_id: "unused",
-  zendesk_instance_domain: "unused",
 )
 
 VitaPartner.find_or_create_by(name: "Liberry Site", parent_organization: first_org)

--- a/spec/controllers/hub/clients_controller_spec.rb
+++ b/spec/controllers/hub/clients_controller_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe Hub::ClientsController do
           html = Nokogiri::HTML.parse(response.body)
           expect(html).to have_text("Updated At")
           expect(html.at_css("#client-#{george_sr.id}")).to have_text("George Sr.")
-          expect(html.at_css("#client-#{george_sr.id}")).to have_text(george_sr.vita_partner.display_name)
+          expect(html.at_css("#client-#{george_sr.id}")).to have_text(george_sr.vita_partner.name)
           expect(html.at_css("#client-#{george_sr.id} a")["href"]).to eq hub_client_path(id: george_sr)
           expect(html.at_css("#client-#{george_sr.id}")).to have_text("English")
           expect(html.at_css("#client-#{tobias.id}")).to have_text("Spanish")

--- a/spec/controllers/hub/documents_controller_spec.rb
+++ b/spec/controllers/hub/documents_controller_spec.rb
@@ -125,11 +125,11 @@ RSpec.describe Hub::DocumentsController, type: :controller do
   end
 
   describe "#update" do
-    let(:new_display_name) { "New Display Name"}
+    let(:new_display_name) { "New Display Name" }
     let(:vita_partner) { create :vita_partner }
     let(:client) { create :client, vita_partner: vita_partner, intake: create(:intake, vita_partner: vita_partner) }
     let(:document) { create :document, client: client }
-    let(:params) { { client_id: client.id, id: document.id, document: { display_name: new_display_name} } }
+    let(:params) { { client_id: client.id, id: document.id, document: { display_name: new_display_name } } }
 
     it_behaves_like :a_post_action_for_authenticated_users_only, action: :update
 

--- a/spec/controllers/hub/sub_organizations_controller_spec.rb
+++ b/spec/controllers/hub/sub_organizations_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Hub::SubOrganizationsController, type: :controller do
     context "as an authenticated admin user" do
       before { sign_in(user) }
 
-      it "accepts a name (and uses for the display name, too) and redirects to the parent organization's show page" do
+      it "accepts a name and redirects to the parent organization's show page" do
         expect do
           put :update, params: { id: vita_partner.id,
                                  hub_sub_organization_form:
@@ -20,7 +20,6 @@ RSpec.describe Hub::SubOrganizationsController, type: :controller do
 
         city_hall_tax_help_center = VitaPartner.last
         expect(city_hall_tax_help_center.name).to eq("City Hall Tax Help Center")
-        expect(city_hall_tax_help_center.display_name).to eq("City Hall Tax Help Center")
         expect(city_hall_tax_help_center.parent_organization).to eq(vita_partner)
 
         expect(response).to redirect_to(hub_vita_partner_path(id: city_hall_tax_help_center.parent_organization.id))
@@ -31,13 +30,11 @@ RSpec.describe Hub::SubOrganizationsController, type: :controller do
           put :update, params: { id: vita_partner.id,
                                  hub_sub_organization_form: {
                                      name: "City Hall Tax Help Center",
-                                     display_name: "City Hall Tax Help Center (Denver)"
                                  } }
         end.to change(VitaPartner, :count).by(1)
 
         city_hall_tax_help_center = VitaPartner.last
         expect(city_hall_tax_help_center.name).to eq("City Hall Tax Help Center")
-        expect(city_hall_tax_help_center.display_name).to eq("City Hall Tax Help Center (Denver)")
         expect(city_hall_tax_help_center.parent_organization).to eq(vita_partner)
 
         expect(response).to redirect_to(hub_vita_partner_path(id: city_hall_tax_help_center.parent_organization.id))

--- a/spec/controllers/hub/vita_partners_controller_spec.rb
+++ b/spec/controllers/hub/vita_partners_controller_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Hub::VitaPartnersController, type: :controller do
 
     context "for orgs with sub-organizations, i.e., sites" do
       let(:user) { create(:admin_user, vita_partner: vita_partner1) }
-      let!(:vita_partner1) { create(:vita_partner, display_name: "Vita Partner 1") }
-      let!(:vita_partner1_site) { create(:vita_partner, display_name: "Library Tax Help of Vita Partner 1", parent_organization: vita_partner1) }
-      let!(:vita_partner2) { create(:vita_partner, display_name: "Vita Partner 2") }
+      let!(:vita_partner1) { create(:vita_partner, name: "Vita Partner 1") }
+      let!(:vita_partner1_site) { create(:vita_partner, name: "Library Tax Help of Vita Partner 1", parent_organization: vita_partner1) }
+      let!(:vita_partner2) { create(:vita_partner, name: "Vita Partner 2") }
 
       before do
         sign_in(user)
@@ -32,7 +32,7 @@ RSpec.describe Hub::VitaPartnersController, type: :controller do
 
     context "sub-organizations" do
       let(:user) { create(:admin_user, vita_partner: vita_partner)}
-      let!(:vita_partner_site) { create(:vita_partner, display_name: "Library Tax Help of Vita Partner", parent_organization: vita_partner) }
+      let!(:vita_partner_site) { create(:vita_partner, name: "Library Tax Help of Vita Partner", parent_organization: vita_partner) }
 
       before do
         sign_in(user)

--- a/spec/controllers/questions/chat_with_us_controller_spec.rb
+++ b/spec/controllers/questions/chat_with_us_controller_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Questions::ChatWithUsController do
   render_views
 
-  let(:vita_partner) { create :vita_partner, display_name: "Fake Partner" }
+  let(:vita_partner) { create :vita_partner, name: "Fake Partner" }
   let(:zip_code) { nil }
   let(:intake) { create :intake, vita_partner: vita_partner, zip_code: zip_code }
 

--- a/spec/factories/intakes.rb
+++ b/spec/factories/intakes.rb
@@ -165,7 +165,6 @@
 #  was_on_visa                                          :integer          default("unfilled"), not null
 #  widowed                                              :integer          default("unfilled"), not null
 #  widowed_year                                         :string
-#  zendesk_instance_domain                              :string
 #  zip_code                                             :string
 #  created_at                                           :datetime
 #  updated_at                                           :datetime
@@ -175,7 +174,6 @@
 #  primary_intake_id                                    :integer
 #  triage_source_id                                     :bigint
 #  visitor_id                                           :string
-#  vita_partner_group_id                                :string
 #  vita_partner_id                                      :bigint
 #
 # Indexes
@@ -263,8 +261,6 @@ FactoryBot.define do
       city { ZipCodes::ZIP_CODES[zip_code][:name].split(", ").first }
       state { ZipCodes::ZIP_CODES[zip_code][:name].split(", ").last }
       state_of_residence { state }
-      zendesk_instance_domain { "eitc" }
-      vita_partner_group_id { vita_partner.zendesk_group_id }
       vita_partner_name { vita_partner.name }
       routing_value { vita_partner.states.first&.abbreviation || "az" }
       routing_criteria { "state" }

--- a/spec/factories/vita_partners.rb
+++ b/spec/factories/vita_partners.rb
@@ -2,20 +2,17 @@
 #
 # Table name: vita_partners
 #
-#  id                      :bigint           not null, primary key
-#  accepts_overflow        :boolean          default(FALSE)
-#  archived                :boolean          default(FALSE)
-#  display_name            :string
-#  logo_path               :string
-#  name                    :string           not null
-#  source_parameter        :string
-#  weekly_capacity_limit   :integer
-#  zendesk_instance_domain :string           not null
-#  created_at              :datetime         not null
-#  updated_at              :datetime         not null
-#  coalition_id            :bigint
-#  parent_organization_id  :bigint
-#  zendesk_group_id        :string           not null
+#  id                     :bigint           not null, primary key
+#  accepts_overflow       :boolean          default(FALSE)
+#  archived               :boolean          default(FALSE)
+#  logo_path              :string
+#  name                   :string           not null
+#  source_parameter       :string
+#  weekly_capacity_limit  :integer
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  coalition_id           :bigint
+#  parent_organization_id :bigint
 #
 # Indexes
 #
@@ -33,9 +30,6 @@ FactoryBot.define do
   end
   factory :vita_partner do
     name { generate :name }
-    display_name { name }
-    zendesk_instance_domain { "eitc" }
-    sequence(:zendesk_group_id) { |n| n.to_s }
 
     factory :organization do
       sequence(:name) { |n| "Organization #{n}" }

--- a/spec/features/hub/add_sub_organization_spec.rb
+++ b/spec/features/hub/add_sub_organization_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Create a sub-organization" do
   context "as an admin user" do
-    let(:vita_partner) { create :vita_partner, name: "Example Partner", display_name: "Example Partner" }
+    let(:vita_partner) { create :vita_partner, name: "Example Partner" }
     let(:current_user) { create :admin_user, vita_partner: vita_partner }
     before { login_as current_user }
 

--- a/spec/features/hub/edit_user_spec.rb
+++ b/spec/features/hub/edit_user_spec.rb
@@ -3,10 +3,10 @@ require "rails_helper"
 RSpec.describe "a user editing a user" do
   context "as an authenticated user" do
     context "as an admin" do
-      let!(:colorado_org) { create :vita_partner, name: "Colorado", display_name: "Colorado" }
-      let!(:denver_org) { create :vita_partner, parent_organization: colorado_org, name: "Denver", display_name: "Denver" }
-      let!(:california_org) { create :vita_partner, name: "California", display_name: "California" }
-      let!(:san_fran_org) { create :vita_partner, parent_organization: california_org, name: "San Francisco", display_name: "San Francisco" }
+      let!(:colorado_org) { create :vita_partner, name: "Colorado" }
+      let!(:denver_org) { create :vita_partner, parent_organization: colorado_org, name: "Denver" }
+      let!(:california_org) { create :vita_partner, name: "California" }
+      let!(:san_fran_org) { create :vita_partner, parent_organization: california_org, name: "San Francisco" }
       let(:current_user) { create :admin_user, vita_partner: colorado_org }
       let(:user_to_edit) { create :user, vita_partner: colorado_org }
       before { login_as current_user }

--- a/spec/features/hub/show_client_spec.rb
+++ b/spec/features/hub/show_client_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "a user viewing a client" do
     scenario "can view and cannot update organization" do
       visit hub_client_path(id: client.id)
       within ".client-header__organization" do
-        expect(page).to have_text client.vita_partner.display_name
+        expect(page).to have_text client.vita_partner.name
         expect(page).not_to have_text "Edit"
       end
     end
@@ -76,15 +76,15 @@ RSpec.describe "a user viewing a client" do
     scenario "can view and update client organization" do
       visit hub_client_path(id: client.id)
       within ".client-header" do
-        expect(page).to have_text client.vita_partner.display_name
+        expect(page).to have_text client.vita_partner.name
         click_on "Edit"
       end
       expect(page.current_path).to eq edit_organization_hub_client_path(id: client.id)
       expect(page).to have_text "Edit Organization for #{client.preferred_name}"
-      select other_vita_partner.display_name, from: "Organization"
+      select other_vita_partner.name, from: "Organization"
       click_on "Save"
       within ".client-header" do
-        expect(page).to have_text other_vita_partner.display_name
+        expect(page).to have_text other_vita_partner.name
       end
     end
   end

--- a/spec/features/web_intake/new_211_filer_spec.rb
+++ b/spec/features/web_intake/new_211_filer_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Web Intake 211 Assisted Filer" do
 
   before do
     # Create the hard-coded VITA partner for EIP-only returns
-    create(:vita_partner, display_name: "Get Your Refund", zendesk_group_id: "360012655454")
+    create(:vita_partner, name: "Get Your Refund")
   end
 
   scenario "new EIP-only client filing joint with a dependent" do

--- a/spec/features/web_intake/new_eip_only_filer_spec.rb
+++ b/spec/features/web_intake/new_eip_only_filer_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Web Intake EIP Only Filer" do
 
   before do
     # Create the hard-coded VITA partner for EIP-only returns
-    create(:vita_partner, display_name: "Get Your Refund", zendesk_group_id: "360012655454")
+    create(:vita_partner, name: "Get Your Refund")
   end
 
   scenario "new EIP-only client filing joint with a dependent" do

--- a/spec/features/web_intake/new_joint_filers_spec.rb
+++ b/spec/features/web_intake/new_joint_filers_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Web Intake Joint Filers" do
   let(:ticket_id) { 9876 }
 
   before do
-    create :vita_partner, display_name: "Virginia Partner", zendesk_group_id: "123", states: [State.find_by(abbreviation: "VA")]
+    create :vita_partner, name: "Virginia Partner", states: [State.find_by(abbreviation: "VA")]
     # see note below about skipping redirects
   end
 

--- a/spec/features/web_intake/new_single_filer_spec.rb
+++ b/spec/features/web_intake/new_single_filer_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Web Intake Single Filer" do
   let(:ticket_id) { 9876 }
 
   before do
-    create :vita_partner, display_name: "Virginia Partner", zendesk_group_id: "123", states: [State.find_by(abbreviation: "VA")]
+    create :vita_partner, name: "Virginia Partner", states: [State.find_by(abbreviation: "VA")]
   end
 
   scenario "new client filing single without dependents" do

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -165,7 +165,6 @@
 #  was_on_visa                                          :integer          default("unfilled"), not null
 #  widowed                                              :integer          default("unfilled"), not null
 #  widowed_year                                         :string
-#  zendesk_instance_domain                              :string
 #  zip_code                                             :string
 #  created_at                                           :datetime
 #  updated_at                                           :datetime
@@ -175,7 +174,6 @@
 #  primary_intake_id                                    :integer
 #  triage_source_id                                     :bigint
 #  visitor_id                                           :string
-#  vita_partner_group_id                                :string
 #  vita_partner_id                                      :bigint
 #
 # Indexes

--- a/spec/models/vita_partner_spec.rb
+++ b/spec/models/vita_partner_spec.rb
@@ -2,20 +2,17 @@
 #
 # Table name: vita_partners
 #
-#  id                      :bigint           not null, primary key
-#  accepts_overflow        :boolean          default(FALSE)
-#  archived                :boolean          default(FALSE)
-#  display_name            :string
-#  logo_path               :string
-#  name                    :string           not null
-#  source_parameter        :string
-#  weekly_capacity_limit   :integer
-#  zendesk_instance_domain :string           not null
-#  created_at              :datetime         not null
-#  updated_at              :datetime         not null
-#  coalition_id            :bigint
-#  parent_organization_id  :bigint
-#  zendesk_group_id        :string           not null
+#  id                     :bigint           not null, primary key
+#  accepts_overflow       :boolean          default(FALSE)
+#  archived               :boolean          default(FALSE)
+#  logo_path              :string
+#  name                   :string           not null
+#  source_parameter       :string
+#  weekly_capacity_limit  :integer
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  coalition_id           :bigint
+#  parent_organization_id :bigint
 #
 # Indexes
 #
@@ -126,7 +123,6 @@ describe VitaPartner do
           create(
             :vita_partner,
             name: "Urban Upbound (NY)",
-            zendesk_group_id: "360010243314",
           )
         end
 
@@ -241,7 +237,7 @@ describe VitaPartner do
 
     it "permits one level of depth" do
       child = VitaPartner.new(
-        name: "Child", parent_organization: vita_partner, zendesk_group_id: "child_group_id", zendesk_instance_domain: "eitc"
+        name: "Child", parent_organization: vita_partner
       )
       expect(child).to be_valid
     end
@@ -249,7 +245,7 @@ describe VitaPartner do
     it "does not permit two levels of depth" do
       child = create(:vita_partner, parent_organization: vita_partner)
       grandchild = VitaPartner.new(
-        name: "Grand Child", parent_organization: child, zendesk_group_id: "grandchild_group_id", zendesk_instance_domain: "eitc"
+        name: "Grand Child", parent_organization: child
       )
       expect(grandchild).not_to be_valid
     end

--- a/spec/services/anonymized_intake_csv_service_spec.rb
+++ b/spec/services/anonymized_intake_csv_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe AnonymizedIntakeCsvService do
-  let!(:vita_partner) { create(:vita_partner, name: "Example", zendesk_group_id: "123") }
+  let!(:vita_partner) { create(:vita_partner, name: "Example") }
   let(:intake_1) { create(:intake, :filled_out) }
   let(:intake_2) { create(:intake, :filled_out) }
   let!(:intake_3) { create(:intake) }

--- a/spec/services/mixpanel_service_spec.rb
+++ b/spec/services/mixpanel_service_spec.rb
@@ -159,7 +159,6 @@ describe MixpanelService do
         partner = create(
           :vita_partner,
           name: "test_partner",
-          zendesk_group_id: "1234567890123456"
         )
         partner.states << state
         partner
@@ -249,8 +248,6 @@ describe MixpanelService do
             needs_help_2017: "yes",
             needs_help_2016: "unfilled",
             needs_help_backtaxes: "yes",
-            zendesk_instance_domain: "eitc",
-            vita_partner_group_id: vita_partner.zendesk_group_id,
             vita_partner_name: vita_partner.name,
             triaged_from_stimulus: "no",
             timezone: "America/Los_Angeles",


### PR DESCRIPTION
Kelly M confirms that we don't need `display_name`.

The Zendesk columns were bugging me.

Whee!