### PR TITLE
Don't show org edit links to coalition leads

### DIFF
--- a/app/views/hub/organizations/_listing.html.erb
+++ b/app/views/hub/organizations/_listing.html.erb
@@ -1,3 +1,7 @@
 <h3>
-  <%= link_to "#{organization.name} (#{t(".site_count", count: organization.child_sites.count)})", edit_hub_organization_path(id: organization) %>
+  <% if can? :edit, organization %>
+    <%= link_to "#{organization.name} (#{t(".site_count", count: organization.child_sites.count)})", edit_hub_organization_path(id: organization) %>
+  <% else %>
+    <%= link_to "#{organization.name} (#{t(".site_count", count: organization.child_sites.count)})", hub_organization_path(id: organization) %>
+  <% end %>
 </h3>

--- a/spec/controllers/hub/organizations_controller_spec.rb
+++ b/spec/controllers/hub/organizations_controller_spec.rb
@@ -99,13 +99,15 @@ RSpec.describe Hub::OrganizationsController, type: :controller do
         let(:user) { create :coalition_lead_user, coalition: coalition }
 
         render_views
-        it "shows my coalition and child organizations but no link to add an org" do
+        it "shows my coalition and child organizations but no link to add or edit orgs" do
           get :index
 
           expect(response).to be_ok
           expect(assigns(:coalitions)).to match_array [coalition]
           expect(assigns(:organizations)).to match_array [organization, second_organization]
+          expect(response.body).to include hub_organization_path(id: organization)
           expect(response.body).not_to include new_hub_organization_path
+          expect(response.body).not_to include edit_hub_organization_path(id: organization)
         end
       end
 


### PR DESCRIPTION
This fixes a bug that I forgot to close in a recent feature. 

We shouldn't show org edit links to coalition leads on the org index because they are not allowed to access the org edit page. Instead, they should be able to click into org show pages.

Feel free to merge or edit while I'm out on vacation!