### PR TITLE
Show document model validation errors to clients during intake [#177322945]

### DIFF
--- a/app/forms/document_type_upload_form.rb
+++ b/app/forms/document_type_upload_form.rb
@@ -1,6 +1,7 @@
 class DocumentTypeUploadForm < QuestionsForm
   set_attributes_for :intake, :document
   validates :document, file_type_allowed: true
+  validate :load_and_validate_document
 
   def initialize(document_type, *args, **kwargs)
     @document_type = document_type
@@ -8,22 +9,32 @@ class DocumentTypeUploadForm < QuestionsForm
   end
 
   def save
+    return false unless valid?
+
+    @doc.save!
+  end
+
+  private
+
+  def load_and_validate_document
     document_file_upload = attributes_for(:intake)[:document]
-    if document_file_upload.present?
-      doc = @intake.documents.new(
+    # Rewind to avoid IntegrityError
+    document_file_upload.tempfile.rewind
+    doc = @intake.documents.new(
         document_type: @document_type,
         client: @intake.client,
-        uploaded_by: @intake.client
-      )
-      # Rewind to avoid IntegrityError
-      document_file_upload.tempfile.rewind
-      # Remove non-utf-8 characters from the original filename
-      doc.upload.attach(
-        io: document_file_upload.tempfile,
-        filename: document_file_upload.original_filename.encode("UTF-8", invalid: :replace, replace: ""),
-        content_type: document_file_upload.content_type
-      )
-      doc.save!
+        uploaded_by: @intake.client,
+        upload: {
+          io: document_file_upload.tempfile,
+          # Remove non-utf-8 characters from the original filename
+          filename: document_file_upload.original_filename.encode("UTF-8", invalid: :replace, replace: ""),
+          content_type: document_file_upload.content_type
+        }
+    )
+    if doc.valid?
+      @doc = doc
+    else
+      doc.errors.values.flatten.each { |msg| errors[:document] << msg }
     end
   end
 end

--- a/app/forms/document_type_upload_form.rb
+++ b/app/forms/document_type_upload_form.rb
@@ -18,6 +18,11 @@ class DocumentTypeUploadForm < QuestionsForm
 
   def load_and_validate_document
     document_file_upload = attributes_for(:intake)[:document]
+    if document_file_upload.blank?
+      errors[:document] << I18n.t("validators.file_type")
+      return
+    end
+
     # Rewind to avoid IntegrityError
     document_file_upload.tempfile.rewind
     doc = @intake.documents.new(

--- a/spec/controllers/documents/employment_controller_spec.rb
+++ b/spec/controllers/documents/employment_controller_spec.rb
@@ -144,21 +144,6 @@ RSpec.describe Documents::EmploymentController, type: :controller do
           })
       end
     end
-
-    context "with a nil document" do
-      let(:params) do
-        {
-            document_type_upload_form: {}
-        }
-      end
-
-      it "redirects back to the same page" do
-        expect do
-          post :update, params: params
-        end.not_to raise_error
-        expect(response).to redirect_to employment_documents_path
-      end
-    end
   end
 end
 

--- a/spec/forms/document_type_upload_form_spec.rb
+++ b/spec/forms/document_type_upload_form_spec.rb
@@ -17,6 +17,35 @@ RSpec.describe DocumentTypeUploadForm do
         expect(form).to be_valid
       end
     end
+
+    context "when uploading a file whose file extension is disallowed" do
+      let(:params) { { document: fixture_file_upload("attachments/test-pattern.html") } }
+
+      it "is not valid" do
+        form = described_class.new("Other", intake, params)
+
+        expect(form).not_to be_valid
+        expect(form.errors[:document]).to be_present
+      end
+    end
+
+    context "when the document model has errors" do
+      let(:params) { { document: fixture_file_upload("attachments/test-pattern.png") } }
+      let!(:fake_document) { build(:document) }
+
+      before do
+        allow(fake_document).to receive(:valid?).and_return(false)
+        allow(fake_document).to receive(:errors).and_return({upload: ["Example error"]})
+        allow(Document).to receive(:new).and_return(fake_document)
+      end
+
+      it "is not valid" do
+        form = described_class.new("Other", intake, params)
+
+        expect(form).not_to be_valid
+        expect(form.errors[:document]).to eq(["Example error"])
+      end
+    end
   end
 
   describe "#save" do

--- a/spec/forms/document_type_upload_form_spec.rb
+++ b/spec/forms/document_type_upload_form_spec.rb
@@ -46,6 +46,17 @@ RSpec.describe DocumentTypeUploadForm do
         expect(form.errors[:document]).to eq(["Example error"])
       end
     end
+
+    context "when the document is missing" do
+      let(:params) { { } }
+
+      it "is not valid" do
+        form = described_class.new("Other", intake, params)
+
+        expect(form).not_to be_valid
+        expect(form.errors[:document]).to be_present
+      end
+    end
   end
 
   describe "#save" do


### PR DESCRIPTION
## Screenshot

![image](https://user-images.githubusercontent.com/67708639/117210915-30867e00-adad-11eb-94cd-975f014cf91a.png)

## Implementation approach

On this page, we now surface any model-level validation errors to clients during intake.