### PR TITLE
Simplifed Efile dashboard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ gem 'statesman', '~> 8.0.3'
 
 group :demo, :development, :test do
   gem 'factory_bot_rails' # added to demo for creating fake data
+  gem 'faker'
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ gem 'ice_nine'
 gem 'business_time'
 gem 'scenic'
 gem 'intercom', '~> 4.1'
+gem 'statesman', '~> 8.0.3'
 
 group :demo, :development, :test do
   gem 'factory_bot_rails' # added to demo for creating fake data

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,6 +191,8 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    faker (2.18.0)
+      i18n (>= 1.6, < 2)
     faraday (1.4.2)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -572,6 +574,7 @@ DEPENDENCIES
   dogapi
   easy_translate
   factory_bot_rails
+  faker
   fix-db-schema-conflicts
   flamegraph
   git-pair

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -480,6 +480,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     stackprof (0.2.17)
+    statesman (8.0.3)
     strip_attributes (1.11.0)
       activemodel (>= 3.0, < 7.0)
     terminal-table (3.0.1)
@@ -617,6 +618,7 @@ DEPENDENCIES
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
   stackprof
+  statesman (~> 8.0.3)
   strip_attributes
   terser (~> 1.0)
   thor

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -60,6 +60,7 @@
 @import "components/link-table";
 @import "components/tagify-overrides";
 @import "components/toggle";
+@import "components/efile_submissions";
 @import "organisms/form-cards";
 @import "organisms/offboarding";
 @import "organisms/provider-list";

--- a/app/assets/stylesheets/components/_efile_submissions.scss
+++ b/app/assets/stylesheets/components/_efile_submissions.scss
@@ -1,0 +1,19 @@
+.submissions-index {
+  .metric-box {
+    border: 1px solid black;
+    margin-left: 20px;
+    width: 15rem;
+    height: 7.5rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center; align-items: center;
+    > div:first-of-type {
+      font-size: 30px;
+      margin-bottom: 10px;
+    }
+    > div:last-of-type {
+      font-weight: bold;
+    }
+  }
+
+}

--- a/app/controllers/hub/efile_submissions_controller.rb
+++ b/app/controllers/hub/efile_submissions_controller.rb
@@ -1,0 +1,8 @@
+module Hub
+  class EfileSubmissionsController < ApplicationController
+    include AccessControllable
+    before_action :require_sign_in
+    load_and_authorize_resource
+    layout "admin"
+  end
+end

--- a/app/models/efile_submission.rb
+++ b/app/models/efile_submission.rb
@@ -11,12 +11,12 @@
 #
 class EfileSubmission < ApplicationRecord
   belongs_to :tax_return
-  has_many :transitions, class_name: "EfileSubmissionTransition", autosave: false
+  has_many :efile_submission_transitions, class_name: "EfileSubmissionTransition", autosave: false, dependent: :destroy
 
   include Statesman::Adapters::ActiveRecordQueries[
-            transition_class: EfileSubmissionTransition,
-            initial_state: :new
-          ]
+    transition_class: EfileSubmissionTransition,
+    initial_state: EfileSubmissionStateMachine.initial_state
+  ]
 
   def state_machine
     @state_machine ||= EfileSubmissionStateMachine.new(self, transition_class: EfileSubmissionTransition)

--- a/app/models/efile_submission.rb
+++ b/app/models/efile_submission.rb
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: efile_submissions
+#
+#  id            :bigint           not null, primary key
+#  tax_return_id :bigint
+#
+# Indexes
+#
+#  index_efile_submissions_on_tax_return_id  (tax_return_id)
+#
+class EfileSubmission < ApplicationRecord
+  belongs_to :tax_return
+  has_many :transitions, class_name: "EfileSubmissionTransition", autosave: false
+
+  include Statesman::Adapters::ActiveRecordQueries[
+            transition_class: EfileSubmissionTransition,
+            initial_state: :new
+          ]
+
+  def state_machine
+    @state_machine ||= EfileSubmissionStateMachine.new(self, transition_class: EfileSubmissionTransition)
+  end
+
+  delegate :can_transition_to?, :current_state, :history, :last_transition, :last_transition_to,
+           :transition_to!, :transition_to, :in_state?, to: :state_machine
+end

--- a/app/models/efile_submission.rb
+++ b/app/models/efile_submission.rb
@@ -3,6 +3,8 @@
 # Table name: efile_submissions
 #
 #  id            :bigint           not null, primary key
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
 #  tax_return_id :bigint
 #
 # Indexes
