### PR TITLE
Use /tmp for storage when running tests

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -7,7 +7,7 @@ deploy_default: &deploy_default
 test:
   service: Disk
   # Use /tmp which is autocleared periodically on macOS
-  root: "/tmp/via-min-test-storage"
+  root: "/tmp/vita-min-test-storage"
 
 local:
   service: Disk

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,7 +6,8 @@ deploy_default: &deploy_default
 
 test:
   service: Disk
-  root: <%= Rails.root.join("tmp/storage") %>
+  # Use /tmp which is autocleared periodically on macOS
+  root: "/tmp/via-min-test-storage"
 
 local:
   service: Disk


### PR DESCRIPTION
On my laptop, `~/projects/vita-min/tmp/storage` was taking up 22 GB of space.

This adjusts ActiveStorage to store its data somewhere that macOS automatically cleans. (See e.g. [superuser.com](https://superuser.com/questions/187071/in-macos-how-often-is-tmp-deleted) or [developer.apple.com](https://developer.apple.com/forums/thread/71382) for info about /tmp autocleaning.)

