### PR TITLE
Log client_id and user_id to Sentry

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -157,7 +157,7 @@ class ApplicationController < ActionController::Base
 
   def set_sentry_context
     Raven.user_context intake_id: current_intake&.id
-    Raven.extra_context visitor_id: visitor_id, is_bot: user_agent.bot?, request_id: request.request_id
+    Raven.extra_context visitor_id: visitor_id, is_bot: user_agent.bot?, request_id: request.request_id, user_id: current_user&.id, client_id: current_client&.id
   end
 
   def switch_locale(&action)


### PR DESCRIPTION
We set up Sentry last year, and we haven't added two new important properties to Sentry - `user_id` for Hub users, and `client_id` for client logins through the "Portal." This adds them.

It also adds tests for the existing Sentry code in ApplicationController.