### PR TITLE
First Unresponded To Message logic for clients

### DIFF
--- a/app/controllers/hub/metrics_controller.rb
+++ b/app/controllers/hub/metrics_controller.rb
@@ -10,14 +10,14 @@ module Hub
       # The view will only display values for vita partners the user has access to view.
       data = Rails.cache.fetch("metrics/sla_breaches/attention_needed", expires_in: 10.minutes) do
         sla_service = SLABreachService.new
-        { breach_threshold: sla_service.breach_threshold,
+        { breach_threshold_date: sla_service.breach_threshold_date,
           current_as_of: sla_service.report_generated_at,
           breach_counts: sla_service.attention_needed_breaches
         }
       end
       data[:total_breaches] = data[:breach_counts].slice(*@vita_partners.map(&:id)).values.inject(:+)
       # Cast UTC stored data in the cache to the current_user's timezone.
-      data[:breach_threshold] = data[:breach_threshold].in_time_zone(current_user.timezone)
+      data[:breach_threshold_date] = data[:breach_threshold_date].in_time_zone(current_user.timezone)
       data[:current_as_of] = data[:current_as_of].in_time_zone(current_user.timezone)
       @attention_needed = OpenStruct.new(data)
     end

--- a/app/controllers/hub/metrics_controller.rb
+++ b/app/controllers/hub/metrics_controller.rb
@@ -12,7 +12,7 @@ module Hub
         sla_service = SLABreachService.new
         { breach_threshold: sla_service.breach_threshold,
           current_as_of: sla_service.report_generated_at,
-          breach_counts: sla_service.attention_needed_breach
+          breach_counts: sla_service.attention_needed_breaches
         }
       end
       data[:total_breaches] = data[:breach_counts].slice(*@vita_partners.map(&:id)).values.inject(:+)

--- a/app/jobs/generate_unanswered_incoming_message_data_job.rb
+++ b/app/jobs/generate_unanswered_incoming_message_data_job.rb
@@ -1,0 +1,33 @@
+class GenerateUnansweredIncomingMessageDataJob < ApplicationJob
+  def perform(start: 0, finish: nil)
+    Client.includes(:outbound_calls, :outgoing_text_messages, :outgoing_emails, :incoming_emails, :incoming_text_messages).find_each(start: start, finish: finish) do |client|
+      if client.first_unanswered_incoming_correspondence_at.present?
+        puts "SKIPPING #{client.id}: fuica already set."
+        next
+      end
+
+      # If there are outbound messages present, we need to get the first inbound after the last outbound.
+      # If there are no outbounds, we can use the first inbound.
+      last_outbound = [client.outgoing_text_messages.last, client.outgoing_emails.last, client.outgoing_emails.last].compact.max_by { |msg| msg&.created_at }
+      if last_outbound.present?
+        itm = client.incoming_text_messages.find { |itm| itm.created_at > last_outbound.created_at }
+        ie = client.incoming_emails.find { |ie| ie.created_at > last_outbound.created_at }
+        fuica = [itm, ie].compact.min_by { |a| a&.created_at }
+      else
+        fuica = [client.incoming_text_messages.first, client.incoming_emails.first].compact.min_by { |msg| msg&.created_at }
+      end
+
+      if fuica.present?
+        if client.update(first_unanswered_incoming_correspondence_at: fuica.created_at)
+          puts "SUCCESS #{client.id}: updated fuica to #{fuica.created_at}"
+        else
+          puts "ERROR #{client.id}: could not persist fuica to #{fuica.created_at}"
+        end
+      else
+        puts "SKIPPING #{client.id}: no unanswered messages for #{client.id}."
+      end
+    end
+  end
+end
+
+# First email sent since the last time we responded.

--- a/app/jobs/generate_unanswered_incoming_message_data_job.rb
+++ b/app/jobs/generate_unanswered_incoming_message_data_job.rb
@@ -1,7 +1,7 @@
-class GenerateUnansweredIncomingMessageDataJob < ApplicationJob
+class GenerateUnansweredIncomingInteractionDataJob < ApplicationJob
   def perform(start: 0, finish: nil)
     Client.includes(:outbound_calls, :outgoing_text_messages, :outgoing_emails, :incoming_emails, :incoming_text_messages).find_each(start: start, finish: finish) do |client|
-      if client.first_unanswered_incoming_correspondence_at.present?
+      if client.first_unanswered_incoming_interaction_at.present?
         puts "SKIPPING #{client.id}: fuica already set."
         next
       end
@@ -22,7 +22,7 @@ class GenerateUnansweredIncomingMessageDataJob < ApplicationJob
       fuica = [doc, itm, ie].compact.min_by { |msg| msg&.created_at }
 
       if fuica.present?
-        if client.update(first_unanswered_incoming_correspondence_at: fuica.created_at)
+        if client.update(first_unanswered_incoming_interaction_at: fuica.created_at)
           puts "SUCCESS #{client.id}: updated fuica to #{fuica.created_at}"
         else
           puts "ERROR #{client.id}: could not persist fuica to #{fuica.created_at}"

--- a/app/jobs/generate_unanswered_incoming_message_data_job.rb
+++ b/app/jobs/generate_unanswered_incoming_message_data_job.rb
@@ -12,10 +12,14 @@ class GenerateUnansweredIncomingMessageDataJob < ApplicationJob
       if last_outbound.present?
         itm = client.incoming_text_messages.find { |itm| itm.created_at > last_outbound.created_at }
         ie = client.incoming_emails.find { |ie| ie.created_at > last_outbound.created_at }
-        fuica = [itm, ie].compact.min_by { |a| a&.created_at }
+        doc = client.documents.find { |doc| doc.uploaded_by == client && doc.created_at > last_outbound.created_at }
       else
-        fuica = [client.incoming_text_messages.first, client.incoming_emails.first].compact.min_by { |msg| msg&.created_at }
+        doc = client.documents.find { |doc| doc.uploaded_by == client }
+        itm = client.incoming_text_messages.first
+        ie = client.incoming_emails.first
       end
+
+      fuica = [doc, itm, ie].compact.min_by { |msg| msg&.created_at }
 
       if fuica.present?
         if client.update(first_unanswered_incoming_correspondence_at: fuica.created_at)

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -2,24 +2,24 @@
 #
 # Table name: clients
 #
-#  id                                          :bigint           not null, primary key
-#  attention_needed_since                      :datetime
-#  current_sign_in_at                          :datetime
-#  current_sign_in_ip                          :inet
-#  failed_attempts                             :integer          default(0), not null
-#  first_unanswered_incoming_correspondence_at :datetime
-#  last_incoming_interaction_at                :datetime
-#  last_interaction_at                         :datetime
-#  last_sign_in_at                             :datetime
-#  last_sign_in_ip                             :inet
-#  locked_at                                   :datetime
-#  login_requested_at                          :datetime
-#  login_token                                 :string
-#  routing_method                              :integer
-#  sign_in_count                               :integer          default(0), not null
-#  created_at                                  :datetime         not null
-#  updated_at                                  :datetime         not null
-#  vita_partner_id                             :bigint
+#  id                                       :bigint           not null, primary key
+#  attention_needed_since                   :datetime
+#  current_sign_in_at                       :datetime
+#  current_sign_in_ip                       :inet
+#  failed_attempts                          :integer          default(0), not null
+#  first_unanswered_incoming_interaction_at :datetime
+#  last_incoming_interaction_at             :datetime
+#  last_interaction_at                      :datetime
+#  last_sign_in_at                          :datetime
+#  last_sign_in_ip                          :inet
+#  locked_at                                :datetime
+#  login_requested_at                       :datetime
+#  login_token                              :string
+#  routing_method                           :integer
+#  sign_in_count                            :integer          default(0), not null
+#  created_at                               :datetime         not null
+#  updated_at                               :datetime         not null
+#  vita_partner_id                          :bigint
 #
 # Indexes
 #

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -2,23 +2,24 @@
 #
 # Table name: clients
 #
-#  id                           :bigint           not null, primary key
-#  attention_needed_since       :datetime
-#  current_sign_in_at           :datetime
-#  current_sign_in_ip           :inet
-#  failed_attempts              :integer          default(0), not null
-#  last_incoming_interaction_at :datetime
-#  last_interaction_at          :datetime
-#  last_sign_in_at              :datetime
-#  last_sign_in_ip              :inet
-#  locked_at                    :datetime
-#  login_requested_at           :datetime
-#  login_token                  :string
-#  routing_method               :integer
-#  sign_in_count                :integer          default(0), not null
-#  created_at                   :datetime         not null
-#  updated_at                   :datetime         not null
-#  vita_partner_id              :bigint
+#  id                                          :bigint           not null, primary key
+#  attention_needed_since                      :datetime
+#  current_sign_in_at                          :datetime
+#  current_sign_in_ip                          :inet
+#  failed_attempts                             :integer          default(0), not null
+#  first_unanswered_incoming_correspondence_at :datetime
+#  last_incoming_interaction_at                :datetime
+#  last_interaction_at                         :datetime
+#  last_sign_in_at                             :datetime
+#  last_sign_in_ip                             :inet
+#  locked_at                                   :datetime
+#  login_requested_at                          :datetime
+#  login_token                                 :string
+#  routing_method                              :integer
+#  sign_in_count                               :integer          default(0), not null
+#  created_at                                  :datetime         not null
+#  updated_at                                  :datetime         not null
+#  vita_partner_id                             :bigint
 #
 # Indexes
 #

--- a/app/models/concerns/interaction_tracking.rb
+++ b/app/models/concerns/interaction_tracking.rb
@@ -5,7 +5,7 @@ module InteractionTracking
   # Only update attention_needed_since if the client did not already need attention.
   def record_incoming_interaction
     touches = [:last_incoming_interaction_at, :last_interaction_at]
-    touches.push(:first_unanswered_incoming_correspondence_at) unless client.first_unanswered_incoming_correspondence_at.present?
+    touches.push(:first_unanswered_incoming_interaction_at) unless client.first_unanswered_incoming_interaction_at.present?
     touches.push(:attention_needed_since) unless client.attention_needed_since.present?
     client&.touch(*touches)
   end
@@ -15,7 +15,7 @@ module InteractionTracking
     client&.update(
       last_interaction_at: Time.now.to_datetime,
       attention_needed_since: nil,
-      first_unanswered_incoming_correspondence_at: nil, # we've explicitly responded to them somehow, so we can clear this value.
+      first_unanswered_incoming_interaction_at: nil, # we've explicitly responded to them somehow, so we can clear this value.
     )
   end
 

--- a/app/models/concerns/interaction_tracking.rb
+++ b/app/models/concerns/interaction_tracking.rb
@@ -5,6 +5,7 @@ module InteractionTracking
   # Only update attention_needed_since if the client did not already need attention.
   def record_incoming_interaction
     touches = [:last_incoming_interaction_at, :last_interaction_at]
+    touches.push(:first_unanswered_incoming_correspondence_at) unless client.first_unanswered_incoming_correspondence_at.present?
     touches.push(:attention_needed_since) unless client.attention_needed_since.present?
     client&.touch(*touches)
   end
@@ -13,7 +14,8 @@ module InteractionTracking
   def record_outgoing_interaction
     client&.update(
       last_interaction_at: Time.now.to_datetime,
-      attention_needed_since: nil
+      attention_needed_since: nil,
+      first_unanswered_incoming_correspondence_at: nil, # we've explicitly responded to them somehow, so we can clear this value.
     )
   end
 

--- a/app/services/sla_breach_service.rb
+++ b/app/services/sla_breach_service.rb
@@ -4,18 +4,18 @@ class SLABreachService
     @report_generated_at = Time.now.utc
   end
 
-  def breach_threshold
+  def breach_threshold_date
     3.business_days.before(@report_generated_at)
   end
 
   # attention_needed_since is present and is before breach threshold
   # returns data in the format { vita_partner_id: breach_count }
   def attention_needed_breaches
-    Client.sla_tracked.group(:vita_partner_id).where(Client.arel_table[:attention_needed_since].lteq(breach_threshold)).count(:id)
+    Client.sla_tracked.group(:vita_partner_id).where(Client.arel_table[:attention_needed_since].lteq(breach_threshold_date)).count(:id)
   end
 
   # clients who messaged us and have not been responded to _with a message, call or email_ within the breach threshold
   def outgoing_communication_breaches
-    Client.sla_tracked.group(:vita_partner_id).where(Client.arel_table[:first_unanswered_incoming_interaction_at].lteq(breach_threshold)).count(:id)
+    Client.sla_tracked.group(:vita_partner_id).where(Client.arel_table[:first_unanswered_incoming_interaction_at].lteq(breach_threshold_date)).count(:id)
   end
 end

--- a/app/services/sla_breach_service.rb
+++ b/app/services/sla_breach_service.rb
@@ -16,6 +16,6 @@ class SLABreachService
 
   # clients who messaged us and have not been responded to _with a message, call or email_ within the breach threshold
   def outgoing_communication_breaches
-    Client.sla_tracked.group(:vita_partner_id).where(Client.arel_table[:first_unanswered_incoming_correspondence_at].lteq(breach_threshold)).count(:id)
+    Client.sla_tracked.group(:vita_partner_id).where(Client.arel_table[:first_unanswered_incoming_interaction_at].lteq(breach_threshold)).count(:id)
   end
 end

--- a/app/services/sla_breach_service.rb
+++ b/app/services/sla_breach_service.rb
@@ -10,7 +10,12 @@ class SLABreachService
 
   # attention_needed_since is present and is before breach threshold
   # returns data in the format { vita_partner_id: breach_count }
-  def attention_needed_breach
+  def attention_needed_breaches
     Client.sla_tracked.group(:vita_partner_id).where(Client.arel_table[:attention_needed_since].lteq(breach_threshold)).count(:id)
+  end
+
+  # clients who messaged us and have not been responded to _with a message, call or email_ within the breach threshold
+  def outgoing_communication_breaches
+    Client.sla_tracked.group(:vita_partner_id).where(Client.arel_table[:first_unanswered_incoming_correspondence_at].lteq(breach_threshold)).count(:id)
   end
 end

--- a/app/views/hub/metrics/index.html.erb
+++ b/app/views/hub/metrics/index.html.erb
@@ -9,10 +9,6 @@
       <div style="margin:0">
         <strong>Breach threshold:<br/></strong>
         <%= @attention_needed.breach_threshold.strftime("%a %m/%d/%Y") %> at <%= formatted_time(@attention_needed.breach_threshold) %>
-<<<<<<< HEAD
-
-=======
->>>>>>> Fix timezone casting problem in controller
       </div>
     </div>
   </div>

--- a/app/views/hub/metrics/index.html.erb
+++ b/app/views/hub/metrics/index.html.erb
@@ -9,6 +9,7 @@
       <div style="margin:0">
         <strong>Breach threshold:<br/></strong>
         <%= @attention_needed.breach_threshold.strftime("%a %m/%d/%Y") %> at <%= formatted_time(@attention_needed.breach_threshold) %>
+
       </div>
     </div>
   </div>

--- a/app/views/hub/metrics/index.html.erb
+++ b/app/views/hub/metrics/index.html.erb
@@ -9,7 +9,10 @@
       <div style="margin:0">
         <strong>Breach threshold:<br/></strong>
         <%= @attention_needed.breach_threshold.strftime("%a %m/%d/%Y") %> at <%= formatted_time(@attention_needed.breach_threshold) %>
+<<<<<<< HEAD
 
+=======
+>>>>>>> Fix timezone casting problem in controller
       </div>
     </div>
   </div>

--- a/app/views/hub/metrics/index.html.erb
+++ b/app/views/hub/metrics/index.html.erb
@@ -4,11 +4,11 @@
     <div style="display: flex" class="spacing-below-25">
       <div style="margin:0; margin-right: 20px">
         <strong>Report run at:<br/></strong>
-        <%= @attention_needed.current_as_of.strftime("%a %m/%d/%Y") %> at <%= formatted_time(@attention_needed.breach_threshold) %>
+        <%= @attention_needed.current_as_of.strftime("%a %m/%d/%Y") %> at <%= formatted_time(@attention_needed.breach_threshold_date) %>
       </div>
       <div style="margin:0">
         <strong>Breach threshold:<br/></strong>
-        <%= @attention_needed.breach_threshold.strftime("%a %m/%d/%Y") %> at <%= formatted_time(@attention_needed.breach_threshold) %>
+        <%= @attention_needed.breach_threshold_date.strftime("%a %m/%d/%Y") %> at <%= formatted_time(@attention_needed.breach_threshold_date) %>
       </div>
     </div>
   </div>

--- a/db/migrate/20210210212319_add_first_unanswered_incoming_interaction_to_client.rb
+++ b/db/migrate/20210210212319_add_first_unanswered_incoming_interaction_to_client.rb
@@ -1,0 +1,5 @@
+class AddFirstUnansweredIncomingInteractionToClient < ActiveRecord::Migration[6.0]
+  def change
+    add_column :clients, :first_unanswered_incoming_interaction_at, :datetime
+  end
+end

--- a/db/migrate/20210210212319_add_first_unanswered_incoming_message_to_client.rb
+++ b/db/migrate/20210210212319_add_first_unanswered_incoming_message_to_client.rb
@@ -1,0 +1,5 @@
+class AddFirstUnansweredIncomingMessageToClient < ActiveRecord::Migration[6.0]
+  def change
+    add_column :clients, :first_unanswered_incoming_correspondence_at, :datetime
+  end
+end

--- a/db/migrate/20210210212319_add_first_unanswered_incoming_message_to_client.rb
+++ b/db/migrate/20210210212319_add_first_unanswered_incoming_message_to_client.rb
@@ -1,5 +1,0 @@
-class AddFirstUnansweredIncomingMessageToClient < ActiveRecord::Migration[6.0]
-  def change
-    add_column :clients, :first_unanswered_incoming_correspondence_at, :datetime
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -80,7 +80,7 @@ ActiveRecord::Schema.define(version: 2021_02_10_212319) do
     t.datetime "current_sign_in_at"
     t.inet "current_sign_in_ip"
     t.integer "failed_attempts", default: 0, null: false
-    t.datetime "first_unanswered_incoming_correspondence_at"
+    t.datetime "first_unanswered_incoming_interaction_at"
     t.datetime "last_incoming_interaction_at"
     t.datetime "last_interaction_at"
     t.datetime "last_sign_in_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_09_221455) do
+ActiveRecord::Schema.define(version: 2021_02_10_212319) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -80,6 +80,7 @@ ActiveRecord::Schema.define(version: 2021_02_09_221455) do
     t.datetime "current_sign_in_at"
     t.inet "current_sign_in_ip"
     t.integer "failed_attempts", default: 0, null: false
+    t.datetime "first_unanswered_incoming_correspondence_at"
     t.datetime "last_incoming_interaction_at"
     t.datetime "last_interaction_at"
     t.datetime "last_sign_in_at"

--- a/lib/tasks/fuica.rake
+++ b/lib/tasks/fuica.rake
@@ -1,0 +1,16 @@
+namespace :fuica do
+  describe "seeds appropriate fuica value onto all existing clients."
+  task "seed" => :environment do
+    client_groups = Client.all.size / 1000
+    puts("client count", Client.all.size)
+    # break job into separate processable jobs in batches of 1000.
+    (0..Client.all.size).step(1000) do |i|
+
+      next if i > Client.last.id
+
+      start = i * 1000
+      finish = start + 999
+      GenerateUnansweredIncomingMessageDataJob.perform_later(start: start, finish: finish)
+    end
+  end
+end

--- a/spec/controllers/hub/metrics_controller_spec.rb
+++ b/spec/controllers/hub/metrics_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Hub::MetricsController do
   describe '#index' do
-    let(:sla_service_double) { double }
+    let(:sla_service_double) { instance_double(SLABreachService) }
     let(:vita_partner_1) { create :vita_partner, name: "Vita Partner 1" }
     let(:vita_partner_2) { create :vita_partner, name: "Vita Partner 2" }
     let(:vita_partner_3) { create :vita_partner, name: "Vita Partner 3" }
@@ -14,7 +14,7 @@ describe Hub::MetricsController do
       allow(SLABreachService).to receive(:new).and_return(sla_service_double)
       allow(sla_service_double).to receive(:report_generated_at).and_return generated_at
       allow(sla_service_double).to receive(:breach_threshold).and_return breach_threshold
-      allow(sla_service_double).to receive(:attention_needed_breach).and_return breach_data
+      allow(sla_service_double).to receive(:attention_needed_breaches).and_return breach_data
     end
 
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :index

--- a/spec/controllers/hub/metrics_controller_spec.rb
+++ b/spec/controllers/hub/metrics_controller_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 describe Hub::MetricsController do
   describe '#index' do
-    it_behaves_like :a_get_action_for_authenticated_users_only, action: :index
     let(:sla_service_double) { double }
     let(:vita_partner_1) { create :vita_partner, name: "Vita Partner 1" }
     let(:vita_partner_2) { create :vita_partner, name: "Vita Partner 2" }
@@ -10,12 +9,16 @@ describe Hub::MetricsController do
     let(:generated_at) { DateTime.new(2020, 9, 2) }
     let(:breach_threshold) { DateTime.new(2020, 8, 30) }
     let(:breach_data) {{ vita_partner_1.id => 2, vita_partner_2.id => 1} }
+
     before do
       allow(SLABreachService).to receive(:new).and_return(sla_service_double)
       allow(sla_service_double).to receive(:report_generated_at).and_return generated_at
       allow(sla_service_double).to receive(:breach_threshold).and_return breach_threshold
       allow(sla_service_double).to receive(:attention_needed_breach).and_return breach_data
     end
+
+    it_behaves_like :a_get_action_for_authenticated_users_only, action: :index
+
     context 'when authenticated as an admin' do
       before do
         sign_in (create :admin_user)

--- a/spec/controllers/hub/metrics_controller_spec.rb
+++ b/spec/controllers/hub/metrics_controller_spec.rb
@@ -7,13 +7,13 @@ describe Hub::MetricsController do
     let(:vita_partner_2) { create :vita_partner, name: "Vita Partner 2" }
     let(:vita_partner_3) { create :vita_partner, name: "Vita Partner 3" }
     let(:generated_at) { DateTime.new(2020, 9, 2) }
-    let(:breach_threshold) { DateTime.new(2020, 8, 30) }
+    let(:breach_threshold_date) { DateTime.new(2020, 8, 30) }
     let(:breach_data) {{ vita_partner_1.id => 2, vita_partner_2.id => 1} }
 
     before do
       allow(SLABreachService).to receive(:new).and_return(sla_service_double)
       allow(sla_service_double).to receive(:report_generated_at).and_return generated_at
-      allow(sla_service_double).to receive(:breach_threshold).and_return breach_threshold
+      allow(sla_service_double).to receive(:breach_threshold_date).and_return breach_threshold_date
       allow(sla_service_double).to receive(:attention_needed_breaches).and_return breach_data
     end
 
@@ -32,7 +32,7 @@ describe Hub::MetricsController do
       it 'makes appropriate data accessible to the template' do
         get :index
         expect(assigns(:attention_needed).current_as_of).to eq generated_at
-        expect(assigns(:attention_needed).breach_threshold).to eq breach_threshold
+        expect(assigns(:attention_needed).breach_threshold_date).to eq breach_threshold_date
         expect(assigns(:attention_needed).total_breaches).to eq 3
         expect(assigns(:attention_needed).breach_counts).to eq breach_data
       end
@@ -50,7 +50,7 @@ describe Hub::MetricsController do
         get :index
 
         expect(assigns(:attention_needed).current_as_of).to eq generated_at
-        expect(assigns(:attention_needed).breach_threshold).to eq breach_threshold
+        expect(assigns(:attention_needed).breach_threshold_date).to eq breach_threshold_date
         expect(assigns(:attention_needed).total_breaches).to eq 2
         expect(assigns(:attention_needed).breach_counts).to eq breach_data
       end

--- a/spec/factories/clients.rb
+++ b/spec/factories/clients.rb
@@ -2,24 +2,24 @@
 #
 # Table name: clients
 #
-#  id                                          :bigint           not null, primary key
-#  attention_needed_since                      :datetime
-#  current_sign_in_at                          :datetime
-#  current_sign_in_ip                          :inet
-#  failed_attempts                             :integer          default(0), not null
-#  first_unanswered_incoming_correspondence_at :datetime
-#  last_incoming_interaction_at                :datetime
-#  last_interaction_at                         :datetime
-#  last_sign_in_at                             :datetime
-#  last_sign_in_ip                             :inet
-#  locked_at                                   :datetime
-#  login_requested_at                          :datetime
-#  login_token                                 :string
-#  routing_method                              :integer
-#  sign_in_count                               :integer          default(0), not null
-#  created_at                                  :datetime         not null
-#  updated_at                                  :datetime         not null
-#  vita_partner_id                             :bigint
+#  id                                       :bigint           not null, primary key
+#  attention_needed_since                   :datetime
+#  current_sign_in_at                       :datetime
+#  current_sign_in_ip                       :inet
+#  failed_attempts                          :integer          default(0), not null
+#  first_unanswered_incoming_interaction_at :datetime
+#  last_incoming_interaction_at             :datetime
+#  last_interaction_at                      :datetime
+#  last_sign_in_at                          :datetime
+#  last_sign_in_ip                          :inet
+#  locked_at                                :datetime
+#  login_requested_at                       :datetime
+#  login_token                              :string
+#  routing_method                           :integer
+#  sign_in_count                            :integer          default(0), not null
+#  created_at                               :datetime         not null
+#  updated_at                               :datetime         not null
+#  vita_partner_id                          :bigint
 #
 # Indexes
 #

--- a/spec/factories/clients.rb
+++ b/spec/factories/clients.rb
@@ -2,23 +2,24 @@
 #
 # Table name: clients
 #
-#  id                           :bigint           not null, primary key
-#  attention_needed_since       :datetime
-#  current_sign_in_at           :datetime
-#  current_sign_in_ip           :inet
-#  failed_attempts              :integer          default(0), not null
-#  last_incoming_interaction_at :datetime
-#  last_interaction_at          :datetime
-#  last_sign_in_at              :datetime
-#  last_sign_in_ip              :inet
-#  locked_at                    :datetime
-#  login_requested_at           :datetime
-#  login_token                  :string
-#  routing_method               :integer
-#  sign_in_count                :integer          default(0), not null
-#  created_at                   :datetime         not null
-#  updated_at                   :datetime         not null
-#  vita_partner_id              :bigint
+#  id                                          :bigint           not null, primary key
+#  attention_needed_since                      :datetime
+#  current_sign_in_at                          :datetime
+#  current_sign_in_ip                          :inet
+#  failed_attempts                             :integer          default(0), not null
+#  first_unanswered_incoming_correspondence_at :datetime
+#  last_incoming_interaction_at                :datetime
+#  last_interaction_at                         :datetime
+#  last_sign_in_at                             :datetime
+#  last_sign_in_ip                             :inet
+#  locked_at                                   :datetime
+#  login_requested_at                          :datetime
+#  login_token                                 :string
+#  routing_method                              :integer
+#  sign_in_count                               :integer          default(0), not null
+#  created_at                                  :datetime         not null
+#  updated_at                                  :datetime         not null
+#  vita_partner_id                             :bigint
 #
 # Indexes
 #

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -2,24 +2,24 @@
 #
 # Table name: clients
 #
-#  id                                          :bigint           not null, primary key
-#  attention_needed_since                      :datetime
-#  current_sign_in_at                          :datetime
-#  current_sign_in_ip                          :inet
-#  failed_attempts                             :integer          default(0), not null
-#  first_unanswered_incoming_correspondence_at :datetime
-#  last_incoming_interaction_at                :datetime
-#  last_interaction_at                         :datetime
-#  last_sign_in_at                             :datetime
-#  last_sign_in_ip                             :inet
-#  locked_at                                   :datetime
-#  login_requested_at                          :datetime
-#  login_token                                 :string
-#  routing_method                              :integer
-#  sign_in_count                               :integer          default(0), not null
-#  created_at                                  :datetime         not null
-#  updated_at                                  :datetime         not null
-#  vita_partner_id                             :bigint
+#  id                                       :bigint           not null, primary key
+#  attention_needed_since                   :datetime
+#  current_sign_in_at                       :datetime
+#  current_sign_in_ip                       :inet
+#  failed_attempts                          :integer          default(0), not null
+#  first_unanswered_incoming_interaction_at :datetime
+#  last_incoming_interaction_at             :datetime
+#  last_interaction_at                      :datetime
+#  last_sign_in_at                          :datetime
+#  last_sign_in_ip                          :inet
+#  locked_at                                :datetime
+#  login_requested_at                       :datetime
+#  login_token                              :string
+#  routing_method                           :integer
+#  sign_in_count                            :integer          default(0), not null
+#  created_at                               :datetime         not null
+#  updated_at                               :datetime         not null
+#  vita_partner_id                          :bigint
 #
 # Indexes
 #

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -2,23 +2,24 @@
 #
 # Table name: clients
 #
-#  id                           :bigint           not null, primary key
-#  attention_needed_since       :datetime
-#  current_sign_in_at           :datetime
-#  current_sign_in_ip           :inet
-#  failed_attempts              :integer          default(0), not null
-#  last_incoming_interaction_at :datetime
-#  last_interaction_at          :datetime
-#  last_sign_in_at              :datetime
-#  last_sign_in_ip              :inet
-#  locked_at                    :datetime
-#  login_requested_at           :datetime
-#  login_token                  :string
-#  routing_method               :integer
-#  sign_in_count                :integer          default(0), not null
-#  created_at                   :datetime         not null
-#  updated_at                   :datetime         not null
-#  vita_partner_id              :bigint
+#  id                                          :bigint           not null, primary key
+#  attention_needed_since                      :datetime
+#  current_sign_in_at                          :datetime
+#  current_sign_in_ip                          :inet
+#  failed_attempts                             :integer          default(0), not null
+#  first_unanswered_incoming_correspondence_at :datetime
+#  last_incoming_interaction_at                :datetime
+#  last_interaction_at                         :datetime
+#  last_sign_in_at                             :datetime
+#  last_sign_in_ip                             :inet
+#  locked_at                                   :datetime
+#  login_requested_at                          :datetime
+#  login_token                                 :string
+#  routing_method                              :integer
+#  sign_in_count                               :integer          default(0), not null
+#  created_at                                  :datetime         not null
+#  updated_at                                  :datetime         not null
+#  vita_partner_id                             :bigint
 #
 # Indexes
 #

--- a/spec/services/sla_breach_service_spec.rb
+++ b/spec/services/sla_breach_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe SLABreachService do
-  describe "#breach_threshold" do
+  describe "#breach_threshold_date" do
     after do
       Timecop.return
     end
@@ -13,7 +13,7 @@ describe SLABreachService do
       end
 
       it "time is 2/8/11, Monday at 10:05am UTC (2:05am PST)" do
-        expect(subject.breach_threshold).to eq Time.utc(2021, 2, 8, 10, 5, 0)
+        expect(subject.breach_threshold_date).to eq Time.utc(2021, 2, 8, 10, 5, 0)
       end
     end
 
@@ -24,7 +24,7 @@ describe SLABreachService do
       end
 
       it "time is Monday at 6:05pm  UTC" do
-        expect(subject.breach_threshold).to eq Time.utc(2021, 2, 8, 18, 5, 0)
+        expect(subject.breach_threshold_date).to eq Time.utc(2021, 2, 8, 18, 5, 0)
       end
     end
 
@@ -35,7 +35,7 @@ describe SLABreachService do
       end
 
       it "time is previous Friday at 10:05 am UTC" do
-        expect(subject.breach_threshold).to eq Time.utc(2021, 2, 5, 10, 5)
+        expect(subject.breach_threshold_date).to eq Time.utc(2021, 2, 5, 10, 5)
       end
     end
 
@@ -46,7 +46,7 @@ describe SLABreachService do
       end
 
       it "time is previous Friday at 6:05pm UTC" do
-        expect(described_class.new.breach_threshold).to eq Time.utc(2021, 2, 5, 18, 5)
+        expect(described_class.new.breach_threshold_date).to eq Time.utc(2021, 2, 5, 18, 5)
 
       end
     end
@@ -111,7 +111,7 @@ describe SLABreachService do
 
       context "on Monday @10:05am UTC" do
         it 'returns a hash of total SLA breaches of attention_needed_breach_since by vita_partner_id' do
-          expect(subject.breach_threshold).to eq(Time.utc(2021, 2, 3, 10, 5)) # Wednesday 2/3/21 @ 10:05am UTC
+          expect(subject.breach_threshold_date).to eq(Time.utc(2021, 2, 3, 10, 5)) # Wednesday 2/3/21 @ 10:05am UTC
           expect(subject.attention_needed_breaches).to eq(
             {
               vita_partner_1.id => 1,
@@ -125,7 +125,7 @@ describe SLABreachService do
         it "trips the 10:55am client into SLA breach" do
           t = Time.utc(2021, 2, 6, 0, 0, 0) # 2/6/21
           Timecop.freeze(t.next_occurring(:monday) + 11.hours + 25.minutes) do
-            expect(subject.breach_threshold).to eq(Time.utc(2021, 2, 3, 11, 25)) # Wednesday 2/3/21 @ 11:25am UTC
+            expect(subject.breach_threshold_date).to eq(Time.utc(2021, 2, 3, 11, 25)) # Wednesday 2/3/21 @ 11:25am UTC
             expect(subject.attention_needed_breaches).to eq(
               {
                 vita_partner_1.id => 1,
@@ -196,7 +196,7 @@ describe SLABreachService do
 
       context "on Monday @10:05am UTC" do
         it 'returns a hash of total SLA breaches of attention_needed_breacheseses_since by vita_partner_id' do
-          expect(subject.breach_threshold).to eq(Time.utc(2021, 2, 3, 10, 5)) # Wednesday 2/3/21 @ 10:05am UTC
+          expect(subject.breach_threshold_date).to eq(Time.utc(2021, 2, 3, 10, 5)) # Wednesday 2/3/21 @ 10:05am UTC
           expect(subject.outgoing_communication_breaches).to eq(
             {
               vita_partner_1.id => 1,
@@ -210,7 +210,7 @@ describe SLABreachService do
         it "trips the 10:55am client into SLA breach" do
           t = Time.utc(2021, 2, 6, 0, 0, 0) # 2/6/21
           Timecop.freeze(t.next_occurring(:monday) + 11.hours + 25.minutes) do
-            expect(subject.breach_threshold).to eq(Time.utc(2021, 2, 3, 11, 25)) # Wednesday 2/3/21 @ 11:25am UTC
+            expect(subject.breach_threshold_date).to eq(Time.utc(2021, 2, 3, 11, 25)) # Wednesday 2/3/21 @ 11:25am UTC
             expect(subject.outgoing_communication_breaches).to eq(
               {
                 vita_partner_1.id => 1,

--- a/spec/services/sla_breach_service_spec.rb
+++ b/spec/services/sla_breach_service_spec.rb
@@ -12,8 +12,13 @@ describe SLABreachService do
         Timecop.freeze(t)
       end
 
+<<<<<<< HEAD
       it "time is 2/8/11, Monday at 10:05am UTC (2:05am PST)" do
         expect(subject.breach_threshold).to eq Time.utc(2021, 2, 8, 10, 5, 0)
+=======
+      it "time is 2/8/11, Monday at 10:00am UTC (2:05am PST)" do
+        expect(subject.breach_threshold).to eq Time.utc(2021, 2, 8, 10, 0, 0)
+>>>>>>> Breach dashboard for needs attention breaches
       end
     end
 
@@ -23,8 +28,13 @@ describe SLABreachService do
         Timecop.freeze(t)
       end
 
+<<<<<<< HEAD
       it "time is Monday at 6:05pm  UTC" do
         expect(subject.breach_threshold).to eq Time.utc(2021, 2, 8, 18, 5, 0)
+=======
+      it "time is Monday at 6:00pm" do
+        expect(subject.breach_threshold).to eq Time.utc(2021, 2, 8, 18)
+>>>>>>> Breach dashboard for needs attention breaches
       end
     end
 
@@ -34,8 +44,13 @@ describe SLABreachService do
         Timecop.freeze(t)
       end
 
+<<<<<<< HEAD
       it "time is previous Friday at 10:05 am UTC" do
         expect(subject.breach_threshold).to eq Time.utc(2021, 2, 5, 10, 5)
+=======
+      it "time is previous Friday at 10:00 am UTC" do
+        expect(subject.breach_threshold).to eq Time.utc(2021, 2, 5, 10)
+>>>>>>> Breach dashboard for needs attention breaches
       end
     end
 
@@ -46,7 +61,11 @@ describe SLABreachService do
       end
 
       it "time is previous Friday at 6:05pm UTC" do
+<<<<<<< HEAD
         expect(described_class.new.breach_threshold).to eq Time.utc(2021, 2, 5, 18, 5)
+=======
+        expect(described_class.new.breach_threshold).to eq Time.utc(2021, 2, 5, 18)
+>>>>>>> Breach dashboard for needs attention breaches
       end
     end
   end
@@ -76,10 +95,18 @@ describe SLABreachService do
       end
 
       it 'returns a hash of total SLA breaches of attention_needed_breach_since by vita_partner_id' do
+<<<<<<< HEAD
         expect(subject.attention_needed_breach).to eq(
           {
               vita_partner_1.id => 1,
               vita_partner_2.id => 2
+=======
+        # puts SLABreachService.breach_threshold
+        expect(described_class.attention_needed_breach).to eq(
+          {
+              vita_partner_1 => 1,
+              vita_partner_2 => 2
+>>>>>>> Breach dashboard for needs attention breaches
           }
         )
       end
@@ -109,11 +136,19 @@ describe SLABreachService do
 
       context "on Monday @10:05am UTC"
       it 'returns a hash of total SLA breaches of attention_needed_breach_since by vita_partner_id' do
+<<<<<<< HEAD
         expect(subject.breach_threshold).to eq(Time.utc(2021, 2, 3, 10, 5)) # Wednesday 2/3/21 @ 10:05am UTC
         expect(subject.attention_needed_breach).to eq(
           {
               vita_partner_1.id => 1,
               vita_partner_2.id => 2
+=======
+        expect(subject.breach_threshold).to eq(Time.utc(2021, 2, 3, 10)) # Wednesday 2/3/21 @ 10:00am UTC
+        expect(subject.attention_needed_breach).to eq(
+          {
+              vita_partner_1 => 1,
+              vita_partner_2 => 2
+>>>>>>> Breach dashboard for needs attention breaches
           }
         )
       end
@@ -122,11 +157,19 @@ describe SLABreachService do
         it "trips the 10:55am client into SLA breach" do
           t = Time.utc(2021, 2, 6, 0, 0, 0) # 2/6/21
           Timecop.freeze(t.next_occurring(:monday) + 11.hours + 25.minutes) do
+<<<<<<< HEAD
             expect(subject.breach_threshold).to eq(Time.utc(2021, 2, 3, 11, 25)) # Wednesday 2/3/21 @ 11:25am UTC
             expect(subject.attention_needed_breach).to eq(
               {
                 vita_partner_1.id => 1,
                 vita_partner_2.id => 3
+=======
+            expect(subject.breach_threshold).to eq(Time.utc(2021, 2, 3, 11)) # Wednesday 2/3/21 @ 11:00am UTC
+            expect(subject.attention_needed_breach).to eq(
+              {
+                vita_partner_1 => 1,
+                vita_partner_2 => 3
+>>>>>>> Breach dashboard for needs attention breaches
               }
             )
           end

--- a/spec/services/sla_breach_service_spec.rb
+++ b/spec/services/sla_breach_service_spec.rb
@@ -147,15 +147,15 @@ describe SLABreachService do
         t = Time.utc(2021, 2, 6, 10, 5) # 2/6/21, Saturday
         Timecop.freeze(t.prev_occurring(:friday)) # 2/5/21, Friday
         # breaches at vita_partner_1
-        create(:client, first_unanswered_incoming_correspondence_at: t.prev_occurring(:monday), vita_partner_id: vita_partner_1.id, tax_returns: [create(:tax_return, status: 'prep_ready_for_prep')]) # breach
+        create(:client, first_unanswered_incoming_interaction_at: t.prev_occurring(:monday), vita_partner_id: vita_partner_1.id, tax_returns: [create(:tax_return, status: 'prep_ready_for_prep')]) # breach
 
         # breaches at vita_partner_2
-        create(:client, first_unanswered_incoming_correspondence_at: 6.days.ago, vita_partner_id: vita_partner_2.id, tax_returns: [create(:tax_return, status: 'prep_ready_for_prep')]) # breach
-        create(:client, first_unanswered_incoming_correspondence_at: t.prev_occurring(:monday), vita_partner_id: vita_partner_2.id, tax_returns:  [create(:tax_return, status: 'prep_ready_for_prep')]) # breach
+        create(:client, first_unanswered_incoming_interaction_at: 6.days.ago, vita_partner_id: vita_partner_2.id, tax_returns: [create(:tax_return, status: 'prep_ready_for_prep')]) # breach
+        create(:client, first_unanswered_incoming_interaction_at: t.prev_occurring(:monday), vita_partner_id: vita_partner_2.id, tax_returns:  [create(:tax_return, status: 'prep_ready_for_prep')]) # breach
 
         # not in breach
-        create(:client, first_unanswered_incoming_correspondence_at: t.prev_occurring(:wednesday), vita_partner_id: vita_partner_2.id,  tax_returns: [create(:tax_return, status: 'prep_ready_for_prep')]) # no breach
-        create(:client, first_unanswered_incoming_correspondence_at: nil, vita_partner_id: vita_partner_2.id, tax_returns:  [create(:tax_return, status: 'prep_ready_for_prep')]) # no breach
+        create(:client, first_unanswered_incoming_interaction_at: t.prev_occurring(:wednesday), vita_partner_id: vita_partner_2.id,  tax_returns: [create(:tax_return, status: 'prep_ready_for_prep')]) # no breach
+        create(:client, first_unanswered_incoming_interaction_at: nil, vita_partner_id: vita_partner_2.id, tax_returns:  [create(:tax_return, status: 'prep_ready_for_prep')]) # no breach
       end
 
       after do
@@ -177,17 +177,17 @@ describe SLABreachService do
         t = Time.utc(2021, 2, 6, 0, 0, 0) # 2/6/21
         Timecop.freeze(t.next_occurring(:monday) + 10.hours + 5.minutes) # 2/8/21, Monday 10:05am
         # breaches at vita_partner_1
-        create(:client, first_unanswered_incoming_correspondence_at: t.prev_occurring(:monday), vita_partner_id: vita_partner_1.id, tax_returns:  [create(:tax_return, status: 'prep_ready_for_prep')]) # breach
+        create(:client, first_unanswered_incoming_interaction_at: t.prev_occurring(:monday), vita_partner_id: vita_partner_1.id, tax_returns:  [create(:tax_return, status: 'prep_ready_for_prep')]) # breach
         # breaches at vita_partner_2
-        create(:client, first_unanswered_incoming_correspondence_at: 6.days.ago, vita_partner_id: vita_partner_2.id, tax_returns:  [create(:tax_return, status: 'prep_ready_for_prep')]) # breach
+        create(:client, first_unanswered_incoming_interaction_at: 6.days.ago, vita_partner_id: vita_partner_2.id, tax_returns:  [create(:tax_return, status: 'prep_ready_for_prep')]) # breach
         wednesday_1am = t.prev_occurring(:wednesday) + 1.hour # Wednesday 2/3/21 @ 1:00am UTC
-        create(:client, first_unanswered_incoming_correspondence_at: wednesday_1am, vita_partner_id: vita_partner_2.id, tax_returns:  [create(:tax_return, status: 'prep_ready_for_prep')]) # breach
+        create(:client, first_unanswered_incoming_interaction_at: wednesday_1am, vita_partner_id: vita_partner_2.id, tax_returns:  [create(:tax_return, status: 'prep_ready_for_prep')]) # breach
 
         wednesday_1055am = t.prev_occurring(:wednesday) + 10.hour + 55.minutes # Wednesday 2/3/21 @ 10:55am UTC
-        create(:client, first_unanswered_incoming_correspondence_at: wednesday_1055am, vita_partner_id: vita_partner_2.id, tax_returns: [create(:tax_return, status: 'prep_ready_for_prep')]) # not in breach t1, in breach t2
+        create(:client, first_unanswered_incoming_interaction_at: wednesday_1055am, vita_partner_id: vita_partner_2.id, tax_returns: [create(:tax_return, status: 'prep_ready_for_prep')]) # not in breach t1, in breach t2
 
         # not in breach
-        create(:client, first_unanswered_incoming_correspondence_at: nil, vita_partner_id: vita_partner_2.id, tax_returns: [create(:tax_return, status: 'prep_ready_for_prep')]) # no breach
+        create(:client, first_unanswered_incoming_interaction_at: nil, vita_partner_id: vita_partner_2.id, tax_returns: [create(:tax_return, status: 'prep_ready_for_prep')]) # no breach
       end
 
       after do

--- a/spec/services/sla_breach_service_spec.rb
+++ b/spec/services/sla_breach_service_spec.rb
@@ -12,13 +12,8 @@ describe SLABreachService do
         Timecop.freeze(t)
       end
 
-<<<<<<< HEAD
       it "time is 2/8/11, Monday at 10:05am UTC (2:05am PST)" do
         expect(subject.breach_threshold).to eq Time.utc(2021, 2, 8, 10, 5, 0)
-=======
-      it "time is 2/8/11, Monday at 10:00am UTC (2:05am PST)" do
-        expect(subject.breach_threshold).to eq Time.utc(2021, 2, 8, 10, 0, 0)
->>>>>>> Breach dashboard for needs attention breaches
       end
     end
 
@@ -28,13 +23,8 @@ describe SLABreachService do
         Timecop.freeze(t)
       end
 
-<<<<<<< HEAD
       it "time is Monday at 6:05pm  UTC" do
         expect(subject.breach_threshold).to eq Time.utc(2021, 2, 8, 18, 5, 0)
-=======
-      it "time is Monday at 6:00pm" do
-        expect(subject.breach_threshold).to eq Time.utc(2021, 2, 8, 18)
->>>>>>> Breach dashboard for needs attention breaches
       end
     end
 
@@ -44,14 +34,9 @@ describe SLABreachService do
         Timecop.freeze(t)
       end
 
-<<<<<<< HEAD
       it "time is previous Friday at 10:05 am UTC" do
         expect(subject.breach_threshold).to eq Time.utc(2021, 2, 5, 10, 5)
-=======
-      it "time is previous Friday at 10:00 am UTC" do
-        expect(subject.breach_threshold).to eq Time.utc(2021, 2, 5, 10)
->>>>>>> Breach dashboard for needs attention breaches
-      end
+
     end
 
     context "running on a Wednesday at 6:05pm UTC" do
@@ -61,15 +46,12 @@ describe SLABreachService do
       end
 
       it "time is previous Friday at 6:05pm UTC" do
-<<<<<<< HEAD
         expect(described_class.new.breach_threshold).to eq Time.utc(2021, 2, 5, 18, 5)
-=======
-        expect(described_class.new.breach_threshold).to eq Time.utc(2021, 2, 5, 18)
->>>>>>> Breach dashboard for needs attention breaches
+
       end
     end
   end
-
+  end
   describe '.attention_needed_breach' do
     let(:vita_partner_1) { create(:organization) }
     let(:vita_partner_2) { create(:organization) }
@@ -95,18 +77,11 @@ describe SLABreachService do
       end
 
       it 'returns a hash of total SLA breaches of attention_needed_breach_since by vita_partner_id' do
-<<<<<<< HEAD
+
         expect(subject.attention_needed_breach).to eq(
           {
               vita_partner_1.id => 1,
               vita_partner_2.id => 2
-=======
-        # puts SLABreachService.breach_threshold
-        expect(described_class.attention_needed_breach).to eq(
-          {
-              vita_partner_1 => 1,
-              vita_partner_2 => 2
->>>>>>> Breach dashboard for needs attention breaches
           }
         )
       end
@@ -134,42 +109,26 @@ describe SLABreachService do
         Timecop.return
       end
 
-      context "on Monday @10:05am UTC"
-      it 'returns a hash of total SLA breaches of attention_needed_breach_since by vita_partner_id' do
-<<<<<<< HEAD
+      context "on Monday @10:05am UTC" do
+        it 'returns a hash of total SLA breaches of attention_needed_breach_since by vita_partner_id' do
         expect(subject.breach_threshold).to eq(Time.utc(2021, 2, 3, 10, 5)) # Wednesday 2/3/21 @ 10:05am UTC
         expect(subject.attention_needed_breach).to eq(
           {
               vita_partner_1.id => 1,
               vita_partner_2.id => 2
-=======
-        expect(subject.breach_threshold).to eq(Time.utc(2021, 2, 3, 10)) # Wednesday 2/3/21 @ 10:00am UTC
-        expect(subject.attention_needed_breach).to eq(
-          {
-              vita_partner_1 => 1,
-              vita_partner_2 => 2
->>>>>>> Breach dashboard for needs attention breaches
           }
         )
       end
-
+      end
       context "on Monday @ 11:25am UTC" do
         it "trips the 10:55am client into SLA breach" do
           t = Time.utc(2021, 2, 6, 0, 0, 0) # 2/6/21
           Timecop.freeze(t.next_occurring(:monday) + 11.hours + 25.minutes) do
-<<<<<<< HEAD
             expect(subject.breach_threshold).to eq(Time.utc(2021, 2, 3, 11, 25)) # Wednesday 2/3/21 @ 11:25am UTC
             expect(subject.attention_needed_breach).to eq(
               {
                 vita_partner_1.id => 1,
                 vita_partner_2.id => 3
-=======
-            expect(subject.breach_threshold).to eq(Time.utc(2021, 2, 3, 11)) # Wednesday 2/3/21 @ 11:00am UTC
-            expect(subject.attention_needed_breach).to eq(
-              {
-                vita_partner_1 => 1,
-                vita_partner_2 => 3
->>>>>>> Breach dashboard for needs attention breaches
               }
             )
           end

--- a/spec/services/sla_breach_service_spec.rb
+++ b/spec/services/sla_breach_service_spec.rb
@@ -36,7 +36,7 @@ describe SLABreachService do
 
       it "time is previous Friday at 10:05 am UTC" do
         expect(subject.breach_threshold).to eq Time.utc(2021, 2, 5, 10, 5)
-
+      end
     end
 
     context "running on a Wednesday at 6:05pm UTC" do
@@ -51,8 +51,6 @@ describe SLABreachService do
       end
     end
   end
-  end
-
 
   describe '.attention_needed_breaches' do
     let(:vita_partner_1) { create(:organization) }

--- a/spec/support/shared_examples/interaction_tracking.rb
+++ b/spec/support/shared_examples/interaction_tracking.rb
@@ -3,6 +3,7 @@ shared_examples_for "an incoming interaction" do
     it "updates the associated client" do
       expect { subject.save }
         .to change(subject.client, :attention_needed_since)
+        .and change(subject.client, :first_unanswered_incoming_correspondence_at)
         .and change(subject.client, :last_incoming_interaction_at)
         .and change(subject.client, :last_interaction_at)
         .and change(subject.client, :updated_at)
@@ -16,8 +17,18 @@ shared_examples_for "an incoming interaction" do
     it "updates the associated client, but does not change attention_needed_since" do
       expect { subject.save }
         .to not_change(subject.client, :attention_needed_since)
+        .and change(subject.client, :first_unanswered_incoming_correspondence_at)
         .and change(subject.client, :last_incoming_interaction_at)
         .and change(subject.client, :last_interaction_at)
+        .and change(subject.client, :updated_at)
+    end
+  end
+
+  context "when first_unanswered_incoming_correspondence value is already set" do
+    before { subject.client.first_unanswered_incoming_correspondence_at = Time.now }
+    it "updates the associated client, but does not change the fuica value" do
+      expect { subject.save }
+        .to not_change(subject.client, :first_unanswered_incoming_correspondence_at)
         .and change(subject.client, :updated_at)
     end
   end
@@ -35,11 +46,15 @@ end
 
 shared_examples_for "an outgoing interaction" do
   # ensure attention_needed_since is set on the client so that we can test that it was cleared properly.
-  before { subject.client.attention_needed_since = Time.now }
+  before do
+    subject.client.attention_needed_since = Time.now
+    subject.client.first_unanswered_incoming_correspondence_at = Time.now
+  end
 
   it "updates the associated client" do
     expect { subject.save }
       .to change(subject.client, :attention_needed_since).to(nil)
+      .and change(subject.client, :first_unanswered_incoming_correspondence_at).to(nil)
       .and change(subject.client, :last_interaction_at)
       .and change(subject.client, :updated_at)
       .and not_change(subject.client, :last_incoming_interaction_at)

--- a/spec/support/shared_examples/interaction_tracking.rb
+++ b/spec/support/shared_examples/interaction_tracking.rb
@@ -3,7 +3,7 @@ shared_examples_for "an incoming interaction" do
     it "updates the associated client" do
       expect { subject.save }
         .to change(subject.client, :attention_needed_since)
-        .and change(subject.client, :first_unanswered_incoming_correspondence_at)
+        .and change(subject.client, :first_unanswered_incoming_interaction_at)
         .and change(subject.client, :last_incoming_interaction_at)
         .and change(subject.client, :last_interaction_at)
         .and change(subject.client, :updated_at)
@@ -17,7 +17,7 @@ shared_examples_for "an incoming interaction" do
     it "updates the associated client, but does not change attention_needed_since" do
       expect { subject.save }
         .to not_change(subject.client, :attention_needed_since)
-        .and change(subject.client, :first_unanswered_incoming_correspondence_at)
+        .and change(subject.client, :first_unanswered_incoming_interaction_at)
         .and change(subject.client, :last_incoming_interaction_at)
         .and change(subject.client, :last_interaction_at)
         .and change(subject.client, :updated_at)
@@ -25,10 +25,10 @@ shared_examples_for "an incoming interaction" do
   end
 
   context "when first_unanswered_incoming_correspondence value is already set" do
-    before { subject.client.first_unanswered_incoming_correspondence_at = Time.now }
+    before { subject.client.first_unanswered_incoming_interaction_at = Time.now }
     it "updates the associated client, but does not change the fuica value" do
       expect { subject.save }
-        .to not_change(subject.client, :first_unanswered_incoming_correspondence_at)
+        .to not_change(subject.client, :first_unanswered_incoming_interaction_at)
         .and change(subject.client, :updated_at)
     end
   end
@@ -48,13 +48,13 @@ shared_examples_for "an outgoing interaction" do
   # ensure attention_needed_since is set on the client so that we can test that it was cleared properly.
   before do
     subject.client.attention_needed_since = Time.now
-    subject.client.first_unanswered_incoming_correspondence_at = Time.now
+    subject.client.first_unanswered_incoming_interaction_at = Time.now
   end
 
   it "updates the associated client" do
     expect { subject.save }
       .to change(subject.client, :attention_needed_since).to(nil)
-      .and change(subject.client, :first_unanswered_incoming_correspondence_at).to(nil)
+      .and change(subject.client, :first_unanswered_incoming_interaction_at).to(nil)
       .and change(subject.client, :last_interaction_at)
       .and change(subject.client, :updated_at)
       .and not_change(subject.client, :last_incoming_interaction_at)


### PR DESCRIPTION
Business stakeholders want to know when the last unresponded to client message was. After considering some ways to query for this, it seemed like a better idea to use a cachetribute to track this. We set / clear this attribute in interaction tracking similarly to the needs_attention notifier. However, it cannot be cleared by anything other than a direct message to the client -- interactions with the profile and manually resolving the indicator won't wipe it out.