### PR TITLE
Generate EfileSubmission.irs_submission_id before validation and validate its format

### DIFF
--- a/spec/controllers/mailgun_webhooks_controller_spec.rb
+++ b/spec/controllers/mailgun_webhooks_controller_spec.rb
@@ -10,8 +10,10 @@ RSpec.describe MailgunWebhooksController do
   end
 
   before do
-    allow(EnvironmentCredentials).to receive(:dig).with(:mailgun, :basic_auth_name).and_return("validuser")
-    allow(EnvironmentCredentials).to receive(:dig).with(:mailgun, :basic_auth_password).and_return("p@sswrd!")
+    @test_environment_credentials.merge!(mailgun: {
+      basic_auth_name: "validuser",
+      basic_auth_password: 'p@sswrd!',
+    })
   end
 
   describe "#create_incoming_email" do

--- a/spec/features/diy/new_diy_client_spec.rb
+++ b/spec/features/diy/new_diy_client_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Web Intake New Client wants to file on their own" do
   let(:fake_taxslayer_link) { "http://example.com/fake-taxslayer" }
 
   before do
-    allow(EnvironmentCredentials).to receive(:dig).with(:tax_slayer_link).and_return fake_taxslayer_link
+    @test_environment_credentials.merge!(tax_slayer_link: fake_taxslayer_link)
   end
 
   scenario "a new client files through TaxSlayer" do

--- a/spec/forms/hub/outbound_call_form_spec.rb
+++ b/spec/forms/hub/outbound_call_form_spec.rb
@@ -41,9 +41,11 @@ describe Hub::OutboundCallForm do
       allow(Twilio::REST::Client).to receive(:new).and_return(twilio_double)
       allow(twilio_double).to receive(:calls).and_return(twilio_calls_double)
       allow(twilio_calls_double).to receive(:create).and_return(twilio_response_double)
-      allow(EnvironmentCredentials).to receive(:dig).with(:twilio, :voice_phone_number).and_return twilio_phone_number
-      allow(EnvironmentCredentials).to receive(:dig).with(:twilio, :account_sid).and_return "abc"
-      allow(EnvironmentCredentials).to receive(:dig).with(:twilio, :auth_token).and_return "123"
+      @test_environment_credentials.merge!(twilio: {
+        voice_phone_number: twilio_phone_number,
+        account_sid: "abc",
+        auth_token: "123",
+      })
       allow(DatadogApi).to receive(:increment)
       allow(DatadogApi).to receive(:gauge)
     end

--- a/spec/lib/submission_builder/documents/adv_ctc_irs1040_spec.rb
+++ b/spec/lib/submission_builder/documents/adv_ctc_irs1040_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 describe SubmissionBuilder::Documents::AdvCtcIrs1040 do
   describe ".build" do
     before do
-      allow(EnvironmentCredentials).to receive(:dig).with(:irs, :efin).and_return "123456"
       dependent = submission.intake.dependents.first
       dependent.update(first_name: "Keeley", birth_date: Date.new(2020, 1, 1), relationship: "daughter", ssn: "123001234")
       dependent2 = submission.intake.dependents.second

--- a/spec/lib/submission_builder/manifest_spec.rb
+++ b/spec/lib/submission_builder/manifest_spec.rb
@@ -2,10 +2,6 @@ require "rails_helper"
 
 describe SubmissionBuilder::Manifest do
   describe ".build" do
-    before do
-      allow(EnvironmentCredentials).to receive(:dig).with(:irs, :efin).and_return "123456"
-    end
-
     let(:submission) { create :efile_submission, :ctc }
     context "when the XML is valid" do
       let(:file_double) { double }

--- a/spec/lib/submission_builder/return1040_spec.rb
+++ b/spec/lib/submission_builder/return1040_spec.rb
@@ -4,9 +4,6 @@ describe SubmissionBuilder::Return1040 do
   let(:submission) { create :efile_submission, :ctc, filing_status: "married_filing_jointly", tax_year: 2020 }
 
   before do