@@ -15,7 +17,7 @@ class EfileSubmission < ApplicationRecord
 
   include Statesman::Adapters::ActiveRecordQueries[
     transition_class: EfileSubmissionTransition,
-    initial_state: EfileSubmissionStateMachine.initial_state
+    initial_state: EfileSubmissionStateMachine.initial_state,
   ]
 
   def state_machine

--- a/app/models/efile_submission_transition.rb
+++ b/app/models/efile_submission_transition.rb
@@ -21,7 +21,7 @@
 #  fk_rails_...  (efile_submission_id => efile_submissions.id)
 #
 class EfileSubmissionTransition < ApplicationRecord
-  belongs_to :efile_submission, inverse_of: :efile_submission_transitions
+  belongs_to :efile_submission, inverse_of: :efile_submission_transitions, touch: true
 
   after_destroy :update_most_recent, if: :most_recent?
 

--- a/app/models/efile_submission_transition.rb
+++ b/app/models/efile_submission_transition.rb
@@ -1,14 +1,36 @@
+# == Schema Information
+#
+# Table name: efile_submission_transitions
+#
+#  id                  :bigint           not null, primary key
+#  metadata            :jsonb
+#  most_recent         :boolean          not null
+#  sort_key            :integer          not null
+#  to_state            :string           not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  efile_submission_id :integer          not null
+#
+# Indexes
+#
+#  index_efile_submission_transitions_parent_most_recent  (efile_submission_id,most_recent) UNIQUE WHERE most_recent
+#  index_efile_submission_transitions_parent_sort         (efile_submission_id,sort_key) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (efile_submission_id => efile_submissions.id)
+#
 class EfileSubmissionTransition < ApplicationRecord
-  belongs_to :efile_submission, inverse_of: :state_transitions
+  belongs_to :efile_submission, inverse_of: :efile_submission_transitions
 
   after_destroy :update_most_recent, if: :most_recent?
 
   private
 
+  # If a transition is deleted, make the new last transition
+  # the "most recent" to maintain proper functionality of most_recent? method.
   def update_most_recent
-    last_transition = efile_submission.state_transitions.order(:sort_key).last
-    return unless last_transition.present?
-
-    last_transition.update_column(:most_recent, true)
+    last_transition = efile_submission.efile_submission_transitions.order(:sort_key).last
+    last_transition.update_column(:most_recent, true) if last_transition.present?
   end
 end

--- a/app/models/efile_submission_transition.rb
+++ b/app/models/efile_submission_transition.rb
@@ -1,0 +1,14 @@
+class EfileSubmissionTransition < ApplicationRecord
+  belongs_to :efile_submission, inverse_of: :state_transitions
+
+  after_destroy :update_most_recent, if: :most_recent?
+
+  private
+
+  def update_most_recent
+    last_transition = efile_submission.state_transitions.order(:sort_key).last
+    return unless last_transition.present?
+
+    last_transition.update_column(:most_recent, true)
+  end
+end

--- a/app/models/tax_return.rb
+++ b/app/models/tax_return.rb
@@ -4,6 +4,7 @@
 #
 #  id                  :bigint           not null, primary key
 #  certification_level :integer
+#  internal_efile      :boolean          default(FALSE), not null
 #  is_ctc              :boolean          default(FALSE)
 #  is_hsa              :boolean
 #  primary_signature   :string
@@ -42,7 +43,7 @@ class TaxReturn < ApplicationRecord
   has_many :assignments, class_name: "TaxReturnAssignment", dependent: :destroy
   has_many :tax_return_selection_tax_returns, dependent: :destroy
   has_many :tax_return_selections, through: :tax_return_selection_tax_returns
-
+  has_many :efile_submissions
   enum status: TaxReturnStatus::STATUSES, _prefix: :status
   enum certification_level: { advanced: 1, basic: 2, foreign_student: 3 }
   enum service_type: { online_intake: 0, drop_off: 1 }, _prefix: :service_type

--- a/app/state_machines/efile_submission_state_machine.rb
+++ b/app/state_machines/efile_submission_state_machine.rb
@@ -22,17 +22,10 @@ class EfileSubmissionStateMachine
   transition from: :transmitted,  to: [:accepted, :rejected]
 
   guard_transition(to: :queued) do |submission|
+    # Example of guard transition. Eventually guard by submission file presence.
     # submission.submission_file.present?
+    submission.present?
   end
-
-  after_transition(to: :preparing, after_commit: true) do |submission|
-    # submission.build_submission_file
-  end
-
-  after_transition(to: :queued) do |submission|
-    # submission.queue
-  end
-
 
   after_transition(to: :rejected) do |submission, transition|
     # Transition associated tax return to rejected

