### PR TITLE
Fix bug that sets message_body to take action form when there are no contact options

### DIFF
--- a/app/forms/hub/take_action_form.rb
+++ b/app/forms/hub/take_action_form.rb
@@ -22,7 +22,6 @@ module Hub
       @tax_returns = client.tax_returns.order(year: :asc)
       @action_list = []
       super(*args, **attributes)
-
       set_default_locale if @locale.blank?
       set_default_message_body if @message_body.nil?
       set_default_contact_method if @contact_method.nil?
@@ -73,7 +72,7 @@ module Hub
     end
 
     def set_default_message_body
-      @message_body = "" and return unless status.present?
+      @message_body = "" and return unless status.present? && contact_method_options.present?
 
       template = TaxReturnStatus.message_template_for(status, locale)
       @message_body = ReplacementParametersService.new(body: template, client: client, tax_return: tax_return, preparer: current_user, locale: locale).process

--- a/app/views/hub/clients/edit_take_action.html.erb
+++ b/app/views/hub/clients/edit_take_action.html.erb
@@ -17,7 +17,6 @@
                 ) %>
       </div>
 
-
       <%= f.cfa_select(
         :locale,
         t("general.language"),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -311,7 +311,7 @@ en:
 
         To approve your return, click on the link below, enter the last four digits of your social security number OR your Client ID (You can find this in your original GYR welcome email/text). You can review your return and click a box saying you approve your return.
 
-        For jointly filed returns: If you provided your spouse's contact info, they'll get this message to. If not, please make sure they have access to this link so they can review and sign as well.
+        For jointly filed returns: If you provided your spouse's contact info, they'll get this message as well. If not, please make sure they have access to this link so they can also review and sign.
 
         Once you electronically sign, we can efile your return.
 


### PR DESCRIPTION
message_body was getting _set_ on the form even if weren't sending a message because there is no contact info. 

Adds logic that does not set the message body from status macro if there is no way to contact the user, which ensures that validations on that "hidden" message don't run.