### PR TITLE
Use document type parameters instead of class name

### DIFF
--- a/app/controllers/documents/documents_help_controller.rb
+++ b/app/controllers/documents/documents_help_controller.rb
@@ -29,6 +29,13 @@ module Documents
 
     def document_type_from_param
       document_type = DocumentType.from_param(params[:doc_type])
+      # support existing class name doc types
+      begin
+        document_type = params[:doc_type].constantize&.key unless document_type.present?
+      rescue
+        raise ArgumentError, "Invalid document type" unless document_type.present?
+      end
+
       raise ArgumentError, "Invalid document type" unless document_type.present?
 
       document_type

--- a/app/controllers/documents/documents_help_controller.rb
+++ b/app/controllers/documents/documents_help_controller.rb
@@ -7,7 +7,7 @@ module Documents
     def show; end
 
     def send_reminder
-      doc_type = params[:doc_type].to_s.constantize.key
+      doc_type = document_type_from_param.key
       ClientMessagingService.send_system_message_to_all_opted_in_contact_methods(
         client: current_intake.client,
         email_body: I18n.t("documents.reminder_link.email_body", doc_type: doc_type),
@@ -22,9 +22,16 @@ module Documents
     def request_doc_help
       raise ArgumentError unless DocumentTypes::HELP_TYPES.include? params[:help_type].to_sym
 
-      current_client.request_document_help(doc_type: params[:doc_type].to_s.constantize, help_type: params[:help_type])
+      current_client.request_document_help(doc_type: document_type_from_param, help_type: params[:help_type])
       flash[:notice] = I18n.t("documents.updated_specialist.notice")
       redirect_to(next_path)
+    end
+
+    def document_type_from_param
+      document_type = DocumentType.from_param(params[:doc_type])
+      raise ArgumentError, "Invalid document type" unless document_type.present?
+
+      document_type
     end
 
     private

--- a/app/lib/document_type.rb
+++ b/app/lib/document_type.rb
@@ -27,16 +27,24 @@ class DocumentType
       false
     end
 
+    def from_param(param)
+      DocumentTypes::ALL_TYPES.find { |doc_type_class| doc_type_class.to_param == param }
+    end
+
+    def to_param
+      key.parameterize(separator: "_")
+    end
+
     def label
-      I18n.t("general.document_types.#{key.parameterize(separator: "_")}", default: key)
+      I18n.t("general.document_types.#{to_param}", default: key)
     end
 
     def translated_label(locale)
-      I18n.t("general.document_types.#{key.parameterize(separator: "_")}", default: key, locale: locale)
+      I18n.t("general.document_types.#{to_param}", default: key, locale: locale)
     end
 
     def translated_label_with_description(locale)
-      I18n.t("general.document_types.with_descriptions.#{key.parameterize(separator: "_")}", default: key, locale: locale)
+      I18n.t("general.document_types.with_descriptions.#{to_param}", default: key, locale: locale)
     end
 
     def to_s

--- a/app/views/layouts/document_upload.html.erb
+++ b/app/views/layouts/document_upload.html.erb
@@ -100,7 +100,7 @@
               </button>
             <% end %>
             <% unless document_type.skip_dont_have? %>
-              <%= link_to (document_type.provide_doc_help? ? documents_help_path(doc_type: document_type.name, next_path: next_path) : next_path), class: "link--cta spacing-above-25", "data-track-click": "dont_have_doc", "data-track-attribute-document_type": "#{document_type.key}" do %>
+              <%= link_to (document_type.provide_doc_help? ? documents_help_path(doc_type: document_type.to_param, next_path: next_path) : next_path), class: "link--cta spacing-above-25", "data-track-click": "dont_have_doc", "data-track-attribute-document_type": "#{document_type.key}" do %>
                 <%=t("views.layouts.document_upload.dont_have") %>
               <% end %>
             <% end %>

--- a/spec/controllers/documents/documents_help_controller_spec.rb
+++ b/spec/controllers/documents/documents_help_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Documents::DocumentsHelpController, type: :controller do
     let(:next_path) { "/en/next" }
     let(:params) do
       {
-          doc_type: "DocumentTypes::Identity",
+          doc_type: "id",
           next_path: next_path
       }
     end
@@ -38,7 +38,7 @@ RSpec.describe Documents::DocumentsHelpController, type: :controller do
     let!(:client) { create(:intake, email_address: "gork@example.com", sms_phone_number: "+14155537865", email_notification_opt_in: "yes", sms_notification_opt_in: "yes", preferred_name: "Gilly").client }
     let(:params) do
       { next_path: "/en/documents/selfies",
-        doc_type: "DocumentTypes::Identity" }
+        doc_type: "id" }
     end
 
     before do
@@ -91,7 +91,7 @@ RSpec.describe Documents::DocumentsHelpController, type: :controller do
       let(:help_type){ }
       let(:params) do
         { next_path: "/en/documents/selfies",
-          doc_type: "DocumentTypes::Identity",
+          doc_type: "employment",
           help_type: help_type
         }
       end
@@ -107,7 +107,7 @@ RSpec.describe Documents::DocumentsHelpController, type: :controller do
 
             it "calls client request_doc_help" do
               post :request_doc_help, params: params
-              expect(assigns(:current_client)).to have_received(:request_document_help).with(doc_type: DocumentTypes::Identity, help_type: help_type)
+              expect(assigns(:current_client)).to have_received(:request_document_help).with(doc_type: DocumentTypes::Employment, help_type: help_type)
             end
           end
         end
@@ -117,7 +117,7 @@ RSpec.describe Documents::DocumentsHelpController, type: :controller do
     context "not valid help type" do
       let(:invalid_params) do
         { next_path: "/en/documents/selfies",
-          doc_type: "DocumentTypes::Identity",
+          doc_type: "1099-g",
           help_type: "garbage"
         }
       end

--- a/spec/controllers/documents/documents_help_controller_spec.rb
+++ b/spec/controllers/documents/documents_help_controller_spec.rb
@@ -128,5 +128,53 @@ RSpec.describe Documents::DocumentsHelpController, type: :controller do
         end.to raise_error(ArgumentError)
       end
     end
+
+    context "doc_type param" do
+      context "with valid doc_type param" do
+        let(:params) do
+          {
+            next_path: "/en/documents/selfies",
+            doc_type: "id",
+            help_type: "doesnt_apply"
+          }
+        end
+
+        it "is successful" do
+          post :request_doc_help, params: params
+          expect(response).to redirect_to params[:next_path]
+        end
+      end
+
+      context "with temporary, legacy class doc type" do
+        let(:params) do
+          {
+              next_path: "/en/documents/selfies",
+              doc_type: "DocumentTypes::Identity",
+              help_type: "doesnt_apply"
+          }
+        end
+
+        it "is successful" do
+          post :request_doc_help, params: params
+          expect(response).to redirect_to params[:next_path]
+        end
+      end
+
+      context "with invalid doc type" do
+        let(:params) do
+          {
+            next_path: "/en/documents/selfies",
+            doc_type: "something",
+            help_type: "doesnt_apply"
+          }
+        end
+
+        it "raises an error" do
+          expect {
+            post :request_doc_help, params: params
+          }.to raise_error ArgumentError
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
funky URLS like documents/doc-help/DocumentTypes::Identity now have nicer urls (documents/doc-help/identity)