### PR TITLE
Begin writing and backfill last_outgoing_message_at #177404043

### DIFF
--- a/app/jobs/backfill_last_outgoing_interaction_at.rb
+++ b/app/jobs/backfill_last_outgoing_interaction_at.rb
@@ -14,7 +14,7 @@ class BackfillLastOutgoingInteractionAt < ApplicationJob
       last_interaction_timestamp = [text, email, call].compact.max
 
       if last_interaction_timestamp.present?
-        if client.update!(last_outgoing_interaction_at: last_interaction_timestamp)
+        if client.update(last_outgoing_interaction_at: last_interaction_timestamp)
           puts "SUCCESS #{client.id}: updated last outgoing interaction to #{last_interaction_timestamp}"
         else
           puts "ERROR #{client.id}: could not persist last_outgoing_interaction to #{last_interaction_timestamp}"

--- a/app/jobs/backfill_last_outgoing_interaction_at.rb
+++ b/app/jobs/backfill_last_outgoing_interaction_at.rb
@@ -1,0 +1,27 @@
+class BackfillLastOutgoingInteractionAt < ApplicationJob
+  def perform(start: 0, finish: nil)
+    Client.includes(:outbound_calls, :outgoing_text_messages, :outgoing_emails).find_each(start: start, finish: finish) do |client|
+      if client.last_outgoing_interaction_at.present?
+        puts "SKIPPING #{client.id}: last_outgoing_interaction_at is already set."
+        next
+      end
+
+      # Looking for the most recent of each outgoing interaction.
+      text = client.outgoing_text_messages.last&.created_at
+      email = client.outgoing_emails.last&.created_at
+      call = client.outbound_calls.last&.created_at
+
+      last_interaction_timestamp = [text, email, call].compact.max
+
+      if last_interaction_timestamp.present?
+        if client.update!(last_outgoing_interaction_at: last_interaction_timestamp)
+          puts "SUCCESS #{client.id}: updated last outgoing interaction to #{last_interaction_timestamp}"
+        else
+          puts "ERROR #{client.id}: could not persist last_outgoing_interaction to #{last_interaction_timestamp}"
+        end
+      else
+        puts "SKIPPING #{client.id}: no interactions for #{client.id}."
+      end
+    end
+  end
+end

--- a/app/models/outbound_call.rb
+++ b/app/models/outbound_call.rb
@@ -26,6 +26,7 @@ class OutboundCall < ApplicationRecord
   validates :from_phone_number, :to_phone_number, e164_phone: true, presence: true
 
   after_create { InteractionTrackingService.record_user_initiated_outgoing_interaction(client) }
+  after_create { InteractionTrackingService.update_last_outgoing_interaction_at(client) }
 
   # twilio_status, twilio_sid, and call_duration are set by responses from twilio
   # twilio_status is set to "queued" on creation of the twilio call which triggers a call to the from_phone_number

--- a/app/models/outgoing_email.rb
+++ b/app/models/outgoing_email.rb
@@ -43,6 +43,7 @@ class OutgoingEmail < ApplicationRecord
   # Use `after_create_commit` so that the attachment is fully saved to S3 before delivering it
   after_create_commit :deliver, :broadcast
   after_create_commit { |msg| InteractionTrackingService.record_user_initiated_outgoing_interaction(client) if msg.user.present? }
+  after_create_commit { InteractionTrackingService.update_last_outgoing_interaction_at(client) }
 
   # has_one_attached needs to be called after defining any callbacks that access attachments, like :deliver; see https://github.com/rails/rails/issues/37304
   has_one_attached :attachment

--- a/app/models/outgoing_text_message.rb
+++ b/app/models/outgoing_text_message.rb
@@ -40,6 +40,7 @@ class OutgoingTextMessage < ApplicationRecord
 
   after_create :deliver, :broadcast
   after_create { |msg| InteractionTrackingService.record_user_initiated_outgoing_interaction(client) if msg.user.present? }
+  after_create { InteractionTrackingService.update_last_outgoing_interaction_at(client) }
 
   scope :succeeded, -> { where(twilio_status: SUCCESSFUL_TWILIO_STATUSES) }
   scope :failed, -> { where(twilio_status: FAILED_TWILIO_STATUSES) }

--- a/spec/jobs/backfill_last_outgoing_interaction_at_spec.rb
+++ b/spec/jobs/backfill_last_outgoing_interaction_at_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe BackfillLastOutgoingInteractionAt, type: :job do
 
     let!(:text) { create(:outgoing_text_message, created_at: Time.now - 1.day, client: client1) }
     let!(:text2) { create(:outgoing_text_message, created_at: Time.now, client: client1) }
