### PR TITLE
Layout bug in questions/overview #177480134

### DIFF
--- a/app/views/questions/overview/edit.html.erb
+++ b/app/views/questions/overview/edit.html.erb
@@ -47,7 +47,7 @@
       </div>
 
       <div class="step">
-        <div class="step-icon-wrapper" style="width: 4rem; height: 4.5rem">
+        <div class="step-icon-wrapper" style="width: 4rem; height: 4.5rem; margin-right: 1.5rem;">
           <%= image_tag("dollar-sign.svg", alt: "") %>
         </div>
         <div class="step-text">


### PR DESCRIPTION
[#177480134](https://www.pivotaltracker.com/story/show/177480134)

The icon size is unique, so I reduced the margin in the same place, so that the horizontal space aligns with the other step info.

<img width="1248" alt="text-now-aligns-with-layout" src="https://user-images.githubusercontent.com/9101728/112700793-ee3c5980-8e5c-11eb-8708-42a485850f53.png">
