### PR TITLE
Fix page overflow bug in Chrome #177953214

### DIFF
--- a/app/assets/stylesheets/templates/_bulk-action-form.scss
+++ b/app/assets/stylesheets/templates/_bulk-action-form.scss
@@ -12,6 +12,7 @@
 
 .bulk-action-checkbox {
   margin-left: 1rem;
+  position: relative;
 }
 
 html[lang="en"] {


### PR DESCRIPTION
[Clients table causes bad horizontal scroll on Chrome based browsers #177953214](https://www.pivotaltracker.com/story/show/177953214)

# What does this PR do?

- Adds `position: relative` to the parent of the `.sr-only` classes for the label of the individual bulk action checkbox.

This fix is for Chome/Safari based browsers. Firefox was unaffected and is still unaffected.