### PR TITLE
Persist reports

### DIFF
--- a/app/controllers/hub/metrics_controller.rb
+++ b/app/controllers/hub/metrics_controller.rb
@@ -6,37 +6,16 @@ module Hub
     load_and_authorize_resource :vita_partner, parent: false
 
     def index
-      # Run SLA queries and cache the result for 10 minutes.
-      # The view will only display values for vita partners the user has access to view.
-      data = Rails.cache.fetch("metrics/sla_breaches/attention_needed", expires_in: 10.minutes) do
-        sla_service = SLABreachService.new
-        attention_needed_breaches = sla_service.attention_needed_breaches
-        outgoing_communication_breaches = sla_service.outgoing_communication_breaches
-        outgoing_interaction_breaches = sla_service.outgoing_interaction_breaches
-        {
-          breach_threshold_date: sla_service.breach_threshold_date,
-          current_as_of: sla_service.report_generated_at,
-          attention_needed_breaches_by_vita_partner: attention_needed_breaches,
-          communication_breaches_by_vita_partner: outgoing_communication_breaches,
-          interaction_breaches_by_vita_partner: outgoing_interaction_breaches,
-          attention_needed_breach_count: attention_needed_breaches.values.inject(:+),
-          communication_breach_count: outgoing_communication_breaches.values.inject(:+),
-          interaction_breach_count: outgoing_interaction_breaches.values.inject(:+)
-        }
-      end
+      generated_in_last_10_minutes = Report.arel_table[:generated_at].gteq(10.minutes.ago)
+      @report = Report::SLABreachReport.where(generated_in_last_10_minutes).last || Report::SLABreachReport.generate!
+      # Recalculate total breaches based on limited vita partner collection if necessary
 
-      # We need to sum these values for the vita_partners the current user has access to.
-      # Admin has access to all vita partners, the values for which we cache, so we don't need to recalculate.
-      unless current_user.admin?
-        data[:attention_needed_breach_count] = data[:attention_needed_breaches_by_vita_partner].slice(*@vita_partners.map(&:id)).values.inject(:+)
-        data[:communication_breach_count] = data[:communication_breaches_by_vita_partner].slice(*@vita_partners.map(&:id)).values.inject(:+)
-        data[:interaction_breach_count] = data[:interaction_breaches_by_vita_partner].slice(*@vita_partners.map(&:id)).values.inject(:+)
-      end
-
-      # Cast UTC stored data in the cache to the current_user's timezone.
-      data[:breach_threshold_date] = data[:breach_threshold_date].in_time_zone(current_user.timezone)
-      data[:current_as_of] = data[:current_as_of].in_time_zone(current_user.timezone)
-      @breach_data = OpenStruct.new(data)
+      limited_partners = @vita_partners unless current_user.admin?
+      @total_breaches = {
+        attention_needed: @report.attention_needed_breach_count(limited_partners),
+        communication: @report.communication_breach_count(limited_partners),
+        interaction: @report.interaction_breach_count(limited_partners)
+      }
     end
   end
 end

--- a/app/helpers/time_helper.rb
+++ b/app/helpers/time_helper.rb
@@ -12,6 +12,10 @@ module TimeHelper
     datetime.strftime("%l:%M %p #{datetime.zone}").strip
   end
 
+  def long_formatted_datetime(datetime)
+    "#{datetime.strftime('%a')} #{default_date_format(datetime)} at #{formatted_time(datetime)}"
+  end
+
   def timezone_select_options
     ActiveSupport::TimeZone.us_zones.map { |tz| [tz.name, tz.tzinfo.name] }
   end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: reports
+#
+#  id           :bigint           not null, primary key
+#  data         :jsonb
+#  generated_at :datetime
+#  type         :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_reports_on_generated_at  (generated_at)
+#
+class Report < ApplicationRecord
+end
+

