### PR TITLE
send metric to datadog for outbound call queue times

### DIFF
--- a/app/forms/hub/outbound_call_form.rb
+++ b/app/forms/hub/outbound_call_form.rb
@@ -42,6 +42,7 @@ module Hub
         )
 
         DatadogApi.increment("twilio.outbound_calls.initiated")
+        DatadogApi.gauge("twilio.outbound_calls.queue_time_ms", twilio_call.queue_time.to_i)
 
         @outbound_call.update(twilio_sid: twilio_call.sid, twilio_status: twilio_call.status, queue_time_ms: twilio_call.queue_time)
       end

--- a/spec/forms/hub/outbound_call_form_spec.rb
+++ b/spec/forms/hub/outbound_call_form_spec.rb
@@ -45,6 +45,7 @@ describe Hub::OutboundCallForm do
       allow(EnvironmentCredentials).to receive(:dig).with(:twilio, :account_sid).and_return "abc"
       allow(EnvironmentCredentials).to receive(:dig).with(:twilio, :auth_token).and_return "123"
       allow(DatadogApi).to receive(:increment)
+      allow(DatadogApi).to receive(:gauge)
     end
 
     it "initializes a twilio instance" do
@@ -85,10 +86,11 @@ describe Hub::OutboundCallForm do
       expect(call.queue_time_ms).to eq twilio_response_double.queue_time.to_i
     end
 
-    it "sends a metric to Datadog" do
+    it "sends metrics to Datadog" do
       subject.dial
 
       expect(DatadogApi).to have_received(:increment).with "twilio.outbound_calls.initiated"
+      expect(DatadogApi).to have_received(:gauge).with("twilio.outbound_calls.queue_time_ms", twilio_response_double.queue_time.to_i)
     end
   end
 end


### PR DESCRIPTION
i would specifically like feedback on the datadog attribute name which i have currently called `twilio.outbound_calls.queue_time_ms`

note: just want to call out that it _is_ redundant to be saving this in the db as well as sending it to datadog - happy to hear opinions on this, otherwise will assume this redundancy doesn't hurt