### PR TITLE
Update statuses and tests that used old statues and write script for migrating existing data

### DIFF
--- a/.aptible.yml
+++ b/.aptible.yml
@@ -1,3 +1,4 @@
 before_release:
     - bundle exec rake db:migrate
     - bundle exec rake db:insert_states
+    - bundle exec rake db:update_tax_return_statuses

--- a/.aptible.yml
+++ b/.aptible.yml
@@ -1,4 +1,3 @@
 before_release:
     - bundle exec rake db:migrate
     - bundle exec rake db:insert_states
-    - bundle exec rake db:update_tax_return_statuses

--- a/app/controllers/documents/additional_documents_controller.rb
+++ b/app/controllers/documents/additional_documents_controller.rb
@@ -1,6 +1,6 @@
 module Documents
   class AdditionalDocumentsController < DocumentUploadQuestionController
-    before_action :advance_to_open, only: [:edit]
+    before_action :advance_to_ready, only: [:edit]
 
     def self.show?(_intake)
       true
@@ -12,8 +12,8 @@ module Documents
 
     private
 
-    def advance_to_open
-      current_intake.advance_tax_return_statuses_to("intake_open")
+    def advance_to_ready
+      current_intake.advance_tax_return_statuses_to("intake_ready")
     end
   end
 end

--- a/app/forms/hub/create_client_form.rb
+++ b/app/forms/hub/create_client_form.rb
@@ -69,7 +69,7 @@ module Hub
     private
 
     def tax_return_defaults
-      { status: :intake_needs_assignment }.merge(attributes_for(:tax_return))
+      { status: :prep_ready_for_prep }.merge(attributes_for(:tax_return))
     end
 
     def create_tax_return_for_year?(year)

--- a/app/lib/tax_return_status.rb
+++ b/app/lib/tax_return_status.rb
@@ -16,11 +16,11 @@ class TaxReturnStatus
 
     def message_templates
       {
-          intake_more_info: "hub.status_macros.needs_more_information",
-          prep_more_info: "hub.status_macros.needs_more_information",
-          review_more_info: "hub.status_macros.needs_more_information",
-          prep_ready_for_review: "hub.status_macros.ready_for_qr",
-          filed_accepted: "hub.status_macros.accepted"
+          intake_info_requested: "hub.status_macros.needs_more_information",
+          prep_info_requested: "hub.status_macros.needs_more_information",
+          review_info_requested: "hub.status_macros.needs_more_information",
+          review_ready_for_qr: "hub.status_macros.ready_for_qr",
+          file_accepted: "hub.status_macros.accepted"
       }
     end
   end
@@ -29,11 +29,13 @@ class TaxReturnStatus
   #
   # The first word of each status name is treated as a "stage" when grouping these in the interface.
   STATUSES = {
-      intake_before_consent: 100, intake_in_progress: 101, intake_open: 102, intake_review: 103, intake_more_info: 104, intake_info_requested: 105, intake_needs_assignment: 106,
-      prep_ready_for_call: 201, prep_more_info: 202, prep_preparing: 203, prep_ready_for_review: 204,
-      review_in_review: 301, review_complete_signature_requested: 302, review_more_info: 303,
-      finalize_closed: 401, finalize_signed: 402,
-      filed_e_file: 501, filed_mail_file: 502, filed_rejected: 503, filed_accepted: 504
+      intake_before_consent: 100, intake_in_progress: 101, intake_ready: 102, intake_reviewing: 103, intake_ready_for_call: 104, intake_info_requested: 105,
+
+      prep_ready_for_prep: 201, prep_preparing: 202, prep_info_requested: 203,
+
+      review_ready_for_qr: 301, review_reviewing: 302, review_ready_for_call: 303, review_signature_requested: 304, review_info_requested: 305,
+
+      file_ready_to_file: 401, file_efiled: 402, file_mailed: 403, file_rejected: 404, file_accepted: 405, file_not_filing: 406
   }.freeze
 
   STATUSES_BY_STAGE = determine_statuses_by_stage.freeze

--- a/app/services/migrate_statuses.rb
+++ b/app/services/migrate_statuses.rb
@@ -1,0 +1,26 @@
+class MigrateStatuses
+  STATUS_UPDATE_MAP = {
+      201 => 104,
+      104 => 105,
+      106 => 201,
+      202 => 203,
+      203 => 202,
+      204 => 301,
+      301 => 302,
+      302 => 304,
+      303 => 305,
+      401 => 406,
+      402 => 401,
+      502 => 402,
+      503 => 403,
+      504 => 404,
+      505 => 405
+  }.freeze
+
+  def self.migrate_all
+    TaxReturn.where(status: STATUS_UPDATE_MAP.keys).find_each(batch_size: 100) do |tax_return|
+      new_status = STATUS_UPDATE_MAP[tax_return.read_attribute_before_type_cast(:status)]
+      tax_return.update(status: new_status)
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -161,29 +161,28 @@ en:
         intake: Intake
         prep: Tax prep
         review: Quality review
