### PR TITLE
Allow slow test to be slow

### DIFF
--- a/spec/features/hub/toggle_client_ssn_info_spec.rb
+++ b/spec/features/hub/toggle_client_ssn_info_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature "Toggle ssn display" do
           click_on "View"
 
           expect(page).to have_text "Last 4 of SSN/ITIN"
-          expect(page).to have_text "View"
+          expect(page).to have_text("View", wait: 10) # can be slow
 
           expect(page).to have_text client.intake.primary_last_four_ssn
 


### PR DESCRIPTION
This was being flaky here: https://app.circleci.com/pipelines/github/codeforamerica/vita-min/4139/workflows/78a830c8-bc18-432e-a281-e82bfb383834/jobs/11196/parallel-runs/2

Maybe if we wait longer, it'll just be fine.