### PR TITLE
Edit site unique URLs [#176419201]

### DIFF
--- a/app/controllers/hub/sites_controller.rb
+++ b/app/controllers/hub/sites_controller.rb
@@ -23,12 +23,13 @@ module Hub
 
     def edit
       @site = @vita_partner
+      @show_unique_links = true
     end
 
     def update
       render :edit unless @vita_partner.update(vita_partner_params)
 
-      redirect_to edit_hub_organization_path(id: @vita_partner.parent_organization_id)
+      redirect_to edit_hub_site_path(id: @vita_partner.id)
     end
 
     private
@@ -38,7 +39,7 @@ module Hub
     end
 
     def vita_partner_params
-      params.require(:vita_partner).permit(:name, :parent_organization_id)
+      params.require(:vita_partner).permit(:name, :parent_organization_id, source_parameters_attributes: [:_destroy, :id, :code])
     end
   end
 end

--- a/app/views/hub/sites/_form.html.erb
+++ b/app/views/hub/sites/_form.html.erb
@@ -1,4 +1,3 @@
-<div class="hub-form">
   <%= form_with model: @site, url: url, method: http_method, local: true, builder: VitaMinFormBuilder do |f| %>
     <h1 class="form-card__title">
       <%= @title %>
@@ -6,6 +5,21 @@
 
     <%= f.cfa_input_field :name, t("general.name") %>
     <%= f.cfa_select :parent_organization_id, t("general.organization"), @organizations.map { |c| [c.name, c.id] } %>
+
+    <% if @show_unique_links %>
+      <% @site.source_parameters.each do |source_parameter| %>
+        <%= f.fields_for :source_parameters, source_parameter, builder: VitaMinFormBuilder do |source_parameter_form| %>
+          <%= source_parameter_form.cfa_input_field :code, t("general.unique_link"), classes: ["form-width--short"] %>
+          <%= source_parameter_form.cfa_checkbox(:_destroy, t("general.remove")) %>
+        <% end %>
+      <% end %>
+
+      <h3><%= f.label t("general.new") %></h3>
+
+      <%= f.fields_for :source_parameters, @site.source_parameters.build do |source_parameter_form| %>
+        <%= source_parameter_form.cfa_input_field :code, t("general.unique_link"), classes: ["form-width--short"] %>
+      <% end %>
+    <% end %>
 
     <button class="button button--primary button--wide" type="submit">
       <%= t("general.save") %>

--- a/app/views/hub/sites/edit.html.erb
+++ b/app/views/hub/sites/edit.html.erb
@@ -1,5 +1,8 @@
 <% @title = @site.name %>
-<% content_for :page_title, @site %>
+<% content_for :page_title, @title %>
 <% content_for :card do %>
-  <%= render "form", url: hub_site_path(organization_id: @organization, id: @site), http_method: :put %>
+  <div class="hub-form">
+    <%= link_to(@site.parent_organization.name, edit_hub_organization_path(id: @site.parent_organization)) %>
+    <%= render "form", url: hub_site_path(organization_id: @organization, id: @site), http_method: :put %>
+  </div>
 <% end %>

--- a/app/views/hub/sites/new.html.erb
+++ b/app/views/hub/sites/new.html.erb
@@ -1,5 +1,7 @@
 <% @title = t(".title") %>
 <% content_for :page_title, @title %>
 <% content_for :card do %>
-  <%= render "hub/sites/form", url: hub_sites_path(parent_organization_id: @organization), http_method: :post %>
+  <div class="hub-form">
+    <%= render "hub/sites/form", url: hub_sites_path(parent_organization_id: @organization), http_method: :post %>
+  </div>
 <% end %>

--- a/spec/controllers/hub/sites_controller_spec.rb
+++ b/spec/controllers/hub/sites_controller_spec.rb
@@ -128,6 +128,7 @@ RSpec.describe Hub::SitesController, type: :controller do
         site.reload
         expect(site.name).to eq "Silly Site"
         expect(site.parent_organization).to eq other_organization
+        expect { source_parameter.reload }.to raise_error ActiveRecord::RecordNotFound
         expect(site.source_parameters.pluck(:code)).to eq(["newshortlink"])
         expect(response).to redirect_to edit_hub_site_path(id: site.id)
       end

--- a/spec/features/hub/create_organization_hierarchy_spec.rb
+++ b/spec/features/hub/create_organization_hierarchy_spec.rb
@@ -42,8 +42,10 @@ RSpec.describe "create VITA organization hierarchy" do
       # Update the site
       click_on "Llama Library"
       fill_in "Name", with: "Lima Bean Library"
+      fill_in "Unique link", with: "limabean"
       click_on "Save"
       expect(page).to have_selector("h1", text: "Lima Bean Library")
+      expect(page).to have_selector("input[value='limabean']")
 
       # Navigate to the org
       click_on "Oregano Org"

--- a/spec/features/hub/create_organization_hierarchy_spec.rb
+++ b/spec/features/hub/create_organization_hierarchy_spec.rb
@@ -39,12 +39,14 @@ RSpec.describe "create VITA organization hierarchy" do
       expect(page).to have_selector("h1", text: "Oregano Org")
       expect(page).to have_text("Llama Library")
 
-      # Update a site
+      # Update the site
       click_on "Llama Library"
       fill_in "Name", with: "Lima Bean Library"
       click_on "Save"
+      expect(page).to have_selector("h1", text: "Lima Bean Library")
 
-      expect(page).to have_selector("h1", text: "Oregano Org")
+      # Navigate to the org
+      click_on "Oregano Org"
       expect(page).to have_text("Lima Bean Library")
 
       # Go back to organization index


### PR DESCRIPTION
Allow editing a site's unique URLs.

![image](https://user-images.githubusercontent.com/67708639/106374249-182e3f80-6336-11eb-91a4-81fef784a38a.png)

I made a few unusual choices worth explaining:

* We don't show the unique URLs for a site when _creating_ it, but we do when _editing_ it. This is consistent with what we do for orgs as of #764.
* I changed the site edit page so it redirects back to itself on success, rather than to the org edit page on success. This is consistent with what we do for orgs in #764.
* I bundled #766 into this PR because I saw it there.

I'm hoping to use this on prod on Monday morning to roll out some org/site unique URL changes.