### PR TITLE
Allow changing tax return assigned users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -249,6 +249,7 @@ class ApplicationController < ActionController::Base
   rescue_from CanCan::AccessDenied do |exception|
     respond_to do |format|
       format.html { head :forbidden }
+      format.js { head :forbidden }
     end
   end
 end

--- a/app/controllers/concerns/access_controllable.rb
+++ b/app/controllers/concerns/access_controllable.rb
@@ -3,8 +3,15 @@ module AccessControllable
 
   def require_sign_in(redirect_after_login: nil )
     unless current_user.present?
-      session[:after_login_path] = redirect_after_login || request.path
-      redirect_to new_user_session_path
+      respond_to do |format|
+        format.html do
+          session[:after_login_path] = redirect_after_login || request.path
+          redirect_to new_user_session_path
+        end
+        format.js do
+          head :forbidden
+        end
+      end
     end
   end
 end

--- a/app/controllers/hub/clients/organizations_controller.rb
+++ b/app/controllers/hub/clients/organizations_controller.rb
@@ -12,8 +12,11 @@ module Hub
       def edit;end
 
       def update
-        @client.update(client_params)
-        redirect_to hub_client_path(id: @client.id)
+        if @client.update(client_params)
+          redirect_to hub_client_path(id: @client.id)
+        else
+          render :edit
+        end
       end
 
       private

--- a/app/controllers/hub/tax_returns_controller.rb
+++ b/app/controllers/hub/tax_returns_controller.rb
@@ -3,7 +3,8 @@ module Hub
     include AccessControllable
     before_action :require_sign_in
     load_and_authorize_resource
-    before_action :set_assignable_users, only: [:edit]
+    before_action :load_assignable_users, only: [:edit, :update]
+    before_action :authorize_assignee, only: [:update]
 
     layout "admin"
     respond_to :js
@@ -24,14 +25,29 @@ module Hub
 
     private
 
-    def set_assignable_users
-      @assignable_users = User.preload(:role).joins(:organization_lead_role).where("organization_lead_roles.vita_partner_id = ?", @tax_return.client.vita_partner_id).to_a
-      @assignable_users.push(@tax_return.assigned_user) if @tax_return.assigned_user # make sure the assigned user displays in the list
-      @assignable_users.push(current_user) unless @assignable_users.include?(current_user)
+    def load_assignable_users
+      @client = @tax_return.client
+      @assignable_users = User.where(id: [current_user.id, @tax_return.assigned_user_id])
+      if @client.vita_partner.present?
+        if @client.vita_partner.site?
+          team_members = User.where(role: TeamMemberRole.where(site: @client.vita_partner))
+          site_coordinators = User.where(role: SiteCoordinatorRole.where(site: @client.vita_partner))
+          @assignable_users = @assignable_users.or(team_members).or(site_coordinators)
+        else # client.vita_partner is an organization
+          org_leads = User.where(role: OrganizationLeadRole.where(organization: @client.vita_partner))
+          @assignable_users = @assignable_users.or(org_leads)
+        end
+      end
     end
 
     def assign_params
       params.permit(:assigned_user_id)
+    end
+
+    def authorize_assignee
+      return if assign_params[:assigned_user_id].blank?
+
+      raise CanCan::AccessDenied unless @assignable_users.find_by(id: assign_params[:assigned_user_id]).present?
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1764,5 +1764,8 @@ en:
         no_phone_number_listed: Sorry, no phone number listed.
         phone_number_title: Call %{provider_name}
         search_radius: Within %{distance} miles of %{zip} (%{zip_name})
+  clients:
+    errors:
+      tax_return_assigned_user_access: "%{affected_users} would lose access if you assign this client to %{new_partner}. Please change tax return assignments before reassigning this client."
 
 

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1767,3 +1767,6 @@ es:
         no_phone_number_listed: Disculpe, no hay número de teléfono.
         phone_number_title: Llame a %{provider_name}
         search_radius: Dentro de %{distance} millas de %{zip} (%{zip_name})
