### PR TITLE
Zip code routing

### DIFF
--- a/app/assets/stylesheets/_honeycrisp-compact.scss
+++ b/app/assets/stylesheets/_honeycrisp-compact.scss
@@ -94,6 +94,8 @@
   .grid {
     margin-left: 0;
     margin-right: 0;
+    max-width: unset;
+    width: 100%;
   }
 
   .slab {

--- a/app/controllers/hub/organizations_controller.rb
+++ b/app/controllers/hub/organizations_controller.rb
@@ -21,7 +21,9 @@ module Hub
     end
 
     def show
-      @organization = VitaPartner.organizations.find(params[:id])
+      @organization = @vita_partner
+      raise ActionController::RoutingError.new('Not Found') unless @vita_partner.organization?
+
       @sites = @organization.child_sites
     end
 
@@ -33,6 +35,8 @@ module Hub
 
     def edit
       @coalitions = Coalition.all
+      @routing_form = ZipCodeRoutingForm.new(@vita_partner)
+      @source_params_form = SourceParamsForm.new(@vita_partner)
       @organization = @vita_partner
     end
 

--- a/app/controllers/hub/organizations_controller.rb
+++ b/app/controllers/hub/organizations_controller.rb
@@ -21,9 +21,9 @@ module Hub
     end
 
     def show
-      @organization = @vita_partner
       raise ActionController::RoutingError.new('Not Found') unless @vita_partner.organization?
 
+      @organization = @vita_partner
       @sites = @organization.child_sites
     end
 

--- a/app/controllers/hub/sites_controller.rb
+++ b/app/controllers/hub/sites_controller.rb
@@ -23,6 +23,8 @@ module Hub
 
     def edit
       @site = @vita_partner
+      @routing_form = ZipCodeRoutingForm.new(@vita_partner)
+      @source_params_form = SourceParamsForm.new(@vita_partner)
       @show_unique_links = true
     end
 

--- a/app/controllers/hub/source_params_controller.rb
+++ b/app/controllers/hub/source_params_controller.rb
@@ -8,8 +8,8 @@ module Hub
       vita_partner = VitaPartner.find(params[:vita_partner_id])
       @form = form_class.new(vita_partner, permitted_params)
       if @form.valid?
-        source_param = @form.save
-        @success_message = I18n.t("hub.source_params.success", code: source_param.code, name: vita_partner.name)
+        @form.save!
+        @success_message = I18n.t("hub.source_params.success", code: @form.code, name: vita_partner.name)
       else
         flash.now[:alert] = @form.error_summary
       end

--- a/app/controllers/hub/source_params_controller.rb
+++ b/app/controllers/hub/source_params_controller.rb
@@ -1,0 +1,42 @@
+module Hub
+  class SourceParamsController < ApplicationController
+    include AccessControllable
+    before_action :require_sign_in
+    authorize_resource :vita_partner, parent: false, only: :create
+
+    def create
+      vita_partner = VitaPartner.find(params[:vita_partner_id])
+      @form = form_class.new(vita_partner, permitted_params)
+      if @form.valid?
+        source_param = @form.save
+        @success_message = I18n.t("hub.source_params.success", code: source_param.code, name: vita_partner.name)
+      else
+        flash.now[:alert] = @form.error_summary
+      end
+      respond_to do |format|
+        format.js
+      end
+    end
+
+    def destroy
+      @source_param = SourceParameter.find_by(id: params[:id])
+
+      unless @source_param.present?
+        flash[:error] = I18n.t("hub.source_params.not_found")
+        redirect_to request.referrer and return
+      end
+      @source_param.destroy!
+      respond_to do |format|
+        format.js
+      end
+    end
+
+    def form_class
+      SourceParamsForm
+    end
+
+    def permitted_params
+      params.require(form_class.form_param).permit(:code)
+    end
+  end
+end

--- a/app/controllers/hub/source_params_controller.rb
+++ b/app/controllers/hub/source_params_controller.rb
@@ -19,12 +19,8 @@ module Hub
     end
 
     def destroy
-      @source_param = SourceParameter.find_by(id: params[:id])
+      @source_param = SourceParameter.find(params[:id])
 
-      unless @source_param.present?
-        flash[:error] = I18n.t("hub.source_params.not_found")
-        redirect_to request.referrer and return
-      end
       @source_param.destroy!
       respond_to do |format|
         format.js

--- a/app/controllers/hub/zip_codes_controller.rb
+++ b/app/controllers/hub/zip_codes_controller.rb
@@ -20,12 +20,8 @@ module Hub
     end
 
     def destroy
-      @zip_code_routing = VitaPartnerZipCode.find_by(id: params[:id])
-
-      unless @zip_code_routing.present?
-        flash[:error] = I18n.t("hub.zip_codes.not_found")
-        redirect_to request.referrer and return
-      end
+      @zip_code_routing = VitaPartnerZipCode.find(params[:id])
+      
       @zip_code_routing.destroy!
 
       respond_to do |format|

--- a/app/controllers/hub/zip_codes_controller.rb
+++ b/app/controllers/hub/zip_codes_controller.rb
@@ -1,0 +1,42 @@
+module Hub
+  class ZipCodesController < ApplicationController
+    include AccessControllable
+    before_action :require_sign_in
+    authorize_resource :vita_partner, parent: false, only: :create
+
+    def create
+      vita_partner = VitaPartner.find(params[:vita_partner_id])
+      @form = ZipCodeRoutingForm.new(vita_partner, permitted_params)
+      if @form.valid?
+        @form.save
+      else
+        flash.now[:alert] = @form.error_summary
+      end
+      respond_to do |format|
+        format.js
+      end
+    end
+
+    def destroy
+      @zip_code_routing = VitaPartnerZipCode.find_by(id: params[:id])
+
+      unless @zip_code_routing.present?
+        flash[:error] = I18n.t("hub.zip_codes.not_found")
+        redirect_to request.referrer and return
+      end
+      @zip_code_routing.destroy!
+
+      respond_to do |format|
+        format.js
+      end
+    end
+
+    def form_class
+      ZipCodeRoutingForm
+    end
+
+    def permitted_params
+      params.require(form_class.form_param).permit(:zip_code)
+    end
+  end
+end

--- a/app/controllers/hub/zip_codes_controller.rb
+++ b/app/controllers/hub/zip_codes_controller.rb
@@ -2,13 +2,15 @@ module Hub
   class ZipCodesController < ApplicationController
     include AccessControllable
     before_action :require_sign_in
+    authorize_resource :vita_partner_zip_code
     authorize_resource :vita_partner, parent: false, only: :create
 
     def create
       vita_partner = VitaPartner.find(params[:vita_partner_id])
       @form = ZipCodeRoutingForm.new(vita_partner, permitted_params)
       if @form.valid?
-        @form.save
+        @form.save!
+        @success_message = I18n.t("hub.zip_codes.success", code: @form.zip_code, name: vita_partner.name)
       else
         flash.now[:alert] = @form.error_summary
       end

--- a/app/forms/hub/source_params_form.rb
+++ b/app/forms/hub/source_params_form.rb
@@ -13,9 +13,8 @@ module Hub
 
     end
 
-    def save
-      @source_param.save
-      @source_param
+    def save!
+      @source_param.save!
     end
 
     def vita_partner_id

--- a/app/forms/hub/source_params_form.rb
+++ b/app/forms/hub/source_params_form.rb
@@ -1,0 +1,38 @@
+module Hub
+  class SourceParamsForm < Form
+    attr_accessor :code
+    attr_accessor :vita_partner
+    delegate :edit_hub_organization_path, :edit_hub_site_path, to: 'Rails.application.routes.url_helpers'
+
+    validate :unused_code
+
+    def initialize(vita_partner, form_params = nil)
+      @vita_partner = vita_partner
+      @params = form_params
+      @source_param = vita_partner.source_parameters.new(@params)
+
+    end
+
+    def save
+      @source_param.save
+      @source_param
+    end
+
+    def vita_partner_id
+      vita_partner.id
+    end
+
+    def unused_code
+      existing = SourceParameter.includes(:vita_partner).find_by(code: @params[:code])
+      if existing.present?
+        if existing.vita_partner == vita_partner
+          errors.add(:code, I18n.t("hub.source_params.already_applied", code: existing.code))
+        else
+          params = { anchor: "source-params-form", id: existing.vita_partner.id }
+          path = existing.vita_partner.organization? ? edit_hub_organization_path(params) : edit_hub_site_path(params)
+          errors.add(:code, I18n.t("hub.source_params.already_taken", vita_partner_name: existing.vita_partner.name, vita_partner_path: path, code: existing.code))
+        end
+      end
+    end
+  end
+end

--- a/app/forms/hub/zip_code_routing_form.rb
+++ b/app/forms/hub/zip_code_routing_form.rb
@@ -14,9 +14,8 @@ module Hub
 
     end
 
-    def save
-      @serviced_zip_code.save
-      @serviced_zip_code
+    def save!
+      @serviced_zip_code.save!
     end
 
     def vita_partner_id

--- a/app/forms/hub/zip_code_routing_form.rb
+++ b/app/forms/hub/zip_code_routing_form.rb
@@ -1,0 +1,44 @@
+module Hub
+  class ZipCodeRoutingForm < Form
+    attr_accessor :zip_code
+    attr_accessor :vita_partner
+    delegate :edit_hub_organization_path, :edit_hub_site_path, to: 'Rails.application.routes.url_helpers'
+
+    validate :unused_zipcode
+    validate :valid_serviced_zip_code
+
+    def initialize(vita_partner, form_params = nil)
+      @vita_partner = vita_partner
+      @params = form_params
+      @serviced_zip_code = vita_partner.serviced_zip_codes.new(@params)
+
+    end
+
+    def save
+      @serviced_zip_code.save
+      @serviced_zip_code
+    end
+
+    def vita_partner_id
+      vita_partner.id
+    end
+
+    def unused_zipcode
+      existing = VitaPartnerZipCode.includes(:vita_partner).find_by(zip_code: @params[:zip_code])
+      if existing.present?
+        if existing.vita_partner == vita_partner
+          errors.add(:zip_code, I18n.t("hub.zip_codes.already_applied", zip_code: existing.zip_code))
+        else
+          params = { anchor: "zip-code-routing-form", id: existing.vita_partner.id }
+          path = existing.vita_partner.organization? ? edit_hub_organization_path(params) : edit_hub_site_path(params)
+          errors.add(:zip_code, I18n.t("hub.zip_codes.already_taken", vita_partner_name: existing.vita_partner.name, vita_partner_path: path, zip_code: existing.zip_code))
+        end
+      end
+    end
+
+    def valid_serviced_zip_code
+      return if errors[:zip_code].present?
+      errors.merge!(@serviced_zip_code.errors) unless @serviced_zip_code.valid?
+    end
+  end
+end

--- a/app/javascript/packs/application.js.erb
+++ b/app/javascript/packs/application.js.erb
@@ -24,6 +24,5 @@ ActiveStorage.start();
 import "../lib/honeycrisp";
 
 // *
-
 AjaxMixpanelEvents.init();
 Listeners.init();

--- a/app/models/vita_partner_zip_code.rb
+++ b/app/models/vita_partner_zip_code.rb
@@ -22,9 +22,13 @@ class VitaPartnerZipCode < ApplicationRecord
   validate :record_of_zip_code
   validates :zip_code, uniqueness: true
 
+  def city_state
+    ZipCodes.details(zip_code)[:name]
+  end
+
   private
 
   def record_of_zip_code
-    errors.add(:zip_code, "No record of zip code") unless ZipCodes.has_key?(zip_code)
+    errors.add(:zip_code, "#{zip_code} is not a valid US zip code.") unless ZipCodes.has_key?(zip_code)
   end
 end

--- a/app/views/hub/clients/organizations/edit.html.erb
+++ b/app/views/hub/clients/organizations/edit.html.erb
@@ -8,7 +8,9 @@
     <%= form_with model: @client, url: organization_hub_client_path(id: @client.id), local: true, method: :patch, builder: VitaMinFormBuilder do |f|%>
 
       <%= f.cfa_select(:vita_partner_id, t("general.organization"), grouped_vita_partner_options) %>
-      <%= f.submit t("general.save"), class: "button button--primary" %>
+      <div>
+        <%= f.submit t("general.save"), class: "button button--primary" %>
+      </div>
     <% end %>
   </div>
 <% end %>

--- a/app/views/hub/organizations/_edit_organization.html.erb
+++ b/app/views/hub/organizations/_edit_organization.html.erb
@@ -1,21 +1,19 @@
-<div class="grid">
-<div class="grid--item width-one-half">
-  <%= f.cfa_input_field :name, t("general.name") %>
-  <%= f.cfa_select :coalition_id, t("general.coalition"), @coalitions.map { |c| [c.name, c.id] }, include_blank: true %>
-  <%= f.cfa_select(:timezone, t("general.timezone"), timezone_select_options) %>
-  <div class="grid-flex center-aligned">
-    <div class="item-15r">
-      <%= f.cfa_input_field :capacity_limit, t("general.capacity_limit"), classes: ["form-width--short"] %>
-    </div>
-
-    <div class="item spacing-below-10">
-      <div class="tooltip" data-position="right" title="<%= t('hub.organizations.form.excludes') %>">
-        <strong><%= @organization&.organization_capacity&.active_client_count || 0 %></strong> <%= t('hub.organizations.form.active_clients') %>
-      </div>
-    </div>
+<%= f.cfa_input_field :name, t("general.name") %>
+<%= f.cfa_select :coalition_id, t("general.coalition"), @coalitions.map { |c| [c.name, c.id] }, include_blank: true %>
+<%= f.cfa_select(:timezone, t("general.timezone"), timezone_select_options) %>
+<div class="grid-flex center-aligned">
+  <div class="item-15r">
+    <%= f.cfa_input_field :capacity_limit, t("general.capacity_limit"), classes: ["form-width--short"] %>
   </div>
 
-  <%= f.hub_checkbox(:allows_greeters, t('hub.organizations.form.allows_greeters'), options: { checked_value: true, unchecked_value: false, **local_assigns[:additional_options] }) %>
+  <div class="item spacing-below-10">
+    <div class="tooltip" data-position="right" title="<%= t('hub.organizations.form.excludes') %>">
+      <strong><%= @organization&.organization_capacity&.active_client_count || 0 %></strong> <%= t('hub.organizations.form.active_clients') %>
+    </div>
+  </div>
 </div>
 
+<%= f.hub_checkbox(:allows_greeters, t('hub.organizations.form.allows_greeters'), options: { checked_value: true, unchecked_value: false, **local_assigns[:additional_options] }) %>
+<div>
+  <%= f.submit t("general.save"), class: "button button--primary button--wide" %>
 </div>

--- a/app/views/hub/organizations/edit.html.erb
+++ b/app/views/hub/organizations/edit.html.erb
@@ -19,13 +19,17 @@
         </div>
 
         <hr/>
+        <% if can? :create, VitaPartnerZipCode %>
+          <div id="zip-code-routing-form">
+            <%= render "hub/zip_codes/form", form: @routing_form %>
+          </div>
+          <hr/>
+        <% end %>
 
-        <div id="zip-code-routing-form">
-          <%= render "hub/zip_codes/form", form: @routing_form %>
-        </div>
-
-        <hr/>
         <h2><%= t("general.sites") %></h2>
+        <div class="spacing-below-25">
+          <%= link_to t("hub.sites.new.title"), new_hub_site_path(parent_organization_id: @organization), class: "button button--cta"%>
+        </div>
         <% if @organization.child_sites.exists? %>
           <ul class="organization-list">
             <% @organization.child_sites.map do |site| %>
@@ -38,9 +42,7 @@
           </div>
 
         <% end %>
-        <div>
-          <%= link_to t("hub.sites.new.title"), new_hub_site_path(parent_organization_id: @organization), class: "button button--cta button--wide text--centered"%>
-        </div>
+
       </div>
     </div>
   </section>

--- a/app/views/hub/organizations/edit.html.erb
+++ b/app/views/hub/organizations/edit.html.erb
@@ -3,41 +3,45 @@
 <% content_for :card do %>
   <section class="slab slab--padded">
     <%= link_to t("general.all_organizations"), hub_organizations_path %>
+    <div class="grid">
+      <div class="grid--item width-one-half">
+        <%= form_with model: @organization, url: hub_organization_path, method: :put, local: true, builder: VitaMinFormBuilder, id: "organization-form" do |f| %>
+          <h1 class="form-card__title">
+            <%= @title %>
+          </h1>
 
-    <%= form_with model: @organization, url: hub_organization_path, method: :put, local: true, builder: VitaMinFormBuilder do |f| %>
-      <h1 class="form-card__title">
-        <%= @title %>
-      </h1>
+          <%= render "hub/organizations/edit_organization", f: f, additional_options: {} %>
+        <% end %>
+        <hr/>
 
-      <%= render "hub/organizations/edit_organization", f: f, additional_options: {} %>
+        <div id="source-params-form">
+          <%= render "hub/source_params/form", form: @source_params_form %>
+        </div>
 
-      <% @organization.source_parameters.each do |source_parameter| %>
-        <%= f.fields_for :source_parameters, source_parameter, builder: VitaMinFormBuilder do |source_parameter_form| %>
-          <div class="inline-form-items-wrapper">
-            <%= source_parameter_form.cfa_input_field :code, t("general.unique_link"), classes: ["form-width--short"] %>
-            <%= source_parameter_form.hub_checkbox(:_destroy, t("general.remove")) %>
+        <hr/>
+
+        <div id="zip-code-routing-form">
+          <%= render "hub/zip_codes/form", form: @routing_form %>
+        </div>
+
+        <hr/>
+        <h2><%= t("general.sites") %></h2>
+        <% if @organization.child_sites.exists? %>
+          <ul class="organization-list">
+            <% @organization.child_sites.map do |site| %>
+              <li><h3 class="spacing-below-0"><%= link_to site.name, edit_hub_site_path(id: site) %></h3></li>
+            <% end %>
+          </ul>
+        <% else %>
+          <div class="spacing-below-25">
+            <%= t("hub.organizations.no_sites") %>
           </div>
+
         <% end %>
-      <% end %>
-
-      <%= f.fields_for :source_parameters, @organization.source_parameters.build do |source_parameter_form| %>
-        <%= source_parameter_form.cfa_input_field :code, t("general.new_unique_link"), classes: ["form-width--short"] %>
-      <% end %>
-
-      <button class="button button--primary button--wide" type="submit">
-        <%= t("general.save") %>
-      </button>
-      <hr />
-      <h2><%= t("general.sites") %></h2>
-      <%= link_to t("hub.sites.new.title"), new_hub_site_path(parent_organization_id: @organization), class: "button button--cta" %>
-
-      <% if @organization.child_sites.exists? %>
-        <% @organization.child_sites.map do |site| %>
-          <h3><%= link_to site.name, edit_hub_site_path(parent_organization_id: @organization, id: site) %></h3>
-        <% end %>
-      <% else %>
-        <%= t("hub.organizations.no_sites") %>
-      <% end %>
-    <% end %>
+        <div>
+          <%= link_to t("hub.sites.new.title"), new_hub_site_path(parent_organization_id: @organization), class: "button button--cta button--wide text--centered"%>
+        </div>
+      </div>
+    </div>
   </section>
 <% end %>

--- a/app/views/hub/organizations/new.html.erb
+++ b/app/views/hub/organizations/new.html.erb
@@ -1,7 +1,7 @@
 <% @title = t(".title") %>
 <% content_for :page_title, @title %>
 <% content_for :card do %>
-  <div class="hub-form">
+  <div class="slab slab--padded">
     <%= form_with model: @organization, url: hub_organizations_path, method: :post, local: true, builder: VitaMinFormBuilder do |f| %>
       <h1 class="form-card__title">
         <%= @title %>
@@ -9,9 +9,6 @@
 
       <%= render "hub/organizations/edit_organization", f: f, additional_options: { checked: "checked" } %>
 
-      <button class="button button--primary button--wide" type="submit">
-        <%= t("general.save") %>
-      </button>
     <% end %>
   </div>
 <% end %>

--- a/app/views/hub/sites/_form.html.erb
+++ b/app/views/hub/sites/_form.html.erb
@@ -1,4 +1,5 @@
-  <%= form_with model: @site, url: url, method: http_method, local: true, builder: VitaMinFormBuilder do |f| %>
+<div>
+  <%= form_with model: @site, url: url, method: http_method, local: true, builder: VitaMinFormBuilder, id: "site-form" do |f| %>
     <h1 class="form-card__title">
       <%= @title %>
     </h1>
@@ -6,24 +7,8 @@
     <%= f.cfa_input_field :name, t("general.name") %>
     <%= f.cfa_select :parent_organization_id, t("general.organization"), @organizations.map { |c| [c.name, c.id] } %>
     <%= f.cfa_select(:timezone, t("general.timezone"), timezone_select_options) %>
-
-    <% if @show_unique_links %>
-      <% @site.source_parameters.each do |source_parameter| %>
-        <%= f.fields_for :source_parameters, source_parameter, builder: VitaMinFormBuilder do |source_parameter_form| %>
-          <div class="inline-form-items-wrapper no-bottom-margin-children">
-            <%= source_parameter_form.cfa_input_field :code, t("general.unique_link"), classes: ["form-width--short"] %>
-            <%= source_parameter_form.cfa_checkbox(:_destroy, t("general.remove")) %>
-          </div>
-        <% end %>
-      <% end %>
-
-      <%= f.fields_for :source_parameters, @site.source_parameters.build do |source_parameter_form| %>
-        <%= source_parameter_form.cfa_input_field :code, t("general.new_unique_link"), classes: ["form-width--short"] %>
-      <% end %>
-    <% end %>
-
-    <button class="button button--primary button--wide" type="submit">
-      <%= t("general.save") %>
-    </button>
+    <div>
+      <%= f.submit t("general.save"), class: "button button--primary button--wide" %>
+    </div>
   <% end %>
 </div>

--- a/app/views/hub/sites/edit.html.erb
+++ b/app/views/hub/sites/edit.html.erb
@@ -1,8 +1,26 @@
 <% @title = @site.name %>
 <% content_for :page_title, @title %>
 <% content_for :card do %>
-  <section class="slab slab--padded honeycrisp-compact">
+  <section class="slab slab--padded">
     <%= link_to(@site.parent_organization.name, edit_hub_organization_path(id: @site.parent_organization)) %>
-    <%= render "form", url: hub_site_path(id: @site), http_method: :put %>
+    <div class="grid">
+      <div class="grid--item width-one-half">
+        <div>
+          <%= render "form", url: hub_site_path(id: @site.id), http_method: :patch %>
+        </div>
+      </div>
+    </div>
+
+    <hr/>
+
+    <div id="source-params-form">
+      <%= render "hub/source_params/form", form: @source_params_form %>
+    </div>
+
+    <hr/>
+
+    <div id="zip-code-routing-form">
+      <%= render "hub/zip_codes/form", form: @routing_form %>
+    </div>
   </section>
 <% end %>

--- a/app/views/hub/sites/edit.html.erb
+++ b/app/views/hub/sites/edit.html.erb
@@ -5,22 +5,23 @@
     <%= link_to(@site.parent_organization.name, edit_hub_organization_path(id: @site.parent_organization)) %>
     <div class="grid">
       <div class="grid--item width-one-half">
-        <div>
-          <%= render "form", url: hub_site_path(id: @site.id), http_method: :patch %>
+        <%= render "form", url: hub_site_path(id: @site.id), http_method: :patch %>
+
+        <hr/>
+
+        <div id="source-params-form">
+          <%= render "hub/source_params/form", form: @source_params_form %>
         </div>
+
+        <hr/>
+        <% if can? :create, VitaPartnerZipCode %>
+          <div id="zip-code-routing-form">
+            <%= render "hub/zip_codes/form", form: @routing_form %>
+          </div>
+        <% end %>
       </div>
     </div>
 
-    <hr/>
 
-    <div id="source-params-form">
-      <%= render "hub/source_params/form", form: @source_params_form %>
-    </div>
-
-    <hr/>
-
-    <div id="zip-code-routing-form">
-      <%= render "hub/zip_codes/form", form: @routing_form %>
-    </div>
   </section>
 <% end %>

--- a/app/views/hub/sites/new.html.erb
+++ b/app/views/hub/sites/new.html.erb
@@ -1,7 +1,11 @@
 <% @title = t(".title") %>
 <% content_for :page_title, @title %>
 <% content_for :card do %>
-  <div class="hub-form">
-    <%= render "hub/sites/form", url: hub_sites_path(parent_organization_id: @organization), http_method: :post %>
+  <div class="slab slab--padded">
+    <div class="grid">
+      <div class="grid-item width-one-half">
+        <%= render "hub/sites/form", url: hub_sites_path(parent_organization_id: @organization), http_method: :post %>
+      </div>
+    </div>
   </div>
 <% end %>

--- a/app/views/hub/source_params/_form.html.erb
+++ b/app/views/hub/source_params/_form.html.erb
@@ -1,7 +1,7 @@
 <h2>Unique Links</h2>
 
 <% if @success_message %>
-  <p aria-live="assertive" class="sr-only"><%= @success %></p>
+  <p aria-live="assertive" class="sr-only"><%= @success_message %></p>
 <% end %>
 
 <ul class="organization-list">

--- a/app/views/hub/source_params/_form.html.erb
+++ b/app/views/hub/source_params/_form.html.erb
@@ -1,0 +1,24 @@
+<h2>Unique Links</h2>
+
+<% if @success_message %>
+  <p aria-live="assertive" class="sr-only"><%= @success %></p>
+<% end %>
+
+<ul class="organization-list">
+  <% form.vita_partner.source_parameters.each do |sp| %>
+    <% next unless sp.id.present? %>
+    <li id="<%= "source-param-#{sp.id}" %>">
+      <%= sp.code %>
+      <%= link_to t("general.delete"), hub_source_param_path(id: sp.id), method: :delete, remote: true, "data-confirm": I18n.t("hub.source_params.confirm", code: sp.code, name: form.vita_partner.name), class: "button button--small spacing-below-0" %>
+    </li>
+  <% end %>
+</ul>
+
+<%= form_with model: form, url: hub_source_params_path(vita_partner_id: form.vita_partner_id), builder: VitaMinFormBuilder do |f| %>
+  <div>
+    <%= f.cfa_input_field :code, "Unique link", classes: ["form-width--short"] %>
+    <div>
+      <%= f.submit t("general.save"), class: "button button--cta button--wide" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/hub/source_params/create.js.erb
+++ b/app/views/hub/source_params/create.js.erb
@@ -1,0 +1,1 @@
+$("#source-params-form").html("<%= escape_javascript render "hub/source_params/form", form: @form %>")

--- a/app/views/hub/source_params/destroy.js.erb
+++ b/app/views/hub/source_params/destroy.js.erb
@@ -1,0 +1,5 @@
+<% if @error_message.present? %>
+  alert("<%= @error_message %>");
+<% else %>
+  $("#source-param-<%= @source_param.id %>").hide();
+<% end %>

--- a/app/views/hub/zip_codes/_form.html.erb
+++ b/app/views/hub/zip_codes/_form.html.erb
@@ -1,6 +1,6 @@
 <h2>Zip Code Routing</h2>
 <% if @success_message %>
-  <p aria-live="assertive" class="sr-only"><%= @success %></p>
+  <p aria-live="assertive" class="sr-only"><%= @success_message %></p>
 <% end %>
 
 <ul class="organization-list">

--- a/app/views/hub/zip_codes/_form.html.erb
+++ b/app/views/hub/zip_codes/_form.html.erb
@@ -1,0 +1,23 @@
+<h2>Zip Code Routing</h2>
+<% if @success_message %>
+  <p aria-live="assertive" class="sr-only"><%= @success %></p>
+<% end %>
+
+<ul class="organization-list">
+  <% form.vita_partner.serviced_zip_codes.each do |szc| %>
+  <% next unless szc.id.present? %>
+    <li id="<%= "zip-code-routing-rule-#{szc.id}" %>">
+      <%= szc.zip_code %> <%= szc.city_state %>
+      <%= link_to t("general.delete"), hub_zip_code_path(id: szc.id), method: :delete, remote: true, "data-confirm": I18n.t("hub.zip_codes.confirm", code: szc.zip_code, name: form.vita_partner.name), class: "button button--small spacing-below-0" %>
+    </li>
+  <% end %>
+</ul>
+
+<%= form_with model: form, url: hub_zip_codes_path(vita_partner_id: form.vita_partner_id), builder: VitaMinFormBuilder do |f| %>
+  <div>
+    <%= f.cfa_input_field :zip_code, "Zip code", classes: ["form-width--short"] %>
+    <div>
+      <%= f.submit t("general.save"), class: "button button--cta button--wide" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/hub/zip_codes/create.js.erb
+++ b/app/views/hub/zip_codes/create.js.erb
@@ -1,0 +1,1 @@
+$("#zip-code-routing-form").html("<%= escape_javascript render "hub/zip_codes/form", form: @form %>")

--- a/app/views/hub/zip_codes/destroy.js.erb
+++ b/app/views/hub/zip_codes/destroy.js.erb
@@ -1,0 +1,5 @@
+<% if @error_message.present? %>
+  alert("<%= @error_message %>");
+<% else %>
+  $("#zip-code-routing-rule-<%= @zip_code_routing.id %>").hide();
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,7 @@ en:
       already_taken: "%{zip_code} is already routed to <a href=%{vita_partner_path}>%{vita_partner_name}</a>."
       already_applied: "%{zip_code} is already routed to this partner."
       not_found: Zip code not found. Try again.
+      success: Added %{code} to %{name}.
       confirm: Are you sure you want to delete %{code} from %{name}?
     source_params:
       already_taken: "%{code} is already in use by <a href=%{vita_partner_path}>%{vita_partner_name}</a>."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,6 +13,17 @@ en:
       return_to_profile: Return to Profile
       my_clients: My Clients
       my_profile: My Profile
+    zip_codes:
+      already_taken: "%{zip_code} is already routed to <a href=%{vita_partner_path}>%{vita_partner_name}</a>."
+      already_applied: "%{zip_code} is already routed to this partner."
+      not_found: Zip code not found. Try again.
+      confirm: Are you sure you want to delete %{code} from %{name}?
+    source_params:
+      already_taken: "%{code} is already in use by <a href=%{vita_partner_path}>%{vita_partner_name}</a>."
+      already_applied: "%{code} is already applied to this partner."
+      not_found: Source param not found. Try again.
+      success: Added unique link %{code} to %{name}.
+      confirm: Are you sure you want to delete %{code} from %{name}?
     users:
       edit:
         delete_confirmation: "Are you sure you want to delete %{name}'s account?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,13 +16,11 @@ en:
     zip_codes:
       already_taken: "%{zip_code} is already routed to <a href=%{vita_partner_path}>%{vita_partner_name}</a>."
       already_applied: "%{zip_code} is already routed to this partner."
-      not_found: Zip code not found. Try again.
       success: Added %{code} to %{name}.
       confirm: Are you sure you want to delete %{code} from %{name}?
     source_params:
       already_taken: "%{code} is already in use by <a href=%{vita_partner_path}>%{vita_partner_name}</a>."
       already_applied: "%{code} is already applied to this partner."
-      not_found: Source param not found. Try again.
       success: Added unique link %{code} to %{name}.
       confirm: Are you sure you want to delete %{code} from %{name}?
     users:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -17,6 +17,7 @@ es:
       already_taken: "%{zip_code} ya está enrutado a <a href=%{vita_partner_path}>%{vita_partner_name}</a>."
       already_applied: "%{zip_code} ya está enrutado a este socio."
       not_found: Código postal no encontrado. Intentar otra vez.
+      success: Se agregó %{code} a %{name}.
       confirm: ¿Estás segura de que quieres eliminar? %{code} de %{name}?
     source_params:
       already_taken: "%{code} ya está siendo utilizado por <a href=%{vita_partner_path}>%{vita_partner_name}</a>."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -16,13 +16,11 @@ es:
     zip_codes:
       already_taken: "%{zip_code} ya está enrutado a <a href=%{vita_partner_path}>%{vita_partner_name}</a>."
       already_applied: "%{zip_code} ya está enrutado a este socio."
-      not_found: Código postal no encontrado. Intentar otra vez.
       success: Se agregó %{code} a %{name}.
       confirm: ¿Estás segura de que quieres eliminar? %{code} de %{name}?
     source_params:
       already_taken: "%{code} ya está siendo utilizado por <a href=%{vita_partner_path}>%{vita_partner_name}</a>."
       already_applied: "%{code} ya se aplicó a este socio."
-      not_found: No se encontró el parámetro de origen. Intentar otra vez.
       success: Se agregó un enlace único %{code} a %{name}.
       confirm: ¿Estás segura de que quieres eliminar? %{code} de %{name}?
     users:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -13,6 +13,17 @@ es:
       return_to_profile: Volver al Perfil
       my_clients: Mis Clientes
       my_profile: Mi Perfil
+    zip_codes:
+      already_taken: "%{zip_code} ya está enrutado a <a href=%{vita_partner_path}>%{vita_partner_name}</a>."
+      already_applied: "%{zip_code} ya está enrutado a este socio."
+      not_found: Código postal no encontrado. Intentar otra vez.
+      confirm: ¿Estás segura de que quieres eliminar? %{code} de %{name}?
+    source_params:
+      already_taken: "%{code} ya está siendo utilizado por <a href=%{vita_partner_path}>%{vita_partner_name}</a>."
+      already_applied: "%{code} ya se aplicó a este socio."
+      not_found: No se encontró el parámetro de origen. Intentar otra vez.
+      success: Se agregó un enlace único %{code} a %{name}.
+      confirm: ¿Estás segura de que quieres eliminar? %{code} de %{name}?
     users:
       edit:
         delete_confirmation: "¿Desea eliminar la cuenta de %{name}?"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -179,6 +179,9 @@ Rails.application.routes.draw do
         put "/:client_selection_id/change-organization", to: "change_organization#update", as: :update_change_organization
       end
 
+      resources :zip_codes, only: [:create, :destroy]
+      resources :source_params, only: [:create, :destroy]
+
       resources :tax_returns, only: [] do
         patch "update_certification", to: "tax_returns/certifications#update", on: :member
       end

--- a/spec/controllers/hub/organizations_controller_spec.rb
+++ b/spec/controllers/hub/organizations_controller_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Hub::OrganizationsController, type: :controller do
         it "is not found" do
           expect do
             get :show, params: params
-          end.to raise_error(ActiveRecord::RecordNotFound) # in deployment configs, this would be a 404
+          end.to raise_error(ActionController::RoutingError) # in deployment configs, this would be a 404
         end
       end
     end
@@ -143,6 +143,7 @@ RSpec.describe Hub::OrganizationsController, type: :controller do
 
         create :site, parent_organization: organization, name: "Salmon Site"
         create :site, parent_organization: organization, name: "Sea Lion Site"
+        create :vita_partner_zip_code, zip_code: 94606, vita_partner: organization
       end
 
       it "displays a list of existing sites and a link to the site" do
@@ -164,6 +165,15 @@ RSpec.describe Hub::OrganizationsController, type: :controller do
 
           expect(response.body).to include("shortlink1")
           expect(response.body).to include("shortlink2")
+        end
+      end
+
+      context "zip code routings" do
+        it "displays existing routings and prepares the form" do
+          get :edit, params: params
+          expect(response.body).to include "94606 Oakland, California"
+
+          expect(assigns(:routing_form)).to be_an_instance_of Hub::ZipCodeRoutingForm
         end
       end
     end

--- a/spec/controllers/hub/sites_controller_spec.rb
+++ b/spec/controllers/hub/sites_controller_spec.rb
@@ -64,7 +64,10 @@ RSpec.describe Hub::SitesController, type: :controller do
     it_behaves_like :a_get_action_for_admins_only, action: :new
 
     context "as an authenticated admin user" do
-      before { sign_in admin_user }
+      before do
+        create :vita_partner_zip_code, zip_code: 94606, vita_partner: site
+        sign_in admin_user
+      end
 
       it "retrieves the site, a list of organizations, and returns OK" do
         get :edit, params: params
@@ -88,6 +91,16 @@ RSpec.describe Hub::SitesController, type: :controller do
 
           expect(response.body).to include("shortlink1")
           expect(response.body).to include("shortlink2")
+        end
+      end
+
+      context "zip code routings" do
+        render_views
+        it "displays existing routings and prepares the form" do
+          get :edit, params: params
+          expect(response.body).to include "94606 Oakland, California"
+
+          expect(assigns(:routing_form)).to be_an_instance_of Hub::ZipCodeRoutingForm
         end
       end
     end

--- a/spec/controllers/hub/source_params_controller_spec.rb
+++ b/spec/controllers/hub/source_params_controller_spec.rb
@@ -75,19 +75,6 @@ describe Hub::SourceParamsController do
       expect { delete :destroy, params: params }.to raise_error ActionController::UnknownFormat
     end
 
-    context "when the source parameter does not exist" do
-      let(:id) { "fake" }
-
-      before do
-        request.env['HTTP_REFERER'] = "https://www.getyourrefund.org/welcome"
-      end
-
-      it "flashes an error and redirects" do
-        delete :destroy, params: params, format: :js, xhr: true
-        expect(response).to redirect_to "https://www.getyourrefund.org/welcome"
-      end
-    end
-
     context "when the source param exists" do
       let!(:id) { source_parameter.id }
 

--- a/spec/controllers/hub/source_params_controller_spec.rb
+++ b/spec/controllers/hub/source_params_controller_spec.rb
@@ -1,0 +1,101 @@
+require "rails_helper"
+
+describe Hub::SourceParamsController do
+  let(:admin_user) { create :admin_user }
+
+  describe "#create" do
+    let(:vita_partner) { create :organization }
+    let(:code) { "code" }
+    let(:params) do
+      {
+          hub_source_params_form: {
+              code: code
+          },
+          vita_partner_id: vita_partner.id
+      }
+    end
+
+    it_behaves_like :a_post_action_for_authenticated_users_only, action: :create
+
+    context "an authenticated user" do
+      before do
+        sign_in admin_user
+      end
+
+      it "responds with js" do
+        post :create, params: params, format: :js, xhr: true
+        expect(response.media_type).to eq "text/javascript"
+      end
+
+      it "does not respond with html" do
+        expect { post :create, params: params }.to raise_error ActionController::UnknownFormat
+      end
+
+      context "when the code does not already exist" do
+        let(:code) { "koala" }
+        it "creates a new source parameter" do
+          expect {
+            post :create, params: params, format: :js, xhr: true
+          }.to change(vita_partner.source_parameters, :count).by 1
+        end
+      end
+
+      context "when the code already exists" do
+        let(:code) { "koala" }
+        before do
+          create :source_parameter, code: "koala", vita_partner: create(:vita_partner)
+        end
+
+        it "does not make a new source parameter" do
+          expect {
+            post :create, params: params, format: :js, xhr: true
+          }.not_to change(SourceParameter, :count)
+        end
+      end
+    end
+  end
+
+  describe "#destroy" do
+    let(:source_parameter) { create :source_parameter, vita_partner: create(:organization), code: "code" }
+    let(:id) { source_parameter.id }
+    let(:params) do
+      { id: id }
+    end
+
+    before do
+      sign_in admin_user
+    end
+
+    it "responds with js" do
+      delete :destroy, params: params, format: :js, xhr: true
+      expect(response.media_type).to eq "text/javascript"
+    end
+
+    it "does not respond with html" do
+      expect { delete :destroy, params: params }.to raise_error ActionController::UnknownFormat
+    end
+
+    context "when the source parameter does not exist" do
+      let(:id) { "fake" }
+
+      before do
+        request.env['HTTP_REFERER'] = "https://www.getyourrefund.org/welcome"
+      end
+
+      it "flashes an error and redirects" do
+        delete :destroy, params: params, format: :js, xhr: true
+        expect(response).to redirect_to "https://www.getyourrefund.org/welcome"
+      end
+    end
+
+    context "when the source param exists" do
+      let!(:id) { source_parameter.id }
+
+      it "deletes the source parameter" do
+        expect {
+          delete :destroy, params: params, format: :js, xhr: true
+        }.to change(SourceParameter, :count).by(-1)
+      end
+    end
+  end
+end

--- a/spec/controllers/hub/zip_codes_controller_spec.rb
+++ b/spec/controllers/hub/zip_codes_controller_spec.rb
@@ -17,9 +17,9 @@ describe Hub::ZipCodesController do
 
     it_behaves_like :a_post_action_for_authenticated_users_only, action: :create
 
-    context "an authenticated user" do
+    context "an authenticated admin user" do
       before do
-        sign_in admin_user
+        sign_in (create :admin_user)
       end
 
       it "responds with js" do
@@ -48,6 +48,19 @@ describe Hub::ZipCodesController do
           expect {
             post :create, params: params, format: :js, xhr: true
           }.not_to change(VitaPartnerZipCode, :count)
+        end
+      end
+    end
+
+    context "other user types" do
+      describe "when attempting to create" do
+        before do
+          sign_in (create :greeter_user)
+        end
+
+        it "is not authorized" do
+          post :create, params: params, format: :js, xhr: true
+          expect(response.status).to eq 403
         end
       end
     end

--- a/spec/controllers/hub/zip_codes_controller_spec.rb
+++ b/spec/controllers/hub/zip_codes_controller_spec.rb
@@ -1,0 +1,99 @@
+require "rails_helper"
+
+describe Hub::ZipCodesController do
+  let(:admin_user) { create :admin_user }
+
+  describe "#create" do
+    let(:vita_partner) { create :organization }
+    let(:zip_code) { "94121" }
+    let(:params) do
+      {
+          hub_zip_code_routing_form: {
+              zip_code: zip_code
+          },
+          vita_partner_id: vita_partner.id
+      }
+    end
+
+    it_behaves_like :a_post_action_for_authenticated_users_only, action: :create
+
+    context "an authenticated user" do
+      before do
+        sign_in admin_user
+      end
+
+      it "responds with js" do
+        post :create, params: params, format: :js, xhr: true
+        expect(response.media_type).to eq "text/javascript"
+      end
+
+      it "does not respond with html" do
+        expect { post :create, params: params }.to raise_error ActionController::UnknownFormat
+      end
+
+      context "when the code does not already exist" do
+        it "creates a new source parameter" do
+          expect {
+            post :create, params: params, format: :js, xhr: true
+          }.to change(vita_partner.serviced_zip_codes, :count).by 1
+        end
+      end
+
+      context "when the code already exists" do
+        before do
+          create :vita_partner_zip_code, zip_code: zip_code, vita_partner: create(:vita_partner)
+        end
+
+        it "does not make a new source parameter" do
+          expect {
+            post :create, params: params, format: :js, xhr: true
+          }.not_to change(VitaPartnerZipCode, :count)
+        end
+      end
+    end
+  end
+
+  describe "#destroy" do
+    let(:vita_partner_zip_code) { create :vita_partner_zip_code, vita_partner: create(:organization), zip_code: "94121" }
+    let(:id) { vita_partner_zip_code.id }
+    let(:params) do
+      { id: id }
+    end
+
+    before do
+      sign_in admin_user
+    end
+
+    it "responds with js" do
+      delete :destroy, params: params, format: :js, xhr: true
+      expect(response.media_type).to eq "text/javascript"
+    end
+
+    it "does not respond with html" do
+      expect { delete :destroy, params: params }.to raise_error ActionController::UnknownFormat
+    end
+
+    context "when the zip code object does not exist" do
+      let(:id) { "fake" }
+
+      before do
+        request.env['HTTP_REFERER'] = "https://www.getyourrefund.org/welcome"
+      end
+
+      it "flashes an error and redirects" do
+        delete :destroy, params: params, format: :js, xhr: true
+        expect(response).to redirect_to "https://www.getyourrefund.org/welcome"
+      end
+    end
+
+    context "when the zip code object exists" do
+      let!(:id) { vita_partner_zip_code.id }
+
+      it "deletes the zip code object" do
+        expect {
+          delete :destroy, params: params, format: :js, xhr: true
+        }.to change(VitaPartnerZipCode, :count).by(-1)
+      end
+    end
+  end
+end

--- a/spec/controllers/hub/zip_codes_controller_spec.rb
+++ b/spec/controllers/hub/zip_codes_controller_spec.rb
@@ -86,19 +86,6 @@ describe Hub::ZipCodesController do
       expect { delete :destroy, params: params }.to raise_error ActionController::UnknownFormat
     end
 
-    context "when the zip code object does not exist" do
-      let(:id) { "fake" }
-
-      before do
-        request.env['HTTP_REFERER'] = "https://www.getyourrefund.org/welcome"
-      end
-
-      it "flashes an error and redirects" do
-        delete :destroy, params: params, format: :js, xhr: true
-        expect(response).to redirect_to "https://www.getyourrefund.org/welcome"
-      end
-    end
-
     context "when the zip code object exists" do
       let!(:id) { vita_partner_zip_code.id }
 

--- a/spec/features/hub/create_organization_hierarchy_spec.rb
+++ b/spec/features/hub/create_organization_hierarchy_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "create VITA organization hierarchy" do
+RSpec.describe "create VITA organization hierarchy", :js do
   context "as an admin user" do
     let(:admin_user) { create :admin_user }
     before { login_as admin_user }
@@ -28,26 +28,63 @@ RSpec.describe "create VITA organization hierarchy" do
 
       expect(page).to have_text("No sites")
 
-      fill_in "Name", with: "Oregano Org"
-      select "Coati Coalition", from: "Coalition"
-      click_on "Save"
+      within "#organization-form" do
+        fill_in "Name", with: "Oregano Org"
+        select "Coati Coalition", from: "Coalition"
+        click_on "Save"
+      end
       expect(page).to have_selector("h1", text: "Oregano Org")
+
+      # adding / removing zip codes
+      within "#zip-code-routing-form" do
+        fill_in "Zip code", with: "94606"
+        click_on "Save"
+        Capybara.using_wait_time(10) do
+          expect(page).to have_text "94606 Oakland, California"
+        end
+        zip = VitaPartnerZipCode.find_by(zip_code: "94606")
+        within "#zip-code-routing-rule-#{zip.id}" do
+          page.accept_alert "Are you sure you want to delete 94606 from Oregano Org?" do
+            click_on "Delete"
+          end
+        end
+        expect(page).not_to have_text "94606 Oakland, California"
+      end
+
+      # adding / removing unique links
+      within "#source-params-form" do
+        fill_in "Unique link", with: "oregano"
+        click_on "Save"
+        Capybara.using_wait_time(10) do
+          expect(page).to have_text "oregano"
+        end
+        sp = SourceParameter.find_by(code: "oregano")
+        within "#source-param-#{sp.id}" do
+          page.accept_alert "Are you sure you want to delete oregano from Oregano Org?" do
+            click_on "Delete"
+          end
+        end
+        expect(page).not_to have_text "oregano"
+      end
 
       # Add a site to an organization
       click_on "Add site"
       fill_in "Name", with: "Llama Library"
-      click_on "Save"
+      within "#site-form" do
+        click_on "Save"
+      end
 
       expect(page).to have_selector("h1", text: "Oregano Org")
       expect(page).to have_text("Llama Library")
 
       # Update the site
       click_on "Llama Library"
-      fill_in "Name", with: "Lima Bean Library"
-      fill_in "Additional unique link", with: "limabean"
-      click_on "Save"
+      within "#site-form" do
+        fill_in "Name", with: "Lima Bean Library"
+        click_on "Save"
+      end
+
       expect(page).to have_selector("h1", text: "Lima Bean Library")
-      expect(page).to have_selector("input[value='limabean']")
 
       # Navigate to the org
       click_on "Oregano Org"

--- a/spec/features/hub/create_organization_hierarchy_spec.rb
+++ b/spec/features/hub/create_organization_hierarchy_spec.rb
@@ -39,9 +39,7 @@ RSpec.describe "create VITA organization hierarchy", :js do
       within "#zip-code-routing-form" do
         fill_in "Zip code", with: "94606"
         click_on "Save"
-        Capybara.using_wait_time(10) do
-          expect(page).to have_text "94606 Oakland, California"
-        end
+        expect(page).to have_text "94606 Oakland, California"
         zip = VitaPartnerZipCode.find_by(zip_code: "94606")
         within "#zip-code-routing-rule-#{zip.id}" do
           page.accept_alert "Are you sure you want to delete 94606 from Oregano Org?" do
@@ -55,9 +53,7 @@ RSpec.describe "create VITA organization hierarchy", :js do
       within "#source-params-form" do
         fill_in "Unique link", with: "oregano"
         click_on "Save"
-        Capybara.using_wait_time(10) do
-          expect(page).to have_text "oregano"
-        end
+        expect(page).to have_text "oregano"
         sp = SourceParameter.find_by(code: "oregano")
         within "#source-param-#{sp.id}" do
           page.accept_alert "Are you sure you want to delete oregano from Oregano Org?" do

--- a/spec/features/hub/edit_organization_spec.rb
+++ b/spec/features/hub/edit_organization_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "a user editing an organization" do
+RSpec.describe "a user editing an organization", :js do
   context "as an authenticated user" do
     context "as an admin" do
       let(:current_user) { create :admin_user }
@@ -23,8 +23,9 @@ RSpec.describe "a user editing an organization" do
         select "Central Time (US & Canada)", from: "Timezone"
         fill_in "Capacity limit", with: "200"
         check "Allows Greeters"
-
-        click_on "Save"
+        within "#organization-form" do
+          click_on "Save"
+        end
 
         expect(page).to have_text "Changes saved"
 
@@ -32,22 +33,31 @@ RSpec.describe "a user editing an organization" do
         expect(find_field('Capacity limit').value).to eq "200"
         expect(find_field('Allows Greeters').value).to eq "true"
 
-        # Now do the same for the child site
+        within "#zip-code-routing-form" do
+          expect(page).to have_field("Zip code")
+          fill_in "Zip code", with: "94606"
+          click_on "Save"
+          # Now do the same for the child site
+        end
+
 
         click_on "Child Site"
 
-        expect(find_field('Name').value).to eq 'Child Site'
-        expect(page).to_not have_text("Capacity limit")
 
-        expect(page).to have_select("Timezone", selected: "Eastern Time (US & Canada)")
 
-        select "Central Time (US & Canada)", from: "Timezone"
+        within "#site-form" do
+          expect(find_field('Name').value).to eq 'Child Site'
+          expect(page).to_not have_text("Capacity limit")
+          expect(page).to have_select("Timezone", selected: "Eastern Time (US & Canada)")
 
-        click_on "Save"
+          select "Central Time (US & Canada)", from: "Timezone"
 
-        expect(page).to have_text "Changes saved"
+          click_on "Save"
 
-        expect(page).to have_select("Timezone", selected: "Central Time (US & Canada)")
+          expect(page).to have_select("Timezone", selected: "Central Time (US & Canada)")
+
+        end
+
 
       end
     end

--- a/spec/forms/hub/source_params_form_spec.rb
+++ b/spec/forms/hub/source_params_form_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+describe Hub::SourceParamsForm do
+  subject { described_class.new(vita_partner, params) }
+
+  let(:vita_partner) { create :vita_partner }
+  let(:code) { "my_code" }
+  let(:params) do
+    {
+        code: code
+    }
+  end
+  describe "#valid?" do
+    context "when the source parameter is already in use" do
+      context "when the source parameter is" do
+        before do
+          create :source_parameter, vita_partner: vita_partner, code: code
+        end
+
+        it "is invalid with appropriate message" do
+          expect(subject.valid?).to eq false
+          expect(subject.errors[:code]).to include "my_code is already applied to this partner."
+        end
+      end
+
+      context "when it belongs to a different vita partner" do
+        let(:other_vita_partner) { create :vita_partner, name: "Oregano Org" }
+        before do
+          create :source_parameter, vita_partner: other_vita_partner, code: code
+        end
+
+        it "is invalid with appropriate message" do
+          expect(subject.valid?).to eq false
+          expect(subject.errors[:code]).to include "my_code is already in use by <a href=/en/hub/organizations/#{other_vita_partner.id}/edit#source-params-form>Oregano Org</a>."
+        end
+      end
+    end
+
+    context "when the source parameter is unique and valid" do
+      it "is valid" do
+        expect(subject.valid?).to eq true
+      end
+    end
+  end
+
+  describe "#save!" do
+    it "creates a new source parameter for the vita partner" do
+      expect {
+        subject.save!
+      }.to change(vita_partner.source_parameters, :count).by 1
+    end
+  end
+end

--- a/spec/forms/hub/zip_code_routing_form_spec.rb
+++ b/spec/forms/hub/zip_code_routing_form_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+describe Hub::ZipCodeRoutingForm do
+  subject { described_class.new(vita_partner, params) }
+
+  let(:vita_partner) { create :vita_partner }
+  let(:zip_code) { 94606 }
+  let(:params) do
+    {
+        zip_code: zip_code
+    }
+  end
+  describe "#valid?" do
+    context "when the zip code is already in use" do
+      context "when it belongs to current vita partner" do
+        before do
+          create :vita_partner_zip_code, vita_partner: vita_partner, zip_code: zip_code
+        end
+
+        it "is invalid with appropriate message" do
+          expect(subject.valid?).to eq false
+          expect(subject.errors[:zip_code]).to include "94606 is already routed to this partner."
+        end
+      end
+
+      context "when it belongs to a different vita partner" do
+        let(:other_vita_partner) { create :vita_partner, name: "Oregano Org" }
+        before do
+          create :vita_partner_zip_code, vita_partner: other_vita_partner, zip_code: zip_code
+        end
+
+        it "is invalid with appropriate message" do
+          expect(subject.valid?).to eq false
+          expect(subject.errors[:zip_code]).to include "94606 is already routed to <a href=/en/hub/organizations/#{other_vita_partner.id}/edit#zip-code-routing-form>Oregano Org</a>."
+        end
+      end
+
+    end
+
+    context "when the zip code is not valid" do
+      let(:zip_code) { "A2345"}
+      it "is invalid" do
+        expect(subject.valid?).to eq false
+        expect(subject.errors[:zip_code]).to include "A2345 is not a valid US zip code."
+      end
+    end
+
+    context "when the zip code is unique and valid" do
+      it "is valid" do
+        expect(subject.valid?).to eq true
+      end
+    end
+  end
+
+  describe "#save!" do
+    it 'creates a new serviced zip code for the vita partner' do
+      expect {
+        subject.save!
+      }.to change(vita_partner.serviced_zip_codes, :count).by 1
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,10 +13,10 @@ Dir[Rails.root.join("lib/strategies/**/*.rb")].each { |f| require f }
 # Set CHROME=true to run specs with a visible Chrome window
 if ENV.fetch("CHROME", false)
   Capybara.javascript_driver = :selenium_chrome
-  Capybara.default_max_wait_time = 10
 else
   Capybara.javascript_driver = :selenium_chrome_headless
 end
+Capybara.default_max_wait_time = 5
 Capybara.server = :puma, { Silent: true }
 Capybara.server_port = 9887 + ENV['TEST_ENV_NUMBER'].to_i
 


### PR DESCRIPTION
Some notes:

- This PR also refactors the Unique Links to use the same pattern. This is both for UX consistency but also for the practical reason that something about the existing fields_for implementation was causing the feature tests to fail when I was running using `js: true`. 🔍 mysterious!
- For both source params and zip codes, if the param or zip code is in use by another partner, the error message links to the partners page in case a change needs to be made on that other partner.
- Uses js to do the adding / removing because it requires less scrolling AND because this is used for both organizations and sites and handling redirecting back to different locations based on whether the partner is an org or site added complexity to the controllers. I added an `aria-live="assertive"` tag and an sr-only success message to alert screen readers of a newly added object when the form re-renders using javascript.
![2021-04-23 09 41 44](https://user-images.githubusercontent.com/4494389/115887880-fa91e300-a417-11eb-8f57-52706d10f6a2.gif)

![2021-04-23 09 43 32](https://user-images.githubusercontent.com/4494389/115888113-2ad98180-a418-11eb-9163-981905f0a269.gif)
