### PR TITLE
Update flash alert color based on design updates

### DIFF
--- a/app/assets/stylesheets/organisms/_flash-messages.scss
+++ b/app/assets/stylesheets/organisms/_flash-messages.scss
@@ -8,7 +8,9 @@
 }
 
 .flash--notice {
-  background-color: $color-green;
+  background-color: $color-green-money;
+  color: #000;
+  font-weight: bold;
 }
 
 .flash--alert {


### PR DESCRIPTION
The design mocks have an updated color for all alert messages. Instead of throwing this into a PR I'm working on, it seemed better to isolate it as its own PR.

<img width="726" alt="Screen Shot 2021-04-28 at 3 11 28 PM" src="https://user-images.githubusercontent.com/4494389/116466279-e8f37580-a833-11eb-9d25-4fd4a3e9772c.png">
