### PR TITLE
Add CTC valet id types

### DIFF
--- a/app/forms/hub/create_ctc_client_form.rb
+++ b/app/forms/hub/create_ctc_client_form.rb
@@ -28,6 +28,10 @@ module Hub
                        :with_incarcerated_navigator,
                        :with_limited_english_navigator,
                        :with_unhoused_navigator,
+                       :with_drivers_license_photo_id,
+                       :with_passport_photo_id,
+                       :with_other_state_photo_id,
+                       :with_vita_approved_photo_id,
                        :bank_account_number,
                        :bank_routing_number,
                        :bank_account_type,
@@ -78,6 +82,8 @@ module Hub
       validates_confirmation_of :spouse_ssn
       validates :spouse_ssn, social_security_number: true
     end
+
+    validate :at_least_one_photo_id_type_selected
 
     before_validation :clean_ssns
 
@@ -147,6 +153,28 @@ module Hub
         status: :prep_ready_for_prep,
         service_type: :drop_off
       }.merge(attributes_for(:tax_return))
+    end
+
+    def selected_drivers_license?
+      with_drivers_license_photo_id == "1"
+    end
+
+    def selected_passport?
+      with_passport_photo_id == "1"
+    end
+
+    def selected_other_state_id?
+      with_other_state_photo_id == "1"
+    end
+
+    def selected_vita_approved_photo_id?
+      with_vita_approved_photo_id == "1"
+    end
+
+    def at_least_one_photo_id_type_selected
+      unless selected_drivers_license? || selected_passport? || selected_other_state_id? || selected_vita_approved_photo_id?
+        errors.add(:photo_id_type, "Please select at least one photo ID type")
+      end
     end
   end
 end

--- a/app/forms/hub/create_ctc_client_form.rb
+++ b/app/forms/hub/create_ctc_client_form.rb
@@ -32,6 +32,9 @@ module Hub
                        :with_passport_photo_id,
                        :with_other_state_photo_id,
                        :with_vita_approved_photo_id,
+                       :with_social_security_taxpayer_id,
+                       :with_itin_taxpayer_id,
+                       :with_vita_approved_taxpayer_id,
                        :bank_account_number,
                        :bank_routing_number,
                        :bank_account_type,
@@ -84,6 +87,7 @@ module Hub
     end
 
     validate :at_least_one_photo_id_type_selected
+    validate :at_least_one_taxpayer_id_type_selected
 
     before_validation :clean_ssns
 
@@ -155,26 +159,20 @@ module Hub
       }.merge(attributes_for(:tax_return))
     end
 
-    def selected_drivers_license?
-      with_drivers_license_photo_id == "1"
-    end
-
-    def selected_passport?
-      with_passport_photo_id == "1"
-    end
-
-    def selected_other_state_id?
-      with_other_state_photo_id == "1"
-    end
-
-    def selected_vita_approved_photo_id?
-      with_vita_approved_photo_id == "1"
-    end
-
     def at_least_one_photo_id_type_selected
-      unless selected_drivers_license? || selected_passport? || selected_other_state_id? || selected_vita_approved_photo_id?
-        errors.add(:photo_id_type, "Please select at least one photo ID type")
+      photo_id_selected = Intake::CtcIntake::PHOTO_ID_TYPES.any? do |_, type|
+        self.send(type[:field_name]) == "1"
       end
+
+      errors.add(:photo_id_type, I18n.t("hub.clients.fields.photo_id.error")) unless photo_id_selected
+    end
+
+    def at_least_one_taxpayer_id_type_selected
+      taxpayer_id_selected = Intake::CtcIntake::TAXPAYER_ID_TYPES.any? do |_, type|
+        self.send(type[:field_name]) == "1"
+      end
+
+      errors.add(:taxpayer_id_type, I18n.t("hub.clients.fields.taxpayer_id.error")) unless taxpayer_id_selected
     end
   end
 end

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -190,6 +190,10 @@
 #  triage_source_id                                     :bigint
 #  visitor_id                                           :string
 #  vita_partner_id                                      :bigint
