### PR TITLE
Avoid referencing unstable models in migrations

### DIFF
--- a/db/migrate/20210128180337_data_migration_create_gyr_national_org.rb
+++ b/db/migrate/20210128180337_data_migration_create_gyr_national_org.rb
@@ -1,4 +1,9 @@
 class DataMigrationCreateGyrNationalOrg < ActiveRecord::Migration[6.0]
+  # Avoid using models in migrations by embedding referenced models
+  # https://makandracards.com/makandra/15575-how-to-write-complex-migrations-in-rails
+  class VitaPartner < ActiveRecord::Base
+  end
+
   def up
     # Ensure this org exists
     VitaPartner.find_or_create_by!(name: "GYR National Organization")


### PR DESCRIPTION
# GYRVitaPartner Migration Bug

## Steps to reproduce

```sh
rails db:drop
rails db:create
rails db:migrate
```

The error that will be raised:
```
== 20210128164534 AllowNullTextMessageBody: migrated (0.0020s) ================

== 20210128170810 AddUniqueIndexToVitaPartnerState: migrating =================
-- add_index(:vita_partner_states, [:state, :vita_partner_id], {:unique=>true})
-> 0.0067s
== 20210128170810 AddUniqueIndexToVitaPartnerState: migrated (0.0068s) ========

== 20210128180337 DataMigrationCreateGyrNationalOrg: migrating ================
rails aborted!
StandardError: An error has occurred, this and all later migrations canceled:

undefined method `capacity_limit' for #<VitaPartner:0x00007fdceff81e38>
/Users/bengolder/Developer/vita-min/db/migrate/20210128180337_data_migration_create_gyr_national_org.rb:4:in `up'
/Users/bengolder/Developer/vita-min/bin/rails:9:in `<top (required)>'
/Users/bengolder/Developer/vita-min/bin/spring:15:in `<top (required)>'
bin/rails:3:in `load'
bin/rails:3:in `<main>'

Caused by:
NoMethodError: undefined method `capacity_limit' for #<VitaPartner:0x00007fdceff81e38>
/Users/bengolder/Developer/vita-min/db/migrate/20210128180337_data_migration_create_gyr_national_org.rb:4:in `up'
/Users/bengolder/Developer/vita-min/bin/rails:9:in `<top (required)>'
/Users/bengolder/Developer/vita-min/bin/spring:15:in `<top (required)>'
bin/rails:3:in `load'
bin/rails:3:in `<main>'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```

## Why this happens

In `DataMigrationCreateGyrNationalOrg`, we are using the `VitaPartner` model as defined in the latest commit to insert a row when the schema is based on a much older commit.

```ruby
class DataMigrationCreateGyrNationalOrg < ActiveRecord::Migration[6.0]
  def up
    # Ensure this org exists
    VitaPartner.find_or_create_by!(name: "GYR National Organization")
  end

  def down
    # Harmless to leave this org in place
  end
end
```

We added new columns to `VitaPartner` in more recent commits than when the migration was written.
When it tries to execute the old migration using the present-day model, it tries to insert values into fields that don't exist, raising an error.

## The fix

Avoid referencing models inside of data migrations. Data migrations are okay, but you need to guard against referencing model classes that will change over time.
[This article on avoiding the usage of models when writing complex Rails migrations](https://makandracards.com/makandra/15575-how-to-write-complex-migrations-in-rails)
gives examples of 3 alternatives: using SQL, using locally-defined model classes, and using helper methods from the database adapter.

In this case I chose to define a `VitaPartner` model directly inside the migration.