### PR TITLE
Sign ALL Unsigned 8879s when you sign for a given tax year

### DIFF
--- a/app/controllers/portal/tax_returns_controller.rb
+++ b/app/controllers/portal/tax_returns_controller.rb
@@ -17,7 +17,7 @@ module Portal
       form_class = Portal::PrimarySignForm8879
       @form = form_class.new(@tax_return, permitted_params(form_class))
       if @form.sign
-        flash[:success] = I18n.t("controllers.tax_returns_controller.success", year: @tax_return.year)
+        flash[:notice] = I18n.t("controllers.tax_returns_controller.success", year: @tax_return.year)
         redirect_to :portal_root
       else
         flash.now[:alert] = I18n.t("controllers.tax_returns_controller.errors.#{@form.errors.keys.first}")

--- a/app/services/sign8879_service.rb
+++ b/app/services/sign8879_service.rb
@@ -1,30 +1,34 @@
 class Sign8879Service
   def self.create(tax_return)
-    unsigned8879 = tax_return.documents.find_by(document_type: DocumentTypes::UnsignedForm8879.key)
+    unsigned8879s = tax_return.documents.where(document_type: DocumentTypes::UnsignedForm8879.key)
+    unsigned8879s.each_with_index do |unsigned8879, i|
+      document_writer = WriteToPdfDocumentService.new(unsigned8879, DocumentTypes::UnsignedForm8879)
 
-    document_writer = WriteToPdfDocumentService.new(unsigned8879, DocumentTypes::UnsignedForm8879)
+      document_writer.write(:primary_signature, tax_return.primary_signature)
+      document_writer.write(:primary_signed_on, tax_return.primary_signed_at.strftime("%m/%d/%Y"))
 
-    document_writer.write(:primary_signature, tax_return.primary_signature)
-    document_writer.write(:primary_signed_on, tax_return.primary_signed_at.strftime("%m/%d/%Y"))
+      if tax_return.spouse_has_signed?
+        document_writer.write(:spouse_signature, tax_return.spouse_signature)
+        document_writer.write(:spouse_signed_on, tax_return.spouse_signed_at.strftime("%m/%d/%Y"))
+      end
 
-    if tax_return.spouse_has_signed?
-      document_writer.write(:spouse_signature, tax_return.spouse_signature)
-      document_writer.write(:spouse_signed_on, tax_return.spouse_signed_at.strftime("%m/%d/%Y"))
+      tempfile = document_writer.tempfile_output
+      tempfile.seek(0)
+
+      display_name = unsigned8879.display_name + " (Signed)"
+      filename = unsigned8879s.length == 1 ? "Signed-f8879.pdf" : "Signed-f8879-#{i + 1}.pdf"
+
+      unsigned8879.update!(
+        uploaded_by: tax_return.client,
+        document_type: DocumentTypes::CompletedForm8879.key,
+        display_name: display_name,
+        upload: {
+          io: tempfile,
+          filename: filename,
+          content_type: "application/pdf",
+          identify: false
+        }
+      )
     end
-
-    tempfile = document_writer.tempfile_output
-
-    tax_return.documents.create!(
-      client: tax_return.client,
-      uploaded_by: tax_return.client,
-      document_type: DocumentTypes::CompletedForm8879.key,
-      display_name: "Taxpayer Signed #{tax_return.year} 8879",
-      upload: {
-        io: tempfile,
-        filename: "Signed-f8879.pdf",
-        content_type: "application/pdf",
-        identify: false
-      }
-    )
   end
 end

--- a/app/views/hub/documents/index.html.erb
+++ b/app/views/hub/documents/index.html.erb
@@ -6,7 +6,6 @@
 
   <%= render "hub/clients/navigation" %>
 
-
   <section class="slab slab--half-padded">
     <div class="grid">
       <div class="grid-item">

--- a/app/views/portal/portal/home.html.erb
+++ b/app/views/portal/portal/home.html.erb
@@ -25,14 +25,32 @@
           <% end %>
         <% end %>
 
