### PR TITLE
Don't list independent orgs in every coalition

### DIFF
--- a/app/views/hub/organizations/index.html.erb
+++ b/app/views/hub/organizations/index.html.erb
@@ -25,12 +25,6 @@
           <%= t('.no_organizations') %>
         <% end %>
 
-        <% if @independent_organizations.present? %>
-          <h2><%= t(".independent_organizations") %></h2>
-          <% @independent_organizations.each do |organization| %>
-            <%= render "hub/organizations/listing", organization: organization %>
-          <% end %>
-        <% end %>
       <% end %>
     <% else %>
       <% if @organizations.present? %>
@@ -42,6 +36,11 @@
       <% end %>
     <% end %>
 
+    <% if @independent_organizations.present? %>
+      <h2><%= t(".independent_organizations") %></h2>
+      <% @independent_organizations.each do |organization| %>
+        <%= render "hub/organizations/listing", organization: organization %>
+      <% end %>
+    <% end %>
   </div>
-
 <% end %>


### PR DESCRIPTION
Independent orgs are orgs that don't belong to any coalition.

Right now, we are listing them repeatedly after every coalition on the org index page:
https://www.getyourrefund.org/hub/organizations