### PR TITLE
Add dependent claims pages to CTC intake

### DIFF
--- a/app/controllers/ctc/questions/dependents/child_can_be_claimed_by_other_controller.rb
+++ b/app/controllers/ctc/questions/dependents/child_can_be_claimed_by_other_controller.rb
@@ -7,6 +7,7 @@ module Ctc
 
         def self.show?(dependent)
           return false unless dependent
+
           dependent.qualifying_child_relationship? &&
             dependent.meets_qc_age_condition_2020? &&
             dependent.meets_qc_misc_conditions? &&
@@ -18,7 +19,7 @@ module Ctc
         end
 
         def method_name
-          'can_be_claimed_by_other'
+          'cant_be_claimed_by_other'
         end
 
         private

--- a/app/controllers/ctc/questions/dependents/child_can_be_claimed_by_other_controller.rb
+++ b/app/controllers/ctc/questions/dependents/child_can_be_claimed_by_other_controller.rb
@@ -1,0 +1,32 @@
+module Ctc
+  module Questions
+    module Dependents
+      class ChildCanBeClaimedByOtherController < BaseDependentController
+        include AuthenticatedCtcClientConcern
+        layout "yes_no_question"
+
+        def self.show?(dependent)
+          return false unless dependent
+          dependent.qualifying_child_relationship? &&
+            dependent.meets_qc_age_condition_2020? &&
+            dependent.meets_qc_misc_conditions? &&
+            dependent.meets_qc_residence_condition_2020?
+        end
+
+        def self.model_for_show_check(current_controller)
+          current_resource_from_params(current_controller.visitor_record, current_controller.params)
+        end
+
+        def method_name
+          'can_be_claimed_by_other'
+        end
+
+        private
+
+        def illustration_path
+          "dependents.svg"
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/ctc/questions/dependents/claim_child_anyway_controller.rb
+++ b/app/controllers/ctc/questions/dependents/claim_child_anyway_controller.rb
@@ -1,0 +1,33 @@
+module Ctc
+  module Questions
+    module Dependents
+      class ClaimChildAnywayController < BaseDependentController
+        include AuthenticatedCtcClientConcern
+        layout "yes_no_question"
+
+        def self.show?(dependent)
+          return false unless dependent
+          dependent.qualifying_child_relationship? &&
+            dependent.meets_qc_age_condition_2020? &&
+            dependent.meets_qc_misc_conditions? &&
+            dependent.meets_qc_residence_condition_2020? &&
+            dependent.can_be_claimed_by_other_yes?
+        end
+
+        def self.model_for_show_check(current_controller)
+          current_resource_from_params(current_controller.visitor_record, current_controller.params)
+        end
+
+        def method_name
+          'claim_regardless'
+        end
+
+        private
+
+        def illustration_path
+          "dependents.svg"
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/ctc/questions/dependents/claim_child_anyway_controller.rb
+++ b/app/controllers/ctc/questions/dependents/claim_child_anyway_controller.rb
@@ -7,11 +7,12 @@ module Ctc
 
         def self.show?(dependent)
           return false unless dependent
+
           dependent.qualifying_child_relationship? &&
             dependent.meets_qc_age_condition_2020? &&
             dependent.meets_qc_misc_conditions? &&
             dependent.meets_qc_residence_condition_2020? &&
-            dependent.can_be_claimed_by_other_yes?
+            dependent.cant_be_claimed_by_other_no?
         end
 
         def self.model_for_show_check(current_controller)

--- a/app/forms/ctc/dependents/child_can_be_claimed_by_other_form.rb
+++ b/app/forms/ctc/dependents/child_can_be_claimed_by_other_form.rb
@@ -1,9 +1,9 @@
 module Ctc
   module Dependents
     class ChildCanBeClaimedByOtherForm < DependentForm
-      set_attributes_for :dependent, :can_be_claimed_by_other
+      set_attributes_for :dependent, :cant_be_claimed_by_other
 
-      validates_presence_of :can_be_claimed_by_other
+      validates_presence_of :cant_be_claimed_by_other
 
       def save
         @dependent.assign_attributes(attributes_for(:dependent))

