### PR TITLE
CTC: add more fields to valet form

### DIFF
--- a/app/forms/hub/create_ctc_client_form.rb
+++ b/app/forms/hub/create_ctc_client_form.rb
@@ -51,6 +51,8 @@ module Hub
     validates :filing_status, presence: true
     after_save :send_confirmation_message, :send_mixpanel_data
 
+    validates :ctc_refund_delivery_method, presence: true
+
     with_options if: -> { ctc_refund_delivery_method == "direct_deposit" } do
       validates_confirmation_of :bank_routing_number
       validates_confirmation_of :bank_account_number

--- a/app/forms/hub/create_ctc_client_form.rb
+++ b/app/forms/hub/create_ctc_client_form.rb
@@ -50,12 +50,19 @@ module Hub
     validates :signature_method, presence: true
     validates :filing_status, presence: true
     after_save :send_confirmation_message, :send_mixpanel_data
-    validates_confirmation_of :bank_routing_number
-    validates_confirmation_of :bank_account_number
+
+    with_options if: -> { ctc_refund_delivery_method == "direct_deposit" } do
+      validates_confirmation_of :bank_routing_number
+      validates_confirmation_of :bank_account_number
+      validates_presence_of :bank_name
+      validates_presence_of :bank_account_type
+      validates_presence_of :bank_account_number
+      validates_presence_of :bank_routing_number
+    end
+
     validates_presence_of :bank_account_number_confirmation, if: :bank_account_number
     validates_presence_of :bank_routing_number_confirmation, if: :bank_routing_number
-    validates_presence_of :bank_account_number
-    validates_presence_of :bank_routing_number
+
     def required_dependents_attributes
       [:birth_date, :first_name, :last_name, :relationship].freeze
     end

--- a/app/forms/hub/create_ctc_client_form.rb
+++ b/app/forms/hub/create_ctc_client_form.rb
@@ -31,7 +31,11 @@ module Hub
                        :bank_account_number,
                        :bank_routing_number,
                        :bank_account_type,
-                       :bank_name
+                       :bank_name,
+                       :recovery_rebate_credit_amount_1,
+                       :recovery_rebate_credit_amount_2,
+                       :recovery_rebate_credit_amount_confidence,
+                       :ctc_refund_delivery_method
     set_attributes_for :tax_return,
                        :filing_status,
                        :filing_status_note

--- a/app/forms/hub/create_ctc_client_form.rb
+++ b/app/forms/hub/create_ctc_client_form.rb
@@ -35,7 +35,9 @@ module Hub
                        :recovery_rebate_credit_amount_1,
                        :recovery_rebate_credit_amount_2,
                        :recovery_rebate_credit_amount_confidence,
-                       :ctc_refund_delivery_method
+                       :ctc_refund_delivery_method,
+                       :navigator_name,
+                       :navigator_has_verified_client_identity
     set_attributes_for :tax_return,
                        :filing_status,
                        :filing_status_note

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -90,6 +90,8 @@
 #  made_estimated_tax_payments                          :integer          default(0), not null
 #  married                                              :integer          default(0), not null
 #  multiple_states                                      :integer          default(0), not null
+#  navigator_has_verified_client_identity               :boolean
+#  navigator_name                                       :string
 #  needs_help_2016                                      :integer          default(0), not null
 #  needs_help_2017                                      :integer          default(0), not null
 #  needs_help_2018                                      :integer          default(0), not null

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -16,6 +16,7 @@
 #  completed_at                                         :datetime
 #  completed_yes_no_questions_at                        :datetime
 #  continued_at_capacity                                :boolean          default(FALSE)
+#  ctc_refund_delivery_method                           :integer
 #  current_step                                         :string
 #  demographic_disability                               :integer          default(0), not null
 #  demographic_english_conversation                     :integer          default(0), not null
@@ -120,6 +121,9 @@
 #  received_homebuyer_credit                            :integer          default(0), not null
 #  received_irs_letter                                  :integer          default(0), not null
 #  received_stimulus_payment                            :integer          default(0), not null
+#  recovery_rebate_credit_amount_1                      :integer
+#  recovery_rebate_credit_amount_2                      :integer
+#  recovery_rebate_credit_amount_confidence             :integer
 #  referrer                                             :string
 #  refund_payment_method                                :integer          default(0), not null
 #  reported_asset_sale_loss                             :integer          default(0), not null
@@ -258,6 +262,11 @@ class Intake < ApplicationRecord
       field_name: :with_unhoused_navigator
     }
   }
+
+  def is_ctc?
+    false
+  end
+
   # Returns the phone number formatted for user display, e.g.: "(510) 555-1234"
   def formatted_phone_number
     Phonelib.parse(phone_number).local_number

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -90,6 +90,8 @@
 #  made_estimated_tax_payments                          :integer          default(0), not null
 #  married                                              :integer          default(0), not null
 #  multiple_states                                      :integer          default(0), not null
+#  navigator_has_verified_client_identity               :boolean
+#  navigator_name                                       :string
 #  needs_help_2016                                      :integer          default(0), not null
 #  needs_help_2017                                      :integer          default(0), not null
 #  needs_help_2018                                      :integer          default(0), not null

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -16,6 +16,7 @@
 #  completed_at                                         :datetime
 #  completed_yes_no_questions_at                        :datetime
 #  continued_at_capacity                                :boolean          default(FALSE)
+#  ctc_refund_delivery_method                           :integer
 #  current_step                                         :string
 #  demographic_disability                               :integer          default(0), not null
 #  demographic_english_conversation                     :integer          default(0), not null
@@ -120,6 +121,9 @@
 #  received_homebuyer_credit                            :integer          default(0), not null
 #  received_irs_letter                                  :integer          default(0), not null
 #  received_stimulus_payment                            :integer          default(0), not null
