### PR TITLE
Use lambdas for I18n.t messages so they are computed after module load time

### DIFF
--- a/app/forms/ctc/cell_phone_number_form.rb
+++ b/app/forms/ctc/cell_phone_number_form.rb
@@ -4,7 +4,7 @@ module Ctc
     set_attributes_for :confirmation, :sms_phone_number_confirmation, :can_receive_texts
     before_validation :normalize_phone_numbers
 
-    validates :can_receive_texts, acceptance: { accept: 'yes', message: I18n.t("views.ctc.questions.cell_phone_number.must_receive_texts_html", email_link: Rails.application.routes.url_helpers.questions_email_address_path) }
+    validates :can_receive_texts, acceptance: { accept: 'yes', message: -> (_object, _data) { I18n.t("views.ctc.questions.cell_phone_number.must_receive_texts_html", email_link: Rails.application.routes.url_helpers.questions_email_address_path) } }
     validates :sms_phone_number, confirmation: true
     validates :sms_phone_number_confirmation, presence: true
     validates :sms_phone_number, e164_phone: true

--- a/app/forms/ctc/direct_deposit_form.rb
+++ b/app/forms/ctc/direct_deposit_form.rb
@@ -4,7 +4,7 @@ module Ctc
     set_attributes_for :confirmation, :my_bank_account
 
     validates_presence_of :account_type, :bank_name
-    validates :my_bank_account, acceptance: { accept: "yes", message: I18n.t("views.ctc.questions.direct_deposit.my_bank_account.error_message_html", link: Rails.application.routes.url_helpers.questions_refund_payment_path) }
+    validates :my_bank_account, acceptance: { accept: "yes", message: -> (_object, _data) { I18n.t("views.ctc.questions.direct_deposit.my_bank_account.error_message_html", link: Rails.application.routes.url_helpers.questions_refund_payment_path) } }
 
     def save
       @intake.update(bank_account_attributes: attributes_for(:bank_account))

--- a/app/forms/ctc/spouse_info_form.rb
+++ b/app/forms/ctc/spouse_info_form.rb
@@ -17,7 +17,7 @@ module Ctc
     validates :spouse_ssn, confirmation: true, if: -> { spouse_ssn.present? }
     validates :spouse_ssn, social_security_number: true, if: -> { spouse_tin_type == "ssn" && spouse_ssn.present? }
 
-    validates_presence_of :spouse_ssn, message: I18n.t('views.ctc.questions.spouse_info.ssn_required_message'), if: -> { spouse_tin_type != "none" }
+    validates_presence_of :spouse_ssn, message: -> (_object, _data) { I18n.t('views.ctc.questions.spouse_info.ssn_required_message') }, if: -> { spouse_tin_type != "none" }
     validates_presence_of :spouse_ssn_confirmation, if: -> { spouse_ssn.present? }
 
     before_validation do


### PR DESCRIPTION
If we don't do this, the message will be baked into the validation in english,
and for some reason `assets:precompile` also fails in prod because the
URL helper raises NoMethodError.

Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>