### PR TITLE
Change default ordering in client index view

### DIFF
--- a/app/controllers/concerns/client_sortable.rb
+++ b/app/controllers/concerns/client_sortable.rb
@@ -1,6 +1,6 @@
 module ClientSortable
   def filtered_and_sorted_clients(default_order: nil)
-    @default_order = default_order || { "id" => "desc" }
+    @default_order = default_order || { "first_unanswered_incoming_interaction_at" => "asc" }
     setup_sortable_client unless @filters.present?
     clients = @clients.after_consent
     clients = clients.delegated_order(@sort_column, @sort_order)

--- a/app/views/hub/clients/index.html.erb
+++ b/app/views/hub/clients/index.html.erb
@@ -40,17 +40,20 @@
 
           <% if @breach_date.present? %>
             <th scope="col" class="index-table__header">
-              <%= render "shared/column_sort_link", title: "No response since", column_name: "first_unanswered_incoming_interaction_at" %>
+              <%= render "shared/column_sort_link", title: t("clients.response_needed_since"), column_name: "first_unanswered_incoming_interaction_at" %>
             </th>
             <th scope="col" class="index-table__header">
-              <%= render "shared/column_sort_link", title: "Attention needed since", column_name: "attention_needed_since" %>
+              <%= render "shared/column_sort_link", title: t("clients.attention_needed_since"), column_name: "attention_needed_since" %>
             </th>
           <% else %>
             <th scope="col" class="index-table__header">
               <%= render "shared/column_sort_link", title: t("general.updated_at"), column_name: "updated_at" %>
             </th>
             <th scope="col" class="index-table__header">
-              <%= render "shared/column_sort_link", title: "Consented At", column_name: "primary_consented_to_service_at" %>
+              <%= render "shared/column_sort_link", title: t("clients.response_needed_since"), column_name: "first_unanswered_incoming_interaction_at" %>
+            </th>
+            <th scope="col" class="index-table__header">
+              <%= render "shared/column_sort_link", title: t("clients.consented_at"), column_name: "primary_consented_to_service_at" %>
             </th>
           <% end %>
 
@@ -83,6 +86,7 @@
               <td class="index-table__cell"><%= formatted_datetime(client.attention_needed_since) %></td>
             <% else %>
               <td class="index-table__cell"><%= formatted_datetime(client.updated_at) %></td>
+              <td class="index-table__cell"><%= formatted_datetime(client.first_unanswered_incoming_interaction_at) %></td>
               <td class="index-table__cell"><%= formatted_datetime(client.intake.primary_consented_to_service_at) || "-"%> </td>
             <% end %>
             <td class="index-table__cell"><%= client.intake.state_of_residence %></td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1939,5 +1939,8 @@ en:
   clients:
     errors:
       tax_return_assigned_user_access: "%{affected_users} would lose access if you assign this client to %{new_partner}. Please change tax return assignments before reassigning this client."
+    response_needed_since: "Waiting on response"
+    attention_needed_since: "Attention needed since"
+    consented_at: "Consented at"
 
 

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1966,3 +1966,6 @@ es:
   clients:
     errors:
       tax_return_assigned_user_access: "%{affected_users} perdería el acceso si asigna este cliente a %{new_partner}. Cambie las asignaciones de la declaración de impuestos antes de reasignar a este cliente."
+    response_needed_since: "Esperando respuesta"
+    attention_needed_since: "Atención necesaria desde"
+    consented_at: "Consentido en"

--- a/spec/controllers/hub/clients_controller_spec.rb
+++ b/spec/controllers/hub/clients_controller_spec.rb
@@ -465,25 +465,25 @@ RSpec.describe Hub::ClientsController do
         end
 
         context "with no or bad params" do
-          let!(:first_id) { create :client, :with_return, vita_partner: organization, intake: create(:intake) }
-          let!(:second_id) { create :client, :with_return, vita_partner: organization, intake: create(:intake) }
+          let!(:first_id) { create :client, :with_return, vita_partner: organization, intake: create(:intake), first_unanswered_incoming_interaction_at: 2.days.ago }
+          let!(:second_id) { create :client, :with_return, vita_partner: organization, intake: create(:intake), first_unanswered_incoming_interaction_at: 1.day.ago }
 
-          it "defaults to sorting by id, desc by default" do
+          it "defaults to sorting by first_unanswered_incoming_interaction_at, asc by default" do
             get :index
 
-            expect(assigns[:sort_column]).to eq "id"
-            expect(assigns[:sort_order]).to eq "desc"
+            expect(assigns[:sort_column]).to eq "first_unanswered_incoming_interaction_at"
+            expect(assigns[:sort_order]).to eq "asc"
 
-            expect(assigns(:clients)).to eq [second_id, first_id]
+            expect(assigns(:clients)).to eq [first_id, second_id]
           end
 
           it "defaults to sorting by id, desc with bad params" do
             get :index, params: { column: "bad_sort", order: "no_order" }
 
-            expect(assigns[:sort_column]).to eq "id"
-            expect(assigns[:sort_order]).to eq "desc"
+            expect(assigns[:sort_column]).to eq "first_unanswered_incoming_interaction_at"
+            expect(assigns[:sort_order]).to eq "asc"
 
-            expect(assigns(:clients)).to eq [second_id, first_id]
+            expect(assigns(:clients)).to eq [first_id, second_id]
           end
         end
       end

--- a/spec/controllers/hub/unattended_clients_controller_spec.rb
+++ b/spec/controllers/hub/unattended_clients_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Hub::UnattendedClientsController, type: :controller do
           get :index
 
           header_row = Nokogiri::HTML.parse(response.body).at_css(".index-table__head")
-          expect(header_row).to have_text("No response since")
+          expect(header_row).to have_text("Waiting on response")
           expect(header_row).to have_text("Attention needed since")
           expect(header_row).not_to have_text("Updated at")
           expect(header_row).not_to have_text("Consented at")


### PR DESCRIPTION
- makes the "Waiting on Response" column visible
- defaults to ordering on that column