### PR TITLE
Undo change to old last_outgoing_interaction_at migration so that it is backwards compatible

### DIFF
--- a/db/migrate/20210428233857_add_last_outgoing_interaction_at_to_client.rb
+++ b/db/migrate/20210428233857_add_last_outgoing_interaction_at_to_client.rb
@@ -1,5 +1,5 @@
 class AddLastOutgoingInteractionAtToClient < ActiveRecord::Migration[6.0]
   def change
-    add_column :clients, :last_outgoing_communication_at, :datetime, null: true
+    add_column :clients, :last_outgoing_interaction_at, :datetime, null: true
   end
 end


### PR DESCRIPTION
It looks like when we refactored `last_outgoing_interaction_at` to `last_outgoing_communication_at`, we changed the column name in the initial migration. The problem is that if you mess up your db (like I did) and have to drop and rerun all migrations, rails gets very confused because it cannot find `last_outgoing_interaction_at` and change it to `last_outgoing_communication_at` in the later migration. This fixes that!