### PR TITLE
Persist filters as cookie

### DIFF
--- a/app/controllers/hub/assigned_clients_controller.rb
+++ b/app/controllers/hub/assigned_clients_controller.rb
@@ -1,5 +1,6 @@
 module Hub
   class AssignedClientsController < ApplicationController
+    FILTER_COOKIE_NAME = "assigned_clients_filters".freeze
     include AccessControllable
     include ClientSortable
 
@@ -19,6 +20,12 @@ module Hub
 
     def load_vita_partners
       @vita_partners = VitaPartner.accessible_by(current_ability)
+    end
+
+    private
+
+    def filter_cookie_name
+      FILTER_COOKIE_NAME
     end
   end
 end

--- a/app/controllers/hub/clients_controller.rb
+++ b/app/controllers/hub/clients_controller.rb
@@ -1,5 +1,6 @@
 module Hub
   class ClientsController < ApplicationController
+    FILTER_COOKIE_NAME = "all_clients_filters".freeze
     include AccessControllable
     include ClientSortable
 
@@ -101,6 +102,10 @@ module Hub
 
     def take_action_form_params
       params.require(TakeActionForm.form_param).permit(TakeActionForm.permitted_params)
+    end
+
+    def filter_cookie_name
+      FILTER_COOKIE_NAME
     end
   end
 end

--- a/app/controllers/hub/unattended_clients_controller.rb
+++ b/app/controllers/hub/unattended_clients_controller.rb
@@ -1,5 +1,6 @@
 module Hub
   class UnattendedClientsController < ApplicationController
+    FILTER_COOKIE_NAME = "sla_violations_filters".freeze
     include AccessControllable
     include ClientSortable
 
@@ -24,6 +25,10 @@ module Hub
     def day_param
       value = params[:sla_days].to_i
       value > 0 ? value : 3
+    end
+
+    def filter_cookie_name
+      FILTER_COOKIE_NAME
     end
   end
 end

--- a/app/views/shared/_client_filters.html.erb
+++ b/app/views/shared/_client_filters.html.erb
@@ -10,9 +10,9 @@
         <select name="status" class="select__element" id="status-filter">
           <option value></option>
           <% TaxReturnStatus.available_statuses_for(current_user).each do |stage, statuses| %>
-            <option value="<%= stage %>" <%= params[:status] == stage && "selected" %>><%= TaxReturnStatusHelper.stage_translation(stage) %></option>
+            <option value="<%= stage %>" <%= @filters[:stage] == stage && "selected" %>><%= TaxReturnStatusHelper.stage_translation(stage) %></option>
             <% statuses.each do |status| %>
-              <option value="<%= status %>" <%= params[:status] == status.to_s && "selected" %>>&emsp;<%= status_translation(status) %></option>
+              <option value="<%= status %>" <%= [status, status.to_s].include?(@filters[:status]) && "selected" %>>&emsp;<%= status_translation(status) %></option>
             <% end %>
           <% end %>
         </select>
@@ -22,7 +22,7 @@
     <div class="form-group">
       <label for="year" class="form-question"><%= t("hub.clients.index.filing_year").humanize %></label>
       <div class="select">
-        <%= select_tag :year, options_for_select(TaxReturn.filing_years, params[:year]), include_blank: true, class: "select__element" %>
+        <%= select_tag :year, options_for_select(TaxReturn.filing_years, @filters[:year]), include_blank: true, class: "select__element" %>
       </div>
     </div>
 
@@ -34,9 +34,9 @@
           <select name="vita_partner_id" class="select__element" id="org-site-filter">
             <option value></option>
             <% @vita_partners.organizations.each do |vita_partner| %>
-              <option value="<%= vita_partner.id %>" <%= params[:vita_partner_id] == vita_partner.id.to_s && "selected" %>><%= vita_partner.name %></option>
+              <option value="<%= vita_partner.id %>" <%= @filters[:vita_partner_id] == vita_partner.id.to_s && "selected" %>><%= vita_partner.name %></option>
               <% vita_partner.child_sites.each do |site| %>
