### PR TITLE
Bump devise_invitable gem to squash `BLACKLIST_FOR_SERIALIZATION` deprecation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,7 +169,7 @@ GEM
       warden (~> 1.2.3)
     devise-i18n (1.9.2)
       devise (>= 4.7.1)
-    devise_invitable (2.0.2)
+    devise_invitable (2.0.5)
       actionmailer (>= 5.0)
       devise (>= 4.6)
     diff-lcs (1.4.4)


### PR DESCRIPTION
https://github.com/scambra/devise_invitable/compare/v2.0.2...v2.0.5