### PR TITLE
Fully I18n-ize the CTC feature spec

### DIFF
--- a/app/forms/ctc/cell_phone_number_form.rb
+++ b/app/forms/ctc/cell_phone_number_form.rb
@@ -4,7 +4,7 @@ module Ctc
     set_attributes_for :confirmation, :sms_phone_number_confirmation, :can_receive_texts
     before_validation :normalize_phone_numbers
 
-    validates :can_receive_texts, acceptance: { accept: 'yes', message: -> (_object, _data) { I18n.t("views.ctc.questions.cell_phone_number.must_receive_texts_html", email_link: Rails.application.routes.url_helpers.questions_email_address_path) } }
+    validates :can_receive_texts, acceptance: { accept: 'yes', message: -> (_object, _data) { I18n.t("views.ctc.questions.cell_phone_number.must_receive_texts_html", email_link: Ctc::Questions::EmailAddressController.to_path_helper) } }
     validates :sms_phone_number, confirmation: true
     validates :sms_phone_number_confirmation, presence: true
     validates :sms_phone_number, e164_phone: true

--- a/app/forms/ctc/direct_deposit_form.rb
+++ b/app/forms/ctc/direct_deposit_form.rb
@@ -4,7 +4,7 @@ module Ctc
     set_attributes_for :confirmation, :my_bank_account
 
     validates_presence_of :account_type, :bank_name
-    validates :my_bank_account, acceptance: { accept: "yes", message: -> (_object, _data) { I18n.t("views.ctc.questions.direct_deposit.my_bank_account.error_message_html", link: Rails.application.routes.url_helpers.questions_refund_payment_path) } }
+    validates :my_bank_account, acceptance: { accept: "yes", message: -> (_object, _data) { I18n.t("views.ctc.questions.direct_deposit.my_bank_account.error_message_html", link: Ctc::Questions::RefundPaymentController.to_path_helper) } }
 
     def save
       @intake.update(bank_account_attributes: attributes_for(:bank_account))

--- a/app/helpers/rrc_helper.rb
+++ b/app/helpers/rrc_helper.rb
@@ -1,7 +1,7 @@
 module RrcHelper
   def calculated_or_provided_dollar_amount(intake_recovery_rebate)
     intake_recovery_rebate.present? ?
-      number_to_currency(intake_recovery_rebate, precision: 0) :
+      number_to_currency(intake_recovery_rebate, precision: 0, locale: :en) :
       "$TBD"
   end
 end

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1348,7 +1348,7 @@ es:
         account_number:
           title: Favor de proporcionarnos el número de su cuenta bancaria
           account_number: Número de cuenta
-          account_number_confirmation: "Confirme su número de cuenta "
+          account_number_confirmation: "Confirme su número de cuenta"
         confirm_bank_account:
           title: ¡Excelente! Revise que sus datos bancarios sean correctos.
           bank_information: La información de su banco
@@ -1461,7 +1461,7 @@ es:
           title: ¡Verifiquemos esa información de contacto con un código!
           body: |
             Se le ha enviado un mensaje con su código a:
-          verification_code_label: "Introduzca el código de 6 números "
+          verification_code_label: "Introduzca el código de 6 números"
           error_message: "El código de verificación está equivocado"
         stimulus_payments:
           title: "En base a su información, creemos que debería haber recibido esta cantidad en pagos de estímulo."

--- a/spec/features/ctc/complete_intake_spec.rb
+++ b/spec/features/ctc/complete_intake_spec.rb
@@ -9,118 +9,119 @@ RSpec.feature "CTC Intake", :flow_explorer_screenshot, active_job: true do
     # =========== BASIC INFO ===========
     visit "/en/questions/overview"
     expect(page).to have_selector(".toolbar", text: "GetCTC") # Check for appropriate header
-    expect(page).to have_selector("h1", text: "Let's get started!")
-    click_on "Continue"
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.overview.title'))
+    click_on I18n.t('general.continue')
 
     expect(page).to have_selector(".toolbar", text: "GetCTC")
-    expect(page).to have_selector("h1", text: "Did you earn any income in 2020?")
-    click_on "No"
-    click_on "Continue"
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.income.title', tax_year: 2020))
+    click_on I18n.t('general.negative')
+    click_on I18n.t('general.continue')
 
