### PR TITLE
Add confirm-legal page

### DIFF
--- a/app/controllers/ctc/questions/confirm_legal_controller.rb
+++ b/app/controllers/ctc/questions/confirm_legal_controller.rb
@@ -1,0 +1,19 @@
+module Ctc
+  module Questions
+    class ConfirmLegalController < QuestionsController
+      include AuthenticatedCtcClientConcern
+
+      layout "intake"
+
+      private
+
+      def next_path
+        ctc_portal_root_path
+      end
+
+      def illustration_path
+        "successfully-submitted.svg"
+      end
+    end
+  end
+end

--- a/app/forms/ctc/confirm_legal_form.rb
+++ b/app/forms/ctc/confirm_legal_form.rb
@@ -1,0 +1,14 @@
+module Ctc
+  class ConfirmLegalForm < QuestionsForm
+    set_attributes_for :intake, :consented_to_legal
+
+    validates :consented_to_legal, acceptance: { accept: 'yes', message: I18n.t("views.ctc.questions.confirm_legal.error") }
+
+    def save
+      @intake.update(attributes_for(:intake))
+      unless @intake.tax_returns.last.efile_submissions.any?
+        EfileSubmission.create(tax_return: @intake.tax_returns.last).transition_to(:preparing)
+      end
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -72,7 +72,7 @@ module ApplicationHelper
 
   def submission_status_icon(status)
     case status
-    when "new", "preparing", "intake_in_progress"
+    when "intake_in_progress"
       "icons/in-progress.svg"
     when "failed", "bundle_failure"
       "icons/exclamation.svg"
@@ -80,7 +80,7 @@ module ApplicationHelper
       "icons/rejected.svg"
     when "accepted"
       "icons/accepted.svg"
-    when "transmitted"
+    when "new", "preparing", "transmitted"
       "icons/sending.svg"
     end
   end

--- a/app/lib/ctc_question_navigation.rb
+++ b/app/lib/ctc_question_navigation.rb
@@ -54,6 +54,7 @@ class CtcQuestionNavigation
     # Review
     Ctc::Questions::IpPinController,
     Ctc::Questions::IpPinEntryController,
-    Ctc::Questions::PlaceholderQuestionController
+    Ctc::Questions::PlaceholderQuestionController,
+    Ctc::Questions::ConfirmLegalController,
   ].freeze
 end

--- a/app/models/automated_message/efile_preparing.rb
+++ b/app/models/automated_message/efile_preparing.rb
@@ -1,0 +1,20 @@
+module AutomatedMessage
+  class EfilePreparing
+
+    def self.name
+      'messages.efile.preparing'.freeze
+    end
+
+    def sms_body(*args)
+      I18n.t("messages.efile.preparing.sms", *args)
+    end
+
+    def email_subject(*args)
+      I18n.t("messages.efile.preparing.email.subject", *args)
+    end
+
+    def email_body(*args)
+      I18n.t("messages.efile.preparing.email.body", *args)
+    end
+  end
+end

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -17,6 +17,7 @@
 #  claimed_by_another                                   :integer          default(0), not null
 #  completed_at                                         :datetime
 #  completed_yes_no_questions_at                        :datetime
+#  consented_to_legal                                   :integer          default(0), not null
 #  continued_at_capacity                                :boolean          default(FALSE)
 #  current_step                                         :string
 #  demographic_disability                               :integer          default(0), not null

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -17,6 +17,7 @@
 #  claimed_by_another                                   :integer          default(0), not null
 #  completed_at                                         :datetime
 #  completed_yes_no_questions_at                        :datetime
+#  consented_to_legal                                   :integer          default("unfilled"), not null
 #  continued_at_capacity                                :boolean          default(FALSE)
 #  current_step                                         :string
 #  demographic_disability                               :integer          default(0), not null
@@ -253,6 +254,7 @@ class Intake::CtcIntake < Intake
   enum primary_member_of_the_armed_forces: { unfilled: 0, yes: 1, no: 2 }, _prefix: :primary_member_of_the_armed_forces
   enum has_primary_ip_pin: { unfilled: 0, yes: 1, no: 2 }, _prefix: :has_primary_ip_pin
   enum has_spouse_ip_pin: { unfilled: 0, yes: 1, no: 2 }, _prefix: :has_spouse_ip_pin
+  enum consented_to_legal: { unfilled: 0, yes: 1, no: 2 }, _prefix: :consented_to_legal
 
   has_one :bank_account, inverse_of: :intake, foreign_key: :intake_id, dependent: :destroy
   accepts_nested_attributes_for :bank_account

