### PR TITLE
Capture source and save on intake

### DIFF
--- a/app/controllers/concerns/first_question_concern.rb
+++ b/app/controllers/concerns/first_question_concern.rb
@@ -5,7 +5,7 @@ module FirstQuestionConcern
   end
 
   def current_intake
-    Intake::CtcIntake.new(visitor_id: cookies[:visitor_id])
+    Intake::CtcIntake.new(visitor_id: cookies[:visitor_id], source: session[:source])
   end
 
   def set_intake_to_session

--- a/app/forms/ctc/consent_form.rb
+++ b/app/forms/ctc/consent_form.rb
@@ -35,6 +35,7 @@ module Ctc
           primary_last_four_ssn: primary_last_four_ssn,
           primary_birth_date: primary_birth_date,
           visitor_id: @intake.visitor_id,
+          source: @intake.source,
           type: @intake.type
       )
       client = Client.create!(intake_attributes: intake_attributes, tax_returns_attributes: [tax_return_attributes])

--- a/app/lib/ctc_question_navigation.rb
+++ b/app/lib/ctc_question_navigation.rb
@@ -5,7 +5,7 @@ class CtcQuestionNavigation
     # Basic info
     Ctc::Questions::OverviewController,
     Ctc::Questions::IncomeController,
-    Ctc::Questions::ConsentController,
+    Ctc::Questions::ConsentController,            # At this point we create the intake, client, and tax return
     Ctc::Questions::ContactPreferenceController,
     Ctc::Questions::CellPhoneNumberController,
     Ctc::Questions::EmailAddressController,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -304,6 +304,9 @@ Rails.application.routes.draw do
           root "portal#home"
           login_routes
         end
+
+        # Any other top level slash just goes to home as a source parameter
+        get "/:source" => "ctc_pages#home", constraints: { source: /[0-9a-zA-Z_-]{1,100}/ }
       end
     end
     get '/.well-known/pki-validation/:id', to: 'public_pages#pki_validation'

--- a/spec/controllers/ctc/questions/consent_controller_spec.rb
+++ b/spec/controllers/ctc/questions/consent_controller_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+describe Ctc::Questions::ConsentController do
+
+  before do
+    cookies[:visitor_id] = "visitor-id"
+    session[:source] = "some-source"
+    allow(MixpanelService).to receive(:send_event)
+  end
+
+  describe "#edit" do
+    it "renders edit template and initializes form" do
+      get :edit, params: {}
+      expect(response).to render_template :edit
+      expect(assigns(:form)).to be_an_instance_of Ctc::ConsentForm
+      expect(assigns(:form).intake).to be_an_instance_of Intake::CtcIntake
+    end
+
+    it "initializes the current intake with a visitor id and source" do
+      expect {
+        get :edit, params: {}
+      }.to change(Intake, :count).by(1)
+      intake = Intake.last
+      expect(intake.visitor_id).to eq("visitor-id")
+      expect(intake.source).to eq("some-source")
+    end
+  end
+end

--- a/spec/forms/ctc/consent_form_spec.rb
+++ b/spec/forms/ctc/consent_form_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe Ctc::ConsentForm do
-  let(:intake) { Intake::CtcIntake.new(visitor_id: "something") }
+  let(:intake) { Intake::CtcIntake.new(visitor_id: "something", source: "some-source") }
 
   context "validations" do
     let(:params) {
@@ -175,6 +175,8 @@ describe Ctc::ConsentForm do
       expect(intake.tax_returns.first.year).to eq 2020
       expect(intake.tax_returns.first.is_ctc).to eq true
       expect(intake.tin_type).to eq "itin"
+      expect(intake.visitor_id).to eq "something"
+      expect(intake.source).to eq "some-source"
       expect(intake.type).to eq "Intake::CtcIntake"
       expect(form.intake).to eq intake # resets intake to be the created and persisted intake
     end


### PR DESCRIPTION
Captures anything after the slash in CTC domain as `:source` param. `ApplicationController` already has a `set_source` method to capture this param and set it in the session. `FirstQuestionConcern` and `ConsentForm` now extract that value from session and save it on the current intake. Based on my understanding, existing Mixpanel behavior will include the `intake_source` attribute on appropriate Mixpanel events.

Feel free to reach out for real-time discussion if needed/desired.

[#178918905]