-    expect(page).to have_selector("h1", text: "In order to file, we’ll need some additional information.")
-    fill_in "Legal first name", with: "Gary"
-    fill_in "Middle initial", with: "H"
-    fill_in "Legal last name", with: "Mango"
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.legal_consent.title'))
+    fill_in I18n.t('views.ctc.questions.legal_consent.first_name'), with: "Gary"
+    fill_in I18n.t('views.ctc.questions.legal_consent.middle_initial'), with: "H"
+    fill_in I18n.t('views.ctc.questions.legal_consent.last_name'), with: "Mango"
     fill_in "ctc_consent_form_primary_birth_date_month", with: "08"
     fill_in "ctc_consent_form_primary_birth_date_day", with: "24"
     fill_in "ctc_consent_form_primary_birth_date_year", with: "1996"
-    fill_in "SSN or ITIN", with: "111-22-8888"
-    fill_in "Confirm SSN or ITIN", with: "111-22-8888"
-    fill_in "Phone number", with: "831-234-5678"
-    click_on "Continue"
+    fill_in I18n.t('views.ctc.questions.legal_consent.ssn'), with: "111-22-8888"
+    fill_in I18n.t('views.ctc.questions.legal_consent.ssn_confirmation'), with: "111-22-8888"
+    fill_in I18n.t('views.ctc.questions.legal_consent.sms_phone_number'), with: "831-234-5678"
+    click_on I18n.t('general.continue')
 
-    expect(page).to have_selector("h1", text: "What is the best way to reach you?")
-    click_on "Send me texts"
-    expect(page).to have_selector("h1", text: "Please share your phone number.")
-    fill_in "Cell phone number", with: "8324658840"
-    fill_in "Confirm cell phone number", with: "8324658840"
-    click_on "Continue"
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.contact_preference.title'))
+    click_on I18n.t('views.ctc.questions.contact_preference.text')
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.cell_phone_number.title'))
+    fill_in I18n.t('views.ctc.questions.cell_phone_number.label'), with: "8324658840"
+    fill_in I18n.t('views.ctc.questions.cell_phone_number.confirm_label'), with: "8324658840"
+    click_on I18n.t('general.continue')
 
-    expect(page).to have_selector("h1", text: "Please share your phone number.")
-    expect(page).to have_selector(".text--error", text: "Please provide a phone number that can receive texts")
-    click_on "provide an email address instead"
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.cell_phone_number.title'))
+    expected_error = I18n.t('views.ctc.questions.cell_phone_number.must_receive_texts_html')
+    expect(page).to have_selector(".text--error", text: ActionView::Base.full_sanitizer.sanitize(expected_error))
+    click_on Nokogiri::HTML(expected_error).css('a').text
 
-    expect(page).to have_selector("h1", text: "Please share your e-mail address.")
-    fill_in "E-mail address", with: "mango@example.com"
-    fill_in "Confirm e-mail address", with: "mango@example.com"
-    click_on "Continue"
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.email_address.title'))
+    fill_in I18n.t('views.questions.email_address.email_address'), with: "mango@example.com"
+    fill_in I18n.t('views.questions.email_address.email_address_confirmation'), with: "mango@example.com"
+    click_on I18n.t('general.continue')
 
-    expect(page).to have_selector("p", text: "A message with your code has been sent to: mango@example.com")
+    expect(page).to have_selector("p", text: I18n.t('views.ctc.questions.verification.body').strip)
 
     perform_enqueued_jobs
     mail = ActionMailer::Base.deliveries.last
-    expect(mail.html_part.body.to_s).to have_text("Your 6-digit GetCTC verification code is: ")
-    code = mail.html_part.body.to_s.match(/Your 6-digit GetCTC verification code is: (\d+)/)[1]
+    code = mail.html_part.body.to_s.match(/\s(\d{6})[.]/)[1]
 
-    fill_in "Enter 6 digit code", with: "000001"
-    click_on "Continue"
-    expect(page).to have_content("Incorrect verification code.")
+    fill_in I18n.t('views.ctc.questions.verification.verification_code_label'), with: "000001"
+    click_on I18n.t('general.continue')
+    expect(page).to have_content(I18n.t('views.ctc.questions.verification.error_message'))
 
