### PR TITLE
Refactor client messaging + replace params before sending messages

### DIFF
--- a/app/controllers/documents/documents_help_controller.rb
+++ b/app/controllers/documents/documents_help_controller.rb
@@ -8,7 +8,7 @@ module Documents
 
     def send_reminder
       ClientMessagingService.send_system_message_to_all_opted_in_contact_methods(
-        current_intake.client,
+        client: current_intake.client,
         email_body: I18n.t("documents.reminder_link.email_body_html",
                            first_name: current_intake.preferred_name,
                            doc_type: params[:doc_type].constantize.key,

--- a/app/controllers/hub/outgoing_emails_controller.rb
+++ b/app/controllers/hub/outgoing_emails_controller.rb
@@ -7,7 +7,12 @@ module Hub
 
     def create
       if outgoing_email_params[:body].present?
-        ClientMessagingService.send_email(@client, current_user, outgoing_email_params[:body], attachment: outgoing_email_params[:attachment])
+        ClientMessagingService.send_email(
+          client: @client,
+          user: current_user,
+          body: outgoing_email_params[:body],
+          attachment: outgoing_email_params[:attachment]
+        )
       end
       redirect_to hub_client_messages_path(client_id: @client, anchor: "last-item")
     end

--- a/app/controllers/hub/outgoing_text_messages_controller.rb
+++ b/app/controllers/hub/outgoing_text_messages_controller.rb
@@ -7,7 +7,11 @@ module Hub
 
     def create
       if outgoing_text_message_params[:body].present?
-        ClientMessagingService.send_text_message(@client, current_user, outgoing_text_message_params[:body])
+        ClientMessagingService.send_text_message(
+          client: @client,
+          user: current_user,
+          body: outgoing_text_message_params[:body]
+        )
       end
       redirect_to hub_client_messages_path(client_id: @client.id, anchor: "last-item")
     end

--- a/app/controllers/questions/consent_controller.rb
+++ b/app/controllers/questions/consent_controller.rb
@@ -13,15 +13,12 @@ module Questions
     def after_update_success
       sign_in current_intake.client
       current_intake.advance_tax_return_statuses_to("intake_in_progress")
-      if current_intake.email_notification_opt_in_yes?
-        body = I18n.t("messages.getting_started.email_body", preferred_name: current_intake.preferred_name, portal_login_url: new_portal_client_login_url(locale: current_intake.locale), locale: current_intake.locale, client_id: current_intake.client_id)
-        subject = I18n.t("messages.getting_started.email_subject", locale: current_intake.locale)
-        ClientMessagingService.send_system_email(current_intake.client, body, subject)
-      end
-      if current_intake.sms_notification_opt_in_yes?
-        body = I18n.t("messages.getting_started.sms_body", preferred_name: current_intake.preferred_name, portal_login_url: new_portal_client_login_url(locale: current_intake.locale), locale: current_intake.locale, client_id: current_intake.client_id)
-        ClientMessagingService.send_system_text_message(current_intake.client, body)
-      end
+      ClientMessagingService.send_system_message_to_all_opted_in_contact_methods(
+        client: current_intake.client,
+        email_body: I18n.t("messages.getting_started.email_body", preferred_name: current_intake.preferred_name, portal_login_url: new_portal_client_login_url(locale: current_intake.locale), locale: current_intake.locale, client_id: current_intake.client_id),
+        subject: I18n.t("messages.getting_started.email_subject", locale: current_intake.locale),
+        sms_body: I18n.t("messages.getting_started.sms_body", preferred_name: current_intake.preferred_name, portal_login_url: new_portal_client_login_url(locale: current_intake.locale), locale: current_intake.locale, client_id: current_intake.client_id)
+      )
       Intake14446PdfJob.perform_later(current_intake, "Consent Form 14446.pdf")
       IntakePdfJob.perform_later(current_intake.id, "Preliminary 13614-C.pdf")
     end

--- a/app/controllers/questions/final_info_controller.rb
+++ b/app/controllers/questions/final_info_controller.rb
@@ -23,7 +23,7 @@ module Questions
     def send_confirmation_message
       @client = current_intake.client
       ClientMessagingService.send_system_message_to_all_opted_in_contact_methods(
-        current_intake.client,
+        client: current_intake.client,
         email_body: I18n.t(
           "messages.successful_submission.sms_body",
           locale: current_intake.locale,

--- a/app/controllers/questions/notification_preference_controller.rb
+++ b/app/controllers/questions/notification_preference_controller.rb
@@ -9,8 +9,8 @@ module Questions
     def after_update_success
       if @form.intake.sms_notification_opt_in_yes?
         ClientMessagingService.send_system_text_message(
-          @form.intake.client,
-          I18n.t(
+          client: @form.intake.client,
+          body: I18n.t(
             "messages.sms_opt_in",
             locale: current_intake.locale,
           )

--- a/app/forms/hub/create_client_form.rb
+++ b/app/forms/hub/create_client_form.rb
@@ -74,7 +74,7 @@ module Hub
                           org_name: @client.vita_partner.name,
                           confirmation_number: @client.id)
       ClientMessagingService.send_system_message_to_all_opted_in_contact_methods(
-        @client,
+        client: @client,
         sms_body: sms_body,
         email_body: email_body,
         subject: subject

--- a/app/jobs/send_client_completion_survey_job.rb
+++ b/app/jobs/send_client_completion_survey_job.rb
@@ -14,14 +14,14 @@ class SendClientCompletionSurveyJob < ApplicationJob
     case best_contact_method
     when :email
       ClientMessagingService.send_system_email(
-        client,
-        I18n.t("messages.surveys.completion.email.body", locale: client.intake.locale, survey_link: survey_link),
-        I18n.t("messages.surveys.completion.email.subject", locale: client.intake.locale)
+        client: client,
+        body: I18n.t("messages.surveys.completion.email.body", locale: client.intake.locale, survey_link: survey_link),
+        subject: I18n.t("messages.surveys.completion.email.subject", locale: client.intake.locale)
       )
     when :sms_phone_number
       ClientMessagingService.send_system_text_message(
-        client,
-        I18n.t("messages.surveys.completion.text", locale: client.intake.locale, survey_link: survey_link),
+        client: client,
+        body: I18n.t("messages.surveys.completion.text", locale: client.intake.locale, survey_link: survey_link),
       )
     end
   end

--- a/app/jobs/send_client_in_progress_survey_job.rb
+++ b/app/jobs/send_client_in_progress_survey_job.rb
@@ -15,14 +15,14 @@ class SendClientInProgressSurveyJob < ApplicationJob
     case best_contact_method
     when :email
       ClientMessagingService.send_system_email(
-        client,
-        I18n.t("messages.surveys.in_progress.email.body", locale: client.intake.locale, survey_link: survey_link, preferred_name: client.preferred_name, portal_login_url: new_portal_client_login_url(locale: client.intake.locale)),
-        I18n.t("messages.surveys.in_progress.email.subject", locale: client.intake.locale)
+        client: client,
+        body: I18n.t("messages.surveys.in_progress.email.body", locale: client.intake.locale, survey_link: survey_link, preferred_name: client.preferred_name, portal_login_url: new_portal_client_login_url(locale: client.intake.locale)),
+        subject: I18n.t("messages.surveys.in_progress.email.subject", locale: client.intake.locale)
       )
     when :sms_phone_number
       ClientMessagingService.send_system_text_message(
-        client,
-        I18n.t("messages.surveys.in_progress.text", locale: client.intake.locale, survey_link: survey_link, preferred_name: client.preferred_name),
+        client: client,
+        body: I18n.t("messages.surveys.in_progress.text", locale: client.intake.locale, survey_link: survey_link, preferred_name: client.preferred_name),
       )
     end
   end

--- a/app/models/outgoing_email.rb
+++ b/app/models/outgoing_email.rb
@@ -46,7 +46,6 @@ class OutgoingEmail < ApplicationRecord
 
   # has_one_attached needs to be called after defining any callbacks that access attachments, like :deliver; see https://github.com/rails/rails/issues/37304
   has_one_attached :attachment
-
   scope :succeeded, ->{ where(mailgun_status: SUCCESSFUL_MAILGUN_STATUSES) }
   scope :failed, ->{ where(mailgun_status: FAILED_MAILGUN_STATUSES) }
   scope :in_progress, ->{ where(mailgun_status: IN_PROGRESS_MAILGUN_STATUSES) }

--- a/app/models/outgoing_text_message.rb
+++ b/app/models/outgoing_text_message.rb
@@ -36,7 +36,6 @@ class OutgoingTextMessage < ApplicationRecord
   validates_presence_of :body
   validates :to_phone_number, e164_phone: true
   validates :twilio_status, inclusion: { in: ALL_KNOWN_TWILIO_STATUSES }
-
   after_create :deliver, :broadcast
   after_create { |msg| InteractionTrackingService.record_user_initiated_outgoing_interaction(client) if msg.user.present? }
   after_create { InteractionTrackingService.update_last_outgoing_communication_at(client) }

--- a/app/services/replacement_parameters_service.rb
+++ b/app/services/replacement_parameters_service.rb
@@ -3,12 +3,12 @@ class ReplacementParametersService
 
   delegate :new_portal_client_login_url, to: "Rails.application.routes.url_helpers"
 
-  def initialize(body:, client:, preparer: nil, tax_return: nil, locale: "en")
+  def initialize(body:, client:, preparer: nil, tax_return: nil, locale: nil)
     @body = body
     @client = client
     @tax_return = tax_return
     @preparer_user = preparer
-    @locale = locale
+    @locale = locale || "en"
   end
 
   def process

--- a/app/services/tax_return_service.rb
+++ b/app/services/tax_return_service.rb
@@ -6,18 +6,18 @@ class TaxReturnService
     form.tax_return.update(status: form.status)
     action_list << I18n.t("hub.clients.update_take_action.flash_message.status")
     SystemNote::StatusChange.generate!(initiated_by: form.current_user, tax_return: form.tax_return)
-
     if form.message_body.present?
+      args = { client: form.client, user: form.current_user, body: form.message_body, tax_return: form.tax_return, locale: form.locale }
       case form.contact_method
       when "email"
         if form.status == "review_signature_requested"
-          ClientMessagingService.send_email_to_all_signers(form.client, form.current_user, form.message_body, subject_locale: form.locale)
+          ClientMessagingService.send_email_to_all_signers(**args)
         else
-          ClientMessagingService.send_email(form.client, form.current_user, form.message_body, subject_locale: form.locale)
+          ClientMessagingService.send_email(**args)
         end
         action_list << I18n.t("hub.clients.update_take_action.flash_message.email")
       when "text_message"
-        ClientMessagingService.send_text_message(form.client, form.current_user, form.message_body)
+        ClientMessagingService.send_text_message(**args)
         action_list << I18n.t("hub.clients.update_take_action.flash_message.text_message")
       end
     end

--- a/spec/controllers/documents/documents_help_controller_spec.rb
+++ b/spec/controllers/documents/documents_help_controller_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Documents::DocumentsHelpController, type: :controller do
       EMAIL
 
       expect(ClientMessagingService).to have_received(:send_system_message_to_all_opted_in_contact_methods).with(
-        client,
+        client: client,
         email_body: email_body,
         sms_body: sms_body,
         subject: "Your tax document reminder"

--- a/spec/controllers/hub/outgoing_emails_controller_spec.rb
+++ b/spec/controllers/hub/outgoing_emails_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Hub::OutgoingEmailsController do
         it "calls the send_email method with the right arguments and redirects to messages page" do
           post :create, params: params
 
-          expect(ClientMessagingService).to have_received(:send_email).with(client, user, "hi client", attachment: instance_of(ActionDispatch::Http::UploadedFile))
+          expect(ClientMessagingService).to have_received(:send_email).with(client: client, user: user, body: "hi client", attachment: instance_of(ActionDispatch::Http::UploadedFile))
           expect(response).to redirect_to hub_client_messages_path(client_id: client.id, anchor: "last-item")
         end
       end

--- a/spec/controllers/hub/outgoing_text_messages_controller_spec.rb
+++ b/spec/controllers/hub/outgoing_text_messages_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Hub::OutgoingTextMessagesController do
       it "calls send_text_message with the right arguments and redirects to messages" do
         post :create, params: params
 
-        expect(ClientMessagingService).to have_received(:send_text_message).with(client, user, "This is an outgoing text")
+        expect(ClientMessagingService).to have_received(:send_text_message).with(client: client, user: user, body: "This is an outgoing text")
         expect(response).to redirect_to(hub_client_messages_path(client_id: client.id, anchor: "last-item"))
       end
 

--- a/spec/controllers/questions/consent_controller_spec.rb
+++ b/spec/controllers/questions/consent_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Questions::ConsentController do
-  let(:intake) { create :intake, preferred_name: "Ruthie Rutabaga" }
+  let(:intake) { create :intake, preferred_name: "Ruthie Rutabaga", email_address: "hi@example.com", sms_phone_number: "+18324651180" }
   let(:client) { intake.client }
   let!(:tax_return) { create :tax_return, client: client }
 
@@ -175,9 +175,9 @@ RSpec.describe Questions::ConsentController do
           BODY
 
           expect(ClientMessagingService).to have_received(:send_system_email).with(
-            intake.client,
-            email_body,
-            "Getting your taxes started with GetYourRefund",
+            client: intake.client,
+            body: email_body,
+            subject: "Getting your taxes started with GetYourRefund",
           )
         end
 
@@ -192,8 +192,8 @@ RSpec.describe Questions::ConsentController do
           BODY
 
           expect(ClientMessagingService).to have_received(:send_system_text_message).with(
-            intake.client,
-            body.chomp,
+              client: intake.client,
+              body: body.chomp
           )
         end
       end
@@ -223,9 +223,9 @@ RSpec.describe Questions::ConsentController do
           BODY
 
           expect(ClientMessagingService).to have_received(:send_system_email).with(
-            intake.client,
-            email_body,
-            "Comience a tramitar sus impuestos con GetYourRefund",
+              client: intake.client,
+              body: email_body,
+              subject: "Comience a tramitar sus impuestos con GetYourRefund",
           )
         end
 
@@ -239,8 +239,8 @@ RSpec.describe Questions::ConsentController do
           BODY
 
           expect(ClientMessagingService).to have_received(:send_system_text_message).with(
-            intake.client,
-            body.chomp,
+              client: intake.client,
+              body: body.chomp
           )
         end
       end

--- a/spec/controllers/questions/notification_preference_controller_spec.rb
+++ b/spec/controllers/questions/notification_preference_controller_spec.rb
@@ -71,13 +71,7 @@ RSpec.describe Questions::NotificationPreferenceController do
         expect(intake.sms_notification_opt_in).to eq("no")
         expect(intake.email_notification_opt_in).to eq("yes")
         expect(intake.sms_phone_number).to eq("+15005550006")
-        expect(ClientMessagingService).to_not have_received(:send_system_text_message).with(
-          intake,
-          I18n.t(
-            "messages.sms_opt_in",
-            locale: intake.locale
-          )
-        )
+        expect(ClientMessagingService).to_not have_received(:send_system_text_message)
       end
 
       it "sends an event to mixpanel with relevant data" do
@@ -107,8 +101,8 @@ RSpec.describe Questions::NotificationPreferenceController do
           post :update, params: params
 
           expect(ClientMessagingService).to have_received(:send_system_text_message).with(
-            intake.client,
-            I18n.t(
+              client: intake.client,
+              body: I18n.t(
               "messages.sms_opt_in",
               locale: intake.locale,
             )

--- a/spec/forms/hub/create_client_form_spec.rb
+++ b/spec/forms/hub/create_client_form_spec.rb
@@ -155,14 +155,14 @@ RSpec.describe Hub::CreateClientForm do
           BODY
 
           expect(ClientMessagingService).to have_received(:send_system_email).with(
-            client,
-            email_body,
-            email_subject,
+            client: client,
+            body: email_body,
+            subject: email_subject,
           )
 
           sms_body = "Hello Newly, thank you for submitting your tax information to Caravan Palace! Your Client ID is #{client.id}. Respond to this message if you have any questions. We’re here to help!"
 
-          expect(ClientMessagingService).to have_received(:send_system_text_message).with(client, sms_body)
+          expect(ClientMessagingService).to have_received(:send_system_text_message).with(client: client, body: sms_body)
         end
       end
 
@@ -193,14 +193,14 @@ RSpec.describe Hub::CreateClientForm do
           BODY
 
           expect(ClientMessagingService).to have_received(:send_system_email).with(
-            client,
-            email_body,
-            email_subject,
-            )
+            client: client,
+            body: email_body,
+            subject: email_subject,
+          )
 
           sms_body = "Hola Newly, ¡Gracias por enviar su información de impuestos a Caravan Palace! Su ID de cliente es #{client.id}. Responda a este mensaje si tiene alguna pregunta. Estamos aquí para ayudarle."
 
-          expect(ClientMessagingService).to have_received(:send_system_text_message).with(client, sms_body)
+          expect(ClientMessagingService).to have_received(:send_system_text_message).with(client: client, body: sms_body)
         end
       end
 

--- a/spec/jobs/send_client_completion_survey_job_spec.rb
+++ b/spec/jobs/send_client_completion_survey_job_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe SendClientCompletionSurveyJob, type: :job do
             described_class.perform_now(client)
 
             expect(ClientMessagingService).to have_received(:send_system_email).with(
-              client,
-              a_string_including("qualtrics.com"),
-              "¡Gracias por declarar tus impuestos con GetYourRefund!"
+              client: client,
+              body: a_string_including("qualtrics.com"),
+              subject: "¡Gracias por declarar tus impuestos con GetYourRefund!"
             )
             expect(client.reload.completion_survey_sent_at).to be_present
           end
@@ -40,8 +40,8 @@ RSpec.describe SendClientCompletionSurveyJob, type: :job do
             described_class.perform_now(client)
 
             expect(ClientMessagingService).to have_received(:send_system_text_message).with(
-              client,
-              a_string_including("qualtrics.com"),
+              client: client,
+              body: a_string_including("qualtrics.com"),
             )
             expect(ClientMessagingService).not_to have_received(:send_system_email)
             expect(client.reload.completion_survey_sent_at).to be_present
@@ -59,9 +59,9 @@ RSpec.describe SendClientCompletionSurveyJob, type: :job do
             described_class.perform_now(client)
 
             expect(ClientMessagingService).to have_received(:send_system_email).with(
-              client,
-              a_string_including("qualtrics.com"),
-              "¡Gracias por declarar tus impuestos con GetYourRefund!"
+              client: client,
+              body: a_string_including("qualtrics.com"),
+              subject: "¡Gracias por declarar tus impuestos con GetYourRefund!"
             )
             expect(ClientMessagingService).not_to have_received(:send_system_text_message)
             expect(client.reload.completion_survey_sent_at).to be_present

--- a/spec/jobs/send_client_in_progress_survey_job_spec.rb
+++ b/spec/jobs/send_client_in_progress_survey_job_spec.rb
@@ -21,10 +21,10 @@ RSpec.describe SendClientInProgressSurveyJob, type: :job do
             described_class.perform_now(client)
 
             expect(ClientMessagingService).to have_received(:send_system_email).with(
-              client,
-              a_string_including("qualtrics.com"),
-              "Bienvenido a GetYourRefund.org. ¡Ya casi estás ahí!",
-              )
+              client: client,
+              body: a_string_including("qualtrics.com"),
+              subject: "Bienvenido a GetYourRefund.org. ¡Ya casi estás ahí!",
+            )
             expect(client.reload.in_progress_survey_sent_at).to be_present
           end
         end
@@ -41,9 +41,9 @@ RSpec.describe SendClientInProgressSurveyJob, type: :job do
             described_class.perform_now(client)
 
             expect(ClientMessagingService).to have_received(:send_system_text_message).with(
-              client,
-              a_string_including("qualtrics.com"),
-              )
+              client: client,
+              body: a_string_including("qualtrics.com"),
+            )
             expect(ClientMessagingService).not_to have_received(:send_system_email)
             expect(client.reload.in_progress_survey_sent_at).to be_present
           end
@@ -60,9 +60,9 @@ RSpec.describe SendClientInProgressSurveyJob, type: :job do
             described_class.perform_now(client)
 
             expect(ClientMessagingService).to have_received(:send_system_email).with(
-              client,
-              a_string_including("qualtrics.com"),
-              "Bienvenido a GetYourRefund.org. ¡Ya casi estás ahí!"
+              client: client,
+              body: a_string_including("qualtrics.com"),
+              subject: "Bienvenido a GetYourRefund.org. ¡Ya casi estás ahí!"
             )
             expect(ClientMessagingService).not_to have_received(:send_system_text_message)
             expect(client.reload.in_progress_survey_sent_at).to be_present

--- a/spec/services/tax_return_service_spec.rb
+++ b/spec/services/tax_return_service_spec.rb
@@ -74,7 +74,7 @@ describe TaxReturnService do
         it "sends an email" do
           TaxReturnService.handle_status_change(form)
 
-          expect(ClientMessagingService).to have_received(:send_email).with(client, user, "message body", subject_locale: "es")
+          expect(ClientMessagingService).to have_received(:send_email).with(client: client, user: user, body: "message body", locale: "es", tax_return: tax_return)
         end
 
         it "records email sending in the action list" do
@@ -97,7 +97,7 @@ describe TaxReturnService do
           it "sends an email addressed to all filers" do
             TaxReturnService.handle_status_change(form)
 
-            expect(ClientMessagingService).to have_received(:send_email_to_all_signers).with(client, user, "message body", subject_locale: "es")
+            expect(ClientMessagingService).to have_received(:send_email_to_all_signers).with(client: client, user: user, body: "message body", locale: "es", tax_return: tax_return)
           end
         end
       end
@@ -108,7 +108,7 @@ describe TaxReturnService do
         it "sends a text message" do
           TaxReturnService.handle_status_change(form)
 
-          expect(ClientMessagingService).to have_received(:send_text_message).with(client, user, "message body")
+          expect(ClientMessagingService).to have_received(:send_text_message).with(client: client, user: user, body: "message body", locale: "es", tax_return: tax_return)
         end
 
         it "records text message sending in the action list" do


### PR DESCRIPTION
This will now pass every email through replacement parameters service before sending, which means that we can use replacement parameters / status macros by default for bulk messaging, and users can use replacement parameters for custom messages on the messages page or take action page.

It also refactors client messaging to consolidate some logic while maintaining the same public API, method wise I also switched to using keyword arguments for all messaging methods since they're unordered.