### PR TITLE
rake flow_explorer:upload_screenshots publishes screenshots to s3

### DIFF
--- a/app/assets/stylesheets/templates/_flow-explorer.scss
+++ b/app/assets/stylesheets/templates/_flow-explorer.scss
@@ -1,5 +1,5 @@
 .flow-explorer-screenshot {
-  width: 150px;
+  width: 300px;
   flex-shrink: 0;
 }
 

--- a/lib/tasks/flow_explorer.rake
+++ b/lib/tasks/flow_explorer.rake
@@ -1,0 +1,27 @@
+namespace :flow_explorer do
+  desc "Upload flow explorer screenshots to s3"
+  task upload_screenshots: :environment do |_task|
+    screenshots_path = Rails.root.join('public', 'assets', 'flow_screenshots')
+
+    credentials = if ENV["AWS_ACCESS_KEY_ID"].present?
+                    Aws::Credentials.new(ENV["AWS_ACCESS_KEY_ID"], ENV["AWS_SECRET_ACCESS_KEY"])
+                  else
+                    Aws::Credentials.new(
+                      Rails.application.credentials.dig(:aws, :access_key_id),
+                      Rails.application.credentials.dig(:aws, :secret_access_key),
+                    )
+    end
+
+    %w[en es].each do |locale|
+      Dir[File.join(screenshots_path, locale, '*')].each do |screenshot_path|
+        puts "Uploading #{screenshot_path}..."
+        Aws::S3::Client.new(region: 'us-west-1', credentials: credentials).put_object(
+          body: File.open(screenshot_path),
+          bucket: "vita-min-flow-explorer-screenshots",
+          key: File.join(locale.to_s, File.basename(screenshot_path)),
+          acl: "public-read"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
the s3 creds in the developement credentials file now have permission
to upload files to this bucket and set the permissions to be public

also increases the default size of the screenshots