-    fill_in "Enter 6 digit code", with: code
-    click_on "Continue"
+    fill_in I18n.t('views.ctc.questions.verification.verification_code_label'), with: code
+    click_on I18n.t('general.continue')
 
     # =========== LIFE SITUATIONS ===========
-    expect(page).to have_selector("h1", text: "Did you file a 2020 tax return this year?")
-    click_on "No"
-    expect(page).to have_selector("h1", text: "Did you either file a 2019 tax return or receive any stimulus payments?")
-    click_on "Yes"
-    expect(page).to have_selector("h1", text: "Let's check one more thing.")
-    click_on "Continue"
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.filed_2020.title'))
+    click_on I18n.t('general.negative')
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.filed_2019.title'))
+    click_on I18n.t('general.affirmative')
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.life_situations_2019.title'))
+    click_on I18n.t('general.continue')
 
-    expect(page).to have_selector("h1", text: "Where was your main home for 2020?")
-    check "Any of the 50 states or the District of Columbia"
-    check "Foreign address"
-    click_on "Continue"
-    expect(page).to have_selector("h1", text:  "Unfortunately, you are not eligible to use GetCTC. But we can still help!")
-    click_on "Go back"
-    expect(page).to have_selector("h1", text: "Where was your main home for 2020?")
-    check "Any of the 50 states or the District of Columbia"
-    check "U.S. military facility"
-    click_on "Continue"
-    expect(page).to have_selector("h1", text: "Select any situations that were true for you in 2020")
-    check "No one can claim me as a dependent"
-    click_on "Continue"
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.home.title'))
+    check I18n.t('views.ctc.questions.home.options.fifty_states')
+    check I18n.t('views.ctc.questions.home.options.foreign_address')
+    click_on I18n.t('general.continue')
+    expect(page).to have_selector("h1", text:  I18n.t('views.ctc.questions.use_gyr.title'))
+    click_on I18n.t('general.back')
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.home.title'))
+    check I18n.t('views.ctc.questions.home.options.fifty_states')
+    check I18n.t('views.ctc.questions.home.options.military_facility')
+    click_on I18n.t('general.continue')
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.life_situations_2020.title'))
+    check I18n.t('views.ctc.questions.life_situations_2020.cannot_claim_me_as_a_dependent')
+    click_on I18n.t('general.continue')
 
     # =========== FILING STATUS ===========
-    expect(page).to have_selector("h1", text: "How will you be filing your tax return?")
-    choose "Married filing jointly"
-    click_on "Continue"
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.filing_status.title'))
+    choose I18n.t('general.filing_status.married_filing_jointly')
+    click_on I18n.t('general.continue')
 
-    expect(page).to have_selector("h1", text: "Tell us about your spouse")
-    fill_in "Spouse's legal first name", with: "Peter"
-    fill_in "Middle initial", with: "P"
-    fill_in "Spouse's legal last name", with: "Pepper"
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.spouse_info.title'))
+    fill_in I18n.t('views.ctc.questions.spouse_info.spouse_first_name'), with: "Peter"
+    fill_in I18n.t('views.ctc.questions.spouse_info.spouse_middle_initial'), with: "P"
+    fill_in I18n.t('views.ctc.questions.spouse_info.spouse_last_name'), with: "Pepper"
     fill_in "ctc_spouse_info_form[spouse_birth_date_month]", with: "01"
     fill_in "ctc_spouse_info_form[spouse_birth_date_day]", with: "11"
     fill_in "ctc_spouse_info_form[spouse_birth_date_year]", with: "1995"
-    select "Social Security Number (SSN)"
-    fill_in "Spouse's SSN or ITIN", with: "222-33-4444"
-    fill_in "Confirm spouse's SSN or ITIN", with: "222-33-4444"
-    click_on "Save this person"
-    expect(page).not_to have_text("Remove this person")
+    select I18n.t('general.tin.ssn')
+    fill_in I18n.t('views.ctc.questions.spouse_info.spouse_ssn_itin'), with: "222-33-4444"
+    fill_in I18n.t('views.ctc.questions.spouse_info.spouse_ssn_itin_confirmation'), with: "222-33-4444"
+    click_on I18n.t('views.ctc.questions.spouse_info.save_button')
+    expect(page).not_to have_text(I18n.t('views.ctc.questions.spouse_info.remove_button'))
 
