### PR TITLE
Clean MIME type headers to avoid InvalidMimeType exceptions

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,4 +1,5 @@
 require_relative 'boot'
+require_relative "../lib/middleware/cleanup_mime_type_headers"
 
 require "rails"
 # Pick the frameworks you want:
@@ -46,5 +47,6 @@ module VitaMin
       staging: "ctc.staging.getyourrefund.org",
       production: "www.getctc.org"
     }
+    config.middleware.use Middleware::CleanupMimeTypeHeaders
   end
 end

--- a/lib/middleware/cleanup_mime_type_headers.rb
+++ b/lib/middleware/cleanup_mime_type_headers.rb
@@ -1,0 +1,24 @@
+module Middleware
+  class CleanupMimeTypeHeaders
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      # Filter out invalid "Accept" or "Content-Type" headers to avoid noisy logs.
+      # https://github.com/rails/rails/issues/37620
+      clean_header!(env, 'CONTENT_TYPE')
+      clean_header!(env, 'HTTP_ACCEPT')
+      @app.call(env)
+    end
+
+    def clean_header!(env, header_name)
+      header_val = env.dig(header_name)
+      return if header_val.nil?
+
+      Mime::Type.parse(header_val)
+    rescue Mime::Type::InvalidMimeType
+      env.store(header_name, 'unknown/unknown')
+    end
+  end
+end

--- a/spec/middleware/cleanup_mime_type_headers_spec.rb
+++ b/spec/middleware/cleanup_mime_type_headers_spec.rb
@@ -1,0 +1,54 @@
+describe Middleware::CleanupMimeTypeHeaders do
+  let(:mock_app) { double }
+  subject { described_class.new(mock_app) }
+
+  before do
+    allow(mock_app).to receive(:call)
+  end
+
+  describe "#clean_header!" do
+    context "with a valid header" do
+      it "passes the header through" do
+        env = { 'HTTP_ACCEPT' => 'text/html' }
+        subject.clean_header!(env, 'HTTP_ACCEPT')
+        expect(env).to eq({ 'HTTP_ACCEPT' => 'text/html' })
+      end
+    end
+
+    context "with a missing header" do
+      it "leaves it unset" do
+        env = { }
+        subject.clean_header!(env, 'HTTP_ACCEPT')
+        expect(env).to eq({ })
+      end
+    end
+
+    context "with a blank header" do
+      it "passes the header through" do
+        env = { 'HTTP_ACCEPT' => '' }
+        subject.clean_header!(env, 'HTTP_ACCEPT')
+        expect(env).to eq({ 'HTTP_ACCEPT' => '' })
+      end
+    end
+
+    context "when called with an invalid Accept header" do
+      it "replaces it with unknown/unknown" do
+        env ={ 'HTTP_ACCEPT' => 'invalid' }
+        subject.clean_header!(env, 'HTTP_ACCEPT')
+        expect(env).to eq({ 'HTTP_ACCEPT' => 'unknown/unknown' })
+      end
+    end
+  end
+
+  describe "#call" do
+    before do
+      allow(subject).to receive(:clean_header!)
+    end
+
+    it "cleans the Accept header and Content-Type headers" do
+      subject.call({})
+      expect(subject).to have_received(:clean_header!).with({}, 'HTTP_ACCEPT')
+      expect(subject).to have_received(:clean_header!).with({}, 'CONTENT_TYPE')
+    end
+  end
+end


### PR DESCRIPTION
This will avoid some meaningless annoying traces sent to Sentry.

It also will reduce the raw frequency of HTTP 500 responses, which is nice.

InvalidMimeType seems vaguely correlated with sad "machine stack overflow in critical region" messages.

I personally think that our "machine stack overflow in critical region" errors relate to some kind of Rails bug (or a bug in a gem? or in our code???) showing our HTTP 500 page, so decreasing the frequency of exceptions is a way to help.