### PR TITLE
Fix silently failing outgoing interaction bug

### DIFF
--- a/app/controllers/hub/outgoing_emails_controller.rb
+++ b/app/controllers/hub/outgoing_emails_controller.rb
@@ -4,13 +4,12 @@ module Hub
 
     before_action :require_sign_in
     load_and_authorize_resource :client
-    load_and_authorize_resource through: :client
 
     def create
       if outgoing_email_params[:body].present?
         ClientMessagingService.send_email(@client, current_user, outgoing_email_params[:body], attachment: outgoing_email_params[:attachment])
       end
-      redirect_to hub_client_messages_path(client_id: @outgoing_email.client_id)
+      redirect_to hub_client_messages_path(client_id: @client)
     end
 
     private

--- a/app/controllers/hub/outgoing_text_messages_controller.rb
+++ b/app/controllers/hub/outgoing_text_messages_controller.rb
@@ -4,7 +4,6 @@ module Hub
 
     before_action :require_sign_in
     load_and_authorize_resource :client
-    load_and_authorize_resource through: :client
 
     def create
       if outgoing_text_message_params[:body].present?

--- a/app/models/concerns/interaction_tracking.rb
+++ b/app/models/concerns/interaction_tracking.rb
@@ -12,7 +12,7 @@ module InteractionTracking
 
   # When we contact a client, update our last touch to them for SLA purposes and clear the attention flag
   def record_outgoing_interaction
-    client&.update(
+    client&.update!(
       last_internal_or_outgoing_interaction_at: Time.now.to_datetime,
       attention_needed_since: nil,
       first_unanswered_incoming_interaction_at: nil, # we've explicitly responded to them somehow, so we can clear this value.


### PR DESCRIPTION
## The Problem

Once we made the "response needed since" value visible, [Yvonne quickly noticed that it wasn't cleared when she sent outgoing messages](https://www.pivotaltracker.com/story/show/177049206/comments/222173284).

It turns out our call to `client.update` has been failing silently when creating outgoing text messages and emails, likely causing more false positives in the interaction tracking.
Once I changed it to `client.update!` I saw errors about the client having invalid text messages or invalid emails.

```
Failure/Error:
client&.update!(
last_internal_or_outgoing_interaction_at: Time.now.to_datetime,
attention_needed_since: nil,
first_unanswered_incoming_interaction_at: nil, # we've explicitly responded to them somehow, so we can clear this value.
)

     ActiveRecord::RecordInvalid:
       Validation failed: Outgoing emails is invalid
     # ./app/models/concerns/interaction_tracking.rb:15:in `record_outgoing_interaction'
     # ./app/services/client_messaging_service.rb:53:in `create_outgoing_email'
     # ./app/services/client_messaging_service.rb:6:in `send_email'
     # ./app/controllers/hub/outgoing_emails_controller.rb:11:in `create'
     # ./app/controllers/application_controller.rb:168:in `switch_locale'
     # ./app/controllers/application_controller.rb:246:in `block in set_time_zone'
     # ./app/controllers/application_controller.rb:246:in `set_time_zone'
     # ------------------
     # --- Caused by: ---
     # ActiveRecord::RecordInvalid:
     #   Validation failed: Outgoing emails is invalid
     #   ./app/models/concerns/interaction_tracking.rb:15:in `record_outgoing_interaction'
```

It turns out that when we instantiate `@outgoing_text_message` and `@outgoing_email` objects linked to `@client`, and then we don't modify them, then when we call client.update!, the client will have an invalid unpersisted invalid email/text message linked to it and will fail validation.

## The Solution

We aren't using these instantiated `@outgoing_text_message` and `@outgoing_email` objects, and we don't really need to authorize them. The authorization is tied to client access, so removing a separate call to authorize and load these objects is redundant. We can safely remove these load and authorize calls.