### PR TITLE
Hotfix: Intake model: temporarily change 'inheritance_column' to something other than 'type'

### DIFF
--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -196,6 +196,8 @@
 class Intake < ApplicationRecord
   include PgSearch::Model
 
+  self.inheritance_column = 'something_other_than_type'
+
   pg_search_scope :search, against: [
     :client_id, :primary_first_name, :primary_last_name, :preferred_name, :spouse_first_name, :spouse_last_name,
     :email_address, :phone_number, :sms_phone_number


### PR DESCRIPTION
We want 'type' to eventually be Intake::GyrIntake to support its future
peer Intake::CtcIntake

If we try to populate 'type' and use it in the same deploy, there may be
some time when 'type' is set to a class that does not yet exist.

Instead, we can set 'inheritance_column' to something phony before populating
the 'type' column, then we will set it back to 'type' when we deploy the code
that defines GyrIntake / CtcIntake