### PR TITLE
Add spouse SSN and fix bug where editing clears ssn info

### DIFF
--- a/app/controllers/hub/clients/ssn_itins_controller.rb
+++ b/app/controllers/hub/clients/ssn_itins_controller.rb
@@ -4,8 +4,23 @@ module Hub
       include AccessControllable
       before_action :require_sign_in
       load_and_authorize_resource :client, parent: false
+      respond_to :js
 
       def show
+        create_access_log
+      end
+
+      def hide; end
+
+      def show_spouse
+        create_access_log
+      end
+
+      def hide_spouse; end
+
+      private
+
+      def create_access_log
         AccessLog.create(
           user: current_user,
           client: @client,
@@ -14,11 +29,6 @@ module Hub
           ip_address: request.remote_ip,
           user_agent: request.user_agent,
         )
-        respond_to :js
-      end
-
-      def hide
-        respond_to :js
       end
     end
   end

--- a/app/forms/hub/create_client_form.rb
+++ b/app/forms/hub/create_client_form.rb
@@ -23,6 +23,7 @@ module Hub
                        :state_of_residence,
                        :zip_code,
                        :primary_last_four_ssn,
+                       :spouse_last_four_ssn,
                        :sms_notification_opt_in,
                        :email_notification_opt_in,
                        :spouse_first_name,

--- a/app/forms/hub/update_client_form.rb
+++ b/app/forms/hub/update_client_form.rb
@@ -22,6 +22,7 @@ module Hub
                        :state,
                        :zip_code,
                        :primary_last_four_ssn,
+                       :spouse_last_four_ssn,
                        :sms_notification_opt_in,
                        :email_notification_opt_in,
                        :spouse_first_name,
@@ -51,6 +52,11 @@ module Hub
         @client.intake.dependents.new formatted_dependent_attrs(v)
       end
       @client.intake.dependents
+    end
+
+    def self.existing_attributes(intake)
+      non_model_attrs = { primary_last_four_ssn: intake.primary_last_four_ssn, spouse_last_four_ssn: intake.spouse_last_four_ssn }
+      super.merge(non_model_attrs)
     end
 
     def self.from_client(client)

--- a/app/views/hub/clients/_displayed_spouse_ssn_itin.html.erb
+++ b/app/views/hub/clients/_displayed_spouse_ssn_itin.html.erb
@@ -1,0 +1,2 @@
+<span class="label-value"><%= @client.intake.spouse_last_four_ssn %></span>
+<span class="sr-only"><%= t("hub.ssn_itins.displayed") %></span>

--- a/app/views/hub/clients/_spouse_info_fields.html.erb
+++ b/app/views/hub/clients/_spouse_info_fields.html.erb
@@ -5,4 +5,12 @@
     <%= f.cfa_input_field(:spouse_last_name, t("hub.clients.fields.legal_last_name"), classes: ["form-width--long"]) %>
   </div>
   <%= f.cfa_input_field(:spouse_email_address, t("general.email"), classes: ["form-width--long"]) %>
+  <%= f.cfa_input_field(
+          :spouse_last_four_ssn,
+          t("general.last_four_ssn"),
+          prefix: "XXX-XX-",
+          type: :tel,
+          classes: ["form-width--name field--last-four-ssn"],
+          options: { maxlength: 4 }
+      ) %>
 </div>

--- a/app/views/hub/clients/show.html.erb
+++ b/app/views/hub/clients/show.html.erb
@@ -145,6 +145,20 @@
             <span class="form-question"><%= t(".email") %>:</span>
             <span class="label-value"><%= @client.intake&.spouse_email_address %> </span>
           </div>
+          <div class="field-display spouse-last-four-ssn">
+            <span class="form-question"><%= t("general.last_four_ssn") %>:</span>
+            <% if @client.intake.spouse_last_four_ssn.present? %>
+            <span id="js-spouse-ssn-itin">
+              <%= render "hub/clients/hidden_ssn_itin" %>
+            </span>
+              <span id="js-toggle-spouse-ssn-itin">
+              <%= link_to("View", show_spouse_ssn_itin_hub_client_path, remote: true)  %>
+            </span>
+            <% else %>
+              <span class="label-value"><%= t("general.NA") %></span>
+            <% end %>
+          </div>
+
         </div>
       <% end %>
 

