### PR TITLE
CTC intake: /ip-pin and /ip-pin-entry pages

### DIFF
--- a/app/controllers/ctc/questions/ip_pin_entry_controller.rb
+++ b/app/controllers/ctc/questions/ip_pin_entry_controller.rb
@@ -1,12 +1,13 @@
 module Ctc
   module Questions
-    class IpPinController < QuestionsController
+    class IpPinEntryController < QuestionsController
       include AuthenticatedCtcClientConcern
+      include AnonymousIntakeConcern
 
       layout "intake"
 
       def form_params
-        params.fetch(form_name, {}).permit(*form_class.attribute_names + [{ dependents_attributes: [:id, :has_ip_pin] }])
+        params.fetch(form_name, {}).permit(*form_class.attribute_names + [{ dependents_attributes: [:id, :ip_pin] }])
       end
 
       def illustration_path

--- a/app/forms/ctc/ip_pin_entry_form.rb
+++ b/app/forms/ctc/ip_pin_entry_form.rb
@@ -1,0 +1,33 @@
+module Ctc
+  class IpPinEntryForm < QuestionsForm
+    set_attributes_for :intake, :primary_ip_pin, :spouse_ip_pin
+
+    attr_accessor :dependents_attributes
+    
+    validates :primary_ip_pin, presence: true, ip_pin: true, if: -> { @intake.has_primary_ip_pin_yes? }
+    validates :spouse_ip_pin, presence: true, ip_pin: true, if: -> { @intake.has_spouse_ip_pin_yes? }
+
+    def self.from_intake(intake)
+      new(intake, existing_attributes(intake, Attributes.new(attribute_names).to_sym))
+    end
+
+    def self.existing_attributes(model, attribute_keys)
+      HashWithIndifferentAccess[attribute_keys.map { |k| [k, model.send(k)] }]
+    end
+
+    def dependents
+      @intake.assign_attributes(dependents_attributes: dependents_attributes.to_h)
+      @intake.dependents.select { |dep| dep.has_ip_pin_yes? }
+    end
+
+    def valid?
+      form_valid = super
+      dependents_valid = dependents.map { |d| d.valid?(:ip_pin_entry_form) }
+      form_valid && !dependents_valid.include?(false)
+    end
+
+    def save
+      @intake.update!(attributes_for(:intake).merge(dependents_attributes: dependents_attributes.to_h))
+    end
+  end
+end

--- a/app/forms/ctc/ip_pin_form.rb
+++ b/app/forms/ctc/ip_pin_form.rb
@@ -1,0 +1,30 @@
+module Ctc
+  class IpPinForm < QuestionsForm
+    set_attributes_for :intake, :has_primary_ip_pin, :has_spouse_ip_pin
+    set_attributes_for :confirmation, :no_ip_pins
+
+    attr_accessor :dependents_attributes
+    validate :at_least_one_selected
+
+    def dependents
+      @intake.dependents
+    end
+
+    def save
+      attributes = { has_primary_ip_pin: has_primary_ip_pin }
+      attributes.merge!(has_spouse_ip_pin: has_spouse_ip_pin) if has_spouse_ip_pin.present?
+      attributes.merge!(dependents_attributes: dependents_attributes) if dependents_attributes.present?
+      @intake.update(attributes)
+    end
+
+    private
+
+    def at_least_one_selected
+      chose_one = has_primary_ip_pin == "yes" ||
+        has_spouse_ip_pin == "yes" ||
+        dependents_attributes.values.any? { |attributes| attributes["has_ip_pin"] == "yes" } ||
+        no_ip_pins == "yes"
+      errors.add(:no_ip_pins, I18n.t("views.ctc.questions.ip_pin.error")) unless chose_one
+    end
+  end
+end

--- a/app/forms/hub/create_ctc_client_form.rb
+++ b/app/forms/hub/create_ctc_client_form.rb
@@ -105,8 +105,8 @@ module Hub
     validates :spouse_ssn, social_security_number: true, if: -> { spouse_tin_type == "ssn" && filing_status == "married_filing_jointly"}
     validates :spouse_ssn, individual_taxpayer_identification_number: true, if: -> { spouse_tin_type == "itin" && filing_status == "married_filing_jointly"}
 
