### PR TITLE
Add current_step to intake, and add appropriate link to portal home dashboard

### DIFF
--- a/app/assets/stylesheets/components/_portal-tax-returns.scss
+++ b/app/assets/stylesheets/components/_portal-tax-returns.scss
@@ -5,6 +5,7 @@
     color: $color-grey-darkest;
     text-decoration: none;
     border-bottom: 1px solid;
+    position: relative;
   }
 
   &__content {
@@ -37,7 +38,9 @@
   }
 
   a::after {
-    content: " \003E";
-    margin-right: .5rem;
+    content: "keyboard_arrow_right";
+    font-family: "Material Icons";
+    position: absolute;
+    top: 2px;
   }
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,7 +23,7 @@ class ApplicationController < ActionController::Base
   end
 
   def current_intake
-    Intake.find_by_id(session[:intake_id])
+    current_client&.intake || Intake.find_by_id(session[:intake_id])
   end
 
   def intake_from_completed_session
@@ -252,6 +252,13 @@ class ApplicationController < ActionController::Base
 
   def load_users
     @users = User.accessible_by(current_ability).order(name: :asc)
+  end
+
+  def set_current_step
+    return unless current_intake.present?
+    return unless request.method_symbol == :get # skip uploads
+
+    current_intake.update(current_step: current_path) unless current_intake.current_step == current_path
   end
 
   rescue_from CanCan::AccessDenied do |exception|

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -256,7 +256,7 @@ class ApplicationController < ActionController::Base
 
   def set_current_step
     return unless current_intake.present?
-    return unless request.method_symbol == :get # skip uploads
+    return unless request.get? # skip uploads
 
     current_intake.update(current_step: current_path) unless current_intake.current_step == current_path
   end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,7 +1,7 @@
 class DocumentsController < ApplicationController
   include AccessControllable
-  before_action :require_intake
-  
+  before_action :require_intake, :set_current_step
+
   def illustration_path; end
 
   def destroy
@@ -14,5 +14,9 @@ class DocumentsController < ApplicationController
     else
       redirect_to overview_documents_path
     end
+  end
+
+  def current_path(params = {})
+    documents_path(self.class.to_param, params)
   end
 end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -15,8 +15,4 @@ class DocumentsController < ApplicationController
       redirect_to overview_documents_path
     end
   end
-
-  def current_path(params = {})
-    documents_path(self.class.to_param, params)
-  end
 end

--- a/app/controllers/portal/portal_controller.rb
+++ b/app/controllers/portal/portal_controller.rb
@@ -4,7 +4,14 @@ module Portal
     layout "portal"
 
     def home
-      @tax_returns = current_client.tax_returns.order(year: :desc)
+      @current_step = nil
+      @tax_returns = []
+
+      if current_client.completed_intake_process?
+        @tax_returns = current_client.tax_returns.order(year: :desc)
+      else
+        @current_step = current_client.intake.determine_current_step
+      end
     end
 
     def current_intake

--- a/app/controllers/portal/portal_controller.rb
+++ b/app/controllers/portal/portal_controller.rb
@@ -7,7 +7,7 @@ module Portal
       @current_step = nil
       @tax_returns = []
 
-      if current_client.completed_intake_process?
+      if completed_onboarding_process?
         @tax_returns = current_client.tax_returns.order(year: :desc)
       else
         @current_step = current_client.intake.determine_current_step
@@ -22,6 +22,18 @@ module Portal
 
     def require_client_sign_in
       redirect_to root_path unless current_client.present?
+    end
+
+    # We'll consider a client to have completed onboarding process if they've
+    # a) completed_at the intake
+    # b) once any of their tax returns are passed the intake stage
+    # The reason we CANNOT simply rely on completed_at? is because
+    # 1) many times clients "fall off" the intake flow but we complete their taxes anyway.
+    # 2) don't currently (3/22/21) set completed_at on drop-off clients.
+    # Once we've started preparing their taxes, we don't want to prompt them through the intake flow, but instead
+    # show their tax return status information.
+    def completed_onboarding_process?
+      current_client.intake.completed_at? || current_client.tax_returns.map(&:status_before_type_cast).any? { |status| status >= 200 }
     end
   end
 end

--- a/app/controllers/questions/questions_controller.rb
+++ b/app/controllers/questions/questions_controller.rb
@@ -1,6 +1,6 @@
 module Questions
   class QuestionsController < ApplicationController
-    before_action :require_intake
+    before_action :require_intake, :set_current_step
 
     delegate :form_name, to: :class
     delegate :form_class, to: :class

--- a/app/lib/question_navigation.rb
+++ b/app/lib/question_navigation.rb
@@ -165,10 +165,14 @@ class QuestionNavigation
     Questions::FeedbackController,
   ].freeze
 
-  def self.determine_current_question(intake)
+  # Provides a backfill to determine the current_step value for clients who started intake previous to the addition of
+  # determining current_step during the intake flow
+  def self.determine_current_step(intake)
     return nil if intake.completed_at?
     return Questions::ConsentController.to_path_helper unless intake.primary_consented_to_service_at?
 
+    # If yes/no questions have been completed and we definitely still need certain documents, send
+    # them to the upload docs page.
     if intake.completed_yes_no_questions_at? && intake.document_types_definitely_needed.present?
       return Documents::OverviewController.to_path_helper
     end

--- a/app/lib/question_navigation.rb
+++ b/app/lib/question_navigation.rb
@@ -167,6 +167,7 @@ class QuestionNavigation
 
   # Provides a backfill to determine the current_step value for clients who started intake previous to the addition of
   # determining current_step during the intake flow
+  # TODO: Remove after 2021 tax season closes.
   def self.determine_current_step(intake)
     return nil if intake.completed_at?
     return Questions::ConsentController.to_path_helper unless intake.primary_consented_to_service_at?
@@ -177,8 +178,8 @@ class QuestionNavigation
       return Documents::OverviewController.to_path_helper
     end
 
-    # If yes/no questions completed + docs uploaded, start at InterviewSscheduling. Else, start at consent
-    i = intake.completed_yes_no_questions_at? ? FLOW.index(Questions::OverviewDocumentsController) : FLOW.index(Questions::ConsentController)
+    # If yes/no questions completed + docs uploaded, start at InterviewSscheduling. Else, start after OptionalConsent
+    i = intake.completed_yes_no_questions_at? ? FLOW.index(Questions::OverviewDocumentsController) : FLOW.index(Questions::OptionalConsentController)
     found_path = nil
     while found_path.nil?
       i += 1

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -527,7 +527,7 @@ class Intake < ApplicationRecord
     end
   end
 
