### PR TITLE
Remove Zendesk user columns [#176896651]

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,6 @@
 # Table name: users
 #
 #  id                        :bigint           not null, primary key
-#  active                    :boolean
 #  current_sign_in_at        :datetime
 #  current_sign_in_ip        :string
 #  email                     :string           not null
@@ -22,22 +21,16 @@
 #  locked_at                 :datetime
 #  name                      :string
 #  phone_number              :string
-#  provider                  :string
 #  reset_password_sent_at    :datetime
 #  reset_password_token      :string
 #  role_type                 :string           not null
 #  sign_in_count             :integer          default(0), not null
 #  suspended_at              :datetime
-#  ticket_restriction        :string
 #  timezone                  :string           default("America/New_York"), not null
-#  two_factor_auth_enabled   :boolean
-#  uid                       :string
-#  verified                  :boolean
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  invited_by_id             :bigint
 #  role_id                   :bigint           not null
-#  zendesk_user_id           :bigint
 #
 # Indexes
 #

--- a/db/migrate/20210212161309_remove_zendesk_columns_from_users.rb
+++ b/db/migrate/20210212161309_remove_zendesk_columns_from_users.rb
@@ -1,0 +1,11 @@
+class RemoveZendeskColumnsFromUsers < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :users, :provider
+    remove_column :users, :uid
+    remove_column :users, :zendesk_user_id
+    remove_column :users, :ticket_restriction
+    remove_column :users, :two_factor_auth_enabled
+    remove_column :users, :active
+    remove_column :users, :verified
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_12_145650) do
+ActiveRecord::Schema.define(version: 2021_02_12_161309) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -565,7 +565,6 @@ ActiveRecord::Schema.define(version: 2021_02_12_145650) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.boolean "active"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "current_sign_in_at"
     t.string "current_sign_in_ip"
@@ -586,20 +585,14 @@ ActiveRecord::Schema.define(version: 2021_02_12_145650) do
     t.datetime "locked_at"
     t.string "name"
     t.string "phone_number"
-    t.string "provider"
     t.datetime "reset_password_sent_at"
     t.string "reset_password_token"
     t.bigint "role_id", null: false
     t.string "role_type", null: false
     t.integer "sign_in_count", default: 0, null: false
     t.datetime "suspended_at"
-    t.string "ticket_restriction"
     t.string "timezone", default: "America/New_York", null: false
-    t.boolean "two_factor_auth_enabled"
-    t.string "uid"
     t.datetime "updated_at", precision: 6, null: false
-    t.boolean "verified"
-    t.bigint "zendesk_user_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invitations_count"], name: "index_users_on_invitations_count"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,7 +3,6 @@
 # Table name: users
 #
 #  id                        :bigint           not null, primary key
-#  active                    :boolean
 #  current_sign_in_at        :datetime
 #  current_sign_in_ip        :string
 #  email                     :string           not null
@@ -22,22 +21,16 @@
 #  locked_at                 :datetime
 #  name                      :string
 #  phone_number              :string
-#  provider                  :string
 #  reset_password_sent_at    :datetime
 #  reset_password_token      :string
 #  role_type                 :string           not null
 #  sign_in_count             :integer          default(0), not null
 #  suspended_at              :datetime
-#  ticket_restriction        :string
 #  timezone                  :string           default("America/New_York"), not null
-#  two_factor_auth_enabled   :boolean
-#  uid                       :string
-#  verified                  :boolean
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  invited_by_id             :bigint
 #  role_id                   :bigint           not null
-#  zendesk_user_id           :bigint
 #
 # Indexes
 #
@@ -54,7 +47,6 @@
 #
 FactoryBot.define do
   factory :user do
-    sequence(:uid)
     sequence(:email) { |n| "gary.gardengnome#{n}@example.green" }
     sequence(:name) { |n| "Gary Gnome the #{n}th" }
     password { "userExamplePassword" }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,7 +3,6 @@
 # Table name: users
 #
 #  id                        :bigint           not null, primary key
-#  active                    :boolean
 #  current_sign_in_at        :datetime
 #  current_sign_in_ip        :string
 #  email                     :string           not null
@@ -22,22 +21,16 @@
 #  locked_at                 :datetime
 #  name                      :string
 #  phone_number              :string
-#  provider                  :string
 #  reset_password_sent_at    :datetime
 #  reset_password_token      :string
 #  role_type                 :string           not null
 #  sign_in_count             :integer          default(0), not null
 #  suspended_at              :datetime
-#  ticket_restriction        :string
 #  timezone                  :string           default("America/New_York"), not null
-#  two_factor_auth_enabled   :boolean
-#  uid                       :string
-#  verified                  :boolean
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  invited_by_id             :bigint
 #  role_id                   :bigint           not null
-#  zendesk_user_id           :bigint
 #
 # Indexes
 #


### PR DESCRIPTION
These were only used in a factory.

Thanks to @bengolder for noticing it's a good time to remove them.