--- a/app/forms/ctc/dependents/child_can_be_claimed_by_other_form.rb
+++ b/app/forms/ctc/dependents/child_can_be_claimed_by_other_form.rb
@@ -1,0 +1,14 @@
+module Ctc
+  module Dependents
+    class ChildCanBeClaimedByOtherForm < DependentForm
+      set_attributes_for :dependent, :can_be_claimed_by_other
+
+      validates_presence_of :can_be_claimed_by_other
+
+      def save
+        @dependent.assign_attributes(attributes_for(:dependent))
+        @dependent.save
+      end
+    end
+  end
+end

--- a/app/forms/ctc/dependents/claim_child_anyway_form.rb
+++ b/app/forms/ctc/dependents/claim_child_anyway_form.rb
@@ -1,0 +1,14 @@
+module Ctc
+  module Dependents
+    class ClaimChildAnywayForm < DependentForm
+      set_attributes_for :dependent, :claim_regardless
+
+      validates_presence_of :claim_regardless
+
+      def save
+        @dependent.assign_attributes(attributes_for(:dependent))
+        @dependent.save
+      end
+    end
+  end
+end

--- a/app/forms/ctc/dependents/temp_toggles_form.rb
+++ b/app/forms/ctc/dependents/temp_toggles_form.rb
@@ -12,7 +12,7 @@ module Ctc
         :passed_away_2020,
         :placed_for_adoption,
         :permanent_residence_with_client,
-        :can_be_claimed_by_other,
+        :cant_be_claimed_by_other,
         :claim_regardless,
         :meets_misc_qualifying_relative_requirements,
       ]

--- a/app/lib/ctc_question_navigation.rb
+++ b/app/lib/ctc_question_navigation.rb
@@ -32,6 +32,8 @@ class CtcQuestionNavigation
     Ctc::Questions::Dependents::InfoController,
     Ctc::Questions::Dependents::ChildLivedWithYouController,
     Ctc::Questions::Dependents::ChildResidenceExceptionsController,
+    Ctc::Questions::Dependents::ChildCanBeClaimedByOtherController,
+    Ctc::Questions::Dependents::ClaimChildAnywayController,
     Ctc::Questions::Dependents::QualifyingRelativeController,
     Ctc::Questions::Dependents::TinController,
     Ctc::Questions::Dependents::TempTogglesController,

--- a/app/models/dependent.rb
+++ b/app/models/dependent.rb
@@ -5,7 +5,7 @@
 #  id                                          :bigint           not null, primary key
 #  birth_date                                  :date
 #  born_in_2020                                :integer          default("unfilled"), not null
-#  can_be_claimed_by_other                     :integer          default("unfilled"), not null
+#  cant_be_claimed_by_other                    :integer          default("unfilled"), not null
 #  claim_regardless                            :integer          default("unfilled"), not null
 #  disabled                                    :integer          default("unfilled"), not null
 #  encrypted_ip_pin                            :string
@@ -63,7 +63,7 @@ class Dependent < ApplicationRecord
   enum provided_over_half_own_support: { unfilled: 0, yes: 1, no: 2 }, _prefix: :provided_over_half_own_support
   enum filed_joint_return: { unfilled: 0, yes: 1, no: 2 }, _prefix: :filed_joint_return
   enum lived_with_more_than_six_months: { unfilled: 0, yes: 1, no: 2 }, _prefix: :lived_with_more_than_six_months
-  enum can_be_claimed_by_other: { unfilled: 0, yes: 1, no: 2 }, _prefix: :can_be_claimed_by_other
+  enum cant_be_claimed_by_other: { unfilled: 0, yes: 1, no: 2 }, _prefix: :cant_be_claimed_by_other
   enum born_in_2020: { unfilled: 0, yes: 1, no: 2 }, _prefix: :born_in_2020
   enum passed_away_2020: { unfilled: 0, yes: 1, no: 2 }, _prefix: :passed_away_2020
   enum placed_for_adoption: { unfilled: 0, yes: 1, no: 2 }, _prefix: :placed_for_adoption
@@ -192,8 +192,8 @@ class Dependent < ApplicationRecord
   end
 
   def meets_qc_claimant_condition?
