### PR TITLE
Add .well-known/pki-validation for Identrust

### DIFF
--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -50,4 +50,12 @@ class PublicPagesController < ApplicationController
   def sms_terms; end
 
   def diy; end
+
+  def pki_validation
+    # Used for Identrust annual EV certificate validation
+    respond_to do |format|
+      format.text { render 'public_pages/pki_validation'  }
+      format.any { head 404 }
+    end
+  end
 end

--- a/app/views/public_pages/pki_validation.text.erb
+++ b/app/views/public_pages/pki_validation.text.erb
@@ -1,0 +1,5 @@
+<% if params[:id] == "6974731"
+  %>1Ie/6YQM5vK0/48NrcV4TQzFe6+7HBTn2VPr4o601k4F<%
+  else
+%>Unknown PKI validation.<%
+  end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -247,6 +247,7 @@ Rails.application.routes.draw do
     resources :ajax_mixpanel_events, only: [:create]
 
     mount ActionCable.server => '/cable'
+    get '/.well-known/pki-validation/:id', to: 'public_pages#pki_validation'
   end
 
   constraints(Routes::CtcDomain.new) do
@@ -282,6 +283,7 @@ Rails.application.routes.draw do
         end
       end
     end
+    get '/.well-known/pki-validation/:id', to: 'public_pages#pki_validation'
   end
 
   get '*unmatched_route', to: 'public_pages#page_not_found', constraints: lambda { |req|


### PR DESCRIPTION
This adds a string that Identrust wants to see on the website per https://www.pivotaltracker.com/story/show/178505321

I was not sure if this was a good Ruby app commit vs. something we could put in a database/config option. I figured in the end they're all good enough. Open to ideas/input.

This random value is not a secret. It validates to Identrust's satisfaction that we operate www.getctc.org.