### PR TITLE
Remove relationships that were never valid

### DIFF
--- a/app/helpers/relationships_helper.rb
+++ b/app/helpers/relationships_helper.rb
@@ -1,28 +1,23 @@
 module RelationshipsHelper
   # provides a list of relationship options for dependents, and pushes the client's provided free-form answer
   # to the list if necessary.
-  def dependent_relationship_options(current_relationship: nil, is_ctc: false)
-    allowed_types = is_ctc ? [:ctc] : [:default]
-    relationships_hash = Hash[sorted_relationships(types: allowed_types)]
+  def dependent_relationship_options(current_relationship: nil)
+    relationships_hash = Hash[sorted_relationships]
     options = relationships_hash.map { |k, v| [v, k] }
     if current_relationship.present?
       key = relationships_hash[current_relationship.to_sym]
-      options.push(["#{I18n.t("general.dependent_relationships.other")}: #{current_relationship}", current_relationship]) unless key.present?
+      options.push(["#{I18n.t("general.dependent_relationships.11_other")}: #{current_relationship}", current_relationship]) unless key.present?
     end
     options
   end
 
   def translated_relationship(relationship)
-    Hash[sorted_relationships(types: [:ctc, :default])][relationship&.to_sym] || relationship
+    Hash[sorted_relationships][relationship&.to_sym] || relationship
   end
 
   private
 
-  def sorted_relationships(types:)
-    yaml_relationships = {}
-    yaml_relationships.merge!(I18n.t("general.dependent_relationships")) if types.include?(:default)
-    yaml_relationships.merge!(I18n.t("general.ctc_dependent_relationships")) if types.include?(:ctc)
-
-    yaml_relationships.map { |k, v| [k.to_s.sub(/^\d+_/, '').to_sym, v] }
+  def sorted_relationships
+    I18n.t("general.dependent_relationships").map { |k, v| [k.to_s.sub(/^\d+_/, '').to_sym, v] }
   end
 end

--- a/app/views/ctc/questions/dependents/had_dependents/edit.html.erb
+++ b/app/views/ctc/questions/dependents/had_dependents/edit.html.erb
@@ -5,7 +5,7 @@
 
   <%= render('components/molecules/reveal', title: t("views.ctc.questions.dependents.had_dependents.what_relationships_reveal")) do %>
     <ul>
-      <% dependent_relationship_options(is_ctc: true).each do |_k, relationship| %>
+      <% dependent_relationship_options.each do |_k, relationship| %>
         <li><%= translated_relationship(relationship) %></li>
       <% end %>
     </ul>

--- a/app/views/ctc/questions/dependents/info/edit.html.erb
+++ b/app/views/ctc/questions/dependents/info/edit.html.erb
@@ -17,7 +17,7 @@
       <%= f.cfa_select(
           :relationship,
           t("views.ctc.questions.dependents.info.relationship_to_you"),
-          dependent_relationship_options(is_ctc: true),
+          dependent_relationship_options,
           include_blank: true
           ) %>
     </div>

--- a/app/views/shared/_dependent.html.erb
+++ b/app/views/shared/_dependent.html.erb
@@ -15,7 +15,7 @@
     <%= f.cfa_select(
             :relationship,
             "Relationship",
-            dependent_relationship_options(current_relationship: f.object.relationship, is_ctc: is_ctc),
+            dependent_relationship_options(current_relationship: f.object.relationship),
             include_blank: true
     ) %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -799,15 +799,6 @@ en:
       head_of_household: Head of household
       qualifying_widow: Qualifying widow(er)
     dependent_relationships:
-      child: "Child"
-      parent: "Parent"
-      sibling: "Sibling"
-      aunt_uncle: "Aunt/Uncle"
-      niece_nephew: "Niece/Nephew"
-      grandchild: "Grandchild"
-      grandparent: "Grandparent"
-      other: "Other"
-    ctc_dependent_relationships:
       00_daughter: Daughter
       01_son: Son
       02_parent: Parent

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -791,7 +791,7 @@ es:
       grandchild: "Nieta/Nieto"
       grandparent: "Abuela/Abuelo"
       other: "Otro"
-    ctc_dependent_relationships:
+    dependent_relationships:
       00_daughter: Hija
       01_son: Hijo
       02_parent: "Madre/Padre"

--- a/spec/features/ctc/complete_intake_spec.rb
+++ b/spec/features/ctc/complete_intake_spec.rb
@@ -139,7 +139,7 @@ RSpec.feature "CTC Intake", :js, :flow_explorer_screenshot, active_job: true do
     fill_in "ctc_dependents_info_form[birth_date_month]", with: "01"
     fill_in "ctc_dependents_info_form[birth_date_day]", with: "11"
     fill_in "ctc_dependents_info_form[birth_date_year]", with: "1995"
-    select I18n.t('general.ctc_dependent_relationships.00_daughter'), from: I18n.t('views.ctc.questions.dependents.info.relationship_to_you')
+    select I18n.t('general.dependent_relationships.00_daughter'), from: I18n.t('views.ctc.questions.dependents.info.relationship_to_you')
     click_on "Continue"
 
     expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.tin.title', name: 'Jessie'))

--- a/spec/helpers/relationships_helper_spec.rb
+++ b/spec/helpers/relationships_helper_spec.rb
@@ -2,23 +2,8 @@ require "rails_helper"
 
 describe RelationshipsHelper do
   describe '#dependent_relationship_options' do
-    it 'provides the correct default options' do
+    it 'provides the correct options' do
       expect(helper.dependent_relationship_options).to eq(
-        [
-          ["Child", :child],
-          ["Parent", :parent],
-          ["Sibling", :sibling],
-          ["Aunt/Uncle", :aunt_uncle],
-          ["Niece/Nephew", :niece_nephew],
-          ["Grandchild", :grandchild],
-          ["Grandparent", :grandparent],
-          ["Other", :other],
-        ]
-      )
-    end
-
-    it 'provides the correct CTC options' do
-      expect(helper.dependent_relationship_options(is_ctc: true)).to eq(
         [
           ["Daughter", :daughter],
           ["Son", :son],
@@ -46,14 +31,24 @@ describe RelationshipsHelper do
       it "provides the original freeform entry as an option" do
         expect(helper.dependent_relationship_options(current_relationship: "My adopted son")).to eq(
           [
-            ["Child", :child],
+            ["Daughter", :daughter],
+            ["Son", :son],
             ["Parent", :parent],
-            ["Sibling", :sibling],
-            ["Aunt/Uncle", :aunt_uncle],
-            ["Niece/Nephew", :niece_nephew],
             ["Grandchild", :grandchild],
-            ["Grandparent", :grandparent],
+            ["Niece", :niece],
+            ["Nephew", :nephew],
+            ["Foster Child", :foster_child],
+            ["Aunt", :aunt],
+            ["Uncle", :uncle],
+            ["Sister", :sister],
+            ["Brother", :brother],
             ["Other", :other],
+            ["Stepchild", :stepchild],
+            ["Stepbrother", :stepbrother],
+            ["Stepsister", :stepsister],
+            ["Half brother", :half_brother],
+            ["Half sister", :half_sister],
+            ["Grandparent", :grandparent],
             ["Other: My adopted son", "My adopted son"]
           ]
         )


### PR DESCRIPTION
The first list of dependents was only added for CTC stuff, its just that the list was incorrect. When we implemented the new list, we left the old list in there thinking it had been around for a while and needed to stay, but it does not.