### PR TITLE
Handle all formats when serving error messages

### DIFF
--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -29,7 +29,12 @@ class PublicPagesController < ApplicationController
 
   def maintenance; end
 
-  def internal_server_error; end
+  def internal_server_error
+    respond_to do |format|
+      format.html { render 'public_pages/internal_server_error', status: 500  }
+      format.any { head 500 }
+    end
+  end
 
   def page_not_found
     respond_to do |format|


### PR DESCRIPTION
In https://github.com/codeforamerica/vita-min/pull/1183 we adjusted `#page_not_found` so that it could return a response even if the request wasn't looking for HTML.

This applies the same change to `#internal_server_error`.

This route is the one that gets rendered when a crash occurs (HTTP 422 or 500) -- see `routes.rb`:

```
config/routes.rb:      get "/500", to: "public_pages#internal_server_error"
config/routes.rb:      get "/422", to: "public_pages#internal_server_error"
```

These are are sometimes called fallback routes. The sad error message seems correlated with the fallback route raising an exception. 