-    def document_types_possibly_needed
+  def document_types_possibly_needed
     relevant_document_types.reject(&:needed_if_relevant?).reject do |document_type|
       document_type == DocumentTypes::Other
     end.reject do |document_type|
@@ -579,5 +579,14 @@ class Intake < ApplicationRecord
 
   def might_encounter_delayed_service?
     vita_partner.at_capacity?
+  end
+
+  # Backfills current_step for clients who started intake before we tracked current_step
+  def determine_current_step
+    return current_step if current_step.present?
+
+    step = QuestionNavigation.determine_current_question(self)
+    update(current_step: step)
+    step
   end
 end

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -585,7 +585,7 @@ class Intake < ApplicationRecord
   def determine_current_step
     return current_step if current_step.present?
 
-    step = QuestionNavigation.determine_current_question(self)
+    step = QuestionNavigation.determine_current_step(self)
     update(current_step: step)
     step
   end

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -582,6 +582,7 @@ class Intake < ApplicationRecord
   end
 
   # Backfills current_step for clients who started intake before we tracked current_step
+  # TODO: Remove after 2021 tax season.
   def determine_current_step
     return current_step if current_step.present?
 

--- a/app/views/portal/portal/home.html.erb
+++ b/app/views/portal/portal/home.html.erb
@@ -2,6 +2,15 @@
 
 <% content_for :card do %>
   <h1 class="h2"><%= t(".title", name: current_client.intake.preferred_name) %></h1>
+  <% if @current_step.present? %>
+    <div class="tax-return-status">
+      <div class="tax-return-status__row tax-return-status__with-alert">
+        <%= image_tag("attn.svg", alt: "") %>
+        <% link_text = @current_step.include?("/documents/") ? t(".tax_returns.submit_additional_documents") : t(".tax_returns.answer_questions") %>
+        <%= link_to link_text, @current_step %>
+      </div>
+    </div>
+  <% end %>
 
   <% @tax_returns.each do |tax_return| %>
     <div class="tax-return-status" id=<%= "tax-year-#{tax_return.year}" %>>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -863,6 +863,8 @@ en:
           empty_state: No documents ready to review yet - check back later.
           view_document: "View/download %{display_name}"
           view_final_tax_document: "View/download final %{year} tax document"
+          submit_additional_documents: Submit remaining tax documents
+          answer_questions: Complete all tax questions
     tax_returns:
       authorize_signature:
         efile_acceptance: I authorize GetYourRefund to enter or generate my PIN as my signature on my tax year %{year} electronically filed income tax return.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -853,6 +853,8 @@ es:
           empty_state: Aún no hay documentos listos para revisar; vuelva a consultar más tarde.
           view_document: Ver/descargar el documento %{display_name}
           view_final_tax_document: Ver/descargar el documento fiscal final de %{year}
+          submit_additional_documents: Envíe los documentos fiscales restantes
+          answer_questions: Complete todas las preguntas sobre impuestos
     tax_returns:
       authorize_signature:
         efile_acceptance: Autorizo a GetYourRefund a ingresar o generar mi PIN como firma mía en mi declaración de impuestos del año %{year} que presentó electrónicamente.

--- a/db/migrate/20210312045547_add_current_step_to_intake.rb
+++ b/db/migrate/20210312045547_add_current_step_to_intake.rb
@@ -1,0 +1,5 @@
+class AddCurrentStepToIntake < ActiveRecord::Migration[6.0]
+  def change
+    add_column :intakes, :current_step, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -289,6 +289,7 @@ ActiveRecord::Schema.define(version: 2021_03_18_180556) do
     t.datetime "completed_yes_no_questions_at"
     t.boolean "continued_at_capacity", default: false
     t.datetime "created_at"
+    t.string "current_step"
     t.integer "demographic_disability", default: 0, null: false
     t.integer "demographic_english_conversation", default: 0, null: false
     t.integer "demographic_english_reading", default: 0, null: false

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -788,6 +788,7 @@ RSpec.describe ApplicationController do
         allow(subject).to receive(:visitor_id).and_return(visitor_id)
         allow(subject).to receive(:current_user).and_return(current_user)
         allow(subject).to receive(:current_client).and_return(current_client)
+        allow(current_client).to receive(:intake)
         allow(subject).to receive(:request).and_return(request)
         allow(Raven).to receive(:extra_context)
       end

--- a/spec/controllers/portal/portal_controller_spec.rb
+++ b/spec/controllers/portal/portal_controller_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Portal::PortalController, type: :controller do
       end
     end
   end
+
   describe "#home" do
     context "when unauthenticated" do
       it "redirects to home page" do
@@ -33,24 +34,49 @@ RSpec.describe Portal::PortalController, type: :controller do
     end
 
     context "as an authenticated client" do
-      let(:client) { create :client }
+      before { sign_in client }
 
-      before do
-        create :tax_return, year: 2018, client: client
-        create :tax_return, year: 2017, client: client
-        create :tax_return, year: 2020, client: client
-        sign_in client
+      context "with onboarding still to do" do
+        let(:client) { create :client, intake: (create :intake, current_step: "/en/questions/additional-info") }
+
+        before do
+          create :tax_return, year: 2018, status: :intake_in_progress, client: client
+          create :tax_return, year: 2017, status: :intake_in_progress, client: client
+        end
+
+        it "is ok" do
+          get :home
+
+          expect(response).to be_ok
+        end
+
+        it "exposes current_step and tax_returns are empty" do
+          get :home
+
+          expect(assigns(:current_step)).to eq "/en/questions/additional-info"
+          expect(assigns(:tax_returns)).to eq []
+        end
       end
 
-      it "is ok" do
-        get :home
+      context "post-onboarding" do
+        let(:client) { create :client, intake: (create :intake) }
 
-        expect(response).to be_ok
-      end
+        before do
+          create :tax_return, year: 2018, status: :intake_in_progress, client: client
+          create :tax_return, year: 2017, status: :prep_ready_for_prep, client: client
+          create :tax_return, year: 2020, status: :intake_ready_for_call, client: client
+        end
 
