### PR TITLE
Upgrade Puma to 5.3.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '2.6.5'
 
 gem 'rack', '>= 2.0.8'
 gem 'rails', '>= 6.0.3.7'
-gem 'puma', '>= 4.3.5'
+gem 'puma', '>= 5.3.2'
 gem 'sass-rails', '~> 5.0'
 gem 'terser', '~> 1.0'
 gem 'cfa-styleguide', git: 'https://github.com/codeforamerica/honeycrisp-gem', branch: 'main'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,7 +309,7 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     public_suffix (4.0.6)
-    puma (5.3.1)
+    puma (5.3.2)
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
@@ -572,7 +572,7 @@ DEPENDENCIES
   pg_search
   phonelib
   pry-byebug
-  puma (>= 4.3.5)
+  puma (>= 5.3.2)
   rack (>= 2.0.8)
   rack-mini-profiler
   rails (>= 6.0.3.7)


### PR DESCRIPTION
This upgrades us from Puma 5.3.1 to Puma 5.3.2.

We're getting a handful of errors from Puma that might relate to our recent Puma 5.3.1 upgrade.

Sentry link: https://sentry.io/organizations/codeforamerica/issues/2443686659/?project=1880327&referrer=slack

Slack thread: https://cfa.slack.com/archives/G013YJMPVAA/p1623153520000500

I believe this will get rid of the errors. I don't know what caused the errors to occur today vs. other days. The devices that are triggering the problem appear to usually be smartphones; I wonder if they use HTTP keep-alive more than other clients.