+#  recovery_rebate_credit_amount_1                      :integer
+#  recovery_rebate_credit_amount_2                      :integer
+#  recovery_rebate_credit_amount_confidence             :integer
 #  referrer                                             :string
 #  refund_payment_method                                :integer          default(0), not null
 #  reported_asset_sale_loss                             :integer          default(0), not null
@@ -194,7 +198,18 @@
 #  fk_rails_...  (vita_partner_id => vita_partners.id)
 #
 class Intake::CtcIntake < Intake
+
+  attribute :recovery_rebate_credit_amount_1, :money
+  attribute :recovery_rebate_credit_amount_2, :money
+
+  enum recovery_rebate_credit_amount_confidence: { unfilled: 0, sure: 1, unsure: 2 }, _prefix: :recovery_rebate_credit_amount_confidence
+  enum ctc_refund_delivery_method: { unfilled: 0, direct_deposit: 1, check: 2 }, _prefix: :ctc_refund_delivery_method
+
   def document_types_definitely_needed
     []
+  end
+
+  def is_ctc?
+    true
   end
 end

--- a/app/models/intake/gyr_intake.rb
+++ b/app/models/intake/gyr_intake.rb
@@ -90,6 +90,8 @@
 #  made_estimated_tax_payments                          :integer          default("unfilled"), not null
 #  married                                              :integer          default("unfilled"), not null
 #  multiple_states                                      :integer          default("unfilled"), not null
+#  navigator_has_verified_client_identity               :boolean
+#  navigator_name                                       :string
 #  needs_help_2016                                      :integer          default("unfilled"), not null
 #  needs_help_2017                                      :integer          default("unfilled"), not null
 #  needs_help_2018                                      :integer          default("unfilled"), not null

--- a/app/models/intake/gyr_intake.rb
+++ b/app/models/intake/gyr_intake.rb
@@ -16,6 +16,7 @@
 #  completed_at                                         :datetime
 #  completed_yes_no_questions_at                        :datetime
 #  continued_at_capacity                                :boolean          default(FALSE)
+#  ctc_refund_delivery_method                           :integer
 #  current_step                                         :string
 #  demographic_disability                               :integer          default("unfilled"), not null
 #  demographic_english_conversation                     :integer          default("unfilled"), not null
@@ -120,6 +121,9 @@
 #  received_homebuyer_credit                            :integer          default("unfilled"), not null
 #  received_irs_letter                                  :integer          default("unfilled"), not null
 #  received_stimulus_payment                            :integer          default("unfilled"), not null
+#  recovery_rebate_credit_amount_1                      :integer
+#  recovery_rebate_credit_amount_2                      :integer
+#  recovery_rebate_credit_amount_confidence             :integer
 #  referrer                                             :string
 #  refund_payment_method                                :integer          default("unfilled"), not null
 #  reported_asset_sale_loss                             :integer          default("unfilled"), not null

--- a/app/models/system_note/verified_client_identity.rb
+++ b/app/models/system_note/verified_client_identity.rb
@@ -1,0 +1,31 @@
+# == Schema Information
+#
+# Table name: system_notes
+#
+#  id         :bigint           not null, primary key
+#  body       :text
+#  data       :jsonb
+#  type       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  client_id  :bigint           not null
+#  user_id    :bigint
+#
+# Indexes
+#
+#  index_system_notes_on_client_id  (client_id)
+#  index_system_notes_on_user_id    (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (client_id => clients.id)
+#  fk_rails_...  (user_id => users.id)
+#
+class SystemNote::VerifiedClientIdentity < SystemNote
+  def self.generate!(client:)
+    create!(
+      client: client,
+      body: "#{client.intake.navigator_name} verified client identity"
+    )
+  end
+end

--- a/app/types/money_type.rb
+++ b/app/types/money_type.rb
@@ -1,0 +1,9 @@
+class MoneyType < ActiveRecord::Type::Integer
+  def cast(value)
+    if value.kind_of?(String) && value.include?('$')
+      super(value.gsub(/\$/, ''))
+    else
+      super
+    end
+  end
+end

--- a/app/views/hub/clients/_displayed_bank_account_info.html.erb
+++ b/app/views/hub/clients/_displayed_bank_account_info.html.erb
@@ -1,5 +1,13 @@
 <div role="alert">
   <h2 class="sr-only"><%= t("hub.bank_accounts.info_displayed") %></h2>
+
+  <% if @client.intake.is_ctc? %>
+    <p>
+      <span class="hc-label">Refund delivery method:</span>
+      <span class="label-value"><%= @client.intake.ctc_refund_delivery_method.humanize %> </span>
+    </p>
+  <% end %>
+
   <p>
     <span class="hc-label"><%= t("hub.bank_accounts.bank_name") %>:</span>
     <span class="label-value"><%= @client.intake.bank_name %> </span>

--- a/app/views/hub/clients/_hidden_bank_account_info.html.erb
+++ b/app/views/hub/clients/_hidden_bank_account_info.html.erb
@@ -1,5 +1,15 @@
 <div>
   <p>
+    <span class="hc-label"><%= "Receive CTC" %>:</span>
+    <span class="label-value" aria-hidden="true">●●●●●●●●●●●</span>
+    <span class="sr-only">Hidden</span>
+  </p>
+  <p>
+    <span class="hc-label"><%= "Refund delivery method" %>:</span>
+    <span class="label-value" aria-hidden="true">●●●●●●●●●●●</span>
+    <span class="sr-only">Hidden</span>
+  </p>
+  <p>
     <span class="hc-label"><%= t("hub.bank_accounts.bank_name") %>:</span>
     <span class="label-value" aria-hidden="true">●●●●●●●●●●●</span>
     <span class="sr-only">Hidden</span>

--- a/app/views/hub/clients/index.html.erb
+++ b/app/views/hub/clients/index.html.erb
@@ -105,7 +105,7 @@
               <%= client.vita_partner&.name || t("general.none") %>
             </td>
             <td class="index-table__cell"><%= client.preferred_language ? t("general.language_options.#{client.preferred_language}") : t('general.NA') %></td>
