### PR TITLE
Rename classes to avoid conflict

### DIFF
--- a/app/lib/vita_partner_zip_codes_importer.rb
+++ b/app/lib/vita_partner_zip_codes_importer.rb
@@ -1,8 +1,8 @@
 require 'csv'
 
-class CreateVitaPartnerZipCodes
+class VitaPartnerZipCodesImporter
   def from_csv(filename)
-    # To use, run "CreateVitaPartnerZipCodes.new().from_csv('./wave_1_routing.csv')" in console
+    # To use, run "VitaPartnerZipCodesImporter.new().from_csv('./wave_1_routing.csv')" in console
     successes = []
     problems = []
     unfound_vita_partners = []


### PR DESCRIPTION
`CreateVitaPartnerZipCodes` used to be both a regular class and a migration.
Rename one to `VitaPartnerZipCodesImporter`.

I believe this only showed up when doing a deploy because we "eagerly load" all the code when doing a deployment.

(Unrelated: I've been interested in making the test suite eagerly load the code. That would have caught this issue. I may do that sometime.)