### PR TITLE
Speed up tests in RubyMine with Spring preloader

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,7 +87,7 @@ end
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 3.3.0'
-  gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'listen', '>= 3.4.0'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
@@ -100,6 +100,7 @@ group :test do
   gem 'webmock'
   gem 'simplecov', require: false
   gem 'shoulda-matchers', '~> 4.3.0'
+  gem 'spring-commands-rspec'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,10 +236,9 @@ GEM
       thor (>= 0.14, < 2.0)
     jwt (2.2.2)
     libv8 (8.4.255.0)
-    listen (3.1.5)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-      ruby_dep (~> 1.2)
+    listen (3.4.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     lograge (0.11.2)
       actionpack (>= 4)
       activesupport (>= 4)
@@ -407,7 +406,6 @@ GEM
     ruby-rc4 (0.1.5)
     ruby-vips (2.0.17)
       ffi (~> 1.9)
-    ruby_dep (1.5.0)
     ruby_http_client (3.5.1)
     rubyzip (2.3.0)
     safe_shell (1.1.0)
@@ -438,6 +436,8 @@ GEM
       simplecov-html (~> 0.11)
     simplecov-html (0.12.3)
     spring (2.1.1)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
@@ -539,7 +539,7 @@ DEPENDENCIES
   i18n-tasks
   image_processing
   jbuilder (~> 2.5)
-  listen (>= 3.0.5, < 3.2)
+  listen (>= 3.4.0)
   lograge
   mailgun-ruby (~> 1.1.6)
   mini_racer
@@ -567,6 +567,7 @@ DEPENDENCIES
   shoulda-matchers (~> 4.3.0)
   simplecov
   spring
+  spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
   strip_attributes
   thor

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
+require 'bundler/setup'
+load Gem.bin_path('rspec-core', 'rspec')


### PR DESCRIPTION
Also upgrade Spring dependencies for macOS Big Sur, which avoids Ruby process sometimes being at 100% uselessly while trying to check for file changes.

## Before

If you ran a test in RubyMine, it would seem to do nothing for 3 seconds, then run your test. This means if the test takes 0.5 sec, you wait 3.5 seconds.

## After

If you run a test in RubyMine after this change, it uses the Spring ruby process pool to run your test, which is usually fast (0-0.5 sec) to initialize. This means if the test takes 0.5 sec, you wait 0.5-1 sec.

Qualitatively this makes a big difference in not being sad/getting distracted, while using RubyMine for me.
