### PR TITLE
Use case-insensitive email address on Intakes

### DIFF
--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -40,7 +40,7 @@
 #  divorced                                             :integer          default("unfilled"), not null
 #  divorced_year                                        :string
 #  eip_only                                             :boolean
-#  email_address                                        :string
+#  email_address                                        :citext
 #  email_notification_opt_in                            :integer          default("unfilled"), not null
 #  encrypted_bank_account_number                        :string
 #  encrypted_bank_account_number_iv                     :string
@@ -146,7 +146,7 @@
 #  spouse_consented_to_service                          :integer          default("unfilled"), not null
 #  spouse_consented_to_service_at                       :datetime
 #  spouse_consented_to_service_ip                       :inet
-#  spouse_email_address                                 :string
+#  spouse_email_address                                 :citext
 #  spouse_first_name                                    :string
 #  spouse_had_disability                                :integer          default("unfilled"), not null
 #  spouse_issued_identity_pin                           :integer          default("unfilled"), not null

--- a/db/migrate/20210202002736_change_intake_email_to_case_insensitive_text.rb
+++ b/db/migrate/20210202002736_change_intake_email_to_case_insensitive_text.rb
@@ -6,7 +6,7 @@ class ChangeIntakeEmailToCaseInsensitiveText < ActiveRecord::Migration[6.0]
   end
 
   def down
-    change_column :intakes, :email_address, :text
-    change_column :intakes, :spouse_email_address, :text
+    change_column :intakes, :email_address, :string
+    change_column :intakes, :spouse_email_address, :string
   end
 end

--- a/db/migrate/20210202002736_change_intake_email_to_case_insensitive_text.rb
+++ b/db/migrate/20210202002736_change_intake_email_to_case_insensitive_text.rb
@@ -6,7 +6,6 @@ class ChangeIntakeEmailToCaseInsensitiveText < ActiveRecord::Migration[6.0]
   end
 
   def down
-    enable_extension("citext")
     change_column :intakes, :email_address, :text
     change_column :intakes, :spouse_email_address, :text
   end

--- a/db/migrate/20210202002736_change_intake_email_to_case_insensitive_text.rb
+++ b/db/migrate/20210202002736_change_intake_email_to_case_insensitive_text.rb
@@ -1,0 +1,13 @@
+class ChangeIntakeEmailToCaseInsensitiveText < ActiveRecord::Migration[6.0]
+  def up
+    enable_extension("citext")
+    change_column :intakes, :email_address, :citext
+    change_column :intakes, :spouse_email_address, :citext
+  end
+
+  def down
+    enable_extension("citext")
+    change_column :intakes, :email_address, :text
+    change_column :intakes, :spouse_email_address, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_30_015122) do
+ActiveRecord::Schema.define(version: 2021_02_02_002736) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "citext"
   enable_extension "plpgsql"
   enable_extension "postgis"
 
@@ -280,7 +281,7 @@ ActiveRecord::Schema.define(version: 2021_01_30_015122) do
     t.integer "divorced", default: 0, null: false
     t.string "divorced_year"
     t.boolean "eip_only"
-    t.string "email_address"
+    t.citext "email_address"
     t.integer "email_notification_opt_in", default: 0, null: false
     t.string "encrypted_bank_account_number"
     t.string "encrypted_bank_account_number_iv"
@@ -389,7 +390,7 @@ ActiveRecord::Schema.define(version: 2021_01_30_015122) do
     t.integer "spouse_consented_to_service", default: 0, null: false
     t.datetime "spouse_consented_to_service_at"
     t.inet "spouse_consented_to_service_ip"
-    t.string "spouse_email_address"
+    t.citext "spouse_email_address"
     t.string "spouse_first_name"
     t.integer "spouse_had_disability", default: 0, null: false
     t.integer "spouse_issued_identity_pin", default: 0, null: false

--- a/spec/factories/intakes.rb
+++ b/spec/factories/intakes.rb
@@ -40,7 +40,7 @@
 #  divorced                                             :integer          default("unfilled"), not null
 #  divorced_year                                        :string
 #  eip_only                                             :boolean
-#  email_address                                        :string
+#  email_address                                        :citext
 #  email_notification_opt_in                            :integer          default("unfilled"), not null
 #  encrypted_bank_account_number                        :string
 #  encrypted_bank_account_number_iv                     :string
@@ -146,7 +146,7 @@
 #  spouse_consented_to_service                          :integer          default("unfilled"), not null
 #  spouse_consented_to_service_at                       :datetime
 #  spouse_consented_to_service_ip                       :inet
-#  spouse_email_address                                 :string
+#  spouse_email_address                                 :citext
 #  spouse_first_name                                    :string
 #  spouse_had_disability                                :integer          default("unfilled"), not null
 #  spouse_issued_identity_pin                           :integer          default("unfilled"), not null

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -40,7 +40,7 @@
 #  divorced                                             :integer          default("unfilled"), not null
 #  divorced_year                                        :string
 #  eip_only                                             :boolean
-#  email_address                                        :string
+#  email_address                                        :citext
 #  email_notification_opt_in                            :integer          default("unfilled"), not null
 #  encrypted_bank_account_number                        :string
 #  encrypted_bank_account_number_iv                     :string
@@ -146,7 +146,7 @@
 #  spouse_consented_to_service                          :integer          default("unfilled"), not null
 #  spouse_consented_to_service_at                       :datetime
 #  spouse_consented_to_service_ip                       :inet
-#  spouse_email_address                                 :string
+#  spouse_email_address                                 :citext
 #  spouse_first_name                                    :string
 #  spouse_had_disability                                :integer          default("unfilled"), not null
 #  spouse_issued_identity_pin                           :integer          default("unfilled"), not null
@@ -240,6 +240,20 @@ describe Intake do
         expect(Intake.new).not_to be_valid
         expect(Intake.new(visitor_id: "present")).to be_valid
       end
+    end
+  end
+
+  describe "email_address" do
+    it "searches case-insensitively" do
+      intake = Intake.create!(email_address: "eXample@EXAMPLE.COM", visitor_id: "visitor_id")
+      expect(Intake.where(email_address: "example@example.com")).to include(intake)
+    end
+  end
+
+  describe "spouse_email_address" do
+    it "searches case-insensitively" do
+      intake = Intake.create!(spouse_email_address: "eXample@EXAMPLE.COM", visitor_id: "visitor_id")
+      expect(Intake.where(spouse_email_address: "example@example.com")).to include(intake)
     end
   end
 


### PR DESCRIPTION
See https://mikecoutermarsh.com/storing-email-in-postgres-rails-use-citext/

We have approx 7,000 Intakes in production. I think it will be acceptable to take the lock and do the migration.