-            <td class="index-table__cell"><%= "✓" if client.intake.had_unemployment_income_yes? %></td>
+            <td class="index-table__cell"><%= "✓" if client.intake.had_unemployment_income == "yes" %></td>
             <td class="index-table__cell"><%= formatted_datetime(client.updated_at) %></td>
 
             <% if client.first_unanswered_incoming_interaction_at.present? %>

--- a/app/views/hub/clients/show.html.erb
+++ b/app/views/hub/clients/show.html.erb
@@ -112,6 +112,24 @@
               <span class="label-value">No bank account info provided.</span>
             <% end %>
           </div>
+
+          <% if @client.intake.is_ctc? %>
+            <div class="client-profile__field_group client-recovery-rebate-creidt-amount">
+              <h2 class="text--bold"><%= t("hub.clients.fields.recovery_rebate_credit") %></h2>
+              <div class="field-display">
+                <span class="form-question"><%= t("hub.recovery_rebate_credit_amount.amount_1") %>:</span>
+                <span class="label-value">$<%= @client.intake.recovery_rebate_credit_amount_1 %> </span>
+              </div>
+              <div class="field-display">
+                <span class="form-question"><%= t("hub.recovery_rebate_credit_amount.amount_2") %>:</span>
+                <span class="label-value">$<%= @client.intake.recovery_rebate_credit_amount_2 %> </span>
+              </div>
+              <div class="field-display">
+                <span class="form-question">Confidence:</span>
+                <span class="label-value"><%= @client.intake.recovery_rebate_credit_amount_confidence.capitalize %> </span>
+              </div>
+            </div>
+            <% end %>
         </div>
 
         <div class="client-profile__column">

--- a/app/views/hub/clients/show.html.erb
+++ b/app/views/hub/clients/show.html.erb
@@ -113,6 +113,7 @@
             <% end %>
           </div>
 
+          <!-- Recovery rebate credit -->
           <% if @client.intake.is_ctc? %>
             <div class="client-profile__field_group client-recovery-rebate-creidt-amount">
               <h2 class="text--bold"><%= t("hub.clients.fields.recovery_rebate_credit") %></h2>
@@ -129,7 +130,7 @@
                 <span class="label-value"><%= @client.intake.recovery_rebate_credit_amount_confidence.capitalize %> </span>
               </div>
             </div>
-            <% end %>
+          <% end %>
         </div>
 
         <div class="client-profile__column">
@@ -203,6 +204,17 @@
             </span>
             </div>
           </div>
+
+          <!-- Identity verification -->
+          <% if @client.intake.is_ctc? %>
+            <div class="client-profile__field_group client-recovery-rebate-credit-amount">
+              <h2 class="text--bold">Navigator Name</h2>
+              <div class="field-display">
+                <span class="form-question">Legal Name:</span>
+                <span class="label-value">$<%= @client.intake.navigator_name %> </span>
+              </div>
+            </div>
+          <% end %>
         </div>
       </div>
       <div class="client-profile__actions"><%= link_to(t("general.edit_info"), edit_hub_client_path, class: "button hc-button--wide") %></div>

--- a/app/views/hub/ctc_clients/new.html.erb
+++ b/app/views/hub/ctc_clients/new.html.erb
@@ -17,6 +17,7 @@
           <%= render "shared/client_spouse_info_fields", f: f %>
           <%= render "shared/dependents_fields", f: f, is_ctc: true %>
           <%= render "shared/address_fields", f: f %>
+          <%= render "shared/recovery_rebate_amount_fields", f: f %>
           <%= render "shared/bank_account_fields", f: f %>
           <%= render "shared/navigator_fields", f: f %>
 

--- a/app/views/hub/ctc_clients/new.html.erb
+++ b/app/views/hub/ctc_clients/new.html.erb
@@ -20,6 +20,7 @@
           <%= render "shared/recovery_rebate_amount_fields", f: f %>
           <%= render "shared/bank_account_fields", f: f %>
           <%= render "shared/navigator_fields", f: f %>
+          <%= render "shared/identity_verification_fields", f: f %>
 
           <div>
             <button class="button button--cta" type="submit" name="save">

--- a/app/views/shared/_bank_account_fields.html.erb
+++ b/app/views/shared/_bank_account_fields.html.erb
@@ -1,12 +1,25 @@
 <div id="bank-account-fields" class="hub-form__card card-small">
   <h3><%= t("hub.clients.fields.payment_information") %></h3>
-  <%= f.cfa_input_field(:bank_name, t("hub.bank_accounts.bank_name")) %>
-  <%= f.cfa_select :bank_account_type, t("hub.bank_accounts.account_type"),[
-      [t("views.questions.bank_details.account_type.checking"), :checking ],
-      [t("views.questions.bank_details.account_type.savings"), :savings ],
-  ] %>
-  <%= f.cfa_input_field :bank_routing_number, t("hub.bank_accounts.routing_number") %>
-  <%= f.cfa_input_field :bank_routing_number_confirmation, t("hub.bank_accounts.routing_number_confirmation") %>
-  <%= f.cfa_input_field :bank_account_number, t("hub.bank_accounts.account_number") %>
-  <%= f.cfa_input_field :bank_account_number_confirmation, t("hub.bank_accounts.account_number_confirmation") %>
+  <div class="question-with-follow-up">
+    <div class="hub-form__radio-set question-with-follow-up__question">
+      <%= f.cfa_radio_set :ctc_refund_delivery_method, label_text: "Refund delivery method", collection: [
+          { label: "Check", value: :check },
+          { label: "Direct Deposit", value: :direct_deposit, input_html: { "data-follow-up": "#bank-account-questions" } },
+      ] %>
+    </div>
+    <div class="question-with-follow-up__follow-up" id="bank-account-questions">
+      <%= f.cfa_input_field(:bank_name, t("hub.bank_accounts.bank_name")) %>
+      <%= f.cfa_select :bank_account_type, t("hub.bank_accounts.account_type"),[
+          [t("views.questions.bank_details.account_type.checking"), :checking ],
+          [t("views.questions.bank_details.account_type.savings"), :savings ],
+      ] %>
+      <%= f.cfa_input_field :bank_routing_number, t("hub.bank_accounts.routing_number") %>
+      <%= f.cfa_input_field :bank_routing_number_confirmation, t("hub.bank_accounts.routing_number_confirmation") %>
+      <%= f.cfa_input_field :bank_account_number, t("hub.bank_accounts.account_number") %>
+      <%= f.cfa_input_field :bank_account_number_confirmation, t("hub.bank_accounts.account_number_confirmation") %>
+    </div>
+  </div>
+
+
+
 </div>

