### PR TITLE
Remove stray } when displaying call notes

### DIFF
--- a/app/lib/synthetic_note.rb
+++ b/app/lib/synthetic_note.rb
@@ -38,7 +38,7 @@ class SyntheticNote
         duration += "#{duration_seconds}s"
       end
       body = I18n.t("hub.notes.index.outbound_call_synthetic_note", user_name: outbound_call.user.name, client_name: outbound_call.client.preferred_name, status: outbound_call.twilio_status, duration: duration)
-      body += "\n#{I18n.t("hub.notes.index.outbound_call_synthetic_note_body")}\n#{outbound_call.note}}" if outbound_call.note.present?
+      body += "\n#{I18n.t("hub.notes.index.outbound_call_synthetic_note_body")}\n#{outbound_call.note}" if outbound_call.note.present?
       SyntheticNote.new(
         created_at: outbound_call.created_at,
         body: body,

--- a/spec/lib/synthetic_note_spec.rb
+++ b/spec/lib/synthetic_note_spec.rb
@@ -59,7 +59,7 @@ describe SyntheticNote do
         result = SyntheticNote.from_outbound_calls(client)
         expect(result.length).to eq 1
         expect(result[0].body).to include "Called by #{user.name}. Call was completed and lasted 1m15s."
-        expect(result[0].body).to include "I talked to them!"
+        expect(result[0].body).to match /^I talked to them!$/
       end
     end
   end


### PR DESCRIPTION
Hi folks!

I'm a VITA volunteer and noticed that there seemed to be a trailing `}` when displaying call notes. I think I tracked it down to this section of code which looks like it was just a inadvertent extra `}` in the variable interpolation string.

![Screenshot 2021-04-12 14 58 45](https://user-images.githubusercontent.com/395621/114447266-328b6180-9ba0-11eb-9131-15845c32dd3c.png)

I debated whether modifying the test was even worthwhile. Feedback welcomed.