### PR TITLE
Make the non-javascript appearance of org input bigger to match its final form

### DIFF
--- a/app/views/shared/_client_filters_and_add_client.html.erb
+++ b/app/views/shared/_client_filters_and_add_client.html.erb
@@ -67,7 +67,7 @@
         <div class="form-group">
           <label for="org-site-filter" class="form-question"><%= t("hub.clients.index.organization") %></label>
           <div>
-            <%= text_field_tag("vita_partners", @filters[:vita_partners], id: "org-site-filter", class: "multi-select-vita-partner") %>
+            <%= text_field_tag("vita_partners", @filters[:vita_partners], id: "org-site-filter", class: "text-input multi-select-vita-partner") %>
           </div>
         </div>
       <% end %>


### PR DESCRIPTION
This is an attempt to deflake the test that clicks 'Add client' -- the suspicion
being that sometimes it misses the click because 'Add client' jumps a few pixels
during load

Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>