### PR TITLE
Add contact preferences to messages page [#177124054]

### DIFF
--- a/app/views/hub/messages/index.html.erb
+++ b/app/views/hub/messages/index.html.erb
@@ -33,7 +33,7 @@
   <% end %>
   <div class="hub-section">
     <div class="communication-preferences">
-      <% if !@client&.intake.email_address.present? && !@client&.intake.sms_phone_number.present? %>
+      <% unless @client&.intake.email_address.present? || @client&.intake.sms_phone_number.present? %>
         <%= t(".no_way_to_communicate") %>
       <% else %>
         <%= t(".preference_intro") %>

--- a/app/views/hub/messages/index.html.erb
+++ b/app/views/hub/messages/index.html.erb
@@ -32,10 +32,31 @@
     <ul class="message-list" data-js="messages-pub-sub" data-client-id="<%=@client.id%>"></ul>
   <% end %>
   <div class="hub-section">
-    <%= form_with model: @outgoing_text_message, url: hub_client_outgoing_text_messages_path(client: @client), local: true, builder: VitaMinFormBuilder, method: "post", html: {class: 'text-message-form'} do |f| %>
-      <%= f.cfa_input_field :body, t(".text_message_form.label") %>
-      <%= f.hidden_field :client_id %>
-      <%= f.submit t(".text_message_form.submit"), class: "button #{"button--disabled" if @client.sms_phone_number.blank?}", disabled: @client.sms_phone_number.blank? %>
+    <div class="communication-preferences">
+      <% if !@client&.intake.email_address.present? && !@client&.intake.sms_phone_number.present? %>
+        <%= t(".no_way_to_communicate") %>
+      <% else %>
+        <%= t(".preference_intro") %>
+        <ul class="with-bullets">
+          <% if @client&.intake.sms_notification_opt_in_yes? && @client&.intake.sms_phone_number.present? %>
+            <li><%= t("general.text_message") %></li>
+          <% end %>
+          <% if @client&.intake.email_notification_opt_in_yes? && @client&.intake.email_address.present? %>
+            <li><%= t("general.email")%></li>
+        <% end %>
+        </ul>
+      <% end %>
+    </div>
+
+
+    <% if @client&.intake.sms_phone_number.present? %>
+      <%= form_with model: @outgoing_text_message, url: hub_client_outgoing_text_messages_path(client: @client), local: true, builder: VitaMinFormBuilder, method: "post", html: {class: 'text-message-form'} do |f| %>
+        <%= f.cfa_input_field :body, t(".text_message_form.label") %>
+        <%= f.hidden_field :client_id %>
+        <%= f.submit t(".text_message_form.submit"), class: "button" %>
+      <% end %>
+    <% else %>
+      <p><%= t(".no_sms_number") %></p>
     <% end %>
 
     <% if @client&.intake.email_address.present? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -150,7 +150,10 @@ en:
         text_message_form:
           label: Send a text message
           submit: Send
-        no_email_address: "No email address for this client found."
+        no_email_address: Client has not provided an email address.
+        no_sms_number: Client has not provided an SMS phone number.
+        no_way_to_communicate: Client has not provided contact info for digital communication.
+        preference_intro: "Client has opted in to contact by:"
       email_from: Email from
       email_to: Email to
       automated: Automated

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -150,7 +150,10 @@ es:
         text_message_form:
           label: Enviar un mensaje de texto
           submit: Enviar
-        no_email_address: "No se encontró la dirección de correo electrónico de este cliente."
+        no_email_address: No se encontró la dirección de correo electrónico de este cliente.
+        no_sms_number: El cliente no ha proporcionado un número de teléfono SMS.
+        no_way_to_communicate: El cliente no ha proporcionado información de contacto para la comunicación digital.
+        preference_intro: "El cliente ha optado por contactar por:"
       email_from: Email de
       email_to: Email a
       automated: Automatizado


### PR DESCRIPTION
Add a list of contact preferences to the messages page so that greeters and vita users dont need to tab back and forth to see this critical messaging-related information.