### PR TITLE
Replacement parameters for messages

### DIFF
--- a/app/lib/tax_return_status.rb
+++ b/app/lib/tax_return_status.rb
@@ -13,6 +13,16 @@ class TaxReturnStatus
       end
       stages
     end
+
+    def message_templates
+      {
+          intake_more_info: "hub.status_macros.needs_more_information",
+          prep_more_info: "hub.status_macros.needs_more_information",
+          review_more_info: "hub.status_macros.needs_more_information",
+          prep_ready_for_review: "hub.status_macros.ready_for_qr",
+          filed_accepted: "hub.status_macros.accepted"
+      }
+    end
   end
   # If we ever need to add statuses between these numbers, we can multiply these by 100, do a data migration, and
   # then insert a value in between.
@@ -28,4 +38,8 @@ class TaxReturnStatus
 
   STATUSES_BY_STAGE = determine_statuses_by_stage.freeze
   STAGES = STATUSES_BY_STAGE.keys.freeze
+
+  def self.message_template_for(status, locale = "en")
+    message_templates[status.to_sym] ? I18n.t(message_templates[status.to_sym], locale: locale) : ""
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -74,4 +74,8 @@ class User < ApplicationRecord
       VitaPartner.where(parent_organization_id: accessible_organization_ids)
     )
   end
+
+  def first_name
+    name&.split(" ")&.first
+  end
 end

