### PR TITLE
Remove temp_tool_tip param for seeing message summaries

### DIFF
--- a/app/controllers/hub/assigned_clients_controller.rb
+++ b/app/controllers/hub/assigned_clients_controller.rb
@@ -11,9 +11,7 @@ module Hub
     def index
       @page_title = I18n.t("hub.assigned_clients.index.title")
       @clients = filtered_and_sorted_clients.with_eager_loaded_associations.page(params[:page]).load
-      if params[:temp_tool_tip].present?
-        @message_summaries = RecentMessageSummaryService.messages(@clients.map(&:id))
-      end
+      @message_summaries = RecentMessageSummaryService.messages(@clients.map(&:id))
       render "hub/clients/index"
     end
 

--- a/app/controllers/hub/bulk_client_messages_controller.rb
+++ b/app/controllers/hub/bulk_client_messages_controller.rb
@@ -14,9 +14,7 @@ module Hub
       @missing_results_message = I18n.t("hub.tax_return_selections.help_text_missing_results", count: @inaccessible_clients_count) unless @inaccessible_clients_count == 0
 
       @clients = filtered_and_sorted_clients.page(params[:page]).load
-      if params[:temp_tool_tip].present?
-        @message_summaries = RecentMessageSummaryService.messages(@clients.map(&:id))
-      end
+      @message_summaries = RecentMessageSummaryService.messages(@clients.map(&:id))
       @page_title = I18n.t("hub.tax_return_selections.page_title", count: @selection.clients.size, id: @selection.id)
       render "hub/clients/index"
     end

--- a/app/controllers/hub/clients_controller.rb
+++ b/app/controllers/hub/clients_controller.rb
@@ -13,9 +13,7 @@ module Hub
     def index
       @page_title = I18n.t("hub.clients.index.title")
       @clients = filtered_and_sorted_clients.with_eager_loaded_associations.page(params[:page]).load
-      if params[:temp_tool_tip].present?
-        @message_summaries = RecentMessageSummaryService.messages(@clients.map(&:id))
-      end
+      @message_summaries = RecentMessageSummaryService.messages(@clients.map(&:id))
     end
 
     def new

--- a/app/controllers/hub/tax_return_selections_controller.rb
+++ b/app/controllers/hub/tax_return_selections_controller.rb
@@ -44,9 +44,7 @@ module Hub
       @missing_results_message = I18n.t("hub.tax_return_selections.help_text_missing_results", count: inaccessible_client_count) unless inaccessible_client_count.zero?
 
       @clients = filtered_and_sorted_clients.page(params[:page]).load
-      if params[:temp_tool_tip].present?
-        @message_summaries = RecentMessageSummaryService.messages(@clients.map(&:id))
-      end
+      @message_summaries = RecentMessageSummaryService.messages(@clients.map(&:id))
       @page_title = I18n.t("hub.tax_return_selections.page_title", count: @selection.clients.size, id: @selection.id)
 
       render "hub/clients/index"

--- a/app/controllers/hub/unattended_clients_controller.rb
+++ b/app/controllers/hub/unattended_clients_controller.rb
@@ -16,9 +16,7 @@ module Hub
       @breach_date = day_param.business_days.ago
       @clients = filtered_and_sorted_clients.first_unanswered_incoming_interaction_communication_breaches(@breach_date)
       @clients = @clients.with_eager_loaded_associations.page(params[:page]).load
-      if params[:temp_tool_tip].present?
-        @message_summaries = RecentMessageSummaryService.messages(@clients.map(&:id))
-      end
+      @message_summaries = RecentMessageSummaryService.messages(@clients.map(&:id))
       render "hub/clients/index"
     end
 

--- a/app/views/hub/clients/index.html.erb
+++ b/app/views/hub/clients/index.html.erb
@@ -85,11 +85,10 @@
               <%= render "shared/urgent_icon", client: client %>
             </td>
             <th scope="row" class="index-table__row-header index-table__row-header--sticky client-attribute__name">
-              <%= tag.span(class: "tooltip", data: {position: "right"}, title: if (@message_summaries.present? && @message_summaries[client.id])
-                                                                                 render("shared/message_summary", message_summary: @message_summaries[client.id])
-                                                                               else
-                                                                                 @message_summaries.present? ? t(".no_message") : ""
-                                                                               end) do %>
+              <%= tag.span(
+                      class: "tooltip",
+                      data: {position: "right"},
+                      title: @message_summaries[client.id] ? render("shared/message_summary", message_summary: @message_summaries[client.id]) : t(".no_message")) do %>
                 <%= link_to hub_client_path(id: client) do %>
                   <%= client.preferred_name || t(".no_name_given") %>
                 <% end %>

