### PR TITLE
CTC reminder page: put the proper spanish translations

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2792,7 +2792,7 @@ en:
         new:
           title: Sign Up
           header: Stay in touch. We can email you when more information is available.
-          sub_header: All you need to do is provide us with your name and either an e-mail address or phone number and we'll e-mail or text you when there is more information.
+          sub_header: All you need to do is provide us with your name and either an email address or phone number and we'll email or text you when there is more information.
           submit: Keep me updated
         confirmation:
           title: Sign Up

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2754,8 +2754,8 @@ es:
             answer_html: |
               No, recibir el Crédito Tributario por Hijos u otros créditos tributarios para los que usted califica, no afectará su estatus migratorio, su capacidad para obtener una tarjeta verde, o sus planes futuros de inmigración. El uso de créditos tributarios no se considera una "carga pública" por parte de los Servicios de Ciudadanía e Inmigración de los Estados Unidos (USCIS en inglés).
         sign_up_for_reminders:
-          body: Mantente en contacto. Podemos enviarle un correo electrónico cuando haya más información disponible.
-          button: Si mantenme actualizada
+          body: Manténgase en contacto. Podemos enviarle un email cuando haya más información disponible.
+          button: Si, manténganme informado
         what_is:
           heading: "¿Qué es el Crédito Tributario por Hijos (CTC)?"
           body1: "El Plan de Rescate Estadounidense, firmado como ley por el presidente Biden el 11 de marzo de 2021, aumenta el Crédito Tributario por Hijos (CTC en inglés) que le podría proporcionar hasta $300 al mes por cada hijo menor de seis años y hasta $250 por hijo con edades entre 6 y 17 años."
@@ -2831,9 +2831,9 @@ es:
       signups:
         new:
           title: Regístrate
-          header: Mantente en contacto. Podemos enviarle un correo electrónico cuando haya más información disponible.
-          sub_header: Todo lo que necesita hacer es proporcionarnos su nombre y una dirección de correo electrónico o un número de teléfono y le enviaremos un correo electrónico o un mensaje de texto cuando haya más información.
-          submit: Mantenme informado
+          header: Manténgase en contacto. Podemos enviarle un email cuando haya más información disponible.
+          sub_header: Lo único que tiene que hacer es proporcionar su nombre y su correo electrónico o número de teléfono y le enviaremos un email o mensaje de texto cuando haya más información disponible.
+          submit: Manténganme actualizado
         confirmation:
           title: Regístrate
           header: Gracias por registrarte!

--- a/spec/features/ctc/home_spec.rb
+++ b/spec/features/ctc/home_spec.rb
@@ -47,7 +47,7 @@ RSpec.feature "Visit CTC home page" do
       expect(page).to have_text I18n.t("views.ctc_pages.signups.confirmation.header")
       expect(page).to have_text I18n.t("views.ctc_pages.signups.confirmation.body")
       click_on I18n.t('views.ctc_pages.signups.confirmation.button')
-      expect(page).to have_text "Child Tax Credit"
+      expect(page).to have_text I18n.t('views.ctc_pages.home.header')
     end
   end
 end


### PR DESCRIPTION
Note that the translations for the confirmation page are still googley
translated

Co-authored-by: Molly T-M <mollyt@codeforamerica.org>