### PR TITLE
Allow percent signs in emails without failure

### DIFF
--- a/app/services/replacement_parameters_service.rb
+++ b/app/services/replacement_parameters_service.rb
@@ -20,22 +20,21 @@ class ReplacementParametersService
 
   def process_replacements_hash(replacements_hash)
     # escape existing percent signs
-    body.gsub!(/%/, "%%")
+    body.gsub!(/%(?!{\S*})/, "%%")
 
     # replace valid <<key>> with %{key}
     replacements_hash.each_key { |key| body.gsub!(/<<\s*#{key}\s*>>/i, "%{#{key}}") }
 
     body % replacements_hash
   end
-
-
+  
   def replacements
     {
-        "Client.PreferredName" => client&.preferred_name,
-        "Preparer.FirstName" => preparer_first_name,
-        "Documents.List" => documents_list,
-        "Documents.UploadLink" => client.intake.requested_docs_token_link,
-        "Client.YouOrMaybeYourSpouse" => you_or_your,
+        "Client.PreferredName": client&.preferred_name,
+        "Preparer.FirstName": preparer_first_name,
+        "Documents.List": documents_list,
+        "Documents.UploadLink": client.intake.requested_docs_token_link,
+        "Client.YouOrMaybeYourSpouse": you_or_your,
     }
   end
 
@@ -48,7 +47,7 @@ class ReplacementParametersService
   # for example, when adding a link to send to the client only
   def sensitive_replacements
     {
-      "Link.E-signature" => client.login_link
+      "Link.E-signature": client.login_link
     }
   end
 

--- a/app/services/replacement_parameters_service.rb
+++ b/app/services/replacement_parameters_service.rb
@@ -19,21 +19,23 @@ class ReplacementParametersService
   private
 
   def process_replacements_hash(replacements_hash)
-    convert_template_keys_to_string_format_syntax(replacements_hash.keys)
+    # escape existing percent signs
+    body.gsub!(/%/, "%%")
+
+    # replace valid <<key>> with %{key}
+    replacements_hash.each_key { |key| body.gsub!(/<<\s*#{key}\s*>>/i, "%{#{key}}") }
+
     body % replacements_hash
   end
 
-  def convert_template_keys_to_string_format_syntax(keys)
-    keys.each{ |key| body.gsub!(/<<\s*#{key}\s*>>/i, "%{#{key}}") }
-  end
 
   def replacements
     {
-        "Client.PreferredName": client&.preferred_name,
-        "Preparer.FirstName": preparer_first_name,
-        "Documents.List": documents_list,
-        "Documents.UploadLink": client.intake.requested_docs_token_link,
-        "Client.YouOrMaybeYourSpouse": you_or_your,
+        "Client.PreferredName" => client&.preferred_name,
+        "Preparer.FirstName" => preparer_first_name,
+        "Documents.List" => documents_list,
+        "Documents.UploadLink" => client.intake.requested_docs_token_link,
+        "Client.YouOrMaybeYourSpouse" => you_or_your,
     }
   end
 
@@ -46,7 +48,7 @@ class ReplacementParametersService
   # for example, when adding a link to send to the client only
   def sensitive_replacements
     {
-      "Link.E-signature": client.login_link
+      "Link.E-signature" => client.login_link
     }
   end
 

--- a/spec/services/replacement_parameters_service_spec.rb
+++ b/spec/services/replacement_parameters_service_spec.rb
@@ -204,5 +204,4 @@ describe ReplacementParametersService do
       end
     end
   end
-
 end

--- a/spec/services/replacement_parameters_service_spec.rb
+++ b/spec/services/replacement_parameters_service_spec.rb
@@ -188,4 +188,21 @@ describe ReplacementParametersService do
       end
     end
   end
+
+  context "handling percent signs in emails" do
+    let(:body) { "¿Esta persona proveyo más del 50% de su propio apoyo?" }
+    describe "when there is a % in an email" do
+      it "does not fail" do
+        expect(subject.process).to eq "¿Esta persona proveyo más del 50% de su propio apoyo?"
+      end
+    end
+
+    describe "when there is a %{ not related to a replacement param in an email" do
+      let(:body) { "with some weird%{ string" }
+      it "does not fail" do
+        expect(subject.process).to eq "with some weird%{ string"
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
When fixing the Delayed::Jobs issues on prod, I looked into some of the specific error messages and realized that replacement parameter replacement failed when the body included a % sign that was not a replacement field (%{key}).

This fixes that by escaping the pre-existing % signs in the body.