### PR TITLE
Fix layout of help text during account creation [#175978650]

### DIFF
--- a/app/assets/stylesheets/_honeycrisp-compact.scss
+++ b/app/assets/stylesheets/_honeycrisp-compact.scss
@@ -19,6 +19,11 @@
   .text--help {
     font-size: $font-size-19;
   }
+  // In Honeycrisp, a form group with help text has a negative margin-top.
+  // This is unnecessary and troublesome in honeycrisp-compact.
+  .form-group .form-question + .text--help, .form-group .data-table .form-question + th, .data-table .form-group .form-question + th, .form-group .form-question + .summary-table__label, .form-group .form-question + .statistic-card__label {
+    margin-top: inherit;
+  }
 }
 
 .background--white {


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/67708639/104388841-e40dee80-54ee-11eb-8d63-07d55829db33.png)


After:

![image](https://user-images.githubusercontent.com/67708639/104388828-dbb5b380-54ee-11eb-8576-26a0fad3eaa4.png)