--- a/app/views/shared/_identity_verification_fields.erb
+++ b/app/views/shared/_identity_verification_fields.erb
@@ -1,0 +1,5 @@
+<div id="identity-verification-fields" class="hub-form__card card-small">
+  <h3><%= t("hub.clients.fields.identity_verification.title")%></h3>
+  <%= f.cfa_input_field(:navigator_name, "Name of navigator") %>
+  <%= f.hub_checkbox(:navigator_has_verified_client_identity, "I have checked and verified this client's identity.", options: { classes: ["checkbox--wide"] }) %>
+</div>

--- a/app/views/shared/_recovery_rebate_amount_fields.html.erb
+++ b/app/views/shared/_recovery_rebate_amount_fields.html.erb
@@ -1,0 +1,9 @@
+<div id="recovery-rebate-credit-fields" class="hub-form__card card-small">
+  <h3><%= t("hub.clients.fields.recovery_rebate_credit") %></h3>
+  <%= f.cfa_input_field :recovery_rebate_credit_amount_1, t("hub.recovery_rebate_credit_amount.amount_1") %>
+  <%= f.cfa_input_field :recovery_rebate_credit_amount_2, t("hub.recovery_rebate_credit_amount.amount_2") %>
+  <%= f.cfa_select :recovery_rebate_credit_amount_confidence, t("hub.recovery_rebate_credit_amount.confidence"),[
+    [t("hub.recovery_rebate_credit_amount.confidence_values.sure"), :sure ],
+    [t("hub.recovery_rebate_credit_amount.confidence_values.unsure"), :unsure ],
+  ] %>
+</div>

--- a/config/initializers/types.rb
+++ b/config/initializers/types.rb
@@ -1,0 +1,3 @@
+Rails.application.reloader.to_prepare do
+  ActiveRecord::Type.register(:money, MoneyType)
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,6 +66,7 @@ en:
         legal_last_name: Legal last name
         mailing_address: Mailing Address
         payment_information: Payment Information
+        recovery_rebate_credit: Recovery rebate credit (optional)
         preferred_name: Preferred full name
         filing_status: Filing Status
         filing_status_notes: Filing status notes (optional)
@@ -433,6 +434,13 @@ en:
       routing_number_confirmation: Confirm routing number
       checking: Checking
       savings: Savings
+    recovery_rebate_credit_amount:
+      amount_1: "Economic Impact Payment 1"
+      amount_2: "Economic Impact Payment 2"
+      confidence: "How confident in this amount?"
+      confidence_values:
+        sure: "Sure"
+        unsure: "Unsure"
     organizations:
       new:
         title: "New Organization"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,6 +79,8 @@ en:
           incarcerated: Incarcerated/reentry
           limited_english: Limited English proficiency
           unhoused: Unhoused
+        identity_verification:
+          title: Identity verification
         spouse_contact_info: Spouse Contact Information
         state_of_residence: State of residence
         signature_method: Signature method

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -435,8 +435,8 @@ en:
       checking: Checking
       savings: Savings
     recovery_rebate_credit_amount:
-      amount_1: "Economic Impact Payment 1"
-      amount_2: "Economic Impact Payment 2"
+      amount_1: "Economic Impact Payment 1 received"
+      amount_2: "Economic Impact Payment 2 received"
       confidence: "How confident in this amount?"
       confidence_values:
         sure: "Sure"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -424,8 +424,8 @@ es:
       checking: Cuenta de Cheques
       savings: Ahorros
     recovery_rebate_credit_amount:
-      amount_1: "Pago de impacto económico 1"
-      amount_2: "Pago de impacto económico 2"
+      amount_1: "Pago de impacto económico 1 recibió"
+      amount_2: "Pago de impacto económico 2 recibió"
       confidence: "¿Qué tan confiado en esta cantidad?"
       confidence_values:
         sure: "Seguro"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -66,6 +66,7 @@ es:
         legal_last_name: Apellido legal
         mailing_address: Dirección postal
         payment_information: Información de pago
+        recovery_rebate_credit: Crédito de recuperación de reembolso (opcional)
         preferred_interview_language: Idioma preferido
         marital_status: Estado civil
         filing_status: Estado civil para impuestos
@@ -422,6 +423,13 @@ es:
       account_type: Tipo de cuenta
       checking: Cuenta de Cheques
       savings: Ahorros
+    recovery_rebate_credit_amount:
+      amount_1: "Pago de impacto económico 1"
+      amount_2: "Pago de impacto económico 2"
+      confidence: "¿Qué tan confiado en esta cantidad?"
+      confidence_values:
+        sure: "Seguro"
+        unsure: "Inseguro"
     organizations:
       new:
         title: "Nueva Organización"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -79,6 +79,8 @@ es:
           incarcerated: Incarcerated/reentry
           limited_english: Limited English proficiency
           unhoused: Unhoused
