### PR TITLE
Show sign-in on production

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -57,13 +57,11 @@
           <% end %>
         </li>
 
-        <% unless Rails.env.production? %>
-          <li>
-            <%= link_to new_user_session_path do %>
-              <%= t("views.shared.footer.volunteer_sign_in") %>
-            <% end %>
-          </li>
-        <% end %>
+        <li>
+          <%= link_to new_user_session_path do %>
+            <%= t("views.shared.footer.volunteer_sign_in") %>
+          <% end %>
+        </li>
       </ul>
 
     </div>


### PR DESCRIPTION
**Before** this change, the "Volunteer sign in" link was missing on production.

**After** this change, we show it.