### PR TITLE
Update file-with-help copy and add deadline notice #177748874

### DIFF
--- a/app/views/questions/file_with_help/edit.html.erb
+++ b/app/views/questions/file_with_help/edit.html.erb
@@ -10,24 +10,16 @@
       <%=t("views.questions.file_with_help.info") %>
     </p>
 
-    <p>
-      <strong><%=t("views.questions.file_with_help.right_option.header") %></strong>
-    </p>
+    <p class="text--error"><%= t("views.questions.file_with_help.note") %></p>
 
-    <ul class="checkmark-list teal">
-      <li>
-        <%=t("views.questions.file_with_help.right_option.need_assistance") %>
-      </li>
-      <li>
-        <%=t("views.questions.file_with_help.right_option.confused") %>
-      </li>
-      <li>
-        <%=t("views.questions.file_with_help.right_option.nervous") %>
-      </li>
-    </ul>
+    <div class="notice--warning">
+      <p><%= t("views.questions.file_with_help.extension_notice_html") %></p>
+    </div>
 
     <%= link_to next_path, class: "button button--primary text--centered button--wide spacing-above-60" do %>
       <%=t("general.continue") %>
     <% end %>
+
+    <%= link_to t("views.questions.file_with_help.diy"), diy_file_yourself_path %>
   </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1944,13 +1944,11 @@ en:
         body: We appreciate any additional feedback you have to better serve clients in the future!
         title: Thank you for sharing your experience.
       file_with_help:
-        info: You selected our full service option. We’ll have you answer a series of questions about your tax situation (to the best of your ability) and have a tax specialist review everything with you.
-        right_option:
-          confused: Your tax situation is confusing/complicated
-          header: 'This is the right option for you if:'
-          need_assistance: You need assistance with tax filing
-          nervous: You’re nervous to file completely on your own
-        title: File with the help of a tax expert!
+        info: With our full-service option, our VITA partners will provide hands-on support and work with you to get the biggest return!
+        title: Based on your answers, we think our full service option is right for you!
+        note: "Note: this process takes 2-3 weeks."
+        extension_notice_html: "<strong>The federal income tax filing deadline has been extended to May 17, you can check your state filing deadline <a href='https://www.taxadmin.org/index.php?option=com_content&view=article&id=1151:state-filing-dates&catid=20:site-content&Itemid=393' target='_blank' rel='noopener noreferrer'>here</a>.</strong> Unless you are filing a 2017 return or anticipate owing money this year, you can file until October 15th without a penalty. If you aren’t sure whether or not you will owe, you can complete and mail this <a href='https://www.irs.gov/pub/irs-pdf/f4868.pdf' target='_blank'>IRS form</a> requesting an extension."
+        diy: "No thank you, I’m looking for a quicker option."
       filing_joint:
         help_text: Usually, filing joint taxes is more beneficial for your return. Your spouse will need to verify their identity and sign your final tax return.
         title: Are you filing joint taxes with your spouse?

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1896,13 +1896,11 @@ es:
         body: Apreciamos cualquier comentario adicional que tenga para servir mejor a nuestros clientes en el futuro.
         title: Gracias por compartir su experiencia.
       file_with_help:
-        info: Seleccionó nuestra opción de servicio completo. Nosotros haremos que responda una serie de preguntas sobre su situación fiscal (lo mejor que pueda) y que un especialista en impuestos revise todo con usted.
-        right_option:
-          confused: Su situación fiscal es confusa / complicada
-          header: 'Esta es la opción correcta para usted si:'
-          need_assistance: Necesita ayuda con la declaración de impuestos.
-          nervous: Le preocupa preparar su declaración de impuestos por su cuenta
-        title: "¡Declara tus impuestos con la ayuda de un experto!"
+        info: "¡Con la opción de servicio completo nuestros socios de VITA lo atenderán y trabajarán con usted para conseguir el reembolso más grande!"
+        title: Por sus respuestas, creemos que la opción de servicio completo es la mejor opción para usted.
+        note: "Nota: este proceso toma de 2 a 3 semanas."
+        extension_notice_html: "<strong>La fecha límite para presentar los impuestos federales se ha extendido hasta el 17 de mayo. Puede consultar la fecha límite de presentación de su estado <a href='https://www.taxadmin.org/index.php?option=com_content&view=article&id=1151:state-filing-dates&catid=20:site-content&Itemid=393' target='_blank' rel='noopener noreferrer'>aquí</a>.</strong> A menos que esté presentando una declaración de 2017 o anticipe deber dinero este año, puede presentar sus impuestos hasta el 15 de octubre sin una multa. Si no está seguro si debe o no, puede completar y enviar por correo este <a href='https://www.irs.gov/pub/irs-pdf/f4868.pdf' target='_blank'>formulario del IRS</a> solicitando una extensión."
+        diy: No, gracias. Estoy buscando una opción más rápida.
       filing_joint:
         help_text: Generalmente, declarar sus impuestos juntos es más beneficioso para su reembolso. Su cónyuge necesitará verificar su identidad y firmar la declaración de impuestos final.
         title: "¿Está declarando sus impuestos con su cónyuge?"

