### PR TITLE
Use CTC layout for CTC questions pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   around_action :switch_locale
   before_action :check_maintenance_mode
   after_action :track_page_view
-  helper_method :include_analytics?, :current_intake, :show_progress?, :show_offseason_banner?, :canonical_url, :hreflang_url, :hub?, :open_for_intake?
+  helper_method :include_analytics?, :current_intake, :show_progress?, :show_offseason_banner?, :canonical_url, :hreflang_url, :hub?, :open_for_intake?, :wrapping_layout
   # This needs to be a class method for the devise controller to have access to it
   # See: http://stackoverflow.com/questions/12550564/how-to-pass-locale-parameter-to-devise
   def self.default_url_options
@@ -281,6 +281,10 @@ class ApplicationController < ActionController::Base
     return unless request.get? # skip uploads
 
     current_intake.update(current_step: current_path) unless current_intake.current_step == current_path
+  end
+
+  def wrapping_layout
+    "application"
   end
 
   rescue_from CanCan::AccessDenied do |exception|

--- a/app/controllers/ctc/questions/questions_controller.rb
+++ b/app/controllers/ctc/questions/questions_controller.rb
@@ -1,6 +1,14 @@
 module Ctc
   module Questions
     class QuestionsController < ::Questions::QuestionsController
+      helper_method :wrapping_layout
+
+      private
+
+      def wrapping_layout
+        "ctc"
+      end
+
       def question_navigator
         CtcQuestionNavigation
       end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,4 +39,17 @@ module ApplicationHelper
   def flash_alerts
     "$('.flash-alerts').html('#{escape_javascript(render("shared/flash_alerts", flash: flash))}');".html_safe
   end
+
+  def extends(layout, &block)
+    # Make sure it's a string
+    layout = layout.to_s
+
+    # If there's no directory component, presume a plain layout name
+    layout = "layouts/#{layout}" unless layout.include?('/')
+
+    # Capture the content to be placed inside the extended layout
+    @view_flow.get(:layout).replace capture(&block)
+
+    render template: layout
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,18 +6,18 @@
       <%= content_for :page_title do %>Free tax help from IRS-certified volunteers.<% end %>
     <% end %>
 
-    <% if content_for :ctc_meta_tags %>
-      <title><%= content_for(:page_title) %></title>
-    <% else %>
-      <title><%= content_for(:page_title) %> | GetYourRefund</title>
+    <% unless content_for? :app_name %>
+      <%= content_for :app_name do %>GetYourRefund<% end %>
     <% end %>
+
+    <title><%= content_for(:page_title) %> | <%= content_for(:app_name) %></title>
 
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
     <meta content="utf-8" http-equiv="encoding">
 
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <% if content_for :ctc_meta_tags %>
-      <%= yield :ctc_meta_tags %>
+    <% if content_for :meta_tags %>
+      <%= yield :meta_tags %>
     <% else %>
       <meta name="description" content="<%=t("views.layouts.application.meta.description") %>">
       <meta property="og:title" content="<%= content_for(:page_title) -%> | GetYourRefund">

--- a/app/views/layouts/ctc.html.erb
+++ b/app/views/layouts/ctc.html.erb
@@ -1,21 +1,25 @@
-<% content_for :header do %>
-  <%= render 'shared/ctc_header_analytics' if Rails.env.production? %>
+<%= extends :application do %>
+  <% content_for :app_name do %>GetCTC<% end %>
 
-  <%= render 'shared/header', title: "GetCTC", home_link: ctc_root_path %>
-<% end %>
-<% content_for :footer do %>
-  <%= render 'shared/ctc_footer_analytics' if Rails.env.production? %>
+  <% content_for :header do %>
+    <%= render 'shared/ctc_header_analytics' if Rails.env.production? %>
 
-  <%= render "shared/footer", variation: "ctc" %>
-<% end %>
-<% content_for :ctc_meta_tags do %>
-  <meta name="description" content="<%= t("views.layouts.ctc.meta.description") %>">
-  <meta property="og:title" content="<%= content_for(:page_title) %>">
-  <meta property="og:description" content="<%= t("views.layouts.ctc.meta.description") %>">
-  <meta property="og:image" content="<%= image_url("social_share_banner-ctc.png") %>">
-  <meta property="twitter:title" content="<%= content_for(:page_title) %>">
-  <meta property="twitter:description" content="<%= t("views.layouts.ctc.meta.description") %>">
-  <meta property="twitter:image" content="<%= image_url("social_share_banner-ctc.png") %>">
-<% end %>
+    <%= render 'shared/header', title: "GetCTC", home_link: ctc_root_path %>
+  <% end %>
+  <% content_for :footer do %>
+    <%= render 'shared/ctc_footer_analytics' if Rails.env.production? %>
 