+#  with_drivers_license_photo_id                        :boolean          default(FALSE)
+#  with_other_state_photo_id                            :boolean          default(FALSE)
+#  with_passport_photo_id                               :boolean          default(FALSE)
+#  with_vita_approved_photo_id                          :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -191,9 +191,12 @@
 #  visitor_id                                           :string
 #  vita_partner_id                                      :bigint
 #  with_drivers_license_photo_id                        :boolean          default(FALSE)
+#  with_itin_taxpayer_id                                :boolean          default(FALSE)
 #  with_other_state_photo_id                            :boolean          default(FALSE)
 #  with_passport_photo_id                               :boolean          default(FALSE)
+#  with_social_security_taxpayer_id                     :boolean          default(FALSE)
 #  with_vita_approved_photo_id                          :boolean          default(FALSE)
+#  with_vita_approved_taxpayer_id                       :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -190,6 +190,10 @@
 #  triage_source_id                                     :bigint
 #  visitor_id                                           :string
 #  vita_partner_id                                      :bigint
+#  with_drivers_license_photo_id                        :boolean          default(FALSE)
+#  with_other_state_photo_id                            :boolean          default(FALSE)
+#  with_passport_photo_id                               :boolean          default(FALSE)
+#  with_vita_approved_photo_id                          :boolean          default(FALSE)
 #
 # Indexes
 #
@@ -218,11 +222,40 @@ class Intake::CtcIntake < Intake
   enum recovery_rebate_credit_amount_confidence: { unfilled: 0, sure: 1, unsure: 2 }, _prefix: :recovery_rebate_credit_amount_confidence
   enum ctc_refund_delivery_method: { unfilled: 0, direct_deposit: 1, check: 2 }, _prefix: :ctc_refund_delivery_method
 
+  PHOTO_ID_TYPES = {
+    drivers_license: {
+      display_name: "Drivers License",
+      field_name: :with_drivers_license_photo_id
+    },
+    passport: {
+      display_name: "US Passport",
+      field_name: :with_passport_photo_id
+    },
+    other_state: {
+      display_name: "Other State ID",
+      field_name: :with_other_state_photo_id
+    },
+    vita_approved: {
+      display_name: "Identification approved by my VITA site",
+      field_name: :with_vita_approved_photo_id
+    }
+  }
+
   def document_types_definitely_needed
     []
   end
 
   def is_ctc?
     true
+  end
+
+  def photo_id_display_names
+    names = []
+    PHOTO_ID_TYPES.each do |_, type|
+      if self.send(type[:field_name])
+        names << type[:display_name]
+      end
+    end
+    names.join(', ')
   end
 end

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -191,9 +191,12 @@
 #  visitor_id                                           :string
 #  vita_partner_id                                      :bigint
 #  with_drivers_license_photo_id                        :boolean          default(FALSE)
+#  with_itin_taxpayer_id                                :boolean          default(FALSE)
 #  with_other_state_photo_id                            :boolean          default(FALSE)
 #  with_passport_photo_id                               :boolean          default(FALSE)
+#  with_social_security_taxpayer_id                     :boolean          default(FALSE)
 #  with_vita_approved_photo_id                          :boolean          default(FALSE)
+#  with_vita_approved_taxpayer_id                       :boolean          default(FALSE)
 #
 # Indexes
 #
@@ -241,6 +244,21 @@ class Intake::CtcIntake < Intake
     }
   }
 
+  TAXPAYER_ID_TYPES = {
+    social_security: {
+      display_name: "Social Security card",
+      field_name: :with_social_security_taxpayer_id
+    },
+    itin: {
+      display_name: "Individual Taxpayer ID Number (ITIN) letter",
+      field_name: :with_itin_taxpayer_id
+    },
+    vita_approved: {
+      display_name: "Identification approved by my VITA site",
+      field_name: :with_vita_approved_taxpayer_id
+    }
+  }
+
   def document_types_definitely_needed
     []
   end
@@ -252,6 +270,16 @@ class Intake::CtcIntake < Intake
   def photo_id_display_names
     names = []
     PHOTO_ID_TYPES.each do |_, type|
