### PR TITLE
Calculate which clients are on the urgent tab based on last outgoing interaction and remove oldest unanswered action column

### DIFF
--- a/app/controllers/hub/unattended_clients_controller.rb
+++ b/app/controllers/hub/unattended_clients_controller.rb
@@ -14,9 +14,8 @@ module Hub
     def index
       @page_title = "Clients who haven't received a response in #{day_param} business days"
       @breach_date = day_param.business_days.ago
-      @clients = filtered_and_sorted_clients.response_needed_breaches(@breach_date)
+      @clients = filtered_and_sorted_clients.last_outgoing_interaction_breaches(@breach_date)
       @clients = @clients.with_eager_loaded_associations.page(params[:page])
-      @show_first_unanswered_incoming_interaction_at = true if current_user.admin?
       render "hub/clients/index"
     end
 

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -85,7 +85,9 @@ class Client < ApplicationRecord
   scope :response_needed_breaches, ->(breach_threshold_datetime) do
     sla_tracked.where(arel_table[:response_needed_since].lteq(breach_threshold_datetime))
   end
-
+  scope :last_outgoing_interaction_breaches, ->(breach_threshold_datetime) do
+    sla_tracked.where(arel_table[:last_outgoing_interaction_at].lteq(breach_threshold_datetime))
+  end
   scope :outgoing_interaction_breaches, ->(breach_threshold_datetime) do
     sla_tracked.where(
       arel_table[:first_unanswered_incoming_interaction_at].lteq(breach_threshold_datetime)

--- a/app/views/hub/clients/index.html.erb
+++ b/app/views/hub/clients/index.html.erb
@@ -57,12 +57,6 @@
           <th scope="col" class="index-table__header">
             <%= render "shared/column_sort_link", title: t("clients.last_outgoing_message_at"), column_name: "last_outgoing_interaction_at" %>
           </th>
-          <% if @show_first_unanswered_incoming_interaction_at %>
-            <th scope="col" class="index-table__header">
-              <%= render "shared/column_sort_link", title: t(".first_unanswered_incoming_interaction_at"), column_name: "first_unanswered_incoming_interaction_at" %>
-            </th>
-          <% end %>
-
           <th scope="col" class="index-table__header">
             <%= render "shared/column_sort_link", title: t(".created_at"), column_name: "created_at" %>
           </th>
@@ -106,9 +100,6 @@
               <td class="index-table__cell <%= business_days_urgent %>"><%= t("general.business_days", count: business_days_count) %></td>
             <% else %>
               <td class="index-table__cell"></td>
-            <% end %>
-            <% if @show_first_unanswered_incoming_interaction_at %>
-              <td class="index-table__cell"><%= formatted_datetime(client.first_unanswered_incoming_interaction_at) %></td>
             <% end %>
             <td class="index-table__cell"><%= formatted_datetime(client.intake.created_at) || "-" %> </td>
             <td class="index-table__cell"><%= client.intake.state_of_residence %></td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -115,7 +115,6 @@ en:
         organization: Organization/site
         assigned_user: Assigned to
         no_name_given: "Name left blank"
-        first_unanswered_incoming_interaction_at: "Oldest unanswered action"
         created_at: Created at
       unlinked_clients:
         title: Unlinked clients

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -99,7 +99,6 @@ es:
         organization: Organización/Sitio
         assigned_user: Asignado a
         no_name_given: "Nombre dejado en blanco"
-        first_unanswered_incoming_interaction_at: Acción más antiguo sin respuesta
         created_at: Creado en
       navigation:
         client_documents: Documentos

--- a/spec/controllers/hub/unattended_clients_controller_spec.rb
+++ b/spec/controllers/hub/unattended_clients_controller_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe Hub::UnattendedClientsController, type: :controller do
     context "as an authenticated team member" do
       let(:user) { create(:team_member_user) }
       let(:site) { user.role.site }
-      let!(:client_within_sla) { create :client_with_intake_and_return, response_needed_since: 2.business_days.ago, last_outgoing_interaction_at: 2.business_days.ago, vita_partner: site }
-      let!(:four_day_breach_client) { create :client_with_intake_and_return, response_needed_since: 4.business_days.ago, last_outgoing_interaction_at: 4.business_days.ago, vita_partner: site }
-      let!(:six_day_breach_client) { create :client_with_intake_and_return, response_needed_since: 6.business_days.ago, last_outgoing_interaction_at: 6.business_days.ago, vita_partner: site }
+      let!(:client_within_sla) { create :client_with_intake_and_return, last_outgoing_interaction_at: 2.business_days.ago, vita_partner: site }
+      let!(:four_day_breach_client) { create :client_with_intake_and_return, last_outgoing_interaction_at: 4.business_days.ago, vita_partner: site }
+      let!(:six_day_breach_client) { create :client_with_intake_and_return, last_outgoing_interaction_at: 6.business_days.ago, vita_partner: site }
       before do
         sign_in user
         [client_within_sla, four_day_breach_client, six_day_breach_client].each do |client|
@@ -23,7 +23,7 @@ RSpec.describe Hub::UnattendedClientsController, type: :controller do
         end
       end
 
-      it "shows clients who haven't gotten a response in 3 or more business days, sorted by how long they've been waiting" do
+      it "shows clients who last outgoing interaction was 3 or more business days, sorted by how long they've been waiting" do
         get :index
 
         expect(assigns(:clients)).to eq [six_day_breach_client, four_day_breach_client]
@@ -47,20 +47,6 @@ RSpec.describe Hub::UnattendedClientsController, type: :controller do
 
           expect(assigns(:clients)).to eq [six_day_breach_client, four_day_breach_client]
         end
-      end
-    end
-
-    context "as an authenticated admin" do
-      let(:user) { create(:admin_user) }
-
-      before do
-        sign_in user
-      end
-
-      it "shows the first_unanswered_incoming_interaction_at column" do
-        get :index
-
-        expect(assigns(:show_first_unanswered_incoming_interaction_at)).to eq true
       end
     end
   end


### PR DESCRIPTION
Co-authored-by: Jenny Heath <jheath@codeforamerica.org>