### PR TITLE
Preserve visibility of bulk actions "Take Action" button even when user clicks "back"

### DIFF
--- a/app/javascript/lib/bulk_action.js
+++ b/app/javascript/lib/bulk_action.js
@@ -10,6 +10,15 @@ function changeElDisplay(el, property) {
     el.style.display = property;
 }
 
+function handleCheckboxChange(formEl, takeActionCountEl, takeActionFooterEl) {
+    changeCountDisplay(takeActionCountEl, getCheckedNum(formEl));
+    if (getCheckedNum(formEl) >= 1) {
+        changeElDisplay(takeActionFooterEl, "");
+    } else if (getCheckedNum(formEl) === 0) {
+        changeElDisplay(takeActionFooterEl, "none");
+    }
+}
+
 export function initBulkAction() {
     const selectAllEl = document.querySelector('#bulk-edit-select-all');
     const allCheckboxEls = [...document.querySelectorAll("[id^='tr_ids_']")];
@@ -17,28 +26,24 @@ export function initBulkAction() {
     const takeActionFooterEl = document.querySelector('#take-action-footer');
     const takeActionCountEl = document.querySelector('#take-action-count');
 
+    handleCheckboxChange(formEl, takeActionCountEl, takeActionFooterEl);
+
     if (selectAllEl) {
         selectAllEl.addEventListener('change', () => {
             if (selectAllEl.checked) {
-                allCheckboxEls.map(checkboxEl => checkboxEl.checked = true);
-                changeElDisplay(takeActionFooterEl, "");
+                allCheckboxEls.forEach(checkboxEl => checkboxEl.checked = true);
             } else {
-                allCheckboxEls.map(checkboxEl => checkboxEl.checked = false);
-                changeElDisplay(takeActionFooterEl, "none");
+                allCheckboxEls.forEach(checkboxEl => checkboxEl.checked = false);
             }
-            changeCountDisplay(takeActionCountEl, getCheckedNum(formEl));
+
+            handleCheckboxChange(formEl, takeActionCountEl, takeActionFooterEl);
         });
     }
 
     if (allCheckboxEls.length > 0) {
         allCheckboxEls.forEach((el) => {
             el.addEventListener('change', () => {
-                if (el.checked && getCheckedNum(formEl) === 1) {
-                    changeElDisplay(takeActionFooterEl, "");
-                } else if (getCheckedNum(formEl) === 0) {
-                    changeElDisplay(takeActionFooterEl, "none");
-                }
-                changeCountDisplay(takeActionCountEl, getCheckedNum(formEl));
+                handleCheckboxChange(formEl, takeActionCountEl, takeActionFooterEl);
             });
         });
     }

--- a/app/javascript/listeners/index.js
+++ b/app/javascript/listeners/index.js
@@ -13,7 +13,7 @@ import { initBulkAction } from "../lib/bulk_action";
 const Listeners =  (function(){
     return {
         init: function () {
-            document.addEventListener("DOMContentLoaded", function() {
+            window.addEventListener("load", function() {
                 documentSubmittingIndicator.init(); // extend styling on honeyCrisp's default ajax upload functionality.
 
                 if (window.appData.controller_action == "Hub::Users::InvitationsController#edit") {


### PR DESCRIPTION
See the follow **before** and **after** videos


https://user-images.githubusercontent.com/67708639/116308625-9430fb80-a75c-11eb-9c5f-40c52d474516.mov


https://user-images.githubusercontent.com/67708639/116308636-9bf0a000-a75c-11eb-91fe-d91d3074c6cb.mov

Implementation notes:


There seem to be two key changes. The first is hooking the `window.load` event rather than `DOMContentLoaded`. I believe this is because the HTML contains `display: none` and that's being applied _after_ JS executes. The second is calling `handleCheckboxChange` in `initBulkAction` at the start of the function. This allows any checkbox state on the page to be respected.

I also did other trivial refactoring.
