### PR TITLE
Remove User.vita_partner_id column

### DIFF
--- a/app/controllers/hub/users_controller.rb
+++ b/app/controllers/hub/users_controller.rb
@@ -7,28 +7,11 @@ module Hub
 
     layout "admin"
 
-    def profile
-      @role_name =
-        if OrganizationLeadRole.exists?(user: current_user)
-          t("general.organization_lead")
-        elsif current_user.is_admin
-          t("general.admin")
-        elsif current_user.is_client_support
-          t("general.client_support")
-        else
-          ""
-        end
-    end
+    def profile; end
 
-    def index
-      # TODO: Fix me!
-      my_org = OrganizationLeadRole.find_by_user_id(current_user.id)
-      my_fellow_users = OrganizationLeadRole.find_by_organization_id(my_org.id)
-      @users = @users.where(vita_partner: my_org.id)
-    end
+    def index; end
 
-    def edit
-    end
+    def edit; end
 
     def update
       return render :edit unless @user.update(user_params)

--- a/app/controllers/hub/users_controller.rb
+++ b/app/controllers/hub/users_controller.rb
@@ -21,7 +21,10 @@ module Hub
     end
 
     def index
-      @users = @users.includes(:vita_partner)
+      # TODO: Fix me!
+      my_org = OrganizationLeadRole.find_by_user_id(current_user.id)
+      my_fellow_users = OrganizationLeadRole.find_by_organization_id(my_org.id)
+      @users = @users.where(vita_partner: my_org.id)
     end
 
     def edit

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -19,7 +19,7 @@ class Users::InvitationsController < Devise::InvitationsController
   before_action :require_valid_invitation_token, only: [:edit, :update]
 
   def create
-    organization = @vita_partners.find(invite_params[:vita_partner_id])
+    organization = @vita_partners.find(params.require(:organization_id))
     authorize!(:manage, organization)
     super do |invited_user|
       OrganizationLeadRole.create(
@@ -38,7 +38,7 @@ class Users::InvitationsController < Devise::InvitationsController
 
   # Override superclass method for default params for newly created invites, allowing us to add attributes
   def invite_params
-    params.require(:user).permit(:name, :email, :vita_partner_id)
+    params.require(:user).permit(:name, :email)
   end
 
   # Override superclass method for accepted invite params, allowing us to add attributes

--- a/app/helpers/role_helper.rb
+++ b/app/helpers/role_helper.rb
@@ -6,4 +6,8 @@ module RoleHelper
         *(I18n.t('general.organization_lead') if OrganizationLeadRole.exists?(user: user))
     ].join(", ")
   end
+
+  def user_org(user)
+    OrganizationLeadRole.where(user: user).first&.organization&.name
+  end
 end

--- a/app/lib/client_router.rb
+++ b/app/lib/client_router.rb
@@ -1,7 +1,8 @@
 class ClientRouter
   def self.route(client)
-    organization_with_most_users = OrganizationLeadRole.group(:id).group("vita_partner_id").order('COUNT(user) DESC').first.organization
-    client.update(vita_partner: organization_with_most_users)
-    client.intake.update(vita_partner: organization_with_most_users)
+    organization_id_with_most_leads = ActiveRecord::Base.connection.execute(
+      "SELECT vita_partners.id FROM vita_partners LEFT JOIN organization_lead_roles on vita_partners.id=organization_lead_roles.vita_partner_id GROUP BY vita_partners.id ORDER BY count(organization_lead_roles.id) DESC LIMIT 1").first["id"]
+    client.update(vita_partner_id: organization_id_with_most_leads)
+    client.intake.update(vita_partner_id: organization_id_with_most_leads)
   end
 end

--- a/app/lib/client_router.rb
+++ b/app/lib/client_router.rb
@@ -1,7 +1,7 @@
 class ClientRouter
   def self.route(client)
