### PR TITLE
Redirect to original path after client login

### DIFF
--- a/app/controllers/concerns/client_access_control_concern.rb
+++ b/app/controllers/concerns/client_access_control_concern.rb
@@ -1,0 +1,12 @@
+module ClientAccessControlConcern
+  extend ActiveSupport::Concern
+
+  private
+
+  def require_client_login
+    unless current_client.present?
+      session[:after_client_login_path] = request.original_fullpath if request.get?
+      redirect_to new_portal_client_login_path
+    end
+  end
+end

--- a/app/controllers/portal/client_logins_controller.rb
+++ b/app/controllers/portal/client_logins_controller.rb
@@ -75,7 +75,7 @@ module Portal
       @form = ClientLoginForm.new(client_login_params)
       if @form.valid?
         sign_in @form.client
-        redirect_to portal_root_path
+        redirect_to session.delete(:after_client_login_path) || portal_root_path
       else
         @clients.each(&:increment_failed_attempts)
 

--- a/app/controllers/portal/documents_controller.rb
+++ b/app/controllers/portal/documents_controller.rb
@@ -9,7 +9,7 @@ module Portal
 
     def load_document
       @document = current_client.documents.find_by(id: params[:id])
-      redirect_to :portal_root if @document.nil?
+      render "public_pages/page_not_found", status: 404 unless @document.present?
     end
   end
 end

--- a/app/controllers/portal/portal_controller.rb
+++ b/app/controllers/portal/portal_controller.rb
@@ -1,6 +1,9 @@
 module Portal
   class PortalController < ApplicationController
-    before_action :require_client_sign_in
+    include ClientAccessControlConcern
+
+    before_action :require_client_login
+
     layout "portal"
 
     def home
@@ -19,10 +22,6 @@ module Portal
     end
 
     private
-
-    def require_client_sign_in
-      redirect_to root_path unless current_client.present?
-    end
 
     # We'll consider a client to have completed onboarding process if they've
     # a) completed_at the intake

--- a/app/controllers/portal/tax_returns_controller.rb
+++ b/app/controllers/portal/tax_returns_controller.rb
@@ -43,7 +43,8 @@ module Portal
 
     def load_client_tax_return
       @tax_return = current_client.tax_returns.includes(client: [:intake]).find_by(id: params[:tax_return_id])
-      redirect_to :portal_root if @tax_return.nil?
+
+      return render "public_pages/page_not_found", status: 404 unless @tax_return.present?
     end
 
     def permitted_params(form_class)

--- a/app/controllers/portal/upload_documents_controller.rb
+++ b/app/controllers/portal/upload_documents_controller.rb
@@ -3,7 +3,7 @@ module Portal
     before_action :find_or_create_document_request
     alias prev_path portal_complete_documents_request_path
     alias next_path portal_complete_documents_request_path
-    helper_method :prev_path, :next_path, :illustration_path, :current_path, :document_type, :destroy_document_path, :current_path
+    helper_method :prev_path, :next_path, :illustration_path, :current_path, :document_type, :destroy_document_path
     layout "document_upload"
 
     def edit

--- a/spec/controllers/concerns/client_access_control_concern_spec.rb
+++ b/spec/controllers/concerns/client_access_control_concern_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe ClientAccessControlConcern, type: :controller do
+  controller(ApplicationController) do
+    include ClientAccessControlConcern
+    before_action :require_client_login
+
+    def index
+      head :ok
+    end
+  end
+
+  describe "#require_client_login" do
+    context "when a client is not authenticated" do
+      it "redirects to a login page" do
+        get :index
+
+        expect(response).to redirect_to new_portal_client_login_path
+      end
+
+      it "adds the current path to the session" do
+        get :index, params: { with_querystring: "cool" }
+
+        expect(session[:after_client_login_path]).to eq("/anonymous?with_querystring=cool")
+      end
+
+      context "with a POST request" do
+        it "redirects but does not store the current path in the session" do
+          post :index
+
+          expect(response).to redirect_to new_portal_client_login_path
+          expect(session).not_to include :after_client_login_path
+        end
+      end
+    end
+
+
+    context "when a client is authenticated" do
+      before { sign_in create(:client) }
+
+      it "does not redirect and doesn't store the current path in the session" do
+        get :index
+
+        expect(response).to be_ok
+        expect(session).not_to include :after_client_login_path
+      end
+    end
+  end
+end