+  clients:
+    errors:
+      tax_return_assigned_user_access: "%{affected_users} perdería el acceso si asigna este cliente a %{new_partner}. Cambie las asignaciones de la declaración de impuestos antes de reasignar a este cliente."

--- a/spec/controllers/hub/tax_returns_controller_spec.rb
+++ b/spec/controllers/hub/tax_returns_controller_spec.rb
@@ -1,9 +1,20 @@
 require "rails_helper"
 
 RSpec.describe Hub::TaxReturnsController, type: :controller do
-  let(:user) { create :organization_lead_user }
-  let(:client) { create :client, intake: create(:intake, preferred_name: "Lucille", vita_partner: user.role.organization), vita_partner: user.role.organization }
-  let(:tax_return) { create :tax_return, client: client, year: 2018, assigned_user: (create :admin_user) }
+  let(:coalition) { create :coalition }
+  let(:organization) { create :organization, coalition: coalition }
+  let(:site) { create :site, parent_organization: organization }
+
+  let!(:organization_lead) { create :organization_lead_user, organization: organization }
+  let!(:site_coordinator) { create :site_coordinator_user, site: site }
+  let!(:team_member) { create :team_member_user, site: site }
+
+  let(:currently_assigned_coalition_lead) { create :coalition_lead_user, coalition: coalition }
+  let(:user) { currently_assigned_coalition_lead }
+
+  let(:client_assigned_group) { organization }
+  let(:client) { create :client, intake: create(:intake, preferred_name: "Lucille"), vita_partner: client_assigned_group }
+  let(:tax_return) { create :tax_return, client: client, year: 2018, assigned_user: currently_assigned_coalition_lead }
 
   describe "#edit" do
     let(:params) {
@@ -13,61 +24,96 @@ RSpec.describe Hub::TaxReturnsController, type: :controller do
       }
     }
 
-    it_behaves_like :a_get_action_for_authenticated_users_only, action: :edit
-
-    context "as an org lead" do
-      render_views
-      let!(:other_user) { create :organization_lead_user, organization: user.role.organization }
-      let!(:outside_org_user) { create :organization_lead_user }
-
-      before { sign_in user }
-      
-      it "offers me a list of other users in the client's organization for assignment + the assigned user and current user" do
+    context "as an anonymous user" do
+      it "is forbidden" do
         get :edit, params: params, format: :js, xhr: true
 
-        expect(response).to be_ok
-        expect(assigns(:assignable_users)).to include(other_user)
-        expect(assigns(:assignable_users)).not_to include(outside_org_user)
-        expect(assigns(:assignable_users)).to include(tax_return.assigned_user)
-        expect(assigns(:assignable_users)).to include(user)
+        expect(response).to be_forbidden
+      end
+    end
+
+    context "as an authenticated coalition lead user" do
+      let(:user) { create :coalition_lead_user, coalition: coalition }
+      before { sign_in user }
+
+      context "client is assigned to an org" do
+        let(:client_assigned_group) { organization }
+
+        it "returns a list of org leads at the client's assigned organization + the assigned user + myself" do
+          get :edit, params: params, format: :js, xhr: true
+
+          expect(response).to be_ok
+          expect(assigns(:assignable_users)).to match_array([user, currently_assigned_coalition_lead, organization_lead])
+        end
+      end
+
+      context "client is assigned to a site" do
+        let(:client_assigned_group) { site }
+
+        it "returns a list of site coordinators and team members at the client's assigned site + the assigned user + myself" do
+          get :edit, params: params, format: :js, xhr: true
+
+          expect(response).to be_ok
+          expect(assigns(:assignable_users)).to match_array([user, currently_assigned_coalition_lead, site_coordinator, team_member])
+        end
       end
     end
   end
 
   describe "#update" do
-    let(:assigned_user) { create :user, name: "Buster" }
+    let(:user) { create :site_coordinator_user, site: site }
+    let(:assigned_user) { team_member }
+    let(:assigned_user_id) { assigned_user.id }
     let(:params) {
       {
         id: tax_return.id,
-        assigned_user_id: assigned_user.id
+        assigned_user_id: assigned_user_id
       }
     }
 
