### PR TITLE
Stop generating walkthroughs automatically in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ workflows:
           requires: [run_js_tests, run_ruby_tests]
           filters:
             branches:
-              only: [circleci-update-walkthroughs, main]
+              only: [circleci-update-walkthroughs]
       - deploy_to_aptible--production:
           requires: [run_js_tests, run_ruby_tests]
           filters:


### PR DESCRIPTION
Walkthrough generation is currently broken.

I have a guess as to why -- maybe the CircleCI ramdisk runs out of ramdisk disk space, so we should move our CircleCI config to stop using a ramdisk.

I haven't tested if that fixes it b/c I have other fish to fry at the moment!

Note that with this change, you can still push to a branch called `circleci-update-walkthroughs` to trigger walkthrough generation. Therefore it should be reasonably easy to test a fix for this.