### PR TITLE
Create confirmation page for Client documents that will be displayed to the client

### DIFF
--- a/app/assets/stylesheets/_honeycrisp-compact.scss
+++ b/app/assets/stylesheets/_honeycrisp-compact.scss
@@ -299,10 +299,22 @@
     flex-shrink: 0;
   }
   .item {
-    margin-right: 60px;
+    margin-right: 6rem;
   }
   .item:last-of-type {
     margin-right: 0;
+  }
+
+  .item-15r {
+    margin-right: 1.5rem;
+  }
+
+  &.full-height, .full-height {
+    height: 100vh;
+  }
+
+  &.column-column {
+    flex-direction: column;
   }
 }
 

--- a/app/controllers/hub/documents_controller.rb
+++ b/app/controllers/hub/documents_controller.rb
@@ -48,19 +48,16 @@ module Hub
     end
 
     def destroy
-      return redirect_back(fallback_location: hub_client_documents_path) unless @client.id == @document.client_id
+      if params[:reupload].present?
+        @document.destroy!
 
-      if @document.destroy!
-        if params[:new]
-          flash[:notice] = "Please upload correct document for #{@client.legal_name}."
-          render :new and return
-        else
-          flash[:notice] = "Document deleted."
-        end
+        flash[:notice] = "Please upload correct document for #{@client.legal_name}."
+        render :new and return
       else
-        flash[:notice] = "Could not delete specified document. Try again."
+        @document.update(archived: true)
+        flash[:notice] = "Document archived."
       end
-      
+
       redirect_back(fallback_location: hub_client_documents_path)
     end
 

--- a/app/controllers/hub/documents_controller.rb
+++ b/app/controllers/hub/documents_controller.rb
@@ -47,6 +47,23 @@ module Hub
       end
     end
 
+    def destroy
+      return redirect_back(fallback_location: hub_client_documents_path) unless @client.id == @document.client_id
+
+      if @document.destroy!
+        if params[:new]
+          flash[:notice] = "Please upload correct document for #{@client.legal_name}."
+          render :new and return
+        else
+          flash[:notice] = "Document deleted."
+        end
+      else
+        flash[:notice] = "Could not delete specified document. Try again."
+      end
+      
+      redirect_back(fallback_location: hub_client_documents_path)
+    end
+
     private
 
     def sorted_documents

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -107,6 +107,10 @@ class Document < ApplicationRecord
     end
   end
 
+  def confirmation_needed?
+    document_type.in? [DocumentTypes::FinalTaxDocument.key, DocumentTypes::UnsignedForm8879.key]
+  end
+
   private
 
   def tax_return_belongs_to_client

--- a/app/views/hub/clients/edit_take_action.html.erb
+++ b/app/views/hub/clients/edit_take_action.html.erb
@@ -3,7 +3,7 @@
 <% content_for :card do %>
   <div class="slab slab--not-padded">
     <%= render "hub/read_only_client_header", client: @client %>
-
+    <hr/>
     <%= form_with model: @take_action_form,
                   url: update_take_action_hub_client_path(id: @client.id),
                   method: :post, local: true, builder: VitaMinFormBuilder,

--- a/app/views/hub/documents/_form.html.erb
+++ b/app/views/hub/documents/_form.html.erb
@@ -4,7 +4,7 @@
     <% if file_upload_enabled %>
       <div class="form-group <%= "form-group--error" if @document.errors[:upload].present? %>">
         <%= f.label(:upload, t("general.select_files"), class: "form-question") %>
-        <%= f.file_field :upload, multiple: "multiple", class: "attachment-upload file-input" %>
+        <%= f.file_field :upload, class: "attachment-upload file-input" %>
         <% @document.errors[:upload].each do |error_message| %>
           <p class="text--error"><i class="icon-warning"></i>
             <%= error_message %>

--- a/app/views/hub/documents/_form.html.erb
+++ b/app/views/hub/documents/_form.html.erb
@@ -3,7 +3,7 @@
     <h1 class="h2"><%= @title %></h1>
     <% if file_upload_enabled %>
       <div class="form-group <%= "form-group--error" if @document.errors[:upload].present? %>">
-        <%= f.label(:upload, t("general.select_files"), class: "form-question") %>
+        <%= f.label(:upload, t("general.select_file"), class: "form-question") %>
         <%= f.file_field :upload, class: "attachment-upload file-input" %>
         <% @document.errors[:upload].each do |error_message| %>
           <p class="text--error"><i class="icon-warning"></i>

--- a/app/views/hub/documents/confirm.html.erb
+++ b/app/views/hub/documents/confirm.html.erb
@@ -21,7 +21,7 @@
           </div>
           <div class="item">
             <%= form_with  %>