-    partner_with_most_users = VitaPartner.left_joins(:users).group(:id).order('COUNT(users.id) DESC').first
-    client.update(vita_partner: partner_with_most_users)
-    client.intake.update(vita_partner: partner_with_most_users)
+    organization_with_most_users = OrganizationLeadRole.group(:id).group("vita_partner_id").order('COUNT(user) DESC').first.organization
+    client.update(vita_partner: organization_with_most_users)
+    client.intake.update(vita_partner: organization_with_most_users)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,7 +38,6 @@
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  invited_by_id             :bigint
-#  vita_partner_id           :bigint
 #  zendesk_user_id           :bigint
 #
 # Indexes
@@ -48,20 +47,16 @@
 #  index_users_on_invitations_count     (invitations_count)
 #  index_users_on_invited_by_id         (invited_by_id)
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
-#  index_users_on_vita_partner_id       (vita_partner_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (invited_by_id => users.id)
-#  fk_rails_...  (vita_partner_id => vita_partners.id)
 #
 class User < ApplicationRecord
   devise :database_authenticatable, :lockable, :validatable, :timeoutable, :trackable, :invitable, :recoverable
 
-  belongs_to :vita_partner, optional: true
   before_validation :format_phone_number
   validates :phone_number, phone: true, allow_blank: true, format: { with: /\A\+1[0-9]{10}\z/ }
-
   has_many :assigned_tax_returns, class_name: "TaxReturn", foreign_key: :assigned_user_id
   has_and_belongs_to_many :supported_organizations,
            join_table: "users_vita_partners",

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -5,7 +5,7 @@
   <%= form_for(resource, as: resource_name, url: invitation_path(resource_name), method: :put, local: true, builder: VitaMinFormBuilder) do |f| %>
     <h1><%= @main_heading %></h1>
 
-    <h2 class="form-question"><%= t("general.organization") %>: <%= resource.vita_partner.name %></h2>
+    <h2 class="form-question"><%= t("general.organization") %>: <%= user_org(resource) %></h2>
     <h2 class="form-question"><%= t(".email_label") %>: <%= resource.email %></h2>
     <%= f.hidden_field :invitation_token, readonly: true %>
     <%= f.cfa_input_field(:name, t(".name_label")) %>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -7,7 +7,9 @@
 
     <%= f.cfa_input_field(:name, t(".name_label")) %>
     <%= f.cfa_input_field(:email, t(".email_label"), type: 'email', classes: ['form-width--email']) %>
-    <%= f.cfa_select(:vita_partner_id, t(".vita_partner_label"), grouped_organization_options) %>
+
+    <%= label_tag(:organization_id, t(".vita_partner_label")) %>
+    <%= select_tag(:organization_id, options_for_select(VitaPartner.organizations.map { |org| [org.name, org.id] })) %>
 
     <%= f.submit t(".submit"), class: "button button--primary" %>
   <% end %>

--- a/app/views/hub/users/index.html.erb
+++ b/app/views/hub/users/index.html.erb
@@ -22,7 +22,7 @@
             <%= link_to user.name, edit_hub_user_path(id: user) %>
           </th>
           <td class="index-table__cell"><%= user_roles(user) %></td>
-          <td class="index-table__cell"><%= user.vita_partner&.name || t("general.none") %></td>
+          <td class="index-table__cell"><%= user_org(user) || t("general.none") %></td>
         </tr>
       <% end %>
 

--- a/app/views/hub/users/profile.html.erb
+++ b/app/views/hub/users/profile.html.erb
@@ -15,11 +15,11 @@
     </p>
     <p>
       <span class="hc-label"><%= t("general.role") %></span>
-      <span class="label-value"><%= @role_name %></span>
+      <span class="label-value"><%= user_roles(current_user) %></span>
     </p>
     <p>
       <span class="hc-label"><%= t("general.organization") %></span>
-      <span class="label-value"><%= current_user.vita_partner&.name || t("general.none") %></span>
+      <span class="label-value"><%= user_org(current_user) || t("general.none") %></span>
     </p>
 
     <ul class="actions">

