### PR TITLE
Circle CI: Only launch database for tasks that need it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,6 @@ executors:
     working_directory: /mnt/ramdisk
     docker:
       - image: circleci/ruby:2.6.5-node-browsers
-        environment:
-          PGHOST: 127.0.0.1
-          PGUSER: root
   rails_executor:
     working_directory: /mnt/ramdisk
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,13 @@
 version: 2.1
 
 executors:
+  ruby_executor:
+    working_directory: /mnt/ramdisk
+    docker:
+      - image: circleci/ruby:2.6.5-node-browsers
+        environment:
+          PGHOST: 127.0.0.1
+          PGUSER: root
   rails_executor:
     working_directory: /mnt/ramdisk
     docker:
@@ -60,7 +67,7 @@ commands:
           paths: [tmp/test_db_schema.rb]
 jobs:
   run_js_tests:
-    executor: rails_executor
+    executor: ruby_executor
     steps:
       - checkout
       - install_js_dependencies
@@ -89,7 +96,7 @@ jobs:
       - store_test_results:
           path: ~/test-results
   deploy_to_aptible--demo:
-    executor: rails_executor
+    executor: ruby_executor
     steps:
       - checkout
       - run: echo $APTIBLE_PUBLIC_KEY >> ~/.ssh/known_hosts
@@ -97,7 +104,7 @@ jobs:
       - run: git push git@beta.aptible.com:vita-min-demo/vita-min-demo.git $CIRCLE_SHA1:master
     parallelism: 1
   deploy_to_aptible--production:
-    executor: rails_executor
+    executor: ruby_executor
     steps:
       - checkout
       - run: echo $APTIBLE_PUBLIC_KEY >> ~/.ssh/known_hosts


### PR DESCRIPTION
This can cause a (approx) 10 sec build speedup.