### PR TITLE
Validate files must be nonzero length [#176927311]

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -51,6 +51,13 @@ class Document < ApplicationRecord
   belongs_to :uploaded_by, polymorphic: true, optional: true
   has_one_attached :upload
   validates :upload, presence: true
+  validate :upload_must_have_data
+  def upload_must_have_data
+    if upload.attached? && upload.blob.byte_size.zero?
+      errors[:upload] << I18n.t("validators.file_zero_length")
+    end
+  end
+
   validate :tax_return_belongs_to_client
 
   before_save :set_display_name

--- a/app/views/hub/documents/index.html.erb
+++ b/app/views/hub/documents/index.html.erb
@@ -31,7 +31,7 @@
           <td><%= document.document_type_label %></td>
           <td>
             <%= link_to hub_client_document_path(client_id: @client.id, id: document.id), target: "_blank", rel: "noopener noreferrer" do %>
-              <%= document.display_name %>
+              <%= document.display_name %> <%= t(".empty_file") if document.upload.blob.byte_size.zero? %>
             <% end %>
           </td>
           <td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -138,6 +138,7 @@ en:
         upload_date: Upload Date
         uploaded_ago: "%{time} ago"
         add_client_envelope_doc: "Add client envelope document"
+        empty_file: "(empty file)"
       display_name: Display name
     messages:
       index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -735,6 +735,7 @@ en:
       header: We'd love to work with you next year to help you file your taxes or claim your stimulus for free!
       subheader: Please sign up here to receive a notification when we open in January 2021.
   validators:
+    file_zero_length: Please upload a valid file. The file you uploaded appears to be empty.
     file_type: Please upload a valid document type. Accepted types include jpg, pdf, and png.
     zip: Please enter a valid 5-digit zip code.
   views:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -138,6 +138,7 @@ es:
         upload_date: Fecha de carga
         uploaded_ago: Hace %{time}
         add_client_envelope_doc: "Agregar documento al sobre de cliente"
+        empty_file: "(archivo vacío)"
       display_name: Nombre Para Mostrar
     messages:
       index:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -740,6 +740,7 @@ es:
   validators:
     file_type: Por favor, sube un tipo de documento válido. Los tipos aceptados incluyen jpg, pdf y png.
     zip: Por favor, introduzca un código postal válido de 5 dígitos.
+    file_zero_length: "Sube un archivo válido. El archivo que cargó parece estar vacío."
   views:
     dependents:
       form:

--- a/spec/controllers/hub/documents_controller_spec.rb
+++ b/spec/controllers/hub/documents_controller_spec.rb
@@ -37,6 +37,16 @@ RSpec.describe Hub::DocumentsController, type: :controller do
                  created_at: 1.hour.ago,
                  client: client
         }
+        let!(:fourth_document) do
+          doc = build :document,
+                      display_name: "zero-bytes.jpg",
+                      document_type: "Email Attachment",
+                      created_at: 1.hour.ago,
+                      client: client,
+                      upload_path: Rails.root.join("spec", "fixtures", "attachments", "zero-bytes.jpg")
+          doc.save(validate: false)
+          doc
+        end
 
         it "displays all the documents for the client" do
           get :index, params: params
@@ -56,6 +66,10 @@ RSpec.describe Hub::DocumentsController, type: :controller do
           expect(third_doc_element).to have_text("Email attachment")
           expect(third_doc_element).to have_text("email-attachment.pdf")
           expect(third_doc_element).to have_text("1 hour ago")
+          fourth_doc_element = html.at_css("#document-#{fourth_document.id}")
+          expect(fourth_doc_element).to have_text("Email attachment")
+          expect(fourth_doc_element).to have_text("zero-bytes.jpg (empty file)")
+          expect(fourth_doc_element).to have_text("1 hour ago")
         end
       end
 

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -83,6 +83,14 @@ describe Document do
         end
       end
     end
+
+    context "with a 0-byte upload" do
+      let(:document) { build :document, upload_path: Rails.root.join("spec", "fixtures", "attachments", "zero-bytes.jpg") }
+      it "rejects the file as invalid" do
+        expect(document).not_to be_valid
+        expect(document.errors).to include :upload
+      end
+    end
   end
 
   describe "#document_type" do

--- a/spec/services/sign8879_service_spec.rb
+++ b/spec/services/sign8879_service_spec.rb
@@ -22,7 +22,7 @@ describe Sign8879Service do
     before do
       allow(tax_return).to receive(:filing_joint?).and_return false
       allow(WriteToPdfDocumentService).to receive(:new).and_return document_service_double
-      allow(document_service_double).to receive(:tempfile_output).and_return Tempfile.new
+      allow(document_service_double).to receive(:tempfile_output).and_return File.open(Rails.root.join("spec", "fixtures", "attachments", "test-pdf.pdf"), "r")
       allow(document_service_double).to receive(:write)
     end
 


### PR DESCRIPTION
There are approx 192 zero-byte uploads, which surely are user error. This PR prevents them from being attached to `Document`s.

This accomplishes 3 useful things:

* Tell clients during intake their uploaded docs are invalid if they're 0-bytes long

* Tell Hub users during doc upload their uploaded docs are invalid if they're 0-bytes long

* For existing files, show Hub users that a doc _is_ 0-bytes long so they know it's a broken file