--- a/app/views/hub/clients/ssn_itins/hide_spouse.js.erb
+++ b/app/views/hub/clients/ssn_itins/hide_spouse.js.erb
@@ -1,0 +1,2 @@
+$('#js-spouse-ssn-itin').html("<%= escape_javascript render(partial: 'hub/clients/hidden_ssn_itin') %>");
+$('#js-toggle-spouse-ssn-itin').html("<%= escape_javascript link_to('View', show_spouse_ssn_itin_hub_client_path, remote: true) %>");

--- a/app/views/hub/clients/ssn_itins/show_spouse.js.erb
+++ b/app/views/hub/clients/ssn_itins/show_spouse.js.erb
@@ -1,0 +1,2 @@
+$('#js-spouse-ssn-itin').html("<%= escape_javascript render(partial: 'hub/clients/displayed_spouse_ssn_itin', client: @client) %>");
+$('#js-toggle-spouse-ssn-itin').html("<%= escape_javascript link_to('Hide', hide_spouse_ssn_itin_hub_client_path, remote: true) %>");

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -132,6 +132,8 @@ Rails.application.routes.draw do
         get "/hide-bai", to: "clients/bank_accounts#hide", on: :member, as: :hide_bank_account
         get "/ssn", to: "clients/ssn_itins#show", on: :member, as: :show_ssn_itin
         get "/hide-ssn", to: "clients/ssn_itins#hide", on: :member, as: :hide_ssn_itin
+        get "/spouse-ssn", to: "clients/ssn_itins#show_spouse", on: :member, as: :show_spouse_ssn_itin
+        get "/hide-spouse-ssn", to: "clients/ssn_itins#hide_spouse", on: :member, as: :hide_spouse_ssn_itin
         resources :documents, only: [:index, :edit, :update, :show, :create, :new]
         resources :notes, only: [:create, :index]
         resources :messages, only: [:index]