--- a/app/views/invitations/index.html.erb
+++ b/app/views/invitations/index.html.erb
@@ -11,10 +11,10 @@
     <ul class="invitations list--bulleted">
       <% @unaccepted_invitations.each do |invitation| %>
         <li id="invitation-<%= invitation.id %>" class="invitation">
-          <%= invitation.name %> &lt;<%= invitation.email %>&gt; <%= invitation.vita_partner&.name %> (<%= t(".invitation.sent_at", datetime: invitation.invitation_sent_at) %>)
+          <%= invitation.name %> &lt;<%= invitation.email %>&gt; <%= user_org(invitation) %> (<%= t(".invitation.sent_at", datetime: invitation.invitation_sent_at) %>)
           <%= form_with(model: invitation, url: user_invitation_path, method: :post, local: true) do |f| %>
             <%= f.hidden_field :email %>
-            <%= f.hidden_field :vita_partner_id %>
+            <%= hidden_field_tag :organization_id, OrganizationLeadRole.find_by_user_id(invitation.id).organization.id %>
             <%= f.submit value: t(".invitation.create"), class: "button button--small" %>
           <% end %>
         </li>

--- a/db/migrate/20201218214947_remove_vita_partner_from_user.rb
+++ b/db/migrate/20201218214947_remove_vita_partner_from_user.rb
@@ -1,0 +1,5 @@
+class RemoveVitaPartnerFromUser < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :users, :vita_partner_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -538,14 +538,12 @@ ActiveRecord::Schema.define(version: 2020_12_21_034618) do
     t.string "uid"
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "verified"
-    t.bigint "vita_partner_id"
     t.bigint "zendesk_user_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invitations_count"], name: "index_users_on_invitations_count"
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
-    t.index ["vita_partner_id"], name: "index_users_on_vita_partner_id"
   end
 
   create_table "users_vita_partners", id: false, force: :cascade do |t|
@@ -612,7 +610,6 @@ ActiveRecord::Schema.define(version: 2020_12_21_034618) do
   add_foreign_key "tax_returns", "clients"
   add_foreign_key "tax_returns", "users", column: "assigned_user_id"
   add_foreign_key "users", "users", column: "invited_by_id"
-  add_foreign_key "users", "vita_partners"
   add_foreign_key "vita_partners", "coalitions"
   add_foreign_key "vita_providers", "provider_scrapes", column: "last_scrape_id"
 end

--- a/spec/controllers/hub/clients_controller_spec.rb
+++ b/spec/controllers/hub/clients_controller_spec.rb
@@ -159,9 +159,9 @@ RSpec.describe Hub::ClientsController do
   end
 
   describe "#show" do
-    let(:vita_partner) { create :organization }
-    let(:user) { create :user, vita_partner: organization }
+    let(:user) { create :user }
     let(:client) { create :client, vita_partner: organization, tax_returns: [(create :tax_return, year: 2019, service_type: "drop_off"), (create :tax_return, year: 2018, service_type: "online_intake")] }
+    before { create :organization_lead_role, user: user, organization: organization }
 
     let!(:intake) do
       create :intake,
@@ -249,7 +249,7 @@ RSpec.describe Hub::ClientsController do
         let!(:michael) { create :client, vita_partner: organization, intake: create(:intake, :filled_out, preferred_name: "Michael", needs_help_2019: "yes", needs_help_2017: "yes", state_of_residence: nil) }
         let!(:michael_2019_return) { create :tax_return, client: michael, year: 2019, assigned_user: assigned_user, status: "intake_in_progress" }
         let!(:tobias) { create :client, vita_partner: organization, intake: create(:intake, :filled_out, preferred_name: "Tobias", needs_help_2018: "yes", locale: "es", state_of_residence: "TX") }
-        let(:assigned_user) { create :user, name: "Lindsay", vita_partner: organization }
+        let(:assigned_user) { create :user, name: "Lindsay" }
         let!(:tobias_2019_return) { create :tax_return, client: tobias, year: 2019, assigned_user: assigned_user, status: "intake_in_progress" }
         let!(:tobias_2018_return) { create :tax_return, client: tobias, year: 2018, assigned_user: assigned_user }
         let!(:lucille) { create :client, vita_partner: organization, intake: create(:intake, preferred_name: "Lucille") }
