### PR TITLE
Align email validations and storage

### DIFF
--- a/app/models/incoming_email.rb
+++ b/app/models/incoming_email.rb
@@ -6,7 +6,7 @@
 #  attachment_count   :integer
 #  body_html          :string
 #  body_plain         :string           not null
-#  from               :string           not null
+#  from               :citext           not null
 #  received           :string
 #  received_at        :datetime         not null
 #  recipient          :string           not null
@@ -15,7 +15,7 @@
 #  stripped_signature :string
 #  stripped_text      :string
 #  subject            :string
-#  to                 :string           not null
+#  to                 :citext           not null
 #  user_agent         :string
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -210,6 +210,7 @@ class Intake < ApplicationRecord
 
   scope :completed_yes_no_questions, -> { where.not(completed_yes_no_questions_at: nil) }
 
+  validates :email_address, 'valid_email_2/email': true
   validates :phone_number, :sms_phone_number, allow_blank: true, phone: true, format: { with: /\A\+1[0-9]{10}\z/ }
   validates_presence_of :visitor_id
 

--- a/app/models/outgoing_email.rb
+++ b/app/models/outgoing_email.rb
@@ -6,7 +6,7 @@
 #  body       :string           not null
 #  sent_at    :datetime         not null
 #  subject    :string           not null
-#  to         :string           not null
+#  to         :citext           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  client_id  :bigint           not null

--- a/app/models/signup.rb
+++ b/app/models/signup.rb
@@ -3,7 +3,7 @@
 # Table name: signups
 #
 #  id            :bigint           not null, primary key
-#  email_address :string
+#  email_address :citext
 #  name          :string
 #  phone_number  :string
 #  zip_code      :string
@@ -15,6 +15,7 @@ class Signup < ApplicationRecord
   validate :phone_number_or_email_address
   validates :zip_code, zip_code: true, allow_blank: true
   validates :phone_number, phone: true, allow_blank: true, format: { with: /\A\+1[0-9]{10}\z/ }
+  validates :email_address, 'valid_email_2/email': true
 
   private
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@
 #  id                        :bigint           not null, primary key
 #  current_sign_in_at        :datetime
 #  current_sign_in_ip        :string
-#  email                     :string           not null
+#  email                     :citext           not null
 #  encrypted_access_token    :string
 #  encrypted_access_token_iv :string
 #  encrypted_password        :string           default(""), not null
@@ -58,6 +58,7 @@ class User < ApplicationRecord
 
   before_validation :format_phone_number
   validates :phone_number, phone: true, allow_blank: true, format: { with: /\A\+1[0-9]{10}\z/ }
+  validates :email, 'valid_email_2/email': true
   has_many :assigned_tax_returns, class_name: "TaxReturn", foreign_key: :assigned_user_id
   has_many :access_logs
   belongs_to :role, polymorphic: true

--- a/db/migrate/20210214022857_change_all_emails_to_case_insensitive_text.rb
+++ b/db/migrate/20210214022857_change_all_emails_to_case_insensitive_text.rb
@@ -1,0 +1,17 @@
+class ChangeAllEmailsToCaseInsensitiveText < ActiveRecord::Migration[6.0]
+  def up
+    change_column :signups, :email_address, :citext
+    change_column :users, :email, :citext
+    change_column :outgoing_emails, :to, :citext
+    change_column :incoming_emails, :from, :citext
+    change_column :incoming_emails, :to, :citext
+  end
+
+  def down
+    change_column :signups, :email_address, :string
+    change_column :users, :email, :string
+    change_column :outgoing_emails, :to, :string
+    change_column :incoming_emails, :from, :string
+    change_column :incoming_emails, :to, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_12_171912) do
+ActiveRecord::Schema.define(version: 2021_02_14_022857) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -211,7 +211,7 @@ ActiveRecord::Schema.define(version: 2021_02_12_171912) do
     t.string "body_plain", null: false
     t.bigint "client_id", null: false
     t.datetime "created_at", precision: 6, null: false
-    t.string "from", null: false
+    t.citext "from", null: false
     t.string "message_id"
     t.string "received"
     t.datetime "received_at", null: false
@@ -221,7 +221,7 @@ ActiveRecord::Schema.define(version: 2021_02_12_171912) do
     t.string "stripped_signature"
     t.string "stripped_text"
     t.string "subject"
-    t.string "to", null: false
+    t.citext "to", null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "user_agent"
     t.index ["client_id"], name: "index_incoming_emails_on_client_id"
@@ -458,7 +458,7 @@ ActiveRecord::Schema.define(version: 2021_02_12_171912) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "sent_at", null: false
     t.string "subject", null: false
-    t.string "to", null: false
+    t.citext "to", null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id"
     t.index ["client_id"], name: "index_outgoing_emails_on_client_id"
@@ -489,7 +489,7 @@ ActiveRecord::Schema.define(version: 2021_02_12_171912) do
 
   create_table "signups", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
-    t.string "email_address"
+    t.citext "email_address"
     t.string "name"
     t.string "phone_number"
     t.datetime "updated_at", precision: 6, null: false
@@ -568,7 +568,7 @@ ActiveRecord::Schema.define(version: 2021_02_12_171912) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "current_sign_in_at"
     t.string "current_sign_in_ip"
-    t.string "email", null: false
+    t.citext "email", null: false
     t.string "encrypted_access_token"
     t.string "encrypted_access_token_iv"
     t.string "encrypted_password", default: "", null: false

--- a/spec/factories/incoming_emails.rb
+++ b/spec/factories/incoming_emails.rb
@@ -6,7 +6,7 @@
 #  attachment_count   :integer
 #  body_html          :string
 #  body_plain         :string           not null
