### PR TITLE
Add default status (sending) to new OutgoingEmails to differentiate from legacy emails w/o mailgun status

### DIFF
--- a/app/helpers/contact_record_helper.rb
+++ b/app/helpers/contact_record_helper.rb
@@ -31,10 +31,9 @@ module ContactRecordHelper
     image_tag(icon, alt: status, title: status, class: 'message__status')
   end
 
-  def mailgun_deliverability_status(message)
-    return unless message.message_id.present?
+  def mailgun_deliverability_status(status)
+    return unless status.present?
 
-    status = message.mailgun_status || "sending"
     sent_statuses = %w[delivered opened]
     failed_statuses = %w[permanent_fail]
     icon = "icons/waiting.svg"

--- a/app/models/outgoing_email.rb
+++ b/app/models/outgoing_email.rb
@@ -34,6 +34,7 @@ class OutgoingEmail < ApplicationRecord
   validates_presence_of :body
   validates_presence_of :subject
   validates_presence_of :sent_at
+  before_create :set_sending_status, if: ->(email) { email.mailgun_status.blank? }
   # Use `after_create_commit` so that the attachment is fully saved to S3 before delivering it
   after_create_commit :deliver, :broadcast
   after_create_commit :record_outgoing_interaction, if: ->(email) { email.user.present? }
@@ -53,6 +54,10 @@ class OutgoingEmail < ApplicationRecord
   end
 
   private
+
+  def set_sending_status
+    self.mailgun_status = "sending"
+  end
 
   def deliver
     SendOutgoingEmailJob.perform_later(id)

--- a/app/views/shared/_message_list_contact_record.html.erb
+++ b/app/views/shared/_message_list_contact_record.html.erb
@@ -16,7 +16,7 @@
         </div>
 
         <%= twilio_deliverability_status(contact_record.twilio_status) if contact_record.respond_to? :twilio_status %>
-        <%= mailgun_deliverability_status(contact_record) if contact_record.respond_to? :mailgun_status %>
+        <%= mailgun_deliverability_status(contact_record.mailgun_status) if contact_record.respond_to? :mailgun_status %>
       </div>
     </div>
 

--- a/spec/helpers/contact_record_helper_spec.rb
+++ b/spec/helpers/contact_record_helper_spec.rb
@@ -40,27 +40,18 @@ describe ContactRecordHelper do
     end
 
     describe "#mailgun_deliverability_status" do
-      context "when there is no message_id saved to the message record" do
-        let(:outgoing_email) { create :outgoing_email, message_id: nil }
+      context "when the status is nil" do
         it "returns nil" do
-          expect(helper.mailgun_deliverability_status(outgoing_email)).to eq nil
+          expect(helper.mailgun_deliverability_status(nil)).to eq nil
         end
       end
-      context "when there is a message_id saved to the message record" do
-        let(:outgoing_email) { create :outgoing_email, message_id: "some_fake_id", mailgun_status: mailgun_status}
-        context "when the mailgun_status is nil" do
-          let(:mailgun_status) { nil }
-          let(:image_tag) { helper.image_tag("icons/waiting.svg", alt: "sending", title: "sending", class: 'message__status') }
-          it "returns the correct image tag" do
-            expect(helper.mailgun_deliverability_status(outgoing_email)).to eq image_tag
-          end
-        end
 
+      context "when status is not nil" do
         context "when the mailgun_status is delivered" do
           let(:mailgun_status) { "delivered" }
           let(:image_tag) { helper.image_tag("icons/check.svg", alt: mailgun_status, title: mailgun_status, class: 'message__status') }
           it "returns the correct image tag" do
-            expect(helper.mailgun_deliverability_status(outgoing_email)).to eq image_tag
+            expect(helper.mailgun_deliverability_status(mailgun_status)).to eq image_tag
           end
         end
 
@@ -68,7 +59,7 @@ describe ContactRecordHelper do
           let(:mailgun_status) { "permanent_fail" }
           let(:image_tag) { helper.image_tag("icons/exclamation.svg", alt: mailgun_status, title: mailgun_status, class: 'message__status') }
           it "returns the correct image tag" do
-            expect(helper.mailgun_deliverability_status(outgoing_email)).to eq image_tag
+            expect(helper.mailgun_deliverability_status(mailgun_status)).to eq image_tag
           end
         end
       end

--- a/spec/models/outgoing_email_spec.rb
+++ b/spec/models/outgoing_email_spec.rb
@@ -105,4 +105,23 @@ RSpec.describe OutgoingEmail, type: :model do
       expect(ClientChannel).to have_received(:broadcast_contact_record).with(message)
     end
   end
+
+  context "before create" do
+    let(:outgoing_email) { build :outgoing_email, mailgun_status: "accepted" }
+    context "when a status is already set" do
+      it "does not overwrite the status" do
+        outgoing_email.save
+        expect(outgoing_email.reload.mailgun_status).to eq "accepted"
+      end
+    end
+
+    context "when the status is blank" do
+      let(:outgoing_email) { build :outgoing_email, mailgun_status: nil }
+
+      it "defaults the status to sending" do
+        outgoing_email.save
+        expect(outgoing_email.reload.mailgun_status).to eq "sending"
+      end
+    end
+  end
 end


### PR DESCRIPTION
Co-authored-by: Catie Talbot <ctalbot@codeforamerica.org>