-    validates :primary_ip_pin, format: { with: /\d{6}/, message: "Must be a 6 digit number."}, if: :primary_ip_pin
-    validates :spouse_ip_pin, format: { with: /\d{6}/, message: "Must be a 6 digit number."}, if: :spouse_ip_pin
+    validates :primary_ip_pin, ip_pin: true
+    validates :spouse_ip_pin, ip_pin: true
 
     validate :at_least_one_photo_id_type_selected
     validate :at_least_one_taxpayer_id_type_selected

--- a/app/forms/hub/update_ctc_client_form.rb
+++ b/app/forms/hub/update_ctc_client_form.rb
@@ -85,8 +85,8 @@ module Hub
       validates :spouse_ssn, social_security_number: true
     end
 
-    validates :primary_ip_pin, format: { with: /\d{6}/, message: "Must be a 6 digit number."}, if: :primary_ip_pin
-    validates :spouse_ip_pin, format: { with: /\d{6}/, message: "Must be a 6 digit number."}, if: :spouse_ip_pin
+    validates :primary_ip_pin, ip_pin: true
+    validates :spouse_ip_pin, ip_pin: true
 
     validate :at_least_one_photo_id_type_selected
     validate :at_least_one_taxpayer_id_type_selected

--- a/app/lib/ctc_question_navigation.rb
+++ b/app/lib/ctc_question_navigation.rb
@@ -50,6 +50,10 @@ class CtcQuestionNavigation
     Ctc::Questions::ConfirmBankAccountController,
     Ctc::Questions::MailingAddressController,
     Ctc::Questions::ConfirmMailingAddressController,
+
+    # Review
     Ctc::Questions::IpPinController,
+    Ctc::Questions::IpPinEntryController,
+    Ctc::Questions::PlaceholderQuestionController
   ].freeze
 end

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -93,6 +93,8 @@
 #  had_tips                                             :integer          default(0), not null
 #  had_unemployment_income                              :integer          default(0), not null
 #  had_wages                                            :integer          default(0), not null
+#  has_primary_ip_pin                                   :integer          default(0), not null
+#  has_spouse_ip_pin                                    :integer          default(0), not null
 #  income_over_limit                                    :integer          default(0), not null
 #  interview_timing_preference                          :string
 #  issued_identity_pin                                  :integer          default(0), not null

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -93,6 +93,8 @@
 #  had_tips                                             :integer          default(0), not null
 #  had_unemployment_income                              :integer          default(0), not null
 #  had_wages                                            :integer          default(0), not null
+#  has_primary_ip_pin                                   :integer          default("unfilled"), not null
+#  has_spouse_ip_pin                                    :integer          default("unfilled"), not null
 #  income_over_limit                                    :integer          default(0), not null
 #  interview_timing_preference                          :string
 #  issued_identity_pin                                  :integer          default(0), not null
@@ -249,6 +251,8 @@ class Intake::CtcIntake < Intake
   enum spouse_veteran: { unfilled: 0, yes: 1, no: 2 }, _prefix: :spouse_veteran
   enum cannot_claim_me_as_a_dependent: { unfilled: 0, yes: 1, no: 2 }, _prefix: :cannot_claim_me_as_a_dependent
   enum primary_member_of_the_armed_forces: { unfilled: 0, yes: 1, no: 2 }, _prefix: :primary_member_of_the_armed_forces
+  enum has_primary_ip_pin: { unfilled: 0, yes: 1, no: 2 }, _prefix: :has_primary_ip_pin
+  enum has_spouse_ip_pin: { unfilled: 0, yes: 1, no: 2 }, _prefix: :has_spouse_ip_pin
 
   has_one :bank_account, inverse_of: :intake, foreign_key: :intake_id, dependent: :destroy
   accepts_nested_attributes_for :bank_account

