### PR TITLE
Use text message id instead of object when sending texts to job

### DIFF
--- a/app/jobs/send_outgoing_text_message_job.rb
+++ b/app/jobs/send_outgoing_text_message_job.rb
@@ -2,7 +2,9 @@ class SendOutgoingTextMessageJob < ApplicationJob
   include Rails.application.routes.url_helpers
   queue_as :default
 
-  def perform(outgoing_text_message)
+  def perform(outgoing_text_message_id)
+    outgoing_text_message = OutgoingTextMessage.find(outgoing_text_message_id)
+
     twilio_client = Twilio::REST::Client.new(
       EnvironmentCredentials.dig(:twilio, :account_sid),
       EnvironmentCredentials.dig(:twilio, :auth_token)

--- a/app/models/outgoing_text_message.rb
+++ b/app/models/outgoing_text_message.rb
@@ -54,7 +54,7 @@ class OutgoingTextMessage < ApplicationRecord
   private
 
   def deliver
-    SendOutgoingTextMessageJob.perform_later(self)
+    SendOutgoingTextMessageJob.perform_later(id)
   end
 
   def broadcast

--- a/spec/controllers/concerns/message_sending_spec.rb
+++ b/spec/controllers/concerns/message_sending_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe MessageSending, type: :controller do
           expect(outgoing_text_message.sent_at).to eq expected_time
           expect(outgoing_text_message.to_phone_number).to eq client.sms_phone_number
           expect(ClientChannel).to have_received(:broadcast_contact_record).with(outgoing_text_message)
-          expect(SendOutgoingTextMessageJob).to have_been_enqueued.with(outgoing_text_message)
+          expect(SendOutgoingTextMessageJob).to have_been_enqueued.with(outgoing_text_message.id)
         end
 
         context "with blank body" do
@@ -214,7 +214,7 @@ RSpec.describe MessageSending, type: :controller do
         expect(system_text_message.sent_at).to eq expected_time
         expect(system_text_message.to_phone_number).to eq client.sms_phone_number
         expect(ClientChannel).to have_received(:broadcast_contact_record).with(system_text_message)
-        expect(SendOutgoingTextMessageJob).to have_been_enqueued.with(system_text_message)
+        expect(SendOutgoingTextMessageJob).to have_been_enqueued.with(system_text_message.id)
       end
     end
   end

--- a/spec/jobs/send_outgoing_text_message_job_spec.rb
+++ b/spec/jobs/send_outgoing_text_message_job_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe SendOutgoingTextMessageJob, type: :job do
     end
 
     it "send the message to Twilio along with a status callback URL and saves the status into the model" do
-      SendOutgoingTextMessageJob.perform_now(outgoing_text_message)
+      SendOutgoingTextMessageJob.perform_now(outgoing_text_message.id)
       expect(fake_twilio_messages).to have_received(:create).with(
         messaging_service_sid: "f@k3s!d",
         to: outgoing_text_message.to_phone_number,

--- a/spec/models/outgoing_text_message_spec.rb
+++ b/spec/models/outgoing_text_message_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe OutgoingTextMessage, type: :model do
         it "enqueues a job to sent the text" do
           expect {
             message.save
-          }.to have_enqueued_job.on_queue("default").with(message)
+          }.to have_enqueued_job.on_queue("default").with(message.id)
         end
 
         it "broadcasts the text message" do


### PR DESCRIPTION
Co-authored-by: Sarah Niemeyer <sniemeyer@vmware.com>