--- a/app/state_machines/efile_submission_state_machine.rb
+++ b/app/state_machines/efile_submission_state_machine.rb
@@ -1,0 +1,44 @@
+class EfileSubmissionStateMachine
+  include Statesman::Machine
+
+  state :new, initial: true
+  state :preparing
+  state :queued
+  state :transmitted
+  state :failed
+  state :rejected
+  state :accepted
+  state :flagged
+  state :cancelled
+
+  transition from: :new,          to: [:preparing]
+  transition from: :preparing,    to: [:cancelled, :flagged]
+  transition from: :queued,       to: [:transmitted, :failed, :rejected]
+  transition from: :transmitted,  to: [:accepted, :rejected, :cancelled]
+  transition from: :rejected,     to: [:cancelled, :flagged, :preparing]
+
+  guard_transition(to: :queued) do |submission|
+    # submission.submission_file.present?
+  end
+
+  after_transition(to: :preparing, after_commit: true) do |submission|
+    # submission.build_submission_file
+  end
+
+  after_transition(to: :queued) do |submission|
+    # SubmitReturnJob.perform_later(submission)
+  end
+
+  after_transition(to: :rejected) do |submission, transition|
+    # Transition associated tax return to rejected
+    # Add note with rejection reason to client notes
+    # Transition to flagged if needs manual changes by a person
+    # Use transition metadata error code and reason to determine whether it is an eng or VITA problem.
+  end
+
+  after_transition(to: :accepted) do |submission|
+    # Send a message to client
+    # Add a note to client page
+    # Transition associated tax return to Accepted
+  end
+end

--- a/app/views/hub/efile_submissions/index.html.erb
+++ b/app/views/hub/efile_submissions/index.html.erb
@@ -1,0 +1,48 @@
+<% content_for :card do %>
+  <div class="spacing-above-25 submissions-index">
+
+    <div style="display: flex; justify-content: center;">
+      <% EfileSubmissionStateMachine.states.each do |state| %>
+        <div class="metric-box">
+          <div><%= EfileSubmission.in_state(state).count %></div>
+          <div><%= state %></div>
+         </div>
+      <% end %>
+    </div>
+    <table class="index-table org-metrics-table spacing-above-25">
+      <thead class="index-table__head">
+      <tr class="index-table__row">
+        <th scope="col" style="width: 12.5rem" class="index-table__header sortable">
+          Status
+        </th>
+        <th scope="col" style="width: 10rem" class="index-table__header sortable">Submission ID</th>
+        <th scope="col" class="index-table__header sortable">
+          Primary Filer
+        </th>
+        <th scope="col" style="width: 10rem"class="index-table__header sortable">
+          Tax Year
+        </th>
+        <th scope="col" class="index-table__header sortable">
+          Last updated
+        </th>
+      </tr>
+      </thead>
+      <% @efile_submissions.each do |submission| %>
+        <tbody class="index-table__body">
+          <td class="index-table__cell"><%= link_to submission.current_state, hub_efile_submission_path(id: submission.id) %></td>
+          <td class="index-table__cell"><%= link_to submission.id, hub_efile_submission_path(id: submission.id) %></td>
+          <td class="index-table__cell">
+            <%= link_to submission.tax_return.client.legal_name, hub_client_path(id: submission.tax_return.client.id) %>
+          </td>
+          <td class="index-table__cell">
+            <%= submission.tax_return.year %>
+          </td>
+          <td class="index-table__cell">
+            <%= timestamp submission.updated_at %>
+          </td>
+        </tbody>
+      <% end %>
+    </table>
+
+  </div>
+<% end %>

--- a/app/views/hub/efile_submissions/show.html.erb
+++ b/app/views/hub/efile_submissions/show.html.erb
@@ -1,0 +1,22 @@
+<% content_for :card do %>
+  <div class="slab slab--not-padded spacing-above-25">
+    <h1 class="h2 spacing-below-5">
+      Submission <%= @efile_submission.id %> <span class="small">(<%= @efile_submission.current_state %>)</span>
+    </h1>
+    <p class="spacing-above-5 spacing-below-5">Client: <%= link_to @efile_submission.tax_return.client.legal_name, hub_clients_path(id: @efile_submission.tax_return.client.id) %></p>
+
+    <div>
+      <h3 class="spacing-above-25 spacing-below-10">Status Logs</h3>
+      <ul>
+        <% @efile_submission.efile_submission_transitions.each do |transition| %>
+          <li>
+            <%= timestamp transition.created_at %>
+            <%= transition.to_state %>
+            <%= transition.metadata["error_code"] %>
+            <%= transition.metadata["error_message"] %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+<% end %>

