### PR TITLE
Run tests in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - run: bundle exec rake db:schema:load
       - run: mkdir ~/test-results && mkdir ~/test-results/rspec && mkdir ~/test-results/jest
       - run: |
-          bundle exec rspec \
+          RAILS_CACHE_CLASSES=1 bundle exec rspec \
               --format RspecJunitFormatter \
               --out ~/test-results/rspec/rspec.xml \
               --format progress \

--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,0 +1,2 @@
+--format progress
+--format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log

--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,7 @@ group :development, :test do
   gem 'i18n-tasks', require: false
   gem 'easy_translate'
   gem 'bundle-audit'
+  gem 'parallel_tests'
 end
 
 group :development do
@@ -101,6 +102,7 @@ group :test do
   gem 'simplecov', require: false
   gem 'shoulda-matchers', '~> 4.3.0'
   gem 'spring-commands-rspec'
+  gem 'database_cleaner'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,7 @@ GEM
     concurrent-ruby (1.1.7)
     crack (0.4.4)
     crass (1.0.6)
+    database_cleaner (1.8.5)
     ddtrace (0.41.0)
       msgpack
     delayed_job (4.1.8)
@@ -283,6 +284,8 @@ GEM
       shellany (~> 0.0)
     orm_adapter (0.5.0)
     parallel (1.19.2)
+    parallel_tests (3.4.0)
+      parallel
     parser (2.7.2.0)
       ast (~> 2.4.1)
     pdf-forms (1.3.0)
@@ -523,6 +526,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   cfa-styleguide!
   combine_pdf
+  database_cleaner
   ddtrace
   delayed_job_active_record
   device_detector
@@ -545,6 +549,7 @@ DEPENDENCIES
   mini_racer
   mixpanel-ruby
   nokogiri (>= 1.10.8)
+  parallel_tests
   pdf-forms
   pdf-reader
   pg

--- a/app/helpers/consolidated_trace_helper.rb
+++ b/app/helpers/consolidated_trace_helper.rb
@@ -1,20 +1,20 @@
 ##
-# provides constants indicating severity
-# the strings associated with the constants match the method names and
-# severity in `logger.rb` for ease of programmability
-module Severity
-  DEBUG = 'debug'.freeze
-  INFO = 'info'.freeze
-  WARN = 'warn'.freeze
-  ERROR = 'error'.freeze
-  FATAL = 'fatal'.freeze
-  UNKNOWN = 'unknown'.freeze
-end
-
-##
 # provides functions for recording error information for traceability. submits
 # to both the rails logger and to Raven (Sentry).
 module ConsolidatedTraceHelper
+
+  ##
+  # provides constants indicating severity
+  # the strings associated with the constants match the method names and
+  # severity in `logger.rb` for ease of programmability
+  module Severity
+    DEBUG = 'debug'.freeze
+    INFO = 'info'.freeze
+    WARN = 'warn'.freeze
+    ERROR = 'error'.freeze
+    FATAL = 'fatal'.freeze
+    UNKNOWN = 'unknown'.freeze
+  end
 
   ##
   # when wrapped around a block of code, this will add the included

--- a/app/lib/datadog_api.rb
+++ b/app/lib/datadog_api.rb
@@ -1,5 +1,3 @@
-require 'dogapi'
-
 module DatadogApi
 
   METRIC_TYPES = {
@@ -9,7 +7,21 @@ module DatadogApi
   }.freeze
 
   class Configuration
-    attr_accessor :enabled, :env, :api_key, :namespace
+    def env
+      Rails.env
+    end
+
+    def api_key
+      Rails.application.credentials.dig(:datadog_api_key)
+    end
+
+    def namespace
+      "vita-min.dogapi"
+    end
+
+    def enabled
+      Rails.env.staging? || Rails.env.demo? || Rails.env.production?
+    end
   end
 
   class << self

--- a/bin/setup
+++ b/bin/setup
@@ -38,6 +38,8 @@ FileUtils.chdir APP_ROOT do
 
   puts "\n== Preparing database =="
   system! "bin/rails db:prepare"
+  system! "bin/rails parallel:create"
+  system! "bin/rails parallel:setup"
 
   puts "\n== Set up database records for development =="
   system! "bin/rails db:seed"

--- a/bin/test
+++ b/bin/test
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-rspec
+RAILS_CACHE_CLASSES=1 bundle exec parallel_test spec -t rspec || { echo "Not running JS tests due to rspec failure." ; exit 1; }
 yarn jest

--- a/config/database.yml
+++ b/config/database.yml
@@ -18,7 +18,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *local_default
-  database: vita-min_test
+  database: vita-min_test<%= ENV['TEST_ENV_NUMBER'] %>
 
 production:
   <<: *deploy_default

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -5,7 +5,7 @@ Rails.application.configure do
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
-  config.cache_classes = true
+  config.cache_classes = ENV['RAILS_CACHE_CLASSES'].present?
   config.cache_store = :null_store
 
   # Do not eager load code on boot. This avoids loading your whole application

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -7,10 +7,3 @@ Datadog.configure do |c|
   c.tracer.enabled = Rails.env.staging? || Rails.env.demo? || Rails.env.production?
   c.tracer hostname: Rails.application.credentials.dig(:datadog_agent_host)
 end
-
-DatadogApi.configure do |c|
-  c.env = Rails.env
-  c.api_key = Rails.application.credentials.dig(:datadog_api_key)
-  c.namespace = "vita-min.dogapi"
-  c.enabled = Rails.env.staging? || Rails.env.demo? || Rails.env.production?
-end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -18,6 +18,7 @@ else
   Capybara.javascript_driver = :selenium_chrome_headless
 end
 Capybara.server = :puma, { Silent: true }
+Capybara.server_port = 9887 + ENV['TEST_ENV_NUMBER'].to_i
 
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,0 +1,6 @@
+RSpec.configure do |config|
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation, except: ['spatial_ref_sys'])
+  end
+end
+


### PR DESCRIPTION
## Before

Tests took about 3.5 minutes to run

## After

Tests take about 1-2 minutes to run. (I've seen them **as fast as 1 minute 6 seconds** and as slow as 1 minute 50 seconds).

## How to use this

Once this is merged, run `bin/setup` to create your many test databases (or run `bin/rails parallel:create` then `bin/rails parallel:setup`). 

If you have lots of annoying warnings from the macOS firewall, you can enable "Block all incoming connections" in the macOS firewall:

![image](https://user-images.githubusercontent.com/67708639/104658733-49d9b200-5678-11eb-9007-17d36983fc42.png)


## Additional changes

* `bin/setup`: Add parallel test setup.
* `bin/test`: When Ruby tests fail, do not run JS tests; this makes the output cleaner.
* Adjust some classes to avoid autoloader warnings
* Before the test suite, use `database_cleaner` to empty the database
* Enable `config.cache_classes` for full test runs, i.e., `bin/test` and Circle-CI. This is a performance trade-off similar to eagerly loading the app.