--- a/spec/controllers/portal/client_logins_controller_spec.rb
+++ b/spec/controllers/portal/client_logins_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Portal::ClientLoginsController, type: :controller do
     context "as an authenticated client" do
       before { sign_in client }
 
-      it "redirects to client portal home" do
+      it "redirects to client portal home by default" do
         get :new
 
         expect(response).to redirect_to portal_root_path
@@ -199,6 +199,29 @@ RSpec.describe Portal::ClientLoginsController, type: :controller do
 
             expect(subject.current_client).to eq(client)
             expect(response).to redirect_to portal_root_path
+          end
+
+          context "when the client was trying to access a protected page" do
+            let(:original_path) { "/portal/fake-page?test=1234" }
+            let(:params) do
+              {
+                id: "raw_token",
+                portal_client_login_form: {
+                  last_four_or_client_id: client.id.to_s,
+                }
+              }
+            end
+
+            before do
+              session[:after_client_login_path] = original_path
+            end
+
+            it "redirects to that page and removes the path from the session" do
+              post :update, params: params
+
+              expect(response).to redirect_to original_path
+              expect(session).not_to include :after_client_login_path
+            end
           end
 
           context "when a client is locked out" do

--- a/spec/controllers/portal/documents_controller_spec.rb
+++ b/spec/controllers/portal/documents_controller_spec.rb
@@ -6,25 +6,20 @@ describe Portal::DocumentsController do
   let(:document) { create :document, client: client }
   let(:transient_url) { "https://gyr-demo.s3.amazonaws.com/data.csv?sig=whatever&expires=whatever" }
 
-  describe '#show' do
-    context "when not logged in" do
-      it "redirects to root_url" do
-        get :show, params: params
-        expect(response).to redirect_to :root
-      end
-    end
+  describe "#show" do
+
+    it_behaves_like :a_get_action_for_authenticated_clients_only, action: :show
 
     context "when logged in" do
-
       context "when the document does not belong to the client" do
         before do
           sign_in create :client
         end
 
-        it "redirects to the client's portal dashboard" do
+        it "shows a not found page" do
           get :show, params: params
 
-          expect(response).to redirect_to :portal_root
+          expect(response).to be_not_found
         end
       end
 

--- a/spec/controllers/portal/portal_controller_spec.rb
+++ b/spec/controllers/portal/portal_controller_spec.rb
@@ -13,10 +13,12 @@ RSpec.describe Portal::PortalController, type: :controller do
       before do
         sign_in client, scope: :client
       end
+
       it "is the clients intake" do
         expect(subject.current_intake).to eq client.intake
       end
     end
+
     context "when the client is not authenticated" do
       it "is nil" do
         expect(subject.current_intake).to eq nil
@@ -25,13 +27,7 @@ RSpec.describe Portal::PortalController, type: :controller do
   end
 
   describe "#home" do
-    context "when unauthenticated" do
-      it "redirects to home page" do
-        get :home
-        # TODO: once the rest of the login flow is implemented we want to change this to redirect to the client sign in path
-        expect(response).to redirect_to(root_path)
-      end
-    end
+    it_behaves_like :a_get_action_for_authenticated_clients_only, action: :home
 
     context "as an authenticated client" do
       before do
@@ -87,6 +83,7 @@ RSpec.describe Portal::PortalController, type: :controller do
 
         it "loads the client tax returns in desc order" do
           get :home
+
           expect(assigns(:tax_returns).map(&:year)).to eq [2020, 2018, 2017]
           expect(assigns(:current_step)).to eq nil
         end

--- a/spec/features/portal/client_login_spec.rb
+++ b/spec/features/portal/client_login_spec.rb
@@ -1,135 +1,168 @@
 require "rails_helper"
 
 RSpec.feature "Logging in" do
-  context "As a client", active_job: true do
+  context "With a client who consented", active_job: true do
     let!(:client) do
-      create(:intake, :primary_consented, preferred_name: "Carrie", primary_first_name: "Carrie", primary_last_name: "Carrot", primary_last_four_ssn: "9876", email_address: "example@example.com", sms_phone_number: "+15005550006").client
+        create(:intake, :primary_consented, preferred_name: "Carrie", primary_first_name: "Carrie", primary_last_name: "Carrot", primary_last_four_ssn: "9876", email_address: "example@example.com", sms_phone_number: "+15005550006").client
     end
 
