### PR TITLE
Add unique links for routing to organization edit page [#176419201]

### DIFF
--- a/app/controllers/hub/organizations_controller.rb
+++ b/app/controllers/hub/organizations_controller.rb
@@ -38,7 +38,7 @@ module Hub
 
     def update
       if @vita_partner.update(vita_partner_params)
-        redirect_to hub_organizations_path
+        redirect_to edit_hub_organization_path(id: @vita_partner.id)
       else
         @coalitions = Coalition.all
         @organization = @vita_partner
@@ -49,7 +49,7 @@ module Hub
     private
 
     def vita_partner_params
-      params.require(:vita_partner).permit(:name, :coalition_id)
+      params.require(:vita_partner).permit(:name, :coalition_id, source_parameters_attributes: [:_destroy, :id, :code])
     end
   end
 end

--- a/app/models/vita_partner.rb
+++ b/app/models/vita_partner.rb
@@ -45,6 +45,7 @@ class VitaPartner < ApplicationRecord
   default_scope { includes(:child_sites) }
 
   after_initialize :defaults
+  accepts_nested_attributes_for :source_parameters, allow_destroy: true, reject_if: lambda { |attributes| attributes['code'].blank? }
 
   def at_capacity?
     actionable_intakes_this_week.count >= weekly_capacity_limit

--- a/app/views/hub/organizations/edit.html.erb
+++ b/app/views/hub/organizations/edit.html.erb
@@ -1,7 +1,7 @@
 <% @title = @organization.name %>
 <% content_for :page_title, @title %>
 <% content_for :card do %>
-  <div class="hub-form">
+  <section class="slab slab--padded">
     <%= link_to t("general.all_organizations"), hub_organizations_path %>
 
     <%= form_with model: @organization, url: hub_organization_path, method: :put, local: true, builder: VitaMinFormBuilder do |f| %>
@@ -9,7 +9,26 @@
         <%= @title %>
       </h1>
 
+      <% if @organization.errors.present? %>
+        <%= @organization.error_summary %>
+      <% end %>
+
       <%= render "hub/organizations/edit_organization", f: f %>
+
+      <h2><%= t(".source_parameters_heading") %></h2>
+
+      <% @organization.source_parameters.each do |source_parameter| %>
+        <%= f.fields_for :source_parameters, source_parameter, builder: VitaMinFormBuilder do |source_parameter_form| %>
+          <%= source_parameter_form.cfa_input_field :code, t("general.unique_link"), classes: ["form-width--short"] %>
+          <%= source_parameter_form.cfa_checkbox(:_destroy, t("general.remove")) %>
+        <% end %>
+      <% end %>
+
+      <h3><%= f.label t("general.new") %></h3>
+
+      <%= f.fields_for :source_parameters, @organization.source_parameters.build do |source_parameter_form| %>
+        <%= source_parameter_form.cfa_input_field :code, t("general.unique_link"), classes: ["form-width--short"] %>
+      <% end %>
 
       <button class="button button--primary button--wide" type="submit">
         <%= t("general.save") %>
@@ -26,5 +45,5 @@
         <%= t("hub.organizations.no_sites") %>
       <% end %>
     <% end %>
-  </div>
+  </section>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -244,6 +244,8 @@ en:
     organizations:
       new:
         title: "New Organization"
+      edit:
+        source_parameters_heading: "Unique links"
       no_sites: "No sites"
       listing:
         site_count:
@@ -485,6 +487,7 @@ en:
     mark_for_attention: Mark as needs attention
     needs_attention: Needs attention
     negative: 'No'
+    new: New
     next: Next
     no_intake: No intake for client
     none: None
@@ -574,6 +577,7 @@ en:
     greeter: "Greeter"
     team_member: "Team member"
     email_address: "Email address"
+    unique_link: "Unique link"
   helpers:
     birth_date_helper:
       valid_birth_date: Please select a valid date

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -246,6 +246,8 @@ es:
     organizations:
       new:
         title: "Nueva Organización"
+      edit:
+        source_parameters_heading: "Enlaces únicos"
       no_sites: "Ningunos sitios"
       index:
         independent_organizations: "Organizaciones Independientes"
@@ -576,6 +578,8 @@ es:
     email_address: "Dirección de correo electrónico"
     greeter: "Saludador"
     team_member: "Miembro del equipo"
+    new: "Nuevo"
+    unique_link: "Enlace único"
   helpers:
     birth_date_helper:
       valid_birth_date: Por favor, seleccione una fecha válida

--- a/spec/features/hub/create_organization_hierarchy_spec.rb
+++ b/spec/features/hub/create_organization_hierarchy_spec.rb
@@ -29,11 +29,9 @@ RSpec.describe "create VITA organization hierarchy" do
       fill_in "Name", with: "Oregano Org"
       select "Coati Coalition", from: "Coalition"
       click_on "Save"
-
-      expect(page).to have_selector("h3", text: "Oregano Org")
+      expect(page).to have_selector("h1", text: "Oregano Org")
 
       # Add a site to an organization
-      click_on "Oregano Org"
       click_on "Add site"
       fill_in "Name", with: "Llama Library"
       click_on "Save"


### PR DESCRIPTION
This creates a source parameters (Unique links for routing) edit area on the organization edit page.

![image](https://user-images.githubusercontent.com/67708639/106342164-b4801580-6254-11eb-936e-11a299972d2a.png)