+        identity_verification:
+          title: Identity verification
         spouse_contact_info: Información de contacto del cónyuge
         state_of_residence: Estado de residencia
         signature_method: Método para recoger

--- a/db/migrate/20210625223212_add_rrc_to_intake.rb
+++ b/db/migrate/20210625223212_add_rrc_to_intake.rb
@@ -1,0 +1,7 @@
+class AddRrcToIntake < ActiveRecord::Migration[6.0]
+  def change
+    add_column :intakes, :recovery_rebate_credit_amount_1, :integer
+    add_column :intakes, :recovery_rebate_credit_amount_2, :integer
+    add_column :intakes, :recovery_rebate_credit_amount_confidence, :integer
+  end
+end

--- a/db/migrate/20210628181638_add_ctc_refund_delivery_method_to_intake.rb
+++ b/db/migrate/20210628181638_add_ctc_refund_delivery_method_to_intake.rb
@@ -1,0 +1,5 @@
+class AddCtcRefundDeliveryMethodToIntake < ActiveRecord::Migration[6.0]
+  def change
+    add_column :intakes, :ctc_refund_delivery_method, :integer
+  end
+end

--- a/db/migrate/20210628222700_add_ctc_identity_verification_fields_to_intake.rb
+++ b/db/migrate/20210628222700_add_ctc_identity_verification_fields_to_intake.rb
@@ -1,0 +1,6 @@
+class AddCtcIdentityVerificationFieldsToIntake < ActiveRecord::Migration[6.0]
+  def change
+    add_column :intakes, :navigator_name, :string
+    add_column :intakes, :navigator_has_verified_client_identity, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_24_173147) do
+ActiveRecord::Schema.define(version: 2021_06_28_181638) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -385,6 +385,7 @@ ActiveRecord::Schema.define(version: 2021_06_24_173147) do
     t.datetime "completed_yes_no_questions_at"
     t.boolean "continued_at_capacity", default: false
     t.datetime "created_at"
+    t.integer "ctc_refund_delivery_method"
     t.string "current_step"
     t.integer "demographic_disability", default: 0, null: false
     t.integer "demographic_english_conversation", default: 0, null: false
@@ -489,6 +490,9 @@ ActiveRecord::Schema.define(version: 2021_06_24_173147) do
     t.integer "received_homebuyer_credit", default: 0, null: false
     t.integer "received_irs_letter", default: 0, null: false
     t.integer "received_stimulus_payment", default: 0, null: false
+    t.integer "recovery_rebate_credit_amount_1"
+    t.integer "recovery_rebate_credit_amount_2"
+    t.integer "recovery_rebate_credit_amount_confidence"
     t.string "referrer"
     t.integer "refund_payment_method", default: 0, null: false
     t.integer "reported_asset_sale_loss", default: 0, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_28_181638) do
+ActiveRecord::Schema.define(version: 2021_06_28_222700) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -459,6 +459,8 @@ ActiveRecord::Schema.define(version: 2021_06_28_181638) do
     t.integer "made_estimated_tax_payments", default: 0, null: false
     t.integer "married", default: 0, null: false
     t.integer "multiple_states", default: 0, null: false
+    t.boolean "navigator_has_verified_client_identity"
+    t.string "navigator_name"
     t.integer "needs_help_2016", default: 0, null: false
     t.integer "needs_help_2017", default: 0, null: false
     t.integer "needs_help_2018", default: 0, null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,6 @@
 # Create client_support_org if needed
-VitaPartner.find_or_create_by!(name: "GYR National Organization", allows_greeters: true)
+national_org = VitaPartner.find_or_create_by!(name: "GYR National Organization")
+national_org.update(allows_greeters: true)
 
 koalas = Coalition.find_or_create_by(name: "Koala Koalition")
 Coalition.find_or_create_by(name: "Cola Coalition")

--- a/spec/controllers/hub/ctc_clients_controller_spec.rb
+++ b/spec/controllers/hub/ctc_clients_controller_spec.rb
@@ -68,6 +68,8 @@ RSpec.describe Hub::CtcClientsController do
           filing_status: "married_filing_jointly",
           ctc_refund_delivery_method: "check",
           bank_account_type: "checking",
+          navigator_name: "Terry Taxseason",
+          navigator_has_verified_client_identity: "1",
         },
       }
     end

--- a/spec/controllers/hub/ctc_clients_controller_spec.rb
+++ b/spec/controllers/hub/ctc_clients_controller_spec.rb
@@ -66,12 +66,8 @@ RSpec.describe Hub::CtcClientsController do
           service_type: "drop_off",
           vita_partner_id: vita_partner_id,
           filing_status: "married_filing_jointly",
+          ctc_refund_delivery_method: "check",
           bank_account_type: "checking",
-          bank_routing_number: "1234567",
-          bank_routing_number_confirmation: "1234567",
-          bank_account_number: "1234567",
-          bank_account_number_confirmation: "1234567",
-          bank_name: "Bank of America"
         },
       }
     end

--- a/spec/factories/intakes.rb
+++ b/spec/factories/intakes.rb
@@ -90,6 +90,8 @@
 #  made_estimated_tax_payments                          :integer          default(0), not null
 #  married                                              :integer          default(0), not null
 #  multiple_states                                      :integer          default(0), not null
+#  navigator_has_verified_client_identity               :boolean
+#  navigator_name                                       :string
 #  needs_help_2016                                      :integer          default(0), not null
 #  needs_help_2017                                      :integer          default(0), not null
 #  needs_help_2018                                      :integer          default(0), not null

--- a/spec/factories/intakes.rb
+++ b/spec/factories/intakes.rb
@@ -16,6 +16,7 @@
 #  completed_at                                         :datetime
 #  completed_yes_no_questions_at                        :datetime
 #  continued_at_capacity                                :boolean          default(FALSE)
+#  ctc_refund_delivery_method                           :integer
 #  current_step                                         :string
 #  demographic_disability                               :integer          default(0), not null
 #  demographic_english_conversation                     :integer          default(0), not null
