### PR TITLE
Restore active storage routing locally

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -274,5 +274,7 @@ Rails.application.routes.draw do
     end
   end
 
-  get '*unmatched_route', to: 'public_pages#page_not_found'
+  get '*unmatched_route', to: 'public_pages#page_not_found', constraints: lambda { |req|
+    req.path.exclude? 'rails/active_storage'
+  }
 end


### PR DESCRIPTION
The catchall was catching too much! And blocking us from viewing active storage uploads in development.