+      if self.send(type[:field_name])
+        names << type[:display_name]
+      end
+    end
+    names.join(', ')
+  end
+
+  def taxpayer_id_display_names
+    names = []
+    TAXPAYER_ID_TYPES.each do |_, type|
       if self.send(type[:field_name])
         names << type[:display_name]
       end

--- a/app/models/intake/gyr_intake.rb
+++ b/app/models/intake/gyr_intake.rb
@@ -190,6 +190,10 @@
 #  triage_source_id                                     :bigint
 #  visitor_id                                           :string
 #  vita_partner_id                                      :bigint
+#  with_drivers_license_photo_id                        :boolean          default(FALSE)
+#  with_other_state_photo_id                            :boolean          default(FALSE)
+#  with_passport_photo_id                               :boolean          default(FALSE)
+#  with_vita_approved_photo_id                          :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/app/models/intake/gyr_intake.rb
+++ b/app/models/intake/gyr_intake.rb
@@ -191,9 +191,12 @@
 #  visitor_id                                           :string
 #  vita_partner_id                                      :bigint
 #  with_drivers_license_photo_id                        :boolean          default(FALSE)
+#  with_itin_taxpayer_id                                :boolean          default(FALSE)
 #  with_other_state_photo_id                            :boolean          default(FALSE)
 #  with_passport_photo_id                               :boolean          default(FALSE)
+#  with_social_security_taxpayer_id                     :boolean          default(FALSE)
 #  with_vita_approved_photo_id                          :boolean          default(FALSE)
+#  with_vita_approved_taxpayer_id                       :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/app/views/hub/clients/show.html.erb
+++ b/app/views/hub/clients/show.html.erb
@@ -108,6 +108,13 @@
                 <span class="label-value"><%= @client.intake.photo_id_display_names %></span>
               </div>
             </div>
+
+            <div class="client-profile__field-group">
+              <h2 class="text--bold"><%= t(".taxpayer_id_types") %></h2>
+              <div class="field-display">
+                <span class="label-value"><%= @client.intake.taxpayer_id_display_names %></span>
+              </div>
+            </div>
           <% end %>
 
           <!-- Bank info-->

--- a/app/views/hub/clients/show.html.erb
+++ b/app/views/hub/clients/show.html.erb
@@ -101,6 +101,15 @@
             </div>
           </div>
 
+          <% if @client.intake.is_ctc? %>
+            <div class="client-profile__field-group">
+              <h2 class="text--bold"><%= t(".photo_id_types") %></h2>
+              <div class="field-display">
+                <span class="label-value"><%= @client.intake.photo_id_display_names %></span>
+              </div>
+            </div>
+          <% end %>
+
           <!-- Bank info-->
           <div class="client-profile__field-group client-bank-account-info">
             <h2 class="text--bold"><%= "Bank Account Info" %>

--- a/app/views/hub/ctc_clients/new.html.erb
+++ b/app/views/hub/ctc_clients/new.html.erb
@@ -21,6 +21,7 @@
           <%= render "shared/bank_account_fields", f: f %>
           <%= render "shared/navigator_fields", f: f %>
           <%= render "shared/photo_id_fields", f: f %>
+          <%= render "shared/taxpayer_id_fields", f: f %>
           <%= render "shared/identity_verification_fields", f: f %>
 
           <div>

--- a/app/views/hub/ctc_clients/new.html.erb
+++ b/app/views/hub/ctc_clients/new.html.erb
@@ -20,6 +20,7 @@
           <%= render "shared/recovery_rebate_amount_fields", f: f %>
           <%= render "shared/bank_account_fields", f: f %>
           <%= render "shared/navigator_fields", f: f %>
+          <%= render "shared/photo_id_fields", f: f %>
           <%= render "shared/identity_verification_fields", f: f %>
 
           <div>

