### PR TITLE
Convert User.vita_partner_id into Organization Lead Roles #175978650

### DIFF
--- a/app/controllers/hub/clients_controller.rb
+++ b/app/controllers/hub/clients_controller.rb
@@ -73,7 +73,7 @@ module Hub
         flash[:notice] = I18n.t("hub.clients.update_take_action.flash_message.success", action_list: @take_action_form.action_list.join(", ").capitalize)
         redirect_to hub_client_path(id: @client)
       else
-        flash[:alert] = I18n.t("forms.errors.general");
+        flash[:alert] = I18n.t("forms.errors.general")
         render :edit_take_action
       end
     end
@@ -89,8 +89,9 @@ module Hub
     end
 
     def create_client_form_params
+      default_vita_partner_id = OrganizationLeadRole.find_by_user_id(current_user.id)&.organization&.id
       filtered_params = params.require(CreateClientForm.form_param).permit(CreateClientForm.permitted_params)
-      filtered_params = filtered_params.merge(vita_partner_id: current_user.vita_partner_id) unless can?(:manage, VitaPartner)
+      filtered_params = filtered_params.merge(vita_partner_id: default_vita_partner_id) unless can?(:manage, VitaPartner)
       filtered_params
     end
 

--- a/app/controllers/hub/tax_returns_controller.rb
+++ b/app/controllers/hub/tax_returns_controller.rb
@@ -27,7 +27,7 @@ module Hub
     private
 
     def set_assignable_users
-      @assignable_users = @client.vita_partner.users
+      @assignable_users = User.where(id: OrganizationLeadRole.where(organization: @client.vita_partner).pluck(:user_id))
     end
 
     def assign_params

--- a/app/controllers/hub/users_controller.rb
+++ b/app/controllers/hub/users_controller.rb
@@ -8,6 +8,16 @@ module Hub
     layout "admin"
 
     def profile
+      @role_name =
+        if OrganizationLeadRole.exists?(user: current_user)
+          t("general.organization_lead")
+        elsif current_user.is_admin
+          t("general.admin")
+        elsif current_user.is_client_support
+          t("general.client_support")
+        else
+          ""
+        end
     end
 
     def index

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -19,10 +19,13 @@ class Users::InvitationsController < Devise::InvitationsController
   before_action :require_valid_invitation_token, only: [:edit, :update]
 
   def create
-    authorize!(:manage, @vita_partners.find(invite_params[:vita_partner_id]))
+    organization = @vita_partners.find(invite_params[:vita_partner_id])
+    authorize!(:manage, organization)
     super do |invited_user|
-      # set default values
-      invited_user.update(role: invited_user.role || "agent")
+      OrganizationLeadRole.create(
+        user: invited_user,
+        organization: organization,
+      )
     end
   end
 

--- a/app/helpers/role_helper.rb
+++ b/app/helpers/role_helper.rb
@@ -2,7 +2,8 @@ module RoleHelper
   def user_roles(user)
     [
         *(I18n.t("general.admin") if user.is_admin),
-        *(I18n.t("general.client_support") if user.is_client_support)
+        *(I18n.t("general.client_support") if user.is_client_support),
+        *(I18n.t('general.organization_lead') if OrganizationLeadRole.exists?(user: user))
     ].join(", ")
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -71,13 +71,7 @@ class User < ApplicationRecord
   def accessible_organizations
     organization_lead_role = OrganizationLeadRole.find_by_user_id(id)
 