-<%= render template: "layouts/application" %>
+    <%= render "shared/footer", variation: "ctc" %>
+  <% end %>
+
+  <% content_for :meta_tags do %>
+    <meta name="description" content="<%= t("views.layouts.ctc.meta.description") %>">
+    <meta property="og:title" content="<%= content_for(:page_title) %>">
+    <meta property="og:description" content="<%= t("views.layouts.ctc.meta.description") %>">
+    <meta property="og:image" content="<%= image_url("social_share_banner-ctc.png") %>">
+    <meta property="twitter:title" content="<%= content_for(:page_title) %>">
+    <meta property="twitter:description" content="<%= t("views.layouts.ctc.meta.description") %>">
+    <meta property="twitter:image" content="<%= image_url("social_share_banner-ctc.png") %>">
+  <% end %>
+  <%= yield %>
+<% end %>

--- a/app/views/layouts/intake.html.erb
+++ b/app/views/layouts/intake.html.erb
@@ -1,11 +1,10 @@
-<% content_for :page_title do %>
-  <% if @form&.errors.present? %>
-    <%= @form.error_summary %>
+<%= extends wrapping_layout do  %>
+  <% content_for :page_title do %>
+    <% if @form&.errors.present? %>
+    <% end %>
+    <%= yield :form_question %>
   <% end %>
-  <%= yield :form_question %>
-<% end %>
 
-<% content_for :main do %>
   <section class="slab slab--white slab--not-padded question-layout">
     <div class="grid">
       <div class="grid__item question-wrapper">
@@ -31,4 +30,4 @@
   </section>
 <% end %>
 
-<%= render template: "layouts/application" %>
+

--- a/app/views/layouts/yes_no_question.html.erb
+++ b/app/views/layouts/yes_no_question.html.erb
@@ -1,11 +1,11 @@
-<% content_for :page_title do %>
-  <% if @form.errors.present? %>
-    <%= @form.error_summary %>
+<%= extends wrapping_layout do  %>
+  <% content_for :page_title do %>
+    <% if @form.errors.present? %>
+      <%= @form.error_summary %>
+    <% end %>
+    <%= yield :form_question %>
   <% end %>
-  <%= yield :form_question %>
-<% end %>
 
-<% content_for :main do %>
   <section class="slab slab--white slab--not-padded question-layout">
     <div class="grid">
       <div class="grid__item question-wrapper">
@@ -49,7 +49,7 @@
                     <% end %>
                   </div>
                 <% end %>
-              <% end %>
+            <% end %>
             </div>
           </main>
         </div>
@@ -58,4 +58,3 @@
   </section>
 <% end %>
 
-<%= render template: "layouts/application" %>

--- a/spec/features/ctc/intake_spec.rb
+++ b/spec/features/ctc/intake_spec.rb
@@ -7,9 +7,11 @@ RSpec.feature "CTC Intake", :js do
 
   scenario "new client entering ctc intake flow" do
     visit "/en/questions/overview"
+    expect(page).to have_selector(".toolbar", text: "GetCTC") # Check for appropriate header
     expect(page).to have_selector("h1", text: "Let's get started!")
     click_on "Continue"
 
+    expect(page).to have_selector(".toolbar", text: "GetCTC")
     expect(page).to have_selector("h1", text: "First, what's your name?")
     expect(page).to have_selector("p", text: "Welcome, we're excited to help you. We need some basic information to get started. We’ll start by asking what you like being called.")
     fill_in "Preferred first name", with: "Gary"


### PR DESCRIPTION
Refactored to create a more clear concept of a "wrapping" layout so that we can define a layout that wraps existing layouts instead of duplicating yes_no_question with ctc_yes_no_question, etc

(We don't really _need_ the extends helper (we could accomplish this by adding a switch to the layout at the bottom), but I think this feels more "composable." 

![Screen Shot 2021-06-29 at 9 49 30 AM](https://user-images.githubusercontent.com/4494389/123819298-49984080-d8bf-11eb-81b2-85d4a7618a5c.png)
