### PR TITLE
Clarify why do not check returning customer metadata fields

### DIFF
--- a/app/lib/submission_builder/return_header1040.rb
+++ b/app/lib/submission_builder/return_header1040.rb
@@ -101,11 +101,12 @@ module SubmissionBuilder
               xml.OOBSecurityVerificationCd oob_security_verification_code if oob_security_verification_code.present?
               xml.LastSubmissionRqrOOBCd last_submission_rqr_oob_code
               xml.AuthenticationAssuranceLevelCd "AAL1"
-              # TODO: Add logic to toggle these when any of this information has changed.
-              # xml.ProfileUserNameChangeInd "X"
-              # xml.ProfilePasswordChangeInd "X"
-              # xml.ProfileEmailAddressChangeInd "X"
-              # xml.ProfileCellPhoneNumChangeInd "X"
+              # These fields should be "X" (checked) if we served this client last year with different contact info. This is
+              # our first e-filing year, so they're always omitted (unchecked).
+              # xml.ProfileUserNameChangeInd ""
+              # xml.ProfilePasswordChangeInd ""
+              # xml.ProfileEmailAddressChangeInd ""
+              # xml.ProfileCellPhoneNumChangeInd ""
             }
           }
           xml.FilingSecurityInformation {


### PR DESCRIPTION
Based on the info we got back from the IRS, this year, we'll never mark these as "X".

@bytheway875 I know this effectively only changes a comment, but I'd still love to have your eyes on it, and if you approve, for you to merge it.