### PR TITLE
Pairing with Anu to fix 5e display issue with header #177827378

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
       <%= content_for :page_title do %>Free tax help from IRS-certified volunteers.<% end %>
     <% end %>
 
-    <title><%= content_for(:page_title) %> | GetYourRefund.org</title>
+    <title><%= content_for(:page_title) %> | GetYourRefund</title>
 
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
     <meta content="utf-8" http-equiv="encoding">
@@ -15,12 +15,12 @@
     <meta name="description" content="<%=t("views.layouts.application.meta.description") %>">
     <meta property="og:type" content="website">
     <meta property="og:url" content="<%= canonical_url %>">
-    <meta property="og:title" content="<%= content_for(:page_title) -%> | GetYourRefund.org">
+    <meta property="og:title" content="<%= content_for(:page_title) -%> | GetYourRefund">
     <meta property="og:description" content="<%=t("views.layouts.application.meta.description") %>">
     <meta property="og:image" content="<%= image_url("social_share_banner.png") %>">
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="<%= canonical_url %>">
-    <meta property="twitter:title" content="<%= content_for(:page_title) -%> | GetYourRefund.org">
+    <meta property="twitter:title" content="<%= content_for(:page_title) -%> | GetYourRefund">
     <meta property="twitter:description" content="<%=t("views.layouts.application.meta.description") %>">
     <meta property="twitter:image" content="<%= image_url("social_share_banner.png") %>">
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,7 +3,7 @@
     <div class="toolbar__left">
       <div class="toolbar__item main-header__title">
         <%= link_to root_path, class: "toolbar__logo-text main-header__logo" do %>
-          GetYourRefund.org
+          GetYourRefund
         <% end %>
       </div>
     </div>

--- a/spec/features/visit_home_page_spec.rb
+++ b/spec/features/visit_home_page_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Visit home page" do
   scenario "has most critical content" do
     visit "/"
     within(".main-header") do
-      expect(page).to have_link("GetYourRefund.org", href: root_path)
+      expect(page).to have_link("GetYourRefund", href: root_path)
     end
     expect(page).to have_text "Free tax filing"
     expect(page).to have_link "Get started"


### PR DESCRIPTION
## What this PR does

- Removes `.org` for header title
- Removes `.org` for social title
- Update tests

Remove `.org` shortens the header link and allows the header to not be cut off on iPhone 5e sized devices

<img width="1093" alt="Screen Shot 2021-04-20 at 10 41 54 AM" src="https://user-images.githubusercontent.com/9101728/115425720-79431200-a1c5-11eb-8455-c6ccbcdb7421.png">