@@ -120,6 +121,9 @@
 #  received_homebuyer_credit                            :integer          default(0), not null
 #  received_irs_letter                                  :integer          default(0), not null
 #  received_stimulus_payment                            :integer          default(0), not null
+#  recovery_rebate_credit_amount_1                      :integer
+#  recovery_rebate_credit_amount_2                      :integer
+#  recovery_rebate_credit_amount_confidence             :integer
 #  referrer                                             :string
 #  refund_payment_method                                :integer          default(0), not null
 #  reported_asset_sale_loss                             :integer          default(0), not null

--- a/spec/features/hub/create_ctc_client_spec.rb
+++ b/spec/features/hub/create_ctc_client_spec.rb
@@ -150,12 +150,7 @@ RSpec.feature "Creating new drop off clients" do
       end
 
       within "#bank-account-fields" do
-        fill_in "Bank name", with: "Bank of America"
-        select "Checking", from: "Account type"
-        fill_in "Routing number", with: "123456789"
-        fill_in "Confirm routing number", with: "123456789"
-        fill_in "Account number", with: "2345678901"
-        fill_in "Confirm account number", with: "2345678901"
+        choose "Check"
       end
 
       expect do

--- a/spec/features/hub/create_ctc_client_spec.rb
+++ b/spec/features/hub/create_ctc_client_spec.rb
@@ -103,8 +103,8 @@ RSpec.feature "Creating new drop off clients" do
         expect(page).to have_content "Refund delivery method: Direct deposit"
       end
 
-      expect(page).to have_text "Economic Impact Payment 1: $500"
-      expect(page).to have_text "Economic Impact Payment 2: $500"
+      expect(page).to have_text "Economic Impact Payment 1 received: $500"
+      expect(page).to have_text "Economic Impact Payment 2 received: $500"
       expect(page).to have_text "Confidence: Sure"
 
       within ".tax-return-list" do

--- a/spec/features/hub/create_ctc_client_spec.rb
+++ b/spec/features/hub/create_ctc_client_spec.rb
@@ -156,6 +156,11 @@ RSpec.feature "Creating new drop off clients" do
         choose "Check"
       end
 
+      within "#identity-verification-fields" do
+        fill_in "Name of navigator", with: "Terry Taxseason"
+        check "I have checked and verified this client's identity."
+      end
+
       expect do
         click_on I18n.t('hub.ctc_clients.new.save_and_add')
       end.to change(Client, :count).by(1)

--- a/spec/features/hub/create_ctc_client_spec.rb
+++ b/spec/features/hub/create_ctc_client_spec.rb
@@ -62,7 +62,16 @@ RSpec.feature "Creating new drop off clients" do
         fill_in "Email", with: "spicypeter@pepper.com"
       end
 
+      within "#recovery-rebate-credit-fields" do
+        fill_in "Economic Impact Payment 1", with: "$500"
+        fill_in "Economic Impact Payment 2", with: "$500"
+        select "Sure", from: "How confident in this amount?"
+      end
+
       within "#bank-account-fields" do
+        choose "Check"
+        expect(find_field("Bank name", visible: :hidden)).to be_present
+        choose "Direct Deposit"
         fill_in "Bank name", with: "Bank of America"
         select "Checking", from: "Account type"
         fill_in "Routing number", with: "123456789"
@@ -88,6 +97,15 @@ RSpec.feature "Creating new drop off clients" do
       expect(page).to have_text "TX"
       expect(page).to have_text "Peter Pepper"
       expect(page).to have_text "spicypeter@pepper.com"
+
+      within ".client-bank-account-info" do
+        click_on "View"
+        expect(page).to have_content "Refund delivery method: Direct deposit"
+      end
+
+      expect(page).to have_text "Economic Impact Payment 1: $500"
+      expect(page).to have_text "Economic Impact Payment 2: $500"
+      expect(page).to have_text "Confidence: Sure"
 
       within ".tax-return-list" do
         expect(page).to have_text "2020"

--- a/spec/features/hub/create_ctc_client_spec.rb
+++ b/spec/features/hub/create_ctc_client_spec.rb
@@ -125,6 +125,9 @@ RSpec.feature "Creating new drop off clients" do
         end.to change(AccessLog, :count).by(1)
         expect(AccessLog.last.event_type).to eq "read_ssn_itin"
       end
+
+      visit hub_clients_path
+      expect(page).to have_content("Colly Cauliflower")
     end
 
     scenario "I can create multiple CTC clients, one after another" do

--- a/spec/features/hub/create_ctc_client_spec.rb
+++ b/spec/features/hub/create_ctc_client_spec.rb
@@ -80,6 +80,11 @@ RSpec.feature "Creating new drop off clients" do
         fill_in "Confirm account number", with: "2345678901"
       end
 
+      within "#identity-verification-fields" do
+        fill_in "Name of navigator", with: "Terry Taxseason"
+        check "I have checked and verified this client's identity."
+      end
+
       click_on I18n.t('general.save')
 
       expect(page).to have_text "Colleen Cauliflower"
@@ -106,6 +111,8 @@ RSpec.feature "Creating new drop off clients" do
       expect(page).to have_text "Economic Impact Payment 1 received: $500"
       expect(page).to have_text "Economic Impact Payment 2 received: $500"
       expect(page).to have_text "Confidence: Sure"
+
+      expect(page).to have_text "Terry Taxseason"
 
       within ".tax-return-list" do
         expect(page).to have_text "2020"

--- a/spec/features/hub/edit_organization_spec.rb
+++ b/spec/features/hub/edit_organization_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe "a user editing an organization", :js do
         expect(find_field('Capacity limit').value).to eq "100"
 
         select "Central Time (US & Canada)", from: "Timezone"