-      it "loads the client tax returns in desc order" do
-        get :home
-        expect(assigns(:tax_returns).map(&:year)).to eq [2020, 2018, 2017]
+        it "is ok" do
+          get :home
+
+          expect(response).to be_ok
+        end
+
+        it "loads the client tax returns in desc order" do
+          get :home
+          expect(assigns(:tax_returns).map(&:year)).to eq [2020, 2018, 2017]
+        end
       end
     end
   end

--- a/spec/controllers/portal/portal_controller_spec.rb
+++ b/spec/controllers/portal/portal_controller_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe Portal::PortalController, type: :controller do
         it "loads the client tax returns in desc order" do
           get :home
           expect(assigns(:tax_returns).map(&:year)).to eq [2020, 2018, 2017]
+          expect(assigns(:current_step)).to eq nil
         end
       end
     end

--- a/spec/features/portal/client_portal_dashboard_spec.rb
+++ b/spec/features/portal/client_portal_dashboard_spec.rb
@@ -1,44 +1,69 @@
 require "rails_helper"
 
 RSpec.feature "a client on their portal" do
-  let(:client) { create :client, intake: (create :intake, preferred_name: "Martha", primary_first_name: "Martha", primary_last_name: "Mango", filing_joint: "yes") }
-  let(:tax_return2019) { create :tax_return, :ready_to_sign, year: 2019, client: client }
-  let(:tax_return2018) { create :tax_return, :ready_to_file_solo, year: 2018, client: client }
-  before do
-    create :document, display_name: "Another 8879", document_type: DocumentTypes::UnsignedForm8879.key, tax_return: tax_return2019, client: tax_return2019.client
-    create :tax_return, year: 2017, client: client
-    create :document, document_type: DocumentTypes::FinalTaxDocument.key, tax_return: tax_return2019, client: tax_return2019.client
-    create :document, document_type: DocumentTypes::FinalTaxDocument.key, display_name: "Some final tax document", tax_return: tax_return2018, client: tax_return2018.client
-    create :document, document_type: DocumentTypes::FinalTaxDocument.key, display_name: "Another final tax document", tax_return: tax_return2018, client: tax_return2018.client
-    login_as client, scope: :client
+  context "when a client has not yet completed onboarding and next step is a question" do
+    let(:client) { create :client, intake: (create :intake, preferred_name: "Katie", current_step: "/en/questions/asset-loss") }
+    before do
+      login_as client, scope: :client
+    end
+    scenario "linking to next step" do
+      visit portal_root_path
+      expect(page).to have_text "Welcome back Katie!"
+      expect(page).to have_link("Complete all tax questions", href: "/en/questions/asset-loss")
+    end
   end
 
-  scenario "viewing their tax return statuses" do
-    visit portal_root_path
-    expect(page).to have_text "Welcome back Martha!"
-
-    expect(page).to have_text "2019 tax documents"
-    expect(page).to have_text "2018 tax documents"
-    expect(page).to have_text "2017 tax documents"
-
-    within "#tax-year-2019" do
-      expect(page).to have_link "View/download Another 8879"
-      expect(page).to have_link "View/download " + tax_return2019.unsigned_8879s.first.display_name
-
-      expect(page).to have_link "View/download final 2019 tax document"
-      expect(page).to have_link "Submit primary taxpayer signature"
-      expect(page).to have_link "Submit spouse signature"
+  context "when a client has not yet completed onboarding and next step is documents" do
+    let(:client) { create :client, intake: (create :intake, preferred_name: "Randall", current_step: "/en/documents/overview") }
+    before do
+      login_as client, scope: :client
+    end
+    scenario "linking to next step" do
+      visit portal_root_path
+      expect(page).to have_text "Welcome back Randall!"
+      expect(page).to have_link("Submit remaining tax documents", href: "/en/documents/overview" )
+    end
+  end
+  context "a client with tax returns ready that have actions to take" do
+    let(:client) { create :client, intake: (create :intake, preferred_name: "Martha", primary_first_name: "Martha", primary_last_name: "Mango", filing_joint: "yes") }
+    let(:tax_return2019) { create :tax_return, :ready_to_sign, year: 2019, client: client }
+    let(:tax_return2018) { create :tax_return, :ready_to_file_solo, year: 2018, client: client }
+    before do
+      create :document, display_name: "Another 8879", document_type: DocumentTypes::UnsignedForm8879.key, tax_return: tax_return2019, client: tax_return2019.client
+      create :tax_return, year: 2017, client: client
+      create :document, document_type: DocumentTypes::FinalTaxDocument.key, tax_return: tax_return2019, client: tax_return2019.client
+      create :document, document_type: DocumentTypes::FinalTaxDocument.key, display_name: "Some final tax document", tax_return: tax_return2018, client: tax_return2018.client
+      create :document, document_type: DocumentTypes::FinalTaxDocument.key, display_name: "Another final tax document", tax_return: tax_return2018, client: tax_return2018.client
+      login_as client, scope: :client
     end
 
-    within "#tax-year-2018" do
-      expect(page).to have_link "View/download signed form 8879"
-      expect(page).to have_link "View/download Some final tax document"
-      expect(page).to have_link "View/download Another final tax document"
-      expect(page).not_to have_link "Submit primary taxpayer signature"
-    end
+    scenario "viewing their tax return statuses" do
+      visit portal_root_path
+      expect(page).to have_text "Welcome back Martha!"
 
-    within "#tax-year-2017" do
-      expect(page).to have_text "No documents ready to review yet - check back later."
+      expect(page).to have_text "2019 tax documents"
+      expect(page).to have_text "2018 tax documents"
+      expect(page).to have_text "2017 tax documents"
+
+      within "#tax-year-2019" do
+        expect(page).to have_link "View/download Another 8879"
+        expect(page).to have_link "View/download " + tax_return2019.unsigned_8879s.first.display_name
+
+        expect(page).to have_link "View/download final 2019 tax document"
+        expect(page).to have_link "Submit primary taxpayer signature"
+        expect(page).to have_link "Submit spouse signature"
+      end
+
+      within "#tax-year-2018" do
+        expect(page).to have_link "View/download signed form 8879"
+        expect(page).to have_link "View/download Some final tax document"
+        expect(page).to have_link "View/download Another final tax document"
+        expect(page).not_to have_link "Submit primary taxpayer signature"
+      end
+
+      within "#tax-year-2017" do
+        expect(page).to have_text "No documents ready to review yet - check back later."
+      end
     end
   end
 end

