### PR TITLE
Flow explorer: document how to capture screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,18 @@ The rubocop settings files is in the root directory as `.rubocop.yml`
 RubyMine integrates Rubocop by default. Settings can be found in the Preferences
 menu, under Editor > Inspections > Ruby > Gems and Gem Management > Rubocop.
 
+### Flow Explorer
+
+There's a publicly accessible page (on demo and dev environments) at /flows that lets you skip around quickly between pages in the intake flows.
+
+The flows page tries to show a preview screenshot from each page, captured during specialized capybara runs. To capture updated screenshots:
+
+`rspec --tag flow_explorer_screenshot spec`
+
+They'll be dumped into `public/assets/flow_explorer_screenshots` locally.
+
+You can upload them to the correct S3 bucket with the task `rake flow_explorer:upload_screenshots`
+
 ## Deploying the Application 🚀☁️
 
 Notes on deployment can be found in [docs/deployment](docs/deployment.md).

--- a/app/javascript/packs/application.js.erb
+++ b/app/javascript/packs/application.js.erb
@@ -24,5 +24,7 @@ ActiveStorage.start();
 import "../lib/honeycrisp";
 
 // *
-AjaxMixpanelEvents.init();
+<% unless Rails.env.test? %>
+  AjaxMixpanelEvents.init();
+<% end %>
 Listeners.init();

--- a/spec/features/ctc/complete_intake_spec.rb
+++ b/spec/features/ctc/complete_intake_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "CTC Intake", :js, active_job: true do
+RSpec.feature "CTC Intake", :js, :flow_explorer_screenshot, active_job: true do
   before do
     allow_any_instance_of(Routes::CtcDomain).to receive(:matches?).and_return(true)
   end

--- a/spec/features/ctc/rrc_intake_questions_spec.rb
+++ b/spec/features/ctc/rrc_intake_questions_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "CTC Intake", :js, active_job: true do
+RSpec.feature "CTC Intake", :js, :flow_explorer_screenshot, active_job: true do
   # TODO: after we have the RRC calculation based on dependents, set up some cases for routing to owed vs received
   let(:client) { create :client, intake: create(:ctc_intake), tax_returns: [create(:tax_return)] }
 

--- a/spec/features/web_intake/at_capacity_spec.rb
+++ b/spec/features/web_intake/at_capacity_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Web Intake Client matches with partner who is at capacity" do
+RSpec.feature "Web Intake Client matches with partner who is at capacity", :flow_explorer_screenshot do
   let(:intake) { create :intake }
   before do
     allow_any_instance_of(ApplicationController).to receive(:current_intake).and_return(intake)

--- a/spec/features/web_intake/document_help_flow_spec.rb
+++ b/spec/features/web_intake/document_help_flow_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Document Help Flow", active_job: true do
+RSpec.feature "Document Help Flow", :flow_explorer_screenshot, active_job: true do
   let(:client) do
     create :client,
            intake: (create :intake, bought_health_insurance: "yes", had_retirement_income: "yes", sms_notification_opt_in: "yes", sms_phone_number: "+15105551234")

--- a/spec/features/web_intake/ineligible_filer_spec.rb
+++ b/spec/features/web_intake/ineligible_filer_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "client is not eligible for VITA services" do
+RSpec.feature "client is not eligible for VITA services", :flow_explorer_screenshot do
   scenario "client checks one of the boxes on the triage_eligibility page" do
     visit "/en/questions/welcome"
 

--- a/spec/features/web_intake/new_211_filer_spec.rb
+++ b/spec/features/web_intake/new_211_filer_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Web Intake 211 Assisted Filer" do
+RSpec.feature "Web Intake 211 Assisted Filer", :flow_explorer_screenshot do
   before do
     # Create the hard-coded VITA partner for EIP-only returns
     create(:vita_partner, name: "Get Your Refund")

--- a/spec/features/web_intake/new_joint_filers_spec.rb
+++ b/spec/features/web_intake/new_joint_filers_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Web Intake Joint Filers" do
+RSpec.feature "Web Intake Joint Filers", :flow_explorer_screenshot do
   let!(:vita_partner) { create :vita_partner, name: "Virginia Partner" }
   let!(:vita_partner_zip_code) { create :vita_partner_zip_code, zip_code: "20121", vita_partner: vita_partner }
 

--- a/spec/features/web_intake/new_single_filer_spec.rb
+++ b/spec/features/web_intake/new_single_filer_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Web Intake Single Filer", active_job: true do
+RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot, active_job: true do
   let!(:vita_partner) { create :vita_partner, name: "Virginia Partner" }
   let!(:vita_partner_zip_code) { create :vita_partner_zip_code, zip_code: "20121", vita_partner: vita_partner }
 

--- a/spec/features/web_intake/requested_documents_token_spec.rb
+++ b/spec/features/web_intake/requested_documents_token_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Client uploads a requested document" do
+RSpec.feature "Client uploads a requested document", :flow_explorer_screenshot do
   scenario "client goes to the follow up documents token link, it redirects to login" do
     visit "/documents/add/1234ABCDEF"
 

--- a/spec/features/web_intake/returning_filer_spec.rb
+++ b/spec/features/web_intake/returning_filer_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Web Intake Single Filer" do
+RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot do
   before do
     create(
       :intake,

--- a/spec/features/web_intake/routing_spec.rb
+++ b/spec/features/web_intake/routing_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-feature "Intake Routing Spec" do
+feature "Intake Routing Spec", :flow_explorer_screenshot do
   let!(:expected_source_param_vita_partner) { create :vita_partner, name: "Cobra Academy" }
   let!(:expected_zip_code_vita_partner) { create :vita_partner, name: "Diagon Alley" }
   let!(:expected_state_vita_partner) { create :vita_partner, name: "Hogwarts", capacity_limit: 10 }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -107,7 +107,7 @@ RSpec.configure do |config|
     CapybaraWalkthroughScreenshots.hook!(config)
   end
 
-  if ENV['FLOW_EXPLORER_SCREENSHOTS'] == 'true'
+  if config.filter.rules[:flow_explorer_screenshot]
     FlowExplorerScreenshots.hook!(config)
   end
 end
@@ -121,7 +121,7 @@ end
 
 RSpec.configure do |config|
   config.before(type: :feature) do |example|
-    if ENV['FLOW_EXPLORER_SCREENSHOTS'] == 'true'
+    if config.filter.rules[:flow_explorer_screenshot]
       example.metadata[:js] = true
       Capybara.current_driver = Capybara.javascript_driver
       Capybara.page.current_window.resize_to(2000, 4000)


### PR DESCRIPTION
make some changes to try to make the flow explorer testrun more reliable

* disable mixpanel in test
* tag specific tests that should be run, not just everything in /ctc + /web_intake