### PR TITLE
Organization index refactor #178205649

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,7 +32,7 @@ class ApplicationController < ActionController::Base
   end
 
   def current_stimulus_triage
-    StimulusTriage.find_by_id(session[:stimulus_triage_id])
+    StimulusTriage.find_by_id(session[:stimulus_triage_id]) unless hub?
   end
 
   def clear_intake_session

--- a/app/controllers/hub/organizations_controller.rb
+++ b/app/controllers/hub/organizations_controller.rb
@@ -32,14 +32,10 @@ module Hub
       organizations = @vita_partners.organizations.includes(:coalition, :child_sites, :organization_capacity).load
 
       @organizations_by_coalition = if can? :read, Coalition
-         organizations.group_by(&:coalition).sort do |coalition_a, coalition_b|
-          a_name = coalition_a[0]&.name
-          b_name = coalition_b[0]&.name
-          a_name && b_name ? (a_name <=> b_name) : 1 # put independent orgs at the end
-        end
-      else
-        { nil => organizations }
-      end
+                                      organizations.group_by(&:coalition).sort_by { |el| [el[0]&.name ? 0 : 1, el[0]&.name || 0] } # sort independent org (nil coalition) to end of list
+                                    else
+                                      { nil => organizations }
+                                    end
     end
 
     def edit

--- a/app/controllers/hub/organizations_controller.rb
+++ b/app/controllers/hub/organizations_controller.rb
@@ -29,15 +29,16 @@ module Hub
 
     def index
       # Load organizations slowly first, to avoid lots of queries later
-      @organizations = @vita_partners.organizations.includes(:coalition, :child_sites, :organization_capacity).load
-      @organizations_by_coalition = if current_user.coalition_lead? || current_user.admin?
-        @organizations.group_by(&:coalition).sort do |coalition_a, coalition_b|
+      organizations = @vita_partners.organizations.includes(:coalition, :child_sites, :organization_capacity).load
+
+      @organizations_by_coalition = if can? :read, Coalition
+         organizations.group_by(&:coalition).sort do |coalition_a, coalition_b|
           a_name = coalition_a[0]&.name
           b_name = coalition_b[0]&.name
-          a_name && b_name ? (a_name <=> b_name) : 1 # put nil coalition at the end
+          a_name && b_name ? (a_name <=> b_name) : 1 # put independent orgs at the end
         end
       else
-        { nil => @organizations }
+        { nil => organizations }
       end
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -205,6 +205,10 @@ class User < ApplicationRecord
     role_type == SiteCoordinatorRole::TYPE
   end
 
+  def coalition_lead?
+    role_type == CoalitionLeadRole::TYPE
+  end
+
   def suspended?
     suspended_at.present?
   end

--- a/app/views/hub/organizations/_listing.html.erb
+++ b/app/views/hub/organizations/_listing.html.erb
@@ -1,10 +1,7 @@
 <li>
   <div>
-    <% if can? :edit, organization %>
-      <%= link_to "#{organization.name} (#{t(".site_count", count: organization.child_sites.count)})", edit_hub_organization_path(id: organization) %>
-    <% else %>
-      <%= link_to "#{organization.name} (#{t(".site_count", count: organization.child_sites.count)})", hub_organization_path(id: organization) %>
-    <% end %>
+    <%= link_to "#{organization.name} (#{t(".site_count", count: organization.child_sites.length)})",
+                can?(:edit, organization) ? edit_hub_organization_path(id: organization) : hub_organization_path(id: organization) %>
   </div>
   <div><%= "#{organization.organization_capacity.active_client_count || "-"} / #{organization.organization_capacity.capacity_limit || "-"}" %></div>
 </li>

--- a/app/views/hub/organizations/index.html.erb
+++ b/app/views/hub/organizations/index.html.erb
@@ -13,8 +13,8 @@
       <div class="grid__item width-one-half">
         <% @organizations_by_coalition.each do |coalition, organizations| %>
           <div class="grid-flex space-between center-aligned spacing-above-10">
-            <h2 class="spacing-below-0"><%= coalition&.name || (t(".independent_organizations", count: @organizations_by_coalition.length)) %></h2>
-            <div class="help-text"><%= t("general.capacity") %>></div>
+            <h2 class="spacing-below-0"><%= coalition.nil? ? t(".independent_organizations", count: @organizations_by_coalition.length) : coalition.name %> </h2>
+            <div class="help-text"><%= t("general.capacity") %></div>
           </div>
 
           <div class="organization-list spacing-below-25">

