### PR TITLE
Add greeter requested info status [#176971703]

### DIFF
--- a/app/lib/tax_return_status.rb
+++ b/app/lib/tax_return_status.rb
@@ -17,6 +17,7 @@ class TaxReturnStatus
     def message_templates
       {
           intake_info_requested: "hub.status_macros.needs_more_information",
+          intake_greeter_info_requested: "hub.status_macros.needs_more_information",
           prep_info_requested: "hub.status_macros.needs_more_information",
           review_info_requested: "hub.status_macros.needs_more_information",
           review_ready_for_qr: "hub.status_macros.ready_for_qr",
@@ -30,7 +31,7 @@ class TaxReturnStatus
   #
   # The first word of each status name is treated as a "stage" when grouping these in the interface.
   STATUSES = {
-      intake_before_consent: 100, intake_in_progress: 101, intake_ready: 102, intake_reviewing: 103, intake_ready_for_call: 104, intake_info_requested: 105,
+      intake_before_consent: 100, intake_in_progress: 101, intake_ready: 102, intake_reviewing: 103, intake_ready_for_call: 104, intake_info_requested: 105, intake_greeter_info_requested: 106,
 
       prep_ready_for_prep: 201, prep_preparing: 202, prep_info_requested: 203,
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -202,6 +202,7 @@ en:
       status:
         intake_before_consent: Before consent
         intake_in_progress: Not ready
+        intake_greeter_info_requested: Greeter - info requested
         intake_ready: Ready for review
         intake_reviewing: Reviewing
         intake_ready_for_call: Ready for call

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -203,7 +203,8 @@ es:
       status:
         intake_before_consent: Antes de consentimiento
         intake_in_progress: No listo
-        intake_ready: Ready for review
+        intake_greeter_info_requested: Saludador - Información solicitada
+        intake_ready: Listo para revisión
         intake_reviewing: Revisando
         intake_ready_for_call: Listo para llamada
         intake_info_requested: Información solicitada

--- a/spec/helpers/tax_return_status_helper_spec.rb
+++ b/spec/helpers/tax_return_status_helper_spec.rb
@@ -10,6 +10,7 @@ describe TaxReturnStatusHelper do
          ["Reviewing", "intake_reviewing"],
          ["Ready for call", "intake_ready_for_call"],
          ["Info requested", "intake_info_requested"],
+         ["Greeter - info requested", "intake_greeter_info_requested"],
        ]
       ],
       ["Tax prep",

--- a/spec/models/tax_return_spec.rb
+++ b/spec/models/tax_return_spec.rb
@@ -717,7 +717,7 @@ describe TaxReturn do
     end
 
     it "includes all intake statuses except before consent" do
-      expect(result["intake"].length).to eq 5
+      expect(result["intake"].length).to eq 6
       expect(result["intake"]).not_to include "intake_before_consent"
     end
 


### PR DESCRIPTION
This is a much-simplified version of the greeter requested info status. To avoid doing a production data migration (which might include downtime), we're just going to add it to the end of the intake statuses. This will be fine, because "Info Requested" is already at the end of the intake statuses and that's the state that Greeters are currently toggling between, so the "advancement-only" concern does not apply -- we are and need to be moving statuses forward and backward here.