-        <% if tax_return.signed_8879.present? %>
-          <div class="tax-return-status__solo">
-            <%= link_to t(".tax_returns.view_signed_8879"), portal_document_path(id: tax_return.signed_8879.id), target: "_blank" %>
-          </div>
-        <% elsif tax_return.unsigned_8879.present? %>
-          <div class="tax-return-status__row tax-return-status__solo">
-            <%= link_to t(".tax_returns.view_unsigned_8879"), portal_document_path(id: tax_return.unsigned_8879.id), target: "_blank" %>
-          </div>
+        <% if tax_return.signed_8879s.present? %>
+          <% if tax_return.signed_8879s.count == 1 %>
+            <div class="tax-return-status__row tax-return-status__solo">
+              <%= link_to t(".tax_returns.view_signed_8879"), portal_document_path(id: tax_return.signed_8879s.first.id), target: "_blank" %>
+            </div>
+          <% else %>
+            <% tax_return.signed_8879s.each do |tax_doc| %>
+              <div class="tax-return-status__row tax-return-status__solo">
+                <%= link_to t(".tax_returns.view_document", display_name: tax_doc.display_name), portal_document_path(id: tax_doc.id), target: "_blank" %>
+              </div>
+            <% end %>
+          <% end %>
+        <% end %>
+
+        <% if tax_return.unsigned_8879s.present? %>
+          <% if tax_return.unsigned_8879s.count == 1 %>
+            <div class="tax-return-status__row tax-return-status__solo">
+              <%= link_to t(".tax_returns.view_unsigned_8879"), portal_document_path(id: tax_return.unsigned_8879s.first.id), target: "_blank" %>
+            </div>
+          <% else %>
+            <% tax_return.unsigned_8879s.each do |tax_doc| %>
+              <div class="tax-return-status__row tax-return-status__solo">
+                <%= link_to t(".tax_returns.view_document", display_name: tax_doc.display_name), portal_document_path(id: tax_doc.id), target: "_blank" %>
+              </div>
+            <% end %>
+          <% end %>
 
           <% if tax_return.ready_for_signature?(TaxReturn::PRIMARY_SIGNATURE) %>
             <div class="tax-return-status__row tax-return-status__with-alert">
@@ -49,7 +67,7 @@
           <% end %>
         <% end %>
 
-        <% if !tax_return.final_tax_documents.present? && !tax_return.unsigned_8879.present? && !tax_return.signed_8879.present? %>
+        <% if !tax_return.final_tax_documents.present? && !tax_return.unsigned_8879s.present? && !tax_return.signed_8879s.present? %>
           <div class="tax-return-status__row tax-return-status__solo">
             <span class="tax-return-status__empty-state"><%= t(".tax_returns.empty_state") %></span>
           </div>

--- a/spec/controllers/portal/tax_returns_controller_spec.rb
+++ b/spec/controllers/portal/tax_returns_controller_spec.rb
@@ -135,8 +135,8 @@ describe Portal::TaxReturnsController do
       before { sign_in tax_return.client }
 
       context "clients tax return cannot be signed" do
-        context "because the tax_return is already signed" do
-          let(:tax_return) { create :tax_return, :ready_to_sign, :ready_to_file_solo, client: (create :client, intake: (create :intake, filing_joint: "no")) }
+        context "because there are no unsigned 8879s is already signed" do
+          let(:tax_return) { create :tax_return, :ready_to_file_solo, client: (create :client, intake: (create :intake, filing_joint: "no")) }
 
           let(:params) { { tax_return_id: tax_return.id } }
 
@@ -188,7 +188,7 @@ describe Portal::TaxReturnsController do
           context "when form successfully saves" do
             it "redirects to success page" do
               post :sign, params: params
-              expect(flash[:success]).to eq "Successfully signed 2019 tax form!"
+              expect(flash[:notice]).to eq "Successfully signed 2019 tax form!"
               expect(response).to redirect_to(portal_root_path)
             end
           end
@@ -267,8 +267,8 @@ describe Portal::TaxReturnsController do
       before { sign_in tax_return.client }
 
       context "tax return cannot be signed" do
-        context "because the signed tax return document is already created" do
-          let(:tax_return) { create :tax_return, :ready_to_sign, :ready_to_file_joint, client: (create :client, intake: (create :intake, filing_joint: "yes"))}
+        context "because there are no unsigned 8879s" do
+          let(:tax_return) { create :tax_return, :ready_to_file_joint, client: (create :client, intake: (create :intake, filing_joint: "yes"))}
 
           let(:params) { { tax_return_id: tax_return.id } }
 

--- a/spec/factories/tax_returns.rb
+++ b/spec/factories/tax_returns.rb
@@ -59,7 +59,7 @@ FactoryBot.define do
         create :document,
                tax_return: tax_return,
                client: tax_return.client,
-               upload_path: Rails.root.join("spec", "fixtures", "attachments", "test-pdf.pdf") ,
+               upload_path: Rails.root.join("spec", "fixtures", "attachments", "test-pdf.pdf"),
                document_type: DocumentTypes::CompletedForm8879.key
       end
     end

--- a/spec/features/portal/client_portal_dashboard_spec.rb
+++ b/spec/features/portal/client_portal_dashboard_spec.rb
@@ -2,10 +2,10 @@ require "rails_helper"
 
 RSpec.feature "a client on their portal" do
   let(:client) { create :client, intake: (create :intake, preferred_name: "Martha", primary_first_name: "Martha", primary_last_name: "Mango", filing_joint: "yes") }