--- a/app/views/hub/organizations/index.html.erb
+++ b/app/views/hub/organizations/index.html.erb
@@ -11,21 +11,21 @@
 
     <div class="grid">
       <div class="grid__item width-one-half">
-        <% if @coalitions.count > 0 %>
-          <p><%= t(".organizations_by_coalition") %></p>
+        <p><%= t(".organizations_by_coalition") %></p>
 
-          <% @coalitions.each do |coalition| %>
+        <% @organizations_by_coalition.each do |coalition, organizations| %>
             <div class="grid-flex space-between center-aligned spacing-above-10">
-              <h2 class="spacing-below-0"><%= coalition.name %></h2>
-              <% unless coalition.organizations.count.zero? %>
+
+              <h2 class="spacing-below-0"><%= coalition&.name || t('.independent_organizations') %></h2>
+              <% unless organizations.length.zero? %>
                 <div class="help-text">Capacity</div>
               <% end %>
             </div>
 
             <div class="organization-list spacing-below-25">
               <ul>
-                <% if coalition.organizations.present? %>
-                  <% coalition.organizations.each do |organization| %>
+                <% if organizations.present? %>
+                  <% organizations.each do |organization| %>
                     <%= render "hub/organizations/listing", organization: organization %>
                   <% end %>
                 <% else %>
@@ -34,36 +34,7 @@
               </ul>
             </div>
           <% end %>
-        <% else %>
-          <% if @organizations.present? %>
-            <ul>
-              <% @organizations.each do |organization| %>
-                <%= render "hub/organizations/listing", organization: organization %>
-              <% end %>
-            </ul>
-          <% else %>
-            <%= t('.no_organizations') %>
-          <% end %>
-        <% end %>
-
-        <% if @independent_organizations.present? %>
-          <div class="grid-flex space-between center-aligned spacing-above-10">
-            <h2 class="spacing-below-0"><%= t(".independent_organizations") %></h2>
-            <% unless @independent_organizations.count.zero? %>
-              <div class="help-text">Capacity</div>
-            <% end %>
-          </div>
-
-          <div class="organization-list">
-            <ul>
-              <% @independent_organizations.each do |organization| %>
-                <%= render "hub/organizations/listing", organization: organization %>
-              <% end %>
-            </ul>
-          </div>
-        <% end %>
       </div>
     </div>
-
   </div>
 <% end %>

--- a/app/views/hub/organizations/index.html.erb
+++ b/app/views/hub/organizations/index.html.erb
@@ -11,18 +11,13 @@
 
     <div class="grid">
       <div class="grid__item width-one-half">
-        <p><%= t(".organizations_by_coalition") %></p>
-
         <% @organizations_by_coalition.each do |coalition, organizations| %>
-            <div class="grid-flex space-between center-aligned spacing-above-10">
+          <div class="grid-flex space-between center-aligned spacing-above-10">
+            <h2 class="spacing-below-0"><%= coalition&.name || (t(".independent_organizations", count: @organizations_by_coalition.length)) %></h2>
+            <div class="help-text"><%= t("general.capacity") %>></div>
+          </div>
 
-              <h2 class="spacing-below-0"><%= coalition&.name || t('.independent_organizations') %></h2>
-              <% unless organizations.length.zero? %>
-                <div class="help-text">Capacity</div>
-              <% end %>
-            </div>
-
-            <div class="organization-list spacing-below-25">
+          <div class="organization-list spacing-below-25">
               <ul>
                 <% if organizations.present? %>
                   <% organizations.each do |organization| %>
@@ -33,7 +28,7 @@
                 <% end %>
               </ul>
             </div>
-          <% end %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -426,10 +426,9 @@ en:
           other: "%{count} sites"
       index:
         independent_organizations:
-          one: ""
-          other: "Independent Organizations"
+          one: " "
+          other: Independent Organizations
         no_organizations: "No organizations"
-        organizations_by_coalition: "Organizations grouped by coalition:"
       form:
         allows_greeters: Allows Greeters
         active_clients: active clients
@@ -746,6 +745,7 @@ en:
     back: Go back
     cancel: Cancel
     call: Call
