### PR TITLE
Hide helper text if no final tax docs on e-signature success page #177171108

### DIFF
--- a/app/views/portal/tax_returns/show.html.erb
+++ b/app/views/portal/tax_returns/show.html.erb
@@ -9,7 +9,9 @@
             <%= image_tag("questions/documents.svg", alt: "") %>
           </div>
           <h1 class="h2 spacing-above-0"><%= t(".title", year: @tax_return.year) %></h1>
-          <p><%= t(".description") %></p>
+          <% if @tax_return.final_tax_documents.count == 1 %>
+            <p><%= t(".description") %></p>
+          <% end %>
           <div class="tax-return-status">
             <div class="tax-return-status__content">
               <% if @tax_return.final_tax_documents.count == 1 %>


### PR DESCRIPTION
[Add success page after e-signature #177171108](https://www.pivotaltracker.com/story/show/177171108)

Improvement to only show helper text on the page when there are documents available to download.

  
<img width="1440" alt="Screen Shot 2021-04-15 at 4 45 32 PM" src="https://user-images.githubusercontent.com/9101728/114942888-cd877400-9e0a-11eb-9966-d0360cb989d4.png">
