### PR TITLE
Still needs help flow: Block client login as needed

### DIFF
--- a/app/controllers/concerns/client_access_control_concern.rb
+++ b/app/controllers/concerns/client_access_control_concern.rb
@@ -4,9 +4,13 @@ module ClientAccessControlConcern
   private
 
   def require_client_login
-    unless current_client.present?
+    if current_client.blank?
       session[:after_client_login_path] = request.original_fullpath if request.get?
-      redirect_to new_portal_client_login_path
+      redirect_to new_portal_client_login_path and return
+    end
+
+    if current_client.triggered_still_needs_help_at.present?
+      redirect_to portal_still_needs_helps_path
     end
   end
 end

--- a/app/controllers/portal/still_needs_helps_controller.rb
+++ b/app/controllers/portal/still_needs_helps_controller.rb
@@ -1,0 +1,9 @@
+module Portal
+  class StillNeedsHelpsController < ApplicationController
+    layout "application"
+
+    def index
+      render html: "No content yet"
+    end
+  end
+end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -21,6 +21,7 @@
 #  login_token                              :string
 #  routing_method                           :integer
 #  sign_in_count                            :integer          default(0), not null
+#  triggered_still_needs_help_at            :datetime
 #  created_at                               :datetime         not null
 #  updated_at                               :datetime         not null
 #  vita_partner_id                          :bigint

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -123,6 +123,7 @@ Rails.application.routes.draw do
         put '/spouse-sign', to: 'tax_returns#spouse_sign', as: :spouse_sign
         get '/success', to: 'tax_returns#success', as: :success
       end
+      resources :still_needs_helps, only: [:index]
       resources :messages, only: [:new, :create]
       resources :documents, only: [:show]
       resources :upload_documents, only: [:destroy]

--- a/db/migrate/20210526144804_add_triggered_still_needs_help_at_to_client.rb
+++ b/db/migrate/20210526144804_add_triggered_still_needs_help_at_to_client.rb
@@ -1,0 +1,5 @@
+class AddTriggeredStillNeedsHelpAtToClient < ActiveRecord::Migration[6.0]
+  def change
+    add_column :clients, :triggered_still_needs_help_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_18_151440) do
+ActiveRecord::Schema.define(version: 2021_05_26_144804) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -147,6 +147,7 @@ ActiveRecord::Schema.define(version: 2021_05_18_151440) do
     t.string "login_token"
     t.integer "routing_method"
     t.integer "sign_in_count", default: 0, null: false
+    t.datetime "triggered_still_needs_help_at"
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "vita_partner_id"
     t.index ["in_progress_survey_sent_at"], name: "index_clients_on_in_progress_survey_sent_at"

--- a/spec/controllers/concerns/client_access_control_concern_spec.rb
+++ b/spec/controllers/concerns/client_access_control_concern_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe ClientAccessControlConcern, type: :controller do
       end
     end
 
-
     context "when a client is authenticated" do
       before { sign_in create(:client) }
 
@@ -42,6 +41,17 @@ RSpec.describe ClientAccessControlConcern, type: :controller do
         get :index
 
         expect(response).to be_ok
+        expect(session).not_to include :after_client_login_path
+      end
+    end
+
+    context "with a client who has triggered the Still Need Help page" do
+      before { sign_in create(:client, triggered_still_needs_help_at: Time.now) }
+
+      it "redirects to Still Need Help page" do
+        get :index
+
+        expect(response).to redirect_to(portal_still_needs_helps_path)
         expect(session).not_to include :after_client_login_path
       end
     end

--- a/spec/factories/clients.rb
+++ b/spec/factories/clients.rb
@@ -21,6 +21,7 @@
 #  login_token                              :string
 #  routing_method                           :integer
 #  sign_in_count                            :integer          default(0), not null
+#  triggered_still_needs_help_at            :datetime
 #  created_at                               :datetime         not null
 #  updated_at                               :datetime         not null
 #  vita_partner_id                          :bigint

--- a/spec/features/portal/still_needs_help_spec.rb
+++ b/spec/features/portal/still_needs_help_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.feature "Still Needs Help" do
+  context "When a client has triggered the Still Needs Help flow", active_job: true do
+    let(:tax_return) { create(:tax_return) }
+    let(:client) { create :client, tax_returns: [tax_return], triggered_still_needs_help_at: Time.now }
+    let!(:intake) { create :intake, :primary_consented, preferred_name: "Carrie", primary_first_name: "Carrie", primary_last_name: "Carrot", primary_last_four_ssn: "9876", email_address: "example@example.com", sms_phone_number: "+15005550006", client: client }
+
+    context "As a client visiting the portal" do
+      before do
+        login_as client, scope: :client
+      end
+
+      scenario "telling us they do not need help" do
+        visit portal_root_path
+        expect(page).not_to have_text "Welcome back Carrie!"
+
+        next # skip rest of test with `next` keyword
+
+        expect(page).to have_text "Are you still interested in filing your taxes with us?"
+
+        click_on "No, I'm not interested"
+        expect(page).to have_text "Thank you for using GetYourRefund."
+
+        click_on "Return to home"
+        expect(page).to have_text "Welcome back Carrie!"
+      end
+    end
+  end
+end

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -21,6 +21,7 @@
 #  login_token                              :string
 #  routing_method                           :integer
 #  sign_in_count                            :integer          default(0), not null
+#  triggered_still_needs_help_at            :datetime
 #  created_at                               :datetime         not null
 #  updated_at                               :datetime         not null
 #  vita_partner_id                          :bigint


### PR DESCRIPTION
When clients are marked as `triggered_still_needs_help_at.present?`, they won't be able to use the portal. They'll have to answer questions about if they still need help.

The controllers for the still needs help flow won't use `require_client_login` so it's peaceful to adjust `require_client_login`.

## About this pull request

This is safe to deploy as-is. No clients have `triggered_still_needs_help_at.present?` in production.

This is part 1 of N to build the [Still needs help](https://www.pivotaltracker.com/n/projects/2409240/stories/178206756) flow.

It adds a feature spec with a `return` in the middle, to mark how much progress has been made.

I'm hoping to use about 5 pull requests to deliver this feature, to avoid creating a situation where merge conflicts create trouble, and to give me a sensation of hope and forward progress.

## Pivotal Tracker story link

[#178206756]