### PR TITLE
Add tax return year from tax return list

### DIFF
--- a/app/assets/stylesheets/components/_client-header.scss
+++ b/app/assets/stylesheets/components/_client-header.scss
@@ -1,15 +1,22 @@
 .client-header {
-  position: relative;
 
+  display: flex;
+  flex-direction: column;
+  @media screen and (min-width: $tablet-up) {
+    flex-direction: row;
+    justify-content: space-between;
+  }
   &__left {
-    display: inline-block;
-    max-width: 50rem;
+    max-width: 40rem;
+    margin-right: 1.5rem;
   }
   &__right {
-    position: absolute;
-    right: 0;
-    top: 0;
+    min-width: 50%;
+    li:first-child {
+      margin-top: -1.5rem; // line the first tax return with the top of the left-hand-side div.
+    }
   }
+
   .h1 {
     margin-right: $s10;
     margin-bottom: $s10;

--- a/app/assets/stylesheets/components/_client-header.scss
+++ b/app/assets/stylesheets/components/_client-header.scss
@@ -13,7 +13,7 @@
   &__right {
     min-width: 50%;
     li:first-child {
-      margin-top: -1.5rem; // line the first tax return with the top of the left-hand-side div.
+      margin-top: -1.5rem;
     }
   }
 

--- a/app/controllers/hub/tax_returns_controller.rb
+++ b/app/controllers/hub/tax_returns_controller.rb
@@ -22,6 +22,7 @@ module Hub
     def create
       if @tax_return.valid?
         @tax_return.save!
+        SystemNote::TaxReturnCreated.generate!(initiated_by: current_user, tax_return: @tax_return)
         flash[:notice] = I18n.t("hub.tax_returns.create.success", year: @tax_return.year, name: @client.preferred_name)
         redirect_to hub_client_path(id: @client.id)
       else

--- a/app/controllers/hub/tax_returns_controller.rb
+++ b/app/controllers/hub/tax_returns_controller.rb
@@ -8,6 +8,7 @@ module Hub
     load_resource only: [:new, :create]
     before_action :prepare_form, only: [:new]
     before_action :load_assignable_users, except: [:show]
+
     before_action :load_and_authorize_assignee, only: [:update]
 
     layout "admin"
@@ -15,7 +16,7 @@ module Hub
 
     def new
       if @remaining_years.blank?
-        flash[:notice] = "There are no remaining tax years to create a return for."
+        flash[:notice] = I18n.t("hub.tax_returns.new.no_remaining_years")
         redirect_to hub_client_path(id: @client.id)
       end
     end

--- a/app/controllers/hub/tax_returns_controller.rb
+++ b/app/controllers/hub/tax_returns_controller.rb
@@ -2,9 +2,10 @@ module Hub
   class TaxReturnsController < ApplicationController
     include AccessControllable
     before_action :require_sign_in
-    authorize_resource :client, parent: false, only: [:new, :create]
     load_and_authorize_resource except: [:new, :create]
-    load_resource through: @client, only: [:new, :create]
+    # on new/create, authorize through client but initialize tax return object
+    authorize_resource :client, parent: false, only: [:new, :create]
+    load_resource only: [:new, :create]
     before_action :prepare_form, only: [:new]
     before_action :load_assignable_users, except: [:show]
     before_action :load_and_authorize_assignee, only: [:update]
@@ -49,7 +50,6 @@ module Hub
 
     def load_assignable_users
       @client ||= @tax_return.client
-      @tax_return ||= TaxReturn.new
       @assignable_users = [current_user, @tax_return.assigned_user].compact
       if @client.vita_partner.present?
         if @client.vita_partner.site?

--- a/app/models/admin_role.rb
+++ b/app/models/admin_role.rb
@@ -8,4 +8,6 @@
 #
 class AdminRole < ApplicationRecord
   TYPE = "AdminRole"
+
+  def served_entity; end
 end

--- a/app/models/coalition_lead_role.rb
+++ b/app/models/coalition_lead_role.rb
@@ -19,4 +19,8 @@ class CoalitionLeadRole < ApplicationRecord
   TYPE = "CoalitionLeadRole"
 
   belongs_to :coalition
+
+  def served_entity
+    coalition
+  end
 end

--- a/app/models/organization_lead_role.rb
+++ b/app/models/organization_lead_role.rb
@@ -21,6 +21,10 @@ class OrganizationLeadRole < ApplicationRecord
   belongs_to :organization, foreign_key: "vita_partner_id", class_name: "VitaPartner"
   validate :no_sites
 
+  def served_entity
+    organization
+  end
+
   private
 
   def no_sites

--- a/app/models/site_coordinator_role.rb
+++ b/app/models/site_coordinator_role.rb
@@ -21,6 +21,10 @@ class SiteCoordinatorRole < ApplicationRecord
   belongs_to :site, foreign_key: "vita_partner_id", class_name: "VitaPartner"
   validate :no_organizations
 
+  def served_entity
+    site
+  end
+
   private
 
   def no_organizations

--- a/app/models/system_note.rb
+++ b/app/models/system_note.rb
@@ -29,4 +29,8 @@ class SystemNote < ApplicationRecord
   def contact_record_type
     "system_note"
   end
+
+  def datetime
+    created_at
+  end
 end

--- a/app/models/system_note/signed_document.rb
+++ b/app/models/system_note/signed_document.rb
@@ -43,12 +43,4 @@ class SystemNote::SignedDocument < SystemNote
       client: tax_return.client,
     )
   end
-
-  def contact_record_type
-    "system_note"
-  end
-
-  def datetime
-    created_at
-  end
 end

--- a/app/models/system_note/tax_return_created.rb
+++ b/app/models/system_note/tax_return_created.rb
@@ -32,12 +32,4 @@ class SystemNote::TaxReturnCreated < SystemNote
       user: initiated_by
     )
   end
