### PR TITLE
CTC home page: presence of the DIY link can be toggled by an env var

### DIFF
--- a/app/views/ctc/ctc_pages/home.html.erb
+++ b/app/views/ctc/ctc_pages/home.html.erb
@@ -132,13 +132,15 @@
           </a>
           <div class="accordion__content" id="a5">
             <p><%=t("views.ctc_pages.home.obtain.full_return.body1_html") %></p>
-            <p><%=t("views.ctc_pages.home.obtain.full_return.body2_html") %></p>
-            <p>
-              <a href="<%= url_for(host: Rails.application.config.gyr_domains[Rails.env.to_sym], controller: "/public_pages", action: 'diy')%> ">
-                <%= t("views.ctc_pages.home.obtain.full_return.gyr_diy_link") %></a><%=
-                  t("views.ctc_pages.home.obtain.full_return.gyr_diy_explanation")
-                %>
-            </p>
+            <% unless ENV['CTC_HIDE_DIY_LINK'] == 'true' %>
+              <p><%=t("views.ctc_pages.home.obtain.full_return.body2_html") %></p>
+              <p>
+                <a href="<%= url_for(host: Rails.application.config.gyr_domains[Rails.env.to_sym], controller: "/public_pages", action: 'diy')%> ">
+                  <%= t("views.ctc_pages.home.obtain.full_return.gyr_diy_link") %></a><%=
+                    t("views.ctc_pages.home.obtain.full_return.gyr_diy_explanation")
+                  %>
+              </p>
+            <% end %>
           </div>
         </div>
       </div>

--- a/spec/features/ctc/home_spec.rb
+++ b/spec/features/ctc/home_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.feature "Visit CTC home page" do
+  before do
+    allow_any_instance_of(Routes::CtcDomain).to receive(:matches?).and_return(true)
+  end
+
+  it "has content" do
+    visit "/"
+    expect(page).to have_text I18n.t("views.ctc_pages.home.header")
+    expect(page).to have_text I18n.t("views.ctc_pages.home.obtain.full_return.gyr_diy_link")
+  end
+
+  context "when the DIY link is disabled" do
+    before do
+      ENV['CTC_HIDE_DIY_LINK'] = 'true'
+    end
+
+    after do
+      ENV.delete('CTC_HIDE_DIY_LINK')
+    end
+
+    it "doesn't show the DIY link" do
+      visit "/"
+      expect(page).to have_text I18n.t("views.ctc_pages.home.header")
+      expect(page).not_to have_text I18n.t("views.ctc_pages.home.obtain.full_return.gyr_diy_link")
+    end
+  end
+end


### PR DESCRIPTION
Set CTC_HIDE_DIY_LINK to 'true' to hide the link

Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>