--- a/spec/features/web_intake/new_single_filer_spec.rb
+++ b/spec/features/web_intake/new_single_filer_spec.rb
@@ -24,8 +24,8 @@ RSpec.feature "Web Intake Single Filer", active_job: true do
     check "2020"
     check "2017"
     click_on "Continue"
-
     intake = Intake.last
+
     expect(intake.client.tax_returns.pluck(:year).sort).to eq [2017, 2020]
 
     #Non-production environment warning
@@ -38,6 +38,7 @@ RSpec.feature "Web Intake Single Filer", active_job: true do
 
     # VITA eligibility checks
     expect(page).to have_selector("h1", text: "Let’s check a few things.")
+    expect(intake.reload.current_step).to eq("/en/questions/eligibility")
 
     check "None of the above"
     click_on "Continue"
@@ -47,6 +48,7 @@ RSpec.feature "Web Intake Single Filer", active_job: true do
     click_on "Continue"
 
     # Personal Info
+    expect(intake.reload.current_step).to eq("/en/questions/personal-info")
     expect(page).to have_selector("h1", text: "First, let's get some basic information.")
     fill_in "Preferred name", with: "Gary"
     fill_in "ZIP code", with: "20121"
@@ -71,6 +73,7 @@ RSpec.feature "Web Intake Single Filer", active_job: true do
     click_on "Continue"
 
     # Notification Preference
+    expect(intake.reload.current_step).to eq("/en/questions/notification-preference")
     expect(page).to have_text("How can we update you on your tax return?")
     check "Email Me"
     check "Text Me"
@@ -114,6 +117,7 @@ RSpec.feature "Web Intake Single Filer", active_job: true do
     click_on "No"
 
     # Dependents
+    expect(intake.reload.current_step).to eq("/en/questions/had-dependents")
     expect(page).to have_selector("h1", text: "Would you like to claim anyone for 2020?")
     click_on "No"
 
@@ -130,6 +134,7 @@ RSpec.feature "Web Intake Single Filer", active_job: true do
     click_on "No"
 
     # Income from working
+    expect(intake.reload.current_step).to eq("/en/questions/job-count")
     select "3 jobs", from: "In 2020, how many jobs did you have?"
     click_on "Next"
     expect(page).to have_selector("h1", text: "In 2020, did you live or work in any other states besides Virginia?")
@@ -152,6 +157,7 @@ RSpec.feature "Web Intake Single Filer", active_job: true do
     click_on "Yes"
 
     # Retirement income/contributions
+    expect(intake.reload.current_step).to eq("/en/questions/social-security-or-retirement")
     expect(page).to have_selector("h1", text: "In 2020, did you have Social Security income, retirement income, or retirement contributions?")
     click_on "No"
 
@@ -190,6 +196,7 @@ RSpec.feature "Web Intake Single Filer", active_job: true do
     click_on "Yes"
 
     # Miscellaneous
+    expect(intake.reload.current_step).to eq("/en/questions/disaster-loss")
     expect(page).to have_selector("h1", text: "In 2020, did you have a loss related to a declared Federal Disaster Area?")
     click_on "No"
     expect(page).to have_selector("h1", text: "In 2020, did you have debt cancelled or forgiven by a lender?")
@@ -210,6 +217,8 @@ RSpec.feature "Web Intake Single Filer", active_job: true do
     click_on "Next"
 
     # Overview: Documents
+    expect(intake.reload.current_step).to eq("/en/questions/overview-documents")
+
     expect(page).to have_selector("h1", text: "Collect all your documents and have them with you.")
     click_on "Continue"
 
@@ -222,14 +231,17 @@ RSpec.feature "Web Intake Single Filer", active_job: true do
     click_on "Upload"
     click_on "Continue"
 
+    expect(intake.reload.current_step).to eq("/en/documents/selfie-instructions")
     expect(page).to have_selector("h1", text: "Confirm your identity with a photo of yourself")
     click_on "Submit a photo"
 
+    expect(intake.reload.current_step).to eq("/en/documents/selfies")
     expect(page).to have_selector("h1", text: "Share a photo of yourself holding your ID card")
     attach_file("document_type_upload_form_document", Rails.root.join("spec", "fixtures", "attachments", "picture_id.jpg"))
     click_on "Upload"
     click_on "Continue"
 
+    expect(intake.reload.current_step).to eq("/en/documents/ssn-itins")
     expect(page).to have_selector("h1", text: "Attach photos of Social Security Card or ITIN")
     attach_file("document_type_upload_form_document", Rails.root.join("spec", "fixtures", "attachments", "picture_id.jpg"))
     click_on "Upload"
@@ -259,12 +271,14 @@ RSpec.feature "Web Intake Single Filer", active_job: true do
     expect(page).to have_content("test-pattern.png")
     click_on "Continue"
 
+    expect(intake.reload.current_step).to eq("/en/documents/overview")
     expect(page).to have_selector("h1", text: "Great work! Here's a list of what we've collected.")
     click_on "I've shared all my documents"
 
     # Interview time preferences
+    expect(intake.reload.current_step).to eq("/en/questions/interview-scheduling")
     fill_in "Do you have any time preferences for your interview phone call?", with: "Wednesday or Tuesday nights"