@@ -594,7 +594,7 @@ RSpec.describe Hub::ClientsController do
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :edit
 
     context "with a signed in user" do
-      let(:user) { create :user, vita_partner: organization }
+      let(:user) { create :user }
       before do
         sign_in user
         allow(SystemNote).to receive(:create_client_change_note)
@@ -736,9 +736,9 @@ RSpec.describe Hub::ClientsController do
   end
 
   describe "#update_take_action" do
-    let(:user) { create :user, vita_partner: (create :organization) }
     let!(:intake) { create :intake, email_address: "gob@example.com", sms_phone_number: "+14155551212", client: client }
     let(:client) { create :client, vita_partner: organization }
+
     let(:params) do
       {
         id: client,

--- a/spec/controllers/hub/users_controller_spec.rb
+++ b/spec/controllers/hub/users_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Hub::UsersController do
       let(:user) { create :user, name: "Adam Avocado" }
 
       before do
-        create :organization_lead_role, user: user
+        create :organization_lead_role, user: user, organization: (create :organization, name: "Orange organization")
         sign_in user
       end
 
@@ -19,6 +19,7 @@ RSpec.describe Hub::UsersController do
         expect(response).to be_ok
         expect(response.body).to have_content "Adam Avocado"
         expect(response.body).to have_content "Organization lead"
+        expect(response.body).to have_content "Orange organization"
         expect(response.body).to include invitations_path
         expect(response.body).to include hub_clients_path
         expect(response.body).to include hub_users_path
@@ -29,29 +30,12 @@ RSpec.describe Hub::UsersController do
   describe "#index" do
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :index
 
-    context "with an authenticated user" do
-      let(:organization) { create :organization }
-      let(:user) { create(:user) }
-
-      before do
-        create :organization_lead_role, user: user, organization: organization
-        sign_in user
-        create :organization_lead_role, user: create(:user), organization: organization
-      end
-
-      it "displays only the user who is logged in" do
-        get :index
-
-        expect(assigns(:users)).to eq [user]
-      end
-    end
-
     context "with an authenticated admin user" do
       render_views
 
       let!(:leslie) { create :admin_user, name: "Leslie" }
       before do
-        create :organization_lead_role, user: leslie, organization: create(:vita_partner, name: "Pawnee Preparers")
+        create :organization_lead_role, user: leslie, organization: create(:organization, name: "Pawnee Preparers")
         sign_in create(:admin_user)
         create :user
       end

--- a/spec/controllers/users/invitations_controller_spec.rb
+++ b/spec/controllers/users/invitations_controller_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe Users::InvitationsController do
       {
         user: {
           name: "Cher Cherimoya",
-          email: "cherry@example.com",
-          vita_partner_id: vita_partner.id
-        }
+          email: "cherry@example.com"
+        },
+        organization_id: vita_partner.id
       }
     end
 
@@ -55,7 +55,6 @@ RSpec.describe Users::InvitationsController do
         expect(invited_user.email).to eq "cherry@example.com"
         expect(invited_user.invitation_token).to be_present
         expect(invited_user.invited_by).to eq user
-        expect(invited_user.vita_partner).to eq vita_partner
         expect(response).to redirect_to invitations_path
       end
 
@@ -82,9 +81,12 @@ RSpec.describe Users::InvitationsController do
         name: "Cherry Cherimoya",
         email: "cherry@example.com",
         invitation_token: Devise.token_generator.digest(User, :invitation_token, raw_invitation_token),
-        invited_by: user,
-        vita_partner: vita_partner
+        invited_by: user
       )
+    end
+
+    before do
+      create(:organization_lead_role, user: invited_user, organization: vita_partner)
     end
 
     it "shows the user's existing information" do
@@ -139,7 +141,6 @@ RSpec.describe Users::InvitationsController do
         :invited_user,
         name: "Cherry Cherimoya",
         invitation_token: Devise.token_generator.digest(User, :invitation_token, raw_invitation_token),