-    expect(page).to have_text("Let's confirm your spouse's information.")
+    expect(page).to have_text(I18n.t('views.ctc.questions.spouse_review.title'))
     expect(page).to have_text("Peter Pepper")
-    expect(page).to have_text("Date of birth: 1/11/1995")
-    expect(page).to have_text("SSN: XXX-XX-4444")
-    click_on "edit"
+    expect(page).to have_text(I18n.t('views.ctc.questions.spouse_review.spouse_birthday', dob: "1/11/1995"))
+    expect(page).to have_text(I18n.t('views.ctc.questions.spouse_review.spouse_ssn', ssn: "4444"))
+    click_on I18n.t('general.edit').downcase
 
-    expect(page).to have_selector("h1", text: "Tell us about your spouse")
-    click_on "Remove this person"
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.spouse_info.title'))
+    click_on I18n.t('views.ctc.questions.spouse_info.remove_button')
 
-    expect(page).to have_selector("h1", text: "You're about to remove Peter Pepper.")
-    click_on "Nevermind, let's save them"
+    remove_confirmation = I18n.t("views.ctc.questions.remove_spouse.title_html", spouse_name: "Peter Pepper")
+    expect(page).to have_selector("h1", text: ActionView::Base.full_sanitizer.sanitize(remove_confirmation))
+    click_on I18n.t('views.ctc.questions.remove_spouse.nevermind_button')
 
-    expect(page).to have_selector("h1", text: "Let's confirm your spouse's information.")
-    click_on "Continue"
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.spouse_review.title'))
+    click_on I18n.t('general.continue')
 
     # =========== DEPENDENTS ===========
     expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.had_dependents.title'))
-    click_on "No"
+    click_on I18n.t('general.negative')
 
     expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.no_dependents.title'))
-    click_on "Go back"
-    click_on "Yes"
+    click_on I18n.t('general.back')
+    click_on I18n.t('general.affirmative')
 
     expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.info.title'))
     fill_in I18n.t('views.ctc.questions.dependents.info.first_name'), with: "Jessie"
@@ -131,13 +132,13 @@ RSpec.feature "CTC Intake", :flow_explorer_screenshot, active_job: true do
     fill_in "ctc_dependents_info_form[birth_date_year]", with: "1995"
     select I18n.t('general.dependent_relationships.00_daughter'), from: I18n.t('views.ctc.questions.dependents.info.relationship_to_you')
     check I18n.t('views.ctc.questions.dependents.info.full_time_student')
-    click_on "Continue"
+    click_on I18n.t('general.continue')
 
     expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.tin.title', name: 'Jessie'))
     select "Social Security Number (SSN)"
     fill_in I18n.t('views.ctc.questions.dependents.tin.ssn_or_atin', name: "Jessie"), with: "222-33-4445"
     fill_in I18n.t('views.ctc.questions.dependents.tin.ssn_or_atin_confirmation', name: "Jessie"), with: "222-33-4445"
-    click_on "Continue"
+    click_on I18n.t('general.continue')
 
     expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.confirm_dependents.title'))
     # Next line skipped for now due to dependent confirmation screen limiting dependents
@@ -145,118 +146,118 @@ RSpec.feature "CTC Intake", :flow_explorer_screenshot, active_job: true do
     # expect(page).to have_content("Jessie")
 
     # Back up to prove that the 'go back' button brings us back to the dependent we were editing
-    click_on "Go back"
+    click_on I18n.t('general.back')
     expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.tin.title', name: 'Jessie'))
-    click_on "Continue"
+    click_on I18n.t('general.continue')
     click_on I18n.t('views.ctc.questions.dependents.confirm_dependents.done_adding')
 
     # =========== RECOVERY REBATE CREDIT ===========
