### PR TITLE
Always scroll to last note or message

### DIFF
--- a/app/controllers/hub/notes_controller.rb
+++ b/app/controllers/hub/notes_controller.rb
@@ -14,7 +14,7 @@ module Hub
     def create
       return render :index unless @note.save
 
-      redirect_to hub_client_notes_path(client_id: params[:client_id])
+      redirect_to hub_client_notes_path(client_id: params[:client_id], anchor: "last-item")
     end
 
     private

--- a/app/controllers/hub/outbound_calls_controller.rb
+++ b/app/controllers/hub/outbound_calls_controller.rb
@@ -23,7 +23,7 @@ module Hub
     def update
       @outbound_call = OutboundCall.find(params[:id])
       @outbound_call.update(params.require(:outbound_call).permit(:note))
-      redirect_to hub_client_notes_path(client_id: @client.id)
+      redirect_to hub_client_messages_path(client_id: @client.id, anchor: "last-item")
     end
 
     def new

--- a/app/controllers/hub/outgoing_emails_controller.rb
+++ b/app/controllers/hub/outgoing_emails_controller.rb
@@ -9,7 +9,7 @@ module Hub
       if outgoing_email_params[:body].present?
         ClientMessagingService.send_email(@client, current_user, outgoing_email_params[:body], attachment: outgoing_email_params[:attachment])
       end
-      redirect_to hub_client_messages_path(client_id: @client)
+      redirect_to hub_client_messages_path(client_id: @client, anchor: "last-item")
     end
 
     private

--- a/app/controllers/hub/outgoing_text_messages_controller.rb
+++ b/app/controllers/hub/outgoing_text_messages_controller.rb
@@ -9,7 +9,7 @@ module Hub
       if outgoing_text_message_params[:body].present?
         ClientMessagingService.send_text_message(@client, current_user, outgoing_text_message_params[:body])
       end
-      redirect_to hub_client_messages_path(client_id: @client.id)
+      redirect_to hub_client_messages_path(client_id: @client.id, anchor: "last-item")
     end
 
     private

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -13,6 +13,7 @@ module NavigationHelper
   end
 
   def remove_leading_locale_from_path(path)
+    path = URI.parse(path).path
     current_locale_path = "/#{I18n.locale}"
     if path.start_with? current_locale_path
       path[current_locale_path.length..-1]

--- a/app/views/hub/clients/_navigation.html.erb
+++ b/app/views/hub/clients/_navigation.html.erb
@@ -1,6 +1,6 @@
 <section class="client-navigation tab-bar is-selected">
   <%= tab_navigation_link(t(".client_profile"), hub_client_path(id: @client)) %>
-  <%= tab_navigation_link(t(".client_messages"), hub_client_messages_path(client_id: @client)) %>
+  <%= tab_navigation_link(t(".client_messages"), hub_client_messages_path(client_id: @client, anchor: "last-item")) %>
   <%= tab_navigation_link(t(".client_documents"), hub_client_documents_path(client_id: @client)) %>
-  <%= tab_navigation_link(t(".client_notes"), hub_client_notes_path(client_id: @client)) %>
+  <%= tab_navigation_link(t(".client_notes"), hub_client_notes_path(client_id: @client, anchor: "last-item")) %>
 </section>

--- a/app/views/hub/messages/index.html.erb
+++ b/app/views/hub/messages/index.html.erb
@@ -11,12 +11,15 @@
   <% if @messages_by_day.present? %>
     <ul class="message-list" aria-live="polite" data-js="messages-pub-sub" data-client-id="<%=@client.id%>">
 
-      <% @messages_by_day.each do |datetime, contact_records| %>
-
+      <% @messages_by_day.each_with_index do |(datetime, contact_records), day_index| %>
         <li class="message__day-heading"><%= date_heading(datetime) %></li>
 
-        <% contact_records.each do |contact_record| %>
-          <%= render "shared/message_list_contact_record", contact_record: contact_record %>
+        <% contact_records.each_with_index do |contact_record, contact_record_index| %>
+          <% if contact_record_index == (contact_records.size - 1) && day_index == (@messages_by_day.size - 1) %>
+            <%= render "shared/message_list_contact_record", contact_record: contact_record, is_last_item: true %>
+          <% else %>
+            <%= render "shared/message_list_contact_record", contact_record: contact_record %>
+          <% end %>
         <% end %>
 
       <% end %> <%# end of day %>