--- a/app/models/intake/gyr_intake.rb
+++ b/app/models/intake/gyr_intake.rb
@@ -93,6 +93,8 @@
 #  had_tips                                             :integer          default("unfilled"), not null
 #  had_unemployment_income                              :integer          default("unfilled"), not null
 #  had_wages                                            :integer          default("unfilled"), not null
+#  has_primary_ip_pin                                   :integer          default(0), not null
+#  has_spouse_ip_pin                                    :integer          default(0), not null
 #  income_over_limit                                    :integer          default("unfilled"), not null
 #  interview_timing_preference                          :string
 #  issued_identity_pin                                  :integer          default("unfilled"), not null

--- a/app/validators/ip_pin_validator.rb
+++ b/app/validators/ip_pin_validator.rb
@@ -1,0 +1,9 @@
+class IpPinValidator < ActiveModel::EachValidator
+  def validate_each(record, attr_name, value)
+    return unless value.present?
+
+    unless /\A\d{6}\z/.match?(value.to_s)
+      record.errors.add(attr_name, I18n.t("validators.ip_pin"))
+    end
+  end
+end

--- a/app/views/ctc/questions/ip_pin/edit.html.erb
+++ b/app/views/ctc/questions/ip_pin/edit.html.erb
@@ -1,0 +1,27 @@
+<% @main_question = t("views.ctc.questions.ip_pin.title") %>
+
+<% content_for :page_title, @main_question %>
+
+<% content_for :form_card do %>
+  <h1 class="h2"><%= @main_question %></h1>
+
+  <%= render('components/molecules/reveal', title: t("views.ctc.questions.ip_pin.reveal_label")) do %>
+    <%= t("views.ctc.questions.ip_pin_explanation_html") %>
+  <% end %>
+
+  <p class="spacing-below-15"><%= t("views.ctc.questions.ip_pin.help_text") %></p>
+
+  <%= form_with model: @form, url: current_path, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
+    <div class="form-card__stacked-checkboxes spacing-above-0 spacing-below-15">
+      <%= f.cfa_checkbox(:has_primary_ip_pin, current_intake.primary_full_name, options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <% if current_intake.client.tax_returns.last.filing_status_married_filing_jointly? %>
+        <%= f.cfa_checkbox(:has_spouse_ip_pin, current_intake.spouse_full_name, options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <% end %>
+      <%= f.fields_for :dependents do |ff| %>
+        <%= ff.cfa_checkbox(:has_ip_pin, ff.object.full_name, options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <% end %>
+      <%= f.cfa_checkbox(:no_ip_pins, t("general.none_of_the_above"), options: { id: "none__checkbox", checked_value: "yes", unchecked_value: "no" }) %>
+    </div>
+    <%= f.submit t("general.continue"), class: "button button--primary button--wide text--centered spacing-above-60" %>
+  <% end %>
+<% end %>

--- a/app/views/ctc/questions/ip_pin_entry/edit.html.erb
+++ b/app/views/ctc/questions/ip_pin_entry/edit.html.erb
@@ -1,0 +1,21 @@
+<% @main_question = t("views.ctc.questions.ip_pin_entry.title") %>
+
+<% content_for :page_title, @main_question %>
+
+<% content_for :form_card do %>
+  <h1 class="h2"><%= @main_question %></h1>
+
+  <p class="spacing-below-15"><%= t("views.ctc.questions.ip_pin_explanation_html") %></p>
+
+  <%= form_with model: @form, url: current_path, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
+    <div class="form-card__stacked-checkboxes spacing-above-0 spacing-below-15">
+      <%= f.cfa_input_field(:primary_ip_pin, t("views.ctc.questions.ip_pin_entry.label", name: current_intake.primary_full_name)) if current_intake.has_primary_ip_pin_yes? %>
+      <%= f.cfa_input_field(:spouse_ip_pin, t("views.ctc.questions.ip_pin_entry.label", name: current_intake.spouse_full_name)) if current_intake.has_spouse_ip_pin_yes? %>
+      <%= f.fields_for :dependents do |ff| %>
+        <%= ff.cfa_input_field(:ip_pin, t("views.ctc.questions.ip_pin_entry.label", name: ff.object.full_name)) %>
+      <% end %>
+    </div>
+
+    <%= f.submit t("general.continue"), class: "button button--primary button--wide text--centered spacing-above-60" %>
+  <% end %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1581,6 +1581,15 @@ en:
           primary_member_of_the_armed_forces: "I was a member of the United States Armed Forces for any time in 2020"
           reveal_label: "Why are you asking this?"
           reveal_content: "Being a member of the Armed Forces will help us better calculate your Recovery Rebate Credit"
+        ip_pin_explanation_html: If you are a confirmed victim of identity theft and the IRS has resolved your tax account issues, the IRS will mail you a CP01A Notice with your IP PIN, a 6 digit number assigned to certain eligible tax filers. <a href="https://www.irs.gov/identity-theft-fraud-scams/retrieve-your-ip-pin" rel="noopener nofollow" target="_blank">You can retrieve your IP PIN through this IRS page.</a>
+        ip_pin:
+          title: Has anyone on your return been issued an IP PIN because of identity theft?
+          reveal_label: What is an IP PIN?
+          help_text: Having an IP PIN is rare. If you are unfamiliar with what this is, it’s likely that you have not been issued an IP PIN. Select ‘None of the above’ to continue.
+          error: Please pick a person or ‘None of the above’.
+        ip_pin_entry:
+          title: Please enter the IP PIN below.
+          label: "%{name}'s IP PIN"
     consent_pages:
       consent_to_use:
         title: Consent to Use

--- a/db/migrate/20210720203857_add_has_primary_and_spouse_ip_pin_to_intakes.rb
+++ b/db/migrate/20210720203857_add_has_primary_and_spouse_ip_pin_to_intakes.rb
@@ -1,0 +1,6 @@
+class AddHasPrimaryAndSpouseIpPinToIntakes < ActiveRecord::Migration[6.0]
+  def change
+    add_column :intakes, :has_primary_ip_pin, :integer, default: 0, null: false
+    add_column :intakes, :has_spouse_ip_pin, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20210720203918_add_has_ip_pin_to_dependents.rb
+++ b/db/migrate/20210720203918_add_has_ip_pin_to_dependents.rb
@@ -1,0 +1,5 @@
+class AddHasIpPinToDependents < ActiveRecord::Migration[6.0]
+  def change
+    add_column :dependents, :has_ip_pin, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_19_174730) do
+ActiveRecord::Schema.define(version: 2021_07_20_203918) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -242,6 +242,7 @@ ActiveRecord::Schema.define(version: 2021_07_19_174730) do
     t.string "encrypted_ssn"
     t.string "encrypted_ssn_iv"
     t.string "first_name"
+    t.integer "has_ip_pin", default: 0, null: false
     t.bigint "intake_id", null: false
     t.string "last_name"
     t.string "middle_initial"
@@ -498,6 +499,8 @@ ActiveRecord::Schema.define(version: 2021_07_19_174730) do
     t.integer "had_tips", default: 0, null: false
     t.integer "had_unemployment_income", default: 0, null: false
     t.integer "had_wages", default: 0, null: false
+    t.integer "has_primary_ip_pin", default: 0, null: false
+    t.integer "has_spouse_ip_pin", default: 0, null: false
     t.integer "income_over_limit", default: 0, null: false
     t.string "interview_timing_preference"
     t.integer "issued_identity_pin", default: 0, null: false

--- a/spec/controllers/ctc/questions/ip_pin_controller_spec.rb
+++ b/spec/controllers/ctc/questions/ip_pin_controller_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+describe Ctc::Questions::IpPinController do
+  let(:intake) { create :ctc_intake }
+  let(:dependent) { create :dependent, intake: intake }
+
+  before do
+    sign_in intake.client
+  end
+
+  describe "#edit" do
+    it "renders edit template and initializes form" do
+      get :edit, params: {}
+
+      expect(response).to render_template :edit
+      expect(assigns(:form)).to be_an_instance_of Ctc::IpPinForm
+      expect(assigns(:form).intake).to be_an_instance_of Intake::CtcIntake
+    end
+  end
+
+  describe "#update" do
+    let(:params) do
+      {
+        ctc_ip_pin_form: {
+          has_primary_ip_pin: "yes",
+          has_spouse_ip_pin: "yes",
+          dependents_attributes: {
+            "0" => {
+              id: dependent.id,
+              has_ip_pin: "yes",
+            }
+          }
+        }
+      }
+    end
+
+    context "when submitting the form" do
+      it "updates the intake and dependents" do
+        post :update, params: params
+
+        expect(intake.reload).to be_has_primary_ip_pin_yes
+        expect(intake.reload).to be_has_spouse_ip_pin_yes
+        expect(dependent.reload).to be_has_ip_pin_yes
+      end
+    end
+  end
+end

--- a/spec/controllers/ctc/questions/ip_pin_entry_controller_spec.rb
+++ b/spec/controllers/ctc/questions/ip_pin_entry_controller_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+describe Ctc::Questions::IpPinEntryController do
+  let(:intake) { create :ctc_intake }
+  let(:dependent) { create :dependent, intake: intake }
+
+  before do
+    sign_in intake.client
+  end
+
+  describe "#edit" do
+    it "renders edit template and initializes form" do
+      get :edit, params: {}
+
+      expect(response).to render_template :edit
+      expect(assigns(:form)).to be_an_instance_of Ctc::IpPinEntryForm
+      expect(assigns(:form).intake).to be_an_instance_of Intake::CtcIntake
+    end
+  end
+
+  describe "#update" do
+    let(:params) do
+      {
+        ctc_ip_pin_entry_form: {
+          primary_ip_pin: "123456",
+          spouse_ip_pin: "123457",
+          dependents_attributes: {
+            "0" => {
+              id: dependent.id,
+              ip_pin: "123458",
+            }
+          }
+        }
+      }
+    end
+
+    context "when submitting the form" do
+      it "updates the intake and dependents" do
+        post :update, params: params
+
+        intake.reload
+        expect(intake.primary_ip_pin).to eq('123456')
+        expect(intake.spouse_ip_pin).to eq('123457')
+        expect(dependent.reload.ip_pin).to eq('123458')
+      end
+    end
+  end
+end

--- a/spec/factories/dependents.rb
+++ b/spec/factories/dependents.rb
@@ -10,6 +10,7 @@
 #  encrypted_ssn           :string
 #  encrypted_ssn_iv        :string
 #  first_name              :string
+#  has_ip_pin              :integer          default("unfilled"), not null
 #  last_name               :string
 #  middle_initial          :string
 #  months_in_home          :integer

--- a/spec/factories/intakes.rb
+++ b/spec/factories/intakes.rb
@@ -93,6 +93,8 @@
 #  had_tips                                             :integer          default(0), not null
 #  had_unemployment_income                              :integer          default(0), not null
 #  had_wages                                            :integer          default(0), not null
+#  has_primary_ip_pin                                   :integer          default(0), not null
+#  has_spouse_ip_pin                                    :integer          default(0), not null
 #  income_over_limit                                    :integer          default(0), not null
 #  interview_timing_preference                          :string
 #  issued_identity_pin                                  :integer          default(0), not null

--- a/spec/features/ctc/complete_intake_spec.rb
+++ b/spec/features/ctc/complete_intake_spec.rb
@@ -221,5 +221,23 @@ RSpec.feature "CTC Intake", :js, :flow_explorer_screenshot, active_job: true do
     expect(page).to have_selector("div", text: "26 William Street")
     expect(page).to have_selector("div", text: "Apt 1234")
     expect(page).to have_selector("div", text: "Bel Air, CA 90001")
+    click_on "Continue"
+
+    # =========== REVIEW ===========
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.ip_pin.title'))
+    check "Gary Mango"
+    check "Jessie Pepper"
+    click_on "Continue"
+
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.ip_pin_entry.title'))
+    fill_in I18n.t('views.ctc.questions.ip_pin_entry.label', name: "Gary Mango"), with: "123456"
+    fill_in I18n.t('views.ctc.questions.ip_pin_entry.label', name: "Jessie Pepper"), with: "123458"
+    click_on "Continue"
+
+    expect(page).to have_selector("h1", text: 'Placeholder -- Coming soon')
+
+    intake.reload
+    expect(intake.primary_ip_pin).to eq "123456"
+    expect(intake.dependents.last.ip_pin).to eq "123458"
   end
 end

--- a/spec/forms/ctc/ip_pin_entry_form_spec.rb
+++ b/spec/forms/ctc/ip_pin_entry_form_spec.rb
@@ -1,0 +1,93 @@
+require "rails_helper"
+
+describe Ctc::IpPinEntryForm do
+  let(:intake) { create :ctc_intake, has_primary_ip_pin: "yes", has_spouse_ip_pin: "yes" }
+  let(:dependent) { create :dependent, intake: intake, has_ip_pin: "yes" }
+
+  let(:params) do
+    {
+      primary_ip_pin: " 123456",
+      spouse_ip_pin: "123457",
+      dependents_attributes: {
+        "0" => {
+          id: dependent.id,
+          ip_pin: "123458"
+        }
+      }
+    }
+  end
+
+  describe "#dependents" do
+    let(:subject) { described_class.new(intake, params) }
+    let!(:dependent) { create(:dependent, intake: intake, has_ip_pin: has_ip_pin) }
+
+    context "with a dependent who has an IP PIN" do
+      let(:has_ip_pin) { "yes" }
+
+      it "returns an array with that dependent" do
+        expect(subject.dependents).to match_array([dependent])
+      end
+    end
+
+    context "with a dependent who has no IP PIN" do
+      let(:has_ip_pin) { "no" }
+
+      it "returns an empty array" do
+        expect(subject.dependents).to match_array([])
+      end
+    end
+  end
+
+  describe "validates" do
+    context "if pins are in the wrong format" do
+      before do
+        params[:primary_ip_pin] = "abc"
+        params[:spouse_ip_pin] = "123456789"
+        params[:dependents_attributes]["0"][:ip_pin] = "-53.4"
+      end
+
+      it "shows errors on each empty field" do
+        form = described_class.new(intake, params)
+        expect(form).not_to be_valid
+        expect(form.errors.keys).to match_array([:primary_ip_pin, :spouse_ip_pin])
+        expect(form.dependents.first.errors.keys).to match_array([:ip_pin])
+      end
+
+      it "displays the errored values on dependents" do
+        form = described_class.new(intake, params)
+        expect(form).not_to be_valid
+        expect(form.dependents.first.ip_pin).to eq("-53.4")
+      end
+    end
+
+    context "if pins are not entered" do
+      before do
+        params[:primary_ip_pin] = ""
+        params[:spouse_ip_pin] = ""
+        params[:dependents_attributes]["0"][:ip_pin] = ""
+      end
+
+      it "shows errors on each empty field" do
+        form = described_class.new(intake, params)
+        expect(form).not_to be_valid
+        expect(form.errors.keys).to match_array([:primary_ip_pin, :spouse_ip_pin])
+        expect(form.dependents.first.errors.keys).to match_array([:ip_pin])
+      end
+    end
+  end
+
+  context "save" do
+    let(:subject) { described_class.new(intake, params) }
+
+    before { subject.valid? }
+
+    it "persists ip pins on the intake and dependents" do
+      subject.save
+
+      intake.reload
+      expect(intake.primary_ip_pin).to eq('123456')
+      expect(intake.spouse_ip_pin).to eq('123457')
+      expect(dependent.reload.ip_pin).to eq('123458')
+    end
+  end
+end

--- a/spec/forms/ctc/ip_pin_form_spec.rb
+++ b/spec/forms/ctc/ip_pin_form_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+describe Ctc::IpPinForm do
+  let(:intake) { create :ctc_intake }
+  let(:dependent) { create :dependent, intake: intake }
+
+  let(:params) do
+    {
+      has_primary_ip_pin: "yes",
+      has_spouse_ip_pin: "yes",
+      dependents_attributes: {
+        "0" => {
+          id: dependent.id,
+          has_ip_pin: "yes"
+        }
+      }
+    }
+  end
+
+  describe "validates" do
+    context "if no options are selected" do
+      before do
+        params[:has_primary_ip_pin] = "unfilled"
+        params[:has_spouse_ip_pin] = "unfilled"
+        params[:dependents_attributes]["0"][:has_ip_pin] = "unfilled"
+      end
+
+      it "shows error on ‘None of the above’ option" do
+        form = described_class.new(intake, params)
+        expect(form).not_to be_valid
+        expect(form.errors.keys).to match_array([:no_ip_pins])
+      end
+    end
+  end
+
+  context "save" do
+    it "persists booleans on the intake and dependents" do
+      described_class.new(intake, params).save
+
+      expect(intake.reload).to be_has_primary_ip_pin_yes
+      expect(intake.reload).to be_has_spouse_ip_pin_yes
+      expect(dependent.reload).to be_has_ip_pin_yes
+    end
+
+    context "with no spouse or dependents" do
+      before do
+        params.delete(:has_spouse_ip_pin)
+        params.delete(:dependents_attributes)
+      end
+
+      it "can accept and save just the primary flag without incident" do
+        described_class.new(intake, params).save
+
+        expect(intake.reload).to be_has_primary_ip_pin_yes
+      end
+    end
+  end
+end

--- a/spec/forms/hub/create_ctc_client_form_spec.rb
+++ b/spec/forms/hub/create_ctc_client_form_spec.rb
@@ -573,7 +573,7 @@ RSpec.describe Hub::CreateCtcClientForm do
         it "can be blank but must be a 6 digit number" do
           obj = described_class.new(params)
           expect(obj.valid?).to eq false
-          expect(obj.errors[:primary_ip_pin]).to include "Must be a 6 digit number."
+          expect(obj.errors[:primary_ip_pin]).to include I18n.t('validators.ip_pin')
           expect(obj.errors[:spouse_ip_pin]).to eq []
         end
 

--- a/spec/models/dependent_spec.rb
+++ b/spec/models/dependent_spec.rb
@@ -10,6 +10,7 @@
 #  encrypted_ssn           :string
 #  encrypted_ssn_iv        :string
 #  first_name              :string
+#  has_ip_pin              :integer          default("unfilled"), not null
 #  last_name               :string
 #  middle_initial          :string
 #  months_in_home          :integer
@@ -31,8 +32,25 @@
 require "rails_helper"
 
 describe Dependent do
-  describe "validations" do
+  it "strips leading or trailing spaces from any free-text attributes" do
+    dependent = Dependent.new(
+      first_name: "  doug",
+      last_name: "  douglasson",
+      middle_initial: "   XYZ ",
+      ssn: "000000000 ",
+      ip_pin: "000111 "
+    )
+    dependent.valid?
+    expect(dependent.attributes).to match(a_hash_including({
+      "first_name" => "doug",
+      "last_name" => "douglasson",
+      "middle_initial" => "XYZ",
+    }))
+    expect(dependent.ip_pin).to eq("000111")
+    expect(dependent.ssn).to eq("000000000")
+  end
 
+  describe "validations" do
     it "requires essential fields" do
       dependent = Dependent.new
 

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -93,6 +93,8 @@
 #  had_tips                                             :integer          default(0), not null
 #  had_unemployment_income                              :integer          default(0), not null
 #  had_wages                                            :integer          default(0), not null
+#  has_primary_ip_pin                                   :integer          default(0), not null
+#  has_spouse_ip_pin                                    :integer          default(0), not null
 #  income_over_limit                                    :integer          default(0), not null
 #  interview_timing_preference                          :string
 #  issued_identity_pin                                  :integer          default(0), not null


### PR DESCRIPTION
Adds new booleans for whether the client said they have any ip pins:
* Intake#has_primary_ip_pin
* Intake#has_spouse_ip_pin
* Dependent#has_ip_pin

Creates an IpPinValidator for all the places that we validate this
beloved 6-digit number

[#178803444]

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>