### PR TITLE
Restore hard deletion of unlinked users

### DIFF
--- a/app/controllers/hub/users_controller.rb
+++ b/app/controllers/hub/users_controller.rb
@@ -14,14 +14,15 @@ module Hub
     def edit; end
 
     def destroy
-      return
-
       if @user.assigned_tax_returns.exists?
         redirect_to edit_hub_user_path(id: @user), alert: I18n.t("hub.users.destroy.user_has_assignments", name: @user.name, client_id: @user.assigned_tax_returns.first.client_id)
       else
         # For now, raise an error if more things are linked to the user. In the future, we probably want to "suspend" or "archive".
-        @user.role.destroy!
-        @user.destroy!
+        ActiveRecord::Base.transaction do
+          # if user deletion fails, don't destroy their role
+          @user.role.destroy!
+          @user.destroy!
+        end
         redirect_to hub_users_path, notice: I18n.t("hub.users.destroy.success", name: @user.name)
       end
     end

--- a/app/views/hub/users/edit.html.erb
+++ b/app/views/hub/users/edit.html.erb
@@ -4,8 +4,11 @@
 
       <h1><%= @user.name %></h1>
 
-    <% if @user.access_locked? && current_user.admin? %>
-      <%= link_to t("hub.unlock_account"), unlock_hub_user_path(id: @user), method: :patch, class: "button button--danger", data: {confirm: t("hub.unlock_confirmation", name: @user.name )} %>
+    <% if current_user.admin? %>
+      <% if @user.access_locked? %>
+        <%= link_to t("hub.unlock_account"), unlock_hub_user_path(id: @user), method: :patch, class: "button button--danger", data: {confirm: t("hub.unlock_confirmation", name: @user.name )} %>
+      <% end %>
+      <%= link_to t("general.delete"), hub_user_path(id: @user), method: :delete, class: "button button--danger", data: {confirm: t(".delete_confirmation", name: @user.name)} %>
     <% end %>
 
     <%= form_with model: [:hub, @user], method: :put, local: true, builder: VitaMinFormBuilder, html: { class: 'form-card form-card--long' } do |f| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,6 +13,7 @@ en:
     users:
       edit:
         is_admin_label: Admin?
+        delete_confirmation: "Are you sure you want to delete %{name}'s account?"
       index:
         title: Users
         needs_to_accept_invite: "Needs to accept invite"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -13,6 +13,7 @@ es:
     users:
       edit:
         is_admin_label: Admin?
+        delete_confirmation: "¿Desea eliminar la cuenta de %{name}?"
       index:
         title: Usuarios
         needs_to_accept_invite: "Necesita aceptar la invitación"


### PR DESCRIPTION
- This restores the ability to "hard delete" users who aren't linked to notes, tax returns, or messages
- It includes the proper DB transaction scoping to ensure that we don't delete the role when the user can't be deleted.