### PR TITLE
Search tab for admins [#176827790]

### DIFF
--- a/app/assets/stylesheets/components/_client-filters.scss
+++ b/app/assets/stylesheets/components/_client-filters.scss
@@ -27,5 +27,5 @@
 .empty-clients {
   margin-top: 2.5rem;
   background: $color-red-light;
-  padding: 10px;
+  padding: 1rem 1rem 1rem 3rem;
 }

--- a/app/controllers/concerns/client_sortable.rb
+++ b/app/controllers/concerns/client_sortable.rb
@@ -12,6 +12,11 @@ module ClientSortable
     clients
   end
 
+  # see if there are any overlapping keys in the provied params and search/sort set
+  def has_search_and_sort_params?
+    (params.keys.map(&:to_sym) & search_and_sort_params).any?
+  end
+
   private
 
   def setup_sortable_client
@@ -29,14 +34,15 @@ module ClientSortable
     }
   end
 
+  def search_and_sort_params
+    [:search, :status, :unassigned, :assigned_to_me, :needs_attention, :year]
+  end
+
   # reset the raw parameters for each filter received by the form
   def reset_filter_params
-    params[:search] = nil
-    params[:status] = nil
-    params[:unassigned] = nil
-    params[:assigned_to_me] = nil
-    params[:needs_attention] = nil
-    params[:year] = nil
+    search_and_sort_params.each do |param|
+      params[param] = nil
+    end
   end
 
   def clients_sort_order

--- a/app/controllers/hub/search_clients_controller.rb
+++ b/app/controllers/hub/search_clients_controller.rb
@@ -1,0 +1,26 @@
+module Hub
+  class SearchClientsController < ApplicationController
+    include AccessControllable
+    include ClientSortable
+    before_action :require_sign_in, :redirect_unless_admin
+    authorize_resource :client, parent: false
+
+    layout 'admin'
+
+    def index
+      @page_title = 'Search clients'
+      if has_search_and_sort_params? && !params[:clear].present?
+        @clients = Client.accessible_by(current_ability)
+        @clients = filtered_and_sorted_clients.with_eager_loaded_associations
+      else
+        @clients = []
+      end
+      render "hub/clients/index"
+    end
+
+    # Product only wants this route available to admins.
+    def redirect_unless_admin
+      redirect_to hub_clients_path unless current_user.admin?
+    end
+  end
+end

--- a/app/controllers/hub/search_clients_controller.rb
+++ b/app/controllers/hub/search_clients_controller.rb
@@ -8,7 +8,7 @@ module Hub
     layout 'admin'
 
     def index
-      @page_title = 'Search clients'
+      @page_title = I18n.t("hub.clients.search_clients.title")
       if has_search_and_sort_params? && !params[:clear].present?
         @clients = Client.accessible_by(current_ability)
         @clients = filtered_and_sorted_clients.with_eager_loaded_associations

--- a/app/views/hub/_back_to.html.erb
+++ b/app/views/hub/_back_to.html.erb
@@ -1,8 +1,12 @@
 <div class="breadcrumb user-navigation">
   <% if back_to == "dashboard" %>
     <%= link_to "< #{t('.return_to_dashboard')}", hub_root_path, class: "breadcrumb-item link--grey" %>
-  <% elsif back_to == "all_clients" %>
-    <%= link_to "< #{t('.return_to_clients')}", hub_clients_path, class: "breadcrumb-item link--grey" %>
+  <% elsif back_to == "clients" %>
+    <% if current_user.admin? %>
+      <%= link_to "< #{t('.return_to_search')}", search_hub_clients_path, class: "breadcrumb-item link--grey" %>
+    <% else %>
+      <%= link_to "< #{t('.return_to_clients')}", hub_clients_path, class: "breadcrumb-item link--grey" %>
+    <% end %>
   <% elsif back_to == "profile" %>
     <%= link_to "< #{t('.return_to_profile')}", hub_user_profile_path, class: "breadcrumb-item link--grey" %>
   <% else %>

--- a/app/views/hub/clients/index.html.erb
+++ b/app/views/hub/clients/index.html.erb
@@ -68,7 +68,7 @@
     </section>
   <% else %>
 
-    <div class="spacing-above-25">
+    <div class="slab slab--not-padded">
       <h1 class="h2"><%= @page_title %></h1>
     </div>
     <div class="empty-clients">

--- a/app/views/hub/clients/index.html.erb
+++ b/app/views/hub/clients/index.html.erb
@@ -72,7 +72,13 @@
       <h1 class="h2"><%= @page_title %></h1>
     </div>
     <div class="empty-clients">