-    it_behaves_like :a_post_action_for_authenticated_users_only, action: :update
+    context "as an unauthenticated user" do
+      it "is forbidden" do
+        put :update, params: params, format: :js, xhr: true
 
-    context "as an authenticated user" do
+        expect(response).to be_forbidden
+      end
+    end
+
+    context "as an authenticated coalition lead" do
+      let(:user) { create :coalition_lead_user, coalition: coalition }
       before do
         sign_in user
         allow(SystemNote).to receive(:create_assignment_change_note)
       end
 
-      it "assigns the user to the tax return" do
-        put :update, params: params, format: :js, xhr: true
+      context "when trying to assign the tax return to an assignable user" do
+        let(:assigned_user) { organization_lead }
 
-        tax_return.reload
-        expect(tax_return.assigned_user).to eq assigned_user
-        expect(response).to render_template :show
-        expect(flash.now[:notice]).to eq "Assigned Lucille's 2018 tax return to Buster."
-        expect(SystemNote).to have_received(:create_assignment_change_note).with(user, tax_return)
+        it "assigns the user to the tax return and creates a system note" do
+          put :update, params: params, format: :js, xhr: true
+
+          tax_return.reload
+          expect(tax_return.assigned_user).to eq organization_lead
+          expect(response).to render_template :show
+          expect(flash.now[:notice]).to eq "Assigned Lucille's 2018 tax return to #{organization_lead.name}."
+          expect(SystemNote).to have_received(:create_assignment_change_note).with(user, tax_return)
+        end
       end
 
-      context "unassigning the tax return" do
-        let(:params) {
-          {
-              id: tax_return.id,
-              assigned_user_id: ""
-          }
-        }
+      context "when reassigning to the already assigned user" do
+        let(:assigned_user) { currently_assigned_coalition_lead }
+
+        it "is ok" do
+          put :update, params: params, format: :js, xhr: true
+
+          expect(response).to be_ok
+          tax_return.reload
+          expect(tax_return.assigned_user).to eq currently_assigned_coalition_lead
+        end
+      end
+
+      context "when unassigning the tax return" do
+        let(:assigned_user_id) { "" }
 
         it "removes the assigned user from the tax return" do
           put :update, params: params, format: :js, xhr: true
@@ -76,6 +122,16 @@ RSpec.describe Hub::TaxReturnsController, type: :controller do
           expect(tax_return.assigned_user).not_to be_present
           expect(flash[:notice]).to eq "Assigned Lucille's 2018 tax return to no one."
           expect(SystemNote).to have_received(:create_assignment_change_note).with(user, tax_return)
+        end
+      end
+
+      context "when trying to assign to an unassignable user" do
+        let(:assigned_user) { site_coordinator }
+
+        it "is is forbidden" do
+          put :update, params: params, format: :js, xhr: true
+
+          expect(response).to be_forbidden
         end
       end
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -56,11 +56,14 @@ FactoryBot.define do
   factory :user do
     sequence(:uid)
     sequence(:email) { |n| "gary.gardengnome#{n}@example.green" }
+    sequence(:name) { |n| "Gary Gnome the #{n}th" }
     password { "userExamplePassword" }
-    name { "Gary Gnome" }
     role { build(:greeter_role) }
 
     factory :organization_lead_user do
+      sequence(:email) { |n| "org.lead#{n}@example.green" }
+      sequence(:name) { |n| "Org Lead the #{n}th" }
+
       transient do
         organization { nil }
       end
@@ -69,6 +72,9 @@ FactoryBot.define do
     end
 
     factory :coalition_lead_user do
+      sequence(:email) { |n| "coalition.lead#{n}@example.green" }
+      sequence(:name) { |n| "Coalition Lead the #{n}th" }
+
       transient do
         coalition { nil }
       end
@@ -77,6 +83,9 @@ FactoryBot.define do
     end
 
     factory :site_coordinator_user do
+      sequence(:email) { |n| "site.coordinator#{n}@example.green" }
+      sequence(:name) { |n| "Site Coordinator the #{n}th" }
+
       transient do
         site { nil }
       end
