### PR TITLE
Hotfix: Intake model: temporarily change 'inheritance_column' and prefill 'type' column

### DIFF
--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -196,6 +196,8 @@
 class Intake < ApplicationRecord
   include PgSearch::Model
 
+  self.inheritance_column = 'something_other_than_type'
+
   pg_search_scope :search, against: [
     :client_id, :primary_first_name, :primary_last_name, :preferred_name, :spouse_first_name, :spouse_last_name,
     :email_address, :phone_number, :sms_phone_number

--- a/db/migrate/20210616204945_add_type_to_intake.rb
+++ b/db/migrate/20210616204945_add_type_to_intake.rb
@@ -1,0 +1,6 @@
+class AddTypeToIntake < ActiveRecord::Migration[6.0]
+  def change
+    add_column :intakes, :type, :string, default: "Intake::GyrIntake"
+    change_column_default(:intakes, :type, from: "Intake::GyrIntake", to: nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -528,6 +528,7 @@ ActiveRecord::Schema.define(version: 2021_06_24_173147) do
     t.string "timezone"
     t.bigint "triage_source_id"
     t.string "triage_source_type"
+    t.string "type"
     t.datetime "updated_at"
     t.boolean "viewed_at_capacity", default: false
     t.string "visitor_id"


### PR DESCRIPTION
We want 'type' to eventually be Intake::GyrIntake to support its future
peer Intake::CtcIntake

If we try to populate 'type' and use it in the same deploy, there may be
some time when 'type' is set to a class that does not yet exist.

Instead, we can set 'inheritance_column' to something phony while populating
the 'type' column, then set it back to 'type' when we deploy the code
that defines GyrIntake / CtcIntake