### PR TITLE
Routing: stop falling back to national site, instead redirect to at capacity page

### DIFF
--- a/app/controllers/questions/personal_info_controller.rb
+++ b/app/controllers/questions/personal_info_controller.rb
@@ -19,6 +19,7 @@ module Questions
           current_intake.update(vita_partner: vita_partner)
           super
         else
+          current_intake.client.update(routing_method: routing_service.routing_method)
           return redirect_to at_capacity_questions_path
         end
       end

--- a/app/controllers/questions/personal_info_controller.rb
+++ b/app/controllers/questions/personal_info_controller.rb
@@ -6,16 +6,21 @@ module Questions
       {}
     end
 
-    def after_update_success
+    def update
       unless Client.after_consent.where(intake: current_intake).exists?
         routing_service = PartnerRoutingService.new(
           source_param: current_intake.source,
-          zip_code: current_intake.zip_code,
+          zip_code: form_params[:zip_code],
         )
         vita_partner = routing_service.determine_partner
 
-        current_intake.client.update(vita_partner: vita_partner, routing_method: routing_service.routing_method)
-        current_intake.update(vita_partner: vita_partner)
+        if vita_partner.present?
+          current_intake.client.update(vita_partner: vita_partner, routing_method: routing_service.routing_method)
+          current_intake.update(vita_partner: vita_partner)
+          super
+        else
+          return redirect_to at_capacity_questions_path
+        end
       end
     end
   end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -58,7 +58,7 @@ class Client < ApplicationRecord
   accepts_nested_attributes_for :tax_returns
   accepts_nested_attributes_for :intake
   attr_accessor :change_initiated_by
-  enum routing_method: { most_org_leads: 0, source_param: 1, zip_code: 2, national_overflow: 3, state: 4 }
+  enum routing_method: { most_org_leads: 0, source_param: 1, zip_code: 2, national_overflow: 3, state: 4, at_capacity: 5 }
 
   validate :tax_return_assigned_user_access_maintained, if: :vita_partner_id_changed?
   after_update_commit :create_org_change_note, if: :saved_change_to_vita_partner_id?

--- a/app/services/partner_routing_service.rb
+++ b/app/services/partner_routing_service.rb
@@ -18,7 +18,7 @@ class PartnerRoutingService
     from_state_routing = vita_partner_from_state if @zip_code.present?
     return from_state_routing if from_state_routing.present?
 
-    route_to_national_overflow_partner
+    nil
   end
 
   private
@@ -69,7 +69,7 @@ class PartnerRoutingService
     end
   end
 
-  # TODO: What happens in the case that there are no national overflow partners? Is there a GYR organization we can route them to?
+  # TODO: keep this method until we bring it back or discard and search git history?
   def route_to_national_overflow_partner
     vita_partner = VitaPartner.where(national_overflow_location: true).order(Arel.sql('RANDOM()')).first
     if vita_partner.present?

--- a/app/services/partner_routing_service.rb
+++ b/app/services/partner_routing_service.rb
@@ -18,7 +18,9 @@ class PartnerRoutingService
     from_state_routing = vita_partner_from_state if @zip_code.present?
     return from_state_routing if from_state_routing.present?
 
-    nil
+    # route_to_national_overflow_partner
+    @routing_method = :at_capacity
+    return
   end
 
   private
@@ -69,7 +71,6 @@ class PartnerRoutingService
     end
   end
 
-  # TODO: keep this method until we bring it back or discard and search git history?
   def route_to_national_overflow_partner
     vita_partner = VitaPartner.where(national_overflow_location: true).order(Arel.sql('RANDOM()')).first
     if vita_partner.present?

--- a/spec/controllers/questions/personal_info_controller_spec.rb
+++ b/spec/controllers/questions/personal_info_controller_spec.rb
@@ -57,6 +57,25 @@ RSpec.describe Questions::PersonalInfoController do
          .and change(intake.client, :vita_partner_id).to(vita_partner.id)
          .and change(intake.client, :routing_method).to eq("source_param")
       end
+
+      context "when routing service returns nil" do
+        before do
+          allow(organization_router).to receive(:determine_partner).and_return nil
+        end
+
+        it "redirects to capacity page" do
+          post :update, params: params
+
+          expect(PartnerRoutingService).to have_received(:new).with(
+            {
+              source_param: "SourceParam",
+              zip_code: "80309"
+            }
+          )
+          expect(organization_router).to have_received(:determine_partner)
+          expect(response).to redirect_to at_capacity_questions_path
+        end
+      end
     end
 
     context "when a client has consented" do

--- a/spec/controllers/questions/personal_info_controller_spec.rb
+++ b/spec/controllers/questions/personal_info_controller_spec.rb
@@ -61,10 +61,13 @@ RSpec.describe Questions::PersonalInfoController do
       context "when routing service returns nil" do
         before do
           allow(organization_router).to receive(:determine_partner).and_return nil
+          allow(organization_router).to receive(:routing_method).and_return :at_capacity
         end
 
         it "redirects to capacity page" do