-    accessible_organization_ids =
-      if organization_lead_role.present?
-        [organization_lead_role.organization.id]
-      else
-        []
-      end
-
+    accessible_organization_ids = organization_lead_role.present? ? [organization_lead_role.organization.id] : []
     accessible_organization_ids += supported_organizations.pluck(:id)
 
     VitaPartner.organizations.where(id: accessible_organization_ids).or(

--- a/app/views/hub/users/profile.html.erb
+++ b/app/views/hub/users/profile.html.erb
@@ -15,7 +15,7 @@
     </p>
     <p>
       <span class="hc-label"><%= t("general.role") %></span>
-      <span class="label-value"><%= current_user.role&.capitalize %></span>
+      <span class="label-value"><%= @role_name %></span>
     </p>
     <p>
       <span class="hc-label"><%= t("general.organization") %></span>

--- a/app/views/invitations/index.html.erb
+++ b/app/views/invitations/index.html.erb
@@ -3,7 +3,7 @@
 
   <div class="actions">
     <%= link_to new_user_invitation_path, class: "button" do %>
-      <%= t(".actions.new_invite") %>
+      <%= t(".actions.new_org_lead_invite") %>
     <% end %>
   </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -432,6 +432,7 @@ en:
     opt_in_email: Opt into email notifications
     opt_in_sms: Opt into sms notifications
     organization: Organization
+    organization_lead: "Organization lead"
     organizations: Organizations
     other_options: Try another free tax filing option
     partner: Partner
@@ -507,7 +508,7 @@ en:
   invitations:
     index:
       actions:
-        new_invite: Invite a new user
+        new_org_lead_invite: Invite a new organization lead
       invitation:
         create: Resend invitation email
         sent_at: Sent at %{datetime}

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -432,6 +432,7 @@ es:
     opt_in_email: Ha optado por recibir notificaciones por email
     opt_in_sms: Ha optado por recibir notificaciones por SMS
     organization: Organización
+    organization_lead: "Líder de organización"
     organizations: Organizaciones
     other_options: Intente otra opción de declaración gratis
     partner: Socio
@@ -507,7 +508,7 @@ es:
   invitations:
     index:
       actions:
-        new_invite: Invitar a alguien nuevo
+        new_org_lead_invite: Invite a un nuevo líder de la organización
       invitation:
         create: Reenviar email de invitación
         sent_at: Enviado a las %{datetime}

--- a/db/migrate/20201218172751_copy_data_into_organization_lead_roles.rb
+++ b/db/migrate/20201218172751_copy_data_into_organization_lead_roles.rb
@@ -1,0 +1,12 @@
+class CopyDataIntoOrganizationLeadRoles < ActiveRecord::Migration[6.0]
+  def up
+    execute "insert into organization_lead_roles (user_id, vita_partner_id, created_at, updated_at)
+             select id as user_id, vita_partner_id, now(), now()
+             from users
+             where users.vita_partner_id is not null and not users.is_admin;"
+  end
+
+  def down
+    execute "truncate organization_lead_roles;"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_17_174546) do
+ActiveRecord::Schema.define(version: 2020_12_18_172751) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/channels/client_channel_spec.rb
+++ b/spec/channels/client_channel_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.describe ClientChannel, type: :channel do
   let(:client) { create :client }
-  let(:user) { create :user_with_org }
+  let(:organization) { create :organization }
+  let(:user) { create :user }
   let(:params) { { id: client.id } }
 
   context "as an unauthenticated user" do
@@ -29,7 +30,9 @@ RSpec.describe ClientChannel, type: :channel do
     end
 
     context 'with valid params' do
-      let(:client) { create(:client, vita_partner: user.vita_partner) }
+      before { create :organization_lead_role, user: user, organization: organization }
+
+      let(:client) { create(:client, vita_partner: organization) }
 
       it 'subscribes to a client' do
         subscribe params

--- a/spec/controllers/hub/assigned_clients_controller_spec.rb
+++ b/spec/controllers/hub/assigned_clients_controller_spec.rb
@@ -6,12 +6,16 @@ RSpec.describe Hub::AssignedClientsController do
   end
 
   context "as an authenticated user" do
-    let(:vita_partner) { create(:vita_partner) }
-    let(:user) { create(:user_with_org, vita_partner: vita_partner) }
+    let(:organization) { create(:organization) }
+    let(:user) { create(:user) }
 
-    before { sign_in user}
-    let!(:assigned_to_me) { create :client, vita_partner: vita_partner, intake: (create :intake), tax_returns: [(create :tax_return, assigned_user: user, status: "intake_in_progress")] }
-    let!(:not_assigned_to_me) { create :client, vita_partner: vita_partner, intake: (create :intake), tax_returns: [(create :tax_return)] }
+    before do
+      create :organization_lead_role, user: user, organization: organization
+      sign_in user
+    end
+
+    let!(:assigned_to_me) { create :client, vita_partner: organization, intake: (create :intake), tax_returns: [(create :tax_return, assigned_user: user, status: "intake_in_progress")] }
+    let!(:not_assigned_to_me) { create :client, vita_partner: organization, intake: (create :intake), tax_returns: [(create :tax_return)] }
 
     it "should allow me to see only clients with tax returns assigned to me" do
       get :index
@@ -83,7 +87,7 @@ RSpec.describe Hub::AssignedClientsController do
       end
 
       context "filtering by needs attention" do
-        let!(:needs_attention) { create :client, attention_needed_since: DateTime.now, vita_partner: user.vita_partner, tax_returns: [(create :tax_return, assigned_user: user)] }
+        let!(:needs_attention) { create :client, attention_needed_since: DateTime.now, vita_partner: organization, tax_returns: [(create :tax_return, assigned_user: user)] }
         it "filters in" do
           get :index, params: { needs_attention: true }
           expect(assigns(:clients)).to include needs_attention
@@ -91,7 +95,7 @@ RSpec.describe Hub::AssignedClientsController do
       end
 
       context "filtering and sorting" do