--- a/spec/features/web_intake/multiple_intake_paths_filer_spec.rb
+++ b/spec/features/web_intake/multiple_intake_paths_filer_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Web Intake Filer Tries Multiple Intake Paths" do
 
     # Skip to file-with-help
     visit "/questions/file-with-help"
-    expect(page).to have_selector("h1", text: "File with the help of a tax expert!")
+    expect(page).to have_selector("h1", text: "Based on your answers, we think our full service option is right for you!")
     click_on "Continue"
 
     # Doesn't get stuck trying to do full service flow

--- a/spec/features/web_intake/new_211_filer_spec.rb
+++ b/spec/features/web_intake/new_211_filer_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Web Intake 211 Assisted Filer" do
     visit "/211intake"
     visit "/en/questions/file-with-help"
 
-    expect(page).to have_selector("h1", text: "File with the help of a tax expert!")
+    expect(page).to have_selector("h1", text: "Based on your answers, we think our full service option is right for you!")
     click_on "Continue"
 
     # Intake created on backtaxes page

--- a/spec/features/web_intake/new_joint_filers_spec.rb
+++ b/spec/features/web_intake/new_joint_filers_spec.rb
@@ -86,7 +86,7 @@ RSpec.feature "Web Intake Joint Filers" do
     expect(page).to have_selector("h1", text: "Your tax return may be delayed so that we can ensure you receive the highest refund!")
     click_on "Continue"
 
-    expect(page).to have_selector("h1", text: "File with the help of a tax expert!")
+    expect(page).to have_selector("h1", text: "Based on your answers, we think our full service option is right for you!")
     click_on "Continue"
 
     # Ask about backtaxes

--- a/spec/features/web_intake/new_single_filer_spec.rb
+++ b/spec/features/web_intake/new_single_filer_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature "Web Intake Single Filer", active_job: true do
     expect(page).to have_selector("h1", text: "Your tax return may be delayed so that we can ensure you receive the highest refund!")
     click_on "Continue"
 
-    expect(page).to have_selector("h1", text: "File with the help of a tax expert!")
+    expect(page).to have_selector("h1", text: "Based on your answers, we think our full service option is right for you!")
     click_on "Continue"
 
     # Ask about backtaxes

--- a/spec/features/web_intake/routing_spec.rb
+++ b/spec/features/web_intake/routing_spec.rb
@@ -20,7 +20,7 @@ feature "Intake Routing Spec" do
 
     visit "questions/file-with-help"
 
-    expect(page).to have_text "File with the help of a tax expert!"
+    expect(page).to have_text "Based on your answers, we think our full service option is right for you!"
     click_on "Continue"
 
     expect(page).to have_text "What years would you like to file for?"
@@ -48,7 +48,7 @@ feature "Intake Routing Spec" do
   scenario "routing by zip code" do
     visit "/questions/file-with-help"
 
-    expect(page).to have_text "File with the help of a tax expert!"
+    expect(page).to have_text "Based on your answers, we think our full service option is right for you!"
     click_on "Continue"
 
     expect(page).to have_text "What years would you like to file for?"
@@ -76,7 +76,7 @@ feature "Intake Routing Spec" do
   scenario "routing by state" do
     visit "/questions/file-with-help"
 
-    expect(page).to have_text "File with the help of a tax expert!"
+    expect(page).to have_text "Based on your answers, we think our full service option is right for you!"
     click_on "Continue"
 
     expect(page).to have_text "What years would you like to file for?"


### PR DESCRIPTION
[Add notice to file-with-help #177748874](https://www.pivotaltracker.com/story/show/177748874)

# What this PR does

- Adds a notice about the tax deadline extension to the `questions/file-with-help` page
- Aligns the `questions/file-with-help` content to the new designs
- Have both English and Spanish copy
- Update any tests that reference the previous copy for this page