### PR TITLE
Fix Bundler version on Aptible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN curl -fsSLO "$SUPERCRONIC_URL" \
 ADD Gemfile /app/
 ADD Gemfile.lock /app/
 WORKDIR /app
+RUN gem install bundler:$(cat Gemfile.lock | tail -1 | tr -d " ")
 RUN bundle install --without test development
 
 ADD . /app


### PR DESCRIPTION
I tested this by doing `docker build .` and seeing that it got past the `bundle install` phase where it failed earlier.