-        finalize: Final steps
-        filed: Filing completed
+        file: Final steps
       status:
         intake_before_consent: Before consent
-        intake_in_progress: In progress
-        intake_open: Open
-        intake_review: In review
-        intake_more_info: Needs more information
+        intake_in_progress: Not ready
+        intake_ready: Ready for review
+        intake_reviewing: Reviewing
+        intake_ready_for_call: Ready for call
         intake_info_requested: Info requested
-        intake_needs_assignment: Needs assignment
-        prep_ready_for_call: Ready for call
-        prep_more_info: Needs more information
-        prep_preparing: Entering in TaxSlayer
-        prep_ready_for_review: Ready for QR
-        review_in_review: In review
-        review_more_info: Needs more information
-        review_complete_signature_requested: Complete/Signature requested
-        finalize_closed: Closed
-        finalize_signed: Return signed
-        filed_e_file: Return e-filed
-        filed_mail_file: Return filed by mail
-        filed_rejected: Rejected
-        filed_accepted: Accepted
+        prep_ready_for_prep: Ready for prep
+        prep_preparing: Preparing
+        prep_info_requested: Info requested
+        review_ready_for_qr: Ready for QR
+        review_reviewing: Reviewing
+        review_ready_for_call: Ready for call
+        review_signature_requested: Signature requested
+        review_info_requested: Info requested
+        file_ready_to_file: Ready to file
+        file_efiled: E-filed
+        file_mailed: Filed by mail
+        file_rejected: Rejected
+        file_accepted: Accepted
+        file_not_filing: Not filing
     status_macros:
       needs_more_information: |
         Hello <<Client.PreferredName>>!

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -162,29 +162,28 @@ es:
         intake: Admisión
         prep: Preparación de impuestos
         review: Revisión de calidad
-        finalize: Pasos finales
-        filed: Presentación de impuestos completada
+        file: Pasos finales
       status:
         intake_before_consent: Antes de consentimiento
-        intake_in_progress: En progreso
-        intake_open: Abierto
-        intake_review: En revisión
-        intake_more_info: Necesita más información
+        intake_in_progress: No listo
+        intake_ready: Ready for review
+        intake_reviewing: Revisando
+        intake_ready_for_call: Listo para llama
         intake_info_requested: Información solicitada
-        intake_needs_assignment: Necesita asignación
-        prep_ready_for_call: Listo para llama
-        prep_preparing: Entrar en TaxSlayer
-        prep_more_info: Necesita más información
-        prep_ready_for_review: Listo para QR
-        review_in_review: En revisión
-        review_more_info: Necesita más información
-        review_complete_signature_requested: Completo/Firma solicitada
-        finalize_closed: Cerrado
-        finalize_signed: Declaración de impuestos firmada
-        filed_e_file: Declaración de impuestos presentada electrónicamente
-        filed_mail_file: Declaración de impuestos presentada por correo
-        filed_rejected: Rechazado
-        filed_accepted: Aceptado
+        prep_ready_for_prep: Listo para la preparación
+        prep_preparing: Preparando
+        prep_info_requested: Información solicitada
+        review_ready_for_qr: Listo para QR
+        review_reviewing: Revisando
+        review_ready_for_call: Listo para llama
+        review_signature_requested: Firma solicitada
+        review_info_requested: Información solicitada
+        file_ready_to_file: Listo para presentar
+        file_efiled: Presentada electrónicamente
+        file_mailed: Presentada por correo
+        file_rejected: Rechazado
+        file_accepted: Aceptado
+        file_not_filing: No archivar
     status_macros:
       needs_more_information: |
         ¡Hola <<Client.PreferredName>>!

--- a/db/migrate/20210104224344_migrate_statuses_for_tax_returns.rb
+++ b/db/migrate/20210104224344_migrate_statuses_for_tax_returns.rb
@@ -1,0 +1,9 @@
+class MigrateStatusesForTaxReturns < ActiveRecord::Migration[6.0]
+  def up
+    MigrateStatuses.migrate_all
+  end
+
+  def down
+    # noop
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_23_232203) do
+ActiveRecord::Schema.define(version: 2021_01_04_224344) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/lib/tasks/migrate_tax_return_statuses.rake
+++ b/lib/tasks/migrate_tax_return_statuses.rake
@@ -1,6 +1,0 @@
-namespace :db do
-  desc 'migrates old tax return statuses to updated statuses'
-  task update_tax_return_statuses: [:environment] do
-    MigrateStatuses.migrate_all
-  end
-end

