### PR TITLE
CTC intake: add child residency pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,6 +44,10 @@ class ApplicationController < ActionController::Base
     current_intake
   end
 
+  def self.model_for_show_check(current_controller)
+    current_controller.visitor_record
+  end
+
   def set_visitor_id
     if visitor_record&.visitor_id.present?
       cookies.permanent[:visitor_id] = { value: visitor_record.visitor_id, httponly: true }

--- a/app/controllers/ctc/questions/dependents/base_dependent_controller.rb
+++ b/app/controllers/ctc/questions/dependents/base_dependent_controller.rb
@@ -16,6 +16,10 @@ module Ctc
           "ctc/dependents/" + controller_name + "_form"
         end
 
+        def self.current_resource_from_params(current_intake, params)
+          current_intake.dependents.find { |d| d.id == params[:id].to_i }
+        end
+
         def edit
           return if form_class == NullForm
 
@@ -29,7 +33,9 @@ module Ctc
         end
 
         def current_dependent
-          @dependent ||= current_intake.dependents.find(params[:id])
+          @dependent ||= self.class.current_resource_from_params(current_intake, params)
+          raise ActiveRecord::RecordNotFound unless @dependent
+          @dependent
         end
 
         def remember_last_edited_dependent_id

--- a/app/controllers/ctc/questions/dependents/child_lived_with_you_controller.rb
+++ b/app/controllers/ctc/questions/dependents/child_lived_with_you_controller.rb
@@ -1,0 +1,30 @@
+module Ctc
+  module Questions
+    module Dependents
+      class ChildLivedWithYouController < BaseDependentController
+        include AuthenticatedCtcClientConcern
+        layout "yes_no_question"
+
+        def self.show?(dependent)
+          return false unless dependent
+          dependent.qualifying_child_relationship? && dependent.meets_qc_age_condition? && dependent.meets_qc_misc_conditions?
+        end
+
+        def self.model_for_show_check(current_controller)
+          current_resource_from_params(current_controller.visitor_record, current_controller.params)
+        end
+
+        def method_name
+          # TODO: the column name seems to be the opposite of the question being asked on this page
+          'lived_with_less_than_six_months'
+        end
+
+        private
+
+        def illustration_path
+          "dependents.svg"
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/ctc/questions/dependents/child_residence_exceptions_controller.rb
+++ b/app/controllers/ctc/questions/dependents/child_residence_exceptions_controller.rb
@@ -1,0 +1,24 @@
+module Ctc
+  module Questions
+    module Dependents
+      class ChildResidenceExceptionsController < BaseDependentController
+        include AuthenticatedCtcClientConcern
+
+        layout "intake"
+
+        def self.show?(dependent)
+          return false unless dependent
+          dependent.qualifying_child_relationship? && dependent.meets_qc_age_condition? && dependent.meets_qc_misc_conditions? && dependent.lived_with_less_than_six_months_yes?
+        end
+
+        def self.model_for_show_check(current_controller)
+          current_resource_from_params(current_controller.visitor_record, current_controller.params)
+        end
+
+        private
+
+        def illustration_path; end
+      end
+    end
+  end
+end

--- a/app/controllers/flows_controller.rb
+++ b/app/controllers/flows_controller.rb
@@ -152,8 +152,8 @@ class FlowsController < ApplicationController
         end
       end
 
-      def unreachable?(reference_object)
-        !show?(reference_object)
+      def unreachable?(current_controller)
+        !show?(model_for_show_check(current_controller))
       end
     end
   end

--- a/app/forms/ctc/dependents/child_lived_with_you_form.rb
+++ b/app/forms/ctc/dependents/child_lived_with_you_form.rb
@@ -1,0 +1,14 @@
+module Ctc
+  module Dependents
+    class ChildLivedWithYouForm < DependentForm
+      set_attributes_for :dependent, :lived_with_less_than_six_months
+
+      validates_presence_of :lived_with_less_than_six_months
+
+      def save
+        @dependent.assign_attributes(attributes_for(:dependent))
+        @dependent.save
+      end
+    end
+  end
+end