-            <%= link_to hub_client_document_path(id: @document.id, new: true), method: :delete, class: "button button--icon button--icon--centered", "data-track-click": "document-confirmed-no" do %>
+            <%= link_to hub_client_document_path(id: @document.id, reupload: true), method: :delete, class: "button button--icon button--icon--centered", "data-track-click": "document-confirmed-no" do %>
               <%= image_tag("crossmark.svg", alt: "") %><%=t("general.negative") %>
             <% end %>
           </div>

--- a/app/views/hub/documents/confirm.html.erb
+++ b/app/views/hub/documents/confirm.html.erb
@@ -1,0 +1,39 @@
+<% @title = t(".title") %>
+<% content_for :page_title, @title %>
+<% content_for :card do %>
+  <div class="slab">
+    <div class="grid-flex full-height">
+      <div class="item">
+        <h1><%= t("hub.documents.confirm.title", document_type: @document.document_type) %></h1>
+        <p>
+          <%= t("hub.documents.confirm.text",
+                document_type: @document.document_type,
+                client_name: @document.client.legal_name,
+                filing_year: @document.tax_return.year
+                )
+          %>
+        </p>
+        <div class="grid-flex">
+          <div class="item-15r">
+            <%= link_to hub_client_documents_path(client_id: @document.client.id), class: "button button--icon button--icon--centered", "data-track-click": "document-confirmed-yes" do %>
+              <%= image_tag("checkmark.svg", alt: "") %><%= t("general.affirmative") %>
+            <% end %>
+          </div>
+          <div class="item">
+            <%= link_to edit_hub_client_document_path(id: @document.id), class: "button button--icon button--icon--centered", "data-track-click": "document-confirmed-no" do %>
+              <%= image_tag("crossmark.svg", alt: "") %><%=t("general.negative") %>
+            <% end %>
+          </div>
+        </div>
+
+      </div>
+      <div class="item">
+        <% if @document.is_pdf? %>
+          <embed src="<%= transient_storage_url(@document.upload.blob) %>" width="800px" height="100%" type="application/pdf" />
+        <% else %>
+          <%= image_tag transient_storage_url(@document.upload.blob) %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/hub/documents/confirm.html.erb
+++ b/app/views/hub/documents/confirm.html.erb
@@ -20,7 +20,8 @@
             <% end %>
           </div>
           <div class="item">
-            <%= link_to edit_hub_client_document_path(id: @document.id), class: "button button--icon button--icon--centered", "data-track-click": "document-confirmed-no" do %>
+            <%= form_with  %>
+            <%= link_to hub_client_document_path(id: @document.id, new: true), method: :delete, class: "button button--icon button--icon--centered", "data-track-click": "document-confirmed-no" do %>
               <%= image_tag("crossmark.svg", alt: "") %><%=t("general.negative") %>
             <% end %>
           </div>

--- a/app/views/hub/documents/edit.html.erb
+++ b/app/views/hub/documents/edit.html.erb
@@ -1,9 +1,9 @@
-<% @title = "#{@client.preferred_name} | #{t(".title")}" %>
+<% @title = "#{t(".title")} | #{@client.legal_name}" %>
 <% content_for :page_title, @title %>
 <% content_for :card do %>
   <div class="slab slab--not-padded">
     <%= render "hub/read_only_client_header", client: @client %>
-
+    <hr/>
     <div class="grid-flex">
       <div class="item no-shrink">
         <%= render 'form', url: [:hub, @client, @document], method: "patch", file_upload_enabled: false %>

--- a/app/views/hub/documents/edit.html.erb
+++ b/app/views/hub/documents/edit.html.erb
@@ -13,7 +13,7 @@
           <embed src="<%= transient_storage_url(@document.upload.blob) %>" width="800px" height="100%" type="application/pdf" />
         <% else %>
           <%= image_tag transient_storage_url(@document.upload.blob) %>
-      <% end %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/hub/documents/new.html.erb
+++ b/app/views/hub/documents/new.html.erb
@@ -1,8 +1,12 @@
-<% @title = t("hub.documents.index.add_doc") %>
+<% @title = "#{t("hub.documents.index.add_doc")} | #{@client.legal_name}" %>
 <% content_for :page_title, @title %>
 
 <% content_for :card do %>
-  <div class="slab">
+
+
+  <div class="slab slab--not-padded">
+    <%= render "hub/read_only_client_header", client: @client %>
+    <hr/>
     <%= render 'form', url: hub_client_documents_path, method: "post", file_upload_enabled: true %>
   </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -829,7 +829,7 @@ en:
       basic: "BAS"
     hsa: "HSA"
     drop_off: Drop Off