--- a/app/models/report/sla_breach_report.rb
+++ b/app/models/report/sla_breach_report.rb
@@ -1,0 +1,67 @@
+# == Schema Information
+#
+# Table name: reports
+#
+#  id           :bigint           not null, primary key
+#  data         :jsonb
+#  generated_at :datetime
+#  type         :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_reports_on_generated_at  (generated_at)
+#
+class Report::SLABreachReport < Report
+  def self.generate!
+    data = SLABreachService.generate_report
+    generated_at = data.delete(:generated_at)
+    create!(data: data, generated_at: generated_at)
+  end
+
+  # JSON keys must be strings, but we need vita_partner id keys to be integers
+  def attention_needed_breaches
+    @attention_needed_breaches ||= format_hash(data["attention_needed_breaches_by_vita_partner_id"])
+  end
+
+  def communication_breaches
+    @communication_breaches ||= format_hash(data["communication_breaches_by_vita_partner_id"])
+  end
+
+  def interaction_breaches
+    @interaction_breaches ||= format_hash(data["interaction_breaches_by_vita_partner_id"])
+  end
+
+  def attention_needed_breach_count(vita_partners = nil)
+    return data["attention_needed_breach_count"] unless vita_partners.present?
+
+    attention_needed_breaches.slice(*vita_partners.map(&:id)).values.inject(:+) || 0
+  end
+
+  def communication_breach_count(vita_partners = nil)
+    return data["communication_breach_count"] unless vita_partners.present?
+
+    communication_breaches.slice(*vita_partners.map(&:id)).values.inject(:+) || 0
+  end
+
+  def interaction_breach_count(vita_partners = nil)
+    return data["interaction_breach_count"] unless vita_partners.present?
+
+    interaction_breaches.slice(*vita_partners.map(&:id)).values.inject(:+) || 0
+  end
+
+
+  def breached_at
+    @breached_at ||= data["breached_at"].in_time_zone
+  end
+
+  private
+
+  # Convert string keys to integers, and set default value
+  def format_hash(hash)
+    hash = Hash[hash.keys.map(&:to_i).zip(hash.values)]
+    hash.default = 0
+    hash
+  end
+end

--- a/app/services/sla_breach_service.rb
+++ b/app/services/sla_breach_service.rb
@@ -1,5 +1,6 @@
 class SLABreachService
   attr_accessor :report_generated_at
+
   def initialize
     @report_generated_at = Time.now.utc
   end
@@ -33,5 +34,22 @@ class SLABreachService
       .where(clients[:last_internal_or_outgoing_interaction_at].lt(clients[:first_unanswered_incoming_interaction_at]).or(clients[:last_internal_or_outgoing_interaction_at].eq(nil)))
       .group(:vita_partner_id)
       .count(:id)
+  end
+
+  def self.generate_report
+    report = SLABreachService.new
+    communication_breaches = report.outgoing_communication_breaches
+    interaction_breaches = report.outgoing_interaction_breaches
+    attention_breaches = report.attention_needed_breaches
+    {
+        breached_at: report.breach_threshold_date,
+        generated_at: report.report_generated_at,
+        attention_needed_breaches_by_vita_partner_id: attention_breaches,
+        attention_needed_breach_count: attention_breaches.values.inject(:+) || 0,
+        communication_breaches_by_vita_partner_id: communication_breaches,
+        communication_breach_count: communication_breaches.values.inject(:+) || 0,
+        interaction_breaches_by_vita_partner_id: interaction_breaches,
+        interaction_breach_count: interaction_breaches.values.inject(:+) || 0,
+    }
   end
 end

--- a/app/views/hub/metrics/index.html.erb
+++ b/app/views/hub/metrics/index.html.erb
@@ -5,11 +5,11 @@
       <div style="display: flex">
         <div>
           <strong>Report run at:<br/></strong>
-          <%= @breach_data.current_as_of.strftime("%a %m/%d/%Y") %> at <%= formatted_time(@breach_data.breach_threshold_date) %>
+          <%= long_formatted_datetime(@report.generated_at) %>
         </div>
         <div>
           <strong>Breach threshold:<br/></strong>
-          <%= @breach_data.breach_threshold_date.strftime("%a %m/%d/%Y") %> at <%= formatted_time(@breach_data.breach_threshold_date) %>
+          <%= long_formatted_datetime(@report.breached_at) %>
         </div>
       </div>
       <div>
