### PR TITLE
Remove support for legacy doc_type param format

### DIFF
--- a/app/controllers/documents/documents_help_controller.rb
+++ b/app/controllers/documents/documents_help_controller.rb
@@ -29,13 +29,6 @@ module Documents
 
     def document_type_from_param
       document_type = DocumentType.from_param(params[:doc_type])
-      # support existing class name doc types
-      begin
-        document_type = params[:doc_type].constantize&.key unless document_type.present?
-      rescue
-        raise ArgumentError, "Invalid document type" unless document_type.present?
-      end
-
       raise ArgumentError, "Invalid document type" unless document_type.present?
 
       document_type

--- a/spec/controllers/documents/documents_help_controller_spec.rb
+++ b/spec/controllers/documents/documents_help_controller_spec.rb
@@ -145,21 +145,6 @@ RSpec.describe Documents::DocumentsHelpController, type: :controller do
         end
       end
 
-      context "with temporary, legacy class doc type" do
-        let(:params) do
-          {
-              next_path: "/en/documents/selfies",
-              doc_type: "DocumentTypes::Identity",
-              help_type: "doesnt_apply"
-          }
-        end
-
-        it "is successful" do
-          post :request_doc_help, params: params
-          expect(response).to redirect_to params[:next_path]
-        end
-      end
-
       context "with invalid doc type" do
         let(:params) do
           {


### PR DESCRIPTION
Co-authored-by: Jenny Heath <jheath@codeforamerica.org>