-          post :update, params: params
+          expect {
+            post :update, params: params
+          }.to change(intake.client, :routing_method).to eq("at_capacity")
 
           expect(PartnerRoutingService).to have_received(:new).with(
             {

--- a/spec/features/web_intake/new_joint_filers_spec.rb
+++ b/spec/features/web_intake/new_joint_filers_spec.rb
@@ -1,9 +1,8 @@
 require "rails_helper"
 
 RSpec.feature "Web Intake Joint Filers" do
-  before do
-    create :vita_partner, name: "Virginia Partner", national_overflow_location: true
-  end
+  let!(:vita_partner) { create :vita_partner, name: "Virginia Partner" }
+  let!(:vita_partner_zip_code) { create :vita_partner_zip_code, zip_code: "20121", vita_partner: vita_partner }
 
   scenario "new client filing joint taxes with spouse and dependents" do
     visit "/en/questions/welcome"

--- a/spec/features/web_intake/new_single_filer_spec.rb
+++ b/spec/features/web_intake/new_single_filer_spec.rb
@@ -1,11 +1,8 @@
 require "rails_helper"
 
 RSpec.feature "Web Intake Single Filer", active_job: true do
-  let(:ticket_id) { 9876 }
-
-  before do
-    create :vita_partner, name: "Virginia Partner", national_overflow_location: true
-  end
+  let!(:vita_partner) { create :vita_partner, name: "Virginia Partner" }
+  let!(:vita_partner_zip_code) { create :vita_partner_zip_code, zip_code: "20121", vita_partner: vita_partner }
 
   scenario "new client filing single without dependents" do
     visit "/en/questions/welcome"

--- a/spec/services/partner_routing_service_spec.rb
+++ b/spec/services/partner_routing_service_spec.rb
@@ -44,8 +44,8 @@ describe PartnerRoutingService do
         subject { PartnerRoutingService.new(source_param: "s0m3th1ng") }
 
         it "returns nil" do
-          # TODO: decide what routing_method should be
           expect(subject.determine_partner).to be_nil
+          expect(subject.routing_method).to eq :at_capacity
         end
       end
     end
@@ -66,8 +66,7 @@ describe PartnerRoutingService do
 
           it "returns nil" do
             expect(subject.determine_partner).to be_nil
-            # TODO: decide what routing_method should be
-            expect(subject.routing_method).not_to eq :zip_code
+            expect(subject.routing_method).to eq :at_capacity
           end
         end
       end
@@ -93,8 +92,8 @@ describe PartnerRoutingService do
             }
 
             it "returns nil" do
-              # TODO: decide what routing_method should be
               expect(subject.determine_partner).to be_nil
+              expect(subject.routing_method).to eq :at_capacity
             end
           end
 
@@ -116,8 +115,8 @@ describe PartnerRoutingService do
           subject { PartnerRoutingService.new(zip_code: "32703") }
 
           it "returns nil" do
-            # TODO: decide what routing_method should be
             expect(subject.determine_partner).to be_nil
+            expect(subject.routing_method).to eq :at_capacity
           end
         end
       end

--- a/spec/services/partner_routing_service_spec.rb
+++ b/spec/services/partner_routing_service_spec.rb
@@ -16,8 +16,8 @@ describe PartnerRoutingService do
 
   describe "#determine_partner" do
     context "fallback logic" do
-      it "routes to an overflow partner" do
-        expect(subject.determine_partner.national_overflow_location).to eq true
+      it "returns nil" do
+        expect(subject.determine_partner).to be_nil
       end
     end
 
@@ -43,8 +43,9 @@ describe PartnerRoutingService do
       context "when source param is not valid" do
         subject { PartnerRoutingService.new(source_param: "s0m3th1ng") }
 
-        it "routes to an overflow partner location" do
-          expect(subject.determine_partner.national_overflow_location).to eq true
+        it "returns nil" do
+          # TODO: decide what routing_method should be
+          expect(subject.determine_partner).to be_nil
         end
       end
     end
@@ -62,8 +63,10 @@ describe PartnerRoutingService do
           before do
             vita_partner.update(capacity_limit: 0)
           end
-          it "does not route to that vita partner by zip code" do
-            expect(subject.determine_partner).not_to eq vita_partner
+
+          it "returns nil" do
+            expect(subject.determine_partner).to be_nil
+            # TODO: decide what routing_method should be
             expect(subject.routing_method).not_to eq :zip_code
           end
         end
@@ -89,8 +92,9 @@ describe PartnerRoutingService do
               end
             }
 
-            it "assigns to a national vita partner" do
-              expect(subject.determine_partner.national_overflow_location).to eq true
+            it "returns nil" do
+              # TODO: decide what routing_method should be
+              expect(subject.determine_partner).to be_nil
             end
           end
 
@@ -111,8 +115,9 @@ describe PartnerRoutingService do
         context "when there are no Vita Partners for the state the zip code is in" do
           subject { PartnerRoutingService.new(zip_code: "32703") }
 
-          it "routes to a national overflow partner location" do
-            expect(subject.determine_partner.national_overflow_location).to eq true
+          it "returns nil" do
+            # TODO: decide what routing_method should be
+            expect(subject.determine_partner).to be_nil
           end
         end
       end


### PR DESCRIPTION
_Note: this should not be merged until [this story](https://www.pivotaltracker.com/story/show/178103177) is merged. that, or the code for this needs to change (talk to me about how)._

Would love some feedback on this! Particularly:
1) replacing `PersonalInfoController#after_update_success` the way i did, and whether there's a better way to do the redirect
2) whether to add a new `routing_method` for those who are now routed to no one