-
+  let(:tax_return2019) { create :tax_return, :ready_to_sign, year: 2019, client: client }
+  let(:tax_return2018) { create :tax_return, :ready_to_file_solo, year: 2018, client: client }
   before do
-    tax_return2019 = create :tax_return, :ready_to_sign, year: 2019, client: client
-    tax_return2018 = create :tax_return, :ready_to_sign, :ready_to_file_solo, year: 2018, client: client
+    create :document, display_name: "Another 8879", document_type: DocumentTypes::UnsignedForm8879.key, tax_return: tax_return2019, client: tax_return2019.client
     create :tax_return, year: 2017, client: client
     create :document, document_type: DocumentTypes::FinalTaxDocument.key, tax_return: tax_return2019, client: tax_return2019.client
     create :document, document_type: DocumentTypes::FinalTaxDocument.key, display_name: "Some final tax document", tax_return: tax_return2018, client: tax_return2018.client
@@ -22,7 +22,9 @@ RSpec.feature "a client on their portal" do
     expect(page).to have_text "2017 tax documents"
 
     within "#tax-year-2019" do
-      expect(page).to have_link "View/download form 8879"
+      expect(page).to have_link "View/download Another 8879"
+      expect(page).to have_link "View/download " + tax_return2019.unsigned_8879s.first.display_name
+
       expect(page).to have_link "View/download final 2019 tax document"
       expect(page).to have_link "Submit primary taxpayer signature"
       expect(page).to have_link "Submit spouse signature"

--- a/spec/models/tax_return_spec.rb
+++ b/spec/models/tax_return_spec.rb
@@ -217,21 +217,13 @@ describe TaxReturn do
           end
         end
 
-        context "the primary has signed" do
+        context "there are no unsigned 8879s" do
           let(:primary_signed_tax_return) {
             create :tax_return,
                    primary_signature: "Bob Pineapple",
                    primary_signed_ip: "127.0.0.1",
                    primary_signed_at: DateTime.current
           }
-
-          before do
-            create :document,
-                   document_type: DocumentTypes::UnsignedForm8879.key,
-                   tax_return: primary_signed_tax_return,
-                   client: primary_signed_tax_return.client,
-                   upload_path:  Rails.root.join("spec", "fixtures", "attachments", "test-pdf.pdf")
-          end
 
           it "returns false" do
             expect(primary_signed_tax_return.ready_for_signature?(TaxReturn::PRIMARY_SIGNATURE)).to eq false
@@ -372,41 +364,39 @@ describe TaxReturn do
     end
   end
 
-  describe "#unsigned_8879" do
-    subject { tax_return.unsigned_8879 }
+  describe "#unsigned_8879s" do
+    subject { tax_return.unsigned_8879s }
 
     context "when an unsigned form 8879 exists for the tax return" do
       let(:tax_return) { create :tax_return, :ready_to_sign }
-      it "returns the document object" do
-        expect(subject).to be_a Document
-        expect(subject.document_type).to eq "Form 8879 (Unsigned)"
+      it "returns form8879 unsigned document objects" do
+        expect(subject.pluck(:document_type).uniq).to eq ["Form 8879 (Unsigned)"]
       end
     end
 
-    context "when an unsigned 8879 does not exist" do
+    context "when unsigned 8879s do not exist" do
       let(:tax_return) { create :tax_return }
 
       it "returns nil" do
-        expect(subject).to be nil
+        expect(subject).to be_empty
       end
     end
   end
 
-  describe "#signed_8879" do
-    subject { tax_return.signed_8879 }
+  describe "#signed_8879s" do
+    subject { tax_return.signed_8879s }
 
     context "when a signed form 8879 exists" do
       let(:tax_return) { create :tax_return, :ready_to_file_solo }
-      it "returns the document object" do
-        expect(subject).to be_a Document
-        expect(subject.document_type).to eq "Form 8879 (Signed)"
+      it "returns the signed document objects" do
+        expect(subject.pluck(:document_type).uniq).to eq ["Form 8879 (Signed)"]
       end
     end
 
     context "when a signed form 8879 does not exist" do
       let(:tax_return) { create :tax_return }
       it "returns nil" do
-        expect(subject).to be nil
+        expect(subject).to be_empty
       end
     end
   end


### PR DESCRIPTION
We used to only allow you to have one 8879 and sign one. But some places have state and federal 8879s, some sites are having to reupload 8879s and get the taxpayer to re-sign after adjustments are made, etc.

Also, it was requested that instead of keeping the unsigned version of the 8879, we convert it into a Signed 8879.