### PR TITLE
Intake: make a searchable_data tsvector column instead of regenerating tsvector every search

### DIFF
--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -101,6 +101,7 @@
 #  needs_help_2018                                      :integer          default(0), not null
 #  needs_help_2019                                      :integer          default(0), not null
 #  needs_help_2020                                      :integer          default(0), not null
+#  needs_to_flush_searchable_data_set_at                :datetime
 #  no_eligibility_checks_apply                          :integer          default(0), not null
 #  no_ssn                                               :integer          default(0), not null
 #  other_income_types                                   :string
@@ -142,6 +143,7 @@
 #  satisfaction_face                                    :integer          default(0), not null
 #  savings_purchase_bond                                :integer          default(0), not null
 #  savings_split_refund                                 :integer          default(0), not null
+#  searchable_data                                      :tsvector
 #  separated                                            :integer          default(0), not null
 #  separated_year                                       :string
 #  signature_method                                     :integer          default("online"), not null
@@ -193,7 +195,9 @@
 #
 #  index_intakes_on_client_id                                (client_id)
 #  index_intakes_on_email_address                            (email_address)
+#  index_intakes_on_needs_to_flush_searchable_data_set_at    (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_intakes_on_phone_number                             (phone_number)
+#  index_intakes_on_searchable_data                          (searchable_data) USING gin
 #  index_intakes_on_sms_phone_number                         (sms_phone_number)
 #  index_intakes_on_triage_source_type_and_triage_source_id  (triage_source_type,triage_source_id)
 #  index_intakes_on_vita_partner_id                          (vita_partner_id)

--- a/app/models/intake/gyr_intake.rb
+++ b/app/models/intake/gyr_intake.rb
@@ -101,6 +101,7 @@
 #  needs_help_2018                                      :integer          default("unfilled"), not null
 #  needs_help_2019                                      :integer          default("unfilled"), not null
 #  needs_help_2020                                      :integer          default("unfilled"), not null
+#  needs_to_flush_searchable_data_set_at                :datetime
 #  no_eligibility_checks_apply                          :integer          default("unfilled"), not null
 #  no_ssn                                               :integer          default("unfilled"), not null
 #  other_income_types                                   :string
@@ -142,6 +143,7 @@
 #  satisfaction_face                                    :integer          default("unfilled"), not null
 #  savings_purchase_bond                                :integer          default("unfilled"), not null
 #  savings_split_refund                                 :integer          default("unfilled"), not null
+#  searchable_data                                      :tsvector
 #  separated                                            :integer          default("unfilled"), not null
 #  separated_year                                       :string
 #  signature_method                                     :integer          default("online"), not null
@@ -193,7 +195,9 @@
 #
 #  index_intakes_on_client_id                                (client_id)
 #  index_intakes_on_email_address                            (email_address)
+#  index_intakes_on_needs_to_flush_searchable_data_set_at    (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_intakes_on_phone_number                             (phone_number)
+#  index_intakes_on_searchable_data                          (searchable_data) USING gin
 #  index_intakes_on_sms_phone_number                         (sms_phone_number)
 #  index_intakes_on_triage_source_type_and_triage_source_id  (triage_source_type,triage_source_id)
 #  index_intakes_on_vita_partner_id                          (vita_partner_id)

--- a/app/models/system_note/client_change.rb
+++ b/app/models/system_note/client_change.rb
@@ -28,6 +28,7 @@ class SystemNote::ClientChange < SystemNote
     changes_list = ""
     intake.saved_changes.each do |k, v|
       next if k == "updated_at"
+      next if k == "needs_to_flush_searchable_data_set_at"
       next if k.include?("encrypted")
 
       changes_list += "\n\u2022 #{k.tr('_', ' ')} from #{v[0]} to #{v[1]}"

--- a/crontab
+++ b/crontab
@@ -1,2 +1,3 @@
 0 0 * * 0 bundle exec rake vita_providers:scrape_vita_providers
+* * * * * bundle exec rake search:refresh
 20 21 * * 1-5 bundle exec rake client_surveys:send_client_in_progress_surveys

--- a/db/migrate/20210701055924_add_searchable_data_to_intakes.rb
+++ b/db/migrate/20210701055924_add_searchable_data_to_intakes.rb
@@ -1,0 +1,6 @@
+class AddSearchableDataToIntakes < ActiveRecord::Migration[6.1]
+  def change
+    add_column :intakes, :searchable_data, :tsvector
+    add_column :intakes, :needs_to_flush_searchable_data_set_at, :datetime
+  end
+end

