### PR TITLE
Update personal info controller to validate the form again and set up next_path to at_capacity if a vita partner is not returned

### DIFF
--- a/app/controllers/questions/personal_info_controller.rb
+++ b/app/controllers/questions/personal_info_controller.rb
@@ -6,23 +6,25 @@ module Questions
       {}
     end
 
-    def update
+    def after_update_success
       unless Client.after_consent.where(intake: current_intake).exists?
         routing_service = PartnerRoutingService.new(
           source_param: current_intake.source,
-          zip_code: form_params[:zip_code],
+          zip_code: current_intake.zip_code,
         )
-        vita_partner = routing_service.determine_partner
+        @vita_partner = routing_service.determine_partner
 
-        if vita_partner.present?
-          current_intake.client.update(vita_partner: vita_partner, routing_method: routing_service.routing_method)
-          current_intake.update(vita_partner: vita_partner)
-          super
+        if @vita_partner.present?
+          current_intake.client.update(vita_partner: @vita_partner, routing_method: routing_service.routing_method)
+          current_intake.update(vita_partner: @vita_partner)
         else
           current_intake.client.update(routing_method: routing_service.routing_method)
-          return redirect_to at_capacity_questions_path
         end
       end
+    end
+
+    def next_path
+      @vita_partner.present? ? super : at_capacity_questions_path
     end
   end
 end


### PR DESCRIPTION
Turns out the form is what validates the zip code, and if we don't validate the zip code the user doesnt see an error message when they enter a bad zip AND that bad zip gets through to our partner router.  😢  So reverting to use update and after_update_success and overriding next_path when there is no vita partner ensures we're validating and also sending people to the right place. 