### PR TITLE
Update honeycrisp from 0.9.6 to 0.10.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rack', '>= 2.0.8'
 gem 'rails', '>= 6.0.3.7'
 gem 'puma', '>= 5.3.2'
 gem 'sass-rails', '~> 5.0'
-gem 'cfa-styleguide', '0.10.2', git: 'https://github.com/codeforamerica/honeycrisp-gem', branch: 'main'
+gem 'cfa-styleguide', '0.10.3', git: 'https://github.com/codeforamerica/honeycrisp-gem', branch: 'main'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 gem 'mini_racer', '~> 0.4.0', platforms: :ruby
 gem 'nokogiri', '>= 1.10.8'

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rack', '>= 2.0.8'
 gem 'rails', '>= 6.0.3.7'
 gem 'puma', '>= 5.3.2'
 gem 'sass-rails', '~> 5.0'
-gem 'cfa-styleguide', git: 'https://github.com/codeforamerica/honeycrisp-gem', branch: 'main'
+gem 'cfa-styleguide', '0.10.2', git: 'https://github.com/codeforamerica/honeycrisp-gem', branch: 'main'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 gem 'mini_racer', '~> 0.4.0', platforms: :ruby
 gem 'nokogiri', '>= 1.10.8'

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rack', '>= 2.0.8'
 gem 'rails', '>= 6.0.3.7'
 gem 'puma', '>= 5.3.2'
 gem 'sass-rails', '~> 5.0'
-gem 'cfa-styleguide', '0.10.3', git: 'https://github.com/codeforamerica/honeycrisp-gem', branch: 'main'
+gem 'cfa-styleguide', '0.10.4', git: 'https://github.com/codeforamerica/honeycrisp-gem', branch: 'main'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 gem 'mini_racer', '~> 0.4.0', platforms: :ruby
 gem 'nokogiri', '>= 1.10.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/codeforamerica/honeycrisp-gem
-  revision: d8f4051f847bcb857fe93b5484de649708f2ddf1
+  revision: af7cd9db0f25fc593914688a76d64100c5e375b6
   branch: main
   specs:
-    cfa-styleguide (0.10.3)
+    cfa-styleguide (0.10.4)
       autoprefixer-rails
       bourbon
       jquery-rails
@@ -574,7 +574,7 @@ DEPENDENCIES
   byebug
   cancancan
   capybara (>= 2.15)
-  cfa-styleguide (= 0.10.3)!
+  cfa-styleguide (= 0.10.4)!
   combine_pdf
   database_cleaner
   ddtrace

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/codeforamerica/honeycrisp-gem
-  revision: ff5b67d5590a61797f0857caa7b63900de1e667d
+  revision: 0537424e260814e4931ab5ad60df0377deaf9f61
   branch: main
   specs:
-    cfa-styleguide (0.9.6)
+    cfa-styleguide (0.10.2)
       autoprefixer-rails
       bourbon
       jquery-rails
@@ -82,8 +82,8 @@ GEM
       encryptor (~> 3.0.0)
     auto_strip_attributes (2.6.0)
       activerecord (>= 4.0)
-    autoprefixer-rails (10.2.4.0)
-      execjs
+    autoprefixer-rails (10.2.5.1)
+      execjs (> 0)
     awesome_print (1.9.2)
     aws-eventstream (1.1.1)
     aws-partitions (1.467.0)
@@ -574,7 +574,7 @@ DEPENDENCIES
   byebug
   cancancan
   capybara (>= 2.15)
-  cfa-styleguide!
+  cfa-styleguide (= 0.10.2)!
   combine_pdf
   database_cleaner
   ddtrace

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/codeforamerica/honeycrisp-gem
-  revision: 0537424e260814e4931ab5ad60df0377deaf9f61
+  revision: d8f4051f847bcb857fe93b5484de649708f2ddf1
   branch: main
   specs:
-    cfa-styleguide (0.10.2)
+    cfa-styleguide (0.10.3)
       autoprefixer-rails
       bourbon
       jquery-rails
@@ -82,8 +82,8 @@ GEM
       encryptor (~> 3.0.0)
     auto_strip_attributes (2.6.0)
       activerecord (>= 4.0)
-    autoprefixer-rails (10.2.5.1)
-      execjs (> 0)
+    autoprefixer-rails (10.3.1.0)
+      execjs (~> 2)
     awesome_print (1.9.2)
     aws-eventstream (1.1.1)
     aws-partitions (1.467.0)
@@ -574,7 +574,7 @@ DEPENDENCIES
   byebug
   cancancan
   capybara (>= 2.15)
-  cfa-styleguide (= 0.10.2)!
+  cfa-styleguide (= 0.10.3)!
   combine_pdf
   database_cleaner
   ddtrace

--- a/app/javascript/lib/honeycrisp.js
+++ b/app/javascript/lib/honeycrisp.js
@@ -128,10 +128,10 @@ var revealer = (function() {
         init: function() {
             $('.reveal').each(function(index, revealer) {
                 var self = revealer;
-                $(self).addClass('is-hidden');
+                $(self).addClass('is-hiding-content');
                 $(self).find('.reveal__link').click(function(e) {
                     e.preventDefault();
-                    $(self).toggleClass('is-hidden');
+                    $(self).toggleClass('is-hiding-content');
                 });
             });
         }

--- a/app/views/flows/show.js.erb
+++ b/app/views/flows/show.js.erb
@@ -3,9 +3,9 @@ $("#flow-wrapper").html("<%= escape_javascript(render(partial: 'flow', locals: {
 // re-initialize reveals -- note that this is the same as revealer.init() from honeycrisp js
 $('.reveal').each(function(index, revealer) {
   var self = revealer;
-  $(self).addClass('is-hidden');
+  $(self).addClass('is-hiding-content');
   $(self).find('.reveal__link').click(function(e) {
     e.preventDefault();
-    $(self).toggleClass('is-hidden');
+    $(self).toggleClass('is-hiding-content');
   });
 });


### PR DESCRIPTION
# What does this PR do?

- Update Honeycrisp to the latest version ([from 0.9.6 to 0.10.4](https://github.com/codeforamerica/honeycrisp-gem/compare/v0.9.6...v0.10.4)).
  - The [migration guide](https://github.com/codeforamerica/honeycrisp-gem/blob/main/MIGRATING.md) mentions that since we are importing the manifest, no changes are needed:
    - > If you imported the manifest (ie as import 'cfa_styleguide_main' in application.scss), no changes are needed.
- Updated Honeycrisp override code in GYR that was using `is-hidden` to now use `is-hiding-content`, [which Honeycrisp now does](https://github.com/codeforamerica/honeycrisp-gem/pull/281).

# Testing

We tested this PR locally and with [Percy](https://percy.io/Code-for-America/vita-min) to check for any differences from [`main`](https://percy.io/Code-for-America/vita-min/builds/12606881/changed/711791099?browser=edge&browser_ids=19%2C20%2C21&subcategories=approved&viewLayout=overlay&viewMode=new&width=375&widths=375%2C1280) (percy calls this the baseline build) and this [pr branch](https://percy.io/Code-for-America/vita-min/builds/12625334/changed/712870418?browser=edge&browser_ids=19%2C20%2C21&subcategories=approved&viewLayout=overlay&viewMode=new&width=1280&widths=375%2C1280).