@@ -44,39 +44,40 @@
         <tbody class="index-table__body org-metrics" data-js-vita-partner-name="<%= vita_partner.name %>">
         <tr class="index-table__row org">
           <td class="index-table__cell"><%= vita_partner.name %></td>
-          <td class="index-table__cell attention-needed-breach"  data-js-count=<%= @breach_data.attention_needed_breaches_by_vita_partner[vita_partner.id] || 0 %>>
-            <%= @breach_data.attention_needed_breaches_by_vita_partner[vita_partner.id] || 0 %>
+          <td class="index-table__cell attention-needed-breach"  data-js-count=<%= @report.attention_needed_breaches[vita_partner.id] %>>
+            <%= @report.attention_needed_breaches[vita_partner.id]%>
           </td>
-          <td class="index-table__cell communication-breach" data-js-count=<%= @breach_data.communication_breaches_by_vita_partner[vita_partner.id] || 0 %>>
-            <%= @breach_data.communication_breaches_by_vita_partner[vita_partner.id] || 0 %>
+          <td class="index-table__cell communication-breach" data-js-count=<%= @report.communication_breaches[vita_partner.id] %>>
+            <%= @report.communication_breaches[vita_partner.id]%>
           </td>
-          <td class="index-table__cell interaction-breach" data-js-count=<%= @breach_data.interaction_breaches_by_vita_partner[vita_partner.id] || 0 %>>
-            <%= @breach_data.interaction_breaches_by_vita_partner[vita_partner.id] || 0 %>
+          <td class="index-table__cell interaction-breach" data-js-count=<%= @report.interaction_breaches[vita_partner.id] %>>
+            <%= @report.interaction_breaches[vita_partner.id]%>
           </td>
         </tr>
         <% vita_partner.child_sites.each do |site| %>
+
           <tr class="index-table__row site">
             <td class="index-table__cell" style="padding-left: 60px; font-style: italic;"><%= vita_partner.name %></td>
-            <td class="index-table__cell attention-needed-breach"  data-js-count=<%= @breach_data.attention_needed_breaches_by_vita_partner[vita_partner.id] || 0 %>>
-              <%= @breach_data.attention_needed_breaches_by_vita_partner[vita_partner.id] || 0 %>
+            <td class="index-table__cell attention-needed-breach"  data-js-count=<%= @report.attention_needed_breaches[vita_partner.id] %>>
+              <%= @report.attention_needed_breaches[vita_partner.id] %>
             </td>
-            <td class="index-table__cell communication-site-breach" data-js-count=<%= @breach_data.communication_breaches_by_vita_partner[vita_partner.id] || 0 %>>
-              <%= @breach_data.communication_breaches_by_vita_partner[vita_partner.id] || 0 %>
+            <td class="index-table__cell communication-site-breach" data-js-count=<%= @report.communication_breaches[vita_partner.id] %>>
+              <%= @report.communication_breaches[vita_partner.id]%>
             </td>
-            <td class="index-table__cell interaction-site-breach" data-js-count=<%= @breach_data.interaction_breaches_by_vita_partner[vita_partner.id] || 0 %>>
-              <%= @breach_data.interaction_breaches_by_vita_partner[vita_partner.id] || 0 %>
+            <td class="index-table__cell interaction-site-breach" data-js-count=<%= @report.interaction_breaches[vita_partner.id] %>>
+              <%= @report.interaction_breaches[vita_partner.id] %>
             </td>
           </tr>
           <tr class="index-table__row site">
             <td class="index-table__cell" style="padding-left: 60px"><%= site.name %> </td>
-            <td class="index-table__cell attention-needed-breach" data-js-count=<%= @breach_data.attention_needed_breaches_by_vita_partner[site.id] || 0 %>>
-              <%= @breach_data.attention_needed_breaches_by_vita_partner[site.id] || 0 %>
+            <td class="index-table__cell attention-needed-breach" data-js-count=<%= @report.attention_needed_breaches[site.id] %>>
+              <%= @report.attention_needed_breaches[site.id] %>
             </td>