-      <%= @filters&.values.any? ? t("hub.clients.index.no_filtered_clients") : t("hub.clients.index.no_clients") %>
+      <% if !@filters %>
+        <%= t("hub.clients.index.apply_filters") %>
+      <% elsif @filters&.values&.any? %>
+        <%= t("hub.clients.index.no_filtered_clients")  %>
+      <% else %>
+        <%= t("hub.clients.index.no_clients") %>
+      <% end %>
     </div>
   <% end %>
   </section

--- a/app/views/hub/clients/show.html.erb
+++ b/app/views/hub/clients/show.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :back_to, "all_clients" %>
+<%= content_for :back_to, "clients" %>
 
 <% content_for :page_title, "#{@client.preferred_name} ##{@client.id}" %>
 

--- a/app/views/hub/documents/index.html.erb
+++ b/app/views/hub/documents/index.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :back_to, "all_clients" %>
+<%= content_for :back_to, "clients" %>
 <% content_for :page_title, "#{@client.preferred_name} ##{@client.id} documents" %>
 
 <% content_for :card do %>

--- a/app/views/hub/messages/index.html.erb
+++ b/app/views/hub/messages/index.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :back_to, "all_clients" %>
+<%= content_for :back_to, "clients" %>
 <% content_for :page_title, "#{@client.preferred_name}, ##{@client.id}" %>
 
 <% content_for :card do %>

--- a/app/views/hub/notes/index.html.erb
+++ b/app/views/hub/notes/index.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :back_to, "all_clients" %>
+<%= content_for :back_to, "clients" %>
 <% content_for :page_title, "Notes: #{@client.preferred_name} ##{@client.id}" %>
 
 <% content_for :card do %>

--- a/app/views/hub/unlinked_clients/index.html.erb
+++ b/app/views/hub/unlinked_clients/index.html.erb
@@ -43,7 +43,7 @@
       </table>
       </section>
     <% else %>
-      <div class="spacing-above-25">
+      <div class="slab slab--not-padded">
         <h1 class="h2"><%= @page_title %></h1>
       </div>
       <div class="empty-clients">

--- a/app/views/shared/_dashboard_navigation.html.erb
+++ b/app/views/shared/_dashboard_navigation.html.erb
@@ -1,7 +1,8 @@
 <div class="client-navigation tab-bar is-selected">
-    <%= tab_navigation_link(t("hub.assigned_clients.index.title"), hub_root_path) %>
-    <%= tab_navigation_link(t("hub.clients.index.title"), hub_clients_path) %>
-    <% if current_user.admin? %>
-      <%= tab_navigation_link(t("hub.clients.unlinked_clients.title"), hub_unlinked_clients_path) %>
-    <% end %>
+  <%= tab_navigation_link(t("hub.assigned_clients.index.title"), hub_root_path) %>
+  <%= tab_navigation_link(t("hub.clients.index.title"), hub_clients_path) %>
+  <% if current_user.admin? %>
+    <%= tab_navigation_link(t("hub.clients.search_clients.title"), search_hub_clients_path) %>
+    <%= tab_navigation_link(t("hub.clients.unlinked_clients.title"), hub_unlinked_clients_path) %>
+  <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,7 @@ en:
     back_to:
       return_to_dashboard: Return to dashboard
       return_to_clients: Return to all clients
+      return_to_search: Return to search
       return_to_profile: Return to profile
     users:
       edit:
@@ -90,10 +91,13 @@ en:
         title: All clients
         no_clients: No clients assigned.
         no_filtered_clients: No clients match selected filters.
+        apply_filters: Apply search / filter to find matching clients.
         assigned_to_me: Assigned to me
         unassigned: Unassigned
         needs_attention: Needs attention
         stage_status: Tax return stage/status
+      search_clients:
+        title: Search clients
       unlinked_clients:
         title: Unlinked clients
       navigation:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4,6 +4,7 @@ es:
     back_to:
       return_to_dashboard: Regresar al tablero
       return_to_clients: Volver a todos los clientes
+      return_to_search: Volver a buscar
       return_to_profile: Volver al perfil
     users:
       edit:
@@ -75,6 +76,7 @@ es:
         title: Todos clientes
         no_clients: No hay clientes asignadas.
         no_filtered_clients: Ninguna cliente coincide con los filtros seleccionados.