--- a/app/models/intake/gyr_intake.rb
+++ b/app/models/intake/gyr_intake.rb
@@ -17,6 +17,7 @@
 #  claimed_by_another                                   :integer          default("unfilled"), not null
 #  completed_at                                         :datetime
 #  completed_yes_no_questions_at                        :datetime
+#  consented_to_legal                                   :integer          default(0), not null
 #  continued_at_capacity                                :boolean          default(FALSE)
 #  current_step                                         :string
 #  demographic_disability                               :integer          default("unfilled"), not null

--- a/app/views/ctc/questions/confirm_legal/edit.html.erb
+++ b/app/views/ctc/questions/confirm_legal/edit.html.erb
@@ -1,0 +1,13 @@
+<% @main_question = t("views.ctc.questions.confirm_legal.title") %>
+
+<% content_for :page_title, @main_question %>
+<%= debug @intake %>
+
+<% content_for :form_card do %>
+  <h1 class="h2"><%= @main_question %></h1>
+  <%= t("views.ctc.questions.confirm_legal.legal_info_html") %>
+  <%= form_with model: @form, url: current_path, local: true, method: "put", builder: VitaMinFormBuilder, html: { class: "form-card" } do |f| %>
+    <%= f.cfa_checkbox(:consented_to_legal, t("views.ctc.questions.confirm_legal.consent"), options: { checked_value: "yes", unchecked_value: "no" }) %>
+    <%= f.submit t("views.ctc.questions.confirm_legal.action"), class: "button button--primary button--wide text--centered spacing-above-60" %>
+  <% end %>
+<% end %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -96,6 +96,7 @@ translation:
 ignore_missing:
   - 'views.ctc.*'
   - 'views.ctc_pages.*'
+  - 'messages.efile.preparing.*'
   - 'general.tin.*'
 # - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'
 # - '{devise,simple_form}.*'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1192,6 +1192,24 @@ en:
           Thank you for filing your taxes with GetCTC! Your taxes have been accepted by the IRS which means that they can begin processing your payments.
 
           You can check the status of your payments with the IRS at https://www.irs.gov/credits-deductions/child-tax-credit-update-portal
+      preparing:
+        email:
+          body: |
+            Hello <<Client.PreferredName>>,
+
+            Your tax information has been successfully submitted to GetCTC!
+
+            We are currently processing your information to send it to the IRS. You will receive a confirmation email within 48 hours to let you know if your information has been accepted or rejected.
+
+            If you have any questions, you can go to GetCTC.org and open a chat with a tax expert or email support@getctc.org.
+
+            We’re here to help!
+            Your tax team at GetCTC.org
+          subject: Your tax information has been successfully submitted!
+        sms: |
+          Hello <<Client.PreferredName>>,
+          Your tax information has been successfully submitted to GetCTC! We are currently processing your information to send it to the IRS. You will receive a confirmation email within 48 hours to let you know if your information has been accepted or rejected.
+          Respond to this message if you have any questions. We’re here to help!
   models:
     intake:
       your_spouse: Your spouse
@@ -1322,10 +1340,10 @@ en:
               label: More information needed
               message: We need more information from you before we can file your return.
             new:
-              label: Submission in progress
+              label: Electronically filed
               message: We are preparing your return. We'll continue to update you on the status of your submission.
             preparing:
-              label: Submission in progress
+              label: Electronically filed
               message: We are preparing your return. We'll continue to update you on the status of your submission.
             failed:
               label: Submission error
@@ -1589,6 +1607,15 @@ en:
         ip_pin_entry:
           title: Please enter the IP PIN below.
           label: "%{name}'s IP PIN"
+        confirm_legal:
+          title: Please read through the legal information before submitting your tax return.
+          legal_info_html: |
+            <p>Under penalties of perjury, I declare that I have examined this return (or request for refund) including any accompanying statements and schedules and, to the best of my knowledge and belief, it is true, correct, and complete.</p>
+            <p>I consent to allow my Intermediate Service Provider, transmitter, or Electronic Return Originator (ERO) to send my return (or request for refund) to the IRS and to receive the following information from the IRS: a) an acknowledgment of receipt or reason for rejection of transmission; b) an indication of any refund offset; c) the reason for any delay processing the return or refund; and d) the date of any refund.</p>
+            <p class="spacing-below-35">I am signing this tax return by entering my self-selected signature PIN and associated electronic signature data on the previous page.</p>
+          consent: I agree
+          action: File my return
+          error: Please agree before continuing.
     consent_pages:
       consent_to_use:
         title: Consent to Use