-    expect(page).to have_selector("h1", text: "Based on your info, we believe you should have received this much in stimulus payments.")
-    click_on "No, I didn’t receive this amount."
-    expect(page).to have_selector("h1", text: "Did you receive any of the first stimulus payment?")
-    click_on "Yes"
-    expect(page).to have_selector("h1", text: "Enter the total amount you received for your first stimulus payment.")
-    fill_in "Economic Impact Payment 1", with: "1200"
-    click_on "Continue"
-    expect(page).to have_selector("h1", text: "Did you receive any of the second stimulus payment?")
-    click_on "Yes"
-    expect(page).to have_selector("h1", text: "Enter the total amount you received for your second stimulus payment.")
-    fill_in "Economic Impact Payment 2", with: "2100"
-    click_on "Continue"
-    # This part is temporary, and will need adjustment when we get RCC calculations working
-    expect(page).to have_selector("h1", text: "Based on your info, it looks like you’ve received your full stimulus payments.")
-    expect(page).to have_text("EIP 1: $1,200")
-    expect(page).to have_text("EIP 2: $2,100")
-    click_on "Continue"
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_payments.title'))
+    click_on I18n.t('views.ctc.questions.stimulus_payments.no_did_not_receive')
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_one.title'))
+    click_on I18n.t('general.affirmative')
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_one_received.title'))
+    fill_in I18n.t('views.ctc.questions.stimulus_one_received.recovery_rebate_credit_amount_1_label'), with: "1200"
+    click_on I18n.t('general.continue')
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_two.title'))
+    click_on I18n.t('general.affirmative')
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_two_received.title'))
+    fill_in I18n.t('views.ctc.questions.stimulus_two_received.recovery_rebate_credit_amount_2_label'), with: "2100"
+    click_on I18n.t('general.continue')
+    # This part is temporary, and will need adjustment when we get RRC calculations working
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_received.title'))
+    expect(page).to have_text("#{I18n.t('views.ctc.questions.stimulus_received.eip_one')}: $1,200")
+    expect(page).to have_text("#{I18n.t('views.ctc.questions.stimulus_received.eip_two')}: $2,100")
+    click_on I18n.t('general.continue')
 
     # =========== BANK AND MAILING INFO ===========
-    expect(page).to have_selector("h1", text: "If you are supposed to get money, how would you like to receive it?")
-    choose "Direct deposit (fastest)"
-    click_on "Continue"
-    expect(page).to have_selector("h1", text: "Great, please provide your bank details below!")
-    fill_in "Bank name", with: "Bank of Two Melons"
-    choose "Checking"
-    check "My name is on this bank account"
-    click_on "Continue"
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.refund_payment.title'))
+    choose I18n.t('views.questions.refund_payment.direct_deposit')
+    click_on I18n.t('general.continue')
+    expect(page).to have_selector("h1", text: I18n.t('views.questions.bank_details.title'))
+    fill_in I18n.t('views.questions.bank_details.bank_name'), with: "Bank of Two Melons"
+    choose I18n.t('views.questions.bank_details.account_type.checking')
+    check I18n.t('views.ctc.questions.direct_deposit.my_bank_account.label')
+    click_on I18n.t('general.continue')
 
-    expect(page).to have_selector("h1", text: "Please provide your bank's routing number")
-    fill_in "Routing number", with: "12345678"
-    fill_in "Confirm routing number", with: "12345678"
-    click_on "Continue"
-    expect(page).to have_selector(".text--error", text: "is the wrong length (should be 9 characters)")
-    fill_in "Routing number", with: "123456789"
-    fill_in "Confirm routing number", with: "123456789"
-    click_on "Continue"
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.routing_number.title'))
+    fill_in I18n.t('views.ctc.questions.routing_number.routing_number'), with: "12345678"
+    fill_in I18n.t('views.ctc.questions.routing_number.routing_number_confirmation'), with: "12345678"
+    click_on I18n.t('general.continue')
+    expect(page).to have_selector(".text--error", text: I18n.t('errors.messages.wrong_length', count: 9))
+    fill_in I18n.t('views.ctc.questions.routing_number.routing_number'), with: "123456789"
+    fill_in I18n.t('views.ctc.questions.routing_number.routing_number_confirmation'), with: "123456789"
+    click_on I18n.t('general.continue')
 