-    expect(page) .to have_select(
+    expect(page).to have_select(
       "What is your preferred language for the review?", selected: "English"
     )
     select("Spanish", from: "What is your preferred language for the review?")
@@ -275,6 +289,7 @@ RSpec.feature "Web Intake Single Filer", active_job: true do
     choose "Direct deposit (fastest)"
     click_on "Continue"
     # Savings Options
+    expect(intake.reload.current_step).to eq("/en/questions/savings-options")
     expect(page).to have_selector("h1", text: "If due a refund, are you interested in using these savings options?")
     check "Purchase United States Savings Bond"
     click_on "Continue"
@@ -290,6 +305,7 @@ RSpec.feature "Web Intake Single Filer", active_job: true do
     click_on "Continue"
 
     # Contact information
+    expect(intake.reload.current_step).to eq("/en/questions/mailing-address")
     expect(page).to have_text("What is your mailing address?")
     fill_in "Street address", with: "123 Main St."
     fill_in "City", with: "Anytown"
@@ -312,6 +328,7 @@ RSpec.feature "Web Intake Single Filer", active_job: true do
     expect(page).to have_text("Are you or your spouse a veteran of the U.S. Armed Forces?")
     choose "Yes"
     click_on "Continue"
+    expect(intake.reload.current_step).to eq("/en/questions/demographic-primary-race")
     expect(page).to have_selector("h1", text: "What is your race?")
     check "Asian"
     check "White"
@@ -326,17 +343,20 @@ RSpec.feature "Web Intake Single Filer", active_job: true do
       click_on "Submit"
     end.to change(OutgoingTextMessage, :count).by(1).and change(OutgoingEmail, :count).by(1)
 
+    expect(intake.reload.current_step).to eq("/en/questions/successfully-submitted")
     expect(page).to have_selector("h1", text: "Success! Your tax information has been submitted.")
     expect(page).to have_text("Your confirmation number is: #{intake.client_id}")
     expect{ track_progress }.to change { @current_progress }.to(100)
     click_on "Great!"
 
+    expect(intake.reload.current_step).to eq("/en/questions/feedback")
     fill_in "Thank you for sharing your experience.", with: "I am the single filer. I file alone."
     click_on "Return to home"
     expect(page).to have_selector("h1", text: "Free tax filing")
 
-    # going back to another page after submit redirects to beginning
+    # going back to another page after submit redirects to beginning, does not reset current_step
     visit "/questions/work-situations"
+    expect(intake.reload.current_step).to eq("/en/questions/feedback")
     expect(page).to have_selector("h1", text: "Welcome! How can we help you?")
   end
 end

--- a/spec/lib/question_navigation_spec.rb
+++ b/spec/lib/question_navigation_spec.rb
@@ -1,0 +1,397 @@
+require "rails_helper"
+
+describe QuestionNavigation do
+  context ".determine_current_question" do
+    context "when before consent" do
+      let(:intake) { create :intake }
+      it "directs to the consent page" do
+        expect(described_class.determine_current_question(intake)).to eq "/en/questions/consent"
+      end
+    end
+
+    context "with all yes_no_questions completed but needs documents" do
+      let(:intake) { create :intake, primary_consented_to_service_at: DateTime.current, completed_yes_no_questions_at: DateTime.current }
+      before do
+        allow(intake).to receive(:document_types_definitely_needed).and_return [DocumentTypes::Selfie]
+      end
+
+      it "directs to the documents overview page" do
+        expect(described_class.determine_current_question(intake)).to eq "/en/documents/overview"
+      end
+    end
+
+    context "with some yes/no questions completed" do
+      context "answered up to life situations" do
+        let(:intake) {
+          create :intake,
+                 primary_consented_to_service_at: DateTime.current,
+                 was_full_time_student: "yes"
+        }
+        it "has next step as issued-identity-pin" do
+          expect(described_class.determine_current_question(intake)).to eq "/en/questions/issued-identity-pin"
+        end
+      end
+
+      context "answered up to ever married with yes" do
+        let(:intake) {
+          create :intake,
+                 primary_consented_to_service_at: DateTime.current,
+                 was_full_time_student: "yes",
+                 issued_identity_pin: "no",
+                 ever_married: "yes"
+        }
+        it "has next step as married" do
+          expect(described_class.determine_current_question(intake)).to eq "/en/questions/married"
+        end
+      end
+
+      context "answered up to ever married with no (takes into account skipped questions)" do
+        let(:intake) {
+          create :intake,
+                 primary_consented_to_service_at: DateTime.current,
+                 was_full_time_student: "yes",
+                 issued_identity_pin: "no",
+                 ever_married: "no"
+        }
+        it "has next step as had-dependents" do
+          expect(described_class.determine_current_question(intake)).to eq "/en/questions/had-dependents"
+        end
+      end
+
+      context "answered up to dependent care" do
+        let(:intake) {
+          create :intake,
+                 primary_consented_to_service_at: DateTime.current,
+                 was_full_time_student: "yes",
+                 issued_identity_pin: "no",
+                 ever_married: "no",
+                 had_dependents: "yes",
+                 paid_dependent_care: "unfilled"
+        }
+        it "has next step as dependent-care" do
+          expect(described_class.determine_current_question(intake)).to eq "/en/questions/dependent-care"
+        end
+      end
+
+      context "answered up to other states" do
+        let(:intake) {
+          create :intake,
+                 primary_consented_to_service_at: DateTime.current,
+                 was_full_time_student: "yes",
+                 issued_identity_pin: "no",
+                 ever_married: "no",
+                 had_dependents: "no",
+                 paid_dependent_care: "yes",
+                 adopted_child: "no",
+                 had_student_in_family: "no",
+                 paid_student_loan_interest: "yes",
+                 job_count: 2,
+                 multiple_states: "unfilled"
+
+        }
+        it "has next step as other-states" do
+          expect(described_class.determine_current_question(intake)).to eq "/en/questions/other-states"
+        end
+      end
+
+      context "answered up to had asset sale" do
+        let(:intake) {
+          create :intake,
+                 primary_consented_to_service_at: DateTime.current,
+                 was_full_time_student: "yes",
+                 issued_identity_pin: "no",
+                 ever_married: "no",
+                 had_dependents: "no",
+                 paid_dependent_care: "yes",
+                 adopted_child: "no",
+                 had_student_in_family: "no",
+                 paid_student_loan_interest: "yes",
+                 job_count: 2,
+                 multiple_states: "yes",
+                 had_wages: "yes",
+                 had_self_employment_income: "no",
+                 had_disability_income: "no",
+                 had_interest_income: "unsure",
+                 sold_assets: "yes",
+                 had_asset_sale_income: "unfilled"
+        }
+        it "has next step as other-states" do
+          expect(described_class.determine_current_question(intake)).to eq "/en/questions/asset-sale-income"
+        end
+      end
+
+      context "answered up to health insurance" do
+        let(:intake) {
+          create :intake,
+                 primary_consented_to_service_at: DateTime.current,
+                 was_full_time_student: "yes",
+                 issued_identity_pin: "no",
+                 ever_married: "no",
+                 had_dependents: "no",
+                 paid_dependent_care: "yes",
+                 adopted_child: "no",
+                 had_student_in_family: "no",
+                 paid_student_loan_interest: "yes",
+                 job_count: 2,
+                 multiple_states: "yes",
+                 had_wages: "yes",
+                 had_self_employment_income: "no",
+                 had_disability_income: "no",
+                 had_interest_income: "unsure",
+                 sold_assets: "no",
+                 had_asset_sale_income: "no",
+                 had_social_security_or_retirement: "no",
+                 had_other_income: "no",
+                 bought_health_insurance: "unfilled"
+        }
+        it "has next step as health-insurance" do
+          expect(described_class.determine_current_question(intake)).to eq "/en/questions/health-insurance"
+        end
+      end
+
+      context "answered up to paid school supplies" do
+        let(:intake) {
+          create :intake,
+                 primary_consented_to_service_at: DateTime.current,
+                 was_full_time_student: "yes",
+                 issued_identity_pin: "no",
+                 ever_married: "no",
+                 had_dependents: "no",
+                 paid_dependent_care: "yes",
+                 adopted_child: "no",
+                 had_student_in_family: "no",
+                 paid_student_loan_interest: "yes",
+                 job_count: 2,
+                 multiple_states: "yes",
+                 had_wages: "yes",
+                 had_self_employment_income: "no",
+                 had_disability_income: "no",
+                 had_interest_income: "unsure",
+                 sold_assets: "no",
+                 had_asset_sale_income: "no",
+                 had_social_security_or_retirement: "no",
+                 had_other_income: "no",
+                 bought_health_insurance: "yes",
+                 had_hsa: "no",
+                 paid_medical_expenses: "no",
+                 paid_charitable_contributions: "no",
+                 had_gambling_income: "no",
+                 paid_school_supplies: "unfilled"
+        }
+        it "has next step as health-insurance" do
+          expect(described_class.determine_current_question(intake)).to eq "/en/questions/school-supplies"
+        end
+      end
+
+      context "answered up to disaster loss" do
+        let(:intake) {
+          create :intake,
+                 primary_consented_to_service_at: DateTime.current,
+                 was_full_time_student: "yes",
+                 issued_identity_pin: "no",
+                 ever_married: "no",
+                 had_dependents: "no",
+                 paid_dependent_care: "yes",
+                 adopted_child: "no",
+                 had_student_in_family: "no",
+                 paid_student_loan_interest: "yes",
+                 job_count: 2,
+                 multiple_states: "yes",
+                 had_wages: "yes",
+                 had_self_employment_income: "no",
+                 had_disability_income: "no",
+                 had_interest_income: "unsure",
+                 sold_assets: "no",
+                 had_asset_sale_income: "no",
+                 had_social_security_or_retirement: "no",
+                 had_other_income: "no",
+                 bought_health_insurance: "yes",
+                 had_hsa: "no",
+                 paid_medical_expenses: "no",
+                 paid_charitable_contributions: "no",
+                 had_gambling_income: "no",
+                 paid_school_supplies: "yes",
+                 paid_local_tax: "no",
+                 had_local_tax_refund: "no",
+                 sold_a_home: "no",
+                 paid_mortgage_interest: "no",
+                 received_homebuyer_credit: "no",
+                 had_disaster_loss: "unfilled"
+        }
+        it "has next step as health-insurance" do
+          expect(described_class.determine_current_question(intake)).to eq "/en/questions/disaster-loss"
+        end
+      end
+
+      context "answered up to additional info" do
+        let(:intake) {
+          create :intake,
+                 primary_consented_to_service_at: DateTime.current,
+                 was_full_time_student: "yes",
+                 issued_identity_pin: "no",
+                 ever_married: "no",
+                 had_dependents: "no",
+                 paid_dependent_care: "yes",
+                 adopted_child: "no",
+                 had_student_in_family: "no",
+                 paid_student_loan_interest: "yes",
+                 job_count: 2,
+                 multiple_states: "yes",
+                 had_wages: "yes",
+                 had_self_employment_income: "no",
+                 had_disability_income: "no",
+                 had_interest_income: "unsure",
+                 sold_assets: "no",
+                 had_asset_sale_income: "no",
+                 had_social_security_or_retirement: "no",
+                 had_other_income: "no",
+                 bought_health_insurance: "yes",
+                 had_hsa: "no",
+                 paid_medical_expenses: "no",
+                 paid_charitable_contributions: "no",
+                 had_gambling_income: "no",
+                 paid_school_supplies: "yes",
+                 paid_local_tax: "no",
+                 had_local_tax_refund: "no",
+                 sold_a_home: "no",
+                 paid_mortgage_interest: "no",
+                 received_homebuyer_credit: "no",
+                 had_disaster_loss: "yes",
+                 had_debt_forgiven: "yes",
+                 received_irs_letter: "yes",
+                 had_tax_credit_disallowed: "yes",
+                 made_estimated_tax_payments: "yes",
+                 reported_self_employment_loss: "yes",
+                 bought_energy_efficient_items: "yes",
+                 additional_info: nil
+        }
+        it "has next step as additional-info" do
+          expect(described_class.determine_current_question(intake)).to eq "/en/questions/additional-info"
+        end
+      end
+
+    end
+
+    context "with documents submitted but final questions to complete" do
+      before do
+        allow(intake).to receive(:document_types_definitely_needed).and_return []
+      end
+
+      context "without interview scheduling answered" do
+        let(:intake) { create :intake, primary_consented_to_service_at: DateTime.current, completed_yes_no_questions_at: DateTime.current }
+        it "sends you to interview scheduling" do
+          expect(described_class.determine_current_question(intake)).to eq "/en/questions/interview-scheduling"
+        end
+      end
+
+      context "with interview scheduling answered" do
+        let(:intake) {
+          create :intake,
+                 primary_consented_to_service_at: DateTime.current,
+                 completed_yes_no_questions_at: DateTime.current,
+                 interview_timing_preference: "anytime is fine with me",
+                 refund_payment_method: "unfilled"
+        }
+
+        it "sends you to refund payment options" do
+          expect(described_class.determine_current_question(intake)).to eq "/en/questions/refund-payment"
+        end
+      end
+
+      context "with refund payment method answered" do
+        let(:intake) {
+          create :intake,
+                 primary_consented_to_service_at: DateTime.current,
+                 completed_yes_no_questions_at: DateTime.current,
+                 interview_timing_preference: "anytime is fine with me",
+                 refund_payment_method: "direct_deposit"
+        }
+
+        it "sends you to refund payment options" do
+          expect(described_class.determine_current_question(intake)).to eq "/en/questions/savings-options"
+        end
+      end
+
+      context "with up to mailing address answered" do
+        let(:intake) {
+          create :intake,
+                 primary_consented_to_service_at: DateTime.current,
+                 completed_yes_no_questions_at: DateTime.current,
+                 interview_timing_preference: "anytime is fine with me",
+                 refund_payment_method: "direct_deposit",
+                 savings_purchase_bond: "yes",
+                 balance_pay_from_bank: "no",
+                 bank_name: "Bank of America",
+                 street_address: "23627 Luna Lane"
+        }
+
+        it "sends you to refund payment options" do
+          expect(described_class.determine_current_question(intake)).to eq "/en/questions/demographic-questions"
+        end
+      end
+
+      context "when demographic questions are not opted into" do
+        let(:intake) {
+          create :intake,
+                 primary_consented_to_service_at: DateTime.current,
+                 completed_yes_no_questions_at: DateTime.current,
+                 interview_timing_preference: "anytime is fine with me",
+                 refund_payment_method: "direct_deposit",
+                 savings_purchase_bond: "yes",
+                 balance_pay_from_bank: "no",
+                 bank_name: "Bank of America",
+                 street_address: "23627 Luna Lane",
+                 demographic_questions_opt_in: "no"
+        }
+
+        it "sends you to refund payment options" do
+          expect(described_class.determine_current_question(intake)).to eq "/en/questions/final-info"
+        end
+      end
+
+      context "when demographic questions are opted into" do
+        let(:intake) {
+          create :intake,
+                 primary_consented_to_service_at: DateTime.current,
+                 completed_yes_no_questions_at: DateTime.current,
+                 interview_timing_preference: "anytime is fine with me",
+                 refund_payment_method: "direct_deposit",
+                 savings_purchase_bond: "yes",
+                 balance_pay_from_bank: "no",
+                 bank_name: "Bank of America",
+                 street_address: "23627 Luna Lane",
+                 demographic_questions_opt_in: "yes"
+        }
+
+        it "takes you through the demographic questions" do
+          expect(described_class.determine_current_question(intake)).to eq "/en/questions/demographic-english-conversation"
+        end
+
+        context "when demographic questions are opted into" do
+          let(:intake) {
+            create :intake,
+                   primary_consented_to_service_at: DateTime.current,
+                   completed_yes_no_questions_at: DateTime.current,
+                   interview_timing_preference: "anytime is fine with me",
+                   refund_payment_method: "direct_deposit",
+                   savings_purchase_bond: "yes",
+                   balance_pay_from_bank: "no",
+                   bank_name: "Bank of America",
+                   street_address: "23627 Luna Lane",
+                   demographic_questions_opt_in: "yes",
+                   demographic_english_conversation: "not_well",
+                   demographic_english_reading: "not_well",
+                   demographic_disability: "no",
+                   demographic_veteran: "yes",
+                   demographic_primary_american_indian_alaska_native: "yes"
+          }
+
+          it "takes you through the demographic questions" do
+            expect(described_class.determine_current_question(intake)).to eq "/en/questions/demographic-primary-ethnicity"
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/spec/lib/question_navigation_spec.rb
+++ b/spec/lib/question_navigation_spec.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
 
 describe QuestionNavigation do
-  context ".determine_current_question" do
+  context ".determine_current_step" do
     context "when before consent" do
       let(:intake) { create :intake }
       it "directs to the consent page" do
-        expect(described_class.determine_current_question(intake)).to eq "/en/questions/consent"
+        expect(described_class.determine_current_step(intake)).to eq "/en/questions/consent"
       end
     end
 
@@ -16,7 +16,7 @@ describe QuestionNavigation do
       end
 
       it "directs to the documents overview page" do
-        expect(described_class.determine_current_question(intake)).to eq "/en/documents/overview"
+        expect(described_class.determine_current_step(intake)).to eq "/en/documents/overview"
       end
     end
 
@@ -28,7 +28,7 @@ describe QuestionNavigation do
                  was_full_time_student: "yes"
         }
         it "has next step as issued-identity-pin" do