--- a/db/migrate/20210701070113_add_gin_index_for_tsvector_search_of_intake.rb
+++ b/db/migrate/20210701070113_add_gin_index_for_tsvector_search_of_intake.rb
@@ -1,0 +1,7 @@
+class AddGinIndexForTsvectorSearchOfIntake < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :intakes, :searchable_data, using: :gin, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20210701070129_add_index_for_search_flush_timestamp_on_intake.rb
+++ b/db/migrate/20210701070129_add_index_for_search_flush_timestamp_on_intake.rb
@@ -1,0 +1,12 @@
+class AddIndexForSearchFlushTimestampOnIntake < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index(
+      :intakes,
+      :needs_to_flush_searchable_data_set_at,
+      where: "needs_to_flush_searchable_data_set_at IS NOT NULL",
+      algorithm: :concurrently
+    )
+  end
+end

--- a/db/migrate/20210701174549_index_all_intake_records.rb
+++ b/db/migrate/20210701174549_index_all_intake_records.rb
@@ -1,0 +1,12 @@
+class IndexAllIntakeRecords < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  class Intake < ActiveRecord::Base; end
+
+  def up
+    Intake.unscoped.in_batches do |relation|
+      relation.update_all needs_to_flush_searchable_data_set_at: Time.current
+      sleep(0.01) # throttle
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_01_150705) do
+ActiveRecord::Schema.define(version: 2021_07_01_174549) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -470,6 +470,7 @@ ActiveRecord::Schema.define(version: 2021_07_01_150705) do
     t.integer "needs_help_2018", default: 0, null: false
     t.integer "needs_help_2019", default: 0, null: false
     t.integer "needs_help_2020", default: 0, null: false
+    t.datetime "needs_to_flush_searchable_data_set_at"
     t.integer "no_eligibility_checks_apply", default: 0, null: false
     t.integer "no_ssn", default: 0, null: false
     t.string "other_income_types"
@@ -511,6 +512,7 @@ ActiveRecord::Schema.define(version: 2021_07_01_150705) do
     t.integer "satisfaction_face", default: 0, null: false
     t.integer "savings_purchase_bond", default: 0, null: false
     t.integer "savings_split_refund", default: 0, null: false
+    t.tsvector "searchable_data"
     t.integer "separated", default: 0, null: false
     t.string "separated_year"
     t.integer "signature_method", default: 0, null: false
@@ -557,7 +559,9 @@ ActiveRecord::Schema.define(version: 2021_07_01_150705) do
     t.string "zip_code"
     t.index ["client_id"], name: "index_intakes_on_client_id"
     t.index ["email_address"], name: "index_intakes_on_email_address"
+    t.index ["needs_to_flush_searchable_data_set_at"], name: "index_intakes_on_needs_to_flush_searchable_data_set_at", where: "(needs_to_flush_searchable_data_set_at IS NOT NULL)"
     t.index ["phone_number"], name: "index_intakes_on_phone_number"
+    t.index ["searchable_data"], name: "index_intakes_on_searchable_data", using: :gin
     t.index ["sms_phone_number"], name: "index_intakes_on_sms_phone_number"
     t.index ["triage_source_type", "triage_source_id"], name: "index_intakes_on_triage_source_type_and_triage_source_id"
     t.index ["vita_partner_id"], name: "index_intakes_on_vita_partner_id"

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -1,0 +1,6 @@
+namespace :search do
+  desc 'Refresh tsvector columns for any searchable models'
+  task refresh: [:environment] do
+    Intake.refresh_search_index
+  end
+end

--- a/spec/factories/intakes.rb
+++ b/spec/factories/intakes.rb
@@ -101,6 +101,7 @@
 #  needs_help_2018                                      :integer          default(0), not null
 #  needs_help_2019                                      :integer          default(0), not null
 #  needs_help_2020                                      :integer          default(0), not null
+#  needs_to_flush_searchable_data_set_at                :datetime
 #  no_eligibility_checks_apply                          :integer          default(0), not null
 #  no_ssn                                               :integer          default(0), not null
 #  other_income_types                                   :string
@@ -142,6 +143,7 @@
 #  satisfaction_face                                    :integer          default(0), not null
 #  savings_purchase_bond                                :integer          default(0), not null
 #  savings_split_refund                                 :integer          default(0), not null
+#  searchable_data                                      :tsvector
 #  separated                                            :integer          default(0), not null
 #  separated_year                                       :string
 #  signature_method                                     :integer          default("online"), not null
@@ -193,7 +195,9 @@
 #
 #  index_intakes_on_client_id                                (client_id)
 #  index_intakes_on_email_address                            (email_address)