-    expect(page).to have_selector("h1", text: "Please provide your account number")
-    fill_in "Account number", with: "123456789"
-    fill_in "Confirm account number", with: "123456789"
-    click_on "Continue"
-    expect(page).to have_selector("h1", text: "Great! Check to make sure your bank information is correct.")
-    expect(page).to have_selector("h2", text: "Your bank information")
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.account_number.title'))
+    fill_in I18n.t('views.ctc.questions.account_number.account_number'), with: "123456789"
+    fill_in I18n.t('views.ctc.questions.account_number.account_number_confirmation'), with: "123456789"
+    click_on I18n.t('general.continue')
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.confirm_bank_account.title'))
+    expect(page).to have_selector("h2", text: I18n.t('views.ctc.questions.confirm_bank_account.bank_information'))
     expect(page).to have_selector("li", text: "Bank of Two Melons")
-    expect(page).to have_selector("li", text: "Type: Checking")
-    expect(page).to have_selector("li", text: "Routing number: 123456789")
-    expect(page).to have_selector("li", text: "Account number: ●●●●●6789")
-    click_on "Continue"
+    expect(page).to have_selector("li", text: "#{I18n.t('general.type')}: Checking")
+    expect(page).to have_selector("li", text: "#{I18n.t('general.bank_account.routing_number')}: 123456789")
+    expect(page).to have_selector("li", text: "#{I18n.t('general.bank_account.account_number')}: ●●●●●6789")
+    click_on I18n.t('general.continue')
 
-    expect(page).to have_selector("h1", text: "Great, please provide your mailing address below.")
-    fill_in "Street address or P.O. box", with: "26 William Street"
-    fill_in "Apartment number (optional)", with: "Apt 1234"
-    fill_in "City", with: "Bel Air"
-    select "California", from: "State"
-    fill_in "ZIP code", with: 90001
-    click_on "Continue"
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.mailing_address.title'))
+    fill_in I18n.t('views.questions.mailing_address.street_address'), with: "26 William Street"
+    fill_in I18n.t('views.questions.mailing_address.street_address2'), with: "Apt 1234"
+    fill_in I18n.t('views.questions.mailing_address.city'), with: "Bel Air"
+    select "California", from: I18n.t('views.questions.mailing_address.state')
+    fill_in I18n.t('views.questions.mailing_address.zip_code'), with: 90001
+    click_on I18n.t('general.continue')
 
-    expect(page).to have_selector("h1", text: "Great! Please confirm your mailing address.")
-    expect(page).to have_selector("h2", text: "Your mailing address")
+    expect(page).to have_selector("h1", text: I18n.t("views.ctc.questions.confirm_mailing_address.title"))
+    expect(page).to have_selector("h2", text: I18n.t('views.ctc.questions.confirm_mailing_address.mailing_address'))
     expect(page).to have_selector("div", text: "26 William Street")
     expect(page).to have_selector("div", text: "Apt 1234")
     expect(page).to have_selector("div", text: "Bel Air, CA 90001")
-    click_on "Continue"
+    click_on I18n.t('general.continue')
 
     # =========== IP PINs ===========
     expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.ip_pin.title'))
     check "Gary Mango"
     check "Jessie Pepper"
-    click_on "Continue"
+    click_on I18n.t('general.continue')
 
     expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.ip_pin_entry.title'))
     fill_in I18n.t('views.ctc.questions.ip_pin_entry.label', name: "Gary Mango"), with: "123456"
     fill_in I18n.t('views.ctc.questions.ip_pin_entry.label', name: "Jessie Pepper"), with: "123458"
-    click_on "Continue"
+    click_on I18n.t('general.continue')
 
     # =========== REVIEW ===========
     expect(page).to have_selector("h1", text: I18n.t("views.ctc.questions.confirm_information.title"))
 
     expect(page).to have_selector("h2", text: I18n.t("views.ctc.questions.confirm_information.your_information"))
     expect(page).to have_selector("div", text: "Gary Mango")
