### PR TITLE
Remove client reference from access logs

### DIFF
--- a/app/models/access_log.rb
+++ b/app/models/access_log.rb
@@ -5,23 +5,20 @@
 #  id          :bigint           not null, primary key
 #  event_type  :string           not null
 #  ip_address  :inet
-#  record_type :string
+#  record_type :string           not null
 #  user_agent  :string           not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  client_id   :bigint
-#  record_id   :bigint
+#  record_id   :bigint           not null
 #  user_id     :bigint           not null
 #
 # Indexes
 #
-#  index_access_logs_on_client_id                  (client_id)
 #  index_access_logs_on_record_type_and_record_id  (record_type,record_id)
 #  index_access_logs_on_user_id                    (user_id)
 #
 # Foreign Keys
 #
-#  fk_rails_...  (client_id => clients.id)
 #  fk_rails_...  (user_id => users.id)
 #
 class AccessLog < ApplicationRecord

--- a/db/migrate/20210313061212_remove_client_from_access_log.rb
+++ b/db/migrate/20210313061212_remove_client_from_access_log.rb
@@ -1,0 +1,20 @@
+class RemoveClientFromAccessLog < ActiveRecord::Migration[6.0]
+  # Follow up migration for AddRecordToAccessLog
+  def up
+    update <<-SQL.squish
+      UPDATE access_logs
+      SET record_type = 'Client', record_id = client_id
+      WHERE record_id = NULL
+    SQL
+
+    remove_reference :access_logs, :client
+    change_column_null :access_logs, :record_id, false
+    change_column_null :access_logs, :record_type, false
+  end
+
+  def down
+    add_reference :access_logs, :client
+    change_column_null :access_logs, :record_id, true
+    change_column_null :access_logs, :record_type, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_12_004659) do
+ActiveRecord::Schema.define(version: 2021_03_13_061212) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -18,16 +18,14 @@ ActiveRecord::Schema.define(version: 2021_03_12_004659) do
   enable_extension "postgis"
 
   create_table "access_logs", force: :cascade do |t|
-    t.bigint "client_id"
     t.datetime "created_at", precision: 6, null: false
     t.string "event_type", null: false
     t.inet "ip_address"
-    t.bigint "record_id"
-    t.string "record_type"
+    t.bigint "record_id", null: false
+    t.string "record_type", null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "user_agent", null: false
     t.bigint "user_id", null: false
-    t.index ["client_id"], name: "index_access_logs_on_client_id"
     t.index ["record_type", "record_id"], name: "index_access_logs_on_record_type_and_record_id"
     t.index ["user_id"], name: "index_access_logs_on_user_id"
   end
@@ -698,7 +696,6 @@ ActiveRecord::Schema.define(version: 2021_03_12_004659) do
     t.index ["last_scrape_id"], name: "index_vita_providers_on_last_scrape_id"
   end
 
-  add_foreign_key "access_logs", "clients"
   add_foreign_key "access_logs", "users"
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "clients", "vita_partners"

--- a/spec/factories/access_logs.rb
+++ b/spec/factories/access_logs.rb
@@ -5,23 +5,20 @@
 #  id          :bigint           not null, primary key
 #  event_type  :string           not null
 #  ip_address  :inet
-#  record_type :string
+#  record_type :string           not null
 #  user_agent  :string           not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  client_id   :bigint
-#  record_id   :bigint
+#  record_id   :bigint           not null
 #  user_id     :bigint           not null
 #
 # Indexes
 #
-#  index_access_logs_on_client_id                  (client_id)
 #  index_access_logs_on_record_type_and_record_id  (record_type,record_id)
 #  index_access_logs_on_user_id                    (user_id)
 #
 # Foreign Keys
 #
-#  fk_rails_...  (client_id => clients.id)
 #  fk_rails_...  (user_id => users.id)
 #
 FactoryBot.define do

--- a/spec/models/access_log_spec.rb
+++ b/spec/models/access_log_spec.rb
@@ -5,23 +5,20 @@
 #  id          :bigint           not null, primary key
 #  event_type  :string           not null
 #  ip_address  :inet
-#  record_type :string
+#  record_type :string           not null
 #  user_agent  :string           not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  client_id   :bigint
-#  record_id   :bigint
+#  record_id   :bigint           not null
 #  user_id     :bigint           not null
 #
 # Indexes
 #
-#  index_access_logs_on_client_id                  (client_id)
 #  index_access_logs_on_record_type_and_record_id  (record_type,record_id)
 #  index_access_logs_on_user_id                    (user_id)
 #
 # Foreign Keys
 #
-#  fk_rails_...  (client_id => clients.id)
 #  fk_rails_...  (user_id => users.id)
 #
 require 'rails_helper'


### PR DESCRIPTION
This is a followup to https://github.com/codeforamerica/vita-min/pull/921

It's not safe to make columns non-nullable or to remove them in a migration until _after_ we deploy code that stops referencing the column or ensures the columns have values. Now that the prior PR is deployed, we can remove the foreign key to client from access_logs, and we can make the new polymorphic association non-nullable.