### PR TITLE
Change status label colors in the Hub #177917593

### DIFF
--- a/app/assets/stylesheets/components/_tax-return-list.scss
+++ b/app/assets/stylesheets/components/_tax-return-list.scss
@@ -190,7 +190,7 @@
     border-color: $color-stimulus-blue;
   }
 
-  &[data-status^="files"] {
+  &[data-status^="file"] {
     background-color: $color-grey-medium-light;
     border-color: $color-grey-medium-light;
   }

--- a/app/assets/stylesheets/components/_tax-return-list.scss
+++ b/app/assets/stylesheets/components/_tax-return-list.scss
@@ -171,5 +171,27 @@
   line-height: $font-size-18;
   padding: $s5 $s10;
   border: 1px solid $color-green-money;
-}
 
+  // More info about styling with data attributes can be found at
+  // https://css-tricks.com/a-complete-guide-to-data-attributes/
+  &[data-status="Intake/Not ready"],
+  &[data-status="Intake/Greeter - info requested"] {
+    background-color: $color-orange-medium;
+    border-color: $color-orange-medium;
+  }
+
+  &[data-status^="Tax prep"] {
+    background-color: $color-lavender;
+    border-color: $color-lavender;
+  }
+
+  &[data-status^="Quality review"] {
+    background-color: $color-stimulus-blue;
+    border-color: $color-stimulus-blue;
+  }
+
+  &[data-status^="Final steps"] {
+    background-color: $color-grey-medium-light;
+    border-color: $color-grey-medium-light;
+  }
+}

--- a/app/assets/stylesheets/components/_tax-return-list.scss
+++ b/app/assets/stylesheets/components/_tax-return-list.scss
@@ -174,28 +174,23 @@
 
   // More info about styling with data attributes can be found at
   // https://css-tricks.com/a-complete-guide-to-data-attributes/
-  &[data-status="Intake/Not ready"],
-  &[data-status="Admisión/No listo"],
-  &[data-status="Intake/Greeter - info requested"],
-  &[data-status="Admisión/Saludador - Información solicitada"] {
+  &[data-status="intake_in_progress"],
+  &[data-status="intake_greeter_info_requested"] {
     background-color: $color-orange-medium;
     border-color: $color-orange-medium;
   }
 
-  &[data-status^="Tax prep"],
-  &[data-status^="Preparación de impuestos"] {
+  &[data-status^="prep"] {
     background-color: $color-lavender;
     border-color: $color-lavender;
   }
 
-  &[data-status^="Quality review"],
-  &[data-status^="Revisión de calidad"] {
+  &[data-status^="review"] {
     background-color: $color-stimulus-blue;
     border-color: $color-stimulus-blue;
   }
 
-  &[data-status^="Final steps"],
-  &[data-status^="Pasos finales"] {
+  &[data-status^="files"] {
     background-color: $color-grey-medium-light;
     border-color: $color-grey-medium-light;
   }

--- a/app/assets/stylesheets/components/_tax-return-list.scss
+++ b/app/assets/stylesheets/components/_tax-return-list.scss
@@ -175,22 +175,27 @@
   // More info about styling with data attributes can be found at
   // https://css-tricks.com/a-complete-guide-to-data-attributes/
   &[data-status="Intake/Not ready"],
-  &[data-status="Intake/Greeter - info requested"] {
+  &[data-status="Admisión/No listo"],
+  &[data-status="Intake/Greeter - info requested"],
+  &[data-status="Admisión/Saludador - Información solicitada"] {
     background-color: $color-orange-medium;
     border-color: $color-orange-medium;
   }
 
-  &[data-status^="Tax prep"] {
+  &[data-status^="Tax prep"],
+  &[data-status^="Preparación de impuestos"] {
     background-color: $color-lavender;
     border-color: $color-lavender;
   }
 
-  &[data-status^="Quality review"] {
+  &[data-status^="Quality review"],
+  &[data-status^="Revisión de calidad"] {
     background-color: $color-stimulus-blue;
     border-color: $color-stimulus-blue;
   }
 
-  &[data-status^="Final steps"] {
+  &[data-status^="Final steps"],
+  &[data-status^="Pasos finales"] {
     background-color: $color-grey-medium-light;
     border-color: $color-grey-medium-light;
   }

--- a/app/views/shared/_tax_return_list.html.erb
+++ b/app/views/shared/_tax_return_list.html.erb
@@ -45,8 +45,7 @@
           <% end %>
         <% else %>
           <div>
-            <% status_text = "#{stage_translation_from_status(tax_return.status)}/#{status_translation(tax_return.status)}" %>
-            <div class="tax-return-list__status label label--status" data-status="<%= status_text %>"><%= status_text %></div>
+            <div class="tax-return-list__status label label--status" data-status="<%= tax_return.status %>"><%= stage_translation_from_status(tax_return.status) %>/<%= status_translation(tax_return.status) %></div>
           </div>
         <% end %>
       </div>

--- a/app/views/shared/_tax_return_list.html.erb
+++ b/app/views/shared/_tax_return_list.html.erb
@@ -45,7 +45,8 @@
           <% end %>
         <% else %>
           <div>
-            <div class="tax-return-list__status label label--status"><%= stage_translation_from_status(tax_return.status) %>/<%= status_translation(tax_return.status) %></div>
+            <% status_text = "#{stage_translation_from_status(tax_return.status)}/#{status_translation(tax_return.status)}" %>
+            <div class="tax-return-list__status label label--status" data-status="<%= status_text %>"><%= status_text %></div>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
[color code HUB statuses #177917593](https://www.pivotaltracker.com/story/show/177917593)

# What does this PR do?

- sets the status text in a `data-status` attribute so that it can be used in CSS
- adds CSS to style different labels based on logic described in the ticket