-          expect(described_class.determine_current_question(intake)).to eq "/en/questions/issued-identity-pin"
+          expect(described_class.determine_current_step(intake)).to eq "/en/questions/issued-identity-pin"
         end
       end
 
@@ -41,7 +41,7 @@ describe QuestionNavigation do
                  ever_married: "yes"
         }
         it "has next step as married" do
-          expect(described_class.determine_current_question(intake)).to eq "/en/questions/married"
+          expect(described_class.determine_current_step(intake)).to eq "/en/questions/married"
         end
       end
 
@@ -54,7 +54,7 @@ describe QuestionNavigation do
                  ever_married: "no"
         }
         it "has next step as had-dependents" do
-          expect(described_class.determine_current_question(intake)).to eq "/en/questions/had-dependents"
+          expect(described_class.determine_current_step(intake)).to eq "/en/questions/had-dependents"
         end
       end
 
@@ -69,7 +69,7 @@ describe QuestionNavigation do
                  paid_dependent_care: "unfilled"
         }
         it "has next step as dependent-care" do
-          expect(described_class.determine_current_question(intake)).to eq "/en/questions/dependent-care"
+          expect(described_class.determine_current_step(intake)).to eq "/en/questions/dependent-care"
         end
       end
 
@@ -90,7 +90,7 @@ describe QuestionNavigation do
 
         }
         it "has next step as other-states" do
