### PR TITLE
Add drop off survey link for drop off clients and add Organization name to completion email

### DIFF
--- a/app/jobs/send_client_completion_survey_job.rb
+++ b/app/jobs/send_client_completion_survey_job.rb
@@ -10,7 +10,10 @@ class SendClientCompletionSurveyJob < ApplicationJob
       client.update!(completion_survey_sent_at: Time.current)
     end
 
-    survey_link = "https://codeforamerica.co1.qualtrics.com/jfe/form/SV_exiL2bLJx8GvjGC?ExternalDataReference=#{client.id}"
+    is_drop_off_client = client.tax_returns.pluck(:service_type).any? "drop_off"
+    survey_code = is_drop_off_client ? "SV_ebtml6MMfhf8Vsa" : "SV_exiL2bLJx8GvjGC"
+    survey_link = "https://codeforamerica.co1.qualtrics.com/jfe/form/#{survey_code}?ExternalDataReference=#{client.id}"
+
     locale = client.intake.locale
     case best_contact_method
     when :email

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1027,14 +1027,14 @@ en:
       completion:
         email:
           body: |
-            Thank you for filing your taxes with GetYourRefund! You can check the status of your refund at the IRS website https://www.irs.gov/refunds.
+            Thank you for filing your taxes with GetYourRefund and <<Client.AssignedOrganization>>! You can check the status of your refund at the IRS website https://www.irs.gov/refunds.
 
             We want to improve the service for future tax filers and need your feedback. Could you tell us about how it went?
 
             Take our 5 minute survey here: %{survey_link}
           subject: Thank you for filing your taxes with GetYourRefund!
         sms: |
-          Thank you for filing your taxes with GetYourRefund. We want to improve the service for future tax filers and need your feedback. Could you tell us about how it went? Take our 5 minute survey here: %{survey_link}
+          Thank you for filing your taxes with GetYourRefund and <<Client.AssignedOrganization>>. We want to improve the service for future tax filers and need your feedback. Could you tell us about how it went? Take our 5 minute survey here: %{survey_link}
       in_progress:
         email:
           body: |


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/177386999 

The ticket also asked that the messages include the organization name that prepared the taxes.