### PR TITLE
Touch client on tax return updates [#176600406]

### DIFF
--- a/app/models/tax_return.rb
+++ b/app/models/tax_return.rb
@@ -33,7 +33,7 @@
 class TaxReturn < ApplicationRecord
   PRIMARY_SIGNATURE = "primary".freeze
   SPOUSE_SIGNATURE = "spouse".freeze
-  belongs_to :client
+  belongs_to :client, touch: true
   belongs_to :assigned_user, class_name: "User", optional: true
   has_many :documents
 

--- a/spec/models/tax_return_spec.rb
+++ b/spec/models/tax_return_spec.rb
@@ -45,6 +45,17 @@ describe TaxReturn do
     end
   end
 
+  describe "touch behavior" do
+    context "when the tax return is updated" do
+      let(:tax_return) { create :tax_return }
+      it "updates the associated client updated at" do
+        expect {
+          tax_return.update(status: :file_ready_to_file)
+        }.to change(tax_return.client, :updated_at)
+      end
+    end
+  end
+
   describe "translation keys" do
     context "english keys" do
       it "has a key for each tax_return status" do


### PR DESCRIPTION
When you add "touch" to a belongs_to association, updated_at on the associated record will be updated anytime you update the child. Here, any time we update the tax return we will update updated_at on the client. 

This covers the two cases outlined in the ticket (Assigning a user to a tax return and changing the status), as well as the case when you update the certification status.