-          expect(described_class.determine_current_question(intake)).to eq "/en/questions/other-states"
+          expect(described_class.determine_current_step(intake)).to eq "/en/questions/other-states"
         end
       end
 
@@ -116,7 +116,7 @@ describe QuestionNavigation do
                  had_asset_sale_income: "unfilled"
         }
         it "has next step as other-states" do
-          expect(described_class.determine_current_question(intake)).to eq "/en/questions/asset-sale-income"
+          expect(described_class.determine_current_step(intake)).to eq "/en/questions/asset-sale-income"
         end
       end
 
@@ -145,7 +145,7 @@ describe QuestionNavigation do
                  bought_health_insurance: "unfilled"
         }
         it "has next step as health-insurance" do
-          expect(described_class.determine_current_question(intake)).to eq "/en/questions/health-insurance"
+          expect(described_class.determine_current_step(intake)).to eq "/en/questions/health-insurance"
         end
       end
 
@@ -179,7 +179,7 @@ describe QuestionNavigation do
                  paid_school_supplies: "unfilled"
         }
         it "has next step as health-insurance" do
-          expect(described_class.determine_current_question(intake)).to eq "/en/questions/school-supplies"
+          expect(described_class.determine_current_step(intake)).to eq "/en/questions/school-supplies"
         end
       end
 
