### PR TITLE
Fix stimulus flow

### DIFF
--- a/app/controllers/questions/questions_controller.rb
+++ b/app/controllers/questions/questions_controller.rb
@@ -43,8 +43,12 @@ module Questions
     def has_unsure_option?
       layout = self.send :_layout, self.lookup_context, [""]
       return false unless layout == "yes_no_question"
-      enum_options = Intake.try(method_name.pluralize)
+      enum_options = parent_class.try(method_name.pluralize)
       enum_options&.has_key?("unsure")
+    end
+
+    def parent_class
+      Intake
     end
 
     def method_name

--- a/app/controllers/stimulus/file_for_stimulus_controller.rb
+++ b/app/controllers/stimulus/file_for_stimulus_controller.rb
@@ -4,7 +4,7 @@ module Stimulus
 
     class << self
       def show?(triage)
-        triage.need_to_correct_yes? || triage.need_to_file_yes?
+        triage.need_to_correct_yes? || triage.need_to_file_yes? || triage.need_to_correct_unsure? || triage.need_to_file_unsure?
       end
 
       def form_class

--- a/app/controllers/stimulus/need_to_file_controller.rb
+++ b/app/controllers/stimulus/need_to_file_controller.rb
@@ -5,7 +5,7 @@ module Stimulus
     end
 
     def self.show?(stimulus_triage)
-      stimulus_triage.filed_recently_no?
+      stimulus_triage.filed_recently_no? || stimulus_triage.filed_recently_unsure?
     end
   end
 end

--- a/app/controllers/stimulus/stimulus_controller.rb
+++ b/app/controllers/stimulus/stimulus_controller.rb
@@ -38,6 +38,10 @@ module Stimulus
       nil
     end
 
+    def parent_class
+      StimulusTriage
+    end
+
     def illustration_folder
       "stimulus"
     end
@@ -65,17 +69,16 @@ module Stimulus
     end
 
     class << self
+      def form_class
+        form_key.classify.constantize
+      end
+
       def form_key
         "stimulus/" + controller_name + "_form"
       end
 
-      def form_class
-        form_name.classify.constantize
-      end
-
       def form_name
-        byebug
-        form_key.parameterize(separator: "_")
+        form_key.gsub("/", "_")
       end
     end
   end

--- a/app/controllers/stimulus/stimulus_controller.rb
+++ b/app/controllers/stimulus/stimulus_controller.rb
@@ -1,15 +1,7 @@
 module Stimulus
-  class StimulusController < ApplicationController
+  class StimulusController < Questions::QuestionsController
+    skip_before_action :require_intake
     before_action :require_stimulus_triage
-
-    delegate :form_name, to: :class
-    delegate :form_class, to: :class
-
-    helper_method :current_path
-    helper_method :illustration_folder
-    helper_method :illustration_path
-    helper_method :next_path
-    helper_method :prev_path
 
     layout "yes_no_question"
 
@@ -50,14 +42,6 @@ module Stimulus
       "stimulus"
     end
 
-    def illustration_path
-      "#{controller_name.dasherize}.svg"
-    end
-
-    def self.show?(stimulus_triage)
-      true
-    end
-
     private
 
     def require_stimulus_triage
@@ -74,10 +58,6 @@ module Stimulus
       @form_navigation ||= StimulusNavigation.new(self)
     end
 
-    def track_validation_error
-      send_mixpanel_validation_error(@form.errors, tracking_data)
-    end
-
     def tracking_data
       return {} unless @form.class.scoped_attributes.key?(:stimulus_triage)
 
@@ -85,19 +65,16 @@ module Stimulus
     end
 
     class << self
-      def to_param
-        controller_name.dasherize
-      end
-
       def form_key
         "stimulus/" + controller_name + "_form"
       end
 
       def form_class
-        form_key.classify.constantize
+        form_name.classify.constantize
       end
 
       def form_name
+        byebug
         form_key.parameterize(separator: "_")
       end
     end


### PR DESCRIPTION
We're not currently using the stimulus flow and there aren't any feature tests for the functionality so it wasn't caught that some of the changes to the questions flow (adding idk) affected the stimulus flow. Namely, the stimulus flow shares layouts with questions in the intake flow but wasn't sharing a parent (QuestionsController) in order to get the methods it needed to support an "I don't know" answer. 