### PR TITLE
Fix conditional touch of document request

### DIFF
--- a/app/controllers/documents/send_requested_documents_later_controller.rb
+++ b/app/controllers/documents/send_requested_documents_later_controller.rb
@@ -1,6 +1,6 @@
 module Documents
   class SendRequestedDocumentsLaterController < DocumentUploadQuestionController
-    append_after_action :reset_session, :track_page_view, :complete_documents_request, only: :edit
+    append_after_action :reset_session, :track_page_view, only: :edit
     skip_before_action :require_intake
 
     def edit
@@ -8,6 +8,7 @@ module Documents
       if @documents_request.nil?
         flash[:warning] = t("controllers.send_requested_documents_later_controller.not_found")
       else
+        @documents_request.touch(:completed_at)
         flash[:notice] = t("controllers.send_requested_documents_later_controller.success")
       end
       redirect_to(root_path)
@@ -23,10 +24,6 @@ module Documents
 
     def self.document_type
       nil
-    end
-
-    def complete_documents_request
-      @documents_request.touch(:completed_at) if @documents_request.present?
     end
   end
 end

--- a/app/controllers/documents/send_requested_documents_later_controller.rb
+++ b/app/controllers/documents/send_requested_documents_later_controller.rb
@@ -6,9 +6,9 @@ module Documents
     def edit
       @documents_request = DocumentsRequest.find_by(id: session[:documents_request_id])
       if @documents_request.nil?
-        flash[:warning] =  t("controllers.send_requested_documents_later_controller.not_found")
+        flash[:warning] = t("controllers.send_requested_documents_later_controller.not_found")
       else
-        flash[:notice] =  t("controllers.send_requested_documents_later_controller.success")
+        flash[:notice] = t("controllers.send_requested_documents_later_controller.success")
       end
       redirect_to(root_path)
     end
@@ -26,7 +26,7 @@ module Documents
     end
 
     def complete_documents_request
-      @documents_request.touch(:completed_at)
+      @documents_request.touch(:completed_at) if @documents_request.present?
     end
   end
 end

--- a/spec/controllers/documents/send_requested_documents_later_controller_spec.rb
+++ b/spec/controllers/documents/send_requested_documents_later_controller_spec.rb
@@ -20,5 +20,14 @@ RSpec.describe Documents::SendRequestedDocumentsLaterController, type: :controll
         expect(response).to redirect_to(root_path)
       end
     end
+
+    context "without an existing documents request in the session" do
+      it "successfully redirects to root path" do
+        get :edit
+        expect(session[:documents_request_id]).to be_nil
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
   end
 end


### PR DESCRIPTION
Doing the touch to completed_at in the after action was concealing the fact that we were trying to run it whether or not a document request was present!