### PR TITLE
Fix eip intake creation

### DIFF
--- a/app/controllers/questions/eip_overview_controller.rb
+++ b/app/controllers/questions/eip_overview_controller.rb
@@ -21,7 +21,7 @@ module Questions
       session[:intake_id] = @form.intake.id
       stimulus_triage_id = session.delete(:stimulus_triage_id)
       if stimulus_triage_id.present?
-        current_intake.update(triage_source: StimulusTriage.find(stimulus_triage_id), visitor_id: visitor_id)
+        @form.intake.update(triage_source: StimulusTriage.find(stimulus_triage_id))
       end
     end
   end

--- a/spec/controllers/questions/eip_overview_controller_spec.rb
+++ b/spec/controllers/questions/eip_overview_controller_spec.rb
@@ -72,7 +72,9 @@ RSpec.describe Questions::EipOverviewController do
       before { session[:stimulus_triage_id] = stimulus_triage.id }
 
       it "links it to the new intake and deletes it from the session" do
-        put :update, params: valid_params
+        expect {
+          put :update, params: valid_params
+        }.to change(Intake, :count).by(1)
 
         intake = Intake.last
         expect(intake.triage_source).to eq stimulus_triage


### PR DESCRIPTION
In the course of requiring visitor_ids onto intakes to facilitate mixpanel updates, we realized that this form/controller was requiring us to explicitly set visitor_id in _two_ places. We realized that the controller after_update_success method was actually creating a _second_ new intake! I think it was expecting to update the current_intake from the application_controller (which would have been updated when setting the intake_id into session), but because this controller has it's own current_intake method that instantiates a new Intake, we were creating a second new intake. For every eip intake we created, we were then creating a second blank one that only stored triage source!