--- a/app/views/shared/_photo_id_fields.html.erb
+++ b/app/views/shared/_photo_id_fields.html.erb
@@ -1,0 +1,8 @@
+<div id="photo-id-type-fields" class="hub-form__card card-small">
+  <h3><%= t("hub.clients.fields.photo_id.title")%></h3>
+  <%= error_message(@form, :photo_id_type) %>
+  <%= f.hub_checkbox(:with_drivers_license_photo_id, t("hub.clients.fields.photo_id.drivers_license"), options: { classes: ["checkbox--wide"] }) %>
+  <%= f.hub_checkbox(:with_passport_photo_id, t("hub.clients.fields.photo_id.passport"), options: { classes: ["checkbox--wide"] }) %>
+  <%= f.hub_checkbox(:with_other_state_photo_id, t("hub.clients.fields.photo_id.other_state"), options: { classes: ["checkbox--wide"] }) %>
+  <%= f.hub_checkbox(:with_vita_approved_photo_id, t("hub.clients.fields.photo_id.vita_approved"), options: { classes: ["checkbox--wide"] }) %>
+</div>

--- a/app/views/shared/_taxpayer_id_fields.html.erb
+++ b/app/views/shared/_taxpayer_id_fields.html.erb
@@ -1,0 +1,7 @@
+<div id="taxpayer-id-type-fields" class="hub-form__card card-small">
+  <h3><%= t("hub.clients.fields.taxpayer_id.title")%></h3>
+  <%= error_message(@form, :taxpayer_id_type) %>
+  <%= f.hub_checkbox(:with_social_security_taxpayer_id, t("hub.clients.fields.taxpayer_id.social_security"), options: { classes: ["checkbox--wide"] }) %>
+  <%= f.hub_checkbox(:with_itin_taxpayer_id, t("hub.clients.fields.taxpayer_id.itin"), options: { classes: ["checkbox--wide"] }) %>
+  <%= f.hub_checkbox(:with_vita_approved_taxpayer_id, t("hub.clients.fields.taxpayer_id.vita_approved"), options: { classes: ["checkbox--wide"] }) %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,6 +84,13 @@ en:
           passport: US Passport
           other_state: Other State ID
           vita_approved: Identification approved by my VITA site
+          error: Please select at least one photo ID type
+        taxpayer_id:
+          title: Type of taxpayer ID used
+          social_security: Social Security card
+          itin: Individual Taxpayer ID Number (ITIN) letter
+          vita_approved: Identification approved by my VITA site
+          error: Please select at least one taxpayer ID type
         identity_verification:
           title: Identity verification
         ctc_spouse_contact_info: Spouse information, if married filing jointly
@@ -170,6 +177,7 @@ en:
         navigator_types: Type of navigator used
         navigator_types_empty: No navigator used
         photo_id_types: Type of photo ID used
+        taxpayer_id_types: Type of taxpayer ID used
         basic_info: Basic Info
         other_info: Other Info
         routing_method: Initial Routing Method

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,6 +78,12 @@ en:
           incarcerated: Incarcerated/reentry
           limited_english: Limited English proficiency
           unhoused: Unhoused
+        photo_id:
+          title: Type of photo ID used
+          drivers_license: Drivers License
+          passport: US Passport
+          other_state: Other State ID
+          vita_approved: Identification approved by my VITA site
         identity_verification:
           title: Identity verification
         ctc_spouse_contact_info: Spouse information, if married filing jointly
@@ -163,6 +169,7 @@ en:
         tax_info: Tax Info
         navigator_types: Type of navigator used
         navigator_types_empty: No navigator used
+        photo_id_types: Type of photo ID used
         basic_info: Basic Info
         other_info: Other Info
         routing_method: Initial Routing Method

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -84,6 +84,13 @@ es:
           passport: US Passport
           other_state: Other State ID
           vita_approved: Identification approved by my VITA site
+          error: Please select at least one photo ID type
+        taxpayer_id:
+          title: Type of taxpayer ID used
+          social_security: Social Security card
+          itin: Individual Taxpayer ID Number (ITIN) letter
+          vita_approved: Identification approved by my VITA site
+          error: Please select at least one taxpayer ID type
         identity_verification:
           title: Identity verification
         ctc_spouse_contact_info: Spouse information, if married filing jointly
@@ -152,6 +159,7 @@ es:
         navigator_types: Tipo de navegador utilizada
         navigator_types_empty: No se utiliza navegador
         photo_id_types: Type of photo ID used