@@ -31,7 +34,8 @@
     %>
     <ul class="message-list" data-js="messages-pub-sub" data-client-id="<%=@client.id%>"></ul>
   <% end %>
-  <div class="slab">
+
+  <div class="slab" id="composer">
     <div class="communication-preferences">
       <% unless @client&.intake.email_address.present? || @client&.intake.sms_phone_number.present? %>
         <%= t(".no_way_to_communicate") %>

--- a/app/views/hub/notes/_note.html.erb
+++ b/app/views/hub/notes/_note.html.erb
@@ -1,4 +1,4 @@
-<li class="note message message--<%= note.user == current_user ? "outgoing" : "incoming"%>">
+<li class="note message message--<%= note.user == current_user ? "outgoing" : "incoming"%>" id="<%= "last-item" if local_assigns[:is_last_item] %>">
   <div class="message__heading">
     <span class="message__author">
       <%= note.user.name %>

--- a/app/views/hub/notes/_system_note.html.erb
+++ b/app/views/hub/notes/_system_note.html.erb
@@ -1,6 +1,6 @@
-<li class="note note--system message">
-<span class="message__time">
-      <%= long_formatted_datetime(note.created_at) %>
-    </span>
+<li class="note note--system message" id="<%= "last-item" if local_assigns[:is_last_item] %>">
+  <span class="message__time">
+    <%= long_formatted_datetime(note.created_at) %>
+  </span>
   <div class="message__body"><%= simple_format(note.body, {}, wrapper_tag: "span") %></div>
 </li>

--- a/app/views/hub/notes/index.html.erb
+++ b/app/views/hub/notes/index.html.erb
@@ -9,10 +9,14 @@
 
   <% if @all_notes_by_day.present? %>
     <ul class="message-list">
-      <% @all_notes_by_day.each do |datetime, records| %>
+      <% @all_notes_by_day.each_with_index do |(datetime, records), day_index| %>
         <li class="message__day-heading"><%= date_heading(datetime) %></li>
-        <% records.each do |note| %>
-          <%= render note.class.name == "Note" ? "note" : "system_note", note: note %>
+        <% records.each_with_index do |note, note_index| %>
+          <% if note_index == (records.size - 1) && day_index == (@all_notes_by_day.size - 1) %>
+            <%= render note.class.name == "Note" ? "note" : "system_note", note: note, is_last_item: true %>
+          <% else %>
+            <%= render note.class.name == "Note" ? "note" : "system_note", note: note %>
+          <% end %>
         <% end %>
       <% end %>
     </ul>

--- a/app/views/shared/_message_list_contact_record.html.erb
+++ b/app/views/shared/_message_list_contact_record.html.erb
@@ -3,8 +3,7 @@
   to add new messages to the page as a result of a websocket broadcast
 !-->
 <% self.extend(ContactRecordHelper) %>
-
-<li class="message message--<%= contact_record.contact_record_type %>">
+<li class="message message--<%= contact_record.contact_record_type %>" id="<%= "last-item" if local_assigns[:is_last_item] %>">
   <div class="message__heading">
     <div>
       <span class="message__author">

--- a/spec/controllers/hub/messages_controller_spec.rb
+++ b/spec/controllers/hub/messages_controller_spec.rb
@@ -114,6 +114,13 @@ RSpec.describe Hub::MessagesController do
           expect(messages[3]).to have_text("Me too! Happy to get every notification")
         end
 
+        it "adds a 'last-item' id attribute to the last contact record" do
+          get :index, params: params
+
+          last_message = Nokogiri::HTML.parse(response.body).css(".message:last-child").first
+          expect(last_message.attr("id")).to eq "last-item"
+        end
+
         it "groups messages by date" do
           get :index, params: params
 

--- a/spec/controllers/hub/notes_controller_spec.rb
+++ b/spec/controllers/hub/notes_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Hub::NotesController, type: :controller do
         expect(note.body).to eq "Note body"
         expect(note.client).to eq client
         expect(note.user).to eq user
-        expect(response).to redirect_to hub_client_notes_path(client_id: client.id)
+        expect(response).to redirect_to hub_client_notes_path(client_id: client.id, anchor: "last-item")
       end
 
       context "with invalid params" do
