### PR TITLE
Fix timezone bug on user edit page

### DIFF
--- a/app/views/hub/clients/_primary_info_fields.html.erb
+++ b/app/views/hub/clients/_primary_info_fields.html.erb
@@ -6,7 +6,13 @@
     <%= f.cfa_input_field(:primary_last_name, t("hub.clients.fields.legal_last_name"), classes: ["form-width--long"]) %>
   </div>
   <%= f.cfa_input_field(:preferred_name, t("hub.clients.fields.preferred_name"), classes: ["form-width--long"]) %>
-  <%= f.cfa_select(:timezone, t("general.timezone"), timezone_select_options) %>
+
+  <% if is_dropoff %>
+    <%= f.cfa_select(:timezone, t("general.timezone"), timezone_select_options, selected: current_user.timezone) %>
+  <% else %>
+    <%= f.cfa_select(:timezone, t("general.timezone"), timezone_select_options) %>
+  <% end %>
+
   <% unless is_dropoff %>
     <%= f.cfa_input_field(:interview_timing_preference, t("hub.clients.show.interview_timing_preference")) %>
   <% end %>

--- a/app/views/hub/clients/_primary_info_fields.html.erb
+++ b/app/views/hub/clients/_primary_info_fields.html.erb
@@ -6,7 +6,7 @@
     <%= f.cfa_input_field(:primary_last_name, t("hub.clients.fields.legal_last_name"), classes: ["form-width--long"]) %>
   </div>
   <%= f.cfa_input_field(:preferred_name, t("hub.clients.fields.preferred_name"), classes: ["form-width--long"]) %>
-  <%= f.cfa_select(:timezone, t("general.timezone"), timezone_select_options, selected: current_user.timezone) %>
+  <%= f.cfa_select(:timezone, t("general.timezone"), timezone_select_options) %>
   <% unless is_dropoff %>
     <%= f.cfa_input_field(:interview_timing_preference, t("hub.clients.show.interview_timing_preference")) %>
   <% end %>

--- a/spec/features/hub/edit_client_spec.rb
+++ b/spec/features/hub/edit_client_spec.rb
@@ -11,9 +11,19 @@ RSpec.describe "a user editing a clients intake fields" do
       create :client,
              vita_partner: organization,
              tax_returns: [tax_return],
-             intake: create(:intake, email_address: "colleen@example.com", filing_joint: "yes", primary_first_name: "Colleen", primary_last_name: "Cauliflower", preferred_interview_language: "es", state_of_residence: "CA", preferred_name: "Colleen Cauliflower", email_notification_opt_in: "yes", dependents: [
-               create(:dependent, first_name: "Lara", last_name: "Legume", birth_date: "2007-03-06"),
-             ])
+             intake: create(:intake,
+                            email_address: "colleen@example.com",
+                            filing_joint: "yes",
+                            primary_first_name: "Colleen",
+                            primary_last_name: "Cauliflower",
+                            preferred_interview_language: "es",
+                            state_of_residence: "CA",
+                            preferred_name: "Colleen Cauliflower",
+                            email_notification_opt_in: "yes",
+                            timezone: "America/Chicago",
+                            dependents: [
+                              create(:dependent, first_name: "Lara", last_name: "Legume", birth_date: "2007-03-06"),
+                          ])
 
     }
     before { login_as user }
@@ -53,6 +63,7 @@ RSpec.describe "a user editing a clients intake fields" do
       within "#primary-info" do
         expect(find_field("hub_update_client_form_primary_first_name").value).to eq "Colleen"
         expect(find_field("hub_update_client_form_primary_last_name").value).to eq "Cauliflower"
+        expect(find_field("hub_update_client_form_timezone").value).to eq "America/Chicago"
         fill_in "Preferred full name", with: "Colly Cauliflower"
         select "Mandarin", from: "Preferred language"
         check "Married"
@@ -73,6 +84,7 @@ RSpec.describe "a user editing a clients intake fields" do
         fill_in "City", with: "Brassicaville"
         select "California", from: "State"
         fill_in "ZIP code", with: "95032"
+        select "Pacific Time (US & Canada)", from: "Timezone"
         check "Opt into email notifications"
         check "Opt into sms notifications"
       end
@@ -139,6 +151,7 @@ RSpec.describe "a user editing a clients intake fields" do
       expect(page).to have_text "Lived with spouse"
       expect(page).to have_text "Divorced 2018"
       expect(page).to have_text "Filing jointly"
+      expect(page).to have_text "Pacific Time (US & Canada)"
       expect(page).to have_text "Dependents: 3", normalize_ws: true
       within "#dependents-list" do
         expect(page).to have_text "Laura Peaches"

--- a/spec/forms/hub/update_client_form_spec.rb
+++ b/spec/forms/hub/update_client_form_spec.rb
@@ -229,7 +229,8 @@ RSpec.describe Hub::UpdateClientForm do
              state_of_residence: "CA",
              preferred_interview_language: "es",
              spouse_last_four_ssn: "5678",
-             primary_last_four_ssn: "1234"
+             primary_last_four_ssn: "1234",
+             timezone: "America/Chicago"
     }
     let!(:client) {
       create :client, intake: intake
@@ -239,6 +240,7 @@ RSpec.describe Hub::UpdateClientForm do
       form = described_class.from_client(client)
       expect(form.spouse_last_four_ssn).to eq "5678"
       expect(form.primary_last_four_ssn).to eq "1234"
+      expect(form.timezone).to eq "America/Chicago"
     end
   end
 end


### PR DESCRIPTION
From investigation, found that the timezone field was originally only being set on the valet drop off page, so we set the default timezone to the current users' timezone as a convenience. However, when we started using a shared partial between the edit client and create client pages, we never updated the logic. This meant that when users from another timezone edited a client, their timezone box value would get changed to the current users timezone in error.

The current fix is to NOT prefill the value with the current users in the valet drop off, and ensure that the current value gets used on the clients page.