### PR TITLE
Refactor user notifications

### DIFF
--- a/app/models/user_notification.rb
+++ b/app/models/user_notification.rb
@@ -20,9 +20,15 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class UserNotification < ApplicationRecord
+  ALLOWED_NOTIFIABLE_TYPES = [
+    "Note",
+    "TaxReturnAssignment"
+  ].freeze
+
   belongs_to :notifiable, polymorphic: true
   belongs_to :user
   scope :unread, -> { where(read: false) }
+  validates :notifiable_type, presence: true, inclusion: { in: ALLOWED_NOTIFIABLE_TYPES }
 
   self.per_page = 25
 end

--- a/spec/factories/user_notifications.rb
+++ b/spec/factories/user_notifications.rb
@@ -21,6 +21,7 @@
 #
 FactoryBot.define do
   factory :user_notification do
+    user
     notifiable { build(:tax_return_assignment) }
   end
 end

--- a/spec/models/user_notification_spec.rb
+++ b/spec/models/user_notification_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe UserNotification do
+  describe "#valid?" do
+    describe "#notifiable" do
+      context "with a random class that is not one of the allowed notifiable types" do
+        let(:notifiable) { create :client }
+        let(:user_notification) { build :user_notification, notifiable: notifiable }
+
+        it "is not valid" do
+          expect(user_notification).not_to be_valid
+          expect(user_notification.errors[:notifiable_type]).to be_present
+        end
+      end
+    end
+  end
+end

--- a/spec/models/user_notification_spec.rb
+++ b/spec/models/user_notification_spec.rb
@@ -12,6 +12,16 @@ RSpec.describe UserNotification do
           expect(user_notification.errors[:notifiable_type]).to be_present
         end
       end
+
+      context "with a class that is one of the allowed notifiable types" do
+        let(:notifiable) { create :note }
+        let(:user_notification) { build :user_notification, notifiable: notifiable }
+
+        it "is valid" do
+          expect(user_notification).to be_valid
+          expect(user_notification.errors[:notifiable_type]).to be_empty
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
BG + I investigated moving all the notifiable models under a notifications/ directory
Ended up going with alternative approach for simplicity and consistency.

**Engineering needs for moving them**
- It would be helpful to be able to see all the types of notifications in one place
- It would be helpful to clearly mark models that are solely used for notifications

**Challenges w/ Approach**
- If we move a model, I think we’ll need to update all Notification#notifiable_type records in all databases to reflect the new class ("TaxReturnAssignment" --> "UserNotifications::TaxReturnAssignment") because the polymorphic foreign key includes a specific class name.
- One kind of notification uses a Note as it’s notifiable. Note was created long before we added notifications, so it’s not a class that is used only as a notification.
- Given the way Note was used to create a new kind of notification, future engineers might create notifications that point to other existing models, rather than making a new model for each new type of notification.

**Alternative ways to address the needs**
- ensure all models used as a notifiable have the reverse relationship added has_one :notification, as: :notifiable or has_many :notifications, as: :notifiable
- Add validation to the notification model that notifiable_type is one of a set of accepted types, so that we have to list all notifiable classes and add new ones to the list when we create new kinds of notifications