### PR TITLE
Use faster JS compressor called Terser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rack', '>= 2.0.8'
 gem 'rails', '>= 6.0.3.4'
 gem 'puma', '>= 4.3.5'
 gem 'sass-rails', '~> 5.0'
-gem 'uglifier', '>= 1.3.0'
+gem 'terser', '~> 1.0'
 gem 'cfa-styleguide', git: 'https://github.com/codeforamerica/honeycrisp-gem', branch: 'master'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 gem 'mini_racer', platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -457,6 +457,8 @@ GEM
       activemodel (>= 3.0, < 7.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
+    terser (1.1.1)
+      execjs (>= 0.3.0, < 3)
     thor (0.20.3)
     thread (0.2.2)
     thread_safe (0.3.6)
@@ -468,8 +470,6 @@ GEM
       nokogiri (>= 1.6, < 2.0)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
@@ -578,10 +578,10 @@ DEPENDENCIES
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
   strip_attributes
+  terser (~> 1.0)
   thor
   twilio-ruby (~> 5.40.1)
   tzinfo-data
-  uglifier (>= 1.3.0)
   valid_email2
   web-console (>= 3.3.0)
   webdrivers

--- a/config/environments/shared_deployment_config.rb
+++ b/config/environments/shared_deployment_config.rb
@@ -26,7 +26,7 @@ Rails.application.configure do
   }
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = :terser
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.

--- a/config/initializers/sprockets.rb
+++ b/config/initializers/sprockets.rb
@@ -1,0 +1,2 @@
+Sprockets.register_compressor 'application/javascript', :terser, Terser::Compressor
+


### PR DESCRIPTION
This improves the speed of our code deploys by improving the speed of `rails assets:precompile`. In my local testing, it improves `rake assets:precompile` by approx 25%, which could speed up a deploy by approx 10-15 seconds.

GitLab also uses terser, suggesting that it's a pretty OK choice: https://gitlab.com/gitlab-org/gitlab/-/merge_requests/44034