+        taxpayer_id_types: Type of taxpayer ID used
         basic_info: Información básica
         other_info: Other info
         routing_method: Método de enrutamiento inicial

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -78,6 +78,12 @@ es:
           incarcerated: Incarcerated/reentry
           limited_english: Limited English proficiency
           unhoused: Unhoused
+        photo_id:
+          title: Type of photo ID used
+          drivers_license: Drivers License
+          passport: US Passport
+          other_state: Other State ID
+          vita_approved: Identification approved by my VITA site
         identity_verification:
           title: Identity verification
         ctc_spouse_contact_info: Spouse information, if married filing jointly
@@ -145,6 +151,7 @@ es:
         tax_info: Información de impuestos
         navigator_types: Tipo de navegador utilizada
         navigator_types_empty: No se utiliza navegador
+        photo_id_types: Type of photo ID used
         basic_info: Información básica
         other_info: Other info
         routing_method: Método de enrutamiento inicial

--- a/db/migrate/20210630225616_add_photo_id_types_to_ctc_intake.rb
+++ b/db/migrate/20210630225616_add_photo_id_types_to_ctc_intake.rb
@@ -1,0 +1,8 @@
+class AddPhotoIdTypesToCtcIntake < ActiveRecord::Migration[6.0]
+  def change
+    add_column :intakes, :with_drivers_license_photo_id, :boolean, default: false
+    add_column :intakes, :with_passport_photo_id, :boolean, default: false
+    add_column :intakes, :with_other_state_photo_id, :boolean, default: false
+    add_column :intakes, :with_vita_approved_photo_id, :boolean, default: false
+  end
+end

--- a/db/migrate/20210701161442_add_taxpayer_id_types_to_intake.rb
+++ b/db/migrate/20210701161442_add_taxpayer_id_types_to_intake.rb
@@ -1,0 +1,7 @@
+class AddTaxpayerIdTypesToIntake < ActiveRecord::Migration[6.0]
+  def change
+    add_column :intakes, :with_social_security_taxpayer_id, :boolean, default: false
+    add_column :intakes, :with_itin_taxpayer_id, :boolean, default: false
+    add_column :intakes, :with_vita_approved_taxpayer_id, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -555,11 +555,14 @@ ActiveRecord::Schema.define(version: 2021_07_01_174549) do
     t.boolean "with_drivers_license_photo_id", default: false
     t.boolean "with_general_navigator", default: false
     t.boolean "with_incarcerated_navigator", default: false
+    t.boolean "with_itin_taxpayer_id", default: false
     t.boolean "with_limited_english_navigator", default: false
     t.boolean "with_other_state_photo_id", default: false
     t.boolean "with_passport_photo_id", default: false
+    t.boolean "with_social_security_taxpayer_id", default: false
     t.boolean "with_unhoused_navigator", default: false
     t.boolean "with_vita_approved_photo_id", default: false
+    t.boolean "with_vita_approved_taxpayer_id", default: false
     t.string "zip_code"
     t.index ["client_id"], name: "index_intakes_on_client_id"
     t.index ["email_address"], name: "index_intakes_on_email_address"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -552,10 +552,14 @@ ActiveRecord::Schema.define(version: 2021_07_01_174549) do
     t.integer "was_on_visa", default: 0, null: false
     t.integer "widowed", default: 0, null: false
     t.string "widowed_year"
+    t.boolean "with_drivers_license_photo_id", default: false
     t.boolean "with_general_navigator", default: false
     t.boolean "with_incarcerated_navigator", default: false
     t.boolean "with_limited_english_navigator", default: false
+    t.boolean "with_other_state_photo_id", default: false
+    t.boolean "with_passport_photo_id", default: false
     t.boolean "with_unhoused_navigator", default: false
+    t.boolean "with_vita_approved_photo_id", default: false
     t.string "zip_code"
     t.index ["client_id"], name: "index_intakes_on_client_id"
     t.index ["email_address"], name: "index_intakes_on_email_address"

--- a/spec/controllers/hub/ctc_clients_controller_spec.rb
+++ b/spec/controllers/hub/ctc_clients_controller_spec.rb
@@ -72,6 +72,8 @@ RSpec.describe Hub::CtcClientsController do
           filing_status: "married_filing_jointly",
           ctc_refund_delivery_method: "check",
           bank_account_type: "checking",