--- a/app/services/replacement_parameters_service.rb
+++ b/app/services/replacement_parameters_service.rb
@@ -1,0 +1,36 @@
+class ReplacementParametersService
+  attr_accessor :body, :client, :preparer_user, :locale
+
+  def initialize(body:, client:, preparer: nil, locale: "en")
+    @body = body
+    @client = client
+    @preparer_user = preparer
+    @locale = locale
+  end
+
+  def process
+    replacements.each_key { |k| body.gsub!(/<<\s*#{k}\s*>>/i, "%{#{k}}") }
+    body % replacements
+  end
+
+  private
+
+  def replacements
+    {
+        "Client.PreferredName": client&.preferred_name,
+        "Preparer.FirstName": preparer_first_name,
+        "Documents.List": documents_list,
+        "Documents.UploadLink": client.intake.requested_docs_token_link
+    }
+  end
+
+  def preparer_first_name
+    preparer_user&.first_name || I18n.t("general.tax_team", locale: locale)
+  end
+
+  def documents_list
+    client.intake.relevant_document_types.map do |doc_type|
+      "  - " + doc_type.translated_label(locale)
+    end.join("\n")
+  end
+end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -106,6 +106,7 @@ ignore_unused:
   - 'devise.failure.*'
   - 'hub.tax_returns.stage.*'
   - 'hub.tax_returns.status.*'
+  - 'hub.status_macros.*'
 # - 'activerecord.attributes.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,31 +165,31 @@ en:
         filed_accepted: Accepted
     status_macros:
       needs_more_information: |
-        Hello!
+        Hello <<Client.PreferredName>>!
 
         In order to continue filing your taxes, we need you to send us:
-        %{required_documents}
-        Securely upload your documents by going to %{document_upload_link}
+        <<Documents.List>>
+        Securely upload your documents by going to <<Documents.UploadLink>>.
 
         Please let us know if you have any questions. We cannot prepare your taxes without this information.
 
         Thanks!
-        Your tax team at GetYourRefund.org
+        <<Preparer.FirstName>> at GetYourRefund.org
       ready_for_qr: |
-        Hello!
+        Hello <<Client.PreferredName>>!
 
         Your return is now being quality reviewed!
 
         Thanks!
-        Your tax team at GetYourRefund.org
+        <<Preparer.FirstName>> at GetYourRefund.org
       accepted: |
-        Hello!
+        Hello <<Client.PreferredName>>!
 
         Your federal and state returns have been accepted! You will not receive any further notifications. If you have questions about your refund and/or amount owed, please address them to the IRS or your state Department of Revenue offices.
         If you have any questions, please reply to this message.
 
         Thanks!
-        Your tax team at GetYourRefund.org
+        <<Preparer.FirstName>> at GetYourRefund.org
     bank_accounts:
       info_displayed: Displaying bank account information
       bank_name: Bank name
@@ -483,6 +483,7 @@ en:
     year: year
     you: you
     you_or_spouse: you or your spouse
+    tax_team: Your tax team
     zendesk:
       access_denied: You are not authorized to access that page
     zip_code: ZIP code

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -165,31 +165,31 @@ es:
         filed_accepted: Aceptado
     status_macros:
       needs_more_information: |
-        ¡Hola!
+        ¡Hola <<Client.PreferredName>>!
 
         Para continuar presentando sus impuestos, necesitamos que nos envíe:
-        %{required_documents}
-        Sube tus documentos de forma segura por %{document_upload_link}
+        <<Documents.List>>
+        Sube tus documentos de forma segura por <<Documents.UploadLink>>
 
         Por favor, háganos saber si usted tiene alguna pregunta. No podemos preparar sus impuestos sin esta información.
 
         ¡Gracias!
-        Su equipo de impuestos en GetYourRefund.org
+        <<Preparer.FirstName>> en GetYourRefund.org
       ready_for_qr: |
-        ¡Hola!
+        ¡Hola <<Client.PreferredName>>!
 
         ¡Su devolución ahora está siendo revisada en calidad!
 
         ¡Gracias!
-        Su equipo de impuestos en GetYourRefund.org
+        <<Preparer.FirstName>> en GetYourRefund.org
       accepted: |
-        ¡Hola!
+        ¡Hola <<Client.PreferredName>>!
 
         ¡Se han aceptado sus declaraciones federales y estatales! No recibirá más notificaciones. Si tiene preguntas sobre su reembolso y / o el monto adeudado, diríjase al Servicio de Impuestos Internos (IRS) oa las oficinas del Departamento de Ingresos de su estado.
         Si tiene alguna pregunta, responda a este mensaje.
 
         ¡Gracias!
-        Su equipo de impuestos en GetYourRefund.org
+        <<Preparer.FirstName>> en GetYourRefund.org
     bank_accounts:
       info_displayed: Visualización de la información de la cuenta bancaria
       bank_name: Nombre del banco
@@ -483,6 +483,7 @@ es:
     year: año
     you: usted
     you_or_spouse: usted o su cónyuge
+    tax_team: Su equipo de impuestos
     zendesk:
       access_denied: No tiene autorización para acceder a esa página
     zip_code: Código postal

--- a/spec/controllers/hub/clients_controller_spec.rb
+++ b/spec/controllers/hub/clients_controller_spec.rb
@@ -702,11 +702,10 @@ RSpec.describe Hub::ClientsController do
         it "prepopulates the form using the locale, status, and relevant template" do
           get :edit_take_action, params: params
 
-          filled_out_template = I18n.t("hub.status_macros.needs_more_information", locale: "es")[0..10]
           expect(assigns(:take_action_form).tax_return_id).to eq tax_return_2019.id
           expect(assigns(:take_action_form).status).to eq "intake_more_info"
           expect(assigns(:take_action_form).locale).to eq "es"
-          expect(assigns(:take_action_form).message_body).to include filled_out_template
+          expect(assigns(:take_action_form).message_body).not_to be_blank
           expect(assigns(:take_action_form).contact_method).to eq "email"
         end
 
@@ -790,8 +789,6 @@ RSpec.describe Hub::ClientsController do
           expect(flash[:notice]).to eq "Success: Action taken! Updated status, sent email, added internal note."
         end
       end
-
-
     end
   end
 end

--- a/spec/lib/tax_return_status_spec.rb
+++ b/spec/lib/tax_return_status_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+describe TaxReturnStatus do
+  context ".message_template_for" do
+    context "prep_more_info" do
+      it "returns a template" do
+        expect(TaxReturnStatus.message_template_for("prep_more_info")).to eq I18n.t("hub.status_macros.needs_more_information", locale: "en")
+        expect(TaxReturnStatus.message_template_for(:prep_more_info, "es")).to eq I18n.t("hub.status_macros.needs_more_information", locale: "es")
+      end
+    end
+
+    context "intake_more_info" do
+      it "returns a template" do
+        expect(TaxReturnStatus.message_template_for("intake_more_info")).to eq I18n.t("hub.status_macros.needs_more_information", locale: "en")
+        expect(TaxReturnStatus.message_template_for(:intake_more_info, "es")).to eq I18n.t("hub.status_macros.needs_more_information", locale: "es")
+      end
+    end
+
+    context "review_more_info" do
+      it "returns a template" do
+        expect(TaxReturnStatus.message_template_for("review_more_info")).to eq I18n.t("hub.status_macros.needs_more_information", locale: "en")
+        expect(TaxReturnStatus.message_template_for(:review_more_info, "es")).to eq I18n.t("hub.status_macros.needs_more_information", locale: "es")
+      end
+    end
+
+    context "prep_ready_for_review" do
+      it "returns a template" do
+        expect(TaxReturnStatus.message_template_for("prep_ready_for_review")).to eq I18n.t("hub.status_macros.ready_for_qr", locale: "en")
+        expect(TaxReturnStatus.message_template_for(:prep_ready_for_review, "es")).to eq I18n.t("hub.status_macros.ready_for_qr", locale: "es")
+      end
+    end
+
+    context "filed_accepted" do
+      it "returns a template" do
+        expect(TaxReturnStatus.message_template_for("filed_accepted")).to eq I18n.t("hub.status_macros.accepted", locale: "en")
+        expect(TaxReturnStatus.message_template_for(:filed_accepted, "es")).to eq I18n.t("hub.status_macros.accepted", locale: "es")
+      end
+    end
+
+    context "statuses without templates" do
+      it "returns an empty string" do
+        expect(TaxReturnStatus.message_template_for("other_status")).to eq ""
+        expect(TaxReturnStatus.message_template_for(:other_status, "es")).to eq ""
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -90,4 +90,27 @@ RSpec.describe User, type: :model do
       expect(accessible_organization_ids).not_to include(not_accessible_partner.id)
     end
   end
+
+  describe "first_name" do
+    context "Luke" do
+      let(:user) { build :user, name: "Luke"}
+      it "returns nil" do
+        expect(user.first_name).to eq "Luke"
+      end
+    end
+
+    context "Luke Skywalker" do
+      let(:user) { build :user, name: "Luke Skywalker"}
+      it "returns nil" do
+        expect(user.first_name).to eq "Luke"
+      end
+    end
+
+    context "without name" do
+      let(:user) { build :user, name: nil}
+      it "returns nil" do
+        expect(user.first_name).to eq nil
+      end
+    end
+  end
 end

--- a/spec/services/replacement_parameters_service_spec.rb
+++ b/spec/services/replacement_parameters_service_spec.rb
@@ -1,0 +1,157 @@
+require 'rails_helper'
+
+describe ReplacementParametersService do
+  let(:client) { create :client, intake: create(:intake, preferred_name: "Preferred Name") }
+  let(:user) { create :user, name: "Preparer Name" }
+  let(:locale) { "en" }
+  subject { ReplacementParametersService.new(body: body, client: client, preparer: user, locale: locale) }
+
+  context "<<Client.PreferredName>>" do
+    let(:body) { "Hi <<Client.PreferredName>>" }
+
+    it "replaces with client's preferred name" do
+      expect(subject.process).to eq "Hi #{client.preferred_name}"
+    end
+
+    context "client without preferred name" do
+      let(:client) { build :client, intake: create(:intake) }
+      it "handles as gracefully as possible" do
+        expect(subject.process).to eq "Hi "
+      end
+    end
+  end
+
+  context "<<Preparer.FirstName>>" do
+    let (:body) { "Sincerely, <<Preparer.FirstName>>" }
+
+    it "replaces with the preparer user's first name" do
+      expect(subject.process).to eq "Sincerely, #{user.first_name}"
+    end
+
+    context "when preparer is nil" do
+      let(:user) { nil }
+      it "uses a fallback string" do
+        expect(subject.process).to eq "Sincerely, Your tax team"
+      end
+    end
+  end
+
+  context "<<Documents.UploadLink>>" do
+    let(:body) { "Upload here: <<Documents.UploadLink>>" }
+    before do
+      allow(client.intake).to receive(:requested_docs_token_link).and_return "https://example.com/my-token-link"
+    end
+
+    it "replaces with the clients intake upload link" do
+      expect(subject.process).to eq "Upload here: #{client.intake.requested_docs_token_link}"
+    end
+  end
+
+  context "<<Documents.List>>" do
+    let(:body) { "We need these: <<Documents.List>>" }
+    before do
+      allow(client.intake).to receive(:relevant_document_types).and_return [DocumentTypes::Identity, DocumentTypes::Selfie, DocumentTypes::SsnItin, DocumentTypes::Other]
+    end
+
+    it "replaces with necessary document types" do
+      expect(subject.process).to eq "We need these:   - ID\n  - Selfie\n  - SSN or ITIN\n  - Other"
+    end
+  end
+
+  context "replacement params with extra whitespace" do
+    let(:body) { "Sincerely, << Preparer.FirstName >>" }
+
+    it "still works" do
+      expect(subject.process).to eq "Sincerely, #{user.first_name}"
+    end
+  end
+
+  context "replacement params with different casing" do
+    let(:body) { "Sincerely, << Preparer.firstname >>" }
+    it "still works" do
+      expect(subject.process).to eq "Sincerely, #{user.first_name}"
+    end
+  end
+
+  context "strings that look like replacement params but don't have a matching replacement" do
+    let(:body) { "Sincerely, <<Sloth.Firstname>>" }
+    it "leaves the original string" do
+      expect(subject.process).to eq "Sincerely, <<Sloth.Firstname>>"
+    end
+  end
+
+  context "translation strings with replacement params" do
+    before do
+      allow(client.intake).to receive(:relevant_document_types).and_return [DocumentTypes::Identity, DocumentTypes::Selfie, DocumentTypes::SsnItin, DocumentTypes::Other]
+      allow(client.intake).to receive(:requested_docs_token_link).and_return "https://example.com/my-token-link"
+    end
+
+    context "needs_more_information" do
+      context "in english" do
+        let(:body) { I18n.t("hub.status_macros.needs_more_information") }
+
+        it "replaces the replacement strings in the template" do
+          expect(subject.process).to include client.preferred_name
+          expect(subject.process).to include "- ID\n  - Selfie\n  - SSN or ITIN\n  - Other"
+          expect(subject.process).to include "https://example.com/my-token-link"
+          expect(subject.process).to include user.first_name
+
+        end
+      end
+
+      context "in spanish" do
+        let(:body) { I18n.t("hub.status_macros.needs_more_information", locale: "es") }
+        let(:locale){ "es" }
+
+        it "replaces the replacement strings in the template" do
+          expect(subject.process).to include client.preferred_name
+          expect(subject.process).to include "https://example.com/my-token-link"
+          expect(subject.process).to include "- Identificación\n  - Selfie\n  - SSN o ITIN\n  - Otro"
+          expect(subject.process).to include user.first_name
+        end
+      end
+    end
+
+    context "accepted" do
+      context "in english" do
+        let(:body) { I18n.t("hub.status_macros.accepted") }
+
+        it "replaces the replacement strings in the template" do
+          expect(subject.process).to include client.preferred_name
+          expect(subject.process).to include user.first_name
+        end
+      end
+
+      context "in spanish" do
+        let(:body) { I18n.t("hub.status_macros.accepted", locale: "es") }
+        let(:locale){ "es" }
+
+        it "replaces the replacement strings in the template" do
+          expect(subject.process).to include client.preferred_name
+          expect(subject.process).to include user.first_name
+        end
+      end
+    end
+
+    context "ready_for_qr" do
+      context "in english" do
+        let(:body) { I18n.t("hub.status_macros.ready_for_qr") }
+
+        it "replaces the replacement strings in the template" do
+          expect(subject.process).to include client.preferred_name
+          expect(subject.process).to include user.first_name
+        end
+      end
+
+      context "in spanish" do
+        let(:body) { I18n.t("hub.status_macros.ready_for_qr", locale: "es") }
+        let(:locale) { "es" }
+
+        it "replaces the replacement strings in the template" do
+          expect(subject.process).to include client.preferred_name
+          expect(subject.process).to include user.first_name
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Second part of the dynamically updating messages ticket:

We create the templates in the format that product will provide to us with the replacement parameters in them: <<Client.PreferredName>>, etc, and then a class called ReplacementParametersService handles parsing the template for replacement on the take action page.

This facilitates a couple of things:
- We should be able to allow product to create templates with existing parameters and we can add them directly to our translation files without any editing or manual setup for each individual email.
- We can use the same templates for the bulk take action page and just skip the "pre-hydrate" we're currently doing.
- We can use the replacement params service to parse ALL outgoing messages if we want to so that users can incorporate replacement params into emails they end up editing on the bulk edit page OR from the regular send message page.

It essentially uses a regex to change recognized replacement parameters and replace them with the values in the hash.