### PR TITLE
RRC calculation should 'zero out' over payments [#179017071]

### DIFF
--- a/app/lib/submission_builder/documents/adv_ctc_irs1040.rb
+++ b/app/lib/submission_builder/documents/adv_ctc_irs1040.rb
@@ -46,11 +46,11 @@ module SubmissionBuilder
             xml.AdjustedGrossIncomeAmt 1
             xml.TotalItemizedOrStandardDedAmt tax_return.standard_deduction
             xml.TaxableIncomeAmt 0
-            xml.RecoveryRebateCreditAmt tax_return.outstanding_recovery_rebate_amount_if_claimed
-            xml.RefundableCreditsAmt tax_return.outstanding_recovery_rebate_amount_if_claimed
+            xml.RecoveryRebateCreditAmt tax_return.outstanding_recovery_rebate_amount if tax_return.claim_rrc?
+            xml.RefundableCreditsAmt tax_return.outstanding_recovery_rebate_amount if tax_return.claim_rrc?
             xml.TotalPaymentsAmt 0
             xml.OverpaidAmt 0
-            xml.RefundAmt tax_return.outstanding_recovery_rebate_amount_if_claimed
+            xml.RefundAmt tax_return.claim_rrc? ? tax_return.outstanding_recovery_rebate_amount : 0
             if bank_account.present? && intake.refund_payment_method_direct_deposit?
               xml.RoutingTransitNum bank_account.routing_number
               xml.BankAccountTypeCd bank_account.account_type_code

--- a/app/lib/submission_builder/return_header1040.rb
+++ b/app/lib/submission_builder/return_header1040.rb
@@ -159,7 +159,7 @@ module SubmissionBuilder
     # 2 - bank account
     # 3 - check
     def refund_disbursement_code
-      return 0 if submission.tax_return.outstanding_recovery_rebate_amount_if_claimed == 0
+      return 0 if !submission.tax_return.claim_rrc? || submission.tax_return.outstanding_recovery_rebate_amount.zero?
 
       submission.intake.refund_payment_method_direct_deposit? ? 2 : 3
     end

--- a/app/models/tax_return.rb
+++ b/app/models/tax_return.rb
@@ -79,11 +79,11 @@ class TaxReturn < ApplicationRecord
   end
 
   def outstanding_recovery_rebate_amount
-    expected_recovery_rebate_credit_one + expected_recovery_rebate_credit_two - intake.eip1_amount_received - intake.eip2_amount_received
+    [expected_recovery_rebate_credit_one - intake.eip1_amount_received, 0].max + [expected_recovery_rebate_credit_two - intake.eip2_amount_received, 0].max
   end
 
-  def outstanding_recovery_rebate_amount_if_claimed
-    intake.claim_owed_stimulus_money_yes? ? outstanding_recovery_rebate_amount : 0
+  def claim_rrc?
+    intake.claim_owed_stimulus_money_yes? && outstanding_recovery_rebate_amount.positive?
   end
 
   def expected_recovery_rebate_credit_one

--- a/spec/lib/submission_builder/documents/adv_ctc_irs1040_spec.rb
+++ b/spec/lib/submission_builder/documents/adv_ctc_irs1040_spec.rb
@@ -81,5 +81,23 @@ describe SubmissionBuilder::Documents::AdvCtcIrs1040 do
         expect(described_class.build(submission)).to be_valid
       end
     end
+
+    context "when not claiming additional rrc credit" do
+      before do
+        allow_any_instance_of(TaxReturn).to receive(:claim_rrc?).and_return false
+      end
+
+      it "does not include credit entries on the XML, and sets refund amount to 0" do
+        xml = Nokogiri::XML::Document.parse(described_class.build(submission).document.to_xml)
+
+        expect(xml.at("RecoveryRebateCreditAmt")).to be_nil
+        expect(xml.at("RecoveryRebateCreditAmt")).to be_nil
+        expect(xml.at("RefundAmt").text).to eq "0"
+      end
+
+      it "conforms to the eFileAttachments schema" do
+        expect(described_class.build(submission)).to be_valid
+      end
+    end
   end
 end

--- a/spec/lib/submission_builder/return_header1040_spec.rb
+++ b/spec/lib/submission_builder/return_header1040_spec.rb
@@ -191,7 +191,8 @@ describe SubmissionBuilder::ReturnHeader1040 do
       context "filing with direct deposit" do
         before do
           submission.intake.update(refund_payment_method: "direct_deposit")
-          allow_any_instance_of(TaxReturn).to receive(:outstanding_recovery_rebate_amount_if_claimed).and_return(refund_amount)
+          allow_any_instance_of(TaxReturn).to receive(:outstanding_recovery_rebate_amount).and_return(refund_amount)
+          allow_any_instance_of(TaxReturn).to receive(:claim_rrc?).and_return(true)
         end
 
         context "with a refund due" do
@@ -229,7 +230,8 @@ describe SubmissionBuilder::ReturnHeader1040 do
     context "filing requesting a check payment" do
       before do
         submission.intake.update(refund_payment_method: "check")
-        allow_any_instance_of(TaxReturn).to receive(:outstanding_recovery_rebate_amount_if_claimed).and_return(refund_amount)
+        allow_any_instance_of(TaxReturn).to receive(:outstanding_recovery_rebate_amount).and_return(refund_amount)
+        allow_any_instance_of(TaxReturn).to receive(:claim_rrc?).and_return true
       end
 
       context "with a refund due" do

--- a/spec/models/tax_return_spec.rb
+++ b/spec/models/tax_return_spec.rb
@@ -111,7 +111,7 @@ describe TaxReturn do
         allow(EconomicImpactPaymentTwoCalculator).to receive(:payment_due).and_return(1200)
       end
 
-      it "qualifies for outstanding eip1 amount" do
+      it "has a 0 amount" do
         expect(tax_return.outstanding_recovery_rebate_amount).to eq 0
       end
     end

--- a/spec/models/tax_return_spec.rb
+++ b/spec/models/tax_return_spec.rb
@@ -97,7 +97,7 @@ describe TaxReturn do
         allow(EconomicImpactPaymentTwoCalculator).to receive(:payment_due).and_return(1200)
       end
 
-      it "qualifies for outstanding eip1 amount" do
+      it "qualifies for outstanding eip1+eip2 amount" do
         expect(tax_return.outstanding_recovery_rebate_amount).to eq 200
       end
     end


### PR DESCRIPTION
- Only claim RRC on the 1040 if the client wants to AND the amount to claim is greater than 0
- If the reported credit is greater than the expected credit from our calculation for either EIP1 or EIP, treat it as zero -- people have no responsibility to report 'excess' EIP payments, and can still claim underpayment on the other check if relevant.