--- a/lib/tasks/migrate_tax_return_statuses.rake
+++ b/lib/tasks/migrate_tax_return_statuses.rake
@@ -1,0 +1,6 @@
+namespace :db do
+  desc 'migrates old tax return statuses to updated statuses'
+  task update_tax_return_statuses: [:environment] do
+    MigrateStatuses.migrate_all
+  end
+end

--- a/spec/controllers/concerns/client_sortable_spec.rb
+++ b/spec/controllers/concerns/client_sortable_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe ClientSortable, type: :controller do
       let(:params) do
         {
           search: "query",
-          status: "intake_in_progress"
+          status: "intake_ready"
         }
       end
 

--- a/spec/controllers/documents/additional_documents_controller_spec.rb
+++ b/spec/controllers/documents/additional_documents_controller_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe Documents::AdditionalDocumentsController do
   describe "#edit" do
     let!(:tax_return) { create :tax_return, client: intake.client, status: "intake_in_progress" }
 
-    it "advances the tax returns to 'Open' status" do
+    it "advances the tax returns to 'Ready for review' status" do
       get :edit
 
-      expect(tax_return.reload.status).to eq "intake_open"
+      expect(tax_return.reload.status).to eq "intake_ready"
     end
 
     context "with no docs that might be needed" do

--- a/spec/factories/clients.rb
+++ b/spec/factories/clients.rb
@@ -21,7 +21,7 @@
 FactoryBot.define do
   factory :client do
     trait :with_return do
-      tax_returns { FactoryBot.create_list(:tax_return, 1, status: "intake_open") }
+      tax_returns { FactoryBot.create_list(:tax_return, 1, status: 101) }
     end
   end
 end

--- a/spec/factories/tax_returns.rb
+++ b/spec/factories/tax_returns.rb
@@ -28,6 +28,6 @@ FactoryBot.define do
   factory :tax_return do
     year { 2019 }
     client
-    status { "intake_in_progress" }
+    status { 101 }
   end
 end

--- a/spec/features/hub/assignments_spec.rb
+++ b/spec/features/hub/assignments_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Assign a user to a tax return", js: true do
     let!(:user_to_assign) { create :user, name: "Lucille 2", role: create(:organization_lead_role, organization: organization) }
     let(:client) { create :client, vita_partner: organization }
     let!(:intake) { create :intake, :with_contact_info, client: client, preferred_name: "Buster" }
-    let!(:tax_return_to_assign) { create :tax_return, status: "intake_open", year: 2019, client: client }
+    let!(:tax_return_to_assign) { create :tax_return, status: "intake_ready", year: 2019, client: client }
 
     before do
       login_as logged_in_user

--- a/spec/features/hub/clients_searching_sorting_and_filtering_spec.rb
+++ b/spec/features/hub/clients_searching_sorting_and_filtering_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe "searching, sorting, and filtering clients" do
     context "with existing clients" do
       let!(:alan_intake_in_progress) { create :client, intake: (create :intake, preferred_name: "Alan Avocado", primary_consented_to_service_at: 1.day.ago, state_of_residence: "CA"), tax_returns: [(create :tax_return, year: 2019, status: "intake_in_progress", assigned_user: user)] }
       let!(:betty_intake_in_progress) { create :client, intake: (create :intake, preferred_name: "Betty Banana", primary_consented_to_service_at: 2.days.ago, state_of_residence: "TX"), tax_returns: [(create :tax_return, year: 2018, status: "intake_in_progress")] }
-      let!(:patty_prep_ready_for_call) { create :client, intake: (create :intake, preferred_name: "Patty Banana", primary_consented_to_service_at: 1.day.ago, state_of_residence: "AL"), tax_returns: [(create :tax_return, year: 2019, status: "prep_ready_for_call", assigned_user: user)] }
-      let!(:zach_prep_ready_for_call) { create :client, intake: (create :intake, preferred_name: "Zach Zucchini", primary_consented_to_service_at: 2.days.ago, state_of_residence: "WI"), tax_returns: [(create :tax_return, year: 2018, status: "prep_ready_for_call")] }
+      let!(:patty_prep_ready_for_call) { create :client, intake: (create :intake, preferred_name: "Patty Banana", primary_consented_to_service_at: 1.day.ago, state_of_residence: "AL"), tax_returns: [(create :tax_return, year: 2019, status: "prep_ready_for_prep", assigned_user: user)] }
+      let!(:zach_prep_ready_for_call) { create :client, intake: (create :intake, preferred_name: "Zach Zucchini", primary_consented_to_service_at: 2.days.ago, state_of_residence: "WI"), tax_returns: [(create :tax_return, year: 2018, status: "prep_ready_for_prep")] }
 
       scenario "I can view all clients and search, sort, and filter" do
         visit hub_clients_path
@@ -40,9 +40,9 @@ RSpec.describe "searching, sorting, and filtering clients" do
         click_button "Clear filters"
 
         within ".filter-form" do