-    expect(page).to have_selector("div", text: "Date of birth: 8/24/1996")
-    expect(page).to have_selector("div", text: "Email: mango@example.com")
-    expect(page).to have_selector("div", text: "Phone: (831) 234-5678")
-    expect(page).to have_selector("div", text: "SSN: XXX-XX-8888")
+    expect(page).to have_selector("div", text: "#{I18n.t('hub.clients.show.date_of_birth')}: 8/24/1996")
+    expect(page).to have_selector("div", text: "#{I18n.t('general.email')}: mango@example.com")
+    expect(page).to have_selector("div", text: "#{I18n.t('general.phone')}: (831) 234-5678")
+    expect(page).to have_selector("div", text: "#{I18n.t('general.ssn')}: XXX-XX-8888")
 
-    expect(page).to have_selector("h2", text: "Your mailing address")
+    expect(page).to have_selector("h2", text: I18n.t("views.ctc.questions.confirm_mailing_address.mailing_address"))
     expect(page).to have_selector("div", text: "26 William Street")
     expect(page).to have_selector("div", text: "Apt 1234")
     expect(page).to have_selector("div", text: "Bel Air, CA 90001")
 
     expect(page).to have_selector("h2", text: I18n.t("views.ctc.questions.spouse_review.your_spouse"))
     expect(page).to have_selector("div", text: "Peter Pepper")
-    expect(page).to have_selector("div", text: "Date of birth: 1/11/1995")
-    expect(page).to have_selector("div", text: "SSN: XXX-XX-4444")
+    expect(page).to have_selector("div", text: "#{I18n.t('general.date_of_birth')}: 1/11/1995")
+    expect(page).to have_selector("div", text: "#{I18n.t('general.ssn')}: XXX-XX-4444")
 
     # TODO: add tests for displaying dependent info after we allow the creation of qualifying dependents
 
-    expect(page).to have_selector("h2", text: "Your bank information")
+    expect(page).to have_selector("h2", text: I18n.t("views.ctc.questions.confirm_bank_account.bank_information"))
     expect(page).to have_selector("li", text: "Bank of Two Melons")
-    expect(page).to have_selector("li", text: "Type: Checking")
-    expect(page).to have_selector("li", text: "Routing number: 123456789")
-    expect(page).to have_selector("li", text: "Account number: ●●●●●6789")
+    expect(page).to have_selector("li", text: "#{I18n.t('general.type')}: Checking")
+    expect(page).to have_selector("li", text: "#{I18n.t('general.bank_account.routing_number')}: 123456789")
+    expect(page).to have_selector("li", text: "#{I18n.t('general.bank_account.account_number')}: ●●●●●6789")
 
     fill_in I18n.t("views.ctc.questions.confirm_information.labels.signature_pin", name: "Gary Mango"), with: "12345"
     fill_in I18n.t("views.ctc.questions.confirm_information.labels.signature_pin", name: "Peter Pepper"), with: "54321"
-    click_on "I'm ready to file"
+    click_on I18n.t('views.ctc.questions.confirm_information.ready_to_file')
 
     expect(page).to have_selector("h1", text: I18n.t("views.ctc.questions.confirm_legal.title"))
     check I18n.t("views.ctc.questions.confirm_legal.consent")

--- a/spec/helpers/rrc_helper_spec.rb
+++ b/spec/helpers/rrc_helper_spec.rb
@@ -6,6 +6,16 @@ describe RrcHelper do
       expect(helper.calculated_or_provided_dollar_amount(1200)).to eq "$1,200"
     end
 
+    context "with Spanish language requested" do
+      around do |example|
+        I18n.with_locale(:es) { example.run }
+      end
+
+      it "return the US English formatted currency anyway" do
+        expect(helper.calculated_or_provided_dollar_amount(1200)).to eq "$1,200"
+      end
+    end
+
     it "returns a $TBD if it is not given a value" do
       expect(helper.calculated_or_provided_dollar_amount(nil)).to eq "$TBD"
     end

--- a/spec/models/tax_return_spec.rb
+++ b/spec/models/tax_return_spec.rb
@@ -68,8 +68,8 @@ describe TaxReturn do
     end
 
     context "spanish" do
-      before do
-        I18n.locale = "es"
+      around do |example|
+        I18n.with_locale(:es) { example.run }
       end
 
       it "has a key for each tax_return status" do


### PR DESCRIPTION
incidentally fixes a bug with some links in error messages that
weren't getting rendered in the current locale