--- a/config/initializers/statesman.rb
+++ b/config/initializers/statesman.rb
@@ -1,0 +1,3 @@
+Statesman.configure do
+  storage_adapter(Statesman::Adapters::ActiveRecord)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -138,11 +138,13 @@ Rails.application.routes.draw do
       end
 
 
-    # Hub Admin routes (Case Management)
+      # Hub Admin routes (Case Management)
       namespace :hub do
         root "assigned_clients#index"
         resources :metrics, only: [:index]
         resources :tax_returns, only: [:edit, :update, :show]
+        resources :efile_submissions, path: "submissions", only: [:index, :show]
+
         resources :unlinked_clients, only: [:index]
         resources :state_routings, only: [:index, :edit, :update], param: :state do
           delete "/:id", to: "state_routings#destroy", on: :member, as: :destroy

--- a/db/migrate/20210610032427_create_efile_submissions.rb
+++ b/db/migrate/20210610032427_create_efile_submissions.rb
@@ -2,6 +2,7 @@ class CreateEfileSubmissions < ActiveRecord::Migration[6.0]
   def change
     create_table :efile_submissions do |t|
       t.references :tax_return
+      t.timestamps
     end
   end
 end

--- a/db/migrate/20210610032427_create_efile_submissions.rb
+++ b/db/migrate/20210610032427_create_efile_submissions.rb
@@ -1,0 +1,7 @@
+class CreateEfileSubmissions < ActiveRecord::Migration[6.0]
+  def change
+    create_table :efile_submissions do |t|
+      t.references :tax_return
+    end
+  end
+end

--- a/db/migrate/20210610040137_create_efile_submission_transitions.rb
+++ b/db/migrate/20210610040137_create_efile_submission_transitions.rb
@@ -1,0 +1,29 @@
+class CreateEfileSubmissionTransitions < ActiveRecord::Migration[6.0]
+  def change
+    create_table :efile_submission_transitions do |t|
+      t.string :to_state, null: false
+      t.jsonb :metadata, default: {}
+      t.integer :sort_key, null: false
+      t.integer :efile_submission_id, null: false
+      t.boolean :most_recent, null: false
+
+      # If you decide not to include an updated timestamp column in your transition
+      # table, you'll need to configure the `updated_timestamp_column` setting in your
+      # migration class.
+      t.timestamps null: false
+    end
+
+    # Foreign keys are optional, but highly recommended
+    add_foreign_key :efile_submission_transitions, :efile_submissions
+
+    add_index(:efile_submission_transitions,
+              %i(efile_submission_id sort_key),
+              unique: true,
+              name: "index_efile_submission_transitions_parent_sort")
+    add_index(:efile_submission_transitions,
+              %i(efile_submission_id most_recent),
+              unique: true,
+              where: "most_recent",
+              name: "index_efile_submission_transitions_parent_most_recent")
+  end
+end

--- a/db/migrate/20210611134455_add_will_efile_to_tax_return.rb
+++ b/db/migrate/20210611134455_add_will_efile_to_tax_return.rb
@@ -1,0 +1,5 @@
+class AddWillEfileToTaxReturn < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tax_returns, :internal_efile, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -257,18 +257,6 @@ ActiveRecord::Schema.define(version: 2021_06_14_215956) do
     t.index ["intake_id"], name: "index_documents_requests_on_intake_id"
   end
 
-  create_table "efile_submission_transitions", force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
-    t.integer "efile_submission_id", null: false
-    t.jsonb "metadata", default: {}
-    t.boolean "most_recent", null: false
-    t.integer "sort_key", null: false
-    t.string "to_state", null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["efile_submission_id", "most_recent"], name: "index_efile_submission_transitions_parent_most_recent", unique: true, where: "most_recent"
-    t.index ["efile_submission_id", "sort_key"], name: "index_efile_submission_transitions_parent_sort", unique: true
-  end
-
   create_table "efile_submissions", force: :cascade do |t|
     t.bigint "tax_return_id"
     t.index ["tax_return_id"], name: "index_efile_submissions_on_tax_return_id"
@@ -867,7 +855,6 @@ ActiveRecord::Schema.define(version: 2021_06_14_215956) do
   add_foreign_key "documents", "documents_requests"
   add_foreign_key "documents", "tax_returns"
   add_foreign_key "documents_requests", "intakes"