-          select "Ready for call", from: "status"
+          select "Ready for prep", from: "status"
           click_button "Apply"
-          expect(page).to have_select("status-filter", selected: "Ready for call")
+          expect(page).to have_select("status-filter", selected: "Ready for prep")
         end
 
         within ".client-table" do
@@ -116,9 +116,9 @@ RSpec.describe "searching, sorting, and filtering clients" do
         end
         within ".filter-form" do
           select "2019", from: "year"
-          select "Ready for call", from: "status"
+          select "Ready for prep", from: "status"
           click_button "Apply"
-          expect(page).to have_select("status-filter", selected: "Ready for call")
+          expect(page).to have_select("status-filter", selected: "Ready for prep")
           expect(page).to have_select("year", selected: "2019")
         end
         within ".client-table" do
@@ -132,10 +132,10 @@ RSpec.describe "searching, sorting, and filtering clients" do
         end
         within ".filter-form" do
           check "assigned_to_me"
-          select "Ready for call", from: "status"
+          select "Ready for prep", from: "status"
           select "2019", from: "year"
           click_button "Apply"
-          expect(page).to have_select("status-filter", selected: "Ready for call")
+          expect(page).to have_select("status-filter", selected: "Ready for prep")
           expect(page).to have_select("year", selected: "2019")
           expect(page).to have_checked_field("assigned_to_me")
         end
@@ -145,7 +145,7 @@ RSpec.describe "searching, sorting, and filtering clients" do
         within ".filter-form" do
           select "2018", from: "year"
           click_button "Apply"
-          expect(page).to have_select("status-filter", selected: "Ready for call")
+          expect(page).to have_select("status-filter", selected: "Ready for prep")
           expect(page).to have_checked_field("assigned_to_me")
           expect(page).to have_select("year", selected: "2018")
         end

--- a/spec/features/hub/take_action_spec.rb
+++ b/spec/features/hub/take_action_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Change tax return status on a client" do
 
       expect(current_path).to eq(edit_take_action_hub_client_path(id: tax_return.client))
       expect(page).to have_select("hub_take_action_form_status")
-      select "Entering in TaxSlayer", from: "Updated status"
+      select "Preparing", from: "Updated status"
       select "2019", from: "Filing year"
 
       expect(page).to have_select("hub_take_action_form_locale", selected: "English")
@@ -28,7 +28,7 @@ RSpec.feature "Change tax return status on a client" do
       fill_in "Send message", with: "Heads up! I am still working on it."
       fill_in "Add an internal note", with: "Leaving a note to the client"
       click_on "Send"
-      expect(page).to have_text "Entering in TaxSlayer"
+      expect(page).to have_text "Preparing"
 
       expect(current_path).to eq hub_client_path(id: client.id)
       click_on "Notes"
@@ -40,7 +40,7 @@ RSpec.feature "Change tax return status on a client" do
 
     scenario "can change a status on a tax return and send a templated message" do
       visit hub_client_path(id: client.id)
-      expect(page).to have_select("tax_return[status]", selected: "In progress")
+      expect(page).to have_select("tax_return[status]", selected: "Not ready")
 
       within "#tax-return-#{tax_return.id}" do
         select "Accepted"
@@ -64,7 +64,7 @@ RSpec.feature "Change tax return status on a client" do
       end
 
       click_on "Notes"
-      expect(page).to have_text("Example Preparer updated 2019 tax return status from Intake/In progress to Filing completed/Accepted")
+      expect(page).to have_text("Example Preparer updated 2019 tax return status from Intake/Not ready to Final steps/Accepted")
     end
   end
 end

--- a/spec/features/web_intake/new_joint_filers_spec.rb
+++ b/spec/features/web_intake/new_joint_filers_spec.rb
@@ -324,7 +324,7 @@ RSpec.feature "Web Intake Joint Filers" do
     expect(page).to have_selector("h1", text: "Attach your 1099-R's")
     expect do
       click_on "Continue"
-    end.to change { intake.client.tax_returns.pluck(:status) }.from(["intake_in_progress"]).to(["intake_open"])
+    end.to change { intake.client.tax_returns.pluck(:status) }.from(["intake_in_progress"]).to(["intake_ready"])
 
     expect(page).to have_selector("h1", text: "Please share any additional documents.")
     attach_file("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"))

--- a/spec/forms/hub/take_action_form_spec.rb
+++ b/spec/forms/hub/take_action_form_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Hub::TakeActionForm do
       end
 
       context "when a status that has a message template is provided and locale is english" do
-        let(:form) { Hub::TakeActionForm.new(client, current_user, { status: "intake_more_info", locale: "en" }) }
+        let(:form) { Hub::TakeActionForm.new(client, current_user, { status: "intake_info_requested", locale: "en" }) }
 
         it "sets message body to the template with replacement parameters substituted" do
           expect(form.message_body).to start_with("Hello")
