### PR TITLE
Add tests for client unlocks outside of orgs and sites #178150745

### DIFF
--- a/spec/controllers/hub/clients_controller_spec.rb
+++ b/spec/controllers/hub/clients_controller_spec.rb
@@ -1078,10 +1078,17 @@ RSpec.describe Hub::ClientsController do
 
     context "as a site coordinator user" do
       let!(:site) { create :site }
+      let!(:client_outside_of_site) { create(:client) }
       before {
         sign_in create(:site_coordinator_user, site: site)
         client.update(vita_partner: site)
       }
+
+      it "can't unlock a client that is not under their site" do
+        patch :unlock, params: { id: client_outside_of_site.id }
+
+        expect(response.status).to eq 403
+      end
 
       it "unlocks the client and redirects to the client profile page" do
         patch :unlock, params: params
@@ -1094,10 +1101,17 @@ RSpec.describe Hub::ClientsController do
 
     context "as a organization lead user" do
       let!(:organization) { create :organization, name: "Org" }
+      let!(:client_outside_of_org) { create(:client) }
       before {
         sign_in create(:organization_lead_user, organization: organization)
         client.update(vita_partner: organization)
       }
+
+      it "can't unlock a client that is not under their organization" do
+        patch :unlock, params: { id: client_outside_of_org.id }
+
+        expect(response.status).to eq 403
+      end
 
       it "unlocks the client and redirects to the client profile page" do
         patch :unlock, params: params


### PR DESCRIPTION
[Allow org leads & site coordinators to unlock clients #178150745](https://www.pivotaltracker.com/story/show/178150745)

# What does this PR do?

- Add tests to make sure clients outside of a site coordinators or organization leads access cannot be unlocked

[Thanks to Shannon for pointing this out](https://github.com/codeforamerica/vita-min/pull/1116/files#r635403579) and luckily ability already had us covered.