### PR TITLE
When request format is not routable, exit early

### DIFF
--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -31,7 +31,12 @@ class PublicPagesController < ApplicationController
 
   def internal_server_error; end
 
-  def page_not_found; end
+  def page_not_found
+    respond_to do |format|
+      format.html { render 'public_pages/page_not_found', status: 404  }
+      format.any { head 404 }
+    end
+  end
 
   def tax_questions; end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -267,4 +267,6 @@ Rails.application.routes.draw do
       end
     end
   end
+
+  get '*unmatched_route', to: 'public_pages#page_not_found'
 end

--- a/spec/routing/source_routing_spec.rb
+++ b/spec/routing/source_routing_spec.rb
@@ -2,10 +2,6 @@ require "rails_helper"
 
 describe "partner source routing" do
   let(:code) { "example" }
-  let(:vita_partner) { create :vita_partner }
-  before do
-    create(:source_parameter, code: "example", vita_partner: vita_partner)
-  end
 
   it "converts the source in the url to a parameter" do
     expect(get: "/#{code}").to route_to(
@@ -42,6 +38,10 @@ describe "partner source routing" do
   end
 
   it "rejects arbitrary paths that contain non-slug-like characters" do
-    expect(get: "/4Rb!_trar-y").not_to be_routable
+    expect(get: "/4Rb!_trar-y").to route_to(
+     controller: "public_pages",
+     action: "page_not_found",
+     unmatched_route: "4Rb!_trar-y"
+    )
   end
 end


### PR DESCRIPTION
There's two parts to this.

1. Make sure the 404 page can render itself even if given a non-HTML format. This appears to be essential in avoiding a server deadlock during `wrk -t6 -c400 -d120s https://staging.getyourrefund.org/es/questions/eligibility/assets/checkbox-logo--black-ef44fd73e20340f869f5a0afdc7448f1079c094ad8d0267b753e03e3539ffbb0.png`

2. We add `get "*unmatched_route"` to avoid excessive log noise; see https://github.com/roidrage/lograge#handle-actioncontrollerroutingerror

To repro the `wrk` deadlock, run it, and also do:

```
aptible logs --app vita-min-staging | tee -a ~/staging-logs.txt
```

and

```
watch grep critical ~/staging-logs.txt
```

You'll eventually see:

```
2021-06-15T22:32:31.522Z [vita-min-staging-cmd 45bb4b05864c]: 2021-06-15 22:32:31 +0000 Rack app ("GET /es/questions/eligibility/assets/checkbox-logo--black-ef44fd73e20340f869f5a0afdc7448f1079c094ad8d0267
b753e03e3539ffbb0.png" - (157.131.203.151, 10.210.0.240)): #<fatal: machine stack overflow in critical region>
```

[I figured it had to do with formats due to this log output](https://slack-files.com/T024F66L9-F025C6VEUCC-ba37c0fa2c)

I think it has to do with exceptions while handling exceptions. I'd call this a Puma and/or Rails bug, and it's probably smart to make a [minimal repro case](http://sscce.org/) but that's a task for another day.