-  add_foreign_key "efile_submission_transitions", "efile_submissions"
   add_foreign_key "greeter_coalition_join_records", "coalitions"
   add_foreign_key "greeter_coalition_join_records", "greeter_roles"
   add_foreign_key "greeter_organization_join_records", "greeter_roles"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -270,7 +270,9 @@ ActiveRecord::Schema.define(version: 2021_06_14_215956) do
   end
 
   create_table "efile_submissions", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
     t.bigint "tax_return_id"
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["tax_return_id"], name: "index_efile_submissions_on_tax_return_id"
   end
 
@@ -704,6 +706,7 @@ ActiveRecord::Schema.define(version: 2021_06_14_215956) do
     t.integer "certification_level"
     t.bigint "client_id", null: false
     t.datetime "created_at", precision: 6, null: false
+    t.boolean "internal_efile", default: false, null: false
     t.boolean "is_ctc", default: false
     t.boolean "is_hsa"
     t.string "primary_signature"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -257,6 +257,23 @@ ActiveRecord::Schema.define(version: 2021_06_14_215956) do
     t.index ["intake_id"], name: "index_documents_requests_on_intake_id"
   end
 
+  create_table "efile_submission_transitions", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.integer "efile_submission_id", null: false
+    t.jsonb "metadata", default: {}
+    t.boolean "most_recent", null: false
+    t.integer "sort_key", null: false
+    t.string "to_state", null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["efile_submission_id", "most_recent"], name: "index_efile_submission_transitions_parent_most_recent", unique: true, where: "most_recent"
+    t.index ["efile_submission_id", "sort_key"], name: "index_efile_submission_transitions_parent_sort", unique: true
+  end
+
+  create_table "efile_submissions", force: :cascade do |t|
+    t.bigint "tax_return_id"
+    t.index ["tax_return_id"], name: "index_efile_submissions_on_tax_return_id"
+  end
+
   create_table "email_access_tokens", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.citext "email_address", null: false
@@ -850,6 +867,7 @@ ActiveRecord::Schema.define(version: 2021_06_14_215956) do
   add_foreign_key "documents", "documents_requests"
   add_foreign_key "documents", "tax_returns"
   add_foreign_key "documents_requests", "intakes"
+  add_foreign_key "efile_submission_transitions", "efile_submissions"
   add_foreign_key "greeter_coalition_join_records", "coalitions"
   add_foreign_key "greeter_coalition_join_records", "greeter_roles"
   add_foreign_key "greeter_organization_join_records", "greeter_roles"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -257,6 +257,18 @@ ActiveRecord::Schema.define(version: 2021_06_14_215956) do
     t.index ["intake_id"], name: "index_documents_requests_on_intake_id"
   end
 
+  create_table "efile_submission_transitions", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.integer "efile_submission_id", null: false
+    t.jsonb "metadata", default: {}
+    t.boolean "most_recent", null: false
+    t.integer "sort_key", null: false
+    t.string "to_state", null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["efile_submission_id", "most_recent"], name: "index_efile_submission_transitions_parent_most_recent", unique: true, where: "most_recent"
+    t.index ["efile_submission_id", "sort_key"], name: "index_efile_submission_transitions_parent_sort", unique: true
+  end
+
   create_table "efile_submissions", force: :cascade do |t|
     t.bigint "tax_return_id"
     t.index ["tax_return_id"], name: "index_efile_submissions_on_tax_return_id"
@@ -855,6 +867,7 @@ ActiveRecord::Schema.define(version: 2021_06_14_215956) do
   add_foreign_key "documents", "documents_requests"
   add_foreign_key "documents", "tax_returns"
   add_foreign_key "documents_requests", "intakes"
+  add_foreign_key "efile_submission_transitions", "efile_submissions"
   add_foreign_key "greeter_coalition_join_records", "coalitions"
   add_foreign_key "greeter_coalition_join_records", "greeter_roles"
   add_foreign_key "greeter_organization_join_records", "greeter_roles"