-    let!(:email) { create(:outgoing_email, client: client2) }
+    let!(:text3) { create(:outgoing_text_message, created_at: Time.now - 1.day, client: client2) }
+    let!(:email) { create(:outgoing_email, created_at: Time.now, client: client2) }
     let!(:call) { create(:outbound_call, client: client3) }
 
     context "when a client has no last_outgoing_interaction_at" do
@@ -22,7 +23,6 @@ RSpec.describe BackfillLastOutgoingInteractionAt, type: :job do
       it "sets the last_outgoing_interaction_at to the last interactions created_at" do
         expect do
           subject.perform_now
-          # TIL that "change" does not reload in-memory objects
           client1.reload
           client2.reload
           client3.reload

--- a/spec/jobs/backfill_last_outgoing_interaction_at_spec.rb
+++ b/spec/jobs/backfill_last_outgoing_interaction_at_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe BackfillLastOutgoingInteractionAt, type: :job do
+  describe '#perform' do
+    let!(:client1) { create(:client) }
+    let!(:client2) { create(:client) }
+    let!(:client3) { create(:client) }
+
+    let!(:text) { create(:outgoing_text_message, created_at: Time.now - 1.day, client: client1) }
+    let!(:text2) { create(:outgoing_text_message, created_at: Time.now, client: client1) }
+    let!(:email) { create(:outgoing_email, client: client2) }
+    let!(:call) { create(:outbound_call, client: client3) }
+
+    context "when a client has no last_outgoing_interaction_at" do
+      before do
+        # have to set these due to after_create hooks
+        client1.update(last_outgoing_interaction_at: nil)
+        client2.update(last_outgoing_interaction_at: nil)
+        client3.update(last_outgoing_interaction_at: nil)
+      end
+
+      it "sets the last_outgoing_interaction_at to the last interactions created_at" do
+        expect do
+          subject.perform_now
+          # TIL that "change" does not reload in-memory objects
+          client1.reload
+          client2.reload
+          client3.reload
+        end
+          .to change(client1, :last_outgoing_interaction_at).from(nil).to(text2.created_at)
+          .and change(client2, :last_outgoing_interaction_at).from(nil).to(email.created_at)
+          .and change(client3, :last_outgoing_interaction_at).from(nil).to(call.created_at)
+      end
+    end
+
+    context "when the client has last_outgoing_interaction_at set" do
+      it "does not set it" do
+        expect { subject.perform }.not_to change(client1, :last_outgoing_interaction_at)
+      end
+    end
+  end
+end

--- a/spec/models/outbound_call_spec.rb
+++ b/spec/models/outbound_call_spec.rb
@@ -26,4 +26,8 @@ describe OutboundCall do
   it_behaves_like "a user-initiated outgoing interaction" do
     let(:subject) { build(:outbound_call) }
   end
+
+  it_behaves_like "an outgoing interaction" do
+    let(:subject) { build :outgoing_text_message }
+  end
 end

--- a/spec/models/outgoing_email_spec.rb
+++ b/spec/models/outgoing_email_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe OutgoingEmail, type: :model do
       let(:subject) { build :outgoing_email }
     end
 
+    it_behaves_like "an outgoing interaction" do
+      let(:subject) { build :outgoing_text_message }
+    end
+
     context "for an automated email with no user" do
       let(:client) { create :client, first_unanswered_incoming_interaction_at: 4.business_days.ago }
       let(:email) { build :outgoing_email, client: client, user: nil }

--- a/spec/models/outgoing_text_message_spec.rb
+++ b/spec/models/outgoing_text_message_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe OutgoingTextMessage, type: :model do
       let(:subject) { build :outgoing_text_message }
     end
 
+    it_behaves_like "an outgoing interaction" do
+      let(:subject) { build :outgoing_text_message }
+    end
+
     context "for an automated message with no user" do
       let(:client) { create :client, first_unanswered_incoming_interaction_at: 4.business_days.ago }
       let(:message) { build :outgoing_text_message, client: client, user: nil }

--- a/spec/support/shared_examples/interaction_tracking.rb
+++ b/spec/support/shared_examples/interaction_tracking.rb
@@ -55,3 +55,12 @@ shared_examples_for "a user-initiated outgoing interaction" do
       .and not_change(subject.client, :last_incoming_interaction_at)
   end
 end
+
+shared_examples_for "an outgoing interaction" do
+  it "updates the associated client" do
+    Timecop.freeze do
+      expect { subject.save }
+      .to change(subject.client, :last_outgoing_interaction_at).to(Time.now)
+    end
+  end
+end


### PR DESCRIPTION
Useful to review by commit, the first commit adds the backfill, the second commit adds writing of last_outgoing_message_at.