--- a/spec/controllers/hub/assigned_clients_controller_spec.rb
+++ b/spec/controllers/hub/assigned_clients_controller_spec.rb
@@ -108,31 +108,16 @@ RSpec.describe Hub::AssignedClientsController do
       end
 
       context "message summaries" do
-        context "with temp_tool_tip param" do
-          let(:fake_message_summaries) { {} }
+        let(:fake_message_summaries) { {} }
 
-          before do
-            allow(RecentMessageSummaryService).to receive(:messages).and_return(fake_message_summaries)
-          end
-
-          it "assigns message_summaries" do
-            get :index, params: {temp_tool_tip: "on"}
-            expect(assigns(:message_summaries)).to eq(fake_message_summaries)
-            expect(RecentMessageSummaryService).to have_received(:messages).with([assigned_to_me.id])
-          end
+        before do
+          allow(RecentMessageSummaryService).to receive(:messages).and_return(fake_message_summaries)
         end
 
-        context "without temp_tool_tip param" do
-          let(:fake_message_summaries) { {} }
-
-          before do
-            allow(RecentMessageSummaryService).to receive(:messages).and_return(fake_message_summaries)
-          end
-
-          it "doesn't assign message_summaries" do
-            get :index
-            expect(assigns(:message_summaries)).to eq(nil)
-          end
+        it "assigns message_summaries" do
+          get :index
+          expect(assigns(:message_summaries)).to eq(fake_message_summaries)
+          expect(RecentMessageSummaryService).to have_received(:messages).with([assigned_to_me.id])
         end
       end
     end

--- a/spec/controllers/hub/bulk_client_messages_controller_spec.rb
+++ b/spec/controllers/hub/bulk_client_messages_controller_spec.rb
@@ -75,31 +75,16 @@ RSpec.describe Hub::BulkClientMessagesController do
       end
 
       context "message summaries" do
-        context "with temp_tool_tip param" do
-          let(:fake_message_summaries) { {} }
+        let(:fake_message_summaries) { {} }
 
-          before do
-            allow(RecentMessageSummaryService).to receive(:messages).and_return(fake_message_summaries)
-          end
-
-          it "assigns message_summaries" do
-            get :show, params: params.merge({temp_tool_tip: "on"})
-            expect(assigns(:message_summaries)).to eq(fake_message_summaries)
-            expect(RecentMessageSummaryService).to have_received(:messages).with(assigns(:clients).map(&:id))
-          end
+        before do
+          allow(RecentMessageSummaryService).to receive(:messages).and_return(fake_message_summaries)
         end
 
-        context "without temp_tool_tip param" do
-          let(:fake_message_summaries) { {} }
-
-          before do
-            allow(RecentMessageSummaryService).to receive(:messages).and_return(fake_message_summaries)
-          end
-
-          it "doesn't assign message_summaries" do
-            get :show, params: params
-            expect(assigns(:message_summaries)).to eq(nil)
-          end
+        it "assigns message_summaries" do
+          get :show, params: params
+          expect(assigns(:message_summaries)).to eq(fake_message_summaries)
+          expect(RecentMessageSummaryService).to have_received(:messages).with(assigns(:clients).map(&:id))
         end
       end
     end

--- a/spec/controllers/hub/clients_controller_spec.rb
+++ b/spec/controllers/hub/clients_controller_spec.rb
@@ -384,30 +384,19 @@ RSpec.describe Hub::ClientsController do
           let(:time) { DateTime.new(2021, 5, 18, 11, 32) }
           let!(:incoming_text_message) { create :incoming_text_message, client: george_sr, body: "Hi I have a \"question\" about my taxes, but my question is very long, so you might not see all of it", created_at: DateTime.new(2021, 5, 18, 11, 32) }
 
-          context "when temp_tool_tip param is missing" do
-            it "does not pass message summaries to the template" do
-              get :index
-              html = Nokogiri::HTML.parse(response.body)
-              attrib = html.at_css("#client-#{george_sr.id}").at_css(".tooltip").attr("title")
-              expect(attrib.strip).to eq("")
-            end
-          end
+          it "shows a preview of the most recent message in a tooltip on the client" do
+            get :index
 
