### PR TITLE
Treat search as having no results if page number too high

### DIFF
--- a/app/controllers/vita_providers_controller.rb
+++ b/app/controllers/vita_providers_controller.rb
@@ -16,7 +16,7 @@ class VitaProvidersController < ApplicationController
         @providers = VitaProvider.sort_by_distance_from_zipcode(@zip, @page)
         @zip_name = ZipCodes.details(@zip)[:name]
 
-        if @providers.total_entries > 0
+        if @providers.count > 0
           track_provider_search
         else
           track_provider_search_no_results


### PR DESCRIPTION
This should fix this trivial crash on demo & prod https://sentry.io/organizations/codeforamerica/issues/2233970805/?project=1880321&query=is%3Aunresolved

The cause is that the code was confused about `total_entries` vs `count` -- `count` is appropriate here, since the Mixpanel tracking code reads `.first`.