### PR TITLE
Add maintenance mode docs; make maintenance page more generic

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,9 @@
 class ApplicationController < ActionController::Base
   include ConsolidatedTraceHelper
   around_action :set_time_zone, if: :current_user
-  before_action :redirect_to_getyourrefund, :set_visitor_id, :set_source, :set_referrer, :set_utm_state, :set_sentry_context, :check_maintenance_mode
+  before_action :redirect_to_getyourrefund, :set_visitor_id, :set_source, :set_referrer, :set_utm_state, :set_sentry_context
   around_action :switch_locale
+  before_action :check_maintenance_mode
   after_action :track_page_view
   helper_method :include_analytics?, :current_intake, :show_progress?, :show_offseason_banner?, :canonical_url, :hreflang_url, :hub?, :open_for_intake?
   # This needs to be a class method for the devise controller to have access to it
@@ -223,7 +224,7 @@ class ApplicationController < ActionController::Base
     if ENV['MAINTENANCE_MODE'].present?
       return redirect_to maintenance_path
     elsif ENV['MAINTENANCE_MODE_SCHEDULED'].present?
-      flash.now[:warning] = I18n.t("controllers.application_controller.maintenance")
+      flash.now[:warning] = I18n.t("controllers.application_controller.maintenance", time: ENV['MAINTENANCE_MODE_SCHEDULED'])
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -488,7 +488,7 @@ en:
     public_pages:
       partner_welcome_notice: Thanks for visiting via %{partner_name}!
     application_controller:
-      maintenance: GetYourRefund.org will be down for scheduled maintenance tonight at 11:00 p.m. Eastern (8:00 p.m. Pacific) until 3:00 a.m. Eastern (12:00 a.m. Pacific). We recommend that you answer all questions by this time or start a new session tomorrow.
+      maintenance: GetYourRefund.org will be down for scheduled maintenance for about 1 hour starting at %{time}.
       redirect: You're missing a ticket or intake. In production, we would have redirected you to the beginning.
     dependents_controller:
       removed_dependent: Removed %{full_name}.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -477,7 +477,7 @@ es:
     public_pages:
       partner_welcome_notice: ¡Gracias por visitarnos a través de %{partner_name}!
     application_controller:
-      maintenance: GetYourRefund.org estará fuera de servicio esta noche debido a un mantenimiento programado entre las 11:00 p.m. hora del Este (8:00 p.m. hora del Pacífico) hasta las 3:00 a.m. hora del Este (12:00 a.m. hora del Pacífico). Le recomendamos que responda  todas las preguntas antes de estos horarios o que comience una nueva sesión mañana.
+      maintenance: GetYourRefund.org estará inactivo por mantenimiento programado durante aproximadamente 1 hora a partir de %{time}.
       redirect: Usted ha perdidio su tiquete. En producción,  lo redireccionaremos al inicio.
     dependents_controller:
       removed_dependent: Eliminado %{full_name}.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -477,7 +477,7 @@ es:
     public_pages:
       partner_welcome_notice: ¡Gracias por visitarnos a través de %{partner_name}!
     application_controller:
-      maintenance: GetYourRefund.org estará inactivo por mantenimiento programado durante aproximadamente 1 hora a partir de %{time}.
+      maintenance: GetYourRefund.org estará inactivo para mantenimiento programado durante aproximadamente 1 hora a partir de %{time}.
       redirect: Usted ha perdidio su tiquete. En producción,  lo redireccionaremos al inicio.
     dependents_controller:
       removed_dependent: Eliminado %{full_name}.

--- a/docs/2021-04-20-maintenance-mode.md
+++ b/docs/2021-04-20-maintenance-mode.md
@@ -1,0 +1,33 @@
+## Maintenance mode
+
+### Scheduling maintenance
+
+You can add a flash message to all pages on the site indicating the site will undergo scheduled maintenance.
+
+Configure this with:
+
+```
+aptible config:set --app vita-min-staging MAINTENANCE_MODE_SCHEDULED="8:00 PM PT"
+```
+
+See `ApplicationController` for implementation details.
+
+Turn the message off with:
+
+```
+aptible config:set --app vita-min-staging MAINTENANCE_MODE_SCHEDULED=""
+```
+
+### Maintenance URL if the website crashes
+
+Aptible will automatically show a crash screen under some circumstances where the
+site is unavailable. This is configured with the `MAINTENANCE_PAGE_URL` config
+option in Aptible. Consider setting it to `https://getyourrefund.org/maintenace/`.
+
+### Disabling the website for maintenance
+
+If you want to make all pages on the site redirect to a maintenance URL, you can
+set the `MAINTENANCE_MODE` variable to a non-blank value. This could result in
+our Twilio/Mailgun/etc. web hooks being marked as succeeded even though we did
+not write them to our database, so use with care.
+


### PR DESCRIPTION
Example banner:

![image](https://user-images.githubusercontent.com/67708639/115463132-4eb28280-a1e0-11eb-8592-729fe2e32972.png)

![image](https://user-images.githubusercontent.com/67708639/115463333-8cafa680-a1e0-11eb-9181-80cc70c5ae4d.png)