-
-  def contact_record_type
-    "system_note"
-  end
-
-  def datetime
-    created_at
-  end
 end

--- a/app/models/system_note/tax_return_created.rb
+++ b/app/models/system_note/tax_return_created.rb
@@ -1,0 +1,43 @@
+# == Schema Information
+#
+# Table name: system_notes
+#
+#  id         :bigint           not null, primary key
+#  body       :text
+#  type       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  client_id  :bigint           not null
+#  user_id    :bigint
+#
+# Indexes
+#
+#  index_system_notes_on_client_id  (client_id)
+#  index_system_notes_on_user_id    (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (client_id => clients.id)
+#  fk_rails_...  (user_id => users.id)
+#
+class SystemNote::TaxReturnCreated < SystemNote
+  def self.generate!(tax_return:, initiated_by:)
+    user_info = initiated_by.role_name
+    user_info += " - #{initiated_by.served_entity.name}" if initiated_by.role.served_entity.present?
+    body = "#{initiated_by.name} (#{user_info}) added a #{tax_return.year} tax return."
+
+    create!(
+      body: body,
+      client: tax_return.client,
+      user: initiated_by
+    )
+  end
+
+  def contact_record_type
+    "system_note"
+  end
+
+  def datetime
+    created_at
+  end
+end

--- a/app/models/team_member_role.rb
+++ b/app/models/team_member_role.rb
@@ -21,6 +21,9 @@ class TeamMemberRole < ApplicationRecord
   belongs_to :site, foreign_key: "vita_partner_id", class_name: "VitaPartner"
   validate :no_organizations
 
+  def served_entity
+    site
+  end
   private
 
   def no_organizations

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -86,6 +86,16 @@ class User < ApplicationRecord
     end
   end
 
+  def role_name
+    return nil unless role_type.present?
+
+    role_type.gsub("Role", "").underscore.humanize.titlecase
+  end
+
+  def served_entity
+    role.served_entity
+  end
+
   def accessible_vita_partners
     case role_type
     when AdminRole::TYPE

--- a/app/views/hub/clients/_client_header.html.erb
+++ b/app/views/hub/clients/_client_header.html.erb
@@ -32,9 +32,9 @@
         <%= link_to "Edit", edit_organization_hub_client_path(id: @client.id), class: "button button--small" %>
       </div>
 
-      <div class="text--help"><%= t("hub.last_client_update") + long_formatted_datetime(@client.updated_at, use_day: false) %></div>
+      <div class="text--help"><%= t("hub.last_client_update") + timestamp(@client.updated_at) %></div>
       <% if @client.needs_response? %>
-        <div class="text--help"><%= t("hub.waiting_on_response") + long_formatted_datetime(@client.response_needed_since, use_day: false) %></div>
+        <div class="text--help"><%= t("hub.waiting_on_response") + timestamp(@client.response_needed_since) %></div>
       <% end %>
 
       <%= form_for [:hub, @client], method: :patch, url: response_needed_hub_client_path(id: @client.id) do |f| %>
