### PR TITLE
No crash on long email messages

### DIFF
--- a/app/channels/client_channel.rb
+++ b/app/channels/client_channel.rb
@@ -14,6 +14,11 @@ class ClientChannel < ApplicationCable::Channel
   end
 
   def self.broadcast_contact_record(contact_record)
-    broadcast_to(contact_record.client, [ApplicationController.render(partial: 'shared/message_list_contact_record', locals: { contact_record: contact_record })])
+    message = ApplicationController.render(partial: 'shared/message_list_contact_record', locals: { contact_record: contact_record })
+    if message.size > 7000
+      # In the case the message is too big for ActionCable + Postgres, ask the user to reload
+      message = I18n.t("hub.client_channel.please_reload_html")
+    end
+    broadcast_to(contact_record.client, [message])
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -279,6 +279,8 @@ en:
         phone_number_or_email: "Phone number/email"
     ssn_itins:
       displayed: Displaying SSN or ITIN
+    client_channel:
+      please_reload_html: "<li style='text-align: right'>↻ Please reload the page to see a new message.</li>"
   controllers:
     public_pages:
       partner_welcome_notice: Thanks for visiting via %{partner_name}!

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -281,6 +281,8 @@ es:
         phone_number_or_email: "Número de teléfono / correo electrónico"
     ssn_itins:
       displayed: Visualización de la SSN o ITIN
+    client_channel:
+      please_reload_html: "↻ Vuelva a cargar la página para ver un mensaje nuevo."
   controllers:
     public_pages:
       partner_welcome_notice: ¡Gracias por visitarnos a través de %{partner_name}!

--- a/spec/channels/client_channel_spec.rb
+++ b/spec/channels/client_channel_spec.rb
@@ -54,6 +54,20 @@ RSpec.describe ClientChannel, type: :channel do
         end.to have_broadcasted_to(ClientChannel.broadcasting_for(outgoing_text_message.client)).with(["template output"])
         expect(ApplicationController).to have_received(:render).with hash_including(locals: { contact_record: outgoing_text_message })
       end
+
+      context "when the rendered template is longer than 7 kilobytes" do
+        before do
+          allow(ApplicationController).to receive(:render).and_return("X" * 7001)
+          allow(I18n).to receive(:t).with("hub.client_channel.please_reload_html").and_return("Plz reload")
+        end
+
+        it "renders the a note saying the user should reload the page" do
+          expect do
+            ClientChannel.broadcast_contact_record(outgoing_text_message)
+          end.to have_broadcasted_to(ClientChannel.broadcasting_for(outgoing_text_message.client)).with(["Plz reload"])
+          expect(ApplicationController).to have_received(:render).with hash_including(locals: { contact_record: outgoing_text_message })
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
To test this, you can run:

```
$ rails c
> message = IncomingEmail.create(client: Client.find(1), body_html: "HI " * 8000, body_plain: "HI " * 8000, from: "example@example.com", to: "example2@example.com", received_at: DateTime.now, recipient: "example3@example.com", sender: "example4@example.com")
> ClientChannel.broadcast_contact_record(message)
```

Before this change, you'll see an exception in `rails c`.

After it, you can visit http://localhost:3000/en/clients/1 and if you re-run the `rails c` code, you'll see a helpful message appear on the screen in real time. 