### PR TITLE
Tweak styling on tax returns list to fix some visual bugginess

### DIFF
--- a/app/assets/stylesheets/components/_tax-return-list.scss
+++ b/app/assets/stylesheets/components/_tax-return-list.scss
@@ -1,13 +1,12 @@
 .tax-return-list {
-  font-size: 1.6rem;
+  font-size: $font-size-18;
   margin: 0;
-
   a {
     color: black;
   }
 
   .certification-label {
-    width: 80px;
+    width: 60px;
     text-align: center;
 
     &.label--unassigned {
@@ -29,7 +28,7 @@
 
     .select__element {
       line-height: 2.5;
-      font-size: 1.6rem;
+      font-size: $font-size-18;
       padding: 0 4rem 0 1.5rem;
       width: 315px;
     }
@@ -42,7 +41,6 @@
   li {
     align-items: center;
     display: flex;
-    justify-content: flex-end;
     line-height: 3.5rem;
     min-height: 60px;
   }
@@ -51,6 +49,7 @@
     position: relative;
     border: 2px solid black;
     min-height: 44px;
+    min-width: 175px;
     display: flex;
     align-items: center;
     font-weight: normal;
@@ -68,12 +67,13 @@
     }
 
     button {
-      margin-left: 5px;
       display: flex;
+      height: 20px;
+      width: 20px;
+      padding: 3px;
 
       img {
-        height: 16px;
-        height: 16px;
+        height: 100%;
       }
     }
 
@@ -90,17 +90,28 @@
     .offset-label {
       position: absolute;
       top: -24px;
-      font-size: 1.6rem;
+      font-size: $font-size-18;
       font-weight: bold;
       left: 0;
     }
   }
 
   &__assignee {
-    font-size: 1.6rem;
-    font-weight: bold;
+    font-size: 1.4rem;
     margin-right: 1.25rem;
-    flex-grow: 1;
+    flex-grow: 0;
+    flex-shrink: 0;
+    width: 175px;
+    a {
+      display: block;
+      overflow: auto;
+      text-overflow: ellipsis;
+      text-decoration: none;
+      line-height: $font-size-18;
+    }
+    a.button {
+      display: inline;
+    }
     .button {
       margin-right: 0;
     }
@@ -108,7 +119,6 @@
 
   &__assignment {
     font-size: 1.4rem;
-    flex-grow: 1;
     display: flex;
     min-height: 60px;
     align-items: center;
@@ -117,14 +127,15 @@
     }
   }
 
-  &__certification {
-    margin-right: 1.5rem;
+  &__right {
+    display: flex;
+    flex-grow: 1;
+    justify-content: space-between;
+    align-items: center;
   }
 
-  &__status-form {
-    .button {
-      height: 44px;
-    }
+  &__certification {
+    margin-right: 1.5rem;
   }
 
   &__service-type {
@@ -135,19 +146,8 @@
 
   &__year {
     font-weight: bold;
-    font-size: 1.6rem;
+    font-size: $font-size-18;
     margin-right: $s10;
-  }
-}
-
-// Style the component a bit differently on the client header where we have more room.
-.client-header {
-  .tax-return-list__assignment {
-    width: 300px;
-  }
-
-  .tax-return-list__service-type {
-    width: 4rem;
   }
 }
 
@@ -156,7 +156,7 @@
   color: black;
   text-transform: none;
   font-size: $font-size-18;
-  line-height: 1.6rem;
+  line-height: $font-size-18;
   padding: $s5 $s10;
   border: 1px solid $color-green-money;
 }

--- a/app/assets/stylesheets/components/_tax-return-list.scss
+++ b/app/assets/stylesheets/components/_tax-return-list.scss
@@ -83,7 +83,7 @@
       justify-content: flex-end;
       align-items: center;
       position: absolute;
-      top: -28px;
+      top: -18px;
       margin: 0;
     }
 
@@ -120,7 +120,7 @@
   &__assignment {
     font-size: 1.4rem;
     display: flex;
-    min-height: 60px;
+    min-height: 65px;
     align-items: center;
     > div {
       margin-right: 5px;

--- a/app/controllers/hub/tax_returns/certifications_controller.rb
+++ b/app/controllers/hub/tax_returns/certifications_controller.rb
@@ -13,7 +13,7 @@ module Hub
       end
 
       def tax_return_params
-        params.permit(:certification_level, :is_hsa)
+        params.permit(:certification_level)
       end
     end
   end

--- a/app/helpers/tax_return_status_helper.rb
+++ b/app/helpers/tax_return_status_helper.rb
@@ -42,9 +42,7 @@ module TaxReturnStatusHelper
     classes = %w[label certification-label]
     classes << "label--unassigned" if tax_return.certification_level.blank?
     localization_key = tax_return.certification_level.blank? ? "NA" : "certification_abbrev.#{tax_return.certification_level}"
-    text = t("general.#{localization_key}")
-    text = "#{text} | #{t("general.hsa")}" if tax_return.is_hsa?
-    tag.span(text, class: classes)
+    tag.span(t("general.#{localization_key}"), class: classes)
   end
 
   def self.stage_translation_from_status(status)

--- a/app/views/shared/_tax_return_certification_form.html.erb
+++ b/app/views/shared/_tax_return_certification_form.html.erb
@@ -7,9 +7,6 @@
     <%= f.select :certification_level, certification_options_for_select, include_blank: true, selected: tax_return.certification_level %>
   </label>
   <%= hidden_field_tag :next, request.path.split("?")[0] %>
-  <label for="is_hsa">
-    <%= f.check_box :is_hsa, checked: tax_return.is_hsa? %><%= "#{t("general.hsa")}?" %>
-  </label>
   <div>
     <%= f.button :submit do %>
       <span class="sr-only"><%= t("general.save") %></span>

--- a/app/views/shared/_tax_return_list.html.erb
+++ b/app/views/shared/_tax_return_list.html.erb
@@ -4,57 +4,64 @@
   <% client.tax_returns.each do |tax_return| %>
     <li id="tax-return-<%= tax_return.id %>">
       <div class="tax-return-list__assignment">
-        <span class="tax-return-list__year">
+        <div class="tax-return-list__year">
           <%= tax_return.year %>
-          &nbsp;
-        </span>
-        <span class="tax-return-list__service-type"><%
-          if tax_return.service_type == "drop_off"
-        %><span class="icon-move_to_inbox" aria-hidden="true" role="img"></span><span class="sr-only"><%=
+        </div>
+        <div class="tax-return-list__service-type">
+          <% if tax_return.service_type == "drop_off" %>
+            <span class="icon-move_to_inbox" aria-hidden="true" role="img"></span>
+            <span class="sr-only"><%=
           t("general.drop_off")
-        %></span><% end %></span><span class ="tax-return-list__assignee">
-          <%= render "hub/tax_returns/assignee", tax_return: tax_return %>
-        </span>
-      </div>
+        %></span>
+          <% end %>
+        </div>
 
-      <div class="tax-return-list__certification">
-        <% if params[:update_cert] && params[:tax_return_id]&.to_i == tax_return.id %>
-          <%= render "shared/tax_return_certification_form", tax_return: tax_return %>
-        <% else %>
-          <% if status_updateable %>
-            <%= link_to update_cert: true, tax_return_id: tax_return.id do %>
+        <div class ="tax-return-list__assignee">
+          <%= render "hub/tax_returns/assignee", tax_return: tax_return %>
+        </div>
+      </div>
+      <div class="tax-return-list__right">
+        <div class="tax-return-list__certification">
+          <% if params[:update_cert] && params[:tax_return_id]&.to_i == tax_return.id %>
+            <%= render "shared/tax_return_certification_form", tax_return: tax_return %>
+          <% else %>
+            <% if status_updateable %>
+              <%= link_to update_cert: true, tax_return_id: tax_return.id do %>
+                <%= certification_label(tax_return) %>
+              <% end %>
+            <% else %>
               <%= certification_label(tax_return) %>
             <% end %>
-          <% else %>
-            <%= certification_label(tax_return) %>
           <% end %>
+        </div>
+
+        <% if status_updateable %>
+          <%= form_with model: tax_return, url: edit_take_action_hub_client_path(id: tax_return.client.id), method: :get, local: true, builder: VitaMinFormBuilder, html: {class: "tax-return-list__status-form form-wrapper"} do |f| %>
+            <%= f.hidden_field "id", value: tax_return.id %>
+            <div>
+              <label for=<%= "tax_return_status_#{tax_return.id}"%>>
+                <div class="sr-only"><%= t("general.status") %></div>
+                <div class="select">
+                  <select name="tax_return[status]" class="select__element" id=<%= "tax_return_status_#{tax_return.id}"%>>
+                    <option value></option>
+                    <% TaxReturnStatus.available_statuses_for(current_user).each do |stage, statuses| %>
+                      <optgroup label=<%= stage_translation(stage) %>></optgroup>
+                      <% statuses.each do |status| %>
+                        <option value="<%= status %>" <%= tax_return.status == status.to_s && "selected" %>>&emsp;<%= status_translation(status) %></option>
+                      <% end %>
+                    <% end %>
+                  </select>
+                </div>
+              </label>
+            </div>
+            <%= f.submit "Update", class: "button"%>
+          <% end %>
+        <% else %>
+          <div>
+            <div class="tax-return-list__status label label--status"><%= stage_translation_from_status(tax_return.status) %>/<%= status_translation(tax_return.status) %></div>
+          </div>
         <% end %>
       </div>
-
-      <% if status_updateable %>
-        <%= form_with model: tax_return, url: edit_take_action_hub_client_path(id: tax_return.client.id), method: :get, local: true, builder: VitaMinFormBuilder, html: {class: "tax-return-list__status-form form-wrapper"} do |f| %>
-          <%= f.hidden_field "id", value: tax_return.id %>
-          <div>
-            <label for=<%= "tax_return_status_#{tax_return.id}"%>>
-              <div class="sr-only"><%= t("general.status") %></div>
-              <div class="select">
-                <select name="tax_return[status]" class="select__element" id=<%= "tax_return_status_#{tax_return.id}"%>>
-                  <option value></option>
-                  <% TaxReturnStatus.available_statuses_for(current_user).each do |stage, statuses| %>
-                    <optgroup label=<%= stage_translation(stage) %>></optgroup>
-                    <% statuses.each do |status| %>
-                      <option value="<%= status %>" <%= tax_return.status == status.to_s && "selected" %>>&emsp;<%= status_translation(status) %></option>
-                    <% end %>
-                  <% end %>
-                </select>
-              </div>
-            </label>
-          </div>
-          <%= f.submit "Update", class: "button button--small"%>
-        <% end %>
-      <% else %>
-        <div class="tax-return-list__status label label--status"><%= stage_translation_from_status(tax_return.status) %>/<%= status_translation(tax_return.status) %></div>
-      <% end %>
     </li>
   <% end %>
 </ul>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -48,7 +48,7 @@ VitaPartnerState.find_or_create_by!(
 # organization lead user
 user = User.where(email: "skywalker@example.com").first_or_initialize
 user.update(
-  name: "Luke",
+  name: "Luke Skywalker",
   password: "theforcevita")
 user.update(role: OrganizationLeadRole.create(organization: first_org)) if user.role_type != OrganizationLeadRole::TYPE
 
@@ -76,20 +76,20 @@ user.update(role: CoalitionLeadRole.create(coalition: koalas)) if user.role_type
 # additional user
 additional_user = User.where(email: "princess@example.com").first_or_initialize
 additional_user.update(
-  name: "Lea",
+  name: "Lea Amidala Organa",
   password: "theforcevita")
 additional_user.update(role: OrganizationLeadRole.create(organization: first_org)) if additional_user.role_type != OrganizationLeadRole::TYPE
 
 admin_user = User.where(email: "admin@example.com").first_or_initialize
 admin_user.update(
-  name: "The Admin",
+  name: "Admin Amdapynurian",
   password: "theforcevita")
 admin_user.update(role: AdminRole.create) if admin_user.role_type != AdminRole::TYPE
 
 
 greeter_user = User.where(email: "greeter@example.com").first_or_initialize
 greeter_user.update(
-  name: "Greeter Greg",
+  name: "Greeter Greg (GYR Greeter)",
   password: "theforcevita"
 )
 

--- a/spec/controllers/hub/tax_returns/certifications_controller_spec.rb
+++ b/spec/controllers/hub/tax_returns/certifications_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Hub::TaxReturns::CertificationsController do
     let(:user) { create :organization_lead_user }
     let(:tax_return) { create :tax_return, client: (create :client, vita_partner: user.role.organization) }
     let(:next_path) { "/next/path" }
-    let(:params) { { id: tax_return.id, certification_level: "advanced", is_hsa: true, next: next_path } }
+    let(:params) { { id: tax_return.id, certification_level: "advanced", next: next_path } }
 
     it_behaves_like :a_post_action_for_authenticated_users_only, action: :update
 
@@ -20,14 +20,6 @@ RSpec.describe Hub::TaxReturns::CertificationsController do
           tax_return.reload
         }.to change(tax_return, :certification_level).to('advanced')
       end
-
-      it "updates the tax_return is_hsa value" do
-        expect {
-          patch :update, params: params
-          tax_return.reload
-        }.to change(tax_return, :is_hsa).to(true)
-      end
-
       context "redirecting on success" do
         context "with next param" do
           it "redirects to referring path without params" do

--- a/spec/features/hub/show_client_spec.rb
+++ b/spec/features/hub/show_client_spec.rb
@@ -37,12 +37,6 @@ RSpec.describe "a user viewing a client" do
         click_button("button")
         expect(page).to have_text("BAS")
         expect(page).not_to have_css(".tax-return-inline-form")
-
-        # change from basic to basic hsa
-        click_on("BAS")
-        check "is_hsa"
-        click_button("button")
-        expect(page).to have_text("BAS | HSA")
       end
     end
   end


### PR DESCRIPTION
revert some styling to use flex box conventions, and deal (as elegantly as possible) with forcing assignment dropdowns to be a useable size. (Previously on prod, I was seeing some assignment components that didn't have enough width to show up correctly. 

Also removes HSA from certification display per product / user research teams.