@@ -63,7 +63,7 @@ RSpec.describe Hub::TakeActionForm do
       end
 
       context "when a status that has a message template is provided and locale is spanish" do
-        let(:form) { Hub::TakeActionForm.new(client, current_user, { status: "intake_more_info", locale: "es" }) }
+        let(:form) { Hub::TakeActionForm.new(client, current_user, { status: "intake_info_requested", locale: "es" }) }
         let(:filled_out_template) {
           <<~MESSAGE
             ¡Hola Luna Lemon!
@@ -259,13 +259,13 @@ RSpec.describe Hub::TakeActionForm do
       let(:tax_return) { create :tax_return, client: client, year: 2019 }
 
       context "only status change" do
-        let(:form) { Hub::TakeActionForm.new(client, current_user, { tax_return_id: tax_return.id, status: "intake_more_info", message_body: "" }) }
+        let(:form) { Hub::TakeActionForm.new(client, current_user, { tax_return_id: tax_return.id, status: "intake_info_requested", message_body: "" }) }
 
         it "changes the status of the client" do
           expect {
             form.take_action
             tax_return.reload
-          }.to change(tax_return, :status).to "intake_more_info"
+          }.to change(tax_return, :status).to "intake_info_requested"
         end
 
         it "does not send an email" do
@@ -293,14 +293,14 @@ RSpec.describe Hub::TakeActionForm do
       end
 
       context "status change with default message" do
-        let(:form) { Hub::TakeActionForm.new(client, current_user, { tax_return_id: tax_return.id, status: "intake_more_info" }) }
+        let(:form) { Hub::TakeActionForm.new(client, current_user, { tax_return_id: tax_return.id, status: "intake_info_requested" }) }
         it "changes the status of the client" do
           expect(SystemNote).to receive(:create_status_change_note).with(current_user, tax_return)
 
           expect {
             form.take_action
             tax_return.reload
-          }.to change(tax_return, :status).to "intake_more_info"
+          }.to change(tax_return, :status).to "intake_info_requested"
         end
 
         it "sends an email" do
@@ -348,7 +348,7 @@ RSpec.describe Hub::TakeActionForm do
 
       context "status change with note" do
         let(:internal_note_body) { "hi" }
-        let(:form) { Hub::TakeActionForm.new(client, current_user, { tax_return_id: tax_return.id, internal_note_body: internal_note_body, message_body: "", status: "intake_more_info" }) }
+        let(:form) { Hub::TakeActionForm.new(client, current_user, { tax_return_id: tax_return.id, internal_note_body: internal_note_body, message_body: "", status: "intake_info_requested" }) }
         it "creates an action list" do
           form.take_action
           expect(form.action_list).to eq ["updated status", "added internal note"]
@@ -370,7 +370,7 @@ RSpec.describe Hub::TakeActionForm do
         let(:internal_note_body) { " \n" }
         let(:message_body) { " \n" }
 
-        let(:form) { Hub::TakeActionForm.new(client, current_user, { tax_return_id: tax_return.id, internal_note_body: internal_note_body, message_body: "", status: "intake_more_info" }) }
+        let(:form) { Hub::TakeActionForm.new(client, current_user, { tax_return_id: tax_return.id, internal_note_body: internal_note_body, message_body: "", status: "intake_info_requested" }) }
 
         it "does not save a note" do
           expect do