-        let!(:starts_with_a_assigned) { create :client, intake: (create :intake, preferred_name: "Aardvark Alan"), vita_partner: user.vita_partner, tax_returns: [(create :tax_return, status: "intake_in_progress", assigned_user: user)] }
+        let!(:starts_with_a_assigned) { create :client, intake: (create :intake, preferred_name: "Aardvark Alan"), vita_partner: organization, tax_returns: [(create :tax_return, status: "intake_in_progress", assigned_user: user)] }
 
         it "preferred_name, asc" do
           get :index, params: { status: "intake_in_progress", column: "preferred_name", order: "asc" }

--- a/spec/controllers/hub/documents_controller_spec.rb
+++ b/spec/controllers/hub/documents_controller_spec.rb
@@ -1,15 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe Hub::DocumentsController, type: :controller do
+  let(:organization) { create :organization }
+  let(:user) { create :user }
+  before { create :organization_lead_role, user: user, organization: organization }
+
   describe "#index" do
-    let(:vita_partner) { create :vita_partner }
-    let(:client) { create :client, vita_partner: vita_partner, intake: create(:intake, vita_partner: vita_partner) }
+    let(:client) { create :client, vita_partner: organization, intake: create(:intake, vita_partner: organization) }
     let(:params) { { client_id: client.id } }
 
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :index
 
     context "as an authenticated user" do
-      let(:user) { create :user, vita_partner: vita_partner }
       before { sign_in(user) }
 
       context "with some existing documents" do
@@ -104,15 +106,13 @@ RSpec.describe Hub::DocumentsController, type: :controller do
   end
 
   describe "#edit" do
-    let(:vita_partner) { create :vita_partner }
-    let(:client) { create :client, vita_partner: vita_partner, intake: create(:intake, vita_partner: vita_partner) }
+    let(:client) { create :client, vita_partner: organization, intake: create(:intake, vita_partner: organization) }
     let(:document) { create :document, client: client }
     let(:params) { { id: document.id, client_id: client.id }}
 
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :edit
 
     context "with an authenticated user" do
-      let(:user) { create :user, vita_partner: vita_partner }
       before { sign_in(user) }
 
       it "renders edit for the document" do
@@ -126,16 +126,15 @@ RSpec.describe Hub::DocumentsController, type: :controller do
 
   describe "#update" do
     let(:new_display_name) { "New Display Name" }
-    let(:vita_partner) { create :vita_partner }
-    let(:client) { create :client, vita_partner: vita_partner, intake: create(:intake, vita_partner: vita_partner) }
+    let(:client) { create :client, vita_partner: organization, intake: create(:intake, vita_partner: organization) }
     let(:document) { create :document, client: client }
     let(:params) { { client_id: client.id, id: document.id, document: { display_name: new_display_name } } }
 
     it_behaves_like :a_post_action_for_authenticated_users_only, action: :update
 
     context "with an authenticated user" do
-      let(:user) { create :user, vita_partner: vita_partner }
       before { sign_in(user) }
+
       context "with valid params" do
         it "updates the display name attribute on the document" do
           post :update, params: params
@@ -162,8 +161,7 @@ RSpec.describe Hub::DocumentsController, type: :controller do
   end
 
   describe "#show" do
-    let(:vita_partner) { create :vita_partner }
-    let(:client) { create :client, vita_partner: vita_partner, intake: create(:intake, vita_partner: vita_partner) }
+    let(:client) { create :client, vita_partner: organization, intake: create(:intake, vita_partner: organization) }
     let(:document) { create :document, client: client }
     let(:params) { { client_id: client.id, id: document.id }}
 
@@ -171,7 +169,6 @@ RSpec.describe Hub::DocumentsController, type: :controller do
 
     context "with a signed in user" do
       let(:document_transient_url) { "https://gyr-demo.s3.amazonaws.com/document.pdf?sig=whatever&expires=whatever" }
-      let(:user) { create :user, vita_partner: vita_partner }
       before do
         sign_in(user)
         allow(subject).to receive(:transient_storage_url).and_return(document_transient_url)
@@ -187,8 +184,7 @@ RSpec.describe Hub::DocumentsController, type: :controller do
   end
 
   describe "#create" do