-          context "when temp_tool_tip param is present" do
-            it "shows a preview of the most recent message in a tooltip on the client" do
-              get :index, params: { temp_tool_tip: "on" }
+            message_summary = <<~BODY
+              "Hi I have a "question" about my taxes, but my question is very long, so you..."
 
-              message_summary = <<~BODY
-                "Hi I have a "question" about my taxes, but my question is very long, so you..."
+              George Sr.
+              Tue 5/18/2021 at 4:32 AM PDT
+            BODY
 
-                George Sr.
-                Tue 5/18/2021 at 4:32 AM PDT
-              BODY
-
-              html = Nokogiri::HTML.parse(response.body)
-              attrib = html.at_css("#client-#{george_sr.id}").at_css(".tooltip").attr("title")
-              expect(attrib.strip).to eq(message_summary.strip)
-            end
+            html = Nokogiri::HTML.parse(response.body)
+            attrib = html.at_css("#client-#{george_sr.id}").at_css(".tooltip").attr("title")
+            expect(attrib.strip).to eq(message_summary.strip)
           end
         end
       end

--- a/spec/controllers/hub/tax_return_selections_controller_spec.rb
+++ b/spec/controllers/hub/tax_return_selections_controller_spec.rb
@@ -55,31 +55,16 @@ RSpec.describe Hub::TaxReturnSelectionsController do
       end
 
       context "message summaries" do
-        context "with temp_tool_tip param" do
-          let(:fake_message_summaries) { {} }
+        let(:fake_message_summaries) { {} }
 
-          before do
-            allow(RecentMessageSummaryService).to receive(:messages).and_return(fake_message_summaries)
-          end
-
-          it "assigns message_summaries" do
-            get :show, params: params.merge({temp_tool_tip: "on"})
-            expect(assigns(:message_summaries)).to eq(fake_message_summaries)
-            expect(RecentMessageSummaryService).to have_received(:messages).with(assigns(:clients).map(&:id))
-          end
+        before do
+          allow(RecentMessageSummaryService).to receive(:messages).and_return(fake_message_summaries)
         end
 
-        context "without temp_tool_tip param" do
-          let(:fake_message_summaries) { {} }
-
-          before do
-            allow(RecentMessageSummaryService).to receive(:messages).and_return(fake_message_summaries)
-          end
-
-          it "doesn't assign message_summaries" do
-            get :show, params: params
-            expect(assigns(:message_summaries)).to eq(nil)
-          end
+        it "assigns message_summaries" do
+          get :show, params: params
+          expect(assigns(:message_summaries)).to eq(fake_message_summaries)
+          expect(RecentMessageSummaryService).to have_received(:messages).with(assigns(:clients).map(&:id))
         end
       end
     end

--- a/spec/controllers/hub/unattended_clients_controller_spec.rb
+++ b/spec/controllers/hub/unattended_clients_controller_spec.rb
@@ -69,31 +69,16 @@ RSpec.describe Hub::UnattendedClientsController, type: :controller do
       end
 
       context "message summaries" do
-        context "with temp_tool_tip param" do
-          let(:fake_message_summaries) { {} }
+        let(:fake_message_summaries) { {} }
 
-          before do
-            allow(RecentMessageSummaryService).to receive(:messages).and_return(fake_message_summaries)
-          end
-
-          it "assigns message_summaries" do
-            get :index, params: {temp_tool_tip: "on"}
-            expect(assigns(:message_summaries)).to eq(fake_message_summaries)
-            expect(RecentMessageSummaryService).to have_received(:messages).with(assigns(:clients).map(&:id))
-          end
+        before do
+          allow(RecentMessageSummaryService).to receive(:messages).and_return(fake_message_summaries)
         end
 
-        context "without temp_tool_tip param" do
-          let(:fake_message_summaries) { {} }
-
-          before do
-            allow(RecentMessageSummaryService).to receive(:messages).and_return(fake_message_summaries)
-          end
-
-          it "doesn't assign message_summaries" do
-            get :index
-            expect(assigns(:message_summaries)).to eq(nil)
-          end
+        it "assigns message_summaries" do
+          get :index
+          expect(assigns(:message_summaries)).to eq(fake_message_summaries)
+          expect(RecentMessageSummaryService).to have_received(:messages).with(assigns(:clients).map(&:id))
         end
       end
     end


### PR DESCRIPTION
Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>