@@ -85,6 +94,9 @@ FactoryBot.define do
     end
 
     factory :team_member_user do
+      sequence(:email) { |n| "team.member#{n}@example.green" }
+      sequence(:name) { |n| "Team Member the #{n}th" }
+
       transient do
         site { nil }
       end
@@ -93,14 +105,23 @@ FactoryBot.define do
     end
 
     factory :admin_user do
+      sequence(:email) { |n| "admin#{n}@example.green" }
+      sequence(:name) { |n| "Admin the #{n}th" }
+
       role { build(:admin_role) }
     end
 
     factory :greeter_user do
+      sequence(:email) { |n| "greeter#{n}@example.green" }
+      sequence(:name) { |n| "Greeter the #{n}th" }
+
       role { build(:greeter_role) }
     end
 
     factory :client_success_user do
+      sequence(:email) { |n| "client.success#{n}@example.green" }
+      sequence(:name) { |n| "Client Success the #{n}th" }
+
       role { build(:client_success_role) }
     end
 

--- a/spec/features/hub/roles/site_coordinator_spec.rb
+++ b/spec/features/hub/roles/site_coordinator_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+describe "Site Coordinator" do
+  let(:site) { create :site }
+  let(:user) { create :site_coordinator_user, site: site }
+  let(:client) { create :client, vita_partner: site}
+  let!(:intake) { create :intake, client: client }
+  let!(:tax_return) { create :tax_return, client: client, assigned_user: nil }
+  let!(:team_member) { create :team_member_user, site: site }
+
+  before { login_as user }
+
+  it "allows me to assign tax returns to users within my site", js: true do
+    visit hub_client_path(id: client.id)
+
+    click_on "Assign"
+
+    select team_member.name, from: "Assign to"
+
+    click_on "Save"
+
+    within(".tax-return-list__assignee") do
+      expect(page).to have_content team_member.name
+    end
+  end
+end

--- a/spec/presenters/notes_presenter_spec.rb
+++ b/spec/presenters/notes_presenter_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe NotesPresenter do
     end
 
     context "with notes from different days" do
-
       it "correctly groups notes by day created" do
         day1 = DateTime.new(2019, 10, 5, 8, 1).utc
         day2 = DateTime.new(2020, 10, 5, 5, 1).utc
@@ -71,7 +70,7 @@ RSpec.describe NotesPresenter do
         result = NotesPresenter.grouped_notes(client)
         notes = result.values.flatten
         expect(notes.length).to eq 1
-        expect(notes[0].body).to include "Called by Gary Gnome. Call was completed and lasted 1m15s."
+        expect(notes[0].body).to include "Called by #{user.name}. Call was completed and lasted 1m15s."
         expect(notes[0].body).to include "I talked to them!"
       end
     end


### PR DESCRIPTION
- Includes `accessible_users` which was originally not needed but will likely be useful later in the same story
- When assigning a tax return, you can only assign the tax return to users who belong to the same level as site/org that the tax return's client is assigned to. This prevents users from assigning tax returns to users who do not have access to view the tax return.
    - anyone who can access a client assigned to an org, can assign that client's tax returns to org leads at that same org
    - anyone who can access a client assigned to a site can assign that client's tax returns to team members or site coordinators at that same site. (Team Members and Site Coordinators have equivalent abilities in this)
- When assigning a tax return, as long as you can access the client, you can always assign to yourself, unassign it, and you can save it with the same user assigned that it already had, even if that user is someone you don't have any ability to manage (higher up in the org chart)
    - a coalition lead can assign any accessible tax return to themselves
- Ensures that a tax return can only be assigned to a user who belongs to the vita partner a client is assigned to. 
- When a clients' vita partner is changed, this change validates that any users who are currently assigned to the client's tax returns will still be able to access the client.
    - If a client is assigned to Site A and I try to reassign the client to Site B, I will see an error message if any team member or site coordinator at Site A is assigned to one of the client's tax returns

Co-authored-by: Ben Smith <besmith@vmware.com>
Co-authored-by: Jenny Heath <jheath@codeforamerica.org>