### PR TITLE
Check for presence of name before attempting upcasing

### DIFF
--- a/app/views/portal/tax_returns/authorize_signature.html.erb
+++ b/app/views/portal/tax_returns/authorize_signature.html.erb
@@ -6,7 +6,7 @@
   <%= form_for @form, url: portal_tax_return_sign_path, method: :put, local: true, builder: VitaMinFormBuilder do |f| %>
     <div class="consent-checkboxes">
       <%= f.cfa_checkbox(:primary_accepts_terms, t(".efile_acceptance", year: @tax_return.year), options: { checked_value: "yes", unchecked_value: "no", classes: ['checkbox--full-width'] }) %>
-      <%= f.cfa_checkbox(:primary_confirms_identity, t(".efile_identity_primary", name: @tax_return.client.legal_name.upcase, year: @tax_return.year), options: { checked_value: "yes", unchecked_value: "no", classes: ['checkbox--full-width'] }) %>
+      <%= f.cfa_checkbox(:primary_confirms_identity, t(".efile_identity_primary", name: @tax_return.client.legal_name&.upcase, year: @tax_return.year), options: { checked_value: "yes", unchecked_value: "no", classes: ['checkbox--full-width'] }) %>
     </div>
     <%= f.submit "Submit", class: 'button button--primary button--wide' %>
   <% end %>

--- a/app/views/portal/tax_returns/spouse_authorize_signature.html.erb
+++ b/app/views/portal/tax_returns/spouse_authorize_signature.html.erb
@@ -6,7 +6,7 @@
   <%= form_for @form, url: portal_tax_return_spouse_sign_path, method: :put, local: true, builder: VitaMinFormBuilder do |f| %>
     <div class="consent-checkboxes">
       <%= f.cfa_checkbox(:spouse_accepts_terms, t("portal.tax_returns.authorize_signature.efile_acceptance", year: @tax_return.year), options: { checked_value: "yes", unchecked_value: "no", classes: ['checkbox--full-width'] }) %>
-      <%= f.cfa_checkbox(:spouse_confirms_identity, t(".efile_identity_spouse", spouse_name: "#{@tax_return.client.intake.spouse_first_name.upcase} #{@tax_return.client.intake.spouse_last_name.upcase}",primary_name: @tax_return.client.legal_name.upcase, year: @tax_return.year), options: { checked_value: "yes", unchecked_value: "no", classes: ['checkbox--full-width'] }) %>
+      <%= f.cfa_checkbox(:spouse_confirms_identity, t(".efile_identity_spouse", spouse_name: @tax_return.client.spouse_legal_name&.upcase ,primary_name: @tax_return.client.legal_name&.upcase, year: @tax_return.year), options: { checked_value: "yes", unchecked_value: "no", classes: ['checkbox--full-width'] }) %>
     </div>
     <%= f.submit "Submit", class: 'button button--primary button--wide' %>
   <% end %>

--- a/db/migrate/20201021160311_add_sla_fields_to_client.rb
+++ b/db/migrate/20201021160311_add_sla_fields_to_client.rb
@@ -1,4 +1,4 @@
-class AddSlaFieldsToClient < ActiveRecord::Migration[6.0]
+class AddSLAFieldsToClient < ActiveRecord::Migration[6.0]
   def change
     add_column :clients, :last_interaction_at, :datetime
     add_column :clients, :response_needed_since, :datetime


### PR DESCRIPTION
Saw an error come through on upcasing the spouse name. I'm kind of surprised that you can be filing jointly without a spouse first/last name being set (wondering if it was either first or last name that wasn't present), but it never really makes sense to have the template fail because of it, at least.

Went ahead and did an &. for spouse and primary.