+#  index_intakes_on_needs_to_flush_searchable_data_set_at    (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_intakes_on_phone_number                             (phone_number)
+#  index_intakes_on_searchable_data                          (searchable_data) USING gin
 #  index_intakes_on_sms_phone_number                         (sms_phone_number)
 #  index_intakes_on_triage_source_type_and_triage_source_id  (triage_source_type,triage_source_id)
 #  index_intakes_on_vita_partner_id                          (vita_partner_id)
@@ -214,6 +218,7 @@ FactoryBot.define do
     had_wages { :unfilled }
     client
     sequence(:visitor_id) { |n| "visitor_id_#{n}" }
+    needs_to_flush_searchable_data_set_at { 1.minute.ago }
 
     trait :primary_consented do
       primary_consented_to_service_at { 2.weeks.ago }

--- a/spec/features/hub/clients_searching_sorting_and_filtering_spec.rb
+++ b/spec/features/hub/clients_searching_sorting_and_filtering_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe "searching, sorting, and filtering clients" do
 
       before do
         allow(DateTime).to receive(:now).and_return DateTime.new(2021, 5, 4)
+        Intake.refresh_search_index
       end
 
       scenario "I can view all clients and search, sort, and filter", js: true do

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -101,6 +101,7 @@
 #  needs_help_2018                                      :integer          default(0), not null
 #  needs_help_2019                                      :integer          default(0), not null
 #  needs_help_2020                                      :integer          default(0), not null
+#  needs_to_flush_searchable_data_set_at                :datetime
 #  no_eligibility_checks_apply                          :integer          default(0), not null
 #  no_ssn                                               :integer          default(0), not null
 #  other_income_types                                   :string
@@ -142,6 +143,7 @@
 #  satisfaction_face                                    :integer          default(0), not null
 #  savings_purchase_bond                                :integer          default(0), not null
 #  savings_split_refund                                 :integer          default(0), not null
+#  searchable_data                                      :tsvector
 #  separated                                            :integer          default(0), not null
 #  separated_year                                       :string
 #  signature_method                                     :integer          default("online"), not null
@@ -193,7 +195,9 @@
 #
 #  index_intakes_on_client_id                                (client_id)
 #  index_intakes_on_email_address                            (email_address)
+#  index_intakes_on_needs_to_flush_searchable_data_set_at    (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_intakes_on_phone_number                             (phone_number)
+#  index_intakes_on_searchable_data                          (searchable_data) USING gin
 #  index_intakes_on_sms_phone_number                         (sms_phone_number)
 #  index_intakes_on_triage_source_type_and_triage_source_id  (triage_source_type,triage_source_id)
 #  index_intakes_on_vita_partner_id                          (vita_partner_id)
@@ -284,6 +288,10 @@ describe Intake do
       let(:other_client) { create :client, id: 333 }
       let!(:intake) { create :intake, id: 444, client: client, primary_first_name: "Jeremy", primary_last_name: "Fisher", preferred_name: "Jerry", spouse_first_name: "Jenny", spouse_last_name: "Fishy", email_address: "jerry@example.com", sms_phone_number: "+15005550006", phone_number: "+15005550007" }
       let!(:other_intake) { create :intake, id: 555, client: other_client, primary_first_name: "Geoffrey", primary_last_name: "Foster", preferred_name: "Jeff", spouse_first_name: "Jennifer", spouse_last_name: "Frosty", email_address: "jeff@example.com", sms_phone_number: "+15005550008", phone_number: "+15005550009" }
+
+      before do
+        described_class.refresh_search_index
+      end
 
       it "can match on each required field" do
         expect(described_class.search("222")).to eq [intake] # client_id


### PR DESCRIPTION
Currently every time someone does a search of the intake records, pg_search
generates a big query that generates a ton of `tsvector` columns just-in-time
to evaluate them against a `tsquery`

This is tremendously wasteful and all our search queries take at least 4 seconds
as a result, when the DB is under no load. We currently have 300k intakes, this
will only increase as we get more.

This approach adds a `searchable_data` column to `intakes` that attempts to store
all the searchable things as a `tsvector`. To keep `searchable_data` up to date,
we periodically call `rake search:refresh` which regenerates the `searchable_data`
for every row that has been marked with `needs_to_flush_searchable_data_set_at`

There's a lot of alternative approaches, we could:
* Update the column every time a row is modified, bypassing the need for a timestamp / cron thing
* Update the column with a database trigger
* Upgrade to Postgres 12+ and keep the column up to date by making it 'GENERATED STORED'

but I think the advantage of this approach is it may make it a little easier to
regenerate the whole search index if we change what columns are searchable or how