-#  from               :string           not null
+#  from               :citext           not null
 #  received           :string
 #  received_at        :datetime         not null
 #  recipient          :string           not null
@@ -15,7 +15,7 @@
 #  stripped_signature :string
 #  stripped_text      :string
 #  subject            :string
-#  to                 :string           not null
+#  to                 :citext           not null
 #  user_agent         :string
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null

--- a/spec/factories/outgoing_emails.rb
+++ b/spec/factories/outgoing_emails.rb
@@ -6,7 +6,7 @@
 #  body       :string           not null
 #  sent_at    :datetime         not null
 #  subject    :string           not null
-#  to         :string           not null
+#  to         :citext           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  client_id  :bigint           not null

--- a/spec/factories/signups.rb
+++ b/spec/factories/signups.rb
@@ -3,7 +3,7 @@
 # Table name: signups
 #
 #  id            :bigint           not null, primary key
-#  email_address :string
+#  email_address :citext
 #  name          :string
 #  phone_number  :string
 #  zip_code      :string

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,7 +5,7 @@
 #  id                        :bigint           not null, primary key
 #  current_sign_in_at        :datetime
 #  current_sign_in_ip        :string
-#  email                     :string           not null
+#  email                     :citext           not null
 #  encrypted_access_token    :string
 #  encrypted_access_token_iv :string
 #  encrypted_password        :string           default(""), not null

--- a/spec/forms/hub/create_client_form_spec.rb
+++ b/spec/forms/hub/create_client_form_spec.rb
@@ -162,6 +162,16 @@ RSpec.describe Hub::CreateClientForm do
     end
 
     context "validations" do
+      context "with an invalid email" do
+        before { params[:email_address] = "someone@example" }
+        let(:form) { described_class.new(params) }
+
+        it "is not valid and adds an error to the email field" do
+          expect(form).not_to be_valid
+          expect(form.errors).to include :email_address
+        end
+      end
+
       context "vita_partner_id" do
         before do
           params[:vita_partner_id] = nil

--- a/spec/models/incoming_email_spec.rb
+++ b/spec/models/incoming_email_spec.rb
@@ -6,7 +6,7 @@
 #  attachment_count   :integer
 #  body_html          :string
 #  body_plain         :string           not null
-#  from               :string           not null
+#  from               :citext           not null
 #  received           :string
 #  received_at        :datetime         not null
 #  recipient          :string           not null
@@ -15,7 +15,7 @@
 #  stripped_signature :string
 #  stripped_text      :string
 #  subject            :string
-#  to                 :string           not null
+#  to                 :citext           not null
 #  user_agent         :string
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -196,6 +196,15 @@ require "rails_helper"
 
 describe Intake do
   describe "validations" do
+    context "with an invalid email" do
+      let(:intake) { build(:intake, email_address: "someone@example .com") }
+
+      it "is not valid and adds an error to the email" do
+        expect(intake).not_to be_valid
+        expect(intake.errors).to include :email_address
+      end
+    end
+
     context "phone_number & sms_phone_number" do
       let(:intake) { build :intake, phone_number: input_number, sms_phone_number: input_number }
       before { intake.valid? }

--- a/spec/models/outgoing_email_spec.rb
+++ b/spec/models/outgoing_email_spec.rb
@@ -6,7 +6,7 @@
 #  body       :string           not null
 #  sent_at    :datetime         not null
 #  subject    :string           not null
-#  to         :string           not null
+#  to         :citext           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  client_id  :bigint           not null

--- a/spec/models/signup_spec.rb
+++ b/spec/models/signup_spec.rb
@@ -3,7 +3,7 @@
 # Table name: signups
 #
 #  id            :bigint           not null, primary key
-#  email_address :string
+#  email_address :citext
 #  name          :string
 #  phone_number  :string
 #  zip_code      :string
@@ -69,6 +69,15 @@ RSpec.describe Signup, type: :model do
         it "is not valid and adds an error to the phone number" do
           expect(signup).not_to be_valid
           expect(signup.errors).to include :phone_number
+        end
+      end
+
+      context "with an invalid email" do
+        let(:signup) { build(:signup, email_address: "someone@example .com") }
+
+        it "is not valid and adds an error to the email" do
+          expect(signup).not_to be_valid
+          expect(signup.errors).to include :email_address
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,7 +5,7 @@
 #  id                        :bigint           not null, primary key
 #  current_sign_in_at        :datetime
 #  current_sign_in_ip        :string
-#  email                     :string           not null
+#  email                     :citext           not null
 #  encrypted_access_token    :string
 #  encrypted_access_token_iv :string
 #  encrypted_password        :string           default(""), not null
@@ -56,6 +56,15 @@ RSpec.describe User, type: :model do
       expect(user.errors).to include :password
       expect(user.errors).to include :email
       expect(user.errors).to include :role
+    end
+
+    context "with an invalid email" do
+      let(:user) { build(:user, email: "someone@example") }
+
+      it "is not valid and adds an error to the email" do
+        expect(user).not_to be_valid
+        expect(user.errors).to include :email
+      end
     end
 
     it "validates timezone" do


### PR DESCRIPTION
- Ensure that anywhere that an email can be input by a user, it will be validated using [valid_email2](https://github.com/micke/valid_email2),  the same good library we started using to validate emails on the email address form during intake.
- Store all email address fields as case insensitive text


### Remaining question

For the "to" field on `OutgoingEmail`, we often store multiple comma-separated values. Should this be stored as an array field?

```ruby
add_column :outgoing_emails, :to, :citext, array: true, default: []
```