-            <td class="index-table__cell communication-breach" data-js-count=<%= @breach_data.communication_breaches_by_vita_partner[site.id] || 0 %>>
-              <%= @breach_data.communication_breaches_by_vita_partner[site.id] || 0 %>
+            <td class="index-table__cell communication-breach" data-js-count=<%= @report.communication_breaches[site.id] %>>
+              <%= @report.communication_breaches[site.id] %>
             </td>
-            <td class="index-table__cell interaction-breach" data-js-count=<%= @breach_data.interaction_breaches_by_vita_partner[site.id] || 0 %>>
-              <%= @breach_data.interaction_breaches_by_vita_partner[site.id] || 0 %>
+            <td class="index-table__cell interaction-breach" data-js-count=<%= @report.interaction_breaches[site.id] %>>
+              <%= @report.interaction_breaches[site.id] %>
             </td>
           </tr>
         <% end %>
@@ -85,9 +86,9 @@
       <tbody>
         <tr class="metrics-totals">
           <td></td>
-          <td class="index-table__cell"><strong><%= @breach_data.attention_needed_breach_count || 0%></strong></td>
-          <td class="index-table__cell"><strong><%= @breach_data.communication_breach_count || 0 %></strong></td>
-          <td class="index-table__cell"><strong><%= @breach_data.interaction_breach_count || 0 %></strong></td>
+          <td class="index-table__cell"><strong><%= @total_breaches[:attention_needed] %></strong></td>
+          <td class="index-table__cell"><strong><%= @total_breaches[:communication] %></strong></td>
+          <td class="index-table__cell"><strong><%= @total_breaches[:interaction] %></strong></td>
         </tr>
       </tbody>
     </table>

--- a/db/migrate/20210215201713_create_reports.rb
+++ b/db/migrate/20210215201713_create_reports.rb
@@ -1,0 +1,11 @@
+class CreateReports < ActiveRecord::Migration[6.0]
+  def change
+    create_table :reports do |t|
+      t.string :type
+      t.jsonb :data
+      t.datetime :generated_at
+      t.index :generated_at
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_14_022857) do
+ActiveRecord::Schema.define(version: 2021_02_15_201713) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -485,6 +485,15 @@ ActiveRecord::Schema.define(version: 2021_02_14_022857) do
     t.datetime "created_at", null: false
     t.integer "created_count", default: 0, null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "reports", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.jsonb "data"
+    t.datetime "generated_at"
+    t.string "type"
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["generated_at"], name: "index_reports_on_generated_at"
   end
 
   create_table "signups", force: :cascade do |t|

--- a/spec/factories/reports.rb
+++ b/spec/factories/reports.rb
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: reports
+#
+#  id           :bigint           not null, primary key
+#  data         :jsonb
+#  generated_at :datetime
+#  type         :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_reports_on_generated_at  (generated_at)
+#
+FactoryBot.define do
+  factory :report do
+    
+  end
+end

--- a/spec/javascript/lib/metrics_table_sort.spec.js
+++ b/spec/javascript/lib/metrics_table_sort.spec.js
@@ -1,6 +1,5 @@
 import { initMetricsTableSortAndFilter } from 'lib/metrics_table_sort';
 