@@ -44,7 +44,7 @@
     </div>
 
     <div class="client-header__right">
-      <%= render "shared/tax_return_list", client: @client, status_updateable: true %>
+      <%= render "shared/tax_return_list", client: @client, status_updateable: true, tax_return_creatable: true %>
     </div>
   </div>
 </section>

--- a/app/views/hub/tax_returns/new.html.erb
+++ b/app/views/hub/tax_returns/new.html.erb
@@ -1,0 +1,47 @@
+<% @page_title = t(".title", name: @client.preferred_name) %>
+<% content_for :page_title, @page_title %>
+
+<% content_for :card do %>
+  <div class="slab">
+    <div class="grid">
+      <h1 class="spacing-below-0"><%= @page_title %></h1>
+      <p><%= t(".current_years") %> <%= @tax_return_years.join(", ") %> </p>
+      <div class="grid__item width-one-half">
+        <%= form_with model: @tax_return, url: [:hub, @client, @tax_return], builder: VitaMinFormBuilder, local: true do |f| %>
+          <%= f.cfa_select :year, t(".tax_year"), @remaining_years %>
+          <%= f.cfa_select :assigned_user_id, t(".assigned_user"), @assignable_users.map { |u| [u.name, u.id]} , { include_blank: true } %>
+          <%= f.cfa_select :certification_level, t(".certification_level"), certification_options_for_select, { include_blank: true } %>
+          <div>
+            <label for="tax_return_status">
+              <p class="form-question"><%= t("general.status") %></p>
+              <div class="select">
+                <select name="tax_return[status]" class="select__element" id="tax_return_status">
+                  <option value></option>
+                  <% TaxReturnStatus.available_statuses_for(current_user).each do |stage, statuses| %>
+                    <optgroup label=<%= stage_translation(stage) %>></optgroup>
+                    <% statuses.each do |status| %>
+                      <option value="<%= status %>" <%= status == :intake_in_progress && "selected" %>>&emsp;<%= status_translation(status) %></option>
+                    <% end %>
+                  <% end %>
+                </select>
+              </div>
+            </label>
+          </div>
+
+          <% if @tax_return.errors.present? %>
+            <% @tax_return.errors.keys.each do |key| %>
+              <div class="form-group">
+                <%= error_message(@tax_return, key) %>
+              </div>
+            <% end %>
+          <% end %>
+
+          <div>
+            <%= f.submit t("general.save"), class: "button button--cta spacing-above-35" %>
+            <%= link_to t("general.cancel"), :back, class: "button" %>
+          </div>
+      <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/shared/_tax_return_list.html.erb
+++ b/app/views/shared/_tax_return_list.html.erb
@@ -1,4 +1,5 @@
 <% status_updateable ||= false %>
+<% tax_return_creatable ||= false %>
 
 <ul class="tax-return-list">
   <% client.tax_returns.sort_by(&:year).each do |tax_return| %>
@@ -54,7 +55,7 @@
                 </div>
               </label>
             </div>
-            <%= f.submit "Update", class: "button"%>
+            <%= f.submit t("general.update"), class: "button"%>
           <% end %>
         <% else %>
           <div>
@@ -63,5 +64,8 @@
         <% end %>
       </div>
     </li>
+  <% end %>
+  <% if tax_return_creatable && client.tax_returns.length != TaxReturn.filing_years.length %>
+    <%= link_to t("views.shared.tax_return_list.add_tax_year"), new_hub_client_tax_return_path(client_id: client.id), class: "button button--small" %>
   <% end %>
 </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -237,6 +237,7 @@ en:
         tax_year: Tax year
         certification_level: Certification level (optional)
         assigned_user: Assigned user (optional)
+        no_remaining_years: There are no remaining tax years for which to create a return.
       create:
         success: "%{year} return created for %{name}."
     status_macros:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -231,6 +231,14 @@ en:
         file_accepted: Accepted
         file_not_filing: Not filing
         file_hold: Hold
+      new:
+        title: Add tax year for %{name}
+        current_years: "Current Tax Years:"
+        tax_year: Tax year
+        certification_level: Certification level (optional)
+        assigned_user: Assigned user (optional)
+      create:
+        success: "%{year} return created for %{name}."
     status_macros:
       needs_more_information: |
         Hello <<Client.PreferredName>>,
