### PR TITLE
Use www.getyourrefund.org for prod email asset_host

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -6,7 +6,7 @@ Rails.application.configure do
   config.action_mailer.default_options = { from: "hello@getyourrefund.org" }
   config.address_for_transactional_authentication_emails = 'no-reply@getyourrefund.org'
   config.action_mailer.default_url_options = { host: 'www.getyourrefund.org' }
-  config.action_mailer.asset_host = "https://getyourrefund.org"
+  config.action_mailer.asset_host = "https://www.getyourrefund.org"
 
   config.offseason = false
   Rails.application.default_url_options = config.action_mailer.default_url_options


### PR DESCRIPTION
Since e.g. https://getyourrefund.org/assets/checkbox-logo--white-252f6970859e7b1ba37367e7820af3472b45415066bb501fae76813011fde48e.png redirects to https://www.getyourrefund.org/assets/checkbox-logo--white-252f6970859e7b1ba37367e7820af3472b45415066bb501fae76813011fde48e.png , I figure it's best to give a URL that doesn't have one extra redirect.