-    can_be_claimed_by_other_no? ||
-      (can_be_claimed_by_other_yes? && claim_regardless_yes?)
+    cant_be_claimed_by_other_yes? ||
+      (cant_be_claimed_by_other_no? && claim_regardless_yes?)
   end
 
   def qualifying_relative_2020?

--- a/app/views/ctc/questions/dependents/child_can_be_claimed_by_other/edit.html.erb
+++ b/app/views/ctc/questions/dependents/child_can_be_claimed_by_other/edit.html.erb
@@ -1,0 +1,1 @@
+<% content_for :form_question, t("views.ctc.questions.dependents.child_can_be_claimed_by_other.title", dependent_name: @form.dependent.first_name) %>

--- a/app/views/ctc/questions/dependents/claim_child_anyway/edit.html.erb
+++ b/app/views/ctc/questions/dependents/claim_child_anyway/edit.html.erb
@@ -1,0 +1,13 @@
+<% content_for :form_question, t("views.ctc.questions.dependents.claim_child_anyway.title", dependent_name: @form.dependent.first_name) %>
+<% content_for :form_help_text do %>
+  <%= t("views.ctc.questions.dependents.claim_child_anyway.help_text", dependent_name: @form.dependent.first_name) %>
+
+  <%= render('components/molecules/reveal', title: t("views.ctc.questions.dependents.claim_child_anyway.not_sure_reveal.title")) do %>
+    <p> <%= t("views.ctc.questions.dependents.claim_child_anyway.not_sure_reveal.p") %> </p>
+    <ul>
+      <li> <%= t("views.ctc.questions.dependents.claim_child_anyway.not_sure_reveal.li1") %> </li>
+      <li> <%= t("views.ctc.questions.dependents.claim_child_anyway.not_sure_reveal.li2") %> </li>
+      <li> <%= t("views.ctc.questions.dependents.claim_child_anyway.not_sure_reveal.li3") %> </li>
+    </ul>
+  <% end %>
+<% end %>

--- a/app/views/ctc/questions/dependents/claim_child_anyway/edit.html.erb
+++ b/app/views/ctc/questions/dependents/claim_child_anyway/edit.html.erb
@@ -4,7 +4,7 @@
 
   <%= render('components/molecules/reveal', title: t("views.ctc.questions.dependents.claim_child_anyway.not_sure_reveal.title")) do %>
     <p> <%= t("views.ctc.questions.dependents.claim_child_anyway.not_sure_reveal.p") %> </p>
-    <ul>
+    <ul class="list--bulleted">
       <li> <%= t("views.ctc.questions.dependents.claim_child_anyway.not_sure_reveal.li1") %> </li>
       <li> <%= t("views.ctc.questions.dependents.claim_child_anyway.not_sure_reveal.li2") %> </li>
       <li> <%= t("views.ctc.questions.dependents.claim_child_anyway.not_sure_reveal.li3") %> </li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1389,6 +1389,17 @@ en:
               li2: "%{dependent_name} earned less than $4,300."
               li3: "%{dependent_name} has a SSN or ATIN."
               li4: "%{dependent_name} did not live with someone else who could claim them."
+          child_can_be_claimed_by_other:
+            title: "Are you the only person who can claim %{dependent_name}?"
+          claim_child_anyway:
+            title: "Would you like to claim %{dependent_name} anyway?"
+            help_text: "If you and someone else are eligible to claim %{dependent_name}, you should follow any existing agreement with the other person about who claims them."
+            not_sure_reveal:
+              title: "I’m unsure. Should I claim them?"
+              p: "You should claim the dependent If one of these situations is true:"
+              li1: "You are the parent who spent more time living with them."
+              li2: "If you and the other parent spent the same amount of time with the dependent, whoever earned more money in 2020 can claim them."
+              li3: "If neither of you are the dependent’s parent, whoever earned more money in 2020 can claim them."
           no_dependents:
             title: "You may still be eligible for other tax credits."
             help_text: "You can still file a simplified tax return and receive any stimulus payments that you are owed and have not received."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1396,7 +1396,7 @@ en:
             help_text: "If you and someone else are eligible to claim %{dependent_name}, you should follow any existing agreement with the other person about who claims them."
             not_sure_reveal:
               title: "I’m unsure. Should I claim them?"
