### PR TITLE
Use a relationship to notifications instead of access control for notifications page

### DIFF
--- a/app/controllers/hub/user_notifications_controller.rb
+++ b/app/controllers/hub/user_notifications_controller.rb
@@ -1,18 +1,16 @@
 module Hub
   class UserNotificationsController < ApplicationController
     include AccessControllable
-
     before_action :require_sign_in
-    load_and_authorize_resource only: [:index]
     layout "admin"
 
     def index
-      @page_title = "Notifications"
-      @user_notifications = @user_notifications.order(created_at: :desc).page(params[:page])
+      @page_title = I18n.t("hub.clients.navigation.notifications")
+      @user_notifications = current_user.notifications.order(created_at: :desc).page(params[:page])
     end
 
     def mark_all_notifications_read
-      UserNotification.accessible_by(current_ability).update_all(read: true)
+      current_user.notifications.unread.update_all(read: true)
 
       redirect_to hub_user_notifications_path
     end

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -21,9 +21,6 @@ class Ability
     # Anyone can read info about users that they can access
     can :read, User, id: user.accessible_users.pluck(:id)
 
-    # Anyone can read their own user notifications
-    can :read, UserNotification, user: user
-
     # Anyone can read info about an organization or site they can access
     can :read, VitaPartner, id: accessible_groups.pluck(:id)
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,6 +61,7 @@ class User < ApplicationRecord
   validates :email, 'valid_email_2/email': { mx: true }
   has_many :assigned_tax_returns, class_name: "TaxReturn", foreign_key: :assigned_user_id
   has_many :access_logs
+  has_many :notifications, class_name: "UserNotification"
   belongs_to :role, polymorphic: true
 
   belongs_to :organization_lead_role, -> { where(users: { role_type: 'OrganizationLeadRole' }) }, foreign_key: 'role_id', optional: true

--- a/app/models/user_notification.rb
+++ b/app/models/user_notification.rb
@@ -22,6 +22,7 @@
 class UserNotification < ApplicationRecord
   belongs_to :notifiable, polymorphic: true
   belongs_to :user
+  scope :unread, -> { where(read: false) }
 
   self.per_page = 25
 end

--- a/app/views/shared/_dashboard_navigation.html.erb
+++ b/app/views/shared/_dashboard_navigation.html.erb
@@ -8,6 +8,6 @@
   <% is_selected = locale_agnostic_current_path?(hub_user_notifications_path) ? " is-selected" : "" %>
   <%= link_to hub_user_notifications_path, class: "tab-bar__tab#{is_selected} tab-bar__notifications" do %>
     <%= t("hub.clients.navigation.notifications")%>
-    <%= render 'shared/unread_icon', flag: true if UserNotification.where(user: current_user, read: false).present? %>
+    <%= render 'shared/unread_icon', flag: true if current_user.notifications.unread.present? %>
   <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -377,7 +377,6 @@ en:
         title: You've Been Assigned a Client
         body_html: "%{assigner} has assigned %{client_link} %{tax_return_year} return to you."
         body_link: "%{client_name}'s"
-
   controllers:
     public_pages:
       partner_welcome_notice: Thanks for visiting via %{partner_name}!

--- a/spec/controllers/hub/user_notifications_controller_spec.rb
+++ b/spec/controllers/hub/user_notifications_controller_spec.rb
@@ -1,76 +1,30 @@
 require "rails_helper"
 
 RSpec.describe Hub::UserNotificationsController, type: :controller do
+  let(:user) { create :team_member_user }
+  let!(:notification_first) { create :user_notification, user: user, read: false, created_at: DateTime.new(2021, 3, 11, 8, 1).utc }
+  let!(:notification_second) { create :user_notification, user: user, read: false, created_at: DateTime.new(2021, 3, 12, 8, 1).utc }
+  let!(:notification_third) { create :user_notification, user: user, read: true, created_at: DateTime.new(2021, 3, 13, 8, 1).utc }
+  let!(:other_notification) { create :user_notification, user: create(:user), read: false, created_at: DateTime.new(2021, 3, 13, 8, 1).utc }
+
   describe "#index" do
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :index
 
     context "as a logged in user loading user notifications" do
-      let(:team_member_user) { create :user, role: create(:team_member_role) }
-      let(:site_coordinator_user) { create :user, role: create(:site_coordinator_role) }
-      let(:admin_user) { create :user, role: create(:admin_role) }
 
-      let!(:team_member_notification_first) { create :user_notification, user: team_member_user, read: false, created_at: DateTime.new(2021, 3, 11, 8, 1).utc }
-      let!(:team_member_notification_second) { create :user_notification, user: team_member_user, read: false, created_at: DateTime.new(2021, 3, 12, 8, 1).utc }
-      let!(:team_member_notification_third) { create :user_notification, user: team_member_user, read: true, created_at: DateTime.new(2021, 3, 13, 8, 1).utc }
+      before { sign_in user }
 