--- a/spec/helpers/tax_return_status_helper_spec.rb
+++ b/spec/helpers/tax_return_status_helper_spec.rb
@@ -5,41 +5,37 @@ describe TaxReturnStatusHelper do
     expected = [
       ["Intake",
        [
-         ["In progress", "intake_in_progress"],
-         ["Open", "intake_open"],
-         ["In review", "intake_review"],
-         ["Needs more information", "intake_more_info"],
+         ["Not ready", "intake_in_progress"],
+         ["Ready for review", "intake_ready"],
+         ["Reviewing", "intake_reviewing"],
+         ["Ready for call", "intake_ready_for_call"],
          ["Info requested", "intake_info_requested"],
-         ["Needs assignment", "intake_needs_assignment"]
        ]
       ],
       ["Tax prep",
        [
-         ["Ready for call", "prep_ready_for_call"],
-         ["Needs more information", "prep_more_info"],
-         ["Entering in TaxSlayer", "prep_preparing"],
-         ["Ready for QR", "prep_ready_for_review"]
+         ["Ready for prep", "prep_ready_for_prep"],
+         ["Preparing", "prep_preparing"],
+         ["Info requested", "prep_info_requested"]
        ]
       ],
       ["Quality review",
        [
-         ["In review", "review_in_review"],
-         ["Complete/Signature requested", "review_complete_signature_requested"],
-         ["Needs more information", "review_more_info"]
+         ["Ready for QR", "review_ready_for_qr"],
+         ["Reviewing", "review_reviewing"],
+         ["Ready for call", "review_ready_for_call"],
+         ["Signature requested", "review_signature_requested"],
+         ["Info requested", "review_info_requested"]
        ]
       ],
-      ["Final steps",
+      [I18n.t("hub.tax_returns.stage.file"),
        [
-         ["Closed", "finalize_closed"],
-         ["Return signed", "finalize_signed"]
-       ]
-      ],
-      [I18n.t("hub.tax_returns.stage.filed"),
-       [
-         ["Return e-filed", "filed_e_file"],
-         ["Return filed by mail", "filed_mail_file"],
-         ["Rejected", "filed_rejected"],
-         ["Accepted", "filed_accepted"]
+         ["Ready to file", "file_ready_to_file"],
+         ['E-filed', "file_efiled"],
+         ["Filed by mail", "file_mailed"],
+         ["Rejected", "file_rejected"],
+         ["Accepted", "file_accepted"],
+         ["Not filing", "file_not_filing"]
        ]
       ]
     ]
@@ -65,7 +61,7 @@ describe TaxReturnStatusHelper do
     describe "with an example status" do
       let(:tax_return) { create :tax_return, status: "intake_in_progress" }
       it "returns the expected text" do
-        expect(helper.stage_and_status_translation(tax_return.status)).to eq "Intake/In progress"
+        expect(helper.stage_and_status_translation(tax_return.status)).to eq "Intake/Not ready"
       end
     end
   end

--- a/spec/lib/tax_return_status_spec.rb
+++ b/spec/lib/tax_return_status_spec.rb
@@ -4,36 +4,36 @@ describe TaxReturnStatus do
   context ".message_template_for" do
     context "prep_more_info" do
       it "returns a template" do
-        expect(TaxReturnStatus.message_template_for("prep_more_info")).to eq I18n.t("hub.status_macros.needs_more_information", locale: "en")
-        expect(TaxReturnStatus.message_template_for(:prep_more_info, "es")).to eq I18n.t("hub.status_macros.needs_more_information", locale: "es")
+        expect(TaxReturnStatus.message_template_for("prep_info_requested")).to eq I18n.t("hub.status_macros.needs_more_information", locale: "en")
+        expect(TaxReturnStatus.message_template_for(:prep_info_requested, "es")).to eq I18n.t("hub.status_macros.needs_more_information", locale: "es")
       end
     end
 
     context "intake_more_info" do
       it "returns a template" do
-        expect(TaxReturnStatus.message_template_for("intake_more_info")).to eq I18n.t("hub.status_macros.needs_more_information", locale: "en")
-        expect(TaxReturnStatus.message_template_for(:intake_more_info, "es")).to eq I18n.t("hub.status_macros.needs_more_information", locale: "es")
+        expect(TaxReturnStatus.message_template_for("intake_info_requested")).to eq I18n.t("hub.status_macros.needs_more_information", locale: "en")
+        expect(TaxReturnStatus.message_template_for(:intake_info_requested, "es")).to eq I18n.t("hub.status_macros.needs_more_information", locale: "es")
       end
     end
 
     context "review_more_info" do
       it "returns a template" do
-        expect(TaxReturnStatus.message_template_for("review_more_info")).to eq I18n.t("hub.status_macros.needs_more_information", locale: "en")
-        expect(TaxReturnStatus.message_template_for(:review_more_info, "es")).to eq I18n.t("hub.status_macros.needs_more_information", locale: "es")
+        expect(TaxReturnStatus.message_template_for("review_info_requested")).to eq I18n.t("hub.status_macros.needs_more_information", locale: "en")
+        expect(TaxReturnStatus.message_template_for(:review_info_requested, "es")).to eq I18n.t("hub.status_macros.needs_more_information", locale: "es")
       end
     end
 
     context "prep_ready_for_review" do
       it "returns a template" do
-        expect(TaxReturnStatus.message_template_for("prep_ready_for_review")).to eq I18n.t("hub.status_macros.ready_for_qr", locale: "en")
-        expect(TaxReturnStatus.message_template_for(:prep_ready_for_review, "es")).to eq I18n.t("hub.status_macros.ready_for_qr", locale: "es")
+        expect(TaxReturnStatus.message_template_for("review_ready_for_qr")).to eq I18n.t("hub.status_macros.ready_for_qr", locale: "en")
+        expect(TaxReturnStatus.message_template_for(:review_ready_for_qr, "es")).to eq I18n.t("hub.status_macros.ready_for_qr", locale: "es")
       end
     end
 
     context "filed_accepted" do
       it "returns a template" do
-        expect(TaxReturnStatus.message_template_for("filed_accepted")).to eq I18n.t("hub.status_macros.accepted", locale: "en")
-        expect(TaxReturnStatus.message_template_for(:filed_accepted, "es")).to eq I18n.t("hub.status_macros.accepted", locale: "es")
+        expect(TaxReturnStatus.message_template_for("file_accepted")).to eq I18n.t("hub.status_macros.accepted", locale: "en")
+        expect(TaxReturnStatus.message_template_for(:file_accepted, "es")).to eq I18n.t("hub.status_macros.accepted", locale: "es")
       end
     end
 

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -933,13 +933,13 @@ describe Intake do
   describe "#advance_tax_return_statuses_to" do
     let(:intake) { create :intake }
     let!(:earlier_tax_return) { create :tax_return, year: 2020, client: intake.client, status: "intake_before_consent" }
-    let!(:later_tax_return) { create :tax_return, year: 2019, client: intake.client, status: "intake_needs_assignment" }
+    let!(:later_tax_return) { create :tax_return, year: 2019, client: intake.client, status: "prep_ready_for_prep" }
 
     it "advances each tax return" do
-      intake.advance_tax_return_statuses_to("intake_open")
+      intake.advance_tax_return_statuses_to("intake_ready")
 
-      expect(earlier_tax_return.reload.status).to eq "intake_open"
-      expect(later_tax_return.reload.status).to eq "intake_needs_assignment"
+      expect(earlier_tax_return.reload.status).to eq "intake_ready"
+      expect(later_tax_return.reload.status).to eq "prep_ready_for_prep"
     end
   end
 

--- a/spec/models/system_note_spec.rb
+++ b/spec/models/system_note_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe SystemNote do
 
     context "with recently persisted changes" do
       before do
-        tax_return.update(status: "intake_open")
+        tax_return.update(status: "intake_ready")
       end
       it "can track the changes" do
         expect {
@@ -39,7 +39,7 @@ RSpec.describe SystemNote do
 
         expect(note.user).to eq(user)
         expect(note.client).to eq(tax_return.client)
-        expect(note.body).to eq("Olive Oil updated 3020 tax return status from Intake/In progress to Intake/Open")
+        expect(note.body).to eq("Olive Oil updated 3020 tax return status from Intake/Not ready to Intake/Ready for review")
       end
     end
   end

--- a/spec/models/tax_return_spec.rb
+++ b/spec/models/tax_return_spec.rb
@@ -62,7 +62,7 @@ describe TaxReturn do
   end
 
   describe "#advance_to" do
-    let(:tax_return) { create :tax_return, status: "intake_open" }
+    let(:tax_return) { create :tax_return, status: status }
 
     context "with a status that comes before the current status" do
       let(:status) { "intake_in_progress" }
@@ -75,12 +75,13 @@ describe TaxReturn do
     end
 
     context "with a status that comes after the current status" do
-      let(:status) { "finalize_signed" }
+      let(:status) { "intake_in_progress" }
+      let(:new_status) { "file_ready_to_file"}
 
       it "changes to the new status" do
         expect do
-          tax_return.advance_to(status)
-        end.to change(tax_return, :status).from("intake_open").to "finalize_signed"
+          tax_return.advance_to(new_status)
+        end.to change(tax_return, :status).from(status).to new_status
       end
     end
   end
@@ -92,29 +93,24 @@ describe TaxReturn do
       expect(result).to have_key("intake")
       expect(result).to have_key("prep")
       expect(result).to have_key("review")
-      expect(result).to have_key("finalize")
-      expect(result).to have_key("filed")
+      expect(result).to have_key("file")
     end
 
     it "includes all intake statuses except before consent" do
-      expect(result["intake"].length).to eq 6
+      expect(result["intake"].length).to eq 5
       expect(result["intake"]).not_to include "intake_before_consent"
     end
 
     it "includes all prep statuses" do
-      expect(result["prep"].length).to eq 4
+      expect(result["prep"].length).to eq 3
     end
 
     it "includes all review statuses" do
-      expect(result["review"].length).to eq 3
-    end
-
-    it "includes all finalize statuses" do
-      expect(result["finalize"].length).to eq 2
+      expect(result["review"].length).to eq 5
     end
 
     it "includes all filed statuses" do
-      expect(result["filed"].length).to eq 4
+      expect(result["file"].length).to eq 6
     end
   end
 end

--- a/spec/services/migrate_statuses_spec.rb
+++ b/spec/services/migrate_statuses_spec.rb
@@ -1,0 +1,163 @@
+require 'rails_helper'
+
+describe MigrateStatuses do
+  let!(:tax_return) { create :tax_return, status: status }
+
+  context '201 (was prep_ready_for_call)' do
+    let(:status) { 201 }
+    it 'changes to 104 / intake_ready_for_call' do
+      MigrateStatuses.migrate_all
+      tax_return.reload
+      expect(tax_return.status).to eq "intake_ready_for_call"
+    end
+  end
+
+  context '104 (was intake_needs_more_information)' do
+    let(:status) { 104 }
+    it 'changes to 105 / intake_info_requested' do
+      MigrateStatuses.migrate_all
+      tax_return.reload
+      expect(tax_return.status).to eq "intake_info_requested"
+    end
+  end
+
+  context '106 (was intake_needs_assignment)' do
+    let(:status) { 101 }
+    # 106 no longer exists -- force it by updating the column directly
+    before do
+      tax_return.update_column(:status, 106)
+      tax_return.save(validate: false)
+    end
+
+    it 'changes to 201 / ready_for_prep' do
+      MigrateStatuses.migrate_all
+      tax_return.reload
+      expect(tax_return.status).to eq "prep_ready_for_prep"
+    end
+  end
+
+  context '202 (was prep_needs_more_information)' do
+    let(:status) { 202 }
+    it 'changes to 203 / prep_info_requested' do
+      MigrateStatuses.migrate_all
+      tax_return.reload
+      expect(tax_return.status).to eq "prep_info_requested"
+    end
+  end
+
+  context '203 (was prep_preparing)' do
+    let(:status) { 203 }
+    it 'changes to 202 / prep_preparing' do
+      MigrateStatuses.migrate_all
+      tax_return.reload
+      expect(tax_return.status).to eq "prep_preparing"
+    end
+  end
+
+  context '204 (was prep_ready_for_qr)' do
+    let(:status) { 101 }
+    # 106 no longer exists -- force it by updating the column directly
+    before do
+      tax_return.update_column(:status, 204)
+      tax_return.save(validate: false)
+    end
+
+    it 'changes to 301 / review_ready_for_review' do
+      MigrateStatuses.migrate_all
+      tax_return.reload
+      expect(tax_return.status).to eq "review_ready_for_qr"
+    end
+  end
+
+  context '302 (was Completed/Signature requested)' do
+    let(:status) { 302 }
+    it 'changes to 304 / review_signature_requested' do
+      MigrateStatuses.migrate_all
+      tax_return.reload
+      expect(tax_return.status).to eq "review_signature_requested"
+    end
+  end
+
+  context '303 (was Needs more information)' do
+    let(:status) { 303 }
+    it 'changes to 305 / review_info_requested' do
+      MigrateStatuses.migrate_all
+      tax_return.reload
+      expect(tax_return.status).to eq "review_info_requested"
+    end
+  end
+
+  context '401 (was closed)' do
+    let(:status) { 401 }
+    it 'changes to 406 / file_not_filing' do
+      MigrateStatuses.migrate_all
+      tax_return.reload
+      expect(tax_return.status).to eq "file_not_filing"
+    end
+  end
+
+  context '402 (was return signed)' do
+    let(:status) { 402 }
+    it 'changes to 401 / file_ready_to_file' do
+      MigrateStatuses.migrate_all
+      tax_return.reload
+      expect(tax_return.status).to eq "file_ready_to_file"
+    end
+  end
+
+  context '502 (was return signed)' do
+    let(:status) { 101 }
+    # 106 no longer exists -- force it by updating the column directly
+    before do
+      tax_return.update_column(:status, 502)
+      tax_return.save(validate: false)
+    end
+    it 'changes to 402 / file_efiled' do
+      MigrateStatuses.migrate_all
+      tax_return.reload
+      expect(tax_return.status).to eq "file_efiled"
+    end
+  end
+
+  context '503 (was filed_by_mail)' do
+    let(:status) { 101 }
+    # 503 no longer exists -- force it by updating the column directly
+    before do
+      tax_return.update_column(:status, 503)
+      tax_return.save(validate: false)
+    end
+    it 'changes to 403 / file_mailed' do
+      MigrateStatuses.migrate_all
+      tax_return.reload
+      expect(tax_return.status).to eq "file_mailed"
+    end
+  end
+
+  context '504 (was _rejected)' do
+    let(:status) { 101 }
+    # 503 no longer exists -- force it by updating the column directly
+    before do
+      tax_return.update_column(:status, 504)
+      tax_return.save(validate: false)
+    end
+    it 'changes to 404 / file_rejected' do
+      MigrateStatuses.migrate_all
+      tax_return.reload
+      expect(tax_return.status).to eq "file_rejected"
+    end
+  end
+
+  context '505 (was _accepted)' do
+    let(:status) { 101 }
+    # 503 no longer exists -- force it by updating the column directly
+    before do
+      tax_return.update_column(:status, 505)
+      tax_return.save(validate: false)
+    end
+    it 'changes to 404 / file_accepted' do
+      MigrateStatuses.migrate_all
+      tax_return.reload
+      expect(tax_return.status).to eq "file_accepted"
+    end
+  end
+end


### PR DESCRIPTION
We can delete the script and tests once we run it, but it was helpful to use TDD for making sure that each of the transitions was happening.