### PR TITLE
Source param routing updates #176262947

### DIFF
--- a/app/helpers/partner_routing_helper.rb
+++ b/app/helpers/partner_routing_helper.rb
@@ -1,0 +1,7 @@
+module PartnerRoutingHelper
+  def readable_routing_method(client)
+    return nil unless client.routing_method.present?
+
+    I18n.t("hub.clients.fields.routing_methods.#{client.routing_method}")
+  end
+end

--- a/app/models/source_parameter.rb
+++ b/app/models/source_parameter.rb
@@ -23,4 +23,12 @@ class SourceParameter < ApplicationRecord
   validates_presence_of :vita_partner_id
   validates_presence_of :code
   validates_uniqueness_of :code
+
+  before_validation :downcase_code
+
+  private
+
+  def downcase_code
+    self.code = code.downcase if code_changed?
+  end
 end

--- a/app/services/partner_routing_service.rb
+++ b/app/services/partner_routing_service.rb
@@ -2,7 +2,7 @@ class PartnerRoutingService
   attr_accessor :source_param, :routing_method
 
   def initialize(source_param: nil, zip_code: nil)
-    @source_param = source_param
+    @source_param = source_param&.downcase
     @zip_code = zip_code
     @routing_method = nil
   end

--- a/app/views/hub/clients/show.html.erb
+++ b/app/views/hub/clients/show.html.erb
@@ -135,11 +135,11 @@
       <% end %>
 
       <div class="client-profile__field-group">
-        <h2 class="text--bold"><%= t(".metadata") %></h2>
+        <h2 class="text--bold"><%= t(".other_info") %></h2>
         <div class="field-display">
           <span class="form-question"><%= t(".routing_method") %>:</span>
           <span class="label-value">
-            <%= @client.routing_method || t("general.NA") %>
+            <%= readable_routing_method(@client) || t("general.NA") %>
           </span>
         </div>
         <div class="field-display">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,10 @@ en:
         signature_methods:
           online: Online
           in_person: In person
+        routing_methods:
+          source_param: Direct URL
+          zip_code: Zip code
+          most_org_leads: Greatest number of org leads (2021 season WIP fallback)
       new:
         title: Add a new client
         assign_to_label: Assign to
@@ -102,7 +106,7 @@ en:
         texting_phone: Phone For Texting
         tax_info: Tax Info
         basic_info: Basic Info
-        metadata: Metadata
+        other_info: Other Info
         routing_method: Initial Routing Method
         source_param: Source Param
     documents:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -42,6 +42,10 @@ es:
         signature_methods:
           online: Firma electrónica
           in_person: En persona
+        routing_methods:
+          source_param: URL directa
+          zip_code: Código postal
+          most_org_leads: Mayor número de clientes potenciales de la organización (reserva de WIP para la temporada 2021)
       new:
         title: Agregar un nuevo cliente
         assign_to_label: Asignado a
@@ -87,7 +91,7 @@ es:
         texting_phone: Número celular
         tax_info: Información de impuestos
         basic_info: Información básica
-        metadata: Metadatos
+        other_info: Other info
         routing_method: Método de enrutamiento inicial
         source_param: Fuente param
       edit_take_action:

--- a/spec/services/partner_routing_service_spec.rb
+++ b/spec/services/partner_routing_service_spec.rb
@@ -1,10 +1,11 @@
 require 'rails_helper'
 
 describe PartnerRoutingService do
+  subject { PartnerRoutingService.new }
+
   let(:vita_partner) { create :vita_partner }
   let(:default_vita_partner) { create :vita_partner }
   let(:code) { "SourceParam" }
-  subject { PartnerRoutingService.new }
   before do
     create :source_parameter, code: code, vita_partner: vita_partner
     create :organization_lead_role, organization: create(:vita_partner)
@@ -21,6 +22,15 @@ describe PartnerRoutingService do
 
     context "when a source param is provided and valid" do
       subject { PartnerRoutingService.new(source_param: code) }
+
+      it "returns the referring organization" do
+        expect(subject.determine_organization).to eq vita_partner
+        expect(subject.routing_method).to eq :source_param
+      end
+    end
+
+    context "when a source param is provided with different casing" do
+      subject { PartnerRoutingService.new(source_param: code.upcase ) }
 
       it "returns the referring organization" do
         expect(subject.determine_organization).to eq vita_partner


### PR DESCRIPTION
Two requested updates to the client param routing stuff:

1) Allow any version of /Hub /HUB /hub /hUb to match the partner's source param. We downcase the code before adding it as a source parameter, and then downcase what we save as the source param when we search for it in the Partner Router. (I didn't transform it when putting it into the db, because that source param seems to be used for a couple of different values...)

2) Make the section that displays this info more readable/understandable to users.

<img width="371" alt="Screen Shot 2021-01-22 at 9 42 35 AM" src="https://user-images.githubusercontent.com/4494389/105512284-891a8b00-5c96-11eb-9846-590937a94f69.png">
