### PR TITLE
In Metabase docs, refer to correct GCloud project

### DIFF
--- a/docs/2021-02-08-metabase.md
+++ b/docs/2021-02-08-metabase.md
@@ -1,6 +1,6 @@
 # Metabase for analytics
 
-*Last updated 2021-02-16 by Asheesh Laroia*
+*Last updated 2021-03-03 by Asheesh Laroia*
 
 ## Summary
 
@@ -144,7 +144,7 @@ from the analytics schema.
 Create a new Google API token for use with Metabase. The details
 tend to change over time, but this worked at the time of writing:
 
-* Visit https://console.cloud.google.com/ and make sure you are in the **getyourrefund-304319** project.
+* Visit https://console.cloud.google.com/ and make sure you are in the **getyourrefund** project.
   It's OK to use this one project for all Aptible environments.
 
 * Click APIs and Services, then Credentials.


### PR DESCRIPTION
Thanks to @loumoore , we moved Metabase login into the main getyourrefund GCloud project.