@@ -705,6 +713,7 @@ en:
     text_message: Text Message
     timezone: Timezone
     today: Today
+    update: Update
     updated_at: Updated At
     unassigned: Unassigned
     unsure: I don't know
@@ -2108,6 +2117,8 @@ en:
           one: Tell us about your work in %{year}
           other: Tell us about you and your spouse's work in %{year}
     shared:
+      tax_return_list:
+        add_tax_year: Add tax year
       consent_agreement:
         details:
           intro: >-

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -231,6 +231,14 @@ es:
         file_accepted: Aceptado
         file_not_filing: No archivar
         file_hold: En pausa
+      new:
+        title: Nuevo año fiscal para %{name}
+        current_years: "Años fiscales actuales:"
+        tax_year: Año fiscal
+        certification_level: Nivel de certificación (opcional)
+        assigned_user: Usuario asignado (opcional)
+      create:
+        success: Declaración de impuestos de %{year} creada para %{name}.
     status_macros:
       needs_more_information: |
         ¡Hola <<Client.PreferredName>>!
@@ -694,6 +702,7 @@ es:
     text_message: Mensaje de texto
     timezone: Zona horaria
     today: Hoy
+    update: Actualizar
     updated_at: Actualizado en
     upload: Subir
     unassigned: No asignado
@@ -2061,6 +2070,8 @@ es:
           one: Cuéntanos sobre tu trabajo en %{year}
           other: Cuéntenos sobre usted y el trabajo de su cónyuge en %{year}
     shared:
+      tax_return_list:
+        add_tax_year: Agregar año fiscal
       consent_agreement:
         details:
           header: Detalles

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -237,6 +237,7 @@ es:
         tax_year: Año fiscal
         certification_level: Nivel de certificación (opcional)
         assigned_user: Usuario asignado (opcional)
+        no_remaining_years: No hay años fiscales restantes para los que crear una declaración.
       create:
         success: Declaración de impuestos de %{year} creada para %{name}.
     status_macros:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -153,6 +153,7 @@ Rails.application.routes.draw do
         resources :outgoing_text_messages, only: [:create]
         resources :outgoing_emails, only: [:create]
         resources :outbound_calls, only: [:new, :create, :show, :update]
+        resources :tax_returns, only: [:new, :create]
         member do
           patch "response_needed"
           get "edit_take_action"

--- a/spec/controllers/hub/tax_returns_controller_spec.rb
+++ b/spec/controllers/hub/tax_returns_controller_spec.rb
@@ -14,7 +14,90 @@ RSpec.describe Hub::TaxReturnsController, type: :controller do
 
   let(:client_assigned_group) { organization }
   let(:client) { create :client, intake: create(:intake, preferred_name: "Lucille"), vita_partner: client_assigned_group }