@@ -219,7 +219,7 @@ describe QuestionNavigation do
                  had_disaster_loss: "unfilled"
         }
         it "has next step as health-insurance" do
-          expect(described_class.determine_current_question(intake)).to eq "/en/questions/disaster-loss"
+          expect(described_class.determine_current_step(intake)).to eq "/en/questions/disaster-loss"
         end
       end
 
@@ -266,7 +266,7 @@ describe QuestionNavigation do
                  additional_info: nil
         }
         it "has next step as additional-info" do
-          expect(described_class.determine_current_question(intake)).to eq "/en/questions/additional-info"
+          expect(described_class.determine_current_step(intake)).to eq "/en/questions/additional-info"
         end
       end
 
@@ -280,7 +280,7 @@ describe QuestionNavigation do
       context "without interview scheduling answered" do
         let(:intake) { create :intake, primary_consented_to_service_at: DateTime.current, completed_yes_no_questions_at: DateTime.current }
         it "sends you to interview scheduling" do
-          expect(described_class.determine_current_question(intake)).to eq "/en/questions/interview-scheduling"
+          expect(described_class.determine_current_step(intake)).to eq "/en/questions/interview-scheduling"
         end
       end
 
@@ -294,7 +294,7 @@ describe QuestionNavigation do
         }
 
         it "sends you to refund payment options" do
-          expect(described_class.determine_current_question(intake)).to eq "/en/questions/refund-payment"
+          expect(described_class.determine_current_step(intake)).to eq "/en/questions/refund-payment"
         end
       end
 
@@ -308,7 +308,7 @@ describe QuestionNavigation do
         }
 
         it "sends you to refund payment options" do
-          expect(described_class.determine_current_question(intake)).to eq "/en/questions/savings-options"
+          expect(described_class.determine_current_step(intake)).to eq "/en/questions/savings-options"
         end
       end
 
@@ -326,7 +326,7 @@ describe QuestionNavigation do
         }
 
         it "sends you to refund payment options" do
-          expect(described_class.determine_current_question(intake)).to eq "/en/questions/demographic-questions"
+          expect(described_class.determine_current_step(intake)).to eq "/en/questions/demographic-questions"
         end
       end
 
@@ -345,7 +345,7 @@ describe QuestionNavigation do
         }
 
         it "sends you to refund payment options" do
-          expect(described_class.determine_current_question(intake)).to eq "/en/questions/final-info"
+          expect(described_class.determine_current_step(intake)).to eq "/en/questions/final-info"
         end
       end
 
@@ -364,7 +364,7 @@ describe QuestionNavigation do
         }
 
         it "takes you through the demographic questions" do
-          expect(described_class.determine_current_question(intake)).to eq "/en/questions/demographic-english-conversation"
+          expect(described_class.determine_current_step(intake)).to eq "/en/questions/demographic-english-conversation"
         end
 
         context "when demographic questions are opted into" do
@@ -387,7 +387,7 @@ describe QuestionNavigation do
           }
 
           it "takes you through the demographic questions" do
-            expect(described_class.determine_current_question(intake)).to eq "/en/questions/demographic-primary-ethnicity"
+            expect(described_class.determine_current_step(intake)).to eq "/en/questions/demographic-primary-ethnicity"
           end
         end
 

--- a/spec/lib/question_navigation_spec.rb
+++ b/spec/lib/question_navigation_spec.rb
@@ -115,7 +115,7 @@ describe QuestionNavigation do
                  sold_assets: "yes",
                  had_asset_sale_income: "unfilled"
         }
-        it "has next step as other-states" do
+        it "has next step as asset-sale-income" do
           expect(described_class.determine_current_step(intake)).to eq "/en/questions/asset-sale-income"
         end
       end

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -1085,14 +1085,14 @@ describe Intake do
 
     describe ".determine_current_step" do
       before do
-        allow(QuestionNavigation).to receive(:determine_current_question).and_return("/en/questions/something")
+        allow(QuestionNavigation).to receive(:determine_current_step).and_return("/en/questions/something")
       end
       context "when current_step is already present" do
         let(:intake) { create :intake, current_step: "already-set" }
 
         it "does not update the intake" do
           expect(intake.determine_current_step).to eq "already-set"
-          expect(QuestionNavigation).not_to have_received(:determine_current_question)
+          expect(QuestionNavigation).not_to have_received(:determine_current_step)
         end
       end
 
@@ -1101,7 +1101,7 @@ describe Intake do
 
         it "updates with the result of the current question" do
           expect(intake.determine_current_step).to eq "/en/questions/something"
-          expect(QuestionNavigation).to have_received(:determine_current_question)
+          expect(QuestionNavigation).to have_received(:determine_current_step)
         end
       end
     end

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -1082,5 +1082,28 @@ describe Intake do
         expect(document.display_name).to eq "new-filename.pdf"
       end
     end
+
+    describe ".determine_current_step" do
+      before do
+        allow(QuestionNavigation).to receive(:determine_current_question).and_return("/en/questions/something")
+      end
+      context "when current_step is already present" do
+        let(:intake) { create :intake, current_step: "already-set" }
+
+        it "does not update the intake" do
+          expect(intake.determine_current_step).to eq "already-set"
+          expect(QuestionNavigation).not_to have_received(:determine_current_question)
+        end
+      end
+
+      context "when current_step is not present" do
+        let(:intake) { create :intake, current_step: nil }
+
+        it "updates with the result of the current question" do
+          expect(intake.determine_current_step).to eq "/en/questions/something"
+          expect(QuestionNavigation).to have_received(:determine_current_question)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Records "current_step" field onto intake, and updates portal dashboard to display a link back to the appropriate location when  onboarding is still in progress.

Some info:


- I decided to store the path instead of the controller name because it simplifies the implementation overall — we can just link directly to the appropriate page without finding the corresponding location and then pathname in the navigation flow. 
- I also decided to set the current path in a before filter on the controller for simplicity’s sake, but that might be worth revisiting! We could save the second post action on each page by instead merging`current_step: next_path` into the form params on the update action of the questions controller which would mean we don’t have to make two post actions on each page. I think that could be done by updating QuestionsForm somehow.
- For returning clients who went through the flow before we started storing current_step on the intake, I decided to simplify the documents logic a bit, sending them to the documents/overview page when they still have documents they need to upload. 