-    context "signing in with verification code" do
+    context "As a client logging in from the login page" do
+      context "signing in with verification code" do
+        let(:hashed_verification_code) { "hashed_verification_code" }
+        let(:double_hashed_verification_code) { "double_hashed_verification_code" }
+
+        before do
+          allow(VerificationCodeService).to receive(:generate).with(anything).and_return ["000004", hashed_verification_code]
+          # mock case for correct code
+          allow(VerificationCodeService).to receive(:hash_verification_code_with_contact_info).with(client.intake.email_address, "000004").and_return(hashed_verification_code)
+          allow(VerificationCodeService).to receive(:hash_verification_code_with_contact_info).with(client.intake.sms_phone_number, "000004").and_return(hashed_verification_code)
+          # mock case for wrong code
+          allow(VerificationCodeService).to receive(:hash_verification_code_with_contact_info).with(client.intake.sms_phone_number, "999999").and_return("hashed_wrong_verification_code")
+          allow(TwilioService).to receive(:send_text_message)
+        end
+
+        scenario "requesting a verification code with an email address and signing in with a client id" do
+          visit new_portal_client_login_path
+
+          expect(page).to have_text "To view your progress, we’ll send you a secure code"
+          fill_in "Email address", with: client.intake.email_address
+          click_on "Send code"
+          expect(page).to have_text "Let’s verify that code!"
+
+          perform_enqueued_jobs
+
+          mail = ActionMailer::Base.deliveries.last
+          text_body = mail.body.parts[0].decoded
+          expect(text_body).to include("Your 6-digit GetYourRefund verification code is: 000004. This code will expire after two days.")
+
+          fill_in "Enter 6 digit code", with: "000004"
+          click_on "Verify"
+
+          fill_in "Client ID or Last 4 of SSN/ITIN", with: client.id
+          click_on "Continue"
+
+          expect(page).to have_text("Welcome back Carrie!")
+        end
+
+        scenario "requesting a verification code with a phone number and signing in with the last four of a social" do
+          visit new_portal_client_login_path
+
+          expect(page).to have_text "To view your progress, we’ll send you a secure code"
+          fill_in "Cell phone number", with: "(500) 555-0006"
+          click_on "Send code"
+          expect(page).to have_text "Let’s verify that code!"
+          expect(page).to have_text("A message with your code has been sent to: (500) 555-0006")
+
+          perform_enqueued_jobs
+
+          expect(TwilioService).to have_received(:send_text_message).with(
+            to: "+15005550006",
+            body: "Your 6-digit GetYourRefund verification code is: 000004. This code will expire after two days."
+          )
+
+          fill_in "Enter 6 digit code", with: "000004"
+          click_on "Verify"
+
+          fill_in "Client ID or Last 4 of SSN/ITIN", with: "9876"
+          click_on "Continue"
+
+          expect(page).to have_text("Welcome back Carrie!")
+        end
+
+        scenario "getting locked out due to too many wrong verification codes" do
+          visit new_portal_client_login_path
+
+          expect(page).to have_text "To view your progress, we’ll send you a secure code"
+          fill_in "Cell phone number", with: "(500) 555-0006"
+          click_on "Send code"
+          expect(page).to have_text "Let’s verify that code!"
+
+          perform_enqueued_jobs
+
+          fill_in "Enter 6 digit code", with: "999999"
+          click_on "Verify"
+
+          fill_in "Enter 6 digit code", with: "999999"
+          click_on "Verify"
+
+          fill_in "Enter 6 digit code", with: "999999"
+          click_on "Verify"
+
+          fill_in "Enter 6 digit code", with: "999999"
+          click_on "Verify"
+
+          fill_in "Enter 6 digit code", with: "999999"
+          click_on "Verify"
+
+          expect(page).to have_text("This account has been locked")
+        end
+      end
+
+      context "signing in with link" do
+        let(:raw_token) { "raw_token" }
+        let(:hashed_token) { "hashed_token" }
+
+        before do
+          allow(Devise.token_generator).to receive(:generate).and_return [raw_token, hashed_token]
+          allow(Devise.token_generator).to receive(:digest).and_return(hashed_token)
+          # Set up login link
+          ClientLoginsService.issue_email_token("example@example.com")
+        end
+
+        scenario "visiting sign-in link at its current url" do
+          visit edit_portal_client_login_path(id: "raw_token", locale: "es")
+          fill_in "ID de cliente o los 4 últimos de SSN / ITIN", with: "9876"
+          click_on "Continuar"
+
+          expect(page).to have_text("Bienvenido de nuevo Carrie!")
+        end
+
+        scenario "visiting a sign-in link with the pre-march-2021 url" do
+          # Validate with empty locale
+          visit "/portal/account/raw_token"
+          fill_in "Client ID or Last 4 of SSN/ITIN", with: "9876"
+
+          # Validate with Spanish
+          visit "/es/portal/account/raw_token"
+          fill_in "ID de cliente o los 4 últimos de SSN / ITIN", with: "9876"
+          click_on "Continuar"
+
+          expect(page).to have_text("Bienvenido de nuevo Carrie!")
+        end
+      end
+    end
+
+    context "As a client trying to access a protected page" do
+      let(:tax_return) { create(:tax_return, :ready_to_sign, client: client) }
       let(:hashed_verification_code) { "hashed_verification_code" }
       let(:double_hashed_verification_code) { "double_hashed_verification_code" }
 
       before do
         allow(VerificationCodeService).to receive(:generate).with(anything).and_return ["000004", hashed_verification_code]