-      let!(:site_coordinator_notification_first) { create :user_notification, user: site_coordinator_user, read: false, created_at: DateTime.new(2021, 3, 11, 8, 1).utc }
-      let!(:site_coordinator_notification_second) { create :user_notification, user: site_coordinator_user, read: false, created_at: DateTime.new(2021, 3, 12, 8, 1).utc }
-      let!(:site_coordinator_notification_third) { create :user_notification, user: site_coordinator_user, read: true, created_at: DateTime.new(2021, 3, 13, 8, 1).utc }
+      it "loads notifications in descending order" do
+        get :index
 
-      let!(:admin_notification_first) { create :user_notification, user: admin_user, read: false, created_at: DateTime.new(2021, 3, 11, 8, 1).utc }
-      let!(:admin_notification_second) { create :user_notification, user: admin_user, read: false, created_at: DateTime.new(2021, 3, 12, 8, 1).utc }
-      let!(:admin_notification_third) { create :user_notification, user: admin_user, read: true, created_at: DateTime.new(2021, 3, 13, 8, 1).utc }
-      let!(:other_admin_notification) { create :user_notification, user: (create :admin_user), read: false, created_at: DateTime.new(2021, 3, 13, 8, 1).utc }
-
-      render_views
-
-      context "team member user" do
-        before { sign_in team_member_user }
-
-        it "loads notifications in descending order" do
-          get :index
-
-          expect(response).to be_ok
-
-          expect(assigns(:user_notifications)).to eq [team_member_notification_third, team_member_notification_second, team_member_notification_first]
-        end
-      end
-
-      context "site coordinator user" do
-        before { sign_in site_coordinator_user }
-
-        it "loads notifications in descending order" do
-          get :index
-
-          expect(response).to be_ok
-
-          expect(assigns(:user_notifications)).to eq [site_coordinator_notification_third, site_coordinator_notification_second, site_coordinator_notification_first]
-        end
-      end
-
-      context "as an admin" do
-        before { sign_in admin_user }
-
-        it "loads notifications in descending order" do
-          get :index
-
-          expect(response).to be_ok
-          expect(assigns(:user_notifications)).not_to include other_admin_notification
-
-          expect(assigns(:user_notifications)).to eq [admin_notification_third, admin_notification_second, admin_notification_first]
-
-        end
+        expect(response).to be_ok
+        expect(assigns(:user_notifications)).not_to include other_notification
+        expect(assigns(:user_notifications)).to eq [notification_third, notification_second, notification_first]
       end
     end
   end
 
   describe "#mark_all_notifications_read" do
-    let(:user) { create :user, role: create(:team_member_role) }
-    let!(:notification_first) { create :user_notification, user: user, read: false, created_at: DateTime.new(2021, 3, 11, 8, 1).utc }
-    let!(:notification_second) { create :user_notification, user: user, read: false, created_at: DateTime.new(2021, 3, 12, 8, 1).utc }
-    let!(:notification_read) { create :user_notification, user: user, read: true, created_at: DateTime.new(2021, 3, 13, 8, 1).utc }
-    let!(:notification_other) { create :user_notification, user: create(:user), read: false }
-
     it_behaves_like :a_post_action_for_authenticated_users_only, action: :mark_all_notifications_read
 
     context "as an authenticated hub user" do
@@ -82,7 +36,7 @@ RSpec.describe Hub::UserNotificationsController, type: :controller do
         expect(response.status).to eq 302
         expect(notification_first.reload.read).to eq true
         expect(notification_second.reload.read).to eq true
-        expect(notification_other.reload.read).to eq false
+        expect(other_notification.reload.read).to eq false
         expect(response).to redirect_to hub_user_notifications_path
       end
     end

--- a/spec/controllers/hub/user_notifications_controller_spec.rb
+++ b/spec/controllers/hub/user_notifications_controller_spec.rb
@@ -1,30 +1,74 @@
 require "rails_helper"
 
 RSpec.describe Hub::UserNotificationsController, type: :controller do
-  let(:user) { create :user, role: create(:team_member_role) }
-  let!(:notification_first) { create :user_notification, user: user, read: false, created_at: DateTime.new(2021, 3, 11, 8, 1).utc }
-  let!(:notification_second) { create :user_notification, user: user, read: false, created_at: DateTime.new(2021, 3, 12, 8, 1).utc }
-  let!(:notification_third) { create :user_notification, user: user, read: true, created_at: DateTime.new(2021, 3, 13, 8, 1).utc }
-
   describe "#index" do
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :index
 
     context "as a logged in user loading user notifications" do