+    capacity: Capacity
     capacity_limit: Capacity limit
     changes_saved: Changes saved
     chat_with_us: Chat with us

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -425,7 +425,9 @@ en:
           one: "%{count} site"
           other: "%{count} sites"
       index:
-        independent_organizations: "Independent Organizations"
+        independent_organizations:
+          one: ""
+          other: "Independent Organizations"
         no_organizations: "No organizations"
         organizations_by_coalition: "Organizations grouped by coalition:"
       form:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -410,9 +410,10 @@ es:
         title: "Nueva Organización"
       no_sites: "Ningunos sitios"
       index:
-        independent_organizations: "Organizaciones Independientes"
+        independent_organizations:
+          one: " "
+          other: "Organizaciones Independientes"
         no_organizations: "Sin organizaciones"
-        organizations_by_coalition: "Organizaciones por coalición:"
       listing:
         site_count:
           one: "%{count} sitio"
@@ -733,6 +734,7 @@ es:
     back: Regresa
     cancel: Cancelar
     call: Llamada
+    capacity: Capacidad
     capacity_limit: Límite de capacidad
     changes_saved: Cambios guardados
     chat_with_us: Hable con nosotros por el chat

--- a/spec/controllers/hub/organizations_controller_spec.rb
+++ b/spec/controllers/hub/organizations_controller_spec.rb
@@ -101,10 +101,8 @@ RSpec.describe Hub::OrganizationsController, type: :controller do
         render_views
         it "shows my coalition and child organizations but no link to add or edit orgs" do
           get :index
-
           expect(response).to be_ok
-          expect(assigns(:coalitions)).to match_array [coalition]
-          expect(assigns(:organizations)).to match_array [organization, second_organization]
+          expect(assigns(:organizations_by_coalition)).to match_array [[coalition, [organization, second_organization]]]
           expect(response.body).to include hub_organization_path(id: organization)
           expect(response.body).not_to include new_hub_organization_path
           expect(response.body).not_to include edit_hub_organization_path(id: organization)
@@ -117,10 +115,13 @@ RSpec.describe Hub::OrganizationsController, type: :controller do
         render_views
         it "shows all coalitions and organizations, with a link to add a new org" do
           get :index
-
+          result = [
+            [coalition, [organization, second_organization]],
+            [external_coalition, [external_organization]],
+            [nil, [VitaPartner.client_support_org]]
+          ]
           expect(response).to be_ok
-          expect(assigns(:coalitions)).to match_array [coalition, external_coalition]
-          expect(assigns(:organizations)).to match_array VitaPartner.organizations.all
+          expect(assigns(:organizations_by_coalition)).to match_array result
           expect(response.body).to include new_hub_organization_path
         end
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -441,7 +441,7 @@ RSpec.describe User, type: :model do
       end
     end
 
-    context "when the user does not have GreeterRole type" do
+    context "when the user does not have OrganizationLeadRole type" do
       let(:user) { create :team_member_user }
       it "returns false" do
         expect(user.org_lead?).to be false
@@ -461,6 +461,22 @@ RSpec.describe User, type: :model do
       let(:user) { create :team_member_user }
       it "returns false" do
         expect(user.site_coordinator?).to be false
+      end
+    end
+  end
+
+  describe "#coalition_lead?" do
+    context "when the user has CoalitionLeadRole type" do
+      let(:user) { create :coalition_lead_user }
+      it "returns true" do
+        expect(user.coalition_lead?).to be true
+      end
+    end
+
+    context "when the user does not have CoalitionLeadRole type" do
+      let(:user) { create :team_member_user }
+      it "returns false" do
+        expect(user.coalition_lead?).to be false
       end
     end
   end


### PR DESCRIPTION
Before: Queries for organization capacity were getting called on each organization individually, + queries for count of sites for each org, because the eagerloaded organization capacity query was on the wrong query due to a misunderstanding of how the instance variables were used
![Screen Shot 2021-05-26 at 2 53 39 PM](https://user-images.githubusercontent.com/4494389/119722825-5d6d0480-be32-11eb-91c1-9bd246c1ca1a.png)

After: We've decreased the number of queries and organization capacity is properly eager loaded, I think. All queries are executed in the action vs executing on render.
![Screen Shot 2021-05-26 at 2 54 17 PM](https://user-images.githubusercontent.com/4494389/119722829-5e059b00-be32-11eb-85b5-9dd91ac4b2d7.png)