--- a/lib/tasks/create_test_efile_submissions.rake
+++ b/lib/tasks/create_test_efile_submissions.rake
@@ -1,0 +1,48 @@
+namespace :efile do
+  desc "Creates a CSV report of critical tracking fields for specific intakes"
+  task :seed_submissions, [:count] => :environment do |_task, args|
+    FactoryBot.create_list :efile_submission, 100, :ctc
+
+    preparing_group = EfileSubmission.take(95)
+    preparing_group.each do |submission|
+      submission.transition_to!(:preparing)
+    end
+
+    queued_group = preparing_group.take(75)
+    queued_group.each do |submission|
+      submission.transition_to!(:queued)
+    end
+
+    failed = queued_group.last(10)
+    failed.each do |submission|
+      submission.transition_to!(:failed, {
+        error_code: "TransmissionError",
+        error_message: "Some response from the service indicating that the IRS e-file service is temporarily down."
+      })
+    end
+
+    transmitted_group = queued_group.first(45)
+    transmitted_group.each do |submission|
+      submission.transition_to!(:transmitted)
+    end
+
+    accepted_group = transmitted_group.first(10)
+    accepted_group.each do |submission|
+      submission.transition_to!(:accepted)
+    end
+
+    rejected_group = transmitted_group.last(25)
+    errors = {
+        "SH-F1040-012-02": "If Schedule H (Form 1040), 'TotalTaxHouseholdEmplCalcAmt' has a non-zero value, then it must be equal to 'TotSSMedcrFedITAftrNrfdblCrAmt'.",
+        "IND-563": "For each dependent in the return with 'EligibleForChildTaxCreditInd' checked, the corresponding 'DependentSSN' must not be the same as a Dependent SSN on another return.",
+        "IND-931-01": "The Dependent SSN (or Qualifying Child Identifying Number on Form 1040-SS (PR)) has been locked because Social Security Administration records indicate the number belongs to a deceased individual.",
+        "R0000-500-01": "'PrimarySSN' and 'PrimaryNameControlTxt' in the Return Header must match the e-File database.",
+        "R0000-503-02": "Spouse SSN and Spouse Name Control in the return must match the e-File database.",
+        "R0000-504-02": "Each 'DependentSSN' and the corresponding 'DependentNameControlTxt' that has a value in 'DependentDetail' in the return must match the SSN and Name Control in the e-File database."
+    }
+    rejected_group.each do |submission|
+      error_key = errors.keys.sample
+      submission.transition_to!(:rejected, { error_code: error_key, error_message: errors[error_key] })
+    end
+  end
+end

--- a/spec/factories/efile_submission_transitions.rb
+++ b/spec/factories/efile_submission_transitions.rb
@@ -1,0 +1,35 @@
+# == Schema Information
+#
+# Table name: efile_submission_transitions
+#
+#  id                  :bigint           not null, primary key
+#  metadata            :jsonb
+#  most_recent         :boolean          not null
+#  sort_key            :integer          not null
+#  to_state            :string           not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  efile_submission_id :integer          not null
+#
+# Indexes
+#
+#  index_efile_submission_transitions_parent_most_recent  (efile_submission_id,most_recent) UNIQUE WHERE most_recent
+#  index_efile_submission_transitions_parent_sort         (efile_submission_id,sort_key) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (efile_submission_id => efile_submissions.id)
+#
+FactoryBot.define do
+  factory :efile_submission_transition do
+    efile_submission
+    
+    EfileSubmissionStateMachine.states.each do |state|
+      trait state.to_sym do
+        to_state { state }
+        sort_key { 0 }
+        most_recent { true }
+      end
+    end
+  end
+end

--- a/spec/factories/efile_submissions.rb
+++ b/spec/factories/efile_submissions.rb
@@ -1,0 +1,41 @@
+FactoryBot.define do
+  factory :efile_submission do
+    tax_return
+
+    trait :preparing do
+      after(:create) do |submission|
+        FactoryGirl.create(:efile_submission_transition, :preparing, efile_submission: submission)
+      end
+    end
+
+    trait :queued do
+      after(:create) do |submission|
+        FactoryGirl.create(:efile_submission_transition, :queued, efile_submission: submission)
+      end
+    end
+
+    trait :transmitted do
+      after(:create) do |submission|
+        FactoryGirl.create(:efile_submission_transition, :transmitted, efile_submission: submission)
+      end
+    end
+
+    trait :failed do
+      after(:create) do |submission|
+        FactoryGirl.create(:efile_submission_transition, :failed, efile_submission: submission)
+      end
+    end
+
+    trait :rejected do
+      after(:create) do |submission|
+        FactoryGirl.create(:efile_submission_transition, :rejected, efile_submission: submission)
+      end
+    end
+
+    trait :accepted do
+      after(:create) do |submission|
+        FactoryGirl.create(:efile_submission_transition, :accepted, efile_submission: submission)
+      end
+    end
+  end
+end

--- a/spec/factories/efile_submissions.rb
+++ b/spec/factories/efile_submissions.rb
@@ -3,6 +3,8 @@
 # Table name: efile_submissions
 #
 #  id            :bigint           not null, primary key
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
 #  tax_return_id :bigint
 #
 # Indexes
@@ -13,10 +15,14 @@ FactoryBot.define do
   factory :efile_submission do
     tax_return
 
+    trait :ctc do
+      tax_return { create(:tax_return, :ctc) }
+    end
+
     EfileSubmissionStateMachine.states.each do |state|
       trait state.to_sym do
