### PR TITLE
Restrict zip code routing to organizations with capacity for new clients

### DIFF
--- a/app/services/partner_routing_service.rb
+++ b/app/services/partner_routing_service.rb
@@ -13,7 +13,7 @@ class PartnerRoutingService
     return from_source_param if from_source_param.present?
 
     from_zip_code = vita_partner_from_zip_code if @zip_code.present?
-    return from_zip_code if  from_zip_code.present?
+    return from_zip_code if from_zip_code.present?
 
     from_state_routing = vita_partner_from_state if @zip_code.present?
     return from_state_routing if from_state_routing.present?
@@ -38,7 +38,11 @@ class PartnerRoutingService
   def vita_partner_from_zip_code
     return false unless @zip_code.present?
 
-    vita_partner = VitaPartnerZipCode.where(zip_code: @zip_code).first&.vita_partner
+    eligible_with_capacity = VitaPartnerZipCode.where(zip_code: @zip_code).joins(vita_partner: :organization_capacity).merge(
+      OrganizationCapacity.with_capacity
+    )
+
+    vita_partner = eligible_with_capacity.first&.vita_partner
 
     if vita_partner.present?
       @routing_method = :zip_code

--- a/spec/services/partner_routing_service_spec.rb
+++ b/spec/services/partner_routing_service_spec.rb
@@ -57,6 +57,16 @@ describe PartnerRoutingService do
           expect(subject.determine_partner).to eq vita_partner
           expect(subject.routing_method).to eq :zip_code
         end
+
+        context "when a Vita Partner matches the zip code but they do not have capacity" do
+          before do
+            vita_partner.update(capacity_limit: 0)
+          end
+          it "does not route to that vita partner by zip code" do
+            expect(subject.determine_partner).not_to eq vita_partner
+            expect(subject.routing_method).not_to eq :zip_code
+          end
+        end
       end
 
       context "when clients zip code doesn't correspond to a Vita Partner" do


### PR DESCRIPTION
Rae requested that we take capacity into account when routing by zip code. The query is the same as how we restrict by capacity for state routing. Expand the diff to compare.