-    select_files: Select files
+    select_file: Select file
     take_picture: Take picture
     certification: Certification
     my_profile: My profile

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -139,6 +139,9 @@ en:
         account_unlocked: "Unlocked %{name}'s account."
       urgent: "Urgent"
     documents:
+      confirm:
+        title: Confirm %{document_type}
+        text: Is this a %{document_type} for %{client_name}'s %{filing_year} tax return?
       edit:
         title: Edit Document
       index:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -153,6 +153,9 @@ es:
       display_name: Nombre Para Mostrar
       form:
         archived_label: "Archivar el documento"
+      confirm:
+        title: Confirmar %{document_type}
+        text: ¿Es esta una %{document_type} para la declaración de impuestos %{filing_year} de %{client_name}?
     messages:
       index:
         email_form:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -819,7 +819,7 @@ es:
       basic: "BAS"
     hsa: "HSA"
     drop_off: Entrega
-    select_files: Seleccionar archivos
+    select_file: Seleccionar archivo
     take_picture: Sacar foto
     certification: Certificación
     my_profile: Mi perfil

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -149,6 +149,7 @@ Rails.application.routes.draw do
         get "/hide-spouse-ssn", to: "clients/ssn_itins#hide_spouse", on: :member, as: :hide_spouse_ssn_itin
         resources :documents, only: [:index, :edit, :update, :show, :create, :new] do
           get "/archived", to: "documents#archived", on: :collection, as: :archived
+          get "/confirm", to: "documents#confirm", on: :member, as: :confirm
         end
         resources :notes, only: [:create, :index]
         resources :messages, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,7 +147,7 @@ Rails.application.routes.draw do
         get "/hide-ssn", to: "clients/ssn_itins#hide", on: :member, as: :hide_ssn_itin
         get "/spouse-ssn", to: "clients/ssn_itins#show_spouse", on: :member, as: :show_spouse_ssn_itin
         get "/hide-spouse-ssn", to: "clients/ssn_itins#hide_spouse", on: :member, as: :hide_spouse_ssn_itin
-        resources :documents, only: [:index, :edit, :update, :show, :create, :new] do
+        resources :documents do
           get "/archived", to: "documents#archived", on: :collection, as: :archived
           get "/confirm", to: "documents#confirm", on: :member, as: :confirm
         end

--- a/spec/controllers/hub/documents_controller_spec.rb
+++ b/spec/controllers/hub/documents_controller_spec.rb
@@ -307,17 +307,16 @@ RSpec.describe Hub::DocumentsController, type: :controller do
   describe "#create" do
     let!(:intake) { client.intake }
     let!(:tax_return) { create :tax_return, client: client, year: 2017 }
+    let(:document_type) { DocumentTypes::Form1098E.key }
+    let(:upload) { fixture_file_upload("attachments/test-pattern.png", "image/png") }
 
     let(:params) do
       { client_id: client.id,
         document: {
-          upload: [
-              fixture_file_upload("attachments/test-pattern.png", "image/png"),
-              fixture_file_upload("attachments/document_bundle.pdf", "application/pdf")
-          ],
+          upload: upload,
           tax_return_id: tax_return.id,
           display_name: "This is a document for the client",
-          document_type: DocumentTypes::Form1098E.key
+          document_type: document_type
         }
       }
     end
@@ -327,31 +326,39 @@ RSpec.describe Hub::DocumentsController, type: :controller do
     context "with an authenticated user" do
       before { sign_in(user) }
 
-      it "appends the documents to the client's documents list" do
+      it "appends the document to the client's documents list and redirects to client index" do
         expect {
           post :create, params: params
-        }.to change(Document, :count).by 2
+        }.to change(Document, :count).by 1
 
-        latest_docs = Document.last(2)
-        expect(latest_docs.map(&:document_type).uniq).to eq ["1098-E"]
-        expect(latest_docs.first.upload.filename).to eq "test-pattern.png"
-        expect(latest_docs.second.upload.filename).to eq "document_bundle.pdf"
-        expect(latest_docs.first.display_name).to eq "This is a document for the client"
-        expect(latest_docs.second.display_name).to eq "This is a document for the client"
-        expect(latest_docs.map(&:client).uniq).to eq [client]
-        expect(latest_docs.map(&:tax_return_id).uniq).to eq [tax_return.id]
-        expect(latest_docs.map(&:uploaded_by).uniq).to eq [user]
+        latest_doc = Document.last
+        expect(latest_doc.document_type).to eq "1098-E"
+        expect(latest_doc.upload.filename).to eq "test-pattern.png"
+        expect(latest_doc.display_name).to eq "This is a document for the client"
+        expect(latest_doc.client).to eq client
+        expect(latest_doc.tax_return_id).to eq tax_return.id
+        expect(latest_doc.uploaded_by).to eq user
         expect(response).to redirect_to(hub_client_documents_path(client_id: client.id))
