### PR TITLE
Expire access tokens after two days

### DIFF
--- a/app/models/email_access_token.rb
+++ b/app/models/email_access_token.rb
@@ -5,6 +5,8 @@
 #  id            :bigint           not null, primary key
 #  email_address :citext           not null
 #  token         :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
 #
 # Indexes
 #
@@ -15,8 +17,8 @@ class EmailAccessToken < ApplicationRecord
   validates_presence_of :email_address
   validate :one_or_more_valid_email_addresses
 
-  scope :by_raw_token, ->(raw_token) do
-    where(token: Devise.token_generator.digest(EmailAccessToken, :token, raw_token))
+  scope :lookup, ->(raw_token) do
+    where(token: Devise.token_generator.digest(EmailAccessToken, :token, raw_token)).where("created_at > ?", Time.current - 2.days)
   end
 
   private

--- a/app/models/text_message_access_token.rb
+++ b/app/models/text_message_access_token.rb
@@ -5,6 +5,8 @@
 #  id               :bigint           not null, primary key
 #  sms_phone_number :string           not null
 #  token            :string           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #
 # Indexes
 #
@@ -14,7 +16,7 @@ class TextMessageAccessToken < ApplicationRecord
   validates_presence_of :token
   validates :sms_phone_number, phone: true, format: { with: /\A\+1[0-9]{10}\z/ }
 
-  scope :by_raw_token, ->(raw_token) do
-    where(token: Devise.token_generator.digest(TextMessageAccessToken, :token, raw_token))
+  scope :lookup, ->(raw_token) do
+    where(token: Devise.token_generator.digest(TextMessageAccessToken, :token, raw_token)).where("created_at > ?", Time.current - 2.days)
   end
 end

--- a/app/services/client_logins_service.rb
+++ b/app/services/client_logins_service.rb
@@ -61,11 +61,11 @@ class ClientLoginsService
 
     def clients_for_token(raw_token)
       # these might have multiple email addresses
-      to_addresses = EmailAccessToken.by_raw_token(raw_token).pluck(:email_address)
+      to_addresses = EmailAccessToken.lookup(raw_token).pluck(:email_address)
       emails = to_addresses.map { |to| to.split(",") }.flatten(1)
       email_intake_matches = Intake.where(email_address: emails)
       spouse_email_intake_matches = Intake.where(spouse_email_address: emails)
-      phone_numbers = TextMessageAccessToken.by_raw_token(raw_token).pluck(:sms_phone_number)
+      phone_numbers = TextMessageAccessToken.lookup(raw_token).pluck(:sms_phone_number)
       phone_intake_matches = Intake.where(sms_phone_number: phone_numbers)
       intake_matches = email_intake_matches.or(spouse_email_intake_matches).or(phone_intake_matches)
 

--- a/db/migrate/20210304015405_add_timestamps_to_access_tokens.rb
+++ b/db/migrate/20210304015405_add_timestamps_to_access_tokens.rb
@@ -1,0 +1,10 @@
+class AddTimestampsToAccessTokens < ActiveRecord::Migration[6.0]
+  def change
+    add_timestamps :email_access_tokens, default: Time.now
+    add_timestamps :text_message_access_tokens, default: Time.now
+    change_column_default :text_message_access_tokens, :created_at, to: nil, from: Time.now
+    change_column_default :text_message_access_tokens, :updated_at, to: nil, from: Time.now
+    change_column_default :email_access_tokens, :created_at, to: nil, from: Time.now
+    change_column_default :email_access_tokens, :updated_at, to: nil, from: Time.now
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_02_225442) do
+ActiveRecord::Schema.define(version: 2021_03_04_015405) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -183,8 +183,10 @@ ActiveRecord::Schema.define(version: 2021_03_02_225442) do
   end
 
   create_table "email_access_tokens", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
     t.citext "email_address", null: false
     t.string "token", null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["token"], name: "index_email_access_tokens_on_token"
   end
 