--- a/app/forms/ctc/dependents/child_residence_exceptions_form.rb
+++ b/app/forms/ctc/dependents/child_residence_exceptions_form.rb
@@ -1,0 +1,16 @@
+module Ctc
+  module Dependents
+    class ChildResidenceExceptionsForm < DependentForm
+      set_attributes_for :dependent,
+                         :born_in_2020,
+                         :passed_away_2020,
+                         :placed_for_adoption,
+                         :permanent_residence_with_client
+
+      def save
+        @dependent.assign_attributes(attributes_for(:dependent))
+        @dependent.save
+      end
+    end
+  end
+end

--- a/app/lib/concerns/controller_navigation.rb
+++ b/app/lib/concerns/controller_navigation.rb
@@ -40,7 +40,8 @@ module ControllerNavigation
   def seek(list, &additional_check)
     list.detect do |controller_class|
       next if additional_check && !additional_check.call(controller_class)
-      controller_class.show?(current_controller.visitor_record)
+      model = controller_class.model_for_show_check(current_controller)
+      controller_class.show?(model)
     end
   end
 end

--- a/app/lib/ctc_question_navigation.rb
+++ b/app/lib/ctc_question_navigation.rb
@@ -30,6 +30,8 @@ class CtcQuestionNavigation
     Ctc::Questions::Dependents::HadDependentsController,
     Ctc::Questions::Dependents::NoDependentsController,
     Ctc::Questions::Dependents::InfoController,
+    Ctc::Questions::Dependents::ChildLivedWithYouController,
+    Ctc::Questions::Dependents::ChildResidenceExceptionsController,
     Ctc::Questions::Dependents::TinController,
     Ctc::Questions::Dependents::ConfirmDependentsController,
 

--- a/app/views/ctc/questions/dependents/child_lived_with_you/edit.html.erb
+++ b/app/views/ctc/questions/dependents/child_lived_with_you/edit.html.erb
@@ -1,0 +1,1 @@
+<% content_for :form_question, t("views.ctc.questions.dependents.child_lived_with_you.title", dependent_name: @form.dependent.first_name, tax_year: 2020) %>