-              p: "You should claim the dependent If one of these situations is true:"
+              p: "You should claim the dependent if one of these situations is true:"
               li1: "You are the parent who spent more time living with them."
               li2: "If you and the other parent spent the same amount of time with the dependent, whoever earned more money in 2020 can claim them."
               li3: "If neither of you are the dependent’s parent, whoever earned more money in 2020 can claim them."

--- a/db/migrate/20210726172905_flip_can_be_claimed_by_other_on_dependent.rb
+++ b/db/migrate/20210726172905_flip_can_be_claimed_by_other_on_dependent.rb
@@ -1,0 +1,5 @@
+class FlipCanBeClaimedByOtherOnDependent < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :dependents, :can_be_claimed_by_other, :cant_be_claimed_by_other
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_23_170413) do
+ActiveRecord::Schema.define(version: 2021_07_26_172905) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -236,7 +236,7 @@ ActiveRecord::Schema.define(version: 2021_07_23_170413) do
   create_table "dependents", force: :cascade do |t|
     t.date "birth_date"
     t.integer "born_in_2020", default: 0, null: false
-    t.integer "can_be_claimed_by_other", default: 0, null: false
+    t.integer "cant_be_claimed_by_other", default: 0, null: false
     t.integer "claim_regardless", default: 0, null: false
     t.datetime "created_at", null: false
     t.integer "disabled", default: 0, null: false

--- a/spec/controllers/ctc/questions/dependents/child_can_be_claimed_by_other_controller_spec.rb
+++ b/spec/controllers/ctc/questions/dependents/child_can_be_claimed_by_other_controller_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+describe Ctc::Questions::Dependents::ChildCanBeClaimedByOtherController do
+  let(:intake) { create :ctc_intake }
+  let(:dependent) { create :dependent, intake: intake }
+
+  before do
+    sign_in intake.client
+  end
+
+  describe "#update" do
+    context "with valid params" do
+      let(:params) do
+        {
+          id: dependent.id,
+          ctc_dependents_child_can_be_claimed_by_other_form: {
+            can_be_claimed_by_other: "yes"
+          }
+        }
+      end
+
+      it "updates the dependent and moves to the next page" do
+        post :update, params: params
+
+        expect(dependent.reload.can_be_claimed_by_other).to eq "yes"
+      end
+    end
+
+    context "with an invalid dependent id" do
+      let(:params) do
+        {
+          id: 'jeff',
+          ctc_dependents_child_can_be_claimed_by_other_form: {
+            can_be_claimed_by_other: "yes"
+          }
+        }
+      end
+
+      it "renders 404" do
+        expect do
+          post :update, params: params
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "with invalid params" do
+      let(:params) do
+        {
+          id: dependent.id
+        }
+      end
+
+      it "re-renders the form with errors" do
+        post :update, params: params
+        expect(response).to render_template :edit
+        expect(assigns(:form).errors.keys).to include(:can_be_claimed_by_other)
+      end
+    end
+  end
+end

--- a/spec/controllers/ctc/questions/dependents/child_can_be_claimed_by_other_controller_spec.rb
+++ b/spec/controllers/ctc/questions/dependents/child_can_be_claimed_by_other_controller_spec.rb
@@ -14,7 +14,7 @@ describe Ctc::Questions::Dependents::ChildCanBeClaimedByOtherController do
         {
           id: dependent.id,
           ctc_dependents_child_can_be_claimed_by_other_form: {
-            can_be_claimed_by_other: "yes"
+            cant_be_claimed_by_other: "no"
           }
         }
       end
@@ -22,7 +22,7 @@ describe Ctc::Questions::Dependents::ChildCanBeClaimedByOtherController do
       it "updates the dependent and moves to the next page" do
         post :update, params: params
 
-        expect(dependent.reload.can_be_claimed_by_other).to eq "yes"
+        expect(dependent.reload.cant_be_claimed_by_other).to eq "no"
       end
     end
 
@@ -31,7 +31,7 @@ describe Ctc::Questions::Dependents::ChildCanBeClaimedByOtherController do
         {
           id: 'jeff',
           ctc_dependents_child_can_be_claimed_by_other_form: {
-            can_be_claimed_by_other: "yes"
+            cant_be_claimed_by_other: "no"
           }
         }
       end