--- a/spec/controllers/hub/clients/ssn_itins_controller_spec.rb
+++ b/spec/controllers/hub/clients/ssn_itins_controller_spec.rb
@@ -1,0 +1,143 @@
+require 'rails_helper'
+
+describe Hub::Clients::SsnItinsController, type: :controller do
+  describe "#show" do
+    let(:client) { create :client }
+
+    let(:params) { { id: client.id } }
+    it_behaves_like :a_get_action_for_authenticated_users_only, action: :show
+
+    context "with a logged in user" do
+      let(:back_to_the_future_day) { DateTime.new(2015, 10, 21, 0, 0, 0)}
+      let(:user) { create(:admin_user) }
+      let(:user_agent_header) { "CERN-NextStep-WorldWideWeb.app/1.1 libwww/2.07" }
+
+      before do
+        allow(DateTime).to receive(:now).and_return(back_to_the_future_day)
+        request.remote_ip = "1.1.1.1"
+        request.headers["HTTP_USER_AGENT"] = user_agent_header
+        sign_in user
+      end
+
+      it "loads the appropriate client" do
+        get :show, params: params, format: :js, xhr: true
+        expect(assigns(:client)).to eq client
+      end
+
+      it "responds with js" do
+        get :show, params: params, format: :js, xhr: true
+        expect(response.media_type).to eq "text/javascript"
+      end
+
+      it "does not respond with html" do
+        expect { get :show, params: params }.to raise_error ActionController::UnknownFormat
+      end
+
+      it "creates an AccessLog" do
+        expect { get :show, params: params, format: :js, xhr: true }.to change(AccessLog, :count).by(1)
+        record = AccessLog.last
+        expect(record.user).to eq(user)
+        expect(record.client).to eq(client)
+        expect(record.event_type).to eq("read_ssn_itin")
+        expect(record.created_at).to eq(back_to_the_future_day)
+        expect(record.ip_address).to eq("1.1.1.1")
+        expect(record.user_agent).to eq(user_agent_header)
+      end
+    end
+  end
+
+  describe "#hide" do
+    let(:client) { create :client }
+
+    let(:params) { { id: client.id } }
+    it_behaves_like :a_get_action_for_authenticated_users_only, action: :show
+
+    context "with a logged in user" do
+      before { sign_in (create :admin_user) }
+
+      it "loads the appropriate client" do
+        get :hide, params: params, format: :js, xhr: true
+        expect(assigns(:client)).to eq client
+      end
+
+      it "responds with js" do
+        get :hide, params: params, format: :js, xhr: true
+        expect(response.media_type).to eq "text/javascript"
+      end
+
+      it "does not respond with html" do
+        expect { get :hide, params: params }.to raise_error ActionController::UnknownFormat
+      end
+    end
+  end
+
+  describe "#show_spouse" do
+    let(:client) { create :client }
+
+    let(:params) { { id: client.id } }
+    it_behaves_like :a_get_action_for_authenticated_users_only, action: :show_spouse
+
+    context "with a logged in user" do
+      let(:back_to_the_future_day) { DateTime.new(2015, 10, 21, 0, 0, 0)}
+      let(:user) { create(:admin_user) }
+      let(:user_agent_header) { "CERN-NextStep-WorldWideWeb.app/1.1 libwww/2.07" }
+
+      before do
+        allow(DateTime).to receive(:now).and_return(back_to_the_future_day)
+        request.remote_ip = "1.1.1.1"
+        request.headers["HTTP_USER_AGENT"] = user_agent_header
+        sign_in user
+      end
+
+      it "loads the appropriate client" do
+        get :show, params: params, format: :js, xhr: true
+        expect(assigns(:client)).to eq client
+      end
+
+      it "responds with js" do
+        get :show_spouse, params: params, format: :js, xhr: true
+        expect(response.media_type).to eq "text/javascript"
+      end
+
+      it "does not respond with html" do
+        expect { get :show_spouse, params: params }.to raise_error ActionController::UnknownFormat
+      end
+
+      it "creates an AccessLog" do
+        expect { get :show_spouse, params: params, format: :js, xhr: true }.to change(AccessLog, :count).by(1)
+        record = AccessLog.last
+        expect(record.user).to eq(user)
+        expect(record.client).to eq(client)
+        expect(record.event_type).to eq("read_ssn_itin")
+        expect(record.created_at).to eq(back_to_the_future_day)
+        expect(record.ip_address).to eq("1.1.1.1")
+        expect(record.user_agent).to eq(user_agent_header)
+      end
+    end
+  end
+
+  describe "#hide_spouse" do
+    let(:client) { create :client }
+
+    let(:params) { { id: client.id } }
+    it_behaves_like :a_get_action_for_authenticated_users_only, action: :show
+
+    context "with a logged in user" do
+      before { sign_in (create :admin_user) }
+
+      it "loads the appropriate client" do
+        get :hide_spouse, params: params, format: :js, xhr: true
+        expect(assigns(:client)).to eq client
+      end
+
+      it "responds with js" do
+        get :hide_spouse, params: params, format: :js, xhr: true
+        expect(response.media_type).to eq "text/javascript"
+      end
+
+      it "does not respond with html" do
+        expect { get :hide_spouse, params: params }.to raise_error ActionController::UnknownFormat
+      end
+    end
+  end
+end

--- a/spec/features/hub/edit_client_spec.rb
+++ b/spec/features/hub/edit_client_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "a user editing a clients intake fields" do
       create :client,
              vita_partner: organization,
              tax_returns: [tax_return],
