### PR TITLE
Unlinked clients tab border is not full width #177582672

### DIFF
--- a/app/views/hub/unlinked_clients/index.html.erb
+++ b/app/views/hub/unlinked_clients/index.html.erb
@@ -1,9 +1,7 @@
 <% content_for :page_title, @page_title %>
 
 <% content_for :card do %>
-  <section class="slab slab--padded client-index-header">
-    <%= render "shared/dashboard_navigation" %>
-  </section>
+  <%= render "shared/dashboard_navigation" %>
 
   <section class="slab slab--padded">
     <p><%= t(".description") %></p>


### PR DESCRIPTION
[Unlinked clients tab border is not full width #177582672](https://www.pivotaltracker.com/story/show/177582672)

## What this PR does

- Removing the `<section>` around the tab navigation on the unlinked clients page, so that it is matches the other navigation pages (all clients, my clients, etc)

<img width="1440" alt="Screen Shot 2021-04-20 at 10 17 59 AM" src="https://user-images.githubusercontent.com/9101728/115421689-c624e980-a1c1-11eb-9db2-86fc8b30f16f.png">