+      end
+
+      context "when the document type requires confirmation" do
+        let(:document_type) { DocumentTypes::FinalTaxDocument.key }
+        let(:upload) { fixture_file_upload("attachments/document_bundle.pdf", "application/pdf") }
+        it "redirects to the confirmation page after creation" do
+          expect {
+            post :create, params: params
+          }.to change(client.documents, :count).by 1
+
+          doc = Document.last
+          expect(response).to redirect_to confirm_hub_client_document_path(id: doc.id, client_id: doc.client.id)
+        end
       end
 
       context "with no display name, or tax return" do
         let(:params) do
           { client_id: client.id,
             document: {
-              upload: [
-                fixture_file_upload("attachments/test-pattern.png", "image/png"),
-                fixture_file_upload("attachments/document_bundle.pdf", "application/pdf")
-              ],
+              upload: fixture_file_upload("attachments/test-pattern.png", "image/png"),
               display_name: "",
               document_type: DocumentTypes::Other.key
             }
@@ -361,10 +368,9 @@ RSpec.describe Hub::DocumentsController, type: :controller do
         it "sets default file name, does not set tax return" do
           post :create, params: params
 
-          latest_docs = Document.last(2)
-          expect(latest_docs.first.display_name).to eq "test-pattern.png"
-          expect(latest_docs.second.display_name).to eq "document_bundle.pdf"
-          expect(latest_docs.map(&:tax_return_id).uniq).to eq [nil]
+          latest_doc = Document.last
+          expect(latest_doc.display_name).to eq "test-pattern.png"
+          expect(latest_doc.tax_return_id).to eq nil
         end
       end
 
@@ -389,9 +395,7 @@ RSpec.describe Hub::DocumentsController, type: :controller do
           let(:params) do
             { client_id: client.id,
               document: {
-                upload: [
-                  fixture_file_upload("attachments/test-pattern.png", "image/png"),
-                ],
+                upload: fixture_file_upload("attachments/test-pattern.png", "image/png"),
                 tax_return_id: tax_return.id,
                 display_name: "This is a document for the client",
                 document_type: DocumentTypes::UnsignedForm8879.key

--- a/spec/features/hub/documents_spec.rb
+++ b/spec/features/hub/documents_spec.rb
@@ -45,6 +45,8 @@ RSpec.feature "View and edit documents for a client" do
     end
 
     scenario "uploading a document to a client's documents page" do
+      original_document_count = client.documents.count
+
       visit hub_client_documents_path(client_id: client.id)
 
       click_on "Add document"
@@ -57,6 +59,20 @@ RSpec.feature "View and edit documents for a client" do
       select "2017", from: "Tax return"
 
       click_on "Save"
+      expect(client.documents.count).to eq original_document_count + 1
+
+      expect(page).to have_text("Confirm Final Tax Document")
+      click_on "No"
+
+      # deletes the original document and renders new
+      expect(client.documents.count).to eq original_document_count + 0
+
+      expect(page).to have_select("Document type", selected: "Final Tax Document")
+      expect(page).to have_select("Tax return", selected: "2017")
+      expect(page).to have_field("Display name", with: "A new final document")
+      attach_file "document_upload", Rails.root.join("spec", "fixtures", "attachments", "document_bundle.pdf")
+
+      click_on "Save"
 
       expect(page).to have_text("Confirm Final Tax Document")
       click_on "Yes"
@@ -66,6 +82,7 @@ RSpec.feature "View and edit documents for a client" do
         expect(page).to have_content("Final Tax Document")
         expect(page).to have_content("Org Lead")
       end
+      expect(client.documents.count).to eq original_document_count + 1
     end
   end
 end

--- a/spec/features/hub/documents_spec.rb
+++ b/spec/features/hub/documents_spec.rb
@@ -49,10 +49,7 @@ RSpec.feature "View and edit documents for a client" do
 
       click_on "Add document"
 
-      attach_file "document_upload", [
-        Rails.root.join("spec", "fixtures", "attachments", "test-pattern.png"),
-        Rails.root.join("spec", "fixtures", "attachments", "document_bundle.pdf"),
-      ]
+      attach_file "document_upload", Rails.root.join("spec", "fixtures", "attachments", "document_bundle.pdf")
 
       fill_in "Display name", with: "A new final document"
 
@@ -60,6 +57,9 @@ RSpec.feature "View and edit documents for a client" do
       select "2017", from: "Tax return"
 
       click_on "Save"
+
+      expect(page).to have_text("Confirm Final Tax Document")
+      click_on "Yes"
 
       within "#document-#{Document.last.id}" do
         expect(page).to have_content("2017")


### PR DESCRIPTION
This removes the multi-select for uploads and limits to uploading one doc at a time. 