### PR TITLE
Eager load some associations for client index pages

### DIFF
--- a/app/controllers/hub/assigned_clients_controller.rb
+++ b/app/controllers/hub/assigned_clients_controller.rb
@@ -10,7 +10,7 @@ module Hub
 
     def index
       @page_title = I18n.t("hub.assigned_clients.index.title")
-      @clients = filtered_and_sorted_clients
+      @clients = filtered_and_sorted_clients.with_eager_loaded_associations
       render "hub/clients/index"
     end
 

--- a/app/controllers/hub/clients_controller.rb
+++ b/app/controllers/hub/clients_controller.rb
@@ -10,7 +10,7 @@ module Hub
 
     def index
       @page_title = I18n.t("hub.clients.index.title")
-      @clients = filtered_and_sorted_clients
+      @clients = filtered_and_sorted_clients.with_eager_loaded_associations
     end
 
     def new

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -62,6 +62,7 @@ class Client < ApplicationRecord
   delegate *delegated_intake_attributes, to: :intake
   scope :after_consent, -> { distinct.joins(:tax_returns).merge(TaxReturn.where("status > 100")) }
   scope :assigned_to, ->(user) { joins(:tax_returns).where({ tax_returns: { assigned_user_id: user } }).distinct }
+  scope :with_eager_loaded_associations, -> { includes(:vita_partner, :intake, tax_returns: [:assigned_user]) }
 
   scope :delegated_order, ->(column, direction) do
     raise ArgumentError, "column and direction are required" if !column || !direction


### PR DESCRIPTION
For client index pages, this eager loads the intakes, vita partners, tax returns, and users assigned to tax returns, to reduce the proliferation of unecessary queries