+          with_passport_photo_id: "1",
+          with_itin_taxpayer_id: "1",
           navigator_name: "Terry Taxseason",
           navigator_has_verified_client_identity: "1",
         },

--- a/spec/factories/intakes.rb
+++ b/spec/factories/intakes.rb
@@ -190,6 +190,10 @@
 #  triage_source_id                                     :bigint
 #  visitor_id                                           :string
 #  vita_partner_id                                      :bigint
+#  with_drivers_license_photo_id                        :boolean          default(FALSE)
+#  with_other_state_photo_id                            :boolean          default(FALSE)
+#  with_passport_photo_id                               :boolean          default(FALSE)
+#  with_vita_approved_photo_id                          :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/spec/factories/intakes.rb
+++ b/spec/factories/intakes.rb
@@ -191,9 +191,12 @@
 #  visitor_id                                           :string
 #  vita_partner_id                                      :bigint
 #  with_drivers_license_photo_id                        :boolean          default(FALSE)
+#  with_itin_taxpayer_id                                :boolean          default(FALSE)
 #  with_other_state_photo_id                            :boolean          default(FALSE)
 #  with_passport_photo_id                               :boolean          default(FALSE)
+#  with_social_security_taxpayer_id                     :boolean          default(FALSE)
 #  with_vita_approved_photo_id                          :boolean          default(FALSE)
+#  with_vita_approved_taxpayer_id                       :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/spec/features/hub/create_ctc_client_spec.rb
+++ b/spec/features/hub/create_ctc_client_spec.rb
@@ -87,6 +87,11 @@ RSpec.feature "Creating new drop off clients" do
         check "I have checked and verified this client's identity."
       end
 
+      within "#photo-id-type-fields" do
+        check "US Passport"
+        check "Other State ID"
+      end
+
       click_on I18n.t('general.save')
 
       expect(page).to have_text "Colleen Cauliflower"
@@ -113,6 +118,8 @@ RSpec.feature "Creating new drop off clients" do
       expect(page).to have_text "Economic Impact Payment 1 received: $500"
       expect(page).to have_text "Economic Impact Payment 2 received: $500"
       expect(page).to have_text "Confidence: Sure"
+
+      expect(page).to have_text "US Passport, Other State ID"
 
       expect(page).to have_text "Terry Taxseason"
 

--- a/spec/features/hub/create_ctc_client_spec.rb
+++ b/spec/features/hub/create_ctc_client_spec.rb
@@ -92,6 +92,10 @@ RSpec.feature "Creating new drop off clients" do
         check "Other State ID"
       end
 
+      within "#taxpayer-id-type-fields" do
+        check "Social Security card"
+      end
+
       click_on I18n.t('general.save')
 
       expect(page).to have_text "Colleen Cauliflower"
@@ -120,6 +124,8 @@ RSpec.feature "Creating new drop off clients" do
       expect(page).to have_text "Confidence: Sure"
 
       expect(page).to have_text "US Passport, Other State ID"
+
+      expect(page).to have_text "Social Security card"
 
       expect(page).to have_text "Terry Taxseason"
 
@@ -169,6 +175,14 @@ RSpec.feature "Creating new drop off clients" do
 
       within "#bank-account-fields" do
         choose "Check"
+      end
+
+      within "#photo-id-type-fields" do
+        check "US Passport"
+      end
+
+      within "#taxpayer-id-type-fields" do
+        check "Social Security card"
       end
 
       within "#identity-verification-fields" do

--- a/spec/forms/hub/create_ctc_client_form_spec.rb
+++ b/spec/forms/hub/create_ctc_client_form_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe Hub::CreateCtcClientForm do
         ctc_refund_delivery_method: "check",
         navigator_name: "Tax Seasonson",
         navigator_has_verified_client_identity: true,
-        with_passport_photo_id: true,
+        with_passport_photo_id: "1",
+        with_itin_taxpayer_id: "1",
       }
     end
 
@@ -100,6 +101,12 @@ RSpec.describe Hub::CreateCtcClientForm do
         described_class.new(params).save(current_user)
         client = Client.last
         expect(client.intake.with_passport_photo_id).to be_truthy