-        # mock case for correct code
         allow(VerificationCodeService).to receive(:hash_verification_code_with_contact_info).with(client.intake.email_address, "000004").and_return(hashed_verification_code)
-        allow(VerificationCodeService).to receive(:hash_verification_code_with_contact_info).with(client.intake.sms_phone_number, "000004").and_return(hashed_verification_code)
-        # mock case for wrong code
-        allow(VerificationCodeService).to receive(:hash_verification_code_with_contact_info).with(client.intake.sms_phone_number, "999999").and_return("hashed_wrong_verification_code")
-        allow(TwilioService).to receive(:send_text_message)
       end
 
-      scenario "requesting a verification code with an email address and signing in with a client id" do
-        visit new_portal_client_login_path
+      scenario "getting redirected to the page client was trying to access after login" do
+        visit portal_tax_return_authorize_signature_path(locale: "es", tax_return_id: tax_return.id)
 
-        expect(page).to have_text "To view your progress, we’ll send you a secure code"
-        fill_in "Email address", with: client.intake.email_address
-        click_on "Send code"
-        expect(page).to have_text "Let’s verify that code!"
+        expect(page).to have_text "Le mandaremos un código seguro para que pueda ver su progreso."
+        fill_in "Dirección de correo electrónico", with: client.intake.email_address
+        click_on "Enviar código"
+        expect(page).to have_text "¡Verifiquemos ese código!"
 
         perform_enqueued_jobs
 
         mail = ActionMailer::Base.deliveries.last
         text_body = mail.body.parts[0].decoded
-        expect(text_body).to include("Your 6-digit GetYourRefund verification code is: 000004. This code will expire after two days.")
+        expect(text_body).to include("Su código de verificación de 6 dígitos para GetYourRefund es: 000004. Este código expirará en dos días.")
 
-        fill_in "Enter 6 digit code", with: "000004"
-        click_on "Verify"
+        fill_in "Ingrese el código de 6 dígitos", with: "000004"
+        click_on "Verificar"
 
