### PR TITLE
Validate that user emails are on domains that accept email [#176721446]

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,7 +58,7 @@ class User < ApplicationRecord
 
   before_validation :format_phone_number
   validates :phone_number, phone: true, allow_blank: true, format: { with: /\A\+1[0-9]{10}\z/ }
-  validates :email, 'valid_email_2/email': true
+  validates :email, 'valid_email_2/email': { mx: true }
   has_many :assigned_tax_returns, class_name: "TaxReturn", foreign_key: :assigned_user_id
   has_many :access_logs
   belongs_to :role, polymorphic: true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -65,6 +65,18 @@ RSpec.describe User, type: :model do
         expect(user).not_to be_valid
         expect(user.errors).to include :email
       end
+
+      context "when the email address looks valid, but the domain's DNS configuration doesn't accept email" do
+        let(:user) { build(:user, email: "someone@example.com") }
+        before do
+          allow_any_instance_of(ValidEmail2::Address).to receive(:valid_mx?).and_return(false)
+        end
+
+        it "is not valid and adds an error to the email" do
+          expect(user).not_to be_valid
+          expect(user.errors).to include :email
+        end
+      end
     end
 
     it "validates timezone" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -95,6 +95,10 @@ RSpec.configure do |config|
     # Stub required credentials to prevent need for RAILS_MASTER_KEY in test
     allow(EnvironmentCredentials).to receive(:dig).and_call_original
     allow(EnvironmentCredentials).to receive(:dig).with(:db_encryption_key).and_return('any-32-character-string-here!!!!')
+    # Stub valid_email2's network-dependent functionality per https://github.com/micke/valid_email2
+    config.before(:each) do
+      allow_any_instance_of(ValidEmail2::Address).to receive(:valid_mx?).and_return(true)
+    end
   end
 end
 


### PR DESCRIPTION
This adds stronger validation to _User_ emails, not _Intake_ (Client) emails.

This should help us avoid situations where Mailgun rejects user invitations b/c Mailgun believes the email addresses are invalid.

We don't do this kind of strong validation on Intake/Client emails yet, but maybe we should. I propose we not worry about that, and then we start worrying about if we find it's a problem.