### PR TITLE
Add foreign student certification to certification options

### DIFF
--- a/app/assets/stylesheets/components/_tax-return-list.scss
+++ b/app/assets/stylesheets/components/_tax-return-list.scss
@@ -102,7 +102,18 @@
     flex-grow: 0;
     flex-shrink: 0;
     width: 175px;
-
+    a.current-assignee {
+      display: block;
+      overflow-x: auto;
+      text-overflow: ellipsis;
+      text-decoration: none;
+      line-height: $font-size-18;
+      -ms-overflow-style: none;
+      scrollbar-width: none;
+      &::-webkit-scrollbar {
+        display: none;
+      }
+    }
     a.button { // assign button
       display: inline;
     }

--- a/app/assets/stylesheets/components/_tax-return-list.scss
+++ b/app/assets/stylesheets/components/_tax-return-list.scss
@@ -83,35 +83,30 @@
       justify-content: flex-end;
       align-items: center;
       position: absolute;
-      top: -18px;
+      top: -29px;
       margin: 0;
     }
 
     .offset-label {
       position: absolute;
-      top: -24px;
+      top: -25px;
       font-size: $font-size-18;
       font-weight: bold;
       left: 0;
     }
   }
 
-  &__assignee {
+  &__assignee, &__certification {
     font-size: 1.4rem;
     margin-right: 1.25rem;
     flex-grow: 0;
     flex-shrink: 0;
     width: 175px;
-    a {
-      display: block;
-      overflow: auto;
-      text-overflow: ellipsis;
-      text-decoration: none;
-      line-height: $font-size-18;
-    }
-    a.button {
+
+    a.button { // assign button
       display: inline;
     }
+
     .button {
       margin-right: 0;
     }

--- a/app/models/tax_return.rb
+++ b/app/models/tax_return.rb
@@ -42,7 +42,7 @@ class TaxReturn < ApplicationRecord
   has_many :assignments, class_name: "TaxReturnAssignment", dependent: :destroy
 
   enum status: TaxReturnStatus::STATUSES, _prefix: :status
-  enum certification_level: { advanced: 1, basic: 2 }
+  enum certification_level: { advanced: 1, basic: 2, foreign_student: 3 }
   enum service_type: { online_intake: 0, drop_off: 1 }, _prefix: :service_type
   validates :year, presence: true
 

--- a/app/views/hub/tax_returns/_assignee.html.erb
+++ b/app/views/hub/tax_returns/_assignee.html.erb
@@ -1,5 +1,5 @@
 <% if tax_return.assigned_user.present? %>
-  <%= link_to edit_hub_tax_return_path(id: tax_return.id), remote: true do %>
+  <%= link_to edit_hub_tax_return_path(id: tax_return.id), class: 'current-assignee', remote: true do %>
     <%= tax_return.assigned_user&.name %>
   <% end %>
 <% else %>

--- a/app/views/shared/_tax_return_certification_form.html.erb
+++ b/app/views/shared/_tax_return_certification_form.html.erb
@@ -1,16 +1,18 @@
-<%= form_with class: tax_return, url: update_certification_hub_tax_return_path(id: tax_return.id), local: true, method: :patch, builder: VitaMinFormBuilder, html: { class: "tax-return-inline-form" } do |f| %>
-  <div class="before">
-    <%= link_to "Cancel", url_for(:locale => params[:locale]) %>
-  </div>
-  <label for="certification_level">
-    <div class="offset-label"><%= t("general.certification") %></div>
-    <%= f.select :certification_level, certification_options_for_select, include_blank: true, selected: tax_return.certification_level %>
-  </label>
-  <%= hidden_field_tag :next, request.path.split("?")[0] %>
-  <div>
-    <%= f.button :submit do %>
-      <span class="sr-only"><%= t("general.save") %></span>
-      <%= image_tag("checkmark.svg", alt: "") %>
-    <% end %>
-  </div>
-<% end %>
+<div role="alert">
+  <%= form_with class: tax_return, url: update_certification_hub_tax_return_path(id: tax_return.id), local: true, method: :patch, builder: VitaMinFormBuilder, html: { class: "tax-return-inline-form" } do |f| %>
+    <div class="before">
+      <%= link_to "Cancel", url_for(:locale => params[:locale]) %>
+    </div>
+    <label for="certification_level">
+      <div class="offset-label"><%= t("general.certification") %></div>
+      <%= f.select :certification_level, certification_options_for_select, include_blank: true, selected: tax_return.certification_level %>
+    </label>
+    <%= hidden_field_tag :next, request.path.split("?")[0] %>
+    <div>
+      <%= f.button :submit do %>
+        <span class="sr-only"><%= t("general.save") %></span>
+        <%= image_tag("checkmark.svg", alt: "") %>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shared/_tax_return_certification_form.html.erb
+++ b/app/views/shared/_tax_return_certification_form.html.erb
@@ -1,18 +1,16 @@
-<div role="alert">
-  <%= form_with class: tax_return, url: update_certification_hub_tax_return_path(id: tax_return.id), local: true, method: :patch, builder: VitaMinFormBuilder, html: { class: "tax-return-inline-form" } do |f| %>
-    <div class="before">
-      <%= link_to "Cancel", url_for(:locale => params[:locale]) %>
-    </div>
-    <label for="certification_level">
-      <div class="offset-label"><%= t("general.certification") %></div>
-      <%= f.select :certification_level, certification_options_for_select, include_blank: true, selected: tax_return.certification_level %>
-    </label>
-    <%= hidden_field_tag :next, request.path.split("?")[0] %>
-    <div>
-      <%= f.button :submit do %>
-        <span class="sr-only"><%= t("general.save") %></span>
-        <%= image_tag("checkmark.svg", alt: "") %>
-      <% end %>
-    </div>
-  <% end %>
-</div>
+<%= form_with class: tax_return, url: update_certification_hub_tax_return_path(id: tax_return.id), local: true, method: :patch, builder: VitaMinFormBuilder, html: { class: "tax-return-inline-form" } do |f| %>
+  <div class="before">
+    <%= link_to "Cancel", url_for(:locale => params[:locale]) %>
+  </div>
+  <label for="certification_level">
+    <div class="offset-label"><%= t("general.certification") %></div>
+    <%= f.select :certification_level, certification_options_for_select, include_blank: true, selected: tax_return.certification_level %>
+  </label>
+  <%= hidden_field_tag :next, request.path.split("?")[0] %>
+  <div>
+    <%= f.button :submit do %>
+      <span class="sr-only"><%= t("general.save") %></span>
+      <%= image_tag("checkmark.svg", alt: "") %>
+    <% end %>
+  </div>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -862,6 +862,7 @@ en:
     certification_abbrev:
       advanced: "ADV"
       basic: "BAS"
+      foreign_student: "FS"
     hsa: "HSA"
     drop_off: Drop Off
     select_file: Select file

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -852,6 +852,7 @@ es:
     certification_abbrev:
       advanced: "AVA"
       basic: "BAS"
+      foreign_student: "EI"
     hsa: "HSA"
     drop_off: Entrega
     select_file: Seleccionar archivo

--- a/spec/controllers/hub/tax_returns/certifications_controller_spec.rb
+++ b/spec/controllers/hub/tax_returns/certifications_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Hub::TaxReturns::CertificationsController do
     let(:user) { create :organization_lead_user }
     let(:tax_return) { create :tax_return, client: (create :client, vita_partner: user.role.organization) }
     let(:next_path) { "/next/path" }
-    let(:params) { { id: tax_return.id, certification_level: "advanced", next: next_path } }
+    let(:params) { { id: tax_return.id, certification_level: "foreign_student", next: next_path } }
 
     it_behaves_like :a_post_action_for_authenticated_users_only, action: :update
 
@@ -18,7 +18,7 @@ RSpec.describe Hub::TaxReturns::CertificationsController do
         expect {
           patch :update, params: params
           tax_return.reload
-        }.to change(tax_return, :certification_level).to('advanced')
+        }.to change(tax_return, :certification_level).to('foreign_student')
       end
       context "redirecting on success" do
         context "with next param" do

--- a/spec/features/hub/show_client_spec.rb
+++ b/spec/features/hub/show_client_spec.rb
@@ -37,6 +37,11 @@ RSpec.describe "a user viewing a client" do
         click_button("button")
         expect(page).to have_text("BAS")
         expect(page).not_to have_css(".tax-return-inline-form")
+        click_on "BAS"
+        select "Foreign Student", from: "Certification"
+        click_button("button")
+        expect(page).to have_text("FS")
+        expect(page).not_to have_css(".tax-return-inline-form")
       end
     end
   end


### PR DESCRIPTION
<img width="343" alt="Screen Shot 2021-04-27 at 3 19 54 PM" src="https://user-images.githubusercontent.com/4494389/116307405-e7f71100-a76b-11eb-8039-5000a9992dc7.png">
<img width="283" alt="Screen Shot 2021-04-27 at 3 14 39 PM" src="https://user-images.githubusercontent.com/4494389/116306752-17f1e480-a76b-11eb-92c8-5b416eb2d10e.png">
<img width="246" alt="Screen Shot 2021-04-27 at 3 14 44 PM" src="https://user-images.githubusercontent.com/4494389/116306753-188a7b00-a76b-11eb-8a0e-d5d33c4bb6c7.png">
<img width="246" alt="Screen Shot 2021-04-27 at 3 14 44 PM" src="https://user-images.githubusercontent.com/4494389/116307964-8edbad00-a76c-11eb-892d-5adc8d1257c8.png">
<img width="246" alt="Screen Shot 2021-04-27 at 3 14 44 PM" src="https://user-images.githubusercontent.com/4494389/116307966-8edbad00-a76c-11eb-9b9b-d203a163f1c2.png">




There was also a mysterious piece of grey showing up after the cancel link and name in certain circumstances, particularly affecting the cancel link on Firefox -- this is because of the overflow logic for name link wasn't scoped to just that link AND we weren't hiding the scroll bar on overflow.