-
 beforeEach(() => {
     document.body.innerHTML = `
     <button id="toggle-zeros" data-expand-text="Expand" data-collapse-text="Collapse"></button>

--- a/spec/models/report/sla_breach_report_spec.rb
+++ b/spec/models/report/sla_breach_report_spec.rb
@@ -1,0 +1,210 @@
+# == Schema Information
+#
+# Table name: reports
+#
+#  id           :bigint           not null, primary key
+#  data         :jsonb
+#  generated_at :datetime
+#  type         :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_reports_on_generated_at  (generated_at)
+#
+require 'rails_helper'
+
+RSpec.describe Report::SLABreachReport, type: :model do
+  describe ".generate!" do
+
+    let(:fake_report) do
+      t = Time.utc(2021, 2, 5, 10, 5)
+      {
+        breached_at: 3.business_days.before(t),
+        generated_at: t,
+        attention_needed_breaches_by_vita_partner_id: {  1 => 1, 2 => 2 },
+        attention_needed_breach_count: 3,
+        communication_breaches_by_vita_partner_id: { 1 => 1 },
+        communication_breach_count: 1,
+        interaction_breaches_by_vita_partner_id: { 2 => 1 },
+        interaction_breach_count: 1
+      }
+    end
+
+    before do
+      allow(SLABreachService).to receive(:generate_report).and_return fake_report.clone
+    end
+
+    it "creates a new SLABreachReport object" do
+      expect {
+        described_class.generate!
+      }.to change(described_class, :count).by(1)
+    end
+
+    it "saves the data as JSON" do
+      report = described_class.generate!
+      expect(report.data).to eq JSON.parse(fake_report.without(:generated_at).to_json)
+      expect(report.generated_at).to eq fake_report[:generated_at]
+    end
+  end
+
+  describe "#attention_needed_breaches" do
+    let(:report) do
+      Report::SLABreachReport.create(data: {
+          attention_needed_breaches_by_vita_partner_id: { 2 => 1, 3 => 2 }
+      }, generated_at: DateTime.current)
+    end
+
+    it "converts json keys into integers" do
+      expect(report.data["attention_needed_breaches_by_vita_partner_id"]).to eq ({ "2" => 1, "3" => 2 })
+      expect(report.attention_needed_breaches).to eq ({2 => 1, 3 => 2})
+    end
+
+    it "uses 0 as a default value for hash keys that cant be found" do
+      expect(report.attention_needed_breaches[1000]).to eq 0
+    end
+  end
+
+  describe "#communication_breaches" do
+    let(:report) do
+      Report::SLABreachReport.create(data: {
+          communication_breaches_by_vita_partner_id: { 2 => 1, 3 => 2 }
+      }, generated_at: DateTime.current)
+    end
+
+    it "converts json keys into integers" do
+      expect(report.data["communication_breaches_by_vita_partner_id"]).to eq({ "2" => 1, "3" => 2 })
+      expect(report.communication_breaches).to eq({ 2 => 1, 3 => 2 })
+    end
+
+    it "uses 0 as a default value for hash keys that cant be found" do
+      expect(report.communication_breaches[1000]).to eq 0
+    end
+  end
+
+  describe "#interaction_breaches" do
+    let(:report) do
+      Report::SLABreachReport.create(data: {
+          interaction_breaches_by_vita_partner_id: { 2 => 1, 3 => 2 }
+      }, generated_at: DateTime.current)
+    end
+
+    it "converts json keys into integers" do
+      expect(report.data["interaction_breaches_by_vita_partner_id"]).to eq ({ "2" => 1, "3" => 2 })
+      expect(report.interaction_breaches).to eq({ 2 => 1, 3 => 2 })
+    end
+
+    it "uses 0 as a default value for hash keys that cant be found" do
+      expect(report.interaction_breaches[1000]).to eq 0
+    end
+  end
+
+  describe "#attention_needed_breach_count" do
+    let(:vita_partner) { create :vita_partner }
+    let(:report) do
+      Report::SLABreachReport.create(data: {
+          attention_needed_breaches_by_vita_partner_id: { vita_partner.id => 1, 58394940 => 2 },
+          attention_needed_breach_count: 3
+      }, generated_at: DateTime.current)
+    end
+
+    context "without vita_partners param" do
+      it "returns the raw count" do
+        expect(report.attention_needed_breach_count).to eq 3
+      end
+    end
+
+    context "with vita_partners param" do
+      context "when breaches are found for the vita partners" do
+        it "returns the limited count based on passed vita_partners" do
+          expect(report.attention_needed_breach_count(VitaPartner.where(id: vita_partner.id ))).to eq 1
+        end
+      end
+
+      context "when breaches aren't found for the vita partners" do
+        it "returns 0" do
+          expect(report.attention_needed_breach_count(VitaPartner.where.not(id: vita_partner.id))).to eq 0
+        end
+      end
+    end
+  end
+
+
+  describe "#communication_breach_count" do
+    let(:vita_partner) { create :vita_partner }
+    let(:report) do
+      Report::SLABreachReport.create(data: {
+          communication_breaches_by_vita_partner_id: { vita_partner.id => 2, 1467580 => 3 },
+          communication_breach_count: 5
+      }, generated_at: DateTime.current)
+    end
+
+    context "without vita_partners param" do
+      it "returns the raw count" do
+        expect(report.communication_breach_count).to eq 5
+      end
+    end
+
+    context "with vita_partners param" do
+      context "when breaches are found for the vita partners" do
+        it "returns the limited count based on passed vita_partners" do
+          expect(report.communication_breach_count(VitaPartner.where(id: vita_partner.id ))).to eq 2
+        end
+      end
+
+      context "when breaches aren't found for the vita partners" do
+        it "returns 0" do
+          expect(report.communication_breach_count(VitaPartner.where.not(id: vita_partner.id))).to eq 0
+        end
+      end
+    end
+  end
+
+  describe "#interacation_breach_count" do
+    let(:vita_partner) { create :vita_partner }
+    let(:report) do
+      Report::SLABreachReport.create(data: {
+          interaction_breaches_by_vita_partner_id: { vita_partner.id => 1, 58394940 => 2 },
+          interaction_breach_count: 3
+      }, generated_at: DateTime.current)
+    end
+
+    context "without vita_partners param" do
+      it "returns the raw count" do
+        expect(report.interaction_breach_count).to eq 3
+      end
+    end
+
+    context "with vita_partners param" do
+      context "when breaches are found for the vita partners" do
+        it "returns the limited count based on passed vita_partners" do
+          expect(report.interaction_breach_count(VitaPartner.where(id: vita_partner.id ))).to eq 1
+        end
+      end
+
+      context "when breaches aren't found for the vita partners" do
+        it "returns 0" do
+          expect(report.interaction_breach_count(VitaPartner.where.not(id: vita_partner.id))).to eq 0
+        end
+      end
+    end
+  end
+
+  describe "#breached_at" do
+    let(:t) { Time.utc(2021, 2, 5, 10, 5) }
+    let(:report) do
+      Report::SLABreachReport.create(data: {
+          breached_at: t
+      }, generated_at: DateTime.current)
+    end
+
+    before do
+      Time.zone = 'Hawaii'
+    end
+
+    it "returns the breached_at value from the json data, informed by set time zone" do
+      expect(report.breached_at).to eq t.in_time_zone('Hawaii')
+    end
+  end
+end

--- a/spec/services/sla_breach_service_spec.rb
+++ b/spec/services/sla_breach_service_spec.rb
@@ -52,14 +52,14 @@ describe SLABreachService do
     end
   end
 
-  describe '.attention_needed_breaches' do
+  describe '#attention_needed_breaches' do
     let(:vita_partner_1) { create(:organization) }
     let(:vita_partner_2) { create(:organization) }
 
     context "processing on a Friday @ 10:05am UTC" do
       before do
-        t = Time.utc(2021, 2, 6, 10, 5) # 2/6/21, Saturday
-        Timecop.freeze(t.prev_occurring(:friday)) # 2/5/21, Friday
+        t = Time.utc(2021, 2, 5, 10, 5) # 2/5/21, Friday
+        Timecop.freeze(t)
         # breaches at vita_partner_1
 
         client1 = create(:client, vita_partner_id: vita_partner_1.id, tax_returns: [create(:tax_return, status: 'prep_ready_for_prep')]) # breach
@@ -151,7 +151,7 @@ describe SLABreachService do
     end
   end
 
-  describe '.outgoing_communication_breaches' do
+  describe '#outgoing_communication_breaches' do
     let(:vita_partner_1) { create(:organization) }
     let(:vita_partner_2) { create(:organization) }
 
@@ -249,7 +249,7 @@ describe SLABreachService do
     end
   end
 
-  describe ".outgoing_interaction_breaches" do
+  describe "#outgoing_interaction_breaches" do
     let(:vita_partner_1) { create(:organization) }
     let(:vita_partner_2) { create(:organization) }
 
@@ -330,7 +330,7 @@ describe SLABreachService do
       end
 
       context "on Monday @10:05am UTC" do
-        it 'returns a hash of total SLA breaches of attention_needed_breacheseses_since by vita_partner_id' do
+        it 'returns a hash of total SLA breaches of attention_needed_breaches_since by vita_partner_id' do
           expect(subject.breach_threshold_date).to eq(Time.utc(2021, 2, 3, 10, 5)) # Wednesday 2/3/21 @ 10:05am UTC
           expect(subject.outgoing_interaction_breaches).to eq(
            {
@@ -354,6 +354,73 @@ describe SLABreachService do
            )
           end
         end
+      end
+    end
+  end
+
+  describe '.generate_report' do
+    let(:t) { Time.utc(2021, 2, 5, 10, 5) }
+    before do
+      Timecop.freeze(t)
+    end
+
+    after do
+      Timecop.return
+    end
+
+    context "without any breaches" do
+      it "returns a hash of attributes for the report" do
+        report_hash = {
+            breached_at: 3.business_days.before(t),
+            generated_at: t,
+            attention_needed_breaches_by_vita_partner_id: {},
+            attention_needed_breach_count: 0,
+            communication_breaches_by_vita_partner_id: {},
+            communication_breach_count: 0,
+            interaction_breaches_by_vita_partner_id: {},
+            interaction_breach_count: 0
+        }
+        expect(SLABreachService.generate_report).to eq report_hash
+      end
+    end
+
+    context "with current breaches" do
+      let(:vita_partner_1) { create :organization }
+      let(:vita_partner_2) { create :organization }
+      before do
+        # breaches at vita_partner_1
+        client1 = create(:client, vita_partner_id: vita_partner_1.id, tax_returns:  [create(:tax_return, status: 'prep_ready_for_prep')]) # breach
+        Timecop.freeze(t.prev_occurring(:monday)) { client1.set_attention_needed }
+
+        # breaches at vita_partner_2
+        client2 = create(:client, vita_partner_id: vita_partner_2.id, tax_returns:  [create(:tax_return, status: 'prep_ready_for_prep')]) # breach
+        Timecop.freeze(6.days.ago) { client2.set_attention_needed }
+
+        tuesday_1am = t.prev_occurring(:tuesday) + 1.hour # Wednesday 2/3/21 @ 1:00am UTC
+        client3 = create(:client, vita_partner_id: vita_partner_2.id, tax_returns:  [create(:tax_return, status: 'prep_ready_for_prep')]) # breach
+        Timecop.freeze(tuesday_1am) { client3.set_attention_needed }
+
+        monday_1055am = t.prev_occurring(:monday) + 10.hour + 55.minutes # Wednesday 2/3/21 @ 10:55am UTC
+        client4 = create(:client, vita_partner_id: vita_partner_2.id, tax_returns: [create(:tax_return, status: 'prep_ready_for_prep')]) # not in breach t1, in breach t2
+        Timecop.freeze(monday_1055am) {
+          client4.tax_returns.first.record_incoming_interaction
+          client4.set_attention_needed
+        }
+        Timecop.freeze(t.prev_occurring(:sunday)) { client4.tax_returns.first.record_internal_interaction }
+      end
+
+      it "returns an accurate hash of attributes for the report" do
+        report_hash = {
+            breached_at: 3.business_days.before(t),
+            generated_at: t,
+            attention_needed_breaches_by_vita_partner_id: { vita_partner_1.id => 1, vita_partner_2.id => 2 },
+            attention_needed_breach_count: 3,
+            communication_breaches_by_vita_partner_id: { vita_partner_2.id => 1 },
+            communication_breach_count: 1,
+            interaction_breaches_by_vita_partner_id: { vita_partner_2.id => 1 },
+            interaction_breach_count: 1
+        }
+        expect(SLABreachService.generate_report).to eq report_hash
       end
     end
   end


### PR DESCRIPTION
Reports were ephemeral and (attempting to) cache. Now, saving them into a reports model in a JSON column so that we can see progression over time.

Currently running the report MAX once every 10 minutes in the foreground -- the way its set up, new reports will only be run when someone requests the metrics dashboard. Probably makes more sense to run this in a cron job, but baby stepping on this!

NOTE TO SELF: For comparison and review purposes, I have the comparison brach as the UI branch that this builds off of. Must retarget to main once that branch is merged!!