### PR TITLE
Use turbo_tests for bin/test output quality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,7 @@ group :development, :test do
   gem 'easy_translate'
   gem 'bundle-audit'
   gem 'parallel_tests'
+  gem 'turbo_tests'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -464,6 +464,9 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.10)
     ttfunk (1.7.0)
+    turbo_tests (1.1.1)
+      parallel_tests (~> 3.3)
+      rspec (~> 3.9)
     twilio-ruby (5.40.4)
       faraday (>= 0.9, < 2.0)
       jwt (>= 1.5, <= 2.5)
@@ -580,6 +583,7 @@ DEPENDENCIES
   strip_attributes
   terser (~> 1.0)
   thor
+  turbo_tests
   twilio-ruby (~> 5.40.1)
   tzinfo-data
   valid_email2

--- a/bin/test
+++ b/bin/test
@@ -6,6 +6,5 @@ if [ $(sysctl -n hw.logicalcpu) != "1" ] && ! psql "postgresql://localhost/vita-
   exit 1
 fi
 
-bundle exec bootsnap precompile --gemfile app/ lib/
-RAILS_CACHE_CLASSES=1 bundle exec parallel_test spec -t rspec || { echo "Not running JS tests due to rspec failure." ; exit 1; }
+RAILS_CACHE_CLASSES=1 bundle exec turbo_tests || { echo "Not running JS tests due to rspec failure." ; exit 1; }
 yarn jest