+        fill_in "Capacity limit", with: "" # force clear field
         fill_in "Capacity limit", with: "200"
         check "Allows Greeters"
         within "#organization-form" do

--- a/spec/forms/hub/create_ctc_client_form_spec.rb
+++ b/spec/forms/hub/create_ctc_client_form_spec.rb
@@ -38,7 +38,9 @@ RSpec.describe Hub::CreateCtcClientForm do
         recovery_rebate_credit_amount_1: "$280",
         recovery_rebate_credit_amount_2: "$250",
         recovery_rebate_credit_amount_confidence: "sure",
-        ctc_refund_delivery_method: "check"
+        ctc_refund_delivery_method: "check",
+        navigator_name: "Tax Seasonson",
+        navigator_has_verified_client_identity: true
       }
     end
 
@@ -162,6 +164,14 @@ RSpec.describe Hub::CreateCtcClientForm do
         end
       end
 
+      context "with system note" do
+        it "creates a system note for identity verification" do
+          expect {
+            described_class.new(params).save(current_user)
+          }.to change(SystemNote, :count).by(1)
+        end
+      end
+
       context "phone numbers" do
         it "normalizes phone_number and sms_phone_number" do
           described_class.new(params.update(sms_phone_number: "650-555-1212", phone_number: "(650) 555-1212")).save(current_user)
@@ -268,6 +278,39 @@ RSpec.describe Hub::CreateCtcClientForm do
           obj = described_class.new(params)
           obj.valid?
           expect(obj.errors[:filing_status]).to include "Can't be blank."
+        end
+      end
+
+
+      context "navigator name" do
+        before do
+          params[:navigator_name] = nil
+        end
+
+        it "is required" do
+          expect(described_class.new(params).valid?).to eq false
+        end
+
+        it "pushes errors for ctc refund method into the errors" do
+          obj = described_class.new(params)
+          obj.valid?
+          expect(obj.errors[:navigator_name]).to include "Can't be blank."
+        end
+      end
+
+      context "navigator has checked identity checkbox" do
+        before do
+          params[:navigator_has_verified_client_identity] = nil
+        end
+
+        it "is required" do
+          expect(described_class.new(params).valid?).to eq false
+        end
+
+        it "pushes errors for ctc refund method into the errors" do
+          obj = described_class.new(params)
+          obj.valid?
+          expect(obj.errors[:navigator_has_verified_client_identity]).to include "Can't be blank."
         end
       end
 

--- a/spec/forms/hub/create_ctc_client_form_spec.rb
+++ b/spec/forms/hub/create_ctc_client_form_spec.rb
@@ -269,77 +269,101 @@ RSpec.describe Hub::CreateCtcClientForm do
           expect(obj.errors[:filing_status]).to include "Can't be blank."
         end
       end
-      
-      context "bank_account_number" do
-        before do
-          params[:bank_account_number] = nil
-        end
-        it "is required" do
-          obj = described_class.new(params)
-          obj.valid?
-          expect(obj.errors[:bank_account_number]).to include "Can't be blank."
-        end
-      end
 
-      context "bank_routing_number" do
+      context "when the CTC refund method is check" do
         before do
-          params[:bank_routing_number] = nil
+          params[:ctc_refund_delivery_method] = "check"
         end
-        it "is required" do
-          obj = described_class.new(params)
-          obj.valid?
-          expect(obj.errors[:bank_routing_number]).to include "Can't be blank."
-        end
-      end
 
-      context "bank_routing_number_confirmation" do
-        context "when bank_routing_number is provided" do
+        context "bank_account_number" do
           before do
-            params[:bank_routing_number] = "1234565"
-            params[:bank_routing_number_confirmation] = nil
+            params[:bank_account_number] = nil
+          end
+
+          it "is not required" do
+            obj = described_class.new(params)
+            obj.valid?
+            expect(obj.errors[:bank_account_number]).to be_blank
+          end
+        end
+      end
+
+      context "when the CTC refund method is direct deposit" do
+        before do
+          params[:ctc_refund_delivery_method] = "direct_deposit"
+        end
+
+        context "bank_account_number" do
+          before do
+            params[:bank_account_number] = nil
           end
           it "is required" do
             obj = described_class.new(params)
             obj.valid?
-            expect(obj.errors[:bank_routing_number_confirmation]).to include "Can't be blank."
+            expect(obj.errors[:bank_account_number]).to include "Can't be blank."
           end
         end
 
-        context "when routing confirmation is provided but does not match" do
+        context "bank_routing_number" do
           before do
-            params[:bank_routing_number] = "1234565"
-            params[:bank_routing_number_confirmation] = "2234565"
-          end
-          it "provides an error" do
-            obj = described_class.new(params)
-            obj.valid?
-            expect(obj.errors[:bank_routing_number_confirmation]).to include "doesn't match Bank routing number"
-          end
-        end
-      end
-
-      context "bank_account_number_confirmation" do
-        context "when bank_account_number is provided" do
-          before do
-            params[:bank_account_number] = "1234565"
-            params[:bank_account_number_confirmation] = nil
+            params[:bank_routing_number] = nil
           end
           it "is required" do
             obj = described_class.new(params)
             obj.valid?
-            expect(obj.errors[:bank_account_number_confirmation]).to include "Can't be blank."
+            expect(obj.errors[:bank_routing_number]).to include "Can't be blank."
           end
         end
 
-        context "when bank account confirmation is provided but does not match" do
-          before do
-            params[:bank_account_number] = "1234565"
-            params[:bank_account_number_confirmation] = "2234565"
+        context "bank_routing_number_confirmation" do
+          context "when bank_routing_number is provided" do
+            before do
+              params[:bank_routing_number] = "1234565"
+              params[:bank_routing_number_confirmation] = nil
+            end
+            it "is required" do
+              obj = described_class.new(params)
+              obj.valid?
+              expect(obj.errors[:bank_routing_number_confirmation]).to include "Can't be blank."
+            end
           end
