### PR TITLE
Remove org access based on all clients tax returns, not just those explicitly selected

### DIFF
--- a/app/controllers/hub/bulk_actions/change_organization_controller.rb
+++ b/app/controllers/hub/bulk_actions/change_organization_controller.rb
@@ -40,8 +40,10 @@ module Hub
         end
       end
 
+      # Must unassign _all_ tax returns from a client who would lose access (even if not explicitly selected in the tax_return_selection)
+      # because you can't change organization if any return is assigned to a user who would lose access.
       def unassign_users_who_will_lose_access!
-        @selection.tax_returns.accessible_by(current_ability).where.not(assigned_user: nil).find_each do |tax_return|
+        TaxReturn.where(client: @clients).where.not(assigned_user: nil).find_each do |tax_return|
           assigned_user_retains_access = tax_return.assigned_user.accessible_vita_partners.include?(@new_vita_partner)
           tax_return.update!(assigned_user: nil) unless assigned_user_retains_access
         end

--- a/spec/controllers/hub/bulk_actions/change_organization_controller_spec.rb
+++ b/spec/controllers/hub/bulk_actions/change_organization_controller_spec.rb
@@ -81,11 +81,14 @@ RSpec.describe Hub::BulkActions::ChangeOrganizationController do
           let(:selected_client) { create :client, intake: (create :intake), vita_partner: old_site}
           let!(:still_assigned_return) { create :tax_return, client: selected_client, assigned_user: assigned_user_who_retains_access, year: 2018, tax_return_selections: [tax_return_selection] }
           let!(:unassigned_return) { create :tax_return, client: selected_client, assigned_user: assigned_user_at_old_site, year: 2017, tax_return_selections: [tax_return_selection] }
+          let!(:not_selected_return) { create :tax_return, client: selected_client, assigned_user: assigned_user_at_old_site, year: 2019 }
 
           it "unassigns all users who are losing access" do
             put :update, params: params
 
+            expect(selected_client.reload.vita_partner).to eq new_vita_partner
             expect(assigned_user_at_old_site.reload.assigned_tax_returns).to be_empty
+            expect(unassigned_return.reload.assigned_user).to eq nil
             expect(assigned_user_who_retains_access.reload.assigned_tax_returns).to eq [still_assigned_return]
           end
         end


### PR DESCRIPTION


Co-authored-by: Catie Talbot <ctalbot@codeforamerica.org>