-                <option value="<%= site.id %>" <%= params[:vita_partner_id] == site.id.to_s && "selected" %>>&emsp;<%= site.name %></option>
+                <option value="<%= site.id %>" <%= @filters[:vita_partner_id] == site.id.to_s && "selected" %>>&emsp;<%= site.name %></option>
               <% end %>
             <% end %>
           </select>
@@ -51,7 +51,7 @@
           <select name="assigned_user_id" class="select__element" id="assignee-filter">
             <option value></option>
             <% @users.each do |user| %>
-              <option value="<%= user.id %>" <%= params[:assigned_user_id] == user.id.to_s && "selected" %>><%= user.name %></option>
+              <option value="<%= user.id %>" <%= @filters[:assigned_user_id] == user.id.to_s && "selected" %>><%= user.name %></option>
             <% end %>
           </select>
         </div>
@@ -62,24 +62,24 @@
       <label for="search" class="form-question">
         <%= t("general.search") %>
       </label>
-      <%= text_field_tag("search", params[:search], id: "search", class: "text-input") %>
+      <%= text_field_tag("search", @filters[:search], id: "search", class: "text-input") %>
     </div>
   </div>
 
   <div class="form-group filters-wrapper checkboxes-wrapper">
     <h4>Marked as:</h4>
     <label class="checkbox--gyr">
-      <%= check_box_tag :assigned_to_me, true, params[:assigned_to_me] || @always_current_user_assigned, disabled: @always_current_user_assigned %>
+      <%= check_box_tag :assigned_to_me, true, @filters[:assigned_to_me] || @always_current_user_assigned, disabled: @always_current_user_assigned %>
       <%= t("hub.clients.index.assigned_to_me") %>
     </label>
 
     <label class="checkbox--gyr">
-      <%= check_box_tag :unassigned, true, params[:unassigned] %>
+      <%= check_box_tag :unassigned, true, @filters[:unassigned] %>
       <%= t("hub.clients.index.unassigned") %>
     </label>
 
     <label class="checkbox--gyr">
-      <%= check_box_tag :needs_response, true, params[:needs_response] %>
+      <%= check_box_tag :needs_response, true, @filters[:needs_response] %>
       <%= t("general.needs_response") %>
     </label>
   </div>
@@ -87,7 +87,8 @@
   <div>
     <%= submit_tag t("hub.clients.index.filter"), class: "button button--cta spacing-below-35", name: nil %>
     <% if @filters && @filters.values.any? %>
-      <%= submit_tag t("hub.clients.index.clear_filters"), class: "button button--danger", name: "clear" %>
+      <%= link_to t("hub.clients.index.clear_filters"), { column: @sort_column, order: @sort_order, clear: true } , class: "button button--danger", name: "clear" %>
     <% end %>
   </div>
+  <%= @filters %>
 <% end %>

--- a/spec/controllers/concerns/client_sortable_spec.rb
+++ b/spec/controllers/concerns/client_sortable_spec.rb
@@ -7,12 +7,17 @@ RSpec.describe ClientSortable, type: :controller do
   # - it assumes that @clients is already set.
   let(:clients_query_double){ double }
   let(:intakes_query_double){ double }
-
+  let(:cookies) { double }
   controller(ApplicationController) do
     include ClientSortable
   end
 
   before do
+    allow(controller).to receive(:cookies).and_return(cookies)
+    allow(cookies).to receive(:delete)
+    allow(cookies).to receive(:[]=)
+    allow(cookies).to receive(:[])
+
     allow(subject).to receive(:params).and_return params
     subject.instance_variable_set(:@clients, clients_query_double)
     allow(clients_query_double).to receive(:after_consent).and_return clients_query_double
@@ -123,20 +128,18 @@ RSpec.describe ClientSortable, type: :controller do
       let(:params) do
         {
             clear: true,
-            search: "query",
-            status: "intake_in_progress",
-            year: "2019",
-            needs_response: true,
-            assigned_to_me: true,
-            unassigned: true,
-            vita_partner_id: 1,
             assigned_user_id: 1
         }
       end
 