+      end
+
+      it "stores the taxpayer ID types used" do
+        described_class.new(params).save(current_user)
+        client = Client.last
+        expect(client.intake.with_itin_taxpayer_id).to be_truthy
       end
 
       it "assigns client to an instance on the form object" do
@@ -318,6 +325,24 @@ RSpec.describe Hub::CreateCtcClientForm do
           obj = described_class.new(params)
           obj.valid?
           expect(obj.errors[:photo_id_type]).to include "Please select at least one photo ID type"
+        end
+      end
+
+      context "taxpayer ID type" do
+        before do
+          params[:with_social_security_taxpayer_id] = "0"
+          params[:with_itin_taxpayer_id] = "0"
+          params[:with_vita_approved_photo_id] = "0"
+        end
+
+        it "must have at least one taxpayer ID type selected" do
+          expect(described_class.new(params).valid?).to eq false
+        end
+
+        it "pushes errors for taxpayer ID type into the errors" do
+          obj = described_class.new(params)
+          obj.valid?
+          expect(obj.errors[:taxpayer_id_type]).to include "Please select at least one taxpayer ID type"
         end
       end
 

--- a/spec/forms/hub/create_ctc_client_form_spec.rb
+++ b/spec/forms/hub/create_ctc_client_form_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe Hub::CreateCtcClientForm do
         ctc_refund_delivery_method: "check",
         navigator_name: "Tax Seasonson",
         navigator_has_verified_client_identity: true,
+        with_passport_photo_id: true,
       }
     end
 
@@ -93,6 +94,12 @@ RSpec.describe Hub::CreateCtcClientForm do
         client = Client.last
         expect(client.intake.spouse_ssn).to eq('111224444')
         expect(client.intake.spouse_last_four_ssn).to eq('4444')
+      end
+
+      it "stores the photo ID types used" do
+        described_class.new(params).save(current_user)
+        client = Client.last
+        expect(client.intake.with_passport_photo_id).to be_truthy
       end
 
       it "assigns client to an instance on the form object" do
@@ -295,6 +302,24 @@ RSpec.describe Hub::CreateCtcClientForm do
         end
       end
 
+      context "photo ID type" do
+        before do
+          params[:with_drivers_license_photo_id] = "0"
+          params[:with_passport_photo_id] = "0"
+          params[:with_other_state_photo_id] = "0"
+          params[:with_vita_approved_photo_id] = "0"
+        end
+
+        it "must have at least one photo ID type selected" do
+          expect(described_class.new(params).valid?).to eq false
+        end
+
+        it "pushes errors for photo ID type into the errors" do
+          obj = described_class.new(params)
+          obj.valid?
+          expect(obj.errors[:photo_id_type]).to include "Please select at least one photo ID type"
+        end
+      end
 
       context "navigator name" do
         before do

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -190,6 +190,10 @@
 #  triage_source_id                                     :bigint
 #  visitor_id                                           :string
 #  vita_partner_id                                      :bigint
+#  with_drivers_license_photo_id                        :boolean          default(FALSE)
+#  with_other_state_photo_id                            :boolean          default(FALSE)
+#  with_passport_photo_id                               :boolean          default(FALSE)
+#  with_vita_approved_photo_id                          :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -191,9 +191,12 @@
 #  visitor_id                                           :string
 #  vita_partner_id                                      :bigint
 #  with_drivers_license_photo_id                        :boolean          default(FALSE)
+#  with_itin_taxpayer_id                                :boolean          default(FALSE)
 #  with_other_state_photo_id                            :boolean          default(FALSE)
 #  with_passport_photo_id                               :boolean          default(FALSE)
+#  with_social_security_taxpayer_id                     :boolean          default(FALSE)
 #  with_vita_approved_photo_id                          :boolean          default(FALSE)
+#  with_vita_approved_taxpayer_id                       :boolean          default(FALSE)
 #
 # Indexes
 #


### PR DESCRIPTION
Add photo ID and taxpayer ID types to the CTC valet form. Display the selected types on the client profile page if the client's intake is CTC.
- At least one of each type must be selected.

 #178699474