-        after(:create) do |submission|
-          FactoryGirl.create(:efile_submission_transition, state, efile_submission: submission)
+        after :create do |submission|
+          create :efile_submission_transition, state, efile_submission: submission
         end
       end
     end

--- a/spec/factories/efile_submissions.rb
+++ b/spec/factories/efile_submissions.rb
@@ -1,40 +1,23 @@
+# == Schema Information
+#
+# Table name: efile_submissions
+#
+#  id            :bigint           not null, primary key
+#  tax_return_id :bigint
+#
+# Indexes
+#
+#  index_efile_submissions_on_tax_return_id  (tax_return_id)
+#
 FactoryBot.define do
   factory :efile_submission do
     tax_return
 
-    trait :preparing do
-      after(:create) do |submission|
-        FactoryGirl.create(:efile_submission_transition, :preparing, efile_submission: submission)
-      end
-    end
-
-    trait :queued do
-      after(:create) do |submission|
-        FactoryGirl.create(:efile_submission_transition, :queued, efile_submission: submission)
-      end
-    end
-
-    trait :transmitted do
-      after(:create) do |submission|
-        FactoryGirl.create(:efile_submission_transition, :transmitted, efile_submission: submission)
-      end
-    end
-
-    trait :failed do
-      after(:create) do |submission|
-        FactoryGirl.create(:efile_submission_transition, :failed, efile_submission: submission)
-      end
-    end
-
-    trait :rejected do
-      after(:create) do |submission|
-        FactoryGirl.create(:efile_submission_transition, :rejected, efile_submission: submission)
-      end
-    end
-
-    trait :accepted do
-      after(:create) do |submission|
-        FactoryGirl.create(:efile_submission_transition, :accepted, efile_submission: submission)
+    EfileSubmissionStateMachine.states.each do |state|
+      trait state.to_sym do
+        after(:create) do |submission|
+          FactoryGirl.create(:efile_submission_transition, state, efile_submission: submission)
+        end
       end
     end
   end

--- a/spec/factories/intakes.rb
+++ b/spec/factories/intakes.rb
@@ -246,6 +246,15 @@ FactoryBot.define do
       email_notification_opt_in { "yes" }
     end
 
+    trait :with_faker_contact_info do
+      primary_first_name { Faker::Name.first_name }
+      primary_last_name { Faker::Name.last_name }
+      preferred_name { primary_first_name }
+      phone_number { "+14155551212" }
+      sms_phone_number { "+14155551212" }
+      email_address { Faker::Internet.email }
+    end
+
     trait :with_deterministic_yes_no_answers do
       married { "yes" }
       divorced { "yes" }

--- a/spec/factories/tax_returns.rb
+++ b/spec/factories/tax_returns.rb
@@ -4,6 +4,7 @@
 #
 #  id                  :bigint           not null, primary key
 #  certification_level :integer
+#  internal_efile      :boolean          default(FALSE), not null
 #  is_ctc              :boolean          default(FALSE)
 #  is_hsa              :boolean
 #  primary_signature   :string
@@ -49,6 +50,13 @@ FactoryBot.define do
                document_type: DocumentTypes::UnsignedForm8879.key
         )
       end
+    end
+
+    trait :ctc do
+      year { 2020 }
+      client { create(:intake, :with_faker_contact_info, :with_dependents, dependent_count: 3).client }
+      is_ctc { true }
+      internal_efile { true }
     end
 
     trait :with_final_tax_doc do

--- a/spec/models/efile_submission_spec.rb
+++ b/spec/models/efile_submission_spec.rb
@@ -3,6 +3,8 @@
 # Table name: efile_submissions
 #
 #  id            :bigint           not null, primary key
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
 #  tax_return_id :bigint
 #
 # Indexes
@@ -13,8 +15,91 @@ require "rails_helper"
 
 describe EfileSubmission do
   context 'a newly created submission' do
+    let(:submission) { create :efile_submission }
     it 'has an initial current_state of new' do
