### PR TITLE
bump devise to 4.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GEM
       descendants_tracker (~> 0.0.1)
     combine_pdf (1.0.21)
       ruby-rc4 (>= 0.1.5)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -161,7 +161,7 @@ GEM
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     device_detector (1.0.5)
-    devise (4.7.3)
+    devise (4.8.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0)


### PR DESCRIPTION
Required for Rails 6.1 upgrade

https://github.com/heartcombo/devise/compare/v4.7.3...v4.8.0

```
UPDATED:
concurrent-ruby  1.1.8  1.1.9
devise           4.7.3  4.8.0
```