### PR TITLE
Logo icon sometimes clipped #177511975

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -123,10 +123,12 @@ body {
 
   .main-header__logo {
     padding-left: 3rem;
+
     &:before {
       top: 0.4rem;
       width: 2.0rem;
       height: 1.7rem;
+      background-size: 100% auto;
       @include retina-bg(checkbox-logo--white, 100% auto);
     }
   }


### PR DESCRIPTION
[#177511975](https://www.pivotaltracker.com/story/show/177511975)

On retina with the fix, no difference:
<img width="1238" alt="retina" src="https://user-images.githubusercontent.com/9101728/112698206-2ccf1580-8e57-11eb-92ce-0484dea08623.png">


On non-retina with the fix:
![non-retina-fixed](https://user-images.githubusercontent.com/9101728/112698211-2fca0600-8e57-11eb-9108-fda2834f3cb5.png)