@@ -75,6 +75,17 @@ RSpec.describe Hub::NotesController, type: :controller do
         it "renders a form" do
           get :index, params: params
           expect(assigns(:note)).to be_a(Note)
+        end
+
+        context "when rendering HTML" do
+          render_views
+
+          it "adds a 'last-item' id attribute to the last note" do
+            get :index, params: params
+
+            last_note = Nokogiri::HTML.parse(response.body).css(".note:last-child").first
+            expect(last_note.attr("id")).to eq "last-item"
+          end
         end
       end
 

--- a/spec/controllers/hub/outbound_calls_controller_spec.rb
+++ b/spec/controllers/hub/outbound_calls_controller_spec.rb
@@ -58,10 +58,11 @@ describe Hub::OutboundCallsController, type: :controller do
     context "with a logged in user" do
       before { sign_in user }
 
-      it "updates the outbound call with the note body" do
+      it "updates the outbound call with the note body and redirects back to messages" do
         put :update, params: params
 
         expect(outbound_call.reload.note).to eq "I talked to them!"
+        expect(response).to redirect_to(hub_client_messages_path(client_id: client.id, anchor: "last-item"))
       end
     end
   end

--- a/spec/controllers/hub/outgoing_emails_controller_spec.rb
+++ b/spec/controllers/hub/outgoing_emails_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Hub::OutgoingEmailsController do
           post :create, params: params
 
           expect(ClientMessagingService).to have_received(:send_email).with(client, user, "hi client", attachment: instance_of(ActionDispatch::Http::UploadedFile))
-          expect(response).to redirect_to hub_client_messages_path(client_id: client.id)
+          expect(response).to redirect_to hub_client_messages_path(client_id: client.id, anchor: "last-item")
         end
       end
 
@@ -46,7 +46,7 @@ RSpec.describe Hub::OutgoingEmailsController do
           post :create, params: params
 
           expect(ClientMessagingService).not_to have_received(:send_email)
-          expect(response).to redirect_to hub_client_messages_path(client_id: client.id)
+          expect(response).to redirect_to hub_client_messages_path(client_id: client.id, anchor: "last-item")
         end
       end
     end

--- a/spec/controllers/hub/outgoing_text_messages_controller_spec.rb
+++ b/spec/controllers/hub/outgoing_text_messages_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Hub::OutgoingTextMessagesController do
         post :create, params: params
 
         expect(ClientMessagingService).to have_received(:send_text_message).with(client, user, "This is an outgoing text")
-        expect(response).to redirect_to(hub_client_messages_path(client_id: client.id))
+        expect(response).to redirect_to(hub_client_messages_path(client_id: client.id, anchor: "last-item"))
       end
 
       context "with a blank body" do
@@ -42,7 +42,7 @@ RSpec.describe Hub::OutgoingTextMessagesController do
           post :create, params: params
 
           expect(ClientMessagingService).not_to have_received(:send_text_message)
-          expect(response).to redirect_to(hub_client_messages_path(client_id: client.id))
+          expect(response).to redirect_to(hub_client_messages_path(client_id: client.id, anchor: "last-item"))
         end
       end
     end

--- a/spec/helpers/navigation_helper_spec.rb
+++ b/spec/helpers/navigation_helper_spec.rb
@@ -49,5 +49,21 @@ RSpec.describe NavigationHelper do
         expect(link_html["href"]).to eq hub_user_profile_path(locale: "en")
       end
     end
+
+    context "when the navigation link includes an anchor fragment but the request does not" do
+      before do
+        controller.request.path = "/hub/profile"
+      end
+
+      it "returns a tab link with is-selected" do
+        link = helper.tab_navigation_link("Tab that is selected", hub_user_profile_path(locale: "en", anchor: "section"))
+
+        link_html = Nokogiri::HTML.fragment(link).at_css("a")
+
+        expect(link_html).to have_text "Tab that is selected"
+        expect(link_html["class"]).to eq "tab-bar__tab is-selected"
+        expect(link_html["href"]).to eq hub_user_profile_path(locale: "en", anchor: "section")
+      end
+    end
   end
 end


### PR DESCRIPTION
From design pairing, this changes the navigation for messages and notes index pages to always scroll to the last note or message in the index. It adds an id to the last note or message, and then uses a URI anchor (`/messages#last-item`) to navigate to that element.

[Pivotal Tracker Story](https://www.pivotaltracker.com/story/show/177149167)

I paired on this with Anu