### PR TITLE
Change ready for review macro to reviewing macro

### DIFF
--- a/app/lib/tax_return_status.rb
+++ b/app/lib/tax_return_status.rb
@@ -23,7 +23,7 @@ class TaxReturnStatus
           prep_info_requested: "hub.status_macros.needs_more_information",
           prep_preparing: "hub.status_macros.prep_preparing",
           review_info_requested: "hub.status_macros.needs_more_information",
-          review_ready_for_qr: "hub.status_macros.review_ready_for_qr",
+          review_reviewing: "hub.status_macros.review_reviewing",
           review_ready_for_call: "hub.status_macros.review_ready_for_call",
           review_signature_requested: "hub.status_macros.review_signature_requested",
           file_accepted: "hub.status_macros.file_accepted",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -267,7 +267,7 @@ en:
 
         Thanks,
         <<Preparer.FirstName>> at GetYourRefund
-      review_ready_for_qr: |
+      review_reviewing: |
         Hello <<Client.PreferredName>>,
 
         Your <<TaxReturn.TaxYear>> return is now being quality reviewed! We'll reach out to schedule a call to review with you soon.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -261,7 +261,7 @@ es:
 
         Muchas gracias,
         <<Preparer.FirstName>> de GetYourRefund
-      review_ready_for_qr: |
+      review_reviewing: |
         ¡Hola <<Client.PreferredName>>!
 
         ¡Su devolución ahora está siendo revisada en calidad!

--- a/spec/lib/tax_return_status_spec.rb
+++ b/spec/lib/tax_return_status_spec.rb
@@ -24,10 +24,10 @@ describe TaxReturnStatus do
       end
     end
 
-    context "prep_ready_for_review" do
+    context "review_reviewing" do
       it "returns a template" do
-        expect(TaxReturnStatus.message_template_for("review_ready_for_qr")).to eq I18n.t("hub.status_macros.review_ready_for_qr", locale: "en")
-        expect(TaxReturnStatus.message_template_for(:review_ready_for_qr, "es")).to eq I18n.t("hub.status_macros.review_ready_for_qr", locale: "es")
+        expect(TaxReturnStatus.message_template_for("review_reviewing")).to eq I18n.t("hub.status_macros.review_reviewing", locale: "en")
+        expect(TaxReturnStatus.message_template_for(:review_reviewing, "es")).to eq I18n.t("hub.status_macros.review_reviewing", locale: "es")
       end
     end
 

--- a/spec/services/replacement_parameters_service_spec.rb
+++ b/spec/services/replacement_parameters_service_spec.rb
@@ -210,9 +210,9 @@ describe ReplacementParametersService do
       end
     end
 
-    context "review_ready_for_qr" do
+    context "review_reviewing" do
       context "in english" do
-        let(:body) { I18n.t("hub.status_macros.review_ready_for_qr") }
+        let(:body) { I18n.t("hub.status_macros.review_reviewing") }
 
         it "replaces the replacement strings in the template" do
           result = subject.process
@@ -222,7 +222,7 @@ describe ReplacementParametersService do
       end
 
       context "in spanish" do
-        let(:body) { I18n.t("hub.status_macros.review_ready_for_qr", locale: "es") }
+        let(:body) { I18n.t("hub.status_macros.review_reviewing", locale: "es") }
         let(:locale) { "es" }
 
         it "replaces the replacement strings in the template" do


### PR DESCRIPTION
Rae requested we change the macro for "ready for review" to "reviewing" to make it more clear when the action is actually being taken.