### PR TITLE
Avoid SQL query in tax return list partial

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,6 +99,10 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'git-pair'
   gem 'annotate'
+  gem 'rack-mini-profiler'
+  gem 'flamegraph'
+  gem 'stackprof'
+  gem 'memory_profiler'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,7 @@ GEM
     ffi (1.14.2)
     fix-db-schema-conflicts (3.0.3)
       rubocop (>= 0.38.0)
+    flamegraph (0.9.5)
     formatador (0.2.5)
     git-pair (0.1.0)
     globalid (0.4.2)
@@ -258,6 +259,7 @@ GEM
       rest-client (~> 2.0.2)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
+    memory_profiler (1.0.0)
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
@@ -316,6 +318,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
+    rack-mini-profiler (2.3.1)
+      rack (>= 1.2.0)
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -456,6 +460,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    stackprof (0.2.16)
     strip_attributes (1.11.0)
       activemodel (>= 3.0, < 7.0)
     terminal-table (1.8.0)
@@ -547,6 +552,7 @@ DEPENDENCIES
   easy_translate
   factory_bot_rails
   fix-db-schema-conflicts
+  flamegraph
   git-pair
   guard-rspec
   http_accept_language
@@ -557,6 +563,7 @@ DEPENDENCIES
   listen (>= 3.4.0)
   lograge
   mailgun-ruby (~> 1.1.6)
+  memory_profiler
   mini_racer
   mixpanel-ruby
   nokogiri (>= 1.10.8)
@@ -569,6 +576,7 @@ DEPENDENCIES
   pry-byebug
   puma (>= 4.3.5)
   rack (>= 2.0.8)
+  rack-mini-profiler
   rails (>= 6.0.3.4)
   rails-controller-testing
   rails-i18n
@@ -586,6 +594,7 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
+  stackprof
   strip_attributes
   terser (~> 1.0)
   thor

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -65,7 +65,7 @@ class Client < ApplicationRecord
   delegate *delegated_intake_attributes, to: :intake
   scope :after_consent, -> { distinct.joins(:tax_returns).merge(TaxReturn.where("status > 100")) }
   scope :assigned_to, ->(user) { joins(:tax_returns).where({ tax_returns: { assigned_user_id: user } }).distinct }
-  scope :with_eager_loaded_associations, -> { includes(:vita_partner, :intake, :tax_returns, tax_returns: [:assigned_user]) }
+  scope :with_eager_loaded_associations, -> { includes(:vita_partner, :intake, :tax_returns, tax_returns: [:assigned_user]).order('tax_returns.year') }
   scope :sla_tracked, -> { distinct.joins(:tax_returns).where(tax_returns: { status: TaxReturnStatus::STATUS_KEYS_INCLUDED_IN_SLA })}
   scope :any_breach, ->(breach_threshold_datetime) do
     where("first_unanswered_incoming_interaction_at <= ?", breach_threshold_datetime).or(

--- a/app/views/shared/_tax_return_list.html.erb
+++ b/app/views/shared/_tax_return_list.html.erb
@@ -1,7 +1,7 @@
 <% status_updateable ||= false %>
 
 <ul class="tax-return-list">
-  <% client.tax_returns.order(year: :asc).each do |tax_return| %>
+  <% client.tax_returns.each do |tax_return| %>
     <li id="tax-return-<%= tax_return.id %>">
       <div class="tax-return-list__assignment">
         <span class="tax-return-list__year">


### PR DESCRIPTION
## Overview

Lou noticed we're running lots of SQL queries in `_tax_return_list.html.erb`.

This pull request:

* Adds a way to visualize SQL queries ([rack-mini-profiler](https://github.com/MiniProfiler/rack-mini-profiler))
* Move a SQL `.order()` call out of the template and into a Rails scope, so that the template doesn't trigger new SQL execution

## Before

When rendering the client list, notice that `_tax_return_list.html.erb` appears twice (presumably once per client)

![image](https://user-images.githubusercontent.com/67708639/108876530-2842e300-75b3-11eb-837d-08bc0af5178a.png)

Notice that it's running at least 1 SQL query per time it's invoked.

## After

![image](https://user-images.githubusercontent.com/67708639/108876647-4e688300-75b3-11eb-9c16-d9e9407af38f.png)

When rendering the client list, notice that `_tax_return_list.html.erb` appears zero times (it's running 0 SQL queries)
