### PR TITLE
Freeze name column on client/index table #177845027

### DIFF
--- a/app/assets/stylesheets/components/_index-table.scss
+++ b/app/assets/stylesheets/components/_index-table.scss
@@ -39,6 +39,31 @@ It expects to be the primary content of the given page (full width).
     font-weight: $font-weight-normal;
     white-space: nowrap;
 
+    &--sticky {
+      position: sticky;
+      left: 0;
+      background-color: inherit;
+      z-index: 1;
+    }
+
+    &--sticky:after,
+    &--sticky:before {
+      content: '';
+      position: absolute;
+      left: 0;
+      width: 100%;
+    }
+
+    &--sticky:before {
+      top: -1px;
+      border-top: 1px solid black;
+    }
+
+    &--sticky:after {
+      bottom: -1px;
+      border-bottom: 1px solid black;
+    }
+
     .sortable-column-link {
       display: flex;
       align-items: center;
@@ -60,37 +85,15 @@ It expects to be the primary content of the given page (full width).
   }
 
   &__row-header {
-    position: sticky;
-    left: 0;
-    z-index: 1;
-    background-color: inherit;
     white-space: nowrap;
     padding: 0.8rem $s25 / 2;
   }
 
-  &__name-column {
+  &__row-header--sticky {
     position: sticky;
     left: 0;
-    background-color: inherit;
     z-index: 1;
-  }
-
-  &__name-column:after,
-  &__name-column:before {
-    content: '';
-    position: absolute;
-    left: 0;
-    width: 100%;
-  }
-
-  &__name-column:before {
-    top: -1px;
-    border-top: 1px solid black;
-  }
-
-  &__name-column:after {
-    bottom: -1px;
-    border-bottom: 1px solid black;
+    background-color: inherit;
   }
 
   &__cell {
@@ -122,14 +125,14 @@ It expects to be the primary content of the given page (full width).
     }
   }
 
-  &__row:first-of-type &__row-header::before {
+  &__row:first-of-type &__row-header--sticky::before {
     content: '';
     position: absolute;
     left: 0;
     width: 100%;
   }
 
-  &__row:first-of-type &__row-header::before {
+  &__row:first-of-type &__row-header--sticky::before {
     top: -1px;
     border-top: 1px solid black;
   }

--- a/app/assets/stylesheets/components/_index-table.scss
+++ b/app/assets/stylesheets/components/_index-table.scss
@@ -11,6 +11,7 @@ It expects to be the primary content of the given page (full width).
   // table resets
   border-collapse: collapse;
   width: 100%;
+
   th {
     text-align: left;
   }
@@ -19,6 +20,7 @@ It expects to be the primary content of the given page (full width).
     color: inherit;
     text-decoration: none;
   }
+
   .button {
     margin: 0;
   }
@@ -51,36 +53,84 @@ It expects to be the primary content of the given page (full width).
     &:first-child {
       padding-left: 3rem;
     }
+
     &:last-child {
       padding-right: 3rem;
     }
   }
 
   &__row-header {
+    position: sticky;
+    left: 0;
+    z-index: 1;
+    background-color: inherit;
     white-space: nowrap;
-    padding: 0.8rem $s25/2;
+    padding: 0.8rem $s25 / 2;
+  }
+
+  &__name-column {
+    position: sticky;
+    left: 0;
+    background-color: inherit;
+    z-index: 1;
+  }
+
+  &__name-column:after,
+  &__name-column:before {
+    content: '';
+    position: absolute;
+    left: 0;
+    width: 100%;
+  }
+
+  &__name-column:before {
+    top: -1px;
+    border-top: 1px solid black;
+  }
+
+  &__name-column:after {
+    bottom: -1px;
+    border-bottom: 1px solid black;
   }
 
   &__cell {
     padding: 0.8rem $s25/2;
     white-space: nowrap;
+
     &:first-child {
       padding-left: 3rem;
     }
+
     &:last-child {
       padding-right: 3rem;
     }
   }
+
   &__row:nth-child(odd) {
     background-color: white;
+
     td {
       background-color: white; // necessary for sticky first column
     }
   }
+
   &__row:nth-child(even) {
     background-color: $color-grey-light;
+
     td {
       background: $color-grey-light; // necessary for sticky first column
     }
+  }
+
+  &__row:first-of-type &__row-header::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    width: 100%;
+  }
+
+  &__row:first-of-type &__row-header::before {
+    top: -1px;
+    border-top: 1px solid black;
   }
 }

--- a/app/views/hub/clients/index.html.erb
+++ b/app/views/hub/clients/index.html.erb
@@ -38,7 +38,7 @@
           <th scope="col" class="index-table__header">!
             <div class="sr-only"><%= t("general.needs_response") %></div>
           </th>
-          <th scope="col" class="index-table__header index-table__name-column">
+          <th scope="col" class="index-table__header index-table__header--sticky">
             <%= render "shared/column_sort_link", title: t("general.name"), column_name: "preferred_name" %>
           </th>
           <th scope="col" class="index-table__header">
@@ -87,7 +87,7 @@
             <td class="index-table__cell client-attribute__needs-response">
               <%= render "shared/urgent_icon", client: client %>
             </td>
-            <th scope="row" class="index-table__row-header client-attribute__name">
+            <th scope="row" class="index-table__row-header index-table__row-header--sticky client-attribute__name">
               <%= link_to hub_client_path(id: client) do %>
                 <%= client.preferred_name || t(".no_name_given") %>
               <% end %>

--- a/app/views/hub/clients/index.html.erb
+++ b/app/views/hub/clients/index.html.erb
@@ -38,7 +38,7 @@
           <th scope="col" class="index-table__header">!
             <div class="sr-only"><%= t("general.needs_response") %></div>
           </th>
-          <th scope="col" class="index-table__header">
+          <th scope="col" class="index-table__header index-table__name-column">
             <%= render "shared/column_sort_link", title: t("general.name"), column_name: "preferred_name" %>
           </th>
           <th scope="col" class="index-table__header">


### PR DESCRIPTION
[Freeze name column client tables #177845027](https://www.pivotaltracker.com/story/show/177845027)

# What this PR does

- Make the "name" column on client index table be sticky when you horizontally scroll
- Clean up whitespace in `app/assets/stylesheets/components/_index-table.scss`
- Need to manually add borders around the name header column with `:before` and `:after` pseudo elements because `border-collapse: collapse` on the `table` doesn't interact will with `sticky` cells.

![2021-04-28 10 13 16](https://user-images.githubusercontent.com/9101728/116428755-d3b62100-a80a-11eb-8b86-95183d181578.gif)