-    allow(EnvironmentCredentials).to receive(:dig).with(:irs, :efin).and_return "123456"
-    allow(EnvironmentCredentials).to receive(:dig).with(:irs, :sin).and_return "11111111"
-
     submission.intake.update(
       primary_first_name: "Hubert Blaine ",
       primary_last_name: "Wolfeschlegelsteinhausenbergerdorff ",

--- a/spec/lib/submission_builder/return_header1040_spec.rb
+++ b/spec/lib/submission_builder/return_header1040_spec.rb
@@ -3,8 +3,6 @@ require "rails_helper"
 describe SubmissionBuilder::ReturnHeader1040 do
   describe ".build" do
     before do
-      allow(EnvironmentCredentials).to receive(:dig).with(:irs, :efin).and_return "123456"
-      allow(EnvironmentCredentials).to receive(:dig).with(:irs, :sin).and_return "11111111"
       submission.intake.update(
         primary_first_name: "Hubert Blaine ",
         primary_last_name: "Wolfeschlegelsteinhausenbergerdorff ",

--- a/spec/lib/submission_bundle_spec.rb
+++ b/spec/lib/submission_bundle_spec.rb
@@ -3,11 +3,6 @@ require "rails_helper"
 describe SubmissionBundle do
   let(:submission) { create :efile_submission, :ctc }
 
-  before do
-    allow(EnvironmentCredentials).to receive(:dig).with(:irs, :efin).and_return "123456"
-    allow(EnvironmentCredentials).to receive(:dig).with(:irs, :sin).and_return "11111111"
-  end
-
   describe "#build" do
     it "stores the submission bundle on the submission" do
       response = described_class.new(submission, documents: ["adv_ctc_irs1040"]).build

--- a/spec/models/efile_submission_spec.rb
+++ b/spec/models/efile_submission_spec.rb
@@ -17,7 +17,6 @@ require "rails_helper"
 describe EfileSubmission do
   before do
     address_service_double = double
-    allow(EnvironmentCredentials).to receive(:dig).with(:irs, :efin).and_return "111111"
     allow_any_instance_of(EfileSubmission).to receive(:generate_irs_address).and_return(address_service_double)
     allow(address_service_double).to receive(:valid?).and_return true
   end
@@ -46,10 +45,10 @@ describe EfileSubmission do
 
       context "dealing with duplicates" do
         before do
-          allow(SecureRandom).to receive(:base36).with(7).and_return "111111"
+          allow(SecureRandom).to receive(:base36).with(7).and_return "1234567"
         end
-        context "after trying 5 times" do
 
+        context "after trying 5 times" do
           it "an error is raised" do
             expect {
               5.times do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -92,8 +92,14 @@ RSpec.configure do |config|
     stub_request(:post, /.*api\.twilio\.com.*/).to_return(status: 200, body: "", headers: {})
     stub_request(:post, "https://api.mixpanel.com/track").to_return(status: 200, body: "", headers: {})
     # Stub required credentials to prevent need for RAILS_MASTER_KEY in test
-    allow(EnvironmentCredentials).to receive(:dig).and_call_original
-    allow(EnvironmentCredentials).to receive(:dig).with(:db_encryption_key).and_return('any-32-character-string-here!!!!')
+    @test_environment_credentials = {
+      db_encryption_key: '12345678901234567890123456789012',
+      irs: {
+        efin: '123456',
+        sin: '11111111'
+      },
+    }
+    allow(Rails.application).to receive(:credentials).and_return(@test_environment_credentials)
     # Stub valid_email2's network-dependent functionality per https://github.com/micke/valid_email2
     allow_any_instance_of(ValidEmail2::Address).to receive(:valid_mx?) { true }
     # Stub DNS implementation to avoid network calls from test suite; valid_email2 uses this

--- a/spec/services/intercom_service_spec.rb
+++ b/spec/services/intercom_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe IntercomService do
 
   before do
     described_class.instance_variable_set(:@intercom, nil)
-    allow(EnvironmentCredentials).to receive(:dig).with(:intercom, :intercom_access_token).and_return("fake_access_token")
+    @test_environment_credentials.merge!(intercom: {intercom_access_token: "fake_access_token"})
     allow(Intercom::Client).to receive(:new).with(token: "fake_access_token").and_return(fake_intercom)
   end
 

--- a/spec/services/replacement_parameters_service_spec.rb
+++ b/spec/services/replacement_parameters_service_spec.rb
@@ -7,7 +7,7 @@ describe ReplacementParametersService do
   subject { ReplacementParametersService.new(body: body, client: client, preparer: user, tax_return: client.tax_returns.first, locale: locale) }
 
   before do
-    allow(EnvironmentCredentials).to receive(:dig).with(:twilio, :voice_phone_number).and_return "+13444444444"
+    @test_environment_credentials.merge!(twilio: { voice_phone_number: "+13444444444" })
   end
 
   context "<<Client.ClientId>>" do

--- a/spec/services/twilio_service_spec.rb
+++ b/spec/services/twilio_service_spec.rb
@@ -212,8 +212,10 @@ describe TwilioService do
 
     before do
       allow(Twilio::REST::Client).to receive(:new).and_return fake_client
-      allow(EnvironmentCredentials).to receive(:dig).with(:twilio, :account_sid).and_return "account_sid"
-      allow(EnvironmentCredentials).to receive(:dig).with(:twilio, :auth_token).and_return "auth_token"
+      @test_environment_credentials.merge!(twilio: {
+        account_sid: "account_sid",
+        auth_token: "auth_token",
+      })
     end
 
     it "uses environment credentials to instantiate a twilio client" do
@@ -228,7 +230,7 @@ describe TwilioService do
     let(:fake_messages_resource) { double }
     let(:fake_message) { double }
     before do
-      allow(EnvironmentCredentials).to receive(:dig).with(:twilio, :messaging_service_sid).and_return "service_sid"
+      @test_environment_credentials.merge!(twilio: { messaging_service_sid: "service_sid" })
       allow(TwilioService).to receive(:client).and_return fake_client
       allow(fake_client).to receive(:messages).and_return fake_messages_resource
       allow(fake_messages_resource).to receive(:create).and_return fake_message


### PR DESCRIPTION
Also change how we mock credentials

Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>