### PR TITLE
Sort by SLA Breach Percentage

### DIFF
--- a/app/assets/stylesheets/_honeycrisp-compact.scss
+++ b/app/assets/stylesheets/_honeycrisp-compact.scss
@@ -209,25 +209,7 @@
   }
 
   .client-navigation {
-    margin: {
-      left: 0;
-      right: 0;
-    }
-    padding: {
-      left: 0;
-      right: 0;
-    }
-
-    @include media($tablet-up) {
-      margin: {
-        left: 0;
-        right: 0;
-      }
-      padding: {
-        left: 0;
-        right: 0;
-      }
-    }
+    @include no-bleed();
   }
 }
 

--- a/app/assets/stylesheets/_honeycrisp-compact.scss
+++ b/app/assets/stylesheets/_honeycrisp-compact.scss
@@ -60,17 +60,6 @@
     left: 0;
     right: 0;
   }
-
-  @include media($tablet-up) {
-    margin: {
-      left: 0;
-      right: 0;
-    }
-    padding: {
-      left: 0;
-      right: 0;
-    }
-  }
 }
 
 // GYR customizations

--- a/app/assets/stylesheets/_honeycrisp-compact.scss
+++ b/app/assets/stylesheets/_honeycrisp-compact.scss
@@ -51,18 +51,53 @@
 .background--white {
   background-color: white;
 }
+@mixin no-bleed() {
+  margin: {
+    left: 0;
+    right: 0;
+  }
+  padding: {
+    left: 0;
+    right: 0;
+  }
+
+  @include media($tablet-up) {
+    margin: {
+      left: 0;
+      right: 0;
+    }
+    padding: {
+      left: 0;
+      right: 0;
+    }
+  }
+}
 
 // GYR customizations
 .honeycrisp-compact {
+  .main-header {
+    @include no-bleed();
+    background: black;
+    height: $s60;
+    line-height: $s60;
+  }
+
   .grid {
     margin-left: 0;
     margin-right: 0;
   }
-  .slab {
-    margin-left: -3rem;
-    margin-right: -3rem;
-  }
 
+  // Override the negative margin and padding on the full-bleed classes that messes with default 100% width in browser.
+  .slab {
+    margin: {
+      left: 0;
+      right: 0;
+    }
+    padding: {
+      left: $s25;
+      right: $s25;
+    }
+  }
   .slab--padded {
     padding-top: 1.5rem;
     padding-bottom: 2rem;
@@ -181,6 +216,28 @@
     button:last-of-type {
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;
+    }
+  }
+
+  .client-navigation {
+    margin: {
+      left: 0;
+      right: 0;
+    }
+    padding: {
+      left: 0;
+      right: 0;
+    }
+
+    @include media($tablet-up) {
+      margin: {
+        left: 0;
+        right: 0;
+      }
+      padding: {
+        left: 0;
+        right: 0;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/components/_slabs.scss
+++ b/app/assets/stylesheets/components/_slabs.scss
@@ -8,8 +8,6 @@
   }
 }
 
-
-
 .slab--cta {
   padding-top: 4rem;
   padding-bottom: 4rem;

--- a/app/assets/stylesheets/components/_slabs.scss
+++ b/app/assets/stylesheets/components/_slabs.scss
@@ -8,6 +8,8 @@
   }
 }
 
+
+
 .slab--cta {
   padding-top: 4rem;
   padding-bottom: 4rem;
@@ -57,3 +59,4 @@
     }
   }
 }
+

--- a/app/assets/stylesheets/components/_tab-bar.scss
+++ b/app/assets/stylesheets/components/_tab-bar.scss
@@ -8,6 +8,10 @@ a.tab-bar__tab {
   min-width: 0;
 }
 
+a.tab-bar__tab:first-of-type {
+  margin-left: $s25;
+}
+
 // Fixes a bug in honeycrisp styleguide https://github.com/codeforamerica/honeycrisp-gem/issues/214
 .tab-bar__tab.is-selected {
   background-color: white;

--- a/app/assets/stylesheets/templates/_admin.scss
+++ b/app/assets/stylesheets/templates/_admin.scss
@@ -1,16 +1,14 @@
 .admin {
   background: white;
-
   .hub-content-wrapper {
     margin-top: 3rem;
   }
-
   .hub-section {
     margin: 3.5rem;
   }
-
   .page-wrapper {
     padding: 0;
+    overflow: unset;
   }
 
   .header {

--- a/app/assets/stylesheets/templates/_hub-metrics.scss
+++ b/app/assets/stylesheets/templates/_hub-metrics.scss
@@ -11,15 +11,24 @@
     }
   }
 }
-
 .org-metrics-table {
+  position: relative;
+  border-collapse: separate;
+  white-space: nowrap;
+  border-spacing: 0 1px;
+  border: 1px solid black;
+  background: darken($color-grey-light, 20%);
+
   thead {
     th {
       border-bottom: 1px solid black;
+      position:sticky;
+      top:0;
+      background: white;
     }
-  }
-  th {
     user-select: none;
+    background: white;
+    top: 0; /* Don't forget this, required for the stickiness */
     &.sortable {
       cursor: pointer;
       &[attr-direction = "asc"]::after {
@@ -31,8 +40,12 @@
     }
   }
 
+  tr {
+    background: white;
+  }
+
+
   .org {
-    border-top: 1px solid darken($color-grey-light, 20%);
     font-weight: bold;
   }
 
@@ -41,3 +54,63 @@
     background-color: $color-teal-light;
   }
 }
+
+//table {
+//  white-space: nowrap;
+//  margin: 0;
+//  border: none;
+//  border-collapse: separate;
+//  border-spacing: 0;
+//  table-layout: fixed;
+//  border: 1px solid black;
+//}
+//table td,
+//table th {
+//  border: 1px solid black;
+//  padding: 0.5rem 1rem;
+//}
+//table thead th {
+//  padding: 3px;
+//  position: sticky;
+//  top: 0;
+//  z-index: 1;
+//  width: 25vw;
+//  background: white;
+//}
+//table td {
+//  background: #fff;
+//  padding: 4px 5px;
+//  text-align: center;
+//}
+//
+//table tbody th {
+//  font-weight: 100;
+//  font-style: italic;
+//  text-align: left;
+//  position: relative;
+//  position: sticky;
+//  left: 0;
+//  background: white;
+//  z-index: 1;
+//}
+//table thead th:first-child {
+//  position: sticky;
+//  left: 0;
+//  z-index: 2;
+//}
+//caption {
+//  text-align: left;
+//  padding: 0.25rem;
+//  position: sticky;
+//  left: 0;
+//}
+//
+//[role="region"][aria-labelledby][tabindex] {
+//  width: 100%;
+//  max-height: 98vh;
+//  overflow: auto;
+//}
+//[role="region"][aria-labelledby][tabindex]:focus {
+//  box-shadow: 0 0 0.5em rgba(0, 0, 0, 0.5);
+//  outline: 0;
+//}

