### PR TITLE
QuestionsController.to_path_helper uses url_for instead of path_helper_string

### DIFF
--- a/app/controllers/ctc/questions/questions_controller.rb
+++ b/app/controllers/ctc/questions/questions_controller.rb
@@ -21,14 +21,6 @@ module Ctc
         def form_key
           "ctc/" + controller_name + "_form"
         end
-
-        def path_helper_string
-          [
-            "questions",
-            controller_name,
-            "path"
-          ].join("_")
-        end
       end
     end
   end

--- a/app/controllers/questions/questions_controller.rb
+++ b/app/controllers/questions/questions_controller.rb
@@ -112,17 +112,15 @@ module Questions
         controller_name.dasherize
       end
 
-      def path_helper_string
-        [
-          controller_name,
-          module_parent.name.underscore,
-          "path"
-        ].join("_") # "controller_name_module_path"
-      end
-
       def to_path_helper
-        # Pass default_url_options (namely, locale) from ApplicationController when computing URL for this controller
-        Rails.application.routes.url_helpers.send(path_helper_string.to_sym, default_url_options)
+        Rails.application.routes.url_helpers.url_for({
+          controller: controller_path,
+          action: :edit,
+          only_path: true,
+          # url_for sometimes uses the current path to determine the right URL in some situations,
+          # expliclitly sending an empty _recall disables that behavior
+          _recall: {}
+        }.merge(default_url_options))
       end
 
       def form_key


### PR DESCRIPTION
Previously, path_helper_string was used to compute the appropriate
url helper from a controller class (something like questions_ip_pin_path in CTC
or irs_letter_questions_path in GYR)

url_for can be used for this purpose and only requires a controller name
and action (which in our form navigation framework is always :edit)