### PR TITLE
Repeat ourselves less in circle config file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,41 +106,15 @@ jobs:
     parallelism: 1
 workflows:
   version: 2
-  build:
+  ci-and-deploy:
     jobs:
-      - run_js_tests:
-          filters:
-            branches:
-              ignore: /^main$/
-      - run_ruby_tests:
-          filters:
-            branches:
-              ignore: /^main$/
-  build-and-deploy:
-    jobs:
-      - run_js_tests:
-          filters:
-            branches:
-              only: main
-      - run_ruby_tests:
-          filters:
-            branches:
-              only: main
+      - run_js_tests
+      - run_ruby_tests
       - deploy_to_aptible--demo:
           requires: [run_js_tests, run_ruby_tests]
           filters:
             branches:
               only: main
-  deploy-release-branch-to-production:
-    jobs:
-      - run_js_tests:
-          filters:
-            branches:
-              only: release
-      - run_ruby_tests:
-          filters:
-            branches:
-              only: release
       - deploy_to_aptible--production:
           requires: [run_js_tests, run_ruby_tests]
           filters:


### PR DESCRIPTION
Before this change, we would run the tests _twice_ for production deploys -- once for the `build` job, and another for the `deploy-release-branch-to-production ` job.

After this change, we only run the tests once for production deploys.

Plus, it's now simpler.