+      let(:team_member_user) { create :user, role: create(:team_member_role) }
+      let(:site_coordinator_user) { create :user, role: create(:site_coordinator_role) }
+      let(:admin_user) { create :user, role: create(:admin_role) }
+
+      let!(:team_member_notification_first) { create :user_notification, user: team_member_user, read: false, created_at: DateTime.new(2021, 3, 11, 8, 1).utc }
+      let!(:team_member_notification_second) { create :user_notification, user: team_member_user, read: false, created_at: DateTime.new(2021, 3, 12, 8, 1).utc }
+      let!(:team_member_notification_third) { create :user_notification, user: team_member_user, read: true, created_at: DateTime.new(2021, 3, 13, 8, 1).utc }
+
+      let!(:site_coordinator_notification_first) { create :user_notification, user: site_coordinator_user, read: false, created_at: DateTime.new(2021, 3, 11, 8, 1).utc }
+      let!(:site_coordinator_notification_second) { create :user_notification, user: site_coordinator_user, read: false, created_at: DateTime.new(2021, 3, 12, 8, 1).utc }
+      let!(:site_coordinator_notification_third) { create :user_notification, user: site_coordinator_user, read: true, created_at: DateTime.new(2021, 3, 13, 8, 1).utc }
+
+      let!(:admin_notification_first) { create :user_notification, user: admin_user, read: false, created_at: DateTime.new(2021, 3, 11, 8, 1).utc }
+      let!(:admin_notification_second) { create :user_notification, user: admin_user, read: false, created_at: DateTime.new(2021, 3, 12, 8, 1).utc }
+      let!(:admin_notification_third) { create :user_notification, user: admin_user, read: true, created_at: DateTime.new(2021, 3, 13, 8, 1).utc }
+      let!(:other_admin_notification) { create :user_notification, user: (create :admin_user), read: false, created_at: DateTime.new(2021, 3, 13, 8, 1).utc }
+
       render_views
 
-      before { sign_in user }
+      context "team member user" do
+        before { sign_in team_member_user }
 
-      it "loads notifications in descending order" do
-        get :index
+        it "loads notifications in descending order" do
+          get :index
 
-        expect(response).to be_ok
+          expect(response).to be_ok
 
-        expect(assigns(:user_notifications)).to eq [notification_third, notification_second, notification_first]
+          expect(assigns(:user_notifications)).to eq [team_member_notification_third, team_member_notification_second, team_member_notification_first]
+        end
+      end
+
+      context "site coordinator user" do
+        before { sign_in site_coordinator_user }
+
+        it "loads notifications in descending order" do
+          get :index
+
+          expect(response).to be_ok
+
+          expect(assigns(:user_notifications)).to eq [site_coordinator_notification_third, site_coordinator_notification_second, site_coordinator_notification_first]
+        end
+      end
+
+      context "as an admin" do
+        before { sign_in admin_user }
+
+        it "loads notifications in descending order" do
+          get :index
+
+          expect(response).to be_ok
+          expect(assigns(:user_notifications)).not_to include other_admin_notification
+
+          expect(assigns(:user_notifications)).to eq [admin_notification_third, admin_notification_second, admin_notification_first]
+
+        end
       end
     end
   end
 
   describe "#mark_all_notifications_read" do
+    let(:user) { create :user, role: create(:team_member_role) }
+    let!(:notification_first) { create :user_notification, user: user, read: false, created_at: DateTime.new(2021, 3, 11, 8, 1).utc }
+    let!(:notification_second) { create :user_notification, user: user, read: false, created_at: DateTime.new(2021, 3, 12, 8, 1).utc }
+    let!(:notification_read) { create :user_notification, user: user, read: true, created_at: DateTime.new(2021, 3, 13, 8, 1).utc }
     let!(:notification_other) { create :user_notification, user: create(:user), read: false }
 
     it_behaves_like :a_post_action_for_authenticated_users_only, action: :mark_all_notifications_read
@@ -39,7 +83,6 @@ RSpec.describe Hub::UserNotificationsController, type: :controller do
         expect(notification_first.reload.read).to eq true
         expect(notification_second.reload.read).to eq true
         expect(notification_other.reload.read).to eq false
-
         expect(response).to redirect_to hub_user_notifications_path
       end
     end

--- a/spec/features/portal/client_portal_dashboard_spec.rb
+++ b/spec/features/portal/client_portal_dashboard_spec.rb
@@ -86,7 +86,6 @@ RSpec.feature "a client on their portal" do
       expect(page).to have_content("test-pattern.png")
 
       expect(page).to have_text "Please share any additional documents"
-
       page.accept_alert 'Are you sure you want to remove "test-pattern.png"?' do
         click_on "Remove"
       end

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -276,22 +276,6 @@ describe Ability do
           expect(subject.can?(:read, inaccessible_user)).to eq false
         end
       end
-
-      context "Viewing user notifications" do
-        let(:user) { create :team_member_user } # role is arbitrary in this test
-        let(:other_user) { create :team_member_user }
-        let(:user_notification) { create :user_notification, user: user }
-        let(:other_user_notification) { create :user_notification, user: other_user }
-
-
-        it "allows viewing your notifications" do
-          expect(subject.can?(:read, user_notification)).to eq true
-        end
-
-        it "does not allow viewing other notifications" do
-          expect(subject.can?(:read, other_user_notification)).to eq false
-        end
-      end
     end
 
     context "Permissions regarding Role objects" do


### PR DESCRIPTION
Using access control for this page seemed weird to me because a) everyone can access it and b) everyone's set of data is the same regardless of role. Restricting access at the ability level is great _when access is dependent on role_. However, when it's based explicitly on ownership/relationship to the data object, as in this case, grabbing data through an active record relationship is probably simpler and more efficient.

Co-authored-by: Jenny Heath <jheath@codeforamerica.org>