### PR TITLE
Change migration name to accommodate SLA acronym inflection

### DIFF
--- a/db/migrate/20201021160311_add_sla_fields_to_client.rb
+++ b/db/migrate/20201021160311_add_sla_fields_to_client.rb
@@ -1,4 +1,4 @@
-class AddSlaFieldsToClient < ActiveRecord::Migration[6.0]
+class AddSLAFieldsToClient < ActiveRecord::Migration[6.0]
   def change
     add_column :clients, :last_interaction_at, :datetime
     add_column :clients, :response_needed_since, :datetime


### PR DESCRIPTION
this is teeny tiny and usually i would push to main but am waiting until after launch day

this should only present a problem in cases where one is dropping and recreating their database