@@ -584,8 +586,10 @@ ActiveRecord::Schema.define(version: 2021_03_02_225442) do
   end
 
   create_table "text_message_access_tokens", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
     t.string "sms_phone_number", null: false
     t.string "token", null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["token"], name: "index_text_message_access_tokens_on_token"
   end
 

--- a/spec/factories/email_access_tokens.rb
+++ b/spec/factories/email_access_tokens.rb
@@ -5,6 +5,8 @@
 #  id            :bigint           not null, primary key
 #  email_address :citext           not null
 #  token         :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
 #
 # Indexes
 #

--- a/spec/factories/text_message_access_tokens.rb
+++ b/spec/factories/text_message_access_tokens.rb
@@ -5,6 +5,8 @@
 #  id               :bigint           not null, primary key
 #  sms_phone_number :string           not null
 #  token            :string           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #
 # Indexes
 #

--- a/spec/models/email_access_token_spec.rb
+++ b/spec/models/email_access_token_spec.rb
@@ -5,6 +5,8 @@
 #  id            :bigint           not null, primary key
 #  email_address :citext           not null
 #  token         :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
 #
 # Indexes
 #

--- a/spec/models/text_message_access_token_spec.rb
+++ b/spec/models/text_message_access_token_spec.rb
@@ -5,6 +5,8 @@
 #  id               :bigint           not null, primary key
 #  sms_phone_number :string           not null
 #  token            :string           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #
 # Indexes
 #

--- a/spec/services/client_logins_service_spec.rb
+++ b/spec/services/client_logins_service_spec.rb
@@ -203,7 +203,7 @@ describe ClientLoginsService do
       end
     end
 
-    context "with a client who's email matches an EmailAccessToken" do
+    context "with a client whose email matches an EmailAccessToken" do
       let!(:client) { create :client }
       before do
         create(:email_access_token, token: "hashed_token", email_address: "someone@example.com")
@@ -215,7 +215,7 @@ describe ClientLoginsService do
       end
     end
 
-    context "with a client who's spouse email matches an EmailAccessToken" do
+    context "with a client whose spouse email matches an EmailAccessToken" do
       let!(:client) { create :client }
       before do
         create(:email_access_token, token: "hashed_token", email_address: "someone@example.com")
@@ -227,7 +227,7 @@ describe ClientLoginsService do
       end
     end
 
-    context "with a client who's email is contained in a comma-separated EmailAccessToken" do
+    context "with a client whose email is contained in a comma-separated EmailAccessToken" do
       let!(:client) { create :client }
       before do
         create(:email_access_token, token: "hashed_token", email_address: "someone@example.com,other@example.com")
@@ -236,6 +236,19 @@ describe ClientLoginsService do
 
       it "returns the client" do
         expect(described_class.clients_for_token("raw_token")).to match_array [client]
+      end
+    end
+
+    context "with a client with matching access tokens older than 2 days" do
+      let!(:client) { create :client }
+      before do
+        create(:email_access_token, token: "hashed_token", email_address: "someone@example.com", created_at: Time.current - (2.1).days)
+        create(:text_message_access_token, token: "hashed_token", sms_phone_number: "+16505551212", created_at: Time.current - (2.1).days)
+        create(:intake, client: client, spouse_email_address: "someone@example.com")
+      end
+
+      it "returns a blank set" do
+        expect(described_class.clients_for_token("raw_token")).to match_array []
       end
     end
 


### PR DESCRIPTION
@bengolder and I discussed that access tokens could expire after two days. The important thing is that valid tokens not live _forever_.

The implementation here is a little messy, but I think it's messy in a good way.

I created an untested model scope called `lookup` which looks up tokens by content and also checks them for being too old. It's a weird name - `lookup` - but it also centralizes the logic, which is good in my opinion.

The service spec is where I test this model scope, in effect, which is good because I don't just want to test that the model scope _exists_; I want to test that we _use_ it; and it seemed like a lot of paperwork to unit-test it in the models, then go mock it out in the service spec.

I'm OK reworking it if a reviewer thinks it's important.