### PR TITLE
Remove analytics.access_logs

### DIFF
--- a/db/create_analytics_views.sql
+++ b/db/create_analytics_views.sql
@@ -14,10 +14,6 @@
 -- `rails analytics:remove` or DROP SCHEMA IF EXISTS analytics CASCADE;
 CREATE SCHEMA IF NOT EXISTS analytics;
 
-CREATE OR REPLACE VIEW analytics.access_logs AS
-    SELECT id, client_id, created_at, event_type, updated_at, user_id, user_agent
-    FROM public.access_logs;
-
 CREATE OR REPLACE VIEW analytics.active_storage_attachments AS
     SELECT id, blob_id, created_at, record_id, record_type
     FROM public.active_storage_attachments;


### PR DESCRIPTION
The `access_logs` schema changed, and we haven't defined how to handle
migrations for these views, so I propose we remove this for now.

This makes the codebase consistent with production, which is good IMHO.

Later on we can re-add this if we like.