-      expect(EfileSubmission.create(tax_return: create(:tax_return)).current_state).to eq "new"
+      expect(submission.current_state).to eq "new"
+    end
+  end
+
+  context "transitions" do
+    context "new" do
+      let(:submission) { create :efile_submission }
+      context "can transition to" do
+        it "preparing" do
+          expect { submission.transition_to!(:preparing) }.not_to raise_error
+        end
+      end
+
+      context "cannot transition to" do
+        EfileSubmissionStateMachine.states.excluding("new", "preparing").each do |state|
+          it state.to_s do
+            expect { submission.transition_to!(state) }.to raise_error(Statesman::TransitionFailedError)
+          end
+        end
+      end
+    end
+
+    context "preparing" do
+      let(:submission) { create :efile_submission, :preparing }
+      context "can transition to" do
+        it "queued" do
+          expect { submission.transition_to!(:queued) }.not_to raise_error
+        end
+      end
+
+      context "cannot transition to" do
+        EfileSubmissionStateMachine.states.excluding("queued", "preparing").each do |state|
+          it state.to_s do
+            expect { submission.transition_to!(state) }.to raise_error(Statesman::TransitionFailedError)
+          end
+        end
+      end
+    end
+
+    context "queued" do
+      let(:submission) { create :efile_submission, :queued }
+      context "can transition to" do
+        it "transmitted" do
+          expect { submission.transition_to!(:transmitted) }.not_to raise_error
+        end
+
+        it "failed" do
+          expect { submission.transition_to!(:failed) }.not_to raise_error
+        end
+
+        it "rejected" do
+          expect { submission.transition_to!(:rejected) }.not_to raise_error
+        end
+      end
+
+      context "cannot transition to" do
+        EfileSubmissionStateMachine.states.excluding("transmitted", "failed", "rejected", "queued").each do |state|
+          it state.to_s do
+            expect { submission.transition_to!(state) }.to raise_error(Statesman::TransitionFailedError)
+          end
+        end
+      end
+    end
+
+    context "transmitted" do
+      let(:submission) { create :efile_submission, :transmitted }
+      context "can transition to" do
+        it "accepted" do
+          expect { submission.transition_to!(:accepted) }.not_to raise_error
+        end
+
+        it "rejected" do
+          expect { submission.transition_to!(:rejected) }.not_to raise_error
+        end
+      end
+
+      context "cannot transition to" do
+        EfileSubmissionStateMachine.states.excluding("accepted", "rejected", "transmitted").each do |state|
+          it state.to_s do
+            expect { submission.transition_to!(state) }.to raise_error(Statesman::TransitionFailedError)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/models/efile_submission_spec.rb
+++ b/spec/models/efile_submission_spec.rb
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: efile_submissions
+#
+#  id            :bigint           not null, primary key
+#  tax_return_id :bigint
+#
+# Indexes
+#
+#  index_efile_submissions_on_tax_return_id  (tax_return_id)
+#
+require "rails_helper"
+
+describe EfileSubmission do
+  context 'a newly created submission' do
+    it 'has an initial current_state of new' do
+      expect(EfileSubmission.create(tax_return: create(:tax_return)).current_state).to eq "new"
+    end
+  end
+end

--- a/spec/models/tax_return_spec.rb
+++ b/spec/models/tax_return_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id                  :bigint           not null, primary key
 #  certification_level :integer
+#  internal_efile      :boolean          default(FALSE), not null
 #  is_ctc              :boolean          default(FALSE)
 #  is_hsa              :boolean
 #  primary_signature   :string

--- a/spec/state_machines/efile_submission_state_machine_spec.rb
+++ b/spec/state_machines/efile_submission_state_machine_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+describe EfileSubmissionStateMachine do
+  context 'when condition' do
+    it 'succeeds' do
+      pending 'Not implemented'
+    end
+  end
+end

--- a/spec/state_machines/efile_submission_state_machine_spec.rb
+++ b/spec/state_machines/efile_submission_state_machine_spec.rb
@@ -1,9 +1,0 @@
-require "rails_helper"
-
-describe EfileSubmissionStateMachine do
-  context 'when condition' do
-    it 'succeeds' do
-      pending 'Not implemented'
-    end
-  end
-end


### PR DESCRIPTION
Includes:

- Schema for efile_submissions w/ relationship to tax returns (including an efiling flag on tax return)
- Setup statesman state machine w/ known states and placeholders for upcoming stories (may remove some of the transition stuff -- felt like it could be helpful to code-document how statesman transitions and guards can work, but ymmv
- Set up factories for efile_submissions, transitions, and tax return with efile_submissions
- Seed file for efile_submissions locally and in demo using FactoryBot and Faker (added faker gem)

<img width="1439" alt="Screen Shot 2021-06-11 at 10 35 10 AM" src="https://user-images.githubusercontent.com/4494389/121712012-d742f600-caa0-11eb-8ca0-33cf470f89ec.png">
<img width="1440" alt="Screen Shot 2021-06-11 at 10 46 47 AM" src="https://user-images.githubusercontent.com/4494389/121713394-6dc3e700-caa2-11eb-89a5-1c386a286dc2.png">

