### PR TITLE
Fix role inconsistencies #176649955

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -25,12 +25,7 @@ class Users::InvitationsController < Devise::InvitationsController
       redirect_to invitations_path and return
     end
 
-    super do |invited_user|
-      if invited_user.errors.empty?
-        @role.save!
-        invited_user.update!(role: @role)
-      end
-    end
+    super
   end
 
   private
@@ -74,7 +69,7 @@ class Users::InvitationsController < Devise::InvitationsController
 
   # Override superclass method for default params for newly created invites, allowing us to add attributes
   def invite_params
-    params.require(:user).permit(:name, :email)
+    params.require(:user).permit(:name, :email).merge(role: @role)
   end
 
   # Override superclass method for accepted invite params, allowing us to add attributes

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,10 +57,10 @@ class User < ApplicationRecord
 
   before_validation :format_phone_number
   validates :phone_number, phone: true, allow_blank: true, format: { with: /\A\+1[0-9]{10}\z/ }
-  validates :role_id, uniqueness: { scope: :role_type }
+  validates :role_type, uniqueness: { scope: :role_id }
   has_many :assigned_tax_returns, class_name: "TaxReturn", foreign_key: :assigned_user_id
   has_many :access_logs
-  belongs_to :role, polymorphic: true, optional: true
+  belongs_to :role, polymorphic: true
 
   belongs_to :organization_lead_role, -> { where(users: { role_type: 'OrganizationLeadRole' }) }, foreign_key: 'role_id', optional: true
 
@@ -153,5 +153,9 @@ class User < ApplicationRecord
     else
       super
     end
+  end
+
+  def admin?
+    role_type == AdminRole::TYPE
   end
 end

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -4,7 +4,13 @@
 
   <%= form_for(resource, as: resource_name, url: invitation_path(resource_name), local: true, builder: VitaMinFormBuilder, html: { method: :post }) do |f| %>
     <h1><%= @main_heading %></h1>
-    
+
+    <ul>
+      <% resource.errors.full_messages.each do |error_message| %>
+        <li><%= error_message %></li>
+      <% end %>
+    </ul>
+
     <%= f.cfa_input_field(:name, t(".name_label")) %>
     <%= f.cfa_input_field(:email, t(".email_label"), type: 'email', classes: ['form-width--email']) %>
     <%= f.hidden_field :role, value: params.dig(:user, :role) %>

--- a/app/views/hub/users/edit.html.erb
+++ b/app/views/hub/users/edit.html.erb
@@ -14,7 +14,7 @@
 
       <fieldset class="input-group form-group">
         <label class="checkbox">
-          <%= check_box_tag("user[is_admin]", true, @user.role_type == AdminRole::TYPE, classes: ["form-width--long"], disabled: current_user.role_type != AdminRole::TYPE) %>
+          <%= check_box_tag("user[is_admin]", true, @user.admin?, classes: ["form-width--long"], disabled: !current_user.admin?) %>
           <%= t('.is_admin_label') %>
         </label>
       </fieldset>

--- a/spec/features/hub/edit_user_spec.rb
+++ b/spec/features/hub/edit_user_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe "a user editing a user" do
         check "Admin"
 
         click_on "Save"
+
         expect(page).to have_text "Changes saved"
 
         expect(page).to have_field("user_is_admin", checked: true)

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -172,7 +172,7 @@ describe Ability do
         end
 
         context "a user with a nil role" do
-          let(:user) { create(:user, role_type: nil, role_id: nil) }
+          let(:user) { build(:user, role_type: nil, role_id: nil) }
           let(:organization) { create :organization }
           let(:client) { create(:client, vita_partner: organization) }
           let(:intake) { create(:intake, vita_partner: organization, client: client) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -337,4 +337,20 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe "#admin?" do
+    context "when the user has AdminRole type" do
+      let(:user) { create :user, role: AdminRole.new }
+      it "returns true" do
+        expect(user.admin?).to be true
+      end
+    end
+
+    context "when the user does not have AdminRole type" do
+      let(:user) { create :user, role: GreeterRole.new }
+      it "returns false" do
+        expect(user.admin?).to be false
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -62,10 +62,11 @@ RSpec.describe User, type: :model do
       expect(user.errors).to include :name
       expect(user.errors).to include :password
       expect(user.errors).to include :email
+      expect(user.errors).to include :role
     end
 
     it "validates timezone" do
-      user = User.new(name: "Gary Guava", email: "example@example.com", password: "examplePassword", timezone: "Invalid timezone")
+      user = User.new(name: "Gary Guava", email: "example@example.com", password: "examplePassword", timezone: "Invalid timezone", role: AdminRole.new)
       expect(user).not_to be_valid
       expect(user.errors).to include :timezone
       user.timezone = "America/New_York"
@@ -79,7 +80,6 @@ RSpec.describe User, type: :model do
 
         it "is invalid" do
           expect(other_user).to be_valid
-          expect(user).to be_valid
           user.role = other_user.role
           expect(user).not_to be_valid
         end


### PR DESCRIPTION
See PT ticket for more details:

When a user is created without a role, the uniqueness scope validation effectively prevents us from assigning new, un-persisted roles to a user. By removing the optional nature of roles for a user and refactoring the logic a bit, we can make the code more resiliant to this "cascading" bug. I also attempted to, in both user creation and user edit/updating, to do ONE update to the object with all params instead of splitting the role update into a second call. This makes sure that we've validating the whole object's proposed changes as a set so that part of the update can be successful while the other part isnt.

I also left the error message output on the form but removed the = sign that was rendering an empty array onto the page -- even though these other validation messages won't mean much to the user, by exposing them when there are problems it can help with error reporting and debugging. Should this fix completely fix the bug as I expect it to, we can remove this additional output if we want to.