-             intake: create(:intake, email_address: "colleen@example.com", primary_first_name: "Colleen", primary_last_name: "Cauliflower", preferred_interview_language: "es", state_of_residence: "CA", preferred_name: "Colleen Cauliflower", email_notification_opt_in: "yes", dependents: [
+             intake: create(:intake, email_address: "colleen@example.com", filing_joint: "yes", primary_first_name: "Colleen", primary_last_name: "Cauliflower", preferred_interview_language: "es", state_of_residence: "CA", preferred_name: "Colleen Cauliflower", email_notification_opt_in: "yes", dependents: [
                create(:dependent, first_name: "Lara", last_name: "Legume", birth_date: "2007-03-06"),
              ])
 
@@ -116,6 +116,7 @@ RSpec.describe "a user editing a clients intake fields" do
         fill_in "Legal first name", with: "Peter"
         fill_in "Legal last name", with: "Pepper"
         fill_in "Email", with: "spicypeter@pepper.com"
+        fill_in "Last 4 of SSN/ITIN", with: "3456"
       end
 
       click_on "Save"
@@ -161,6 +162,21 @@ RSpec.describe "a user editing a clients intake fields" do
         end.to change(AccessLog, :count).by(1)
         expect(AccessLog.last.event_type).to eq "read_ssn_itin"
       end
+
+      within ".spouse-last-four-ssn" do
+        expect do
+          click_on "View"
+          expect(page).to have_text "3456"
+        end.to change(AccessLog, :count).by(1)
+        expect(AccessLog.last.event_type).to eq "read_ssn_itin"
+      end
+
+      within ".client-profile" do
+        click_on "Edit"
+      end
+
+      expect(find_field("hub_update_client_form[spouse_last_four_ssn]").value).to eq "3456"
+      expect(find_field("hub_update_client_form[primary_last_four_ssn]").value).to eq "4444"
     end
 
     it "creates a system note for client profile change" do

--- a/spec/features/hub/toggle_client_ssn_info_spec.rb
+++ b/spec/features/hub/toggle_client_ssn_info_spec.rb
@@ -3,13 +3,20 @@ require "rails_helper"
 RSpec.feature "Toggle ssn display" do
   context "As an authenticated user" do
     let(:user) { create :admin_user}
-    let(:client) { create(:client, intake: create(:intake, primary_last_four_ssn: "1234" )) }
-    let(:client_no_ssn) { create(:client, intake: create(:intake)) }
+    let(:client) { create(:client, intake: create(:intake, filing_joint: "yes", primary_last_four_ssn: "1234", spouse_last_four_ssn: "4444" )) }
+    let(:client_no_ssn) { create(:client, intake: create(:intake, filing_joint: "yes")) }
     before { login_as user }
 
     scenario "client without ssn/itin" do
       visit hub_client_path(id: client_no_ssn)
       within(".last-four-ssn") do
+        expect(page).to have_text "Last 4 of SSN/ITIN"
+        expect(page).not_to have_text "View"
+
+        expect(page).to have_text "N/A"
+      end
+
+      within(".spouse-last-four-ssn") do
         expect(page).to have_text "Last 4 of SSN/ITIN"
         expect(page).not_to have_text "View"
 
@@ -40,6 +47,28 @@ RSpec.feature "Toggle ssn display" do
 
         expect(page).not_to have_text client.intake.primary_last_four_ssn
       end
+
+      within(".spouse-last-four-ssn") do
+        expect(page).to have_text "Last 4 of SSN/ITIN"
+        expect(page).to have_text "View"
+
+        expect(page).not_to have_text client.intake.spouse_last_four_ssn
+
+        expect do
+          click_on "View"
+
+          expect(page).to have_text "Last 4 of SSN/ITIN"
+          expect(page).to have_text "View"
+
+          expect(page).to have_text client.intake.spouse_last_four_ssn
+
+        end.to change(AccessLog, :count).by(1)
+
+        click_on "Hide"
+
+        expect(page).not_to have_text client.intake.spouse_last_four_ssn
+      end
+
     end
   end
 end

--- a/spec/forms/hub/create_client_form_spec.rb
+++ b/spec/forms/hub/create_client_form_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Hub::CreateClientForm do
           spouse_first_name: "Newly",
           spouse_last_name: "Wed",
           spouse_email_address: "spouse@example.com",
+          spouse_last_four_ssn: "5678",
           filing_joint: "yes",
           timezone: "America/Chicago",
           needs_help_2020: "yes",
@@ -94,6 +95,7 @@ RSpec.describe Hub::CreateClientForm do
         intake = Intake.last
         expect(intake.vita_partner).to eq vita_partner
         expect(intake.primary_last_four_ssn).to eq "1234"
+        expect(intake.spouse_last_four_ssn).to eq "5678"
       end
 
       it "creates tax returns for each tax_return where _create is true" do


### PR DESCRIPTION
There was a bug that was causing an existing SSN to get cleared when the user edited it. That is also fixed here.

Probably could have refactored to reuse some templates between spouse and primary, but I didn't feel that it greatly added to complexity to keep them seperate.