### PR TITLE
Improve onboarding docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,32 +4,82 @@ Vita-Min is a Rails app that helps people access the VITA program through a digi
 
 ## Setup
 
-```bash
+### Assumptions before first time setup
+
+> ℹ️ These steps assume you are working with a macOS operating system, if that is not the case, some steps may be different. Ask a fellow teammate and we can update these setup steps to include the operating system you are using.
+
+There are a few dependencies that are common for many web applications. The first being [Homebrew](https://brew.sh/).It is used to install many different types of packages for macOS.
+
+If you don't already have Homebrew, install it with:
+
+```shell
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+MacOS comes with git installed but you can also [install it with Homebrew](https://git-scm.com/download/mac) if you want:
+
+```shell
+brew install git
+```
+
+If you don't have an SSH key on your computer to connect to GitHub, their documentation on [how to add an SSH key](https://docs.github.com/en/github/authenticating-to-github/adding-a-new-ssh-key-to-your-github-account) is a good starting point. You will need to have an SSH key to download this repository locally.
+
+### Install PDFtk
+
+[PDFtk](https://en.wikipedia.org/wiki/PDFtk) is a toolkit for manipulating PDF documents. Download and install PDFtk from https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk_server-2.02-mac_osx-10.11-setup.pkg
+
+### Add credentials
+
+Get the development secret key from LastPass (`development.key`) or ask a teammate who has it set up.
+
+Add it to your configuration:
+
+```shell
+# In the root of vita-min
+echo "[secret key]" > config/credentials/development.key
+```
+
+### Setup script
+
+There is a setup script that handles virtually everything with a single command:
+
+```shell
+# In the root of vita-min
 bin/setup
 ```
 
-1.  Download and install PDFtk from
-    https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk_server-2.02-mac_osx-10.11-setup.pkg
+#### Troubleshooting during setup
 
-1.  Get the development secret key from LastPass / someone who has it set up.
-    Add it to your configuration:
+**Is the server running locally and accepting connections on Unix domain socket "/tmp/.s.PGSQL.5432"?**
 
-    ```bash
-    echo "[secret key]" > config/credentials/development.key
-    ```
+If you see this error, `PostgreSQL` is not running. You can get it running with:
 
+```shell
+brew services start postgresql
+```
+
+### Run the server
+
+Is this all that's needed?
+
+```shell
+bin/rails server
+
+# or for short
+bin/rails s
+```
 
 ## Development
 
 In development, you'll need to manually start the delayed_job worker using the following command:
 
 ```shell
-rails jobs:work
+bin/rails jobs:work
 ```
 
 ### Emails
 
-To see emails in development, run `rails jobs:work`. All emails are printed to its output console.
+To see emails in development, run `bin/rails jobs:work`. All emails are printed to its output console.
 They are also logged in `tmp/mail/#{to_address}`.
 
 ### Run some tests!
@@ -56,13 +106,10 @@ The rubocop settings files is in the root directory as `.rubocop.yml`
 RubyMine integrates Rubocop by default. Settings can be found in the Preferences
 menu, under Editor > Inspections > Ruby > Gems and Gem Management > Rubocop.
 
-## Environments
-
-Notes on environments can be found in [docs/environments.md](docs/environments.md).
-
 ## Deploying the Application
 
-Notes on deployment can be found in [docs/deployment.md](docs/deployment.md).
+Notes on deployment can be found in [docs/deployment](docs/deployment.md).
 
+## Documentation
 
-
+More documentation can be found in the [docs folder](docs/README.md).

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ rails jobs:work
 
 ### Emails
 
-To see emails in development, run `bin/rails jobs:work`. All emails are printed to its output console.
+To see emails in development, run `rails jobs:work`. All emails are printed to its output console.
 They are also logged in `tmp/mail/#{to_address}`.
 
 ### Run some tests!

--- a/README.md
+++ b/README.md
@@ -1,28 +1,42 @@
-# vita-min
+# vita-min 💊
 
 Vita-Min is a Rails app that helps people access the VITA program through a digital intake form, a "valet" drop-off workflow using Zendesk, and a national landing page to find the nearest VITA site.
 
-## Setup
+## Setup 🧰
 
 ### Assumptions before first time setup
 
 > ℹ️ These steps assume you are working with a macOS operating system, if that is not the case, some steps may be different. Ask a fellow teammate and we can update these setup steps to include the operating system you are using.
 
+#### Homebrew
+
 There are a few dependencies that are common for many web applications. The first being [Homebrew](https://brew.sh/).It is used to install many different types of packages for macOS.
 
 If you don't already have Homebrew, install it with:
 
-```shell
+```sh
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
+#### Git
+
 MacOS comes with git installed but you can also [install it with Homebrew](https://git-scm.com/download/mac) if you want:
 
-```shell
+```sh
 brew install git
 ```
 
+#### Connect GitHub with a SSH key
+
 If you don't have an SSH key on your computer to connect to GitHub, their documentation on [how to add an SSH key](https://docs.github.com/en/github/authenticating-to-github/adding-a-new-ssh-key-to-your-github-account) is a good starting point. You will need to have an SSH key to download this repository locally.
+
+#### Git duet
+
+To make pairing commit history easier, we use [git duet](https://github.com/git-duet/git-duet/), which can be installed with:
+
+```sh
+brew install git-duet/tap/git-duet
+```
 
 ### Install PDFtk
 
@@ -34,7 +48,7 @@ Get the development secret key from LastPass (`development.key`) or ask a teamma
 
 Add it to your configuration:
 
-```shell
+```sh
 # In the root of vita-min
 echo "[secret key]" > config/credentials/development.key
 ```
@@ -43,7 +57,7 @@ echo "[secret key]" > config/credentials/development.key
 
 There is a setup script that handles virtually everything with a single command:
 
-```shell
+```sh
 # In the root of vita-min
 bin/setup
 ```
@@ -54,27 +68,29 @@ bin/setup
 
 If you see this error, `PostgreSQL` is not running. You can get it running with:
 
-```shell
+```sh
 brew services start postgresql
 ```
 
 ### Run the server
 
-Is this all that's needed?
+If you don't have rails installed, you can follow the [official getting started guide](https://guides.rubyonrails.org/getting_started.html#creating-a-new-rails-project-installing-rails-installing-rails).
 
-```shell
-bin/rails server
+With Rails installed, you can serve the application with:
+
+```sh
+rails server
 
 # or for short
-bin/rails s
+rails s
 ```
 
-## Development
+## Development 💻
 
 In development, you'll need to manually start the delayed_job worker using the following command:
 
-```shell
-bin/rails jobs:work
+```sh
+rails jobs:work
 ```
 
 ### Emails
@@ -84,13 +100,45 @@ They are also logged in `tmp/mail/#{to_address}`.
 
 ### Run some tests!
 
+#### Run all test suites
+
+To run all test suites (RSpec unit & feature specs, Javascript Jest unit tests).
+
 ```sh
-bin/test # run all test suites (RSpec unit & feature specs, Javascript Jest unit tests)
-yarn jest # run Jest Javascript unit tests
-rspec # run RSpec unit & feature specs
-rspec --only-failures # run RSpec tests that failed on the last run
-CHROME=y rspec # run feature specs with Chrome visible
-COVERAGE=y rspec # run RSpec with test coverage report
+bin/test
+```
+
+#### Only JavaScript unit tests
+
+We use [Jest](https://jestjs.io/) to run our JavaScript unit tests.
+
+```sh
+yarn jest
+```
+
+#### RSpec tests
+
+We us [RSpec](https://rspec.info/) to run unit & feature tests.
+
+```sh
+# run RSpec unit & feature specs
+rspec
+
+# - or -
+
+# run RSpec tests that failed on the last run
+rspec --only-failures
+
+# - or -
+
+# run feature specs with Chrome visible
+# (Chrome runs in the background normally without this flag enabled)
+CHROME=y rspec
+
+# - or -
+
+# run RSpec with test coverage report
+COVERAGE=y rspec
 ```
 
 ### Linter
@@ -106,10 +154,10 @@ The rubocop settings files is in the root directory as `.rubocop.yml`
 RubyMine integrates Rubocop by default. Settings can be found in the Preferences
 menu, under Editor > Inspections > Ruby > Gems and Gem Management > Rubocop.
 
-## Deploying the Application
+## Deploying the Application 🚀☁️
 
 Notes on deployment can be found in [docs/deployment](docs/deployment.md).
 
-## Documentation
+## Documentation 📚
 
 More documentation can be found in the [docs folder](docs/README.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,11 @@
+# Vita-min documentation
+
+- [Access control data model](2020-10-20-access-control-data-model.md)
+- [Consolidated errors](2020-05-06-consolidated-errors.md)
+- [Datadog metrics](2021-02-09-datadog-metrics.md)
+- [Deployment](deployment.md)
+- [Exact matching on source parameter](2020-05-12-exact-matching-on-source-parameter.md)
+- [Interaction tracking](2021-01-08-interaction-tracking.md)
+- [Mailgun web hook security](2020-10-30-mailgun-web-hook-security.md)
+- [Metabase](2021-02-08-metabase.md)
+- [Refactor zendesk routing logic](2020-05-07-refactor-zendesk-routing-logic.md)


### PR DESCRIPTION
# Why

When on-boarding to GYR, I tried to distill my knowledge and troubles into updating the setup documentation.

## Things I added

- Added a table of contents README in the `/docs` folder
- Added a section for "assumptions" that have to happen before the setup steps can be started
- Added a troubleshooting section when getting errors from the `bin/setup` script
- Added a section about running the rails server
- Spaced out the testing section and added sub headings
- Removed the "environment" section as the docs for that have been deleted
- Added emojis to the major headings in the main README (to add levity)