@@ -53,7 +53,7 @@ describe Ctc::Questions::Dependents::ChildCanBeClaimedByOtherController do
       it "re-renders the form with errors" do
         post :update, params: params
         expect(response).to render_template :edit
-        expect(assigns(:form).errors.keys).to include(:can_be_claimed_by_other)
+        expect(assigns(:form).errors.keys).to include(:cant_be_claimed_by_other)
       end
     end
   end

--- a/spec/controllers/ctc/questions/dependents/claim_child_anyway_controller_spec.rb
+++ b/spec/controllers/ctc/questions/dependents/claim_child_anyway_controller_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+describe Ctc::Questions::Dependents::ClaimChildAnywayController do
+  let(:intake) { create :ctc_intake }
+  let(:dependent) { create :dependent, intake: intake }
+
+  before do
+    sign_in intake.client
+  end
+
+  describe "#update" do
+    context "with valid params" do
+      let(:params) do
+        {
+          id: dependent.id,
+          ctc_dependents_claim_child_anyway_form: {
+            claim_regardless: "yes"
+          }
+        }
+      end
+
+      it "updates the dependent and moves to the next page" do
+        post :update, params: params
+
+        expect(dependent.reload.claim_regardless).to eq "yes"
+      end
+    end
+
+    context "with an invalid dependent id" do
+      let(:params) do
+        {
+          id: 'jeff',
+          ctc_dependents_claim_child_anyway_form: {
+            claim_regardless: "yes"
+          }
+        }
+      end
+
+      it "renders 404" do
+        expect do
+          post :update, params: params
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "with invalid params" do
+      let(:params) do
+        {
+          id: dependent.id
+        }
+      end
+
+      it "re-renders the form with errors" do
+        post :update, params: params
+        expect(response).to render_template :edit
+        expect(assigns(:form).errors.keys).to include(:claim_regardless)
+      end
+    end
+  end
+end

--- a/spec/factories/dependents.rb
+++ b/spec/factories/dependents.rb
@@ -5,7 +5,7 @@
 #  id                                          :bigint           not null, primary key
 #  birth_date                                  :date
 #  born_in_2020                                :integer          default("unfilled"), not null
-#  can_be_claimed_by_other                     :integer          default("unfilled"), not null
+#  cant_be_claimed_by_other                    :integer          default("unfilled"), not null
 #  claim_regardless                            :integer          default("unfilled"), not null
 #  disabled                                    :integer          default("unfilled"), not null
 #  encrypted_ip_pin                            :string
@@ -67,7 +67,7 @@ FactoryBot.define do
       no_ssn_atin { "no" }
       filed_joint_return { "no" }
       lived_with_more_than_six_months { "yes" }
-      can_be_claimed_by_other { "no" }
+      cant_be_claimed_by_other { "yes" }
       claim_regardless { "yes" }
     end
 
@@ -85,7 +85,7 @@ FactoryBot.define do
       no_ssn_atin { "no" }
       filed_joint_return { "no" }
       lived_with_more_than_six_months { "no" }
-      can_be_claimed_by_other { "yes" }
+      cant_be_claimed_by_other { "no" }
       claim_regardless { "yes" }
     end
   end

--- a/spec/forms/ctc/dependents/child_can_be_claimed_by_other_form_spec.rb
+++ b/spec/forms/ctc/dependents/child_can_be_claimed_by_other_form_spec.rb
@@ -7,9 +7,9 @@ describe Ctc::Dependents::ChildCanBeClaimedByOtherForm do
 
     it "saves the field on the dependent" do
       expect {
-        form = described_class.new(dependent, { can_be_claimed_by_other: "yes" })
+        form = described_class.new(dependent, { cant_be_claimed_by_other: "no" })
         form.save
-      }.to change(dependent, :can_be_claimed_by_other).to("yes")
+      }.to change(dependent, :cant_be_claimed_by_other).to("no")
     end
   end
 end