+        apply_filters: Aplicar búsqueda / filtro para encontrar clientes coincidentes.
         assigned_to_me: Asignado a mí
         unassigned: No asignado
         needs_attention: Necesita attentión
@@ -119,6 +121,8 @@ es:
           status: actualizó estado
           success: 'Éxito: Acción completo! %{action_list}.'
           text_message: envió mensjaje de texto
+      search_clients:
+        title: Buscar clientes
       unlinked_clients:
         title: "Clientes no vinculados"
     documents:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,6 +126,8 @@ Rails.application.routes.draw do
       resources :tax_returns, only: [:edit, :update, :show]
       resources :unlinked_clients, only: [:index]
       resources :clients do
+        get '/search', to: "search_clients#index", on: :collection, as: :search
+
         get "/organization", to: "clients/organizations#edit", on: :member, as: :edit_organization
         patch "/organization", to: "clients/organizations#update", on: :member, as: :organization
         get "/bai", to: "clients/bank_accounts#show", on: :member, as: :show_bank_account

--- a/spec/controllers/concerns/client_sortable_spec.rb
+++ b/spec/controllers/concerns/client_sortable_spec.rb
@@ -115,4 +115,57 @@ RSpec.describe ClientSortable, type: :controller do
       end
     end
   end
+
+  describe "#has_search_and_sort_params?" do
+    context "when containing a sort or search param" do
+      context "search" do
+        let(:params) { { search: "que" } }
+        it "returns true" do
+          expect(subject.has_search_and_sort_params?).to eq true
+        end
+      end
+
+      context "status" do
+        let(:params) { { search: "prep_ready_for_prep" } }
+        it "returns true" do
+          expect(subject.has_search_and_sort_params?).to eq true
+        end
+      end
+
+      context "unassigned" do
+        let(:params) { { unassigned: true } }
+        it "returns true" do
+          expect(subject.has_search_and_sort_params?).to eq true
+        end
+      end
+
+      context "assigned_to_me" do
+        let(:params) { { assigned_to_me: true } }
+        it "returns true" do
+          expect(subject.has_search_and_sort_params?).to eq true
+        end
+      end
+
+      context "needs_attention" do
+        let(:params) { { needs_attention: true } }
+        it "returns true" do
+          expect(subject.has_search_and_sort_params?).to eq true
+        end
+      end
+
+      context "year" do
+        let(:params) { { year: 2019 } }
+        it "returns true" do
+          expect(subject.has_search_and_sort_params?).to eq true
+        end
+      end
+    end
+
+    context "without a search or sort param" do
+      let(:params) { { something: 'hello' } }
+      it "returns false" do
+        expect(subject.has_search_and_sort_params?).to eq false
+      end
+    end
+  end
 end

--- a/spec/controllers/hub/assigned_clients_controller_spec.rb
+++ b/spec/controllers/hub/assigned_clients_controller_spec.rb
@@ -3,9 +3,8 @@ require 'rails_helper'
 RSpec.describe Hub::AssignedClientsController do
   describe "#index" do
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :index
-  end
 
-  context "as an authenticated user" do
+    context "as an authenticated user" do
     let(:organization) { create(:organization) }
     let(:user) { create(:user, role: create(:organization_lead_role, organization: organization)) }
 
@@ -106,6 +105,7 @@ RSpec.describe Hub::AssignedClientsController do
           expect(assigns(:clients)).to eq [assigned_to_me, starts_with_a_assigned]
         end
       end
+    end
     end
   end
 end

--- a/spec/controllers/hub/search_clients_controller_spec.rb
+++ b/spec/controllers/hub/search_clients_controller_spec.rb
@@ -1,14 +1,6 @@
 require 'rails_helper'
 
 describe Hub::SearchClientsController do
-  before do
-    # Do nothing
-  end
-
-  after do
-    # Do nothing
-  end
-
   context "#index" do
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :index
 
@@ -27,8 +19,6 @@ describe Hub::SearchClientsController do
       let(:current_user) { create :admin_user }
       before {
         sign_in current_user
-        create(:client, intake: (create :intake, primary_first_name: 'Matching', primary_last_name: 'Client'), tax_returns: [(create :tax_return, status: 'prep_ready_for_prep')])
-        create(:client, intake: (create :intake, primary_first_name: 'Matching', primary_last_name: 'Client'), tax_returns: [(create :tax_return, status: 'prep_ready_for_prep')])
         create(:client, intake: (create :intake, primary_first_name: 'Matching', primary_last_name: 'Client'), tax_returns: [(create :tax_return, status: 'prep_ready_for_prep')])
         create(:client, intake: (create :intake, primary_first_name: 'Matching', primary_last_name: 'Client'), tax_returns: [(create :tax_return, status: 'prep_ready_for_prep')])
       }

