### PR TITLE
Only show CLIENT uploaded messages on the message upload note

### DIFF
--- a/app/presenters/notes_presenter.rb
+++ b/app/presenters/notes_presenter.rb
@@ -3,7 +3,7 @@ class NotesPresenter
     # Extract Note and SystemNote data from the database.
     # Generate notes from documents on-the-fly, so the summary can change as clients upload more documents.
     notes = (client.notes.includes(:user) + SystemNote.where(client: client))
-    synthetic_notes = synthetic_notes_from_documents(client.documents.order(created_at: :asc))
+    synthetic_notes = synthetic_notes_from_documents(client.documents.where(uploaded_by: client).order(created_at: :asc))
     synthetic_notes += synthetic_notes_from_outbound_calls(client.outbound_calls.order(created_at: :asc))
     (notes + synthetic_notes).sort_by(&:created_at).group_by { |note| note.created_at.beginning_of_day }
   end

--- a/spec/features/hub/notes_spec.rb
+++ b/spec/features/hub/notes_spec.rb
@@ -4,8 +4,9 @@ RSpec.feature "View and add internal notes for a client" do
   context "As an authenticated user" do
     let(:organization) { create :organization }
     let(:user) { create :user, timezone: "America/Los_Angeles", role: create(:organization_lead_role, organization: organization) }
-    let(:documents) { create_list(:document, 3, created_at: DateTime.new(2020, 3, 1).utc, document_type: "Employment") }
-    let(:client) { create :client, vita_partner: organization, intake: create(:intake, preferred_name: "Bart Simpson"), documents: documents }
+    let!(:documents) { create_list(:document, 3, created_at: DateTime.new(2020, 3, 1).utc, document_type: "Employment", uploaded_by: client, client: client) }
+    let!(:not_included_docs) { create_list(:document, 2, created_at: DateTime.new(2020, 3,1).utc, uploaded_by: user, client: client) }
+    let(:client) { create :client, vita_partner: organization, intake: create(:intake, preferred_name: "Bart Simpson") }
     before do
       login_as user
     end

--- a/spec/presenters/notes_presenter_spec.rb
+++ b/spec/presenters/notes_presenter_spec.rb
@@ -32,13 +32,27 @@ RSpec.describe NotesPresenter do
 
     context "with documents on one day" do
       let(:day1) { DateTime.new(2019, 10, 5, 8, 1).utc }
-      let!(:documents) { create_list(:document, 5, created_at: day1, client: client) }
+      let!(:documents) { create_list(:document, 5, created_at: day1, client: client, uploaded_by: client) }
 
       it "groups recently created documents into one message" do
         result = NotesPresenter.grouped_notes(client)
         expect(result[day1.beginning_of_day][0].created_at).to eq day1
         expect(result[day1.beginning_of_day][0].body).to eq "Client added 5 documents."
       end
+
+      context "when there are documents uploaded by the system or a user" do
+        before do
+          create_list(:document, 2, created_at: day1, client: client)
+          create_list(:document, 1, created_at: day1, client: client, uploaded_by: create(:user))
+        end
+
+        it "does not include docs that are not uploaded by the client" do
+          result = NotesPresenter.grouped_notes(client)
+          expect(result[day1.beginning_of_day][0].created_at).to eq day1
+          expect(result[day1.beginning_of_day][0].body).to eq "Client added 5 documents."
+        end
+      end
+
     end
 
     context "with documents on multiple days" do
@@ -47,9 +61,9 @@ RSpec.describe NotesPresenter do
       let(:day2_noon) { DateTime.new(2019, 10, 8, 12).utc }
 
       before do
-        create_list(:document, 1, created_at: day1, client: client)
-        create_list(:document, 2, created_at: day2, client: client)
-        create_list(:document, 2, created_at: day2_noon, client: client)
+        create_list(:document, 1, created_at: day1, client: client, uploaded_by: client)
+        create_list(:document, 2, created_at: day2, client: client, uploaded_by: client)
+        create_list(:document, 2, created_at: day2_noon, client: client, uploaded_by: client)
       end
 
       it "groups recently created documents into one message" do


### PR DESCRIPTION
The implementation of the synthetic notes on the notes presenter was around since before we started keeping track of WHO uploaded a document. This only displays client actions.