### PR TITLE
Nil protector for empty notes

### DIFF
--- a/app/views/hub/notes/index.html.erb
+++ b/app/views/hub/notes/index.html.erb
@@ -10,7 +10,7 @@
   <div class="slab slab--padded">
     <div class="client-container">
       <ul class="day-list">
-        <% @all_notes_by_day.each_with_index do |(datetime, notes), day_index| %>
+        <% @all_notes_by_day&.each_with_index do |(datetime, notes), day_index| %>
           <li class="day-heading"><%= date_heading(datetime) %></li>
           <%= render partial: "note", collection: notes, locals: { last_day: day_index == @all_notes_by_day.size - 1 }  %>
         <% end %>

--- a/spec/controllers/hub/notes_controller_spec.rb
+++ b/spec/controllers/hub/notes_controller_spec.rb
@@ -66,14 +66,20 @@ RSpec.describe Hub::NotesController, type: :controller do
               }
           }
         end
+        
+        # rendering views to expose known bug with re-rendering the entire index after a failed note save.
+        # When a note cannot be saved, the index is re-rendered without index template variables, and the page still
+        # needs to render without totally breaking.
+        context "with views rendered" do
+          render_views
+          it "returns 200 OK and does not save" do
+            expect do
+              post :create, params: params
+            end.not_to change(Note, :count)
 
-        it "returns 200 OK and does not save" do
-          expect do
-            post :create, params: params
-          end.not_to change(Note, :count)
-
-          expect(response).to be_ok
-          expect(response).to render_template :index
+            expect(response).to be_ok
+            expect(response).to render_template :index
+          end
         end
       end
     end


### PR DESCRIPTION
The nil guard was removed on the notes page because NotesPresenter service object always responds with an object and should never be nil. 

HOWEVER, notes#create re-renders the index when there is a failure (because the note creation is on the index), but render doesn't load the template variables for the rendered template, so the page was erroring out.

I felt that the appropriate level of effort at this point in time was just to add back the nil check, and create a ticket for refactoring. Reasoning: The change exposed a bug we did not know we had, but happens rarely enough that it hadn't been reported to is. Thus, it is important to fix in a more thorough manner but not at this point in time.