-  let(:tax_return) { create :tax_return, client: client, year: 2018, assigned_user: currently_assigned_coalition_lead }
+  let!(:tax_return) { create :tax_return, client: client, year: 2018, assigned_user: currently_assigned_coalition_lead }
+
+  describe "#new" do
+    let(:params) do
+      {
+        client_id: client.id
+      }
+    end
+
+    it_behaves_like :a_get_action_for_authenticated_users_only, action: :new
+
+    context "an authenticated user" do
+      let(:user) { create :admin_user }
+      before do
+        sign_in user
+      end
+
+      it "renders the new template and assigns tax_return related variables" do
+        get :new, params: params
+        expect(response).to render_template :new
+        expect(assigns(:tax_return_years)).to eq [2018]
+        expect(assigns(:remaining_years)).to eq TaxReturn.filing_years - [2018]
+      end
+    end
+  end
+
+  describe "#create" do
+    let(:user) { create :admin_user }
+    let(:params) do
+      {
+          client_id: client.id
+      }
+    end
+
+    it_behaves_like :a_post_action_for_authenticated_users_only, action: :create
+
+    context "as an authenticated user" do
+      before do
+        sign_in user
+      end
+
+      let(:params) do
+        {
+            client_id: client.id,
+            tax_return: {
+                year: "2020",
+                certification_level: "basic",
+                assigned_user_id: user.id,
+                status: :intake_in_progress
+            }
+        }
+      end
+
+      context "with valid parameters" do
+        it "creates a new tax return object for the client and redirects with success message" do
+          expect {
+            post :create, params: params
+          }.to change(client.tax_returns, :count).by(1)
+          tax_return = TaxReturn.last
+          expect(tax_return.year).to eq 2020
+          expect(tax_return.status).to eq "intake_in_progress"
+          expect(tax_return.assigned_user).to eq user
+          expect(tax_return.certification_level).to eq "basic"
+          expect(response).to redirect_to(hub_client_path(id: client.id))
+          expect(flash[:notice]).to eq "2020 return created for #{client.preferred_name}."
+        end
+      end
+
+      context "with invalid tax return" do
+        before do
+          allow_any_instance_of(TaxReturn).to receive(:valid?).and_return false
+        end
+
+        it "does not persist the tax return, renders new and flashes an error" do
+          expect {
+            post :create, params: params
+          }.not_to change(client.tax_returns, :count)
+          expect(response).to render_template :new
+          expect(flash[:notice]).to include "Please fix indicated"
+        end
+      end
+    end
+
+  end
 
   describe "#edit" do
     let(:params) {

--- a/spec/controllers/hub/tax_returns_controller_spec.rb
+++ b/spec/controllers/hub/tax_returns_controller_spec.rb
@@ -72,6 +72,8 @@ RSpec.describe Hub::TaxReturnsController, type: :controller do
           expect {
             post :create, params: params
           }.to change(client.tax_returns, :count).by(1)
+           .and change(client.system_notes, :count).by(1)
+          
           tax_return = TaxReturn.last
           expect(tax_return.year).to eq 2020
           expect(tax_return.status).to eq "intake_in_progress"

--- a/spec/controllers/hub/tax_returns_controller_spec.rb
+++ b/spec/controllers/hub/tax_returns_controller_spec.rb
@@ -34,6 +34,8 @@ RSpec.describe Hub::TaxReturnsController, type: :controller do
       it "renders the new template and assigns tax_return related variables" do
         get :new, params: params
         expect(response).to render_template :new
+        expect(assigns(:client)).to eq client
+        expect(assigns(:tax_return)).to be_an_instance_of TaxReturn
         expect(assigns(:tax_return_years)).to eq [2018]
         expect(assigns(:remaining_years)).to eq TaxReturn.filing_years - [2018]
       end

--- a/spec/features/hub/create_tax_return_spec.rb
+++ b/spec/features/hub/create_tax_return_spec.rb
@@ -33,11 +33,22 @@ RSpec.feature "Add a tax return for an existing client" do
         expect(page).to have_text "Org Lead"
         expect(page).to have_text "Greeter - info requested"
       end
-      # when tax returns are created for all years, do not show Add tax year button
-      create :tax_return, client: client, year: 2018
-      create :tax_return, client: client, year: 2020
-      visit hub_client_path(id: client.id)
-      expect(page).not_to have_text "Add tax year"
     end
+
+    context "when there are no more tax return years to create objects for" do
+      before do
+        # 2019 already created above
+        create :tax_return, client: client, year: 2018
+        create :tax_return, client: client, year: 2020
+        create :tax_return, client: client, year: 2017
+      end
+
+      scenario "it does not show the button on the client show page" do
+        # when tax returns are created for all years, do not show Add tax year button
+        visit hub_client_path(id: client.id)
+        expect(page).not_to have_text "Add tax year"
+      end
+    end
+
   end
 end

--- a/spec/features/hub/create_tax_return_spec.rb
+++ b/spec/features/hub/create_tax_return_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.feature "Add a tax return for an existing client" do
+  context "As an authenticated user" do
+    let(:user) { create :organization_lead_user, name: "Org Lead" }
+    let(:client) { create :client, vita_partner: user.role.organization, intake: create(:intake, preferred_name: "Bart Simpson") }
+    let!(:tax_return2019) { create :tax_return, client: client, year: 2019 }
+
+    before do
+      login_as user
+    end
+
+    scenario "creating a tax return" do
+
+      visit hub_client_path(id: client.id)
+
+      expect(page).to have_text("Add tax year")
+      click_on "Add tax year"
+
+      expect(page).to have_selector("h1", text: "Add tax year for Bart Simpson")
+      expect(page).to have_select("Tax year", options: (TaxReturn.filing_years - [2019]).map(&:to_s))
+      select "2017", from: "Tax year"
+      select "Org Lead", from: "Assigned user"
+      select "Basic", from: "Certification level"
+      select "Greeter - info requested", from: "Status"
+
+      click_on "Save"
+
+      new_tax_return = TaxReturn.last
+      within "#tax-return-#{new_tax_return.id}" do
+        expect(page).to have_selector(".certification-label", text: "BAS")
+        expect(page).to have_text "2017"
+        expect(page).to have_text "Org Lead"
+        expect(page).to have_text "Greeter - info requested"
+      end
+      # when tax returns are created for all years, do not show Add tax year button
+      create :tax_return, client: client, year: 2018
+      create :tax_return, client: client, year: 2020
+      visit hub_client_path(id: client.id)
+      expect(page).not_to have_text "Add tax year"
+    end
+  end
+end

--- a/spec/models/system_note/tax_return_created_spec.rb
+++ b/spec/models/system_note/tax_return_created_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+describe SystemNote::TaxReturnCreated do
+  describe ".generate!" do
+    let(:tax_return) { create(:tax_return, year: 2018) }
+
+    context "an org lead" do
+      let(:user) { create :organization_lead_user, name: "Org Lead", organization: (create :vita_partner, name: "Orange Org") }
+
+      it "creates the appropriate system note" do
+        note = described_class.generate!(tax_return: tax_return, initiated_by: user)
+
+        expect(note).to be_persisted
+        expect(note.client).to eq tax_return.client
+        expect(note.user).to eq user
+        expect(note.body).to eq "Org Lead (Organization Lead - Orange Org) added a 2018 tax return."
+      end
+    end
+
+    context "an admin" do
+      let(:user) { create :admin_user, name: "Admin User" }
+
+      it "creates the appropriate system note" do
+        note = described_class.generate!(tax_return: tax_return, initiated_by: user)
+
+        expect(note).to be_persisted
+        expect(note.client).to eq tax_return.client
+        expect(note.user).to eq user
+        expect(note.body).to eq "Admin User (Admin) added a 2018 tax return."
+      end
+    end
+
+    context "a team member" do
+      let(:user) { create :team_member_user, name: "Team User", site: (create :site, name: "Some Site") }
+
+      it "creates the appropriate system note" do
+        note = described_class.generate!(tax_return: tax_return, initiated_by: user)
+
+        expect(note).to be_persisted
+        expect(note.client).to eq tax_return.client
+        expect(note.user).to eq user
+        expect(note.body).to eq "Team User (Team Member - Site 1) added a 2018 tax return."
+      end
+    end
+
+    context "a site coordinator" do
+      let(:user) { create :site_coordinator_user, name: "Site User", site: (create :site, name: "Some Site") }
+
+      it "creates the appropriate system note" do
+        note = described_class.generate!(tax_return: tax_return, initiated_by: user)
+
+        expect(note).to be_persisted
+        expect(note.client).to eq tax_return.client
+        expect(note.user).to eq user
+        expect(note.body).to eq "Site User (Site Coordinator - Some Site) added a 2018 tax return."
+      end
+    end
+
+    context "A coalition lead" do
+      let(:user) { create :coalition_lead_user, name: "Coal Ition", coalition: (create :coalition, name: "Some Coalition") }
+
+      it "creates the appropriate system note" do
+        note = described_class.generate!(tax_return: tax_return, initiated_by: user)
+
+        expect(note).to be_persisted
+        expect(note.client).to eq tax_return.client
+        expect(note.user).to eq user
+        expect(note.body).to eq "Coal Ition (Coalition Lead - Some Coalition) added a 2018 tax return."
+      end
+    end
+  end
+end

--- a/spec/models/system_note/tax_return_created_spec.rb
+++ b/spec/models/system_note/tax_return_created_spec.rb
@@ -4,19 +4,6 @@ describe SystemNote::TaxReturnCreated do
   describe ".generate!" do
     let(:tax_return) { create(:tax_return, year: 2018) }
 
-    context "an org lead" do
-      let(:user) { create :organization_lead_user, name: "Org Lead", organization: (create :vita_partner, name: "Orange Org") }
-
-      it "creates the appropriate system note" do
-        note = described_class.generate!(tax_return: tax_return, initiated_by: user)
-
-        expect(note).to be_persisted
-        expect(note.client).to eq tax_return.client
-        expect(note.user).to eq user
-        expect(note.body).to eq "Org Lead (Organization Lead - Orange Org) added a 2018 tax return."
-      end
-    end
-
     context "an admin" do
       let(:user) { create :admin_user, name: "Admin User" }
 
@@ -40,19 +27,6 @@ describe SystemNote::TaxReturnCreated do
         expect(note.client).to eq tax_return.client
         expect(note.user).to eq user
         expect(note.body).to eq "Team User (Team Member - Some Site) added a 2018 tax return."
-      end
-    end
-
-    context "a site coordinator" do
-      let(:user) { create :site_coordinator_user, name: "Site User", site: (create :site, name: "Some Site") }
-
-      it "creates the appropriate system note" do
-        note = described_class.generate!(tax_return: tax_return, initiated_by: user)
-
-        expect(note).to be_persisted
-        expect(note.client).to eq tax_return.client
-        expect(note.user).to eq user
-        expect(note.body).to eq "Site User (Site Coordinator - Some Site) added a 2018 tax return."
       end
     end
 

--- a/spec/models/system_note/tax_return_created_spec.rb
+++ b/spec/models/system_note/tax_return_created_spec.rb
@@ -39,7 +39,7 @@ describe SystemNote::TaxReturnCreated do
         expect(note).to be_persisted
         expect(note.client).to eq tax_return.client
         expect(note.user).to eq user
-        expect(note.body).to eq "Team User (Team Member - Site 1) added a 2018 tax return."
+        expect(note.body).to eq "Team User (Team Member - Some Site) added a 2018 tax return."
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -379,4 +379,82 @@ RSpec.describe User, type: :model do
       expect(User.active).to match_array([user])
     end
   end
+
+  describe "#served_entity" do
+    context "an admin user" do
+      let(:user) { create :admin_user }
+      it "returns nil" do
+        expect(user.served_entity).to eq nil
+      end
+    end
+
+    context "a team member user" do
+      let(:site) { create :site}
+      let(:user) { create :team_member_user, site: site }
+      it "returns their site" do
+        expect(user.served_entity).to eq site
+      end
+    end
+
+    context "a coalition lead user" do
+      let(:coalition) { create :coalition }
+      let(:user) { create :coalition_lead_user, coalition: coalition }
+      it "returns their coalition" do
+        expect(user.served_entity).to eq coalition
+      end
+    end
+
+    context "a org lead user" do
+      let(:organization) { create :organization }
+      let(:user) { create :organization_lead_user, organization: organization }
+      it "returns their organization" do
+        expect(user.served_entity).to eq organization
+      end
+    end
+
+    context "a site coordinator user" do
+      let(:site) { create :site }
+      let(:user) { create :site_coordinator_user, site: site }
+      it "returns their organization" do
+        expect(user.served_entity).to eq site
+      end
+    end
+  end
+
+  describe "#role_name" do
+    context "an admin" do
+      let(:user) { create :admin_user }
+      it "is Admin" do
+        expect(user.role_name).to eq "Admin"
+      end
+    end
+
+    context "a team member" do
+      let(:user) { create :team_member_user }
+      it "is Admin" do
+        expect(user.role_name).to eq "Team Member"
+      end
+    end
+
+    context "site coordinator" do
+      let(:user) { create :site_coordinator_user }
+      it "is Site Coordinator" do
+        expect(user.role_name).to eq "Site Coordinator"
+      end
+    end
+
+    context "coalition lead" do
+      let(:user) { create :coalition_lead_user }
+      it "is Admin" do
+        expect(user.role_name).to eq "Coalition Lead"
+      end
+    end
+
+    context "organization lead" do
+      let(:user) { create :organization_lead_user }
+      it "is Admin" do
+        expect(user.role_name).to eq "Organization Lead"
+      end
+    end
+  end
 end


### PR DESCRIPTION
![Screen Shot 2021-03-31 at 12 27 40 PM](https://user-images.githubusercontent.com/4494389/113185882-9c108500-921c-11eb-873a-eb0403838fca.png)
![Screen Shot 2021-03-31 at 12 34 51 PM](https://user-images.githubusercontent.com/4494389/113186867-c9a9fe00-921d-11eb-8d01-91f91ee95b27.png)
![Screen Shot 2021-03-31 at 12 35 28 PM](https://user-images.githubusercontent.com/4494389/113186870-ca429480-921d-11eb-9f08-bded60d33d56.png)


Additionally, I noticed that the client header was originally designed as a flex layout but had been replaced at some point with absolute positioning of the tax return list. Absolutely positioning dynamically sized divs is dangerous, and that's why we were seeing bleed of the tax return list into the rest of the client header + the top of the tabs section. This PR reverts the flex layout.