### PR TITLE
Create an access log when user views document in the hub

### DIFF
--- a/app/controllers/hub/clients/bank_accounts_controller.rb
+++ b/app/controllers/hub/clients/bank_accounts_controller.rb
@@ -8,7 +8,7 @@ module Hub
       def show
         AccessLog.create(
           user: current_user,
-          client: @client,
+          record: @client,
           created_at: DateTime.now,
           event_type: "read_bank_account_info",
           ip_address: request.remote_ip,

--- a/app/controllers/hub/clients/ssn_itins_controller.rb
+++ b/app/controllers/hub/clients/ssn_itins_controller.rb
@@ -23,7 +23,7 @@ module Hub
       def create_access_log
         AccessLog.create(
           user: current_user,
-          client: @client,
+          record: @client,
           event_type: "read_ssn_itin",
           created_at: DateTime.now,
           ip_address: request.remote_ip,

--- a/app/controllers/hub/documents_controller.rb
+++ b/app/controllers/hub/documents_controller.rb
@@ -17,6 +17,14 @@ module Hub
     end
 
     def show
+      AccessLog.create(
+        user: current_user,
+        client: @document.client,
+        created_at: DateTime.now,
+        event_type: "viewed_document",
+        ip_address: request.remote_ip,
+        user_agent: request.user_agent,
+      )
       redirect_to transient_storage_url(@document.upload.blob)
     end
 

--- a/app/controllers/hub/documents_controller.rb
+++ b/app/controllers/hub/documents_controller.rb
@@ -19,7 +19,7 @@ module Hub
     def show
       AccessLog.create(
         user: current_user,
-        client: @document.client,
+        record: @document,
         created_at: DateTime.now,
         event_type: "viewed_document",
         ip_address: request.remote_ip,

--- a/app/models/access_log.rb
+++ b/app/models/access_log.rb
@@ -22,7 +22,7 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class AccessLog < ApplicationRecord
-  EVENT_TYPES = ["read_bank_account_info", "read_ssn_itin"]
+  EVENT_TYPES = ["read_bank_account_info", "read_ssn_itin", "viewed_document"]
   belongs_to :client
   belongs_to :user
   validate :valid_event_type

--- a/app/models/access_log.rb
+++ b/app/models/access_log.rb
@@ -2,28 +2,28 @@
 #
 # Table name: access_logs
 #
-#  id         :bigint           not null, primary key
-#  event_type :string           not null
-#  ip_address :inet
-#  user_agent :string           not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  client_id  :bigint           not null
-#  user_id    :bigint           not null
+#  id          :bigint           not null, primary key
+#  event_type  :string           not null
+#  ip_address  :inet
+#  record_type :string           not null
+#  user_agent  :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  record_id   :bigint           not null
+#  user_id     :bigint           not null
 #
 # Indexes
 #
-#  index_access_logs_on_client_id  (client_id)
-#  index_access_logs_on_user_id    (user_id)
+#  index_access_logs_on_record_type_and_record_id  (record_type,record_id)
+#  index_access_logs_on_user_id                    (user_id)
 #
 # Foreign Keys
 #
-#  fk_rails_...  (client_id => clients.id)
 #  fk_rails_...  (user_id => users.id)
 #
 class AccessLog < ApplicationRecord
   EVENT_TYPES = ["read_bank_account_info", "read_ssn_itin", "viewed_document"]
-  belongs_to :client
+  belongs_to :record, polymorphic: true
   belongs_to :user
   validate :valid_event_type
 

--- a/db/migrate/20210306011032_add_record_id_to_access_logs.rb
+++ b/db/migrate/20210306011032_add_record_id_to_access_logs.rb
@@ -1,0 +1,16 @@
+class AddRecordIdToAccessLogs < ActiveRecord::Migration[6.0]
+  def up
+    add_reference :access_logs, :record, polymorphic: true, null: false
+    AccessLog.all.find_each do |access_log|
+      access_log.update(
+        record_id: access_log.client_id,
+      )
+    end
+    remove_column :access_logs, :client_id
+  end
+
+  def down
+    add_reference :access_logs, :client, foreign_key: true
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_05_233848) do
+ActiveRecord::Schema.define(version: 2021_03_06_011032) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -18,14 +18,15 @@ ActiveRecord::Schema.define(version: 2021_03_05_233848) do
   enable_extension "postgis"
 
   create_table "access_logs", force: :cascade do |t|
-    t.bigint "client_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.string "event_type", null: false
     t.inet "ip_address"
+    t.bigint "record_id", null: false
+    t.string "record_type", null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "user_agent", null: false
     t.bigint "user_id", null: false
-    t.index ["client_id"], name: "index_access_logs_on_client_id"
+    t.index ["record_type", "record_id"], name: "index_access_logs_on_record_type_and_record_id"
     t.index ["user_id"], name: "index_access_logs_on_user_id"
   end
 
@@ -692,7 +693,6 @@ ActiveRecord::Schema.define(version: 2021_03_05_233848) do
     t.index ["last_scrape_id"], name: "index_vita_providers_on_last_scrape_id"
   end
 
-  add_foreign_key "access_logs", "clients"
   add_foreign_key "access_logs", "users"
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "clients", "vita_partners"

--- a/spec/controllers/hub/clients/bank_accounts_controller_spec.rb
+++ b/spec/controllers/hub/clients/bank_accounts_controller_spec.rb
@@ -35,13 +35,13 @@ describe Hub::Clients::BankAccountsController, type: :controller do
 
       it "creates an AccessLog" do
         expect { get :show, params: params, format: :js, xhr: true }.to change(AccessLog, :count).by(1)
-        record = AccessLog.last
-        expect(record.user).to eq(user)
-        expect(record.client).to eq(client)
-        expect(record.event_type).to eq("read_bank_account_info")
-        expect(record.created_at).to eq(back_to_the_future_day)
-        expect(record.ip_address).to eq("1.1.1.1")
-        expect(record.user_agent).to eq(user_agent_header)
+        access_log = AccessLog.last
+        expect(access_log.user).to eq(user)
+        expect(access_log.record).to eq(client)
+        expect(access_log.event_type).to eq("read_bank_account_info")
+        expect(access_log.created_at).to eq(back_to_the_future_day)
+        expect(access_log.ip_address).to eq("1.1.1.1")
+        expect(access_log.user_agent).to eq(user_agent_header)
       end
     end
   end

--- a/spec/controllers/hub/clients/ssn_itins_controller_spec.rb
+++ b/spec/controllers/hub/clients/ssn_itins_controller_spec.rb
@@ -35,13 +35,13 @@ describe Hub::Clients::SsnItinsController, type: :controller do
 
       it "creates an AccessLog" do
         expect { get :show, params: params, format: :js, xhr: true }.to change(AccessLog, :count).by(1)
-        record = AccessLog.last
-        expect(record.user).to eq(user)
-        expect(record.client).to eq(client)
-        expect(record.event_type).to eq("read_ssn_itin")
-        expect(record.created_at).to eq(back_to_the_future_day)
-        expect(record.ip_address).to eq("1.1.1.1")
-        expect(record.user_agent).to eq(user_agent_header)
+        access_log = AccessLog.last
+        expect(access_log.user).to eq(user)
+        expect(access_log.record).to eq(client)
+        expect(access_log.event_type).to eq("read_ssn_itin")
+        expect(access_log.created_at).to eq(back_to_the_future_day)
+        expect(access_log.ip_address).to eq("1.1.1.1")
+        expect(access_log.user_agent).to eq(user_agent_header)
       end
     end
   end
@@ -105,13 +105,13 @@ describe Hub::Clients::SsnItinsController, type: :controller do
 
       it "creates an AccessLog" do
         expect { get :show_spouse, params: params, format: :js, xhr: true }.to change(AccessLog, :count).by(1)
-        record = AccessLog.last
-        expect(record.user).to eq(user)
-        expect(record.client).to eq(client)
-        expect(record.event_type).to eq("read_ssn_itin")
-        expect(record.created_at).to eq(back_to_the_future_day)
-        expect(record.ip_address).to eq("1.1.1.1")
-        expect(record.user_agent).to eq(user_agent_header)
+        access_log = AccessLog.last
+        expect(access_log.user).to eq(user)
+        expect(access_log.record).to eq(client)
+        expect(access_log.event_type).to eq("read_ssn_itin")
+        expect(access_log.created_at).to eq(back_to_the_future_day)
+        expect(access_log.ip_address).to eq("1.1.1.1")
+        expect(access_log.user_agent).to eq(user_agent_header)
       end
     end
   end

--- a/spec/controllers/hub/documents_controller_spec.rb
+++ b/spec/controllers/hub/documents_controller_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe Hub::DocumentsController, type: :controller do
 
         access_log = AccessLog.last
         expect(access_log.user).to eq user
-        expect(access_log.client).to eq client
+        expect(access_log.record).to eq document
         expect(access_log.event_type).to eq "viewed_document"
         expect(access_log.ip_address).to eq ip_address
         expect(access_log.user_agent).to eq user_agent

--- a/spec/controllers/hub/unattended_clients_controller_spec.rb
+++ b/spec/controllers/hub/unattended_clients_controller_spec.rb
@@ -1,4 +1,3 @@
-
 require "rails_helper"
 
 RSpec.describe Hub::UnattendedClientsController, type: :controller do

--- a/spec/factories/access_logs.rb
+++ b/spec/factories/access_logs.rb
@@ -2,28 +2,28 @@
 #
 # Table name: access_logs
 #
-#  id         :bigint           not null, primary key
-#  event_type :string           not null
-#  ip_address :inet
-#  user_agent :string           not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  client_id  :bigint           not null
-#  user_id    :bigint           not null
+#  id          :bigint           not null, primary key
+#  event_type  :string           not null
+#  ip_address  :inet
+#  record_type :string           not null
+#  user_agent  :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  record_id   :bigint           not null
+#  user_id     :bigint           not null
 #
 # Indexes
 #
-#  index_access_logs_on_client_id  (client_id)
-#  index_access_logs_on_user_id    (user_id)
+#  index_access_logs_on_record_type_and_record_id  (record_type,record_id)
+#  index_access_logs_on_user_id                    (user_id)
 #
 # Foreign Keys
 #
-#  fk_rails_...  (client_id => clients.id)
 #  fk_rails_...  (user_id => users.id)
 #
 FactoryBot.define do
   factory :access_log do
-    client
+    record { build :client }
     user
     ip_address { "1.1.1.1" }
     user_agent { "CERN-NextStep-WorldWideWeb.app/1.1 libwww/2.07" }

--- a/spec/models/access_log_spec.rb
+++ b/spec/models/access_log_spec.rb
@@ -2,23 +2,23 @@
 #
 # Table name: access_logs
 #
-#  id         :bigint           not null, primary key
-#  event_type :string           not null
-#  ip_address :inet
-#  user_agent :string           not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  client_id  :bigint           not null
-#  user_id    :bigint           not null
+#  id          :bigint           not null, primary key
+#  event_type  :string           not null
+#  ip_address  :inet
+#  record_type :string           not null
+#  user_agent  :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  record_id   :bigint           not null
+#  user_id     :bigint           not null
 #
 # Indexes
 #
-#  index_access_logs_on_client_id  (client_id)
-#  index_access_logs_on_user_id    (user_id)
+#  index_access_logs_on_record_type_and_record_id  (record_type,record_id)
+#  index_access_logs_on_user_id                    (user_id)
 #
 # Foreign Keys
 #
-#  fk_rails_...  (client_id => clients.id)
 #  fk_rails_...  (user_id => users.id)
 #
 require 'rails_helper'


### PR DESCRIPTION
This is for a small fry ticket to create an access log when users view a document. We created this after doing a threat modeling exercise and realizing that documents have the most potential to contain the most sensitive information clients give to us.

Part of this story included making the client association on `access_log` polymorphic to include documents as an associated record. 