--- a/db/migrate/20210722155730_add_consented_to_legal_to_intake.rb
+++ b/db/migrate/20210722155730_add_consented_to_legal_to_intake.rb
@@ -1,0 +1,5 @@
+class AddConsentedToLegalToIntake < ActiveRecord::Migration[6.0]
+  def change
+    add_column :intakes, :consented_to_legal, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_21_214545) do
+ActiveRecord::Schema.define(version: 2021_07_22_155730) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -435,6 +435,7 @@ ActiveRecord::Schema.define(version: 2021_07_21_214545) do
     t.bigint "client_id"
     t.datetime "completed_at"
     t.datetime "completed_yes_no_questions_at"
+    t.integer "consented_to_legal", default: 0, null: false
     t.boolean "continued_at_capacity", default: false
     t.datetime "created_at"
     t.string "current_step"

--- a/spec/controllers/ctc/questions/confirm_legal_controller_spec.rb
+++ b/spec/controllers/ctc/questions/confirm_legal_controller_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+describe Ctc::Questions::ConfirmLegalController do
+  let(:intake) { create :ctc_intake, client: client }
+  let(:client) { create :client, tax_returns: [create(:tax_return, year: 2020)] }
+
+  before do
+    sign_in intake.client
+  end
+
+  describe "#edit" do
+    it "renders edit template and initializes form" do
+      get :edit, params: {}
+
+      expect(response).to render_template :edit
+      expect(assigns(:form)).to be_an_instance_of Ctc::ConfirmLegalForm
+      expect(assigns(:form).intake).to be_an_instance_of Intake::CtcIntake
+    end
+  end
+
+  describe "#update" do
+    let(:params) do
+      {
+        ctc_confirm_legal_form: {
+          consented_to_legal: "yes",
+        }
+      }
+    end
+
+    context "when submitting the form" do
+      context "when checking 'I agree'" do
+        it "create a submission with the status of 'preparing' and send client a message and redirect to portal home" do
+          post :update, params: params
+
+          expect(response).to redirect_to ctc_portal_root_path
+          expect(client.reload.tax_returns.last.efile_submissions.last.current_state).to eq "preparing"
+        end
+      end
+
+      context "when not checking 'I agree'" do
+        before do
+          params[:ctc_confirm_legal_form][:consented_to_legal] = "no"
+        end
+
+        it "render edit with errors" do
+          post :update, params: params
+          expect(response).to render_template :edit
+          expect(assigns(:form).errors).not_to be_blank
+          expect(intake.consented_to_legal).to eq "unfilled"
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/intakes.rb
+++ b/spec/factories/intakes.rb
@@ -17,6 +17,7 @@
 #  claimed_by_another                                   :integer          default(0), not null
 #  completed_at                                         :datetime
 #  completed_yes_no_questions_at                        :datetime
+#  consented_to_legal                                   :integer          default(0), not null
 #  continued_at_capacity                                :boolean          default(FALSE)
 #  current_step                                         :string
 #  demographic_disability                               :integer          default(0), not null

--- a/spec/features/ctc/complete_intake_spec.rb
+++ b/spec/features/ctc/complete_intake_spec.rb
@@ -239,5 +239,14 @@ RSpec.feature "CTC Intake", :js, :flow_explorer_screenshot, active_job: true do
     intake.reload
     expect(intake.primary_ip_pin).to eq "123456"
     expect(intake.dependents.last.ip_pin).to eq "123458"
+
+    visit "en/questions/confirm-legal" # TODO: remove redirect when other review pages are in
+    expect(page).to have_selector("h1", text: I18n.t("views.ctc.questions.confirm_legal.title"))
+    check I18n.t("views.ctc.questions.confirm_legal.consent")
+    click_on I18n.t("views.ctc.questions.confirm_legal.action")
+
+    # =========== PORTAL ===========
+    expect(page).to have_selector("h1", text: I18n.t("views.ctc.portal.home.title"))
+    expect(page).to have_text(I18n.t("views.ctc.portal.home.status.preparing.label"))
   end
 end

--- a/spec/features/ctc/portal_spec.rb
+++ b/spec/features/ctc/portal_spec.rb
@@ -77,9 +77,9 @@ RSpec.feature "CTC Intake", active_job: true do
       fill_in "Client ID or Last 4 of SSN/ITIN", with: intake.client.id
       click_on "Continue"
 