-        fill_in "Client ID or Last 4 of SSN/ITIN", with: client.id
-        click_on "Continue"
-
-        expect(page).to have_text("Welcome back Carrie!")
-      end
-
-      scenario "requesting a verification code with a phone number and signing in with the last four of a social" do
-        visit new_portal_client_login_path
-
-        expect(page).to have_text "To view your progress, we’ll send you a secure code"
-        fill_in "Cell phone number", with: "(500) 555-0006"
-        click_on "Send code"
-        expect(page).to have_text "Let’s verify that code!"
-        expect(page).to have_text("A message with your code has been sent to: (500) 555-0006")
-
-        perform_enqueued_jobs
-
-        expect(TwilioService).to have_received(:send_text_message).with(
-          to: "+15005550006",
-          body: "Your 6-digit GetYourRefund verification code is: 000004. This code will expire after two days."
-        )
-
-        fill_in "Enter 6 digit code", with: "000004"
-        click_on "Verify"
-
-        fill_in "Client ID or Last 4 of SSN/ITIN", with: "9876"
-        click_on "Continue"
-
-        expect(page).to have_text("Welcome back Carrie!")
-      end
-
-      scenario "getting locked out due to too many wrong verification codes" do
-        visit new_portal_client_login_path
-
-        expect(page).to have_text "To view your progress, we’ll send you a secure code"
-        fill_in "Cell phone number", with: "(500) 555-0006"
-        click_on "Send code"
-        expect(page).to have_text "Let’s verify that code!"
-
-        perform_enqueued_jobs
-
-        fill_in "Enter 6 digit code", with: "999999"
-        click_on "Verify"
-
-        fill_in "Enter 6 digit code", with: "999999"
-        click_on "Verify"
-
-        fill_in "Enter 6 digit code", with: "999999"
-        click_on "Verify"
-
-        fill_in "Enter 6 digit code", with: "999999"
-        click_on "Verify"
-
-        fill_in "Enter 6 digit code", with: "999999"
-        click_on "Verify"
-
-        expect(page).to have_text("This account has been locked")
-      end
-    end
-
-    context "signing in with link" do
-      let(:raw_token) { "raw_token" }
-      let(:hashed_token) { "hashed_token" }
-
-      before do
-        allow(Devise.token_generator).to receive(:generate).and_return [raw_token, hashed_token]
-        allow(Devise.token_generator).to receive(:digest).and_return(hashed_token)
-      end
-
-      before do
-        # Set up login link
-        ClientLoginsService.issue_email_token("example@example.com")
-      end
-
-      scenario "visiting sign-in link at its current url" do
-        visit edit_portal_client_login_path(id: "raw_token", locale: "es")
-        fill_in "ID de cliente o los 4 últimos de SSN / ITIN", with: "9876"
+        fill_in "ID de cliente o los 4 últimos de SSN / ITIN", with: client.id
         click_on "Continuar"
 
-        expect(page).to have_text("Bienvenido de nuevo Carrie!")
-      end
-
-      scenario "visiting a sign-in link with the pre-march-2021 url" do
-        # Validate with empty locale
-        visit "/portal/account/raw_token"
-        fill_in "Client ID or Last 4 of SSN/ITIN", with: "9876"
-
-        # Validate with Spanish
-        visit "/es/portal/account/raw_token"
-        fill_in "ID de cliente o los 4 últimos de SSN / ITIN", with: "9876"
-        click_on "Continuar"
-
-        expect(page).to have_text("Bienvenido de nuevo Carrie!")
+        expect(page).to have_text "¡Entregue su firma electrónica/e-file final!"
       end
     end
   end

--- a/spec/support/shared_examples/client_access_control_concern_examples.rb
+++ b/spec/support/shared_examples/client_access_control_concern_examples.rb
@@ -1,0 +1,41 @@
+# Usage:
+#
+#   it_behaves_like :a_get_action_for_authenticated_clients_only, action: :new
+#
+#   # set params for this spec
+#   it_behaves_like :a_get_action_for_authenticated_clients_only, action: :new do
+#     let(:params) do
+#       { my_mode: { name: "some name" } }
+#     end
+#   end
+#
+#   # set values for this & other specs
+#   let(:params) do
+#     { my_mode: { name: "some name" } }
+#   end
+#
+#   it_behaves_like :a_get_action_for_authenticated_clients_only, action: :new
+#
+shared_examples :a_get_action_for_authenticated_clients_only do |action:|
+  let(:params) { {} } unless method_defined?(:params)
+
+  context "with an anonymous client" do
+    it "redirects to the login path" do
+      get action, params: params
+
+      expect(response).to redirect_to new_portal_client_login_path
+    end
+  end
+end
+
+shared_examples :a_post_action_for_authenticated_clients_only do |action:|
+  let(:params) { {} } unless method_defined?(:params)
+
+  context "with an anonymous client" do
+    it "redirects to the login path" do
+      post action, params: params
+
+      expect(response).to redirect_to new_portal_client_login_path
+    end
+  end
+end


### PR DESCRIPTION
This adds a ClientAccessControlConcern that will set `after_client_login_path` in the session & redirect to login if a protected client page is requested by an unauthenticated client.

The final login step will redirect to `after_client_login_path` if it exists.

We added shared examples for ClientAccessControlConcern, similar to Access controllable. For example:

```ruby
    it_behaves_like :a_get_action_for_authenticated_clients_only, action: :show
```

Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>
Co-authored-by: Jenny Heath <jheath@codeforamerica.org>