### PR TITLE
Use id for most recent tax return instead of created_at so that scope is based on an indexed column

### DIFF
--- a/app/models/efile_submission.rb
+++ b/app/models/efile_submission.rb
@@ -32,7 +32,7 @@ class EfileSubmission < ApplicationRecord
   ]
 
   scope :most_recent_by_tax_return, lambda {
-    joins(:tax_return).where("efile_submissions.created_at = (SELECT MAX(efile_submissions.created_at) FROM efile_submissions WHERE efile_submissions.tax_return_id = tax_returns.id)")
+    joins(:tax_return).where("efile_submissions.id = (SELECT MAX(efile_submissions.id) FROM efile_submissions WHERE efile_submissions.tax_return_id = tax_returns.id)")
   }
 
   def state_machine


### PR DESCRIPTION
By design, does not need additional testing because the old tests for the same scope still pass