### PR TITLE
Fix heading hierarchy on homepage

### DIFF
--- a/app/views/public_pages/home.html.erb
+++ b/app/views/public_pages/home.html.erb
@@ -49,7 +49,7 @@
   <div class="slab slab--info-section">
     <div class="grid">
       <div class="grid__item width-one-whole">
-        <h3 class="spacing-below-0"><%= t("views.public_pages.home.stimulus_banner.heading") %></h3>
+        <h2 class="h3 spacing-below-0"><%= t("views.public_pages.home.stimulus_banner.heading") %></h2>
       </div>
       <div class="grid__item width-one-whole">
         <ul>
@@ -103,7 +103,7 @@
 
   <div class="slab slab--partners">
     <div class="grid">
-      <h3 class="text--centered"><%= t("views.public_pages.home.partners.header") %></h3>
+      <h2 class="h3 text--centered"><%= t("views.public_pages.home.partners.header") %></h2>
       <ul class="partner-logos">
         <%= render(
                 "shared/grayscale_partner_logo",
@@ -176,7 +176,7 @@
   <div class="slab slab--secondary-cta">
     <div class="grid">
       <div class="grid__item width-three-fourths cta-text">
-        <h3 class="spacing-below-0"><%= t("views.public_pages.home.features.header") %></h3>
+        <h2 class="h3 spacing-below-0"><%= t("views.public_pages.home.features.header") %></h2>
         <ul class="list--bulleted text--small text--semibold">
           <li class="spacing-below-0"><%= t("views.public_pages.home.features.free") %></li>
           <li class="spacing-below-0"><%= t("views.public_pages.home.features.chat") %></li>
@@ -197,7 +197,7 @@
       <div class="grid__item width-one-whole">
         <div><%= image_tag("lock-gear.svg", alt: "a padlock icon") %></div>
         <div>
-          <h4 class="spacing-below-5"><%= t("views.public_pages.home.security.header") %></h4>
+          <h2 class="h4 spacing-below-5"><%= t("views.public_pages.home.security.header") %></h2>
           <p class="text--small spacing-below-0"><%= t("views.public_pages.home.security.body") %></p>
         </div>
       </div>


### PR DESCRIPTION
not 100% certain that turning each slab heading into an h2 was the right move but:
- my WAVE plugin no longer has the alert for the skipped heading
- the homepage looks exactly the way it did before