-      expect(page).to have_selector("h1", text: "Thank you for filing with GetCTC!")
-      expect(page).to have_text "Submission in progress"
-      expect(page).to have_text "We are preparing your return. We'll continue to update you on the status of your submission."
+      expect(page).to have_selector("h1", text: I18n.t("views.ctc.portal.home.title"))
+      expect(page).to have_text I18n.t("views.ctc.portal.home.status.new.label")
+      expect(page).to have_text I18n.t("views.ctc.portal.home.status.new.message")
     end
   end
 
@@ -106,9 +106,9 @@ RSpec.feature "CTC Intake", active_job: true do
       fill_in "Client ID or Last 4 of SSN/ITIN", with: intake.client.id
       click_on "Continue"
 
-      expect(page).to have_selector("h1", text: "Thank you for filing with GetCTC!")
-      expect(page).to have_text "Submission in progress"
-      expect(page).to have_text "We are preparing your return. We'll continue to update you on the status of your submission."
+      expect(page).to have_selector("h1", text: I18n.t("views.ctc.portal.home.title"))
+      expect(page).to have_text I18n.t("views.ctc.portal.home.status.preparing.label")
+      expect(page).to have_text I18n.t("views.ctc.portal.home.status.preparing.message")
     end
   end
 

--- a/spec/forms/ctc/confirm_legal_form_spec.rb
+++ b/spec/forms/ctc/confirm_legal_form_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+describe Ctc::ConfirmLegalForm do
+  let(:client) { create :client, tax_returns: [(create :tax_return, filing_status: nil)] }
+  let!(:intake) { create :ctc_intake, client: client }
+  let(:params) { { consented_to_legal: "yes" } }
+
+  context "validations" do
+    context "when consented to legal is selected" do
+      it "is valid" do
+        expect(
+          described_class.new(intake, params)
+        ).to be_valid
+      end
+    end
+
+    context "when consented to legal is not selected" do
+      before do
+        params[:consented_to_legal] = "no"
+      end
+
+      it "is not valid" do
+        form = described_class.new(intake, params)
+        expect(form).not_to be_valid
+        expect(form.errors.keys).to include(:consented_to_legal)
+      end
+    end
+  end
+
+  context "save" do
+    it "persists the consented to legal to intake and create an efile submission and set status to preparing" do
+      expect { described_class.new(intake, params).save }
+        .to change(intake.reload, :consented_to_legal).from("unfilled").to("yes")
+                                                      .and change(intake.tax_returns.last.efile_submissions, :count).by(1)
+    end
+
+    context 'when a submission already exists' do
+      before do
+        create :efile_submission, tax_return: intake.tax_returns.last
+      end
+
+      it "does not create another one" do
+        expect { described_class.new(intake, params).save }
+          .not_to change(intake.tax_returns.last.efile_submissions, :count)
+      end
+    end
+  end
+end

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -17,6 +17,7 @@
 #  claimed_by_another                                   :integer          default(0), not null
 #  completed_at                                         :datetime
 #  completed_yes_no_questions_at                        :datetime
+#  consented_to_legal                                   :integer          default(0), not null
 #  continued_at_capacity                                :boolean          default(FALSE)
 #  current_step                                         :string
 #  demographic_disability                               :integer          default(0), not null

--- a/spec/state_machines/efile_submission_state_machine_spec.rb
+++ b/spec/state_machines/efile_submission_state_machine_spec.rb
@@ -16,6 +16,22 @@ describe EfileSubmissionStateMachine do
         submission.transition_to!(:preparing)
         expect(submission.tax_return.status).to eq("file_ready_to_file")
       end
+
+      context "from new to preparing" do
+        before do
+          allow(ClientMessagingService).to receive(:send_system_message_to_all_opted_in_contact_methods)
+        end
+
+        it "sends a message to the client" do
+          submission.transition_to!(:preparing)
+
+          expect(ClientMessagingService).to have_received(:send_system_message_to_all_opted_in_contact_methods).with(
+            client: submission.client.reload,
+            message: instance_of(AutomatedMessage::EfilePreparing),
+            locale: submission.client.intake.locale
+          )
+        end
+      end
     end
 
     context "to transmitted" do


### PR DESCRIPTION
- create efile_submission and set state to preparing
- add state transition new to preparing to send message
- update portal home status labeling
 [#178803704]

Co-authored-by: Molly T-M <mollyt@codeforamerica.org>