-        vita_partner: vita_partner
       )
     end
 
@@ -162,7 +163,6 @@ RSpec.describe Users::InvitationsController do
         end.to change{ controller.current_user }.from(nil).to(invited_user)
         invited_user.reload
         expect(invited_user.name).to eq "Cher Cherimoya"
-        expect(invited_user.vita_partner).to eq vita_partner
         expect(invited_user.timezone).to eq "America/Los_Angeles"
         expect(response).to redirect_to hub_user_profile_path
       end

--- a/spec/factories/organization_lead_roles.rb
+++ b/spec/factories/organization_lead_roles.rb
@@ -21,5 +21,6 @@
 FactoryBot.define do
   factory :organization_lead_role do
     organization { create(:organization) }
+    user { create(:user) }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -71,7 +71,6 @@ FactoryBot.define do
       association :invited_by, factory: :admin_user
       invitation_created_at { 1.day.ago - 1.minute }
       invitation_sent_at { 1.day.ago }
-      vita_partner { invited_by.vita_partner }
       sequence(:invitation_token) do |n|
         Devise.token_generator.digest(User, :invitation_token, "InvitationToken#{n}")
       end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -38,7 +38,6 @@
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  invited_by_id             :bigint
-#  vita_partner_id           :bigint
 #  zendesk_user_id           :bigint
 #
 # Indexes
@@ -48,12 +47,10 @@
 #  index_users_on_invitations_count     (invitations_count)
 #  index_users_on_invited_by_id         (invited_by_id)
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
-#  index_users_on_vita_partner_id       (vita_partner_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (invited_by_id => users.id)
-#  fk_rails_...  (vita_partner_id => vita_partners.id)
 #
 FactoryBot.define do
   factory :user do
@@ -64,11 +61,6 @@ FactoryBot.define do
 
     factory :admin_user do
       is_admin { true }
-      vita_partner { nil }
-    end
-
-    factory :zendesk_admin_user do
-      role { "admin" }
     end
 
     factory :agent_user do

--- a/spec/features/hub/clients_searching_sorting_and_filtering_spec.rb
+++ b/spec/features/hub/clients_searching_sorting_and_filtering_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "searching, sorting, and filtering clients" do
   context "as an admin user" do
-    let(:user) { create :admin_user, vita_partner: create(:vita_partner) }
+    let(:user) { create :admin_user }
 
     before { login_as user }
 

--- a/spec/features/hub/edit_client_spec.rb
+++ b/spec/features/hub/edit_client_spec.rb
@@ -2,10 +2,11 @@ require "rails_helper"
 
 RSpec.describe "a user editing a clients intake fields" do
   context "as an admin user" do
