### PR TITLE
Foreman Spike: Modified procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-cmd: bundle exec rails s -b 0.0.0.0 -p 3000
+server: bundle exec rails s -b 0.0.0.0 -p 3000
 worker: bundle exec rails jobs:work
-cron: exec supercronic /app/crontab
+webpack: exec bin/webpack-dev-server


### PR DESCRIPTION
We already had a procfile (news to me!), so I just modified it.

Foreman suggests that you do NOT add foreman to your Gemfile and instead people should install it on their computer outside of bundler:

`gem install foreman`

Make sure that all other processes are dead before trying to start with this, or else all processes will terminate.

Spike result:

Since we already have a procfile that I was able to just modify, I think we should just merge this after typical review. People can decide whether to use or not use foreman to start the app. I will show at next computer gardening.