### PR TITLE
Don't count automated system messages as outgoing interactions

### DIFF
--- a/app/models/outgoing_email.rb
+++ b/app/models/outgoing_email.rb
@@ -34,7 +34,8 @@ class OutgoingEmail < ApplicationRecord
   validates_presence_of :sent_at
   has_one_attached :attachment
 
-  after_create :record_outgoing_interaction, :deliver, :broadcast
+  after_create :deliver, :broadcast
+  after_create :record_outgoing_interaction, if: ->(email) { email.user.present? }
 
   def datetime
     sent_at

--- a/app/models/outgoing_text_message.rb
+++ b/app/models/outgoing_text_message.rb
@@ -33,7 +33,8 @@ class OutgoingTextMessage < ApplicationRecord
   validates_presence_of :sent_at
   validates :to_phone_number, phone: true, format: { with: /\A\+1[0-9]{10}\z/ }
 
-  after_create :record_outgoing_interaction, :deliver, :broadcast
+  after_create :deliver, :broadcast
+  after_create :record_outgoing_interaction, if: ->(msg) { msg.user.present? }
 
   def datetime
     sent_at

--- a/spec/models/outgoing_email_spec.rb
+++ b/spec/models/outgoing_email_spec.rb
@@ -33,6 +33,17 @@ RSpec.describe OutgoingEmail, type: :model do
     it_behaves_like "an outgoing interaction" do
       let(:subject) { build :outgoing_email }
     end
+
+    context "for an automated email with no user" do
+      let(:client) { create :client, first_unanswered_incoming_interaction_at: 4.business_days.ago }
+      let(:email) { build :outgoing_email, client: client, user: nil }
+
+      it "does not count as an outgoing interaction" do
+        expect do
+          email.save
+        end.not_to change { client.first_unanswered_incoming_interaction_at }
+      end
+    end
   end
 
   describe "required fields" do

--- a/spec/models/outgoing_text_message_spec.rb
+++ b/spec/models/outgoing_text_message_spec.rb
@@ -35,6 +35,17 @@ RSpec.describe OutgoingTextMessage, type: :model do
     it_behaves_like "an outgoing interaction" do
       let(:subject) { build :outgoing_text_message }
     end
+
+    context "for an automated message with no user" do
+      let(:client) { create :client, first_unanswered_incoming_interaction_at: 4.business_days.ago }
+      let(:message) { build :outgoing_text_message, client: client, user: nil }
+
+      it "does not count as an outgoing interaction" do
+        expect do
+          message.save
+        end.not_to change { client.first_unanswered_incoming_interaction_at }
+      end
+    end
   end
 
   describe "required fields" do


### PR DESCRIPTION
Automated messages are clearing out needs attention and needs response. Consequently, clients who complete the intake aren't being marked as needs attention, nor as needs response. At the end of intake, we set needs attention and then immediately clear it by sending an automated confirmation message.

For example, in the `FinalInfoController`
```ruby
 def after_update_success
      current_intake.update(completed_at: Time.now) # records an incoming interaction through the intake
      IntakePdfJob.perform_later(current_intake.id, "Original 13614-C with 15080.pdf")

      MixpanelService.send_event(
        event_id: current_intake.visitor_id,
        event_name: "intake_finished",
        data: MixpanelService.data_from([current_intake.client, current_intake])
      )
      send_confirmation_message # records an outgoing interaction through the outgoing email or text message
    end
```

This fixes the above example , so that  outgoing text messages and outgoing emails only record outgoing interactions if they are attributed to a user.