--- a/spec/forms/ctc/dependents/child_can_be_claimed_by_other_form_spec.rb
+++ b/spec/forms/ctc/dependents/child_can_be_claimed_by_other_form_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe Ctc::Dependents::ChildCanBeClaimedByOtherForm do
+  describe "#save" do
+    let(:intake) { create :ctc_intake }
+    let(:dependent) { create :dependent, intake: intake }
+
+    it "saves the field on the dependent" do
+      expect {
+        form = described_class.new(dependent, { can_be_claimed_by_other: "yes" })
+        form.save
+      }.to change(dependent, :can_be_claimed_by_other).to("yes")
+    end
+  end
+end

--- a/spec/forms/ctc/dependents/claim_child_anyway_form_spec.rb
+++ b/spec/forms/ctc/dependents/claim_child_anyway_form_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe Ctc::Dependents::ClaimChildAnywayForm do
+  describe "#save" do
+    let(:intake) { create :ctc_intake }
+    let(:dependent) { create :dependent, intake: intake }
+
+    it "saves the field on the dependent" do
+      expect {
+        form = described_class.new(dependent, { claim_regardless: "yes" })
+        form.save
+      }.to change(dependent, :claim_regardless).to("yes")
+    end
+  end
+end

--- a/spec/models/dependent_spec.rb
+++ b/spec/models/dependent_spec.rb
@@ -5,7 +5,7 @@
 #  id                                          :bigint           not null, primary key
 #  birth_date                                  :date
 #  born_in_2020                                :integer          default("unfilled"), not null
-#  can_be_claimed_by_other                     :integer          default("unfilled"), not null
+#  cant_be_claimed_by_other                    :integer          default("unfilled"), not null
 #  claim_regardless                            :integer          default("unfilled"), not null
 #  disabled                                    :integer          default("unfilled"), not null
 #  encrypted_ip_pin                            :string
@@ -162,7 +162,7 @@ describe Dependent do
               no_ssn_atin: "no",
               filed_joint_return: "no",
               lived_with_more_than_six_months: "yes",
-              can_be_claimed_by_other: "yes",
+              cant_be_claimed_by_other: "no",
               claim_regardless: "yes"
       end
 
@@ -182,7 +182,7 @@ describe Dependent do
               no_ssn_atin: "no",
               filed_joint_return: "no",
               lived_with_more_than_six_months: "no",
-              can_be_claimed_by_other: "yes",
+              cant_be_claimed_by_other: "no",
               claim_regardless: "yes"
       end
 
@@ -291,7 +291,7 @@ describe Dependent do
 
   describe "#meets_qc_claimant_condition?" do
     context "with a dependent that cannot be claimed by another" do
-      let(:dependent) { build :dependent, can_be_claimed_by_other: "no" }
+      let(:dependent) { build :dependent, cant_be_claimed_by_other: "yes" }
 
       it "returns true" do
         expect(dependent.meets_qc_claimant_condition?).to eq true
@@ -300,7 +300,7 @@ describe Dependent do
 
     context "with a dependent that can be claimed by another" do
       context "and is claimed anyways" do
-        let(:dependent) { build :dependent, can_be_claimed_by_other: "yes", claim_regardless: "yes" }
+        let(:dependent) { build :dependent, cant_be_claimed_by_other: "no", claim_regardless: "yes" }
 
         it "returns true" do
           expect(dependent.meets_qc_claimant_condition?).to eq true
@@ -308,7 +308,7 @@ describe Dependent do
       end
 
       context "and is not claimed anyways" do
-        let(:dependent) { build :dependent, can_be_claimed_by_other: "yes", claim_regardless: "no" }
+        let(:dependent) { build :dependent, cant_be_claimed_by_other: "no", claim_regardless: "no" }
 
         it "returns false" do
           expect(dependent.meets_qc_claimant_condition?).to eq false


### PR DESCRIPTION
This completes [this story.](https://www.pivotaltracker.com/story/show/178966147)

I haven't added to the feature spec yet because these pages are gated by prior pages that are not yet in the flow.

Once this and the [disqualifiers page](https://www.pivotaltracker.com/story/show/178965959) is in, we can update the feature spec accordingly (update: oh wow [there is a story](https://www.pivotaltracker.com/story/show/178819620) for that)