--- a/spec/controllers/hub/search_clients_controller_spec.rb
+++ b/spec/controllers/hub/search_clients_controller_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+describe Hub::SearchClientsController do
+  before do
+    # Do nothing
+  end
+
+  after do
+    # Do nothing
+  end
+
+  context "#index" do
+    it_behaves_like :a_get_action_for_authenticated_users_only, action: :index
+
+    context "when user is not an admin" do
+      let(:current_user) { create :coalition_lead_user }
+      before { sign_in current_user }
+
+      it "redirects to the clients index" do
+        expect(
+          get :index
+        ).to redirect_to hub_clients_path
+      end
+    end
+
+    context "when user is an admin" do
+      let(:current_user) { create :admin_user }
+      before {
+        sign_in current_user
+        create(:client, intake: (create :intake, primary_first_name: 'Matching', primary_last_name: 'Client'), tax_returns: [(create :tax_return, status: 'prep_ready_for_prep')])
+        create(:client, intake: (create :intake, primary_first_name: 'Matching', primary_last_name: 'Client'), tax_returns: [(create :tax_return, status: 'prep_ready_for_prep')])
+        create(:client, intake: (create :intake, primary_first_name: 'Matching', primary_last_name: 'Client'), tax_returns: [(create :tax_return, status: 'prep_ready_for_prep')])
+        create(:client, intake: (create :intake, primary_first_name: 'Matching', primary_last_name: 'Client'), tax_returns: [(create :tax_return, status: 'prep_ready_for_prep')])
+      }
+
+      it "sets the page title" do
+        get :index
+        expect(assigns(:page_title)).to eq "Search clients"
+      end
+
+      context "without params" do
+        it "loads the page without any clients" do
+          get :index
+          expect(assigns(:clients)).to eq []
+        end
+      end
+
+      context "with the clear param" do
+        it "loads the page without any clients" do
+          get :index, params: { clear: true }
+          expect(assigns(:clients)).to eq []
+        end
+      end
+
+      context "with sort and search params" do
+        it "loads the page with matching clients" do
+          get :index, params: { search: 'Matching' }
+          expect(assigns(:clients)).not_to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/features/hub/show_client_spec.rb
+++ b/spec/features/hub/show_client_spec.rb
@@ -46,15 +46,15 @@ RSpec.describe "a user viewing a client" do
       end
     end
 
-    scenario "can return to the client list page" do
+    scenario "returns to the client search page" do
       visit hub_client_path(id: client.id)
-      click_on("Return to all clients")
+      click_on("Return to search")
 
-      expect(current_path).to eq(hub_clients_path)
+      expect(current_path).to eq(search_hub_clients_path)
     end
   end
 
-  xcontext "user without admin access, but is coalition lead for client organization" do
+  context "user without admin access, but is coalition lead for client organization" do
     # we have not yet implemented coalition leads
     let(:coalition) { create :coalition }
     let(:user) { create :coalition_lead_user, role: create(:coalition_lead_role, coalition: coalition) }
@@ -62,6 +62,13 @@ RSpec.describe "a user viewing a client" do
     let(:client) { create :client, vita_partner: first_org, intake: create(:intake, :with_contact_info) }
     let!(:second_org) { create :organization, coalition: coalition }
     before { login_as user }
+
+    scenario "returns to the client search page" do
+      visit hub_client_path(id: client.id)
+      click_on("Return to all clients")
+
+      expect(current_path).to eq(hub_clients_path)
+    end
 
     scenario "can view and update client organization" do
       visit hub_client_path(id: client.id)

--- a/spec/features/hub/show_client_spec.rb
+++ b/spec/features/hub/show_client_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe "a user viewing a client" do
   end
 
   context "user without admin access, but is coalition lead for client organization" do
-    # we have not yet implemented coalition leads
     let(:coalition) { create :coalition }
     let(:user) { create :coalition_lead_user, role: create(:coalition_lead_role, coalition: coalition) }
     let(:first_org) { create :organization, coalition: coalition }


### PR DESCRIPTION
Loading _all_ clients is prohibitively slow, especially for admins/cs reps. Since the primary task of CS is to _search_ for a specific user, adding a search tab to the dashboard and redirecting to that when navigating will keep the site speedy by preventing unnecessary queries for all clients.