-      it "clears all of the existing params" do
+      before do
+        allow(cookies).to receive(:delete)
+        allow(cookies).to receive(:[]).with(anything)
+      end
+
+      it "removes the filter cookie" do
         subject.filtered_and_sorted_clients
-        expect(assigns(:filters).values.compact).to be_empty
+        expect(cookies).to have_received(:delete).with(described_class::COOKIE_NAME)
       end
     end
 

--- a/spec/controllers/concerns/client_sortable_spec.rb
+++ b/spec/controllers/concerns/client_sortable_spec.rb
@@ -10,6 +10,12 @@ RSpec.describe ClientSortable, type: :controller do
   let(:cookies) { double }
   controller(ApplicationController) do
     include ClientSortable
+
+    private
+
+    def filter_cookie_name
+      "some_filter_cookie_name"
+    end
   end
 
   before do
@@ -139,7 +145,7 @@ RSpec.describe ClientSortable, type: :controller do
 
       it "removes the filter cookie" do
         subject.filtered_and_sorted_clients
-        expect(cookies).to have_received(:delete).with(described_class::COOKIE_NAME)
+        expect(cookies).to have_received(:delete).with("some_filter_cookie_name")
       end
     end
 

--- a/spec/features/hub/clients_searching_sorting_and_filtering_spec.rb
+++ b/spec/features/hub/clients_searching_sorting_and_filtering_spec.rb
@@ -37,17 +37,7 @@ RSpec.describe "searching, sorting, and filtering clients" do
         click_button "Filter results"
         expect(page.all('.client-row').length).to eq 1
         expect(page.all('.client-row')[0]).to have_text(zach_prep_ready_for_call.preferred_name)
-        click_button "Clear"
-
-        within ".filter-form" do
-          select "Alan's Org", from: "vita_partner_id"
-          click_button "Filter results"
-          expect(page).to have_select("vita_partner_id", selected: "Alan's Org")
-        end
-
-        expect(page.all('.client-row').length).to eq 1
-        # expect(page.all('.client-row')[0]).to have_text alan_intake_in_progress.preferred_name
-        click_button "Clear"
+        click_link "Clear"
 
         within ".filter-form" do
           select "Alan's Org", from: "vita_partner_id"
@@ -57,7 +47,30 @@ RSpec.describe "searching, sorting, and filtering clients" do
 
         expect(page.all('.client-row').length).to eq 1
         expect(page.all('.client-row')[0]).to have_text alan_intake_in_progress.preferred_name
-        click_button "Clear"
+        click_link "Clear"
+
+        within ".filter-form" do
+          select "Alan's Org", from: "vita_partner_id"
+          select "2020", from: "year"
+          select "Mona Mandarin", from: "assigned_user_id"
+          select "Ready for prep", from: "status"
+          fill_in "Search", with: "Zach"
+
+          click_button "Filter results"
+          expect(page).to have_select("vita_partner_id", selected: "Alan's Org")
+          expect(page).to have_select("year", selected: "2020")
+          expect(page).to have_select("assigned_user_id", selected: "Mona Mandarin")
+          expect(page).to have_select("status", selected: "Ready for prep")
+
+          # reload page and filters persist
+          visit hub_clients_path
+          expect(page).to have_select("vita_partner_id", selected: "Alan's Org")
+          expect(page).to have_select("year", selected: "2020")
+          expect(page).to have_select("assigned_user_id", selected: "Mona Mandarin")
+          expect(page).to have_select("status", selected: "Ready for prep")
+        end
+        
+        click_link "Clear"
 
         within ".filter-form" do
           select "Mona Mandarin", from: "assigned_user_id"
@@ -67,7 +80,7 @@ RSpec.describe "searching, sorting, and filtering clients" do
 
         expect(page.all('.client-row').length).to eq 1
         expect(page.all('.client-row')[0]).to have_text betty_intake_in_progress.preferred_name
-        click_button "Clear"
+        click_link "Clear"
 
         within ".filter-form" do
           select "Ready for prep", from: "status"
@@ -101,7 +114,7 @@ RSpec.describe "searching, sorting, and filtering clients" do
           expect(page.all('.client-row')[1]).to have_text(zach_prep_ready_for_call.preferred_name)
         end
         within ".filter-form" do