--- a/app/assets/stylesheets/templates/_hub-metrics.scss
+++ b/app/assets/stylesheets/templates/_hub-metrics.scss
@@ -1,5 +1,7 @@
 .hub-metrics {
   .header {
+    position: sticky;
+    top: 0;
     display: flex;
     justify-content: space-between;
     margin-bottom: $s25;
@@ -11,31 +13,33 @@
     }
   }
 }
+
 .org-metrics-table {
   position: relative;
   border-collapse: separate;
   white-space: nowrap;
   border-spacing: 0 1px;
-  border: 1px solid black;
+  border-top: 1px solid black;
   background: darken($color-grey-light, 20%);
-
+  max-height: 500px;
+  margin-bottom: 0;
   thead {
-    th {
-      border-bottom: 1px solid black;
-      position:sticky;
-      top:0;
-      background: white;
+    th:first-child {
+      left: 0;
+      z-index: 3;
     }
-    user-select: none;
-    background: white;
-    top: 0; /* Don't forget this, required for the stickiness */
-    &.sortable {
-      cursor: pointer;
-      &[attr-direction = "asc"]::after {
-        content: "↑"
-      }
-      &[attr-direction = "desc"]::after {
-        content: "↓"
+    th {
+      user-select: none;
+      background: white;
+      top: 0; /* Don't forget this, required for the stickiness */
+      &.sortable {
+        cursor: pointer;
+        &[attr-direction = "asc"]::after {
+          content: "↑"
+        }
+        &[attr-direction = "desc"]::after {
+          content: "↓"
+        }
       }
     }
   }
@@ -44,73 +48,41 @@
     background: white;
   }
 
+  tr > :first-child {
+    position: sticky;
+    left: 0;
+  }
+
+  tfoot th {
+    position: sticky;
+    bottom: 94px;
+    z-index: 5;
+    background: $color-teal-light;
+  }
+
+  tfoot th:first-child {
+    background: $color-teal-light;
+  }
+
+  th {
+    background: white;
+    border-bottom: 1px solid black;
+    position:sticky;
+    top:0;
+    left: 0;
+  }
+
+  tbody {
+    overflow: scroll;
+  }
 
   .org {
     font-weight: bold;
   }
 
-  .metrics-totals {
-    border-top: 2px solid $color-teal-dark;
-    background-color: $color-teal-light;
+  .site {
+    td:first-child {
+      padding-left: $s60;
+    }
   }
 }
-
-//table {
-//  white-space: nowrap;
-//  margin: 0;
-//  border: none;
-//  border-collapse: separate;
-//  border-spacing: 0;
-//  table-layout: fixed;
-//  border: 1px solid black;
-//}
-//table td,
-//table th {
-//  border: 1px solid black;
-//  padding: 0.5rem 1rem;
-//}
-//table thead th {
-//  padding: 3px;
-//  position: sticky;
-//  top: 0;
-//  z-index: 1;
-//  width: 25vw;
-//  background: white;
-//}
-//table td {
-//  background: #fff;
-//  padding: 4px 5px;
-//  text-align: center;
-//}
-//
-//table tbody th {
-//  font-weight: 100;
-//  font-style: italic;
-//  text-align: left;
-//  position: relative;
-//  position: sticky;
-//  left: 0;
-//  background: white;
-//  z-index: 1;
-//}
-//table thead th:first-child {
-//  position: sticky;
-//  left: 0;
-//  z-index: 2;
-//}
-//caption {
-//  text-align: left;
-//  padding: 0.25rem;
-//  position: sticky;
-//  left: 0;
-//}
-//
-//[role="region"][aria-labelledby][tabindex] {
-//  width: 100%;
-//  max-height: 98vh;
-//  overflow: auto;
-//}
-//[role="region"][aria-labelledby][tabindex]:focus {
-//  box-shadow: 0 0 0.5em rgba(0, 0, 0, 0.5);
-//  outline: 0;
-//}

--- a/app/javascript/lib/metrics_table_sort.js
+++ b/app/javascript/lib/metrics_table_sort.js
@@ -175,4 +175,19 @@ export function initMetricsTableSortAndFilter() {
     initSortableColumn("tbody.org-metrics", "th#organization-name", function (row) {
         return $(row).attr('data-js-vita-partner-name');
     });
+
+    initSortableColumn("tbody.org-metrics", "th#needs-attention-percentage", function (row) {
+        const calc = parseInt($(row).find('.attention-needed-breach-percentage').attr('data-js-percentage'));
+        return isNaN(calc) ? 0 : calc;
+    });
+
+    initSortableColumn("tbody.org-metrics", "th#outgoing-communication-percentage", function (row) {
+        const calc = parseInt($(row).find('.communication-breach-percentage').attr('data-js-percentage'));
+        return isNaN(calc) ? 0 : calc;
+    });
+
+    initSortableColumn("tbody.org-metrics", "th#profile-interaction-percentage", function (row) {
+        const calc = parseInt($(row).find('.interaction-breach-percentage').attr('data-js-percentage'));
+        return isNaN(calc) ? 0 : calc;
+    });
 }

--- a/app/javascript/lib/metrics_table_sort.js
+++ b/app/javascript/lib/metrics_table_sort.js
@@ -4,9 +4,9 @@ import { initSortableColumn } from './table_sort';
 function setupOrgLevelCounts() {
     $(".org-metrics").each(function() {
         let denominator = 0;
-        let attention_count = 0;
-        let communication_count = 0;
-        let interaction_count = 0;
+        let attentionCount = 0;
+        let communicationCount = 0;
+        let interactionCount = 0;
 
         if ($(this).find('tr.site').length == 0) {
             denominator += parseInt($(this).find('tr.org').first().attr('data-js-count'));
@@ -17,60 +17,47 @@ function setupOrgLevelCounts() {
         });
 
         $(this).find('tr.site td.attention-needed-breach').each(function() {
-            attention_count += parseInt($(this).attr('data-js-count'));
+            attentionCount += parseInt($(this).attr('data-js-count'));
         });
 
         $(this).find('tr.site td.communication-breach').each(function() {
-            communication_count += parseInt($(this).attr('data-js-count'));
+            communicationCount += parseInt($(this).attr('data-js-count'));
         });
 
         $(this).find('tr.site td.interaction-breach').each(function() {
-            interaction_count += parseInt($(this).attr('data-js-count'));
+            interactionCount += parseInt($(this).attr('data-js-count'));
         });
 
         // Set viewable value and sortable data-js-count value for org based on accumulated value.
-        $(this).find('.attention-needed-breach').first().text(attention_count).attr('data-js-count', attention_count);
-        let attention_percentage, attention_percentage_text;
-        [attention_percentage, attention_percentage_text] = determineBreaches(attention_count, denominator);
-        $(this).find('.attention-needed-breach-percentage').first().text(attention_percentage_text).attr('data-js-percentage', attention_percentage);
+        $(this).find('.attention-needed-breach').first().text(attentionCount).attr('data-js-count', attentionCount);
+        $(this).find('.communication-breach').first().text(communicationCount).attr('data-js-count', communicationCount);
+        $(this).find('.interaction-breach').first().text(interactionCount).attr('data-js-count', interactionCount);
+        updatePercentages(this, '.attention-needed-breach', denominator);
+        updatePercentages(this, '.communication-breach', denominator);
+        updatePercentages(this, '.interaction-breach', denominator);
 
-        $(this).find('.communication-breach').first().text(communication_count).attr('data-js-count', communication_count);
-        let comm_percentage, comm_percentage_text;
-        [comm_percentage, comm_percentage_text] = determineBreaches(communication_count, denominator);
-        $(this).find('.communication-breach-percentage').first().text(comm_percentage_text).attr('data-js-percentage', comm_percentage);
-
-        $(this).find('.interaction-breach').first().text(interaction_count).attr('data-js-count', interaction_count);
-        let interaction_percentage, interaction_percentage_text;
-        [interaction_percentage, interaction_percentage_text] = determineBreaches(interaction_count, denominator);
-        $(this).find('.interaction-breach-percentage').first().text(interaction_percentage_text).attr('data-js-percentage', interaction_percentage);
-
-        // Loop through all sites to set breach percentages
+        // // Loop through all sites to set breach percentages
         $(this).find('tr.site').each(function() {
-            let attention_percentage, attention_percentage_text;
-            [attention_percentage, attention_percentage_text] = determineBreaches(parseInt($(this).find('.attention-needed-breach').attr('data-js-count')), parseInt($(this).attr('data-js-count')));
-            $(this).find('.attention-needed-breach-percentage').first().text(attention_percentage_text).attr('data-js-percentage', attention_percentage);
-            let comm_percentage, comm_percentage_text;
-            [comm_percentage, comm_percentage_text] = determineBreaches(parseInt($(this).find('.communication-breach').attr('data-js-count')), parseInt($(this).attr('data-js-count')));
-            $(this).find('.communication-breach-percentage').first().text(comm_percentage_text).attr('data-js-percentage', comm_percentage);
-            let interaction_percentage, interaction_percentage_text;
-            [interaction_percentage, interaction_percentage_text] = determineBreaches(parseInt($(this).find('.interaction-breach').attr('data-js-count')), parseInt($(this).attr('data-js-count')));
-            $(this).find('.interaction-breach-percentage').first().text(interaction_percentage_text).attr('data-js-percentage', interaction_percentage);
+            const siteDenominator = parseInt($(this).attr('data-js-count'))
+            updatePercentages(this, '.attention-needed-breach', siteDenominator);
+            updatePercentages(this, '.communication-breach', siteDenominator);
+            updatePercentages(this, '.interaction-breach', siteDenominator);
         });
     });
-
     let totalSLATracked = $('.metrics-totals').attr('data-js-count');
-    let attention_percentage, attention_percentage_text;
-    [attention_percentage, attention_percentage_text] = determineBreaches(parseInt($('.metrics-totals').find('.attention-needed-breach').attr('data-js-count')), totalSLATracked);
-    $('.metrics-totals').find('.attention-needed-breach-percentage').first().text(attention_percentage_text).attr('data-js-percentage', attention_percentage);
-    let comm_percentage, comm_percentage_text;
-    [comm_percentage, comm_percentage_text] = determineBreaches(parseInt($('.metrics-totals').find('.communication-breach').attr('data-js-count')), totalSLATracked);
-    $('.metrics-totals').find('.communication-breach-percentage').first().text(comm_percentage_text).attr('data-js-percentage', comm_percentage);
-    let interaction_percentage, interaction_percentage_text;
-    [interaction_percentage, interaction_percentage_text] = determineBreaches(parseInt($('.metrics-totals').find('.interaction-breach').attr('data-js-count')), totalSLATracked);
-    $('.metrics-totals').find('.interaction-breach-percentage').first().text(interaction_percentage_text).attr('data-js-percentage', interaction_percentage);
+    updatePercentages('.metrics-totals', '.attention-needed-breach', totalSLATracked);
+    updatePercentages('.metrics-totals', '.communication-breach', totalSLATracked);
+    updatePercentages('.metrics-totals', '.interaction-breach', totalSLATracked);
 }
 
-function determineBreaches(breachCount, totalCount) {
+function updatePercentages(sectionSelector, breachTypeSelector, denominator) {
+    let percentageSelector = breachTypeSelector + "-percentage";
+    let percentage, percentageText;
+    [percentage, percentageText] = determineBreachPercentages($(sectionSelector).find(breachTypeSelector).attr('data-js-count'), denominator);
+    $(sectionSelector).find(percentageSelector).first().text(percentageText).attr('data-js-percentage', percentage);
+}
+
+function determineBreachPercentages(breachCount, totalCount) {
     let percentage = isNaN(breachCount/totalCount) ? 0 : (breachCount/totalCount * 100).toFixed(2).replace(/[.,]00$/, "");
     let text = `${breachCount}/${totalCount} (${percentage}%)`;
     return [percentage, text];

--- a/app/javascript/lib/table_sort.js
+++ b/app/javascript/lib/table_sort.js
@@ -35,12 +35,12 @@ function sort(rowSelector, direction, sortableParamCallback) {
 
 export function initSortableColumn(sortableElementsSelector, headerSelector, callback) {
     $(headerSelector).click(function() {
-        if($(this).attr('attr-direction') == 'desc') {
-            $(this).attr('attr-direction', 'asc')
-            sort(sortableElementsSelector, 'asc', callback);
-        } else {
-            $(this).attr('attr-direction', 'desc');
+        if($(this).attr('attr-direction') == 'asc') {
+            $(this).attr('attr-direction', 'desc')
             sort(sortableElementsSelector, 'desc', callback);
+        } else {
+            $(this).attr('attr-direction', 'asc');
+            sort(sortableElementsSelector, 'asc', callback);
         }
     });
 }

--- a/app/javascript/lib/table_sort.js
+++ b/app/javascript/lib/table_sort.js
@@ -33,6 +33,8 @@ function sort(rowSelector, direction, sortableParamCallback) {
     }
 }
 
+// Sorts desc by default on first click -- generally expects the table to already be sorted asc on primary column.
+// Add attr-direction="asc" to sortable column clickable selector if you'd like to sort asc on first click.
 export function initSortableColumn(sortableElementsSelector, headerSelector, callback) {
     $(headerSelector).click(function() {
         if($(this).attr('attr-direction') == 'asc') {

--- a/app/views/hub/clients/_navigation.html.erb
+++ b/app/views/hub/clients/_navigation.html.erb
@@ -1,8 +1,6 @@
-<section class="client-navigation slab slab--padded">
-  <div class="tab-bar is-selected">
-    <%= tab_navigation_link(t(".client_profile"), hub_client_path(id: @client)) %>
-    <%= tab_navigation_link(t(".client_messages"), hub_client_messages_path(client_id: @client)) %>
-    <%= tab_navigation_link(t(".client_documents"), hub_client_documents_path(client_id: @client)) %>
-    <%= tab_navigation_link(t(".client_notes"), hub_client_notes_path(client_id: @client)) %>
-  </div>
+<section class="client-navigation tab-bar is-selected">
+  <%= tab_navigation_link(t(".client_profile"), hub_client_path(id: @client)) %>
+  <%= tab_navigation_link(t(".client_messages"), hub_client_messages_path(client_id: @client)) %>
+  <%= tab_navigation_link(t(".client_documents"), hub_client_documents_path(client_id: @client)) %>
+  <%= tab_navigation_link(t(".client_notes"), hub_client_notes_path(client_id: @client)) %>
 </section>

--- a/app/views/hub/clients/index.html.erb
+++ b/app/views/hub/clients/index.html.erb
@@ -3,9 +3,12 @@
 <% content_for :card do %>
   <section class="slab slab--padded client-index-header">
     <%= render "shared/user_header" %>
-    <%= render "shared/dashboard_navigation" %>
+  </section>
+  <%= render "shared/dashboard_navigation" %>
+  <section class="slab slab--padded">
     <%= render "shared/client_filters" %>
-
+  </section>
+  <section class="slab slab--padded">
     <div class="actions-wrapper">
       <%= link_to t(".add_client"), new_hub_client_path, class: "button" %>
     </div>

--- a/app/views/hub/metrics/_breach_row.html.erb
+++ b/app/views/hub/metrics/_breach_row.html.erb
@@ -1,0 +1,23 @@
+<tr class="index-table__row <%= type %>" data-js-count="<%= @report.active_sla_clients[id] %>">
+  <td class="index-table__cell"><%= name %></td>
+  <td class="index-table__cell attention-needed-breach"  data-js-count=<%= @report.attention_needed_breaches[id] %>>
+    <%= @report.attention_needed_breaches[id]%>
+  </td>
+  <td class="index-table__cell attention-needed-breach-percentage">
+    <%= @report.active_sla_clients_count[id] %>
+  </td>
+  <td class="index-table__cell communication-breach" data-js-count=<%= @report.communication_breaches[id] %>>
+    <%= @report.communication_breaches[id]%>
+  </td>
+
+  <td class="index-table__cell communication-breach-percentage">
+    <%= @report.active_sla_clients_count[id] %>
+
+  </td>
+  <td class="index-table__cell interaction-breach" data-js-count=<%= @report.interaction_breaches[id] %>>
+    <%= @report.interaction_breaches[id]%>
+  </td>
+  <td class="index-table__cell interaction-breach-percentage">
+    <%= @report.active_sla_clients_count[id] %>
+  </td>
+</tr>

--- a/app/views/hub/metrics/index.html.erb
+++ b/app/views/hub/metrics/index.html.erb
@@ -20,37 +20,36 @@
       </div>
     </div>
   </div>
-
   <div class="scrollable-table-wrapper">
     <table class="index-table org-metrics-table">
       <thead class="index-table__head">
-        <tr class="index-table__row">
-          <th scope="col" class="index-table__header sortable" id="organization-name" attr-dir="asc" width="40%">
-            Organization Name
-          </th>
-          <th scope="col" class="index-table__header sortable" id="needs-attention-breaches">
-            Attention breaches<sup>1</sup>
-          </th>
-          <th scope="col" class="index-table__header sortable" id="needs-attention-percentage">
-            Attention %
-          </th>
+      <tr class="index-table__row">
+        <th scope="col" class="sticky index-table__header sortable" id="organization-name" width="40%" attr-direction="asc">
+          Organization Name
+        </th>
+        <th scope="col" class="index-table__header sortable" id="needs-attention-breaches" >
+          Attention breaches<sup>1</sup>
+        </th>
+        <th scope="col" class="index-table__header sortable" id="needs-attention-percentage">
+          Attention %
+        </th>
 
-          <th scope="col" class="index-table__header sortable" id="outgoing-communication-breaches">
-            Outgoing comm. breaches<sup>2</sup>
-          </th>
+        <th scope="col" class="index-table__header sortable" id="outgoing-communication-breaches" >
+          Outgoing comm. breaches<sup>2</sup>
+        </th>
 
-          <th scope="col" class="index-table__header sortable" id="outgoing-communication-percentage">
-            Outgoing comm. %
-          </th>
+        <th scope="col" class="index-table__header sortable" id="outgoing-communication-percentage" >
+          Outgoing comm. %
+        </th>
 
-          <th scope="col" class="index-table__header sortable" id="profile-interaction-breaches">
-             Interaction breaches<sup>3</sup>
-          </th>
+        <th scope="col" class="index-table__header sortable" id="profile-interaction-breaches" >
+          Interaction breaches<sup>3</sup>
+        </th>
 
-          <th scope="col" class="index-table__header sortable" id="profile-interaction-percentage">
-            Interaction %
-          </th>
-        </tr>
+        <th scope="col" class="index-table__header sortable" id="profile-interaction-percentage" >
+          Interaction %
+        </th>
+      </tr>
       </thead>
       <% @vita_partners.each do |vita_partner| %>
         <% next unless vita_partner.organization? || @vita_partners.length == 1 %>
@@ -164,41 +163,40 @@
         </tbody>
       <% end %>
       <tbody>
-        <tr class="metrics-totals" data-js-count=<%= @total_breaches[:total_count] %>>
-          <td></td>
-          <td class="index-table__cell attention-needed-breach" data-js-count=<%= @total_breaches[:attention_needed] %>>
-            <strong><%= @total_breaches[:attention_needed] %></strong>
-          </td>
-          <td class="index-table__cell attention-needed-breach-percentage">
-          </td>
+      <tr class="metrics-totals" data-js-count=<%= @total_breaches[:total_count] %>>
+        <td></td>
+        <td class="index-table__cell attention-needed-breach" data-js-count=<%= @total_breaches[:attention_needed] %>>
+          <strong><%= @total_breaches[:attention_needed] %></strong>
+        </td>
+        <td class="index-table__cell attention-needed-breach-percentage">
+        </td>
 
-          <td class="index-table__cell communication-breach" data-js-count="<%= @total_breaches[:communication] %>">
-            <strong><%= @total_breaches[:communication] %></strong>
-          </td>
-          <td class="index-table__cell communication-breach-percentage">
-          </td>
+        <td class="index-table__cell communication-breach" data-js-count="<%= @total_breaches[:communication] %>">
+          <strong><%= @total_breaches[:communication] %></strong>
+        </td>
+        <td class="index-table__cell communication-breach-percentage">
+        </td>
 
-          <td class="index-table__cell interaction-breach" data-js-count=<%= @total_breaches[:interaction] %>>
-            <strong><%= @total_breaches[:interaction] %></strong>
-          </td>
-          <td class="index-table__cell interaction-breach-percentage">
-          </td>
-
-        </tr>
+        <td class="index-table__cell interaction-breach" data-js-count=<%= @total_breaches[:interaction] %>>
+          <strong><%= @total_breaches[:interaction] %></strong>
+        </td>
+        <td class="index-table__cell interaction-breach-percentage">
+        </td>
+      </tr>
       </tbody>
-
     </table>
+    <div class="slab slab--not-padded spacing-above-25">
+      <div>
+        <small><sup>1 </sup>Client needs attention indicator has been on for more than 3 business days.</small>
+      </div>
+      <div>
+        <small><sup>2 </sup>Client messaged us or uploaded document more than 3 business days ago, and we have not contacted them by text/call/email.</small>
+      </div>
+      <div>
+        <small><sup>3 </sup>Client messaged us or uploaded document more than 3 business days ago, and we have not interacted with their profile (written internal note, changed status, assigned user, etc).</small>
+      </div>
+    </div>
   </div>
 
-  <div class="slab slab--not-padded spacing-above-25">
-    <div>
-      <small><sup>1 </sup>Client needs attention indicator has been on for more than 3 business days.</small>
-    </div>
-    <div>
-      <small><sup>2 </sup>Client messaged us or uploaded document more than 3 business days ago, and we have not contacted them by text/call/email.</small>
-    </div>
-    <div>
-      <small><sup>3 </sup>Client messaged us or uploaded document more than 3 business days ago, and we have not interacted with their profile (written internal note, changed status, assigned user, etc).</small>
-    </div>
-  </div>
+
 <% end %>

--- a/app/views/hub/metrics/index.html.erb
+++ b/app/views/hub/metrics/index.html.erb
@@ -25,13 +25,13 @@
     <table class="index-table org-metrics-table">
       <thead class="index-table__head">
         <tr class="index-table__row">
-          <th scope="col" class="index-table__header sortable" id="organization-name" width="40%">
+          <th scope="col" class="index-table__header sortable" id="organization-name" attr-dir="asc" width="40%">
             Organization Name
           </th>
           <th scope="col" class="index-table__header sortable" id="needs-attention-breaches">
             Attention breaches<sup>1</sup>
           </th>
-          <th scope="col" class="index-table__header" id="needs-attention-percentage">
+          <th scope="col" class="index-table__header sortable" id="needs-attention-percentage">
             Attention %
           </th>
 
@@ -39,7 +39,7 @@
             Outgoing comm. breaches<sup>2</sup>
           </th>
 
-          <th scope="col" class="index-table__header" id="needs-attention-percentage">
+          <th scope="col" class="index-table__header sortable" id="outgoing-communication-percentage">
             Outgoing comm. %
           </th>
 
@@ -47,7 +47,7 @@
              Interaction breaches<sup>3</sup>
           </th>
 
-          <th scope="col" class="index-table__header" id="needs-attention-percentage">
+          <th scope="col" class="index-table__header sortable" id="profile-interaction-percentage">
             Interaction %
           </th>
         </tr>

--- a/app/views/hub/metrics/index.html.erb
+++ b/app/views/hub/metrics/index.html.erb
@@ -66,6 +66,29 @@
             <%= render 'breach_row', type: 'org', id: 0, name: "Unassigned Clients" %>
           </tbody>
         <% end %>
+        <tfoot>
+          <tr class="metrics-totals" data-js-count=<%= @total_breaches[:total_count] %>>
+            <th></th>
+            <th class="index-table__cell attention-needed-breach" data-js-count=<%= @total_breaches[:attention_needed] %>>
+              <strong><%= @total_breaches[:attention_needed] %></strong>
+            </th>
+            <th class="index-table__cell attention-needed-breach-percentage">
+            </th>
+
+            <th class="index-table__cell communication-breach" data-js-count="<%= @total_breaches[:communication] %>">
+              <strong><%= @total_breaches[:communication] %></strong>
+            </th>
+            <th class="index-table__cell communication-breach-percentage">
+            </th>
+
+            <th class="index-table__cell interaction-breach" data-js-count=<%= @total_breaches[:interaction] %>>
+              <strong><%= @total_breaches[:interaction] %></strong>
+            </th>
+            <th class="index-table__cell interaction-breach-percentage">
+            </th>
+
+          </tr>
+        </tfoot>
       </table>
     </div>
 

--- a/app/views/hub/metrics/index.html.erb
+++ b/app/views/hub/metrics/index.html.erb
@@ -20,172 +20,57 @@
       </div>
     </div>
   </div>
-  <div class="scrollable-table-wrapper">
-    <table class="index-table org-metrics-table">
-      <thead class="index-table__head">
-      <tr class="index-table__row">
-        <th scope="col" class="sticky index-table__header sortable" id="organization-name" width="40%" attr-direction="asc">
-          Organization Name
-        </th>
-        <th scope="col" class="index-table__header sortable" id="needs-attention-breaches" >
-          Attention breaches<sup>1</sup>
-        </th>
-        <th scope="col" class="index-table__header sortable" id="needs-attention-percentage">
-          Attention %
-        </th>
-
-        <th scope="col" class="index-table__header sortable" id="outgoing-communication-breaches" >
-          Outgoing comm. breaches<sup>2</sup>
-        </th>
-
-        <th scope="col" class="index-table__header sortable" id="outgoing-communication-percentage" >
-          Outgoing comm. %
-        </th>
-
-        <th scope="col" class="index-table__header sortable" id="profile-interaction-breaches" >
-          Interaction breaches<sup>3</sup>
-        </th>
-
-        <th scope="col" class="index-table__header sortable" id="profile-interaction-percentage" >
-          Interaction %
-        </th>
-      </tr>
-      </thead>
-      <% @vita_partners.each do |vita_partner| %>
-        <% next unless vita_partner.organization? || @vita_partners.length == 1 %>
-        <tbody class="index-table__body org-metrics" data-js-vita-partner-name="<%= vita_partner.name %>">
-        <tr class="index-table__row org" data-js-count="<%= @report.active_sla_clients[vita_partner.id] %>">
-          <td class="index-table__cell"><%= vita_partner.name %></td>
-          <td class="index-table__cell attention-needed-breach"  data-js-count=<%= @report.attention_needed_breaches[vita_partner.id] %>>
-            <%= @report.attention_needed_breaches[vita_partner.id]%>
-          </td>
-          <td class="index-table__cell attention-needed-breach-percentage">
-            <%= @report.active_sla_clients_count[vita_partner.id] %>
-
-          </td>
-          <td class="index-table__cell communication-breach" data-js-count=<%= @report.communication_breaches[vita_partner.id] %>>
-            <%= @report.communication_breaches[vita_partner.id]%>
-          </td>
-
-          <td class="index-table__cell communication-breach-percentage">
-            <%= @report.active_sla_clients_count[vita_partner.id] %>
-
-          </td>
-          <td class="index-table__cell interaction-breach" data-js-count=<%= @report.interaction_breaches[vita_partner.id] %>>
-            <%= @report.interaction_breaches[vita_partner.id]%>
-          </td>
-          <td class="index-table__cell interaction-breach-percentage">
-            <%= @report.active_sla_clients_count[vita_partner.id] %>
-          </td>
+    <div class="table-wrapper">
+      <table class="index-table org-metrics-table">
+        <thead class="index-table__head">
+        <tr class="index-table__row">
+          <th scope="col" class="sticky index-table__header sortable" id="organization-name" width="40%" attr-direction="asc">
+            Organization Name
+          </th>
+          <th scope="col" class="index-table__header sortable" id="needs-attention-breaches" >
+            Attention breaches<sup>1</sup>
+          </th>
+          <th scope="col" class="index-table__header sortable" id="needs-attention-percentage">
+            Attention %
+          </th>
+          <th scope="col" class="index-table__header sortable" id="outgoing-communication-breaches" >
+            Outgoing comm. breaches<sup>2</sup>
+          </th>
+          <th scope="col" class="index-table__header sortable" id="outgoing-communication-percentage" >
+            Outgoing comm. %
+          </th>
+          <th scope="col" class="index-table__header sortable" id="profile-interaction-breaches" >
+            Interaction breaches<sup>3</sup>
+          </th>
+          <th scope="col" class="index-table__header sortable" id="profile-interaction-percentage" >
+            Interaction %
+          </th>
         </tr>
-        <% if vita_partner.child_sites.present? %>
-          <!--           Add a row for the organization to track org-level breaches.-->
-          <tr class="index-table__row site" data-js-count=<%= @report.active_sla_clients[vita_partner.id] %>>
-            <td class="index-table__cell" style="padding-left: 60px; font-style: italic;"><%= vita_partner.name %></td>
-            <td class="index-table__cell attention-needed-breach"  data-js-count=<%= @report.attention_needed_breaches[vita_partner.id] %>>
-              <%= @report.attention_needed_breaches[vita_partner.id] %>
-            </td>
-            <td class="index-table__cell attention-needed-breach-percentage">
-              <%= @report.active_sla_clients_count[vita_partner.id] %>
+        </thead>
+        <% @vita_partners.each do |vita_partner| %>
+          <% next unless vita_partner.organization? || @vita_partners.length == 1 %>
+          <tbody class="index-table__body org-metrics" data-js-vita-partner-name="<%= vita_partner.name %>">
+          <%= render 'breach_row', type: 'org', id: vita_partner.id, name: vita_partner.name %>
+          <% if vita_partner.child_sites.present? %>
+            <!--           Add a row for the organization to track org-level breaches.-->
+            <%= render 'breach_row', type: 'site', id: vita_partner.id, name: vita_partner.name %>
 
-            </td>
-            <td class="index-table__cell communication-breach" data-js-count=<%= @report.communication_breaches[vita_partner.id] %>>
-              <%= @report.communication_breaches[vita_partner.id]%>
-            </td>
-            <td class="index-table__cell communication-breach-percentage">
-              <%= @report.active_sla_clients_count[vita_partner.id] %>
-
-            </td>
-            <td class="index-table__cell interaction-breach" data-js-count=<%= @report.interaction_breaches[vita_partner.id] %>>
-              <%= @report.interaction_breaches[vita_partner.id] %>
-            </td>
-            <td class="index-table__cell interaction-breach-percentage">
-              <%= @report.active_sla_clients_count[vita_partner.id] %>
-
-            </td>
-          </tr>
-
-          <% vita_partner.child_sites.each do |site| %>
-            <tr class="index-table__row site" data-js-count=<%= @report.active_sla_clients[site.id] %>>
-              <td class="index-table__cell" style="padding-left: 60px"><%= site.name %> </td>
-
-              <td class="index-table__cell attention-needed-breach" data-js-count=<%= @report.attention_needed_breaches[site.id] %>>
-                <%= @report.attention_needed_breaches[site.id] %>
-              </td>
-              <td class="index-table__cell attention-needed-breach-percentage">
-                <%= @report.active_sla_clients_count[site.id] %>
-
-              </td>
-              <td class="index-table__cell communication-breach" data-js-count=<%= @report.communication_breaches[site.id] %>>
-                <%= @report.communication_breaches[site.id] %>
-              </td>
-              <td class="index-table__cell communication-breach-percentage">
-                <%= @report.active_sla_clients[site.id] %>
-
-              </td>
-              <td class="index-table__cell interaction-breach" data-js-count=<%= @report.interaction_breaches[site.id] %>>
-                <%= @report.interaction_breaches[site.id] %>
-              </td>
-              <td class="index-table__cell interaction-breach-percentage">
-                <%= @report.active_sla_clients[site.id] %>
-
-              </td>
-            </tr>
+            <% vita_partner.child_sites.each do |site| %>
+              <%= render 'breach_row', type: 'site', id: site.id, name: site.name %>
+            <% end %>
           <% end %>
+          </tbody>
         <% end %>
-        </tbody>
-      <% end %>
-      <% if @report.active_sla_clients[0] && current_user.admin? %>
-        <tbody class="index-table__body org-metrics" data-js-vita-partner-name="Unassigned Clients">
-        <tr class="index-table__row org" data-js-count="<%= @report.active_sla_clients[0] %>">
-          <td class="index-table__cell">Unassigned Clients</td>
-          <td class="index-table__cell attention-needed-breach"  data-js-count=<%= @report.attention_needed_breaches[0] %>>
-            <%= @report.attention_needed_breaches[0]%>
-          </td>
-          <td class="index-table__cell attention-needed-breach-percentage">
-            <%= @report.active_sla_clients_count[0] %>
+        <% if @report.active_sla_clients[0] && current_user.admin? %>
+          <tbody class="index-table__body org-metrics" data-js-vita-partner-name="Unassigned Clients">
+            <%= render 'breach_row', type: 'org', id: 0, name: "Unassigned Clients" %>
+          </tbody>
+        <% end %>
+      </table>
+    </div>
 
-          </td>
-          <td class="index-table__cell communication-breach" data-js-count=<%= @report.communication_breaches[0] %>>
-            <%= @report.communication_breaches[0]%>
-          </td>
-
-          <td class="index-table__cell communication-breach-percentage">
-            <%= @report.active_sla_clients_count[0] %>
-
-          </td>
-          <td class="index-table__cell interaction-breach" data-js-count=<%= @report.interaction_breaches[0] %>>
-            <%= @report.interaction_breaches[0]%>
-          </td>
-          <td class="index-table__cell interaction-breach-percentage">
-            <%= @report.active_sla_clients_count[0] %>
-          </td>
-        </tbody>
-      <% end %>
-      <tbody>
-      <tr class="metrics-totals" data-js-count=<%= @total_breaches[:total_count] %>>
-        <td></td>
-        <td class="index-table__cell attention-needed-breach" data-js-count=<%= @total_breaches[:attention_needed] %>>
-          <strong><%= @total_breaches[:attention_needed] %></strong>
-        </td>
-        <td class="index-table__cell attention-needed-breach-percentage">
-        </td>
-
-        <td class="index-table__cell communication-breach" data-js-count="<%= @total_breaches[:communication] %>">
-          <strong><%= @total_breaches[:communication] %></strong>
-        </td>
-        <td class="index-table__cell communication-breach-percentage">
-        </td>
-
-        <td class="index-table__cell interaction-breach" data-js-count=<%= @total_breaches[:interaction] %>>
-          <strong><%= @total_breaches[:interaction] %></strong>
-        </td>
-        <td class="index-table__cell interaction-breach-percentage">
-        </td>
-      </tr>
-      </tbody>
-    </table>
-    <div class="slab slab--not-padded spacing-above-25">
+  <%= content_for :sticky_action_footer do %>
+    <section class="take-action-box">
       <div>
         <small><sup>1 </sup>Client needs attention indicator has been on for more than 3 business days.</small>
       </div>
@@ -195,8 +80,6 @@
       <div>
         <small><sup>3 </sup>Client messaged us or uploaded document more than 3 business days ago, and we have not interacted with their profile (written internal note, changed status, assigned user, etc).</small>
       </div>
-    </div>
-  </div>
-
-
+    </section>
+  <% end %>
 <% end %>

--- a/app/views/hub/metrics/index.html.erb
+++ b/app/views/hub/metrics/index.html.erb
@@ -20,7 +20,7 @@
       </div>
     </div>
   </div>
-    <div class="table-wrapper">
+  <div class="table-wrapper">
       <table class="index-table org-metrics-table">
         <thead class="index-table__head">
         <tr class="index-table__row">
@@ -74,19 +74,16 @@
             </th>
             <th class="index-table__cell attention-needed-breach-percentage">
             </th>
-
             <th class="index-table__cell communication-breach" data-js-count="<%= @total_breaches[:communication] %>">
               <strong><%= @total_breaches[:communication] %></strong>
             </th>
             <th class="index-table__cell communication-breach-percentage">
             </th>
-
             <th class="index-table__cell interaction-breach" data-js-count=<%= @total_breaches[:interaction] %>>
               <strong><%= @total_breaches[:interaction] %></strong>
             </th>
             <th class="index-table__cell interaction-breach-percentage">
             </th>
-
           </tr>
         </tfoot>
       </table>

--- a/spec/javascript/lib/metrics_table_sort.spec.js
+++ b/spec/javascript/lib/metrics_table_sort.spec.js
@@ -11,6 +11,24 @@ beforeEach(() => {
             <th id="profile-interaction-breaches"></th>
             <th id="outgoing-communication-breaches"></th>
         </thead>
+        <tbody class="org-metrics" data-js-vita-partner-name="Apple Org">
+            <tr class="org">
+                <td class="attention-needed-breach"></td>
+                <td class="communication-breach"></td>
+                <td class="interaction-breach"></td>
+            </tr>
+            <tr class="site">
+                <td class="attention-needed-breach" data-js-count="1"></td>
+                <td class="communication-breach" data-js-count="14"></td>
+                <td class="interaction-breach" data-js-count="14"></td>
+            </tr>
+            <tr class="site">
+                <td class="attention-needed-breach" data-js-count="1"></td>
+                <td class="communication-breach" data-js-count="1"></td>
+                <td class="interaction-breach" data-js-count="1"></td>
+            </tr>
+        </tbody>
+
         <tbody class="org-metrics" data-js-vita-partner-name="Perfect Org">
             <tr class="org">
                 <td class="attention-needed-breach"></td>
@@ -114,23 +132,6 @@ beforeEach(() => {
               <td class="index-table__cell interaction-breach" data-js-count=3>
                 3
               </td>
-            </tr>
-        </tbody>
-        <tbody class="org-metrics" data-js-vita-partner-name="Apple Org">
-            <tr class="org">
-                <td class="attention-needed-breach"></td>
-                <td class="communication-breach"></td>
-                <td class="interaction-breach"></td>
-            </tr>
-            <tr class="site">
-                <td class="attention-needed-breach" data-js-count="15"></td>
-                <td class="communication-breach" data-js-count="15"></td>
-                <td class="interaction-breach" data-js-count="15"></td>
-            </tr>
-            <tr class="site">
-                <td class="attention-needed-breach" data-js-count="1"></td>
-                <td class="communication-breach" data-js-count="1"></td>
-                <td class="interaction-breach" data-js-count="1"></td>
             </tr>
         </tbody>
     </table>
@@ -241,13 +242,69 @@ test("collapse and expand sites and zeros simultaneously", () => {
 });
 
 test('sorting by name', () => {
-    expect($('.org-metrics').first().attr('data-js-vita-partner-name')).toEqual("Perfect Org");
+    expect($('.org-metrics').first().attr('data-js-vita-partner-name')).toEqual("Apple Org");
     initMetricsTableSortAndFilter();
     $('th#organization-name').click();
+    expect($('.org-metrics').first().attr('data-js-vita-partner-name')).toEqual("United Way of Greater Richmond and Petersburg");
+    $('th#organization-name').click();
     expect($('.org-metrics').first().attr('data-js-vita-partner-name')).toEqual("Apple Org");
+});
+
+test('sorting by breach count', () => {
+    expect($('.org-metrics').first().attr('data-js-vita-partner-name')).toEqual("Apple Org");
+    initMetricsTableSortAndFilter();
     $('th#organization-name').click();
     expect($('.org-metrics').first().attr('data-js-vita-partner-name')).toEqual("United Way of Greater Richmond and Petersburg");
+    $('th#organization-name').click();
+    expect($('.org-metrics').first().attr('data-js-vita-partner-name')).toEqual("Apple Org");
+});
+
+test('sorting by attention breach count', () => {
+    expect($('.org-metrics').first().attr('data-js-vita-partner-name')).toEqual("Apple Org");
+    initMetricsTableSortAndFilter();
+    $('th#needs-attention-breaches').click();
+    expect($('.org-metrics').first().attr('data-js-vita-partner-name')).toEqual("United Way of Greater Richmond and Petersburg");
+    expect($('.org-metrics').first().find('.org .attention-needed-breach').attr('data-js-count')).toEqual('3')
+    expect($('.org-metrics').last().attr('data-js-vita-partner-name')).toEqual("Perfect Org");
+
+    $('th#needs-attention-breaches').click();
+    expect($('.org-metrics').first().attr('data-js-vita-partner-name')).toEqual("Perfect Org");
+    expect($('.org-metrics').first().find('.org .attention-needed-breach').attr('data-js-count')).toEqual('0')
+
+    expect($('.org-metrics').last().attr('data-js-vita-partner-name')).toEqual("United Way of Greater Richmond and Petersburg");
+    $('th#organization-name').click();
 });
 
 
+test('sorting by profile-interaction-breaches count', () => {
+    expect($('.org-metrics').first().attr('data-js-vita-partner-name')).toEqual("Apple Org");
+    initMetricsTableSortAndFilter();
+    $('th#profile-interaction-breaches').click();
+    expect($('.org-metrics').first().attr('data-js-vita-partner-name')).toEqual("Apple Org");
+    expect($('.org-metrics').first().find('.org .interaction-breach').attr('data-js-count')).toEqual('15')
+    expect($('.org-metrics').last().attr('data-js-vita-partner-name')).toEqual("Perfect Org");
 
+    $('th#profile-interaction-breaches').click();
+    expect($('.org-metrics').first().attr('data-js-vita-partner-name')).toEqual("Perfect Org");
+    expect($('.org-metrics').first().find('.org .interaction-breach').attr('data-js-count')).toEqual('0')
+
+    expect($('.org-metrics').last().attr('data-js-vita-partner-name')).toEqual("Apple Org");
+    $('th#organization-name').click();
+});
+
+
+test('sorting by communication-interaction-breaches count', () => {
+    expect($('.org-metrics').first().attr('data-js-vita-partner-name')).toEqual("Apple Org");
+    initMetricsTableSortAndFilter();
+    $('th#profile-interaction-breaches').click();
+    expect($('.org-metrics').first().attr('data-js-vita-partner-name')).toEqual("Apple Org");
+    expect($('.org-metrics').first().find('.org .interaction-breach').attr('data-js-count')).toEqual('15')
+    expect($('.org-metrics').last().attr('data-js-vita-partner-name')).toEqual("Perfect Org");
+
+    $('th#profile-interaction-breaches').click();
+    expect($('.org-metrics').first().attr('data-js-vita-partner-name')).toEqual("Perfect Org");
+    expect($('.org-metrics').first().find('.org .interaction-breach').attr('data-js-count')).toEqual('0')
+
+    expect($('.org-metrics').last().attr('data-js-vita-partner-name')).toEqual("Apple Org");
+    $('th#organization-name').click();
+});

--- a/spec/javascript/lib/table_sort.spec.js
+++ b/spec/javascript/lib/table_sort.spec.js
@@ -8,6 +8,19 @@ beforeEach(() => {
             </thead>
             <tbody>
                 <tr class="member">
+                    <td class="name">Harry</td>
+                    <td data-age="27">27</td>
+                </tr>
+             
+                <tr class="member">
+                    <td class="name">Liam</td>
+                    <td data-age="27">27</td>
+                </tr>
+                <tr class="member">
+                    <td class="name">Louis</td>
+                    <td data-age="29">29</td>
+                </tr>
+                <tr class="member">
                     <td class="name">Niall</td>
                     <td data-age="26">26</td>
                 </tr>
@@ -15,26 +28,13 @@ beforeEach(() => {
                     <td class="name">Zayn</td>
                     <td data-age="28">28</td>
                 </tr>
-                <tr class="member">
-                    <td class="name">Harry</td>
-                    <td data-age="27">27</td>
-                </tr>
-                <tr class="member">
-                    <td class="name">Liam</td>
-                    <td data-age="27">27</td>
-
-                </tr>
-                <tr class="member">
-                    <td class="name">Louis</td>
-                    <td data-age="29">29</td>
-                </tr>
             </tbody>
         </table>
     `;
 });
 
 test('sorts rows asc and desc', () => {
-    expect($('tr td.name').first().text()).toEqual("Niall");
+    expect($('tr td.name').first().text()).toEqual("Harry");
 
     initSortableColumn("tr.member", "th#name", function(row) {
         return $(row).find('td.name').first().text();
@@ -42,15 +42,15 @@ test('sorts rows asc and desc', () => {
 
     $("th#name")[0].click();
 
-    expect($('tr td.name').first().text()).toEqual("Harry");
+    expect($('tr td.name').first().text()).toEqual("Zayn");
 
     $("th#name")[0].click();
 
-    expect($('tr td.name').first().text()).toEqual("Zayn");
+    expect($('tr td.name').first().text()).toEqual("Harry");
 });
 
 test('sorts by multiple rows', () => {
-    expect($('tr td').first().text()).toEqual("Niall");
+    expect($('tr td').first().text()).toEqual("Harry");
 
     initSortableColumn("tr.member", "th#name", function(row) {
         return $(row).find('td').first().text();
@@ -60,15 +60,14 @@ test('sorts by multiple rows', () => {
     });
 
     $("th#name")[0].click();
-
-    expect($('tr td.name').first().text()).toEqual("Harry");
+    expect($('tr td.name').first().text()).toEqual("Zayn");
 
     $("th#name")[0].click();
 
-    expect($('tr td.name').first().text()).toEqual("Zayn");
+    expect($('tr td.name').first().text()).toEqual("Harry");
 
     $("th#age")[0].click();
-
-    expect($('tr td.name').last().text()).toEqual("Louis");
-    expect($('tr td.name').first().text()).toEqual("Niall");
+    // Sorts desc by default
+    expect($('tr td.name').last().text()).toEqual("Niall");
+    expect($('tr td.name').first().text()).toEqual("Louis");
 });


### PR DESCRIPTION
- Update JS so that you can sort by breach percentage
- Refactors and tests JS for breach percentages and sorting by numeric column
- Swaps default order so that numeric columns will show highest # breaches first on first click
- Adds "sticky" header and footer for table as recommended by Anu
- Refactors CSS to accomplish this.