### PR TITLE
Ensure clients w/o names are clickable in index

### DIFF
--- a/app/views/hub/clients/index.html.erb
+++ b/app/views/hub/clients/index.html.erb
@@ -75,7 +75,7 @@
             </td>
             <th scope="row" class="index-table__row-header client-attribute__name">
               <%= link_to hub_client_path(id: client) do %>
-                <%= client.preferred_name %>
+                <%= client.preferred_name || t(".no_name_given") %>
               <% end %>
               <% if client.access_locked? %>
                 <span class="locked label label--red"><%= t("general.locked") %></span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -102,6 +102,7 @@ en:
         stage_status: Tax return stage/status
         organization: Organization/site
         assigned_user: Assigned to
+        no_name_given: "Name left blank"
       unlinked_clients:
         title: Unlinked clients
       navigation:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -87,6 +87,7 @@ es:
         stage_status: Estado/etapa de declaración de impuestos
         organization: Organización/Sitio
         assigned_user: Asignado a
+        no_name_given: "Nombre dejado en blanco"
       navigation:
         client_documents: Documentos
         client_messages: Mensajes

--- a/spec/controllers/hub/clients_controller_spec.rb
+++ b/spec/controllers/hub/clients_controller_spec.rb
@@ -356,6 +356,17 @@ RSpec.describe Hub::ClientsController do
             expect(html.at_css("#client-#{george_sr.id}")).to have_text("Locked")
           end
         end
+
+        context "when a client has no preferred name" do
+          before { george_sr.intake.update(preferred_name: nil) }
+
+          it "shows a default value so you can still click on the client" do
+            get :index
+
+            html = Nokogiri::HTML.parse(response.body)
+            expect(html.at_css("#client-#{george_sr.id}")).to have_text("Name left blank")
+          end
+        end
       end
 
       context "sorting and ordering" do


### PR DESCRIPTION
Some of the [clients who have been waiting for weeks for a response](https://www.getyourrefund.org/en/hub/clients/sla-breaches) do not appear to have any recorded preferred name in our database. As a result, there is no way to click on them in the index  page in order to view their case. This just adds a default placeholder if the name is missing so there's something to click.