--- a/app/views/ctc/questions/dependents/child_residence_exceptions/edit.html.erb
+++ b/app/views/ctc/questions/dependents/child_residence_exceptions/edit.html.erb
@@ -1,0 +1,23 @@
+<% content_for :page_title, t("views.ctc.questions.dependents.child_residence_exceptions.title", dependent_name: @form.dependent.first_name) %>
+
+<% content_for :form_card do %>
+  <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder, html: { class: "form-card form-card--long" } do |f| %>
+    <h1 class="form-question spacing-below-35">
+      <%= content_for(:page_title) %>
+    </h1>
+    <p>
+      <%=t('views.ctc.questions.dependents.child_residence_exceptions.help_text') %>
+    </p>
+    <div class="form-card__stacked-checkboxes spacing-above-0">
+      <%= f.cfa_checkbox(:born_in_2020, t('views.ctc.questions.dependents.child_residence_exceptions.born_in_2020', dependent_name: @form.dependent.first_name), options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <%= f.cfa_checkbox(:passed_away_2020, t('views.ctc.questions.dependents.child_residence_exceptions.passed_away_2020', dependent_name: @form.dependent.first_name), options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <%= f.cfa_checkbox(:placed_for_adoption, t('views.ctc.questions.dependents.child_residence_exceptions.placed_for_adoption', dependent_name: @form.dependent.first_name), options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <%= f.cfa_checkbox(:permanent_residence_with_client, t('views.ctc.questions.dependents.child_residence_exceptions.permanent_residence_with_client', dependent_name: @form.dependent.first_name), options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <%= f.cfa_checkbox(:none, t("general.none_of_the_above"), options: { id: "none__checkbox", checked_value: "yes", unchecked_value: "no" }) %>
+    </div>
+
+    <button class="button button--primary button--wide" type="submit">
+      <%=t("general.continue") %>
+    </button>
+  <% end %>
+<% end %>

--- a/app/views/flows/_flow.html.erb
+++ b/app/views/flows/_flow.html.erb
@@ -23,7 +23,7 @@
             link_to(
               decorated_controller.controller_url,
               class: 'flow-explorer-link',
-              style: flow_params.reference_object && decorated_controller.unreachable?(flow_params.reference_object) ? 'font-style: italic; color: #aaa;' : ''
+              style: flow_params.reference_object && decorated_controller.unreachable?(controller) ? 'font-style: italic; color: #aaa;' : ''
             ) do %>
             <% navigation_entry_action_title = decorated_controller.navigation_entry_action_title(flow_params.title_i18n_params) %>
             <% if navigation_entry_action_title.is_a?(Hash) %>

--- a/app/views/layouts/yes_no_question.html.erb
+++ b/app/views/layouts/yes_no_question.html.erb
@@ -19,7 +19,7 @@
             <%= render "shared/progress_bar" %>
           </div>
           <main role="main">
-            <%= form_with model: @form, url: current_path, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
+            <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
               <% if illustration_path.present? %>
                 <div class="question__illustration">
                   <%= image_tag("#{illustration_folder}/#{illustration_path}", alt: "") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1357,6 +1357,15 @@ en:
             title: "Would you like to claim a dependent for 2020?"
             help_text: "Someone who lives with you for a majority of the year or who you support financially could qualify as a dependent."
             what_relationships_reveal: "What relationships qualify?"
+          child_lived_with_you:
+            title: "Did %{dependent_name} live with you for more than 6 months in %{tax_year}?"
+          child_residence_exceptions:
+            title: "Were any of the following true for %{dependent_name}?"
+            help_text: "They could still qualify for payments if they lived with you for less than 6 months and any of the following were true."
+            born_in_2020: "%{dependent_name} was born in 2020"
+            passed_away_2020: "%{dependent_name} was lawfully placed with you for adoption in 2020"
+            placed_for_adoption: "%{dependent_name} passed away in 2020"
+            permanent_residence_with_client: "%{dependent_name}’s permanent residence was with you for at least six months, even if they were away for part of that time"
           no_dependents:
             title: "You may still be eligible for other tax credits."
             help_text: "You can still file a simplified tax return and receive any stimulus payments that you are owed and have not received."

--- a/spec/controllers/ctc/questions/dependents/child_lived_with_you_controller_spec.rb
+++ b/spec/controllers/ctc/questions/dependents/child_lived_with_you_controller_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+describe Ctc::Questions::Dependents::ChildLivedWithYouController do
+  let(:intake) { create :ctc_intake }
+  let(:dependent) { create :dependent, intake: intake }
+
+  before do
+    sign_in intake.client
+  end
+
+  describe "#update" do
+    context "with valid params" do
+      let(:params) do
+        {
+          id: dependent.id,
+          ctc_dependents_child_lived_with_you_form: {
+            lived_with_less_than_six_months: "yes"
+          }
+        }
+      end
+
+      it "updates the dependent and moves to the next page" do
+        post :update, params: params
+
+        expect(dependent.reload.lived_with_less_than_six_months).to eq "yes"
+      end
+    end
+
+    context "with an invalid dependent id" do
+      let(:params) do
+        {
+          id: 'jeff',
+          ctc_dependents_child_lived_with_you_form: {
+            lived_with_less_than_six_months: "yes"
+          }
+        }
+      end
+
+      it "renders 404" do
+        expect do
+          post :update, params: params
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "with invalid params" do
+      let(:params) do
+        {
+          id: dependent.id
+        }
+      end
+
+      it "re-renders the form with errors" do
+        post :update, params: params
+        expect(response).to render_template :edit
+        expect(assigns(:form).errors.keys).to include(:lived_with_less_than_six_months)
+      end
+    end
+  end
+end

--- a/spec/controllers/ctc/questions/dependents/child_residence_exceptions_controller_spec.rb
+++ b/spec/controllers/ctc/questions/dependents/child_residence_exceptions_controller_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+describe Ctc::Questions::Dependents::ChildResidenceExceptionsController do
+  let(:intake) { create :ctc_intake }
+  let(:dependent) { create :dependent, intake: intake, lived_with_less_than_six_months: "yes" }
+
+  before do
+    sign_in intake.client
+  end
+
+  describe "#update" do
+    context "with valid params" do
+      let(:params) do
+        {
+          id: dependent.id,
+          ctc_dependents_child_residence_exceptions_form: {
+            born_in_2020: "yes",
+            passed_away_2020: "no",
+            placed_for_adoption: "yes",
+            permanent_residence_with_client: "no"
+          }
+        }
+      end
+
+      it "updates the dependent and moves to the next page" do
+        post :update, params: params
+
+        expect(dependent.reload.born_in_2020).to eq 'yes'
+        expect(dependent.reload.passed_away_2020).to eq 'no'
+        expect(dependent.reload.placed_for_adoption).to eq 'yes'
+        expect(dependent.reload.permanent_residence_with_client).to eq 'no'
+      end
+    end
+
+    context "with an invalid dependent id" do
+      let(:params) do
+        {
+          id: 'jeff',
+          ctc_dependents_child_residence_exceptions_form: {
+            born_in_2020: "yes",
+            passed_away_2020: "no",
+            placed_for_adoption: "yes",
+            permanent_residence_with_client: "no"
+          }
+        }
+      end
+
+      it "renders 404" do
+        expect do
+          post :update, params: params
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/spec/forms/ctc/dependents/child_lived_with_you_form_spec.rb
+++ b/spec/forms/ctc/dependents/child_lived_with_you_form_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe Ctc::Dependents::ChildLivedWithYouForm do
+  describe "#save" do
+    let(:intake) { create :ctc_intake }
+    let(:dependent) { create :dependent, intake: intake }
+
+    it "saves the field on the dependent" do
+      expect {
+        form = described_class.new(dependent, { lived_with_less_than_six_months: "yes" })
+        form.save
+      }.to change(dependent, :lived_with_less_than_six_months).to("yes")
+    end
+  end
+end

--- a/spec/forms/ctc/dependents/child_residence_exceptions_form_spec.rb
+++ b/spec/forms/ctc/dependents/child_residence_exceptions_form_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe Ctc::Dependents::ChildResidenceExceptionsForm do
+  describe "#save" do
+    let(:intake) { create :ctc_intake }
+    let(:dependent) { create :dependent, intake: intake, lived_with_less_than_six_months: "yes" }
+
+    it "saves fields on the dependent" do
+      expect {
+        form = described_class.new(dependent, {
+          born_in_2020: "yes",
+          passed_away_2020: "no",
+          placed_for_adoption: "yes",
+          permanent_residence_with_client: "no"
+        })
+        form.save
+      }.to change(dependent, :born_in_2020).to("yes")
+                                           .and change(dependent, :passed_away_2020).to("no")
+                                                                                          .and change(dependent, :placed_for_adoption).to("yes")
+                                                                                                                                            .and change(dependent, :permanent_residence_with_client).to("no")
+    end
+  end
+end

--- a/spec/lib/concerns/controller_navigation_spec.rb
+++ b/spec/lib/concerns/controller_navigation_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe ControllerNavigation do
         true
       end
 
+      def self.model_for_show_check(controller)
+        controller.visitor_record
+      end
+
       def visitor_record; end
     end
 

--- a/spec/lib/document_navigation_spec.rb
+++ b/spec/lib/document_navigation_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe DocumentNavigation do
         true
       end
 
+      def self.model_for_show_check(controller)
+        controller.visitor_record
+      end
+
       def visitor_record; end
 
     end


### PR DESCRIPTION
Make ControllerNavigation send models other than intake to `.show?`:
controllers can define a `self.model_for_show_check` which can
choose to pull a model out of the session, params, whatever.

Co-authored-by: Ben Golder <bgolder@codeforamerica.org>
Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>
Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>