### PR TITLE
Fix Sentry crash on VitaProviders search page

### DIFF
--- a/app/forms/provider_search_form.rb
+++ b/app/forms/provider_search_form.rb
@@ -1,6 +1,7 @@
 class ProviderSearchForm < Form
   attr_accessor :zip, :page
   validates :zip, zip_code: true
+  validates :page, numericality: { only_integer: true, greater_than_or_equal_to: 1 }, allow_blank: true
 
   def valid_zip_searched?
     zip.present? && errors.empty?

--- a/spec/controllers/vita_providers_controller_spec.rb
+++ b/spec/controllers/vita_providers_controller_spec.rb
@@ -136,6 +136,20 @@ RSpec.describe VitaProvidersController do
           expect(subject).to have_received(:send_mixpanel_event).with(event_name: "provider_search", data: expected_data)
         end
       end
+
+      context "with invalid page number" do
+        let!(:closest_providers) { create_list :vita_provider, 5, :with_coordinates, lat_lon: [37.834519, -122.263273] }
+        let!(:next_closest_providers) { create_list :vita_provider, 5, :with_coordinates, lat_lon: [37.826387, -122.269738] }
+        let(:params) do
+          { zip: "94609", page: "invalid" }
+        end
+
+        it "shows no search results" do
+          get :index, params: params
+
+          expect(assigns(:providers)).to eq([])
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This uses Rails model (form) validation to fix a Sentry crash on the VitaProviders search page.

https://sentry.io/organizations/codeforamerica/issues/2206272501/?project=1880327&query=vitaproviders&sort=freq&statsPeriod=14d