### PR TITLE
Save attachments before delivering emails

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -55,13 +55,17 @@ class Document < ApplicationRecord
 
   before_save :set_display_name
 
-  after_create do
+  after_create_commit do
     uploaded_by.is_a?(Client) ? record_incoming_interaction : record_internal_interaction
 
     if upload.filename.extension_without_delimiter.downcase == "heic"
       HeicToJpgJob.perform_later(id)
     end
   end
+
+  # has_one_attached needs to be called after defining any callbacks that access attachments, like
+  # the HEIC conversion; see https://github.com/rails/rails/issues/37304
+  has_one_attached :upload
 
   def document_type_label
     DocumentTypes::ALL_TYPES.find { |doc_type_class| doc_type_class.key == document_type } || document_type

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -49,7 +49,6 @@ class Document < ApplicationRecord
   belongs_to :contact_record, polymorphic: true, optional: true
   belongs_to :tax_return, optional: true
   belongs_to :uploaded_by, polymorphic: true, optional: true
-  has_one_attached :upload
   validates :upload, presence: true
   validate :tax_return_belongs_to_client
 

--- a/app/models/outgoing_email.rb
+++ b/app/models/outgoing_email.rb
@@ -35,8 +35,7 @@ class OutgoingEmail < ApplicationRecord
   # Use `after_create_commit` so that the attachment is fully saved to S3 before delivering it
   after_create_commit :deliver, :broadcast
   after_create_commit :record_outgoing_interaction, if: ->(email) { email.user.present? }
-  # Use `has_one_attached` below `after_create_commit`; ActiveRecord runs callbacks in last-in, first-out order
-  # See also https://github.com/rails/rails/issues/37304#issuecomment-546246357
+  # has_one_attached needs to be called after defining any callbacks that access attachments, like :deliver; see https://github.com/rails/rails/issues/37304
   has_one_attached :attachment
 
   def datetime

--- a/app/models/outgoing_email.rb
+++ b/app/models/outgoing_email.rb
@@ -32,10 +32,12 @@ class OutgoingEmail < ApplicationRecord
   validates_presence_of :body
   validates_presence_of :subject
   validates_presence_of :sent_at
+  # Use `after_create_commit` so that the attachment is fully saved to S3 before delivering it
+  after_create_commit :deliver, :broadcast
+  after_create_commit :record_outgoing_interaction, if: ->(email) { email.user.present? }
+  # Use `has_one_attached` below `after_create_commit`; ActiveRecord runs callbacks in last-in, first-out order
+  # See also https://github.com/rails/rails/issues/37304#issuecomment-546246357
   has_one_attached :attachment
-
-  after_create :deliver, :broadcast
-  after_create :record_outgoing_interaction, if: ->(email) { email.user.present? }
 
   def datetime
     sent_at

--- a/spec/models/outgoing_email_spec.rb
+++ b/spec/models/outgoing_email_spec.rb
@@ -76,19 +76,31 @@ RSpec.describe OutgoingEmail, type: :model do
         expect(message).to be_valid
         expect(message.errors).to be_blank
       end
+    end
+  end
 
-      context "after create" do
-        it "enqueues delivery of the message" do
-          expect {
-            message.save
-          }.to have_enqueued_email
-        end
+  context "after save" do
+    let(:message) do
+      OutgoingEmail.new(
+        client: create(:client),
+        to: "someone@example.com",
+        subject: "this is a subject",
+        body: "hi",
+        sent_at: DateTime.now,
+        user: create(:user),
+        attachment: fixture_file_upload("attachments/test-pattern.png"),
+      )
+    end
 
-        it "broadcasts a message" do
-          message.save
-          expect(ClientChannel).to have_received(:broadcast_contact_record).with(message)
-        end
-      end
+    it "enqueues delivery of the message" do
+      expect {
+        message.save
+      }.to have_enqueued_email
+    end
+
+    it "broadcasts a message" do
+      message.save
+      expect(ClientChannel).to have_received(:broadcast_contact_record).with(message)
     end
   end
 end

--- a/spec/models/outgoing_email_spec.rb
+++ b/spec/models/outgoing_email_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe OutgoingEmail, type: :model do
     end
   end
 
-  context "after save" do
+  context "after create" do
     let(:message) do
       OutgoingEmail.new(
         client: create(:client),


### PR DESCRIPTION
I manually tested this, but I'm not thrilled with the lack of automated testing for this issue, but I don't have any really great ideas how to do that, so I say let's roll with it.

This fixes [MailDeliveryJob failures due to ActiveStorage::FileNotFoundError](https://www.pivotaltracker.com/story/show/177029790)