### PR TITLE
Update communication breach metric and reporting

### DIFF
--- a/app/assets/stylesheets/templates/_hub-metrics.scss
+++ b/app/assets/stylesheets/templates/_hub-metrics.scss
@@ -56,7 +56,7 @@
 
   tfoot th {
     position: sticky;
-    bottom: 10.6rem;
+    bottom: 8.8rem;
     height: 5rem;
     border-bottom: 1px solid $color-teal-light;
     z-index: 5;

--- a/app/controllers/hub/metrics_controller.rb
+++ b/app/controllers/hub/metrics_controller.rb
@@ -13,7 +13,7 @@ module Hub
       limited_partners = @vita_partners unless current_user.admin?
       @total_breaches = {
         response_needed: @report.response_needed_breach_count(limited_partners),
-        communication: @report.communication_breach_count(limited_partners),
+        communication: @report.last_outgoing_communication_breach_count(limited_partners),
         interaction: @report.interaction_breach_count(limited_partners),
         total_count: @report.active_sla_clients_count(limited_partners)
       }

--- a/app/controllers/hub/metrics_controller.rb
+++ b/app/controllers/hub/metrics_controller.rb
@@ -12,7 +12,6 @@ module Hub
       @vita_partners = @vita_partners.includes(:organization_capacity)
       limited_partners = @vita_partners unless current_user.admin?
       @total_breaches = {
-        response_needed: @report.response_needed_breach_count(limited_partners),
         communication: @report.last_outgoing_communication_breach_count(limited_partners),
         interaction: @report.interaction_breach_count(limited_partners),
         total_count: @report.active_sla_clients_count(limited_partners)

--- a/app/javascript/lib/metrics_table_sort.js
+++ b/app/javascript/lib/metrics_table_sort.js
@@ -167,18 +167,8 @@ export function initMetricsTableSortAndFilter() {
         return isNaN(calc) ? 0 : calc;
     });
 
-    initSortableColumn("tbody.org-metrics", "th#needs-response-breaches", function(row) {
-        const calc = parseInt($(row).find('.response-needed-breach').attr('data-js-count'));
-        return isNaN(calc) ? 0 : calc;
-    });
-
     initSortableColumn("tbody.org-metrics", "th#organization-name", function (row) {
         return $(row).attr('data-js-vita-partner-name');
-    });
-
-    initSortableColumn("tbody.org-metrics", "th#needs-response-percentage", function (row) {
-        const calc = parseInt($(row).find('.response-needed-breach-percentage').attr('data-js-percentage'));
-        return isNaN(calc) ? 0 : calc;
     });
 
     initSortableColumn("tbody.org-metrics", "th#outgoing-communication-percentage", function (row) {

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -82,12 +82,10 @@ class Client < ApplicationRecord
   scope :assigned_to, ->(user) { joins(:tax_returns).where({ tax_returns: { assigned_user_id: user } }).distinct }
   scope :with_eager_loaded_associations, -> { includes(:vita_partner, :intake, :tax_returns, tax_returns: [:assigned_user]) }
   scope :sla_tracked, -> { distinct.joins(:tax_returns).where(tax_returns: { status: TaxReturnStatus::STATUS_KEYS_INCLUDED_IN_SLA })}
-  scope :outgoing_communication_breaches, ->(breach_threshold_datetime) do
-    sla_tracked.where(arel_table[:first_unanswered_incoming_interaction_at].lteq(breach_threshold_datetime))
-  end
   scope :response_needed_breaches, ->(breach_threshold_datetime) do
     sla_tracked.where(arel_table[:response_needed_since].lteq(breach_threshold_datetime))
   end
+
   scope :outgoing_interaction_breaches, ->(breach_threshold_datetime) do
     sla_tracked.where(
       arel_table[:first_unanswered_incoming_interaction_at].lteq(breach_threshold_datetime)
@@ -97,6 +95,15 @@ class Client < ApplicationRecord
       ).or(arel_table[:last_internal_or_outgoing_interaction_at].eq(nil))
     )
   end
+
+  scope :last_outgoing_communication_breaches, ->(breach_threshold_datetime) do
+    sla_tracked.where(arel_table[:last_outgoing_interaction_at].lteq(breach_threshold_datetime))
+  end
+
+  scope :first_unanswered_incoming_interaction_communication_breaches, ->(breach_threshold_datetime) do
+    sla_tracked.where(arel_table[:first_unanswered_incoming_interaction_at].lteq(breach_threshold_datetime))
+  end
+
   scope :by_raw_login_token, ->(raw_token) do
     where(login_token: Devise.token_generator.digest(Client, :login_token, raw_token))
   end

--- a/app/models/report/sla_breach_report.rb
+++ b/app/models/report/sla_breach_report.rb
@@ -29,6 +29,10 @@ class Report::SLABreachReport < Report
     @communication_breaches ||= format_hash(data["communication_breaches_by_vita_partner_id"])
   end
 
+  def last_outgoing_communication_breaches
+    @last_outgoing_communication_breaches ||= format_hash(data["last_outgoing_communication_breaches_by_vita_partner_id"])
+  end
+
   def interaction_breaches
     @interaction_breaches ||= format_hash(data["interaction_breaches_by_vita_partner_id"])
   end
@@ -45,6 +49,12 @@ class Report::SLABreachReport < Report
 
   def communication_breach_count(vita_partners = nil)
     return data["communication_breach_count"] unless vita_partners.present?
+
+    communication_breaches.slice(*vita_partners.map(&:id)).values.sum
+  end
+
+  def last_outgoing_communication_breach_count(vita_partners = nil)
+    return data["last_outgoing_communication_breach_count"] unless vita_partners.present?
 
     communication_breaches.slice(*vita_partners.map(&:id)).values.sum
   end

--- a/app/services/sla_breach_service.rb
+++ b/app/services/sla_breach_service.rb
@@ -20,8 +20,12 @@ class SLABreachService
   end
 
   # clients who messaged us and have not been responded to _with a message, call or email_ within the breach threshold
-  def outgoing_communication_breaches
-    count_by_vita_partner(Client.outgoing_communication_breaches(breach_threshold_date))
+  def first_unanswered_incoming_interaction_communication_breaches
+    count_by_vita_partner(Client.first_unanswered_incoming_interaction_communication_breaches(breach_threshold_date))
+  end
+
+  def last_outgoing_communication_breaches
+    count_by_vita_partner(Client.last_outgoing_communication_breaches(breach_threshold_date))
   end
 
   # clients who've messaged us _and we've not interacted with their profile at all_ within the breach threshold.
@@ -31,7 +35,8 @@ class SLABreachService
 
   def self.generate_report
     report = SLABreachService.new
-    communication_breaches = report.outgoing_communication_breaches
+    communication_breaches = report.first_unanswered_incoming_interaction_communication_breaches
+    last_outgoing_communication_breaches = report.last_outgoing_communication_breaches
     interaction_breaches = report.outgoing_interaction_breaches
     response_breaches = report.response_needed_breaches
     active_sla_clients = report.active_sla_clients_count
@@ -44,6 +49,8 @@ class SLABreachService
         response_needed_breach_count: response_breaches.values.sum,
         communication_breaches_by_vita_partner_id: communication_breaches,
         communication_breach_count: communication_breaches.values.sum,
+        last_outgoing_communication_breaches_by_vita_partner_id: last_outgoing_communication_breaches,
+        last_outgoing_communication_breach_count: last_outgoing_communication_breaches.values.sum,
         interaction_breaches_by_vita_partner_id: interaction_breaches,
         interaction_breach_count: interaction_breaches.values.sum,
     }

--- a/app/views/hub/metrics/_breach_row.html.erb
+++ b/app/views/hub/metrics/_breach_row.html.erb
@@ -16,7 +16,7 @@
     <%= @report.active_sla_clients_count[id] %>
   </td>
   <td class="index-table__cell communication-breach" data-js-count=<%= @report.communication_breaches[id] %>>
-    <%= @report.communication_breaches[id]%>
+    <%= @report.last_outgoing_communication_breaches[id]%>
   </td>
 
   <td class="index-table__cell communication-breach-percentage">

--- a/app/views/hub/metrics/_breach_row.html.erb
+++ b/app/views/hub/metrics/_breach_row.html.erb
@@ -9,12 +9,6 @@
   <% else %>
     <td class="index-table__cell capacity capacity-percentage" data-js-capacity="0" data-js-count="0"></td>
   <% end %>
-  <td class="index-table__cell response-needed-breach"  data-js-count=<%= @report.response_needed_breaches[id] %>>
-    <%= @report.response_needed_breaches[id] %>
-  </td>
-  <td class="index-table__cell response-needed-breach-percentage">
-    <%= @report.active_sla_clients_count[id] %>
-  </td>
   <td class="index-table__cell communication-breach" data-js-count=<%= @report.communication_breaches[id] %>>
     <%= @report.last_outgoing_communication_breaches[id]%>
   </td>

--- a/app/views/hub/metrics/index.html.erb
+++ b/app/views/hub/metrics/index.html.erb
@@ -31,13 +31,13 @@
             Capacity %<sup>1</sup>
           </th>
           <th scope="col" class="index-table__header sortable" id="outgoing-communication-breaches" >
-            Outgoing comm. breaches<sup>3</sup>
+            Outgoing comm. breaches<sup>2</sup>
           </th>
           <th scope="col" class="index-table__header sortable" id="outgoing-communication-percentage" >
             Outgoing comm. %
           </th>
           <th scope="col" class="index-table__header sortable" id="profile-interaction-breaches" >
-            Interaction breaches<sup>4</sup>
+            Interaction breaches<sup>3</sup>
           </th>
           <th scope="col" class="index-table__header sortable" id="profile-interaction-percentage" >
             Interaction %
@@ -86,16 +86,12 @@
     <section class="take-action-box">
       <div>
         <small><sup>1 </sup><%= t("hub.organizations.form.excludes") %></small>
-
       </div>
       <div>
-        <small><sup>2 </sup>Client needs response indicator has been on for more than 3 business days.</small>
+        <small><sup>2 </sup>We have not contacted this client by email/text/phone call in more than three business days.</small>
       </div>
       <div>
-        <small><sup>3 </sup>Client messaged us or uploaded document more than 3 business days ago, and we have not contacted them by text/call/email.</small>
-      </div>
-      <div>
-        <small><sup>4 </sup>Client messaged us or uploaded document more than 3 business days ago, and we have not interacted with their profile (written internal note, changed status, assigned user, etc).</small>
+        <small><sup>3 </sup>Client messaged us or uploaded document more than 3 business days ago, and we have not interacted with their profile (written internal note, changed status, assigned user, etc).</small>
       </div>
     </section>
   <% end %>

--- a/app/views/hub/metrics/index.html.erb
+++ b/app/views/hub/metrics/index.html.erb
@@ -30,12 +30,6 @@
           <th scope="col" class="index-table__header sortable" id="capacity-percentage">
             Capacity %<sup>1</sup>
           </th>
-          <th scope="col" class="index-table__header sortable" id="needs-response-breaches" >
-            Response breaches<sup>2</sup>
-          </th>
-          <th scope="col" class="index-table__header sortable" id="needs-response-percentage">
-            Response %
-          </th>
           <th scope="col" class="index-table__header sortable" id="outgoing-communication-breaches" >
             Outgoing comm. breaches<sup>3</sup>
           </th>
@@ -73,11 +67,6 @@
           <tr class="metrics-totals" data-js-count=<%= @total_breaches[:total_count] %>>
             <th></th>
             <th class="index_table__cell capacity capacity-percentage"></th>
-            <th class="index-table__cell response-needed-breach" data-js-count=<%= @total_breaches[:response_needed] %>>
-              <strong><%= @total_breaches[:response_needed] %></strong>
-            </th>
-            <th class="index-table__cell response-needed-breach-percentage">
-            </th>
             <th class="index-table__cell communication-breach" data-js-count="<%= @total_breaches[:communication] %>">
               <strong><%= @total_breaches[:communication] %></strong>
             </th>

--- a/spec/controllers/hub/metrics_controller_spec.rb
+++ b/spec/controllers/hub/metrics_controller_spec.rb
@@ -13,11 +13,9 @@ describe Hub::MetricsController do
     let(:report_data) do
       {
         breached_at: breach_threshold_date,
-        response_needed_breaches_by_vita_partner_id: breach_data,
         communication_breaches_by_vita_partner_id: breach_data,
         last_outgoing_communication_breaches_by_vita_partner_id: breach_data,
         interaction_breaches_by_vita_partner_id: breach_data,
-        response_needed_breach_count: breach_count,
         interaction_breach_count: breach_count,
         communication_breach_count: breach_count,
         last_outgoing_communication_breach_count: breach_count,
@@ -53,7 +51,6 @@ describe Hub::MetricsController do
         it 'uses the accumulated totals for all vita partners' do
           get :index
           expect(assigns(:total_breaches)[:communication]).to eq 3
-          expect(assigns(:total_breaches)[:response_needed]).to eq 3
           expect(assigns(:total_breaches)[:interaction]).to eq 3
         end
       end
@@ -91,7 +88,6 @@ describe Hub::MetricsController do
         it 'limits the totals to those that are relevant to the vita partner the user has access to' do
           get :index
 
-          expect(assigns(:total_breaches)[:response_needed]).to eq 2
           expect(assigns(:total_breaches)[:communication]).to eq 2
           expect(assigns(:total_breaches)[:interaction]).to eq 2
         end

--- a/spec/controllers/hub/metrics_controller_spec.rb
+++ b/spec/controllers/hub/metrics_controller_spec.rb
@@ -15,10 +15,12 @@ describe Hub::MetricsController do
         breached_at: breach_threshold_date,
         response_needed_breaches_by_vita_partner_id: breach_data,
         communication_breaches_by_vita_partner_id: breach_data,
+        last_outgoing_communication_breaches_by_vita_partner_id: breach_data,
         interaction_breaches_by_vita_partner_id: breach_data,
         response_needed_breach_count: breach_count,
         interaction_breach_count: breach_count,
         communication_breach_count: breach_count,
+        last_outgoing_communication_breach_count: breach_count,
         active_sla_clients_by_vita_partner_id: breach_data,
         active_sla_clients_count: breach_count
       }

--- a/spec/javascript/lib/metrics_table_sort.spec.js
+++ b/spec/javascript/lib/metrics_table_sort.spec.js
@@ -8,24 +8,20 @@ beforeEach(() => {
         <thead>
             <th id="organization-name"></th>
             <th id="capacity-percentage"></th>
-            <th id="needs-response-breaches"></th>
             <th id="profile-interaction-breaches"></th>
             <th id="outgoing-communication-breaches"></th>
         </thead>
         <tbody class="org-metrics" data-js-vita-partner-name="Apple Org">
             <tr class="org" data-js-capacity="10">
-                <td class="response-needed-breach"></td>
                 <td class="capacity capacity-percentage" data-js-count="5">5/10</td>
                 <td class="communication-breach"></td>
                 <td class="interaction-breach"></td>
             </tr>
             <tr class="site">
-                <td class="response-needed-breach" data-js-count="1"></td>
                 <td class="communication-breach" data-js-count="14"></td>
                 <td class="interaction-breach" data-js-count="14"></td>
             </tr>
             <tr class="site">
-                <td class="response-needed-breach" data-js-count="1"></td>
                 <td class="communication-breach" data-js-count="1"></td>
                 <td class="interaction-breach" data-js-count="1"></td>
             </tr>
@@ -33,17 +29,14 @@ beforeEach(() => {
 
         <tbody class="org-metrics" data-js-vita-partner-name="Perfect Org">
             <tr class="org">
-                <td class="response-needed-breach"></td>
                 <td class="communication-breach"></td>
                 <td class="interaction-breach"></td>
             </tr>
             <tr class="site">
-                <td class="response-needed-breach" data-js-count="0"></td>
                 <td class="communication-breach" data-js-count="0"></td>
                 <td class="interaction-breach" data-js-count="0"></td>
             </tr>
             <tr class="site">
-                <td class="response-needed-breach" data-js-count="0"></td>
                 <td class="communication-breach" data-js-count="0"></td>
                 <td class="interaction-breach" data-js-count="0"></td>
             </tr>
@@ -51,9 +44,6 @@ beforeEach(() => {
         <tbody class="index-table__body org-metrics" data-js-vita-partner-name="United Way of Greater Richmond and Petersburg">
           <tr class="index-table__row org">
             <td class="index-table__cell">United Way of Greater Richmond and Petersburg</td>
-            <td class="index-table__cell response-needed-breach"  data-js-count=1>
-              1
-            </td>
             <td class="index-table__cell communication-breach" data-js-count=3>
               3
             </td>
@@ -64,9 +54,6 @@ beforeEach(() => {
           <!-- Add a row for the organization to track org-level breaches. -->
           <tr class="index-table__row site">
             <td class="index-table__cell" style="padding-left: 60px; font-style: italic;">United Way of Greater Richmond and Petersburg</td>
-            <td class="index-table__cell response-needed-breach"  data-js-count=1>
-              1
-            </td>
             <td class="index-table__cell communication-breach" data-js-count=3>
               3
             </td>
@@ -77,9 +64,6 @@ beforeEach(() => {
 
           <tr class="index-table__row site">
             <td class="index-table__cell" style="padding-left: 60px">Chesterfield Meadowdale Library </td>
-            <td class="index-table__cell response-needed-breach" data-js-count=0>
-              0
-            </td>
             <td class="index-table__cell communication-breach" data-js-count=0>
               0
             </td>
@@ -89,9 +73,6 @@ beforeEach(() => {
           </tr>
           <tr class="index-table__row site">
             <td class="index-table__cell" style="padding-left: 60px">Libbie Mill Library </td>
-            <td class="index-table__cell response-needed-breach" data-js-count=1>
-              1
-            </td>
             <td class="index-table__cell communication-breach" data-js-count=0>
               0
             </td>
@@ -101,9 +82,6 @@ beforeEach(() => {
           </tr>
             <tr class="index-table__row site">
               <td class="index-table__cell" style="padding-left: 60px">Fairfield Library - UWGRP </td>
-              <td class="index-table__cell response-needed-breach" data-js-count=1>
-                1
-              </td>
               <td class="index-table__cell communication-breach" data-js-count=1>
                 1
               </td>
@@ -113,9 +91,6 @@ beforeEach(() => {
             </tr>
             <tr class="index-table__row site">
               <td class="index-table__cell" style="padding-left: 60px">Neighborhood Resource Center </td>
-              <td class="index-table__cell response-needed-breach" data-js-count=0>
-                0
-              </td>
               <td class="index-table__cell communication-breach" data-js-count=0>
                 0
               </td>
@@ -125,9 +100,6 @@ beforeEach(() => {
             </tr>
             <tr class="index-table__row site">
               <td class="index-table__cell" style="padding-left: 60px">UWGRP-site </td>
-              <td class="index-table__cell response-needed-breach" data-js-count=0>
-                0
-              </td>
               <td class="index-table__cell communication-breach" data-js-count=3>
                 3
               </td>
@@ -141,16 +113,13 @@ beforeEach(() => {
 });
 
 test('determines org-level counts', () => {
-    const responseBreach = $('.org-metrics[data-js-vita-partner-name="United Way of Greater Richmond and Petersburg"]').find('tr.org td.response-needed-breach').first();
     const communicationBreach = $('.org-metrics[data-js-vita-partner-name="United Way of Greater Richmond and Petersburg"]').find('tr.org td.communication-breach').first();
     const interactionBreach =$('.org-metrics[data-js-vita-partner-name="United Way of Greater Richmond and Petersburg"]').find('tr.org td.interaction-breach').first();
-    expect(responseBreach.attr('data-js-count')).toEqual("1");
     expect(communicationBreach.attr('data-js-count')).toEqual('3');
     expect(interactionBreach.attr('data-js-count')).toEqual('1');
 
     initMetricsTableSortAndFilter();
 
-    expect(responseBreach.attr('data-js-count')).toEqual("3");
     expect(communicationBreach.attr('data-js-count')).toEqual("7");
     expect(interactionBreach.attr('data-js-count')).toEqual("5");
 });
@@ -268,23 +237,6 @@ test('sorting by breach count', () => {
     expect($('.org-metrics').first().attr('data-js-vita-partner-name')).toEqual("Apple Org");
 });
 
-test('sorting by response breach count', () => {
-    expect($('.org-metrics').first().attr('data-js-vita-partner-name')).toEqual("Apple Org");
-    initMetricsTableSortAndFilter();
-    $('th#needs-response-breaches').click();
-    expect($('.org-metrics').first().attr('data-js-vita-partner-name')).toEqual("United Way of Greater Richmond and Petersburg");
-    expect($('.org-metrics').first().find('.org .response-needed-breach').attr('data-js-count')).toEqual('3')
-    expect($('.org-metrics').last().attr('data-js-vita-partner-name')).toEqual("Perfect Org");
-
-    $('th#needs-response-breaches').click();
-    expect($('.org-metrics').first().attr('data-js-vita-partner-name')).toEqual("Perfect Org");
-    expect($('.org-metrics').first().find('.org .response-needed-breach').attr('data-js-count')).toEqual('0')
-
-    expect($('.org-metrics').last().attr('data-js-vita-partner-name')).toEqual("United Way of Greater Richmond and Petersburg");
-    $('th#organization-name').click();
-});
-
-
 test('sorting by profile-interaction-breaches count', () => {
     expect($('.org-metrics').first().attr('data-js-vita-partner-name')).toEqual("Apple Org");
     initMetricsTableSortAndFilter();
@@ -300,7 +252,6 @@ test('sorting by profile-interaction-breaches count', () => {
     expect($('.org-metrics').last().attr('data-js-vita-partner-name')).toEqual("Apple Org");
     $('th#organization-name').click();
 });
-
 
 test('sorting by communication-interaction-breaches count', () => {
     expect($('.org-metrics').first().attr('data-js-vita-partner-name')).toEqual("Apple Org");


### PR DESCRIPTION
This PR:
- Adds a scope for the last_outgoing_interaction_at calculation
- Adds new SLA determination to report, and leaves old reporting structure too (for ongoing seasonal data analysis comparisons)
- Removes response_needed SLA metric and replaces communication breach with new definition on metrics tab.
![Screen Shot 2021-05-04 at 5 19 19 PM](https://user-images.githubusercontent.com/4494389/117076963-eba30e80-acfc-11eb-9c25-3798acce1fed.png)
