### PR TITLE
Remove two potentially unused gems (arel_extensions/strip_attributes) -- second try

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,10 +25,8 @@ gem 'image_processing'
 # gem 'capistrano-rails', group: :development
 
 # Reduces boot times through caching; required in config/boot.rb
-gem 'arel_extensions'
 gem 'bootsnap', '>= 1.5.1', require: false
 gem 'phonelib'
-gem 'strip_attributes'
 gem 'pg'
 gem 'pg_search'
 gem 'activerecord-postgis-adapter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,8 +77,6 @@ GEM
     annotate (3.1.1)
       activerecord (>= 3.2, < 7.0)
       rake (>= 10.4, < 14.0)
-    arel_extensions (2.0.12)
-      activerecord (>= 6.0)
     ast (2.4.1)
     attr_encrypted (3.1.0)
       encryptor (~> 3.0.0)
@@ -493,8 +491,6 @@ GEM
       sprockets (>= 3.0.0)
     stackprof (0.2.17)
     statesman (8.0.3)
-    strip_attributes (1.11.0)
-      activemodel (>= 3.0, < 7.0)
     terminal-table (3.0.1)
       unicode-display_width (>= 1.1.1, < 3)
     terser (1.1.3)
@@ -561,7 +557,6 @@ PLATFORMS
 DEPENDENCIES
   activerecord-postgis-adapter
   annotate
-  arel_extensions
   attr_encrypted
   auto_strip_attributes
   aws-sdk-s3
@@ -635,7 +630,6 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   stackprof
   statesman (~> 8.0.3)
-  strip_attributes
   terser (~> 1.0)
   thor
   timecop

--- a/app/controllers/hub/tax_return_selections_controller.rb
+++ b/app/controllers/hub/tax_return_selections_controller.rb
@@ -31,7 +31,7 @@ module Hub
 
     def new
       @clients = Client.accessible_by(current_ability).with_eager_loaded_associations
-      @tr_ids = (new_params.dig(:create_tax_return_selection, :action_type) == "all-filtered-clients") ? TaxReturn.where(client: filtered_and_sorted_clients).pluck(:id) : new_params[:tr_ids]
+      @tr_ids = (new_params.dig(:create_tax_return_selection, :action_type) == "all-filtered-clients") ? TaxReturn.where(client: filtered_and_sorted_clients.reorder(nil)).pluck(:id) : new_params[:tr_ids]
       @client_count = @clients.distinct.joins(:tax_returns).where(tax_returns: { id: @tr_ids }).size
       @tax_return_count = TaxReturn.accessible_by(current_ability).where(id: @tr_ids).size
       @selection = TaxReturnSelection.new


### PR DESCRIPTION
Last time this was merged with the Rails 6.1 upgrade and stuff started going
wrong, not sure if it was this commit or Rails 6.1

Remove strip_attributes gem which may be unused: we definitely auto_strip_attributes but maybe not this

Remove arel_extensions gem that was added in ea885a9e62753cefbfcf40f8218bfe0d2b4326e2

Fix a usage of `TaxReturn.where(client: scope)` when `scope` was an ordered
relation, which apparently crashes when arel_extensions is removed
I'm not sure what part of the gem was actually being used at the time, but that
code has been refactored to do a lot less Arel shenanigans since then.

```
REMOVED:
arel_extensions   2.0.12
strip_attributes  1.11.0
```