-    let(:user) { create :admin_user, vita_partner: create(:vita_partner) }
+    let(:organization) { create(:organization) }
+    let(:user) { create :admin_user }
     let(:client) {
       create :client,
-             vita_partner: user.vita_partner,
+             vita_partner: organization,
              intake: create(:intake, email_address: "colleen@example.com", primary_first_name: "Colleen", primary_last_name: "Cauliflower", preferred_interview_language: "es", state_of_residence: "CA", preferred_name: "Colleen Cauliflower", email_notification_opt_in: "yes", dependents: [
                create(:dependent, first_name: "Lara", last_name: "Legume", birth_date: "2007-03-06"),
              ])

--- a/spec/helpers/role_helper_spec.rb
+++ b/spec/helpers/role_helper_spec.rb
@@ -20,4 +20,26 @@ describe RoleHelper do
       end
     end
   end
+
+  describe "#user_org" do
+    context "for a user in no org" do
+      let(:user) { create :user }
+
+      it "returns a blank value" do
+        expect(helper.user_org(user)).to be_blank
+      end
+    end
+
+    context "for an org lead user" do
+      let(:user) { create :user }
+      let(:organization) { create :organization, name: "Orange Organization" }
+      before do
+        create :organization_lead_role, user: user, organization: organization
+      end
+
+      it "returns the name of the org that they are a lead for" do
+        expect(helper.user_org(user)).to eq("Orange Organization")
+      end
+    end
+  end
 end

--- a/spec/lib/client_router_spec.rb
+++ b/spec/lib/client_router_spec.rb
@@ -2,33 +2,39 @@ require "rails_helper"
 
 RSpec.describe ClientRouter do
   describe ".route" do
-    context "with more than one vita partner" do
-      let!(:big_vita_partner) { create(:vita_partner, users: create_list(:user, 3)) }
-      let!(:small_vita_partner) { create(:vita_partner, users: create_list(:user, 1)) }
+    context "with more than one organization" do
+      let!(:small_organization) { create(:organization) }
+      let!(:big_organization) { create(:organization) }
       let(:intake) { create :intake }
 
-      it "assigns to the one with the most users" do
+      before do
+        create_list(:organization_lead_role, 3, organization: big_organization)
+        create(:organization_lead_role, organization: small_organization)
+      end
+
+      it "assigns to the one with the most org leads" do
         described_class.route(intake.client)
 
-        expect(intake.reload.client.vita_partner).to eq(big_vita_partner)
-        expect(intake.reload.vita_partner).to eq(big_vita_partner)
+        expect(intake.reload.client.vita_partner).to eq(big_organization)
+        expect(intake.reload.vita_partner).to eq(big_organization)
       end
     end
 
-    context "when client already has a vita_partner" do
-      let(:old_vita_partner) { create(:vita_partner) }
-      let!(:big_vita_partner) { create(:vita_partner, users: create_list(:user, 3)) }
-      let(:intake) { create(:intake, vita_partner: old_vita_partner) }
+    context "when client already has a .vita_partner" do
+      let(:old_organization) { create(:organization) }
+      let!(:big_organization) { create(:organization) }
+      let(:intake) { create(:intake, vita_partner: old_organization) }
 
       before do
-        intake.client.update(vita_partner: old_vita_partner)
+        intake.client.update(vita_partner: old_organization)
+        create(:organization_lead_role, organization: big_organization)
       end
 
       it "re-assigns" do
         described_class.route(intake.client)
 
-        expect(intake.reload.client.vita_partner).to eq(big_vita_partner)
-        expect(intake.reload.vita_partner).to eq(big_vita_partner)
+        expect(intake.reload.client.vita_partner).to eq(big_organization)
+        expect(intake.reload.vita_partner).to eq(big_organization)
       end
     end
   end

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -216,7 +216,8 @@ describe Client do
   describe "#destroy_completely" do
     context "with many associated records" do
       let(:vita_partner) { create :vita_partner }
-      let(:user) { create :user, vita_partner: vita_partner }
+      let(:user) { create :user }
+      let(:organization_lead_role) { create :organization_lead_role, user: user, organization: vita_partner }
       let(:client) { create :client, vita_partner: vita_partner }
       let(:intake) { create :intake, client: client, vita_partner: vita_partner }
       let!(:unrelated_intake) { create :intake }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -38,7 +38,6 @@
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  invited_by_id             :bigint
-#  vita_partner_id           :bigint
 #  zendesk_user_id           :bigint
 #
 # Indexes
@@ -48,12 +47,10 @@
 #  index_users_on_invitations_count     (invitations_count)
 #  index_users_on_invited_by_id         (invited_by_id)
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
-#  index_users_on_vita_partner_id       (vita_partner_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (invited_by_id => users.id)
-#  fk_rails_...  (vita_partner_id => vita_partners.id)
 #
 require "rails_helper"
 


### PR DESCRIPTION
This is a code quality cleanup commit that removes User.vita_partner_id and relies exclusively on the OrganizationLeadRole model for modeling roles.

In the future, we expect more role tables that contain different data.

For now, please allow Sarah & Asheesh to merge it.

Co-authored-by: Sarah Niemeyer <sniemeyer@vmware.com>
Co-authored-by: Alex Sartan <asartan@vmware.com>
Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>