-    let(:vita_partner) { create :vita_partner }
-    let(:client) { create :client, vita_partner: vita_partner }
+    let(:client) { create :client, vita_partner: organization }
     let!(:intake) { create :intake, client: client }
     let(:params) do
       { client_id: client.id,
@@ -204,7 +200,6 @@ RSpec.describe Hub::DocumentsController, type: :controller do
     it_behaves_like :a_post_action_for_authenticated_users_only, action: :create
 
     context "with an authenticated user" do
-      let(:user) { create :user, vita_partner: vita_partner }
       before { sign_in(user) }
 
       it "appends the documents to the client's documents list" do

--- a/spec/controllers/hub/messages_controller_spec.rb
+++ b/spec/controllers/hub/messages_controller_spec.rb
@@ -1,13 +1,14 @@
 require "rails_helper"
 
 RSpec.describe Hub::MessagesController do
-  let(:vita_partner) { create :vita_partner }
-  let(:client) { create :client, vita_partner: vita_partner }
+  let(:organization) { create :vita_partner }
+  let(:client) { create :client, vita_partner: organization }
   let!(:intake) { create :intake, client: client }
   let(:params) do
     { client_id: client.id }
   end
-  let(:user) { create :user, vita_partner: vita_partner }
+  let(:user) { create :user }
+  before { create :organization_lead_role, user: user, organization: organization }
 
   describe "#index" do
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :index
@@ -19,7 +20,7 @@ RSpec.describe Hub::MessagesController do
         render_views
 
         let(:twilio_status) { nil }
-        let(:client) { create(:client, vita_partner: vita_partner) }
+        let(:client) { create(:client, vita_partner: organization) }
         let(:intake) { create(:intake, client: client, preferred_name: "George Sr.", phone_number: "+14155551233", email_address: "money@banana.stand") }
         let!(:expected_contact_history) do
           [
@@ -120,7 +121,7 @@ RSpec.describe Hub::MessagesController do
         end
 
         context "with messages from different days" do
-          let(:user) { create :user, timezone: "America/Los_Angeles" , vita_partner: vita_partner}
+          let(:user) { create :user, timezone: "America/Los_Angeles" }
 
           before do
             create(:outgoing_email, sent_at: DateTime.new(2019, 10, 4, 14), client: client)

--- a/spec/controllers/hub/notes_controller_spec.rb
+++ b/spec/controllers/hub/notes_controller_spec.rb
@@ -1,9 +1,11 @@
 require "rails_helper"
 
 RSpec.describe Hub::NotesController, type: :controller do
-  let(:vita_partner) { create :vita_partner }
-  let(:client) { create :client, vita_partner: vita_partner }
+  let(:organization) { create :organization }
+  let(:client) { create :client, vita_partner: organization }
   let!(:intake) { create :intake, client: client }
+  let(:user) { create :user }
+  before { create :organization_lead_role, user: user, organization: organization }
 
   describe "#create" do
     let(:params) {
@@ -18,9 +20,8 @@ RSpec.describe Hub::NotesController, type: :controller do
     it_behaves_like :a_post_action_for_authenticated_users_only, action: :create
 
     context "as an authenticated user" do
-      let(:current_user) { create :user, vita_partner: vita_partner }
       before do
-        sign_in current_user
+        sign_in user
       end
 
       it "creates a new note" do
@@ -29,7 +30,7 @@ RSpec.describe Hub::NotesController, type: :controller do
         note = Note.last
         expect(note.body).to eq "Note body"
         expect(note.client).to eq client
-        expect(note.user).to eq current_user
+        expect(note.user).to eq user
         expect(response).to redirect_to hub_client_notes_path(client_id: client.id)
       end
 
@@ -56,9 +57,8 @@ RSpec.describe Hub::NotesController, type: :controller do
   end
 
   describe "#index" do
-    let(:client) { create :client, vita_partner: vita_partner }
+    let(:client) { create :client, vita_partner: organization }
     let(:params) { { client_id: client.id } }
-    let(:user) { create :user, vita_partner: vita_partner }
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :index
 
     context "as a logged in user loading a clients notes" do
@@ -83,7 +83,7 @@ RSpec.describe Hub::NotesController, type: :controller do
           allow(NotesPresenter).to receive(:grouped_notes).with(client).and_return({})
         end
 
-        let(:user) { create :user, timezone: "America/Los_Angeles" , vita_partner: vita_partner}
+        let(:user) { create :user, timezone: "America/Los_Angeles" }
 
         it "assigns grouped notes for use in template" do
           get :index, params: params
@@ -94,4 +94,3 @@ RSpec.describe Hub::NotesController, type: :controller do
     end
   end
 end
-

--- a/spec/controllers/hub/outgoing_emails_controller_spec.rb
+++ b/spec/controllers/hub/outgoing_emails_controller_spec.rb
@@ -1,9 +1,12 @@
 require "rails_helper"
 
 RSpec.describe Hub::OutgoingEmailsController do
+  let(:organization) { create :organization }
+  let(:user) { create :user }
+  before { create :organization_lead_role, user: user, organization: organization }
+
   describe "#create" do
-    let(:vita_partner) { create :vita_partner }
-    let(:client) { create :client, vita_partner: vita_partner }
+    let(:client) { create :client, vita_partner: organization }
     let!(:intake) { create :intake, client: client, email_address: "loose.seal@example.com" }
     let(:params) do
       { client_id: client.id, outgoing_email: { body: "hi client" } }
@@ -12,7 +15,6 @@ RSpec.describe Hub::OutgoingEmailsController do
     it_behaves_like :a_post_action_for_authenticated_users_only, action: :create
 
     context "as an authenticated admin user" do
-      let(:user) { create :user, vita_partner: vita_partner }
       before do
         sign_in user
         allow(subject).to receive(:send_email)

--- a/spec/controllers/hub/outgoing_text_messages_controller_spec.rb
+++ b/spec/controllers/hub/outgoing_text_messages_controller_spec.rb
@@ -1,9 +1,12 @@
 require "rails_helper"
 
 RSpec.describe Hub::OutgoingTextMessagesController do
+  let(:organization) { create :organization }
+  let(:user) { create :user }
+  before { create :organization_lead_role, user: user, organization: organization }
+
   describe "#create" do
-    let(:vita_partner) { create :vita_partner }
-    let(:client) { create :client, vita_partner: vita_partner, intake: create(:intake, sms_phone_number: "+15105551234", phone_number: "+15105551777") }
+    let(:client) { create :client, vita_partner: organization, intake: create(:intake, sms_phone_number: "+15105551234", phone_number: "+15105551777") }
     let(:params) do
       {
         client_id: client.id,
@@ -18,7 +21,6 @@ RSpec.describe Hub::OutgoingTextMessagesController do
     it_behaves_like :a_post_action_for_authenticated_users_only, action: :create
 
     context "as an authenticated user" do
-      let(:user) { create :user, vita_partner: vita_partner }
       before { sign_in user }
 
       it "calls send_text_message with the right arguments and redirects to messages" do

--- a/spec/controllers/hub/tax_returns/certifications_controller_spec.rb
+++ b/spec/controllers/hub/tax_returns/certifications_controller_spec.rb
@@ -2,11 +2,15 @@ require 'rails_helper'
 
 RSpec.describe Hub::TaxReturns::CertificationsController do
   describe "#update" do
-    let(:vita_partner) { create(:vita_partner) }
-    let(:user) { create(:user_with_org, vita_partner: vita_partner) }
-    let(:tax_return) { create :tax_return, client: (create :client, vita_partner: vita_partner)}
+    let(:organization) { create(:organization) }
+    let(:user) { create(:user) }
+    let(:tax_return) { create :tax_return, client: (create :client, vita_partner: organization) }
     let(:next_path) { "/next/path" }
-    let(:params) { { id: tax_return.id, certification_level: "advanced", is_hsa: true, next: next_path }}
+    let(:params) { { id: tax_return.id, certification_level: "advanced", is_hsa: true, next: next_path } }
+
+    before do
+      create(:organization_lead_role, user: user, organization: organization)
+    end
 
     it_behaves_like :a_post_action_for_authenticated_users_only, action: :update
 

--- a/spec/controllers/hub/users_controller_spec.rb
+++ b/spec/controllers/hub/users_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Hub::UsersController do
 
     context "with an authenticated user" do
       render_views
-      let(:user) { create :user_with_org, name: "Adam Avocado" }
+      let(:user) { create :user, name: "Adam Avocado" }
 
       before do
         create :organization_lead_role, user: user

--- a/spec/controllers/hub/users_controller_spec.rb
+++ b/spec/controllers/hub/users_controller_spec.rb
@@ -2,20 +2,23 @@ require "rails_helper"
 
 RSpec.describe Hub::UsersController do
   describe "#profile" do
-    let(:vita_partner) { create :vita_partner }
-
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :profile
 
     context "with an authenticated user" do
       render_views
-      let(:user) { create :user_with_org, role: "agent", name: "Adam Avocado", vita_partner: vita_partner}
-      before { sign_in user }
+      let(:user) { create :user_with_org, name: "Adam Avocado" }
+
+      before do
+        create :organization_lead_role, user: user
+        sign_in user
+      end
 
       it "renders information about the current user with helpful links" do
         get :profile
 
         expect(response).to be_ok
         expect(response.body).to have_content "Adam Avocado"
+        expect(response.body).to have_content "Organization lead"
         expect(response.body).to include invitations_path
         expect(response.body).to include hub_clients_path
         expect(response.body).to include hub_users_path

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe InvitationsController do
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :index
 
     context "with a user who has prior invites" do
-      let(:user) { create :user_with_org }
+      let(:user) { create :user }
       let!(:unaccepted_invite) { create :invited_user, invited_by: user }
       let!(:someone_elses_unaccepted_invite) { create :invited_user }
       let!(:accepted_invite) { create :accepted_invite_user, invited_by: user }

--- a/spec/controllers/users/invitations_controller_spec.rb
+++ b/spec/controllers/users/invitations_controller_spec.rb
@@ -43,14 +43,18 @@ RSpec.describe Users::InvitationsController do
       it "creates a new invited user" do
         expect do
           post :create, params: params
-        end.to change(User, :count).by 1
+        end.to (change(User, :count).by 1).and(change(OrganizationLeadRole, :count).by(1))
+
+        org_lead_role = OrganizationLeadRole.last
+        expect(org_lead_role.organization).to eq vita_partner
 
         invited_user = User.last
+        expect(org_lead_role.user_id).to eq invited_user.id
+
         expect(invited_user.name).to eq "Cher Cherimoya"
         expect(invited_user.email).to eq "cherry@example.com"
         expect(invited_user.invitation_token).to be_present
         expect(invited_user.invited_by).to eq user
-        expect(invited_user.role).to eq "agent"
         expect(invited_user.vita_partner).to eq vita_partner
         expect(response).to redirect_to invitations_path
       end

--- a/spec/factories/organization_lead_roles.rb
+++ b/spec/factories/organization_lead_roles.rb
@@ -20,6 +20,6 @@
 #
 FactoryBot.define do
   factory :organization_lead_role do
-
+    organization { create(:organization) }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -60,7 +60,6 @@ FactoryBot.define do
     sequence(:email) { |n| "gary.gardengnome#{n}@example.green" }
     password { "userExamplePassword" }
     name { "Gary Gnome" }
-    vita_partner
 
     factory :admin_user do
       is_admin { true }
@@ -73,10 +72,6 @@ FactoryBot.define do
 
     factory :agent_user do
       role { "agent" }
-    end
-
-    factory :user_with_org do
-      vita_partner
     end
 
     factory :invited_user do

--- a/spec/features/hub/assignments_spec.rb
+++ b/spec/features/hub/assignments_spec.rb
@@ -2,14 +2,16 @@ require "rails_helper"
 
 RSpec.feature "Assign a user to a tax return" do
   context "As an authenticated user" do
-    let(:vita_partner) { create :vita_partner}
-    let(:logged_in_user) { create :user, vita_partner: vita_partner, name: "Lucille 1" }
-    let!(:user_to_assign) { create :user, name: "Lucille 2", vita_partner: vita_partner }
-    let(:client) { create :client, vita_partner: vita_partner }
+    let(:organization) { create :organization}
+    let(:logged_in_user) { create :user, name: "Lucille 1" }
+    let!(:user_to_assign) { create :user, name: "Lucille 2" }
+    let(:client) { create :client, vita_partner: organization }
     let!(:intake) { create :intake, :with_contact_info, client: client }
     let!(:tax_return_to_assign) { create :tax_return, status: "intake_open", year: 2019, client: client }
 
     before do
+      create :organization_lead_role, user: logged_in_user, organization: organization
+      create :organization_lead_role, user: user_to_assign, organization: organization
       login_as logged_in_user
     end
 

--- a/spec/features/hub/authenticate_spec.rb
+++ b/spec/features/hub/authenticate_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Logging in and out to the volunteer portal" do
-  let!(:user) { create(:user_with_org, name: "German Geranium", email: "german@flowers.orange", password: "goodPassword", role: "agent") }
+  let!(:user) { create(:user, name: "German Geranium", email: "german@flowers.orange", password: "goodPassword", role: "agent") }
 
   scenario "logging in and out" do
     # go to password-based sign in page

--- a/spec/features/hub/documents_spec.rb
+++ b/spec/features/hub/documents_spec.rb
@@ -2,12 +2,13 @@ require "rails_helper"
 
 RSpec.feature "View and edit documents for a client" do
   context "As an authenticated user" do
-    let(:vita_partner) { create :vita_partner }
-    let(:user) { create :user, vita_partner: vita_partner }
-    let(:client) { create :client, vita_partner: vita_partner, intake: create(:intake, preferred_name: "Bart Simpson") }
+    let(:organization) { create :organization }
+    let(:user) { create :user }
+    let(:client) { create :client, vita_partner: organization, intake: create(:intake, preferred_name: "Bart Simpson") }
     let!(:document_1) { create :document, display_name: "ID.jpg", client: client, intake: client.intake }
     let!(:document_2) { create :document, display_name: "W-2.pdf", client: client, intake: client.intake }
     before do
+      create :organization_lead_role, user: user, organization: organization
       login_as user
     end
 

--- a/spec/features/hub/edit_user_spec.rb
+++ b/spec/features/hub/edit_user_spec.rb
@@ -3,12 +3,13 @@ require "rails_helper"
 RSpec.describe "a user editing a user" do
   context "as an authenticated user" do
     context "as an admin" do
-      let!(:colorado_org) { create :vita_partner, name: "Colorado" }
-      let!(:denver_org) { create :vita_partner, parent_organization: colorado_org, name: "Denver" }
-      let!(:california_org) { create :vita_partner, name: "California" }
-      let!(:san_fran_org) { create :vita_partner, parent_organization: california_org, name: "San Francisco" }
-      let(:current_user) { create :admin_user, vita_partner: colorado_org }
-      let(:user_to_edit) { create :user, vita_partner: colorado_org }
+      let!(:colorado_org) { create :organization, name: "Colorado" }
+      let!(:denver_site) { create :site, parent_organization: colorado_org, name: "Denver" }
+      let!(:california_org) { create :organization, name: "California" }
+      let!(:san_fran_site) { create :site, parent_organization: california_org, name: "San Francisco" }
+      let(:current_user) { create :admin_user }
+      let(:organization_lead_role) { create(:organization_lead_role, user: user_to_edit, organization: colorado_org) }
+      let(:user_to_edit) { create :user }
       before { login_as current_user }
 
       scenario "update all fields" do
@@ -26,9 +27,9 @@ RSpec.describe "a user editing a user" do
         expect(page).to have_text "Changes saved"
 
         expect(page).to have_field("user_supported_organization_ids_#{colorado_org.id}", checked: true)
-        expect(page).to have_field("user_supported_organization_ids_#{denver_org.id}", checked: true)
+        expect(page).to have_field("user_supported_organization_ids_#{denver_site.id}", checked: true)
         expect(page).to have_field("user_supported_organization_ids_#{california_org.id}", checked: false)
-        expect(page).to have_field("user_supported_organization_ids_#{san_fran_org.id}", checked: false)
+        expect(page).to have_field("user_supported_organization_ids_#{san_fran_site.id}", checked: false)
         expect(page).to have_field("user_is_admin", checked: true)
         expect(page).to have_field("user_is_client_support", checked: true)
       end

--- a/spec/features/hub/invitations/org_lead_spec.rb
+++ b/spec/features/hub/invitations/org_lead_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Sending and accepting invitations" do
+RSpec.feature "Inviting organization leads" do
   context "As an admin user" do
     let(:user) { create :admin_user }
     let!(:vita_partner) { create :vita_partner, name: "Brassica Asset Builders" }
@@ -16,7 +16,7 @@ RSpec.feature "Sending and accepting invitations" do
       within("h1") do
         expect(page).to have_text "Invitations"
       end
-      click_on "Invite a new user"
+      click_on "Invite a new organization lead"
 
       # new invitation page
       expect(page).to have_text "Send a new invitation"
@@ -69,7 +69,7 @@ RSpec.feature "Sending and accepting invitations" do
 
       expect(page).to have_text "You're all set and ready to go! You've joined an amazing team!"
       expect(page).to have_text "Colleen Cauliflower"
-      expect(page).to have_text "Agent"
+      expect(page).to have_text "Organization lead"
       expect(page).to have_text "Brassica Asset Builders"
     end
   end

--- a/spec/features/hub/notes_spec.rb
+++ b/spec/features/hub/notes_spec.rb
@@ -2,11 +2,12 @@ require "rails_helper"
 
 RSpec.feature "View and add internal notes for a client" do
   context "As an authenticated user" do
-    let(:vita_partner) { create :vita_partner }
-    let(:user) { create :user, vita_partner: vita_partner, timezone: "America/Los_Angeles" }
+    let(:organization) { create :organization }
+    let(:user) { create :user, timezone: "America/Los_Angeles" }
     let(:documents) { create_list(:document, 3, created_at: DateTime.new(2020, 3, 1).utc, document_type: "Employment") }
-    let(:client) { create :client, vita_partner: vita_partner, intake: create(:intake, preferred_name: "Bart Simpson"), documents: documents }
+    let(:client) { create :client, vita_partner: organization, intake: create(:intake, preferred_name: "Bart Simpson"), documents: documents }
     before do
+      create :organization_lead_role, user: user, organization: organization
       login_as user
     end
 

--- a/spec/features/hub/send_messages_spec.rb
+++ b/spec/features/hub/send_messages_spec.rb
@@ -2,12 +2,12 @@ require "rails_helper"
 
 RSpec.feature "Read and send messages to a client", js: true do
   context "As an authenticated user" do
-    let(:vita_partner) { create :vita_partner }
-    let(:user) { create :user, vita_partner: vita_partner }
+    let(:organization) { create :organization }
+    let(:user) { create :user }
     let(:client) do
       create(
         :client,
-        vita_partner: vita_partner,
+        vita_partner: organization,
         intake: create(
           :intake,
           preferred_name: "Tobias",
@@ -18,6 +18,7 @@ RSpec.feature "Read and send messages to a client", js: true do
       )
     end
     before do
+      create :organization_lead_role, user: user, organization: organization
       login_as user
     end
 

--- a/spec/features/hub/show_client_spec.rb
+++ b/spec/features/hub/show_client_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe "a user viewing a client" do
     let(:client) { create :client, vita_partner: (create :vita_partner), intake: create(:intake, :with_contact_info), tax_returns: [create(:tax_return, certification_level: "advanced")] }
     let(:tax_return) { client.tax_returns.first }
     let!(:other_vita_partner) { create :vita_partner, name: "Tax Help Test" }
-    before { login_as user }
+    before do
+      login_as user
+    end
 
     scenario "can view and update client organization" do
       visit hub_client_path(id: client.id)
@@ -53,10 +55,14 @@ RSpec.describe "a user viewing a client" do
   end
 
   context "user without admin access" do
-    let!(:client) { create :client, vita_partner: (create :vita_partner), intake: create(:intake, :with_contact_info) }
+    let(:organization) {create :organization}
+    let!(:client) { create :client, vita_partner: organization, intake: create(:intake, :with_contact_info) }
 
-    let!(:user) { create :user, vita_partner_id: client.vita_partner_id }
-    before { login_as user }
+    let!(:user) { create :user }
+    before do
+      create :organization_lead_role, user: user, organization: organization
+      login_as user
+    end
 
     scenario "can view and cannot update organization" do
       visit hub_client_path(id: client.id)

--- a/spec/features/hub/take_action_spec.rb
+++ b/spec/features/hub/take_action_spec.rb
@@ -1,19 +1,20 @@
 require "rails_helper"
 
 RSpec.feature "Change tax return status on a client" do
-  context "As a beta tester" do
-    let(:vita_partner) { create :vita_partner }
-    let(:user) { create :user, name: "Example Preparer", vita_partner: vita_partner }
-    let(:client) { create :client, vita_partner: vita_partner }
+  context "As an authenticated user" do
+    let(:organization) { create :organization }
+    let(:user) { create :user, name: "Example Preparer" }
+    let(:client) { create :client, vita_partner: organization }
     let!(:intake) { create :intake, client: client, locale: "en", email_address: "client@example.com", phone_number: "+14155551212", sms_phone_number: "+14155551212", email_notification_opt_in: "yes", sms_notification_opt_in: "yes" }
     let!(:tax_return) { create :tax_return, year: 2019, client: client, status: "intake_in_progress" }
     let!(:other_tax_return) { create :tax_return, year: 2018, client: client, status: "intake_in_progress" }
 
     before do
+      create :organization_lead_role, user: user, organization: organization
       login_as user
     end
 
-    scenario "logged in user changes status from any hub page, sends a message, and creates an internal note" do
+    scenario "can changes status from any hub page, sends a message, and creates an internal note" do
       # One day, when switching the status causes a page reload, this test can expect a templated message.
       visit hub_client_notes_path(client_id: client.id)
       click_on "Take action"
@@ -38,7 +39,7 @@ RSpec.feature "Change tax return status on a client" do
       expect(page).to have_text "Heads up! I am still working on it."
     end
 
-    scenario "logged in user can change a status on a tax return and send a templated message" do
+    scenario "can change a status on a tax return and send a templated message" do
       visit hub_client_path(id: client.id)
       expect(page).to have_select("tax_return_status", selected: "In progress")
 

--- a/spec/helpers/role_helper_spec.rb
+++ b/spec/helpers/role_helper_spec.rb
@@ -8,5 +8,16 @@ describe RoleHelper do
         expect(helper.user_roles(user)).to eq "Admin"
       end
     end
+
+    context "as an org lead" do
+      let(:user) { create :user }
+      before do
+        create :organization_lead_role, user: user
+      end
+
+      it 'shows they are an org lead' do
+        expect(helper.user_roles(user)).to eq "Organization lead"
+      end
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -76,16 +76,18 @@ RSpec.describe User, type: :model do
   end
 
   describe "#accessible_organizations" do
-    let!(:user) { create :user, vita_partner: parent_org, supported_organizations: [greetable_org] }
+    let!(:user) { create :user, supported_organizations: [greetable_org] }
     let!(:greetable_org) { create :vita_partner, name: "Greetable org" }
-    let!(:parent_org) { create :vita_partner, name: "Parent org" }
-    let!(:child_org) { create :vita_partner, parent_organization: parent_org, name: "Child org" }
+    let!(:organization) { create :organization, name: "Parent org" }
+    let!(:site) { create :site, parent_organization: organization, name: "Child org" }
     let!(:not_accessible_partner) { create :vita_partner, name: "Not accessible" }
+
+    before { create :organization_lead_role, user: user, organization: organization }
 
     it "should return a user's primary org, supportable orgs, and coalition members" do
       accessible_organization_ids = user.accessible_organizations.pluck(:id)
-      expect(accessible_organization_ids).to include(parent_org.id)
-      expect(accessible_organization_ids).to include(child_org.id)
+      expect(accessible_organization_ids).to include(organization.id)
+      expect(accessible_organization_ids).to include(site.id)
       expect(accessible_organization_ids).to include(greetable_org.id)
       expect(accessible_organization_ids).not_to include(not_accessible_partner.id)
     end


### PR DESCRIPTION
This retains our existing access control and starts being explicit about storing data in a role object specific to org leads.

A good next role to implement is coalition leads.

There's room for further cleanup after this PR, but we think it's peaceful to merge this ASAP and do the cleanups afterward since the app works fine with this change.

(We're reviewing this ourselves & will merge shortly.)