### PR TITLE
Allow users to share hub links with query params

### DIFF
--- a/app/controllers/concerns/access_controllable.rb
+++ b/app/controllers/concerns/access_controllable.rb
@@ -5,7 +5,7 @@ module AccessControllable
     unless current_user.present?
       respond_to do |format|
         format.html do
-          session[:after_login_path] = redirect_after_login || request.path
+          session[:after_login_path] = redirect_after_login || request.original_fullpath
           redirect_to new_user_session_path
         end
         format.js do


### PR DESCRIPTION
Currently, if you try to visit a login protected page in the hub, you'll be redirected to sign in, and then once you sign in you will be redirected to the page you were originally trying to access. However, if there were any query parameters in the URL you tried to visit, they will disappear after you login. This change retains the query params you originally tried to use, and should help hub users share links to specific searches.