### PR DESCRIPTION
[turbo_tests](https://github.com/serpapi/turbo_tests) is a gem that makes our parallel test output look like serial test output, i.e., removes weird interleaving of output.

It also _might_ improve test execution time by using a queue rather than pre-assigning tests to different parallel workers.

Also avoid explicit call to warm up bootsnap cache; it seems to
warm itself up over time.

## After

```
vita-min on  turbo_tests [$] via ⬢ v15.0.1 via 💎 v2.6.5 on ☁️  us-east-1
❯ bin/test
Using recorded test runtime
Using recorded test runtime
8 processes for 249 specs, ~ 31 specs per process
warning: parser/current is loading parser/ruby26, which recognizes
warning: 2.6.6-compliant syntax, but you are running 2.6.5.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
.........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................*......................................................................................................................................*.........*..............................................................................................................*..........................................................................................*.**.....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Signing in As a client requesting a sign-in link
     # Temporarily disabled with xscenario
     # ./spec/features/portal/client_sign_in_spec.rb:9

  2) a user viewing a client user without admin access, but is coalition lead for client organization can view and update client organization
     # Temporarily skipped with xcontext
     # ./spec/features/hub/show_client_spec.rb:66

  3) Client uploads a requested document client goes to the follow up documents token link
     # Temporarily disabled with xscenario
     # ./spec/features/web_intake/requested_documents_token_spec.rb:6

  4) Portal::RequestClientLoginForm#valid? with an invalid email is not valid
     # Temporarily skipped with xcontext
     # ./spec/forms/portal/request_client_login_form_spec.rb:34

  5) ClientLoginRequestJob#perform with contact info with an email with matching clients sends an email with a token link
     # Temporarily skipped with xit
     # ./spec/jobs/client_login_request_job_spec.rb:28

  6) ClientLoginRequestJob#perform with contact info with a phone number with matching clients sends a text message with a token link
     # Temporarily skipped with xcontext
     # ./spec/jobs/client_login_request_job_spec.rb:56

  7) ClientLoginRequestJob#perform with contact info with a phone number without matching clients sends a text message with helpful guidance
     # Temporarily skipped with xcontext
     # ./spec/jobs/client_login_request_job_spec.rb:66


Finished in 45.71 seconds (files took 0 seconds to load)
1533 examples, 0 failures, 7 pending

yarn run v1.22.10
warning package.json: No license field
$ /Users/asheesh/projects/vita-min/node_modules/.bin/jest
 PASS  spec/javascript/channels/client_channel.spec.js
 PASS  spec/javascript/lib/nested_attributes/index.spec.js
 PASS  spec/javascript/lib/dynamic_take_action_changes.spec.js
 PASS  spec/javascript/helpers/index.spec.js
 PASS  spec/javascript/lib/nested_attributes/nested_attributes.spec.js

Test Suites: 5 passed, 5 total
Tests:       8 passed, 8 total
Snapshots:   0 total
Time:        2.602 s
Ran all test suites.
✨  Done in 4.15s.

vita-min on  turbo_tests [$] via ⬢ v15.0.1 via 💎 v2.6.5 on ☁️  us-east-1 took 51s
```

## Before

```
❯ bin/test
Using recorded test runtime
8 processes for 249 specs, ~ 31 specs per process
warning: parser/current is loading parser/ruby26, which recognizes
warning: 2.6.6-compliant syntax, but you are running 2.6.5.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
.................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................*......................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................*........................*.................................................................................................................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Client uploads a requested document client goes to the follow up documents token link
     # Temporarily disabled with xscenario
     # ./spec/features/web_intake/requested_documents_token_spec.rb:6


Finished in 27.17 seconds (files took 5.78 seconds to load)
147 examples, 0 failures, 1 pending

...........................................................................................................................................................................................................................*..**................
.
Finished in 30.47 seconds (files took 5.91 seconds to load)
202 examples, 0 failures

....................................................................

Finished in 31.07 seconds (files took 5.88 seconds to load)
138 examples, 0 failures

..........................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) ClientLoginRequestJob#perform with contact info with an email with matching clients sends an email with a token link
     # Temporarily skipped with xit
     # ./spec/jobs/client_login_request_job_spec.rb:28

  2) ClientLoginRequestJob#perform with contact info with a phone number with matching clients sends a text message with a token link
     # Temporarily skipped with xcontext
     # ./spec/jobs/client_login_request_job_spec.rb:56

  3) ClientLoginRequestJob#perform with contact info with a phone number without matching clients sends a text message with helpful guidance
     # Temporarily skipped with xcontext
     # ./spec/jobs/client_login_request_job_spec.rb:66


Finished in 31.36 seconds (files took 6.03 seconds to load)
155 examples, 0 failures, 3 pending

...............................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Signing in As a client requesting a sign-in link
     # Temporarily disabled with xscenario
     # ./spec/features/portal/client_sign_in_spec.rb:9


Finished in 32.2 seconds (files took 6.32 seconds to load)
402 examples, 0 failures, 1 pending

...........................................................................

Finished in 35.09 seconds (files took 5.84 seconds to load)
239 examples, 0 failures

.....................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) a user viewing a client user without admin access, but is coalition lead for client organization can view and update client organization
     # Temporarily skipped with xcontext
     # ./spec/features/hub/show_client_spec.rb:66


Finished in 35.97 seconds (files took 5.82 seconds to load)
217 examples, 0 failures, 1 pending

....................................*....................................................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Portal::RequestClientLoginForm#valid? with an invalid email is not valid
     # Temporarily skipped with xcontext
     # ./spec/forms/portal/request_client_login_form_spec.rb:34


Finished in 39.94 seconds (files took 6.44 seconds to load)
222 examples, 0 failures, 1 pending


1722 examples, 0 failures, 7 pendings

Took 47 seconds
yarn run v1.22.10
warning package.json: No license field
$ /Users/asheesh/projects/vita-min/node_modules/.bin/jest
 PASS  spec/javascript/lib/nested_attributes/index.spec.js
 PASS  spec/javascript/helpers/index.spec.js
 PASS  spec/javascript/lib/dynamic_take_action_changes.spec.js
 PASS  spec/javascript/lib/nested_attributes/nested_attributes.spec.js
 PASS  spec/javascript/channels/client_channel.spec.js

Test Suites: 5 passed, 5 total
Tests:       8 passed, 8 total
Snapshots:   0 total
Time:        2.733 s
Ran all test suites.
✨  Done in 3.98s.

vita-min on  turbo_tests [$] via ⬢ v15.0.1 via 💎 v2.6.5 on ☁️  us-east-1 took 1m2s
```