-          click_button "Clear"
+          click_link "Clear"
         end
         within ".client-table" do
           expect(page.all('.client-row').length).to eq 4
@@ -139,7 +152,7 @@ RSpec.describe "searching, sorting, and filtering clients" do
         expect(page.all('.client-row')[0]).to have_text(patty_prep_ready_for_call.preferred_name)
 
         within ".filter-form" do
-          click_button "Clear"
+          click_link "Clear"
         end
         within ".client-table" do
           expect(page.all('.client-row').length).to eq 4
@@ -155,7 +168,7 @@ RSpec.describe "searching, sorting, and filtering clients" do
           expect(page.all('.client-row').length).to eq 1
         end
         within ".filter-form" do
-          click_button "Clear"
+          click_link "Clear"
         end
         within ".client-table" do
           expect(page.all('.client-row').length).to eq 4

--- a/spec/features/hub/clients_searching_sorting_and_filtering_spec.rb
+++ b/spec/features/hub/clients_searching_sorting_and_filtering_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "searching, sorting, and filtering clients" do
 
     context "with existing clients" do
       let(:vita_partner) { create :vita_partner, name: "Alan's Org" }
+      let!(:vita_partner_other) { create :vita_partner, name: "Some Other Org" }
       let!(:alan_intake_in_progress) { create :client, vita_partner_id: vita_partner.id, intake: (create :intake, preferred_name: "Alan Avocado", primary_consented_to_service_at: 1.day.ago, state_of_residence: "CA"), tax_returns: [(create :tax_return, year: 2019, status: "intake_in_progress", assigned_user: user)] }
       let!(:betty_intake_in_progress) { create :client, intake: (create :intake, preferred_name: "Betty Banana", primary_consented_to_service_at: 2.days.ago, state_of_residence: "TX"), tax_returns: [(create :tax_return, year: 2018, status: "intake_in_progress", assigned_user: mona_user)] }
       let!(:patty_prep_ready_for_call) { create :client, intake: (create :intake, preferred_name: "Patty Banana", primary_consented_to_service_at: 1.day.ago, state_of_residence: "AL"), tax_returns: [(create :tax_return, year: 2019, status: "prep_ready_for_prep", assigned_user: user)] }
@@ -68,8 +69,36 @@ RSpec.describe "searching, sorting, and filtering clients" do
           expect(page).to have_select("year", selected: "2020")
           expect(page).to have_select("assigned_user_id", selected: "Mona Mandarin")
           expect(page).to have_select("status", selected: "Ready for prep")
+
+          visit hub_root_path
+          expect(page).to have_select("vita_partner_id", selected: nil)
+          expect(page).to have_select("year", selected: nil)
+          expect(page).to have_select("status", selected: nil)
+
+          select "Some Other Org", from: "vita_partner_id"
+          select "2019", from: "year"
+          select "Not filing", from: "status"
+          fill_in "Search", with: "Bob"
+          click_button "Filter results"
+          # Filters persist after submitting with filters
+          expect(page).to have_select("vita_partner_id", selected: "Some Other Org")
+          expect(page).to have_select("year", selected: "2019")
+          expect(page).to have_select("status", selected: "Not filing")
+
+          # Filters persist when visiting the page directly
+          visit hub_root_path
+          expect(page).to have_select("vita_partner_id", selected: "Some Other Org")
+          expect(page).to have_select("year", selected: "2019")
+          expect(page).to have_select("status", selected: "Not filing")
+
+          # Can navigate to another dashboard and see that pages persisted filters again.
+          visit hub_clients_path
+          expect(page).to have_select("vita_partner_id", selected: "Alan's Org")
+          expect(page).to have_select("year", selected: "2020")
+          expect(page).to have_select("assigned_user_id", selected: "Mona Mandarin")
+          expect(page).to have_select("status", selected: "Ready for prep")
         end
-        
+        # Clear links on hub_clients_path filter form
         click_link "Clear"
 
         within ".filter-form" do


### PR DESCRIPTION
Refactors client filters logic to store filters in a cookie. "Clear" now clears the cookie and reloads the page.