-          it "provides an error" do
-            obj = described_class.new(params)
-            obj.valid?
-            expect(obj.errors[:bank_account_number_confirmation]).to include "doesn't match Bank account number"
+
+          context "when routing confirmation is provided but does not match" do
+            before do
+              params[:bank_routing_number] = "1234565"
+              params[:bank_routing_number_confirmation] = "2234565"
+            end
+            it "provides an error" do
+              obj = described_class.new(params)
+              obj.valid?
+              expect(obj.errors[:bank_routing_number_confirmation]).to include "doesn't match Bank routing number"
+            end
+          end
+        end
+
+        context "bank_account_number_confirmation" do
+          context "when bank_account_number is provided" do
+            before do
+              params[:bank_account_number] = "1234565"
+              params[:bank_account_number_confirmation] = nil
+            end
+            it "is required" do
+              obj = described_class.new(params)
+              obj.valid?
+              expect(obj.errors[:bank_account_number_confirmation]).to include "Can't be blank."
+            end
+          end
+
+          context "when bank account confirmation is provided but does not match" do
+            before do
+              params[:bank_account_number] = "1234565"
+              params[:bank_account_number_confirmation] = "2234565"
+            end
+            it "provides an error" do
+              obj = described_class.new(params)
+              obj.valid?
+              expect(obj.errors[:bank_account_number_confirmation]).to include "doesn't match Bank account number"
+            end
           end
         end
       end

--- a/spec/forms/hub/create_ctc_client_form_spec.rb
+++ b/spec/forms/hub/create_ctc_client_form_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe Hub::CreateCtcClientForm do
         bank_name: "Bank of America",
         recovery_rebate_credit_amount_1: "$280",
         recovery_rebate_credit_amount_2: "$250",
-        recovery_rebate_credit_amount_confidence: "sure"
+        recovery_rebate_credit_amount_confidence: "sure",
+        ctc_refund_delivery_method: "check"
       }
     end
 
@@ -267,6 +268,22 @@ RSpec.describe Hub::CreateCtcClientForm do
           obj = described_class.new(params)
           obj.valid?
           expect(obj.errors[:filing_status]).to include "Can't be blank."
+        end
+      end
+
+      context "CTC refund method" do
+        before do
+          params[:ctc_refund_delivery_method] = nil
+        end
+
+        it "is required" do
+          expect(described_class.new(params).valid?).to eq false
+        end
+
+        it "pushes errors for ctc refund method into the errors" do
+          obj = described_class.new(params)
+          obj.valid?
+          expect(obj.errors[:ctc_refund_delivery_method]).to include "Can't be blank."
         end
       end
 

--- a/spec/forms/hub/create_ctc_client_form_spec.rb
+++ b/spec/forms/hub/create_ctc_client_form_spec.rb
@@ -34,7 +34,10 @@ RSpec.describe Hub::CreateCtcClientForm do
         bank_routing_number_confirmation: "1234567",
         bank_account_number: "1234567",
         bank_account_number_confirmation: "1234567",
-        bank_name: "Bank of America"
+        bank_name: "Bank of America",
+        recovery_rebate_credit_amount_1: "$280",
+        recovery_rebate_credit_amount_2: "$250",
+        recovery_rebate_credit_amount_confidence: "sure"
       }
     end
 
@@ -63,6 +66,14 @@ RSpec.describe Hub::CreateCtcClientForm do
         expect(client.intake.bank_routing_number).to eq params[:bank_routing_number]
         expect(client.intake.bank_account_type).to eq "checking"
         expect(client.intake.bank_name).to eq "Bank of America"
+      end
+
+      it "stores recovery rebate credit amount on the intake" do
+        described_class.new(params).save(current_user)
+        client = Client.last
+        expect(client.intake.recovery_rebate_credit_amount_1).to eq 280
+        expect(client.intake.recovery_rebate_credit_amount_2).to eq 250
+        expect(client.intake.recovery_rebate_credit_amount_confidence).to eq "sure"
       end
 
       it "assigns client to an instance on the form object" do

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -90,6 +90,8 @@
 #  made_estimated_tax_payments                          :integer          default(0), not null
 #  married                                              :integer          default(0), not null
 #  multiple_states                                      :integer          default(0), not null
+#  navigator_has_verified_client_identity               :boolean
+#  navigator_name                                       :string
 #  needs_help_2016                                      :integer          default(0), not null
 #  needs_help_2017                                      :integer          default(0), not null
 #  needs_help_2018                                      :integer          default(0), not null

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -16,6 +16,7 @@
 #  completed_at                                         :datetime
 #  completed_yes_no_questions_at                        :datetime
 #  continued_at_capacity                                :boolean          default(FALSE)
+#  ctc_refund_delivery_method                           :integer
 #  current_step                                         :string
 #  demographic_disability                               :integer          default(0), not null
 #  demographic_english_conversation                     :integer          default(0), not null
@@ -120,6 +121,9 @@
 #  received_homebuyer_credit                            :integer          default(0), not null
 #  received_irs_letter                                  :integer          default(0), not null
 #  received_stimulus_payment                            :integer          default(0), not null
+#  recovery_rebate_credit_amount_1                      :integer
+#  recovery_rebate_credit_amount_2                      :integer
+#  recovery_rebate_credit_amount_confidence             :integer
 #  referrer                                             :string
 #  refund_payment_method                                :integer          default(0), not null
 #  reported_asset_sale_loss                             :integer          default(0), not null


### PR DESCRIPTION
* RRC amount (Recovery Rebate Credit / Economic Recovery Payment)
* Name of navigator
* Confirmation that navigator verified identity, where someone will input their name as a string
* Check vs Direct Deposit (if check, hide other bank account fields and do not require. If direct deposit, require all bank account fields.)

Co-authored-by: Molly T-M <mollyt@codeforamerica.org>