### PR TITLE
CTC intake: feature test that a dependent can actually show on the dependents review

### DIFF
--- a/app/controllers/ctc/questions/dependents/base_dependent_controller.rb
+++ b/app/controllers/ctc/questions/dependents/base_dependent_controller.rb
@@ -20,22 +20,26 @@ module Ctc
           current_intake.dependents.find { |d| d.id == params[:id].to_i }
         end
 
+        def self.model_for_show_check(current_controller)
+          current_controller.current_resource
+        end
+
         def edit
           return if form_class == NullForm
 
-          @form = form_class.from_dependent(current_dependent)
+          @form = form_class.from_dependent(current_resource)
+        end
+
+        def current_resource
+          @dependent ||= self.class.current_resource_from_params(current_intake, params)
+          raise ActiveRecord::RecordNotFound unless @dependent
+          @dependent
         end
 
         private
 
         def initialized_update_form
-          form_class.new(current_dependent, form_params)
-        end
-
-        def current_dependent
-          @dependent ||= self.class.current_resource_from_params(current_intake, params)
-          raise ActiveRecord::RecordNotFound unless @dependent
-          @dependent
+          form_class.new(current_resource, form_params)
         end
 
         def remember_last_edited_dependent_id

--- a/app/controllers/ctc/questions/dependents/child_can_be_claimed_by_other_controller.rb
+++ b/app/controllers/ctc/questions/dependents/child_can_be_claimed_by_other_controller.rb
@@ -14,10 +14,6 @@ module Ctc
             dependent.meets_qc_residence_condition_2020?
         end
 
-        def self.model_for_show_check(current_controller)
-          current_resource_from_params(current_controller.visitor_record, current_controller.params)
-        end
-
         def method_name
           'cant_be_claimed_by_other'
         end

--- a/app/controllers/ctc/questions/dependents/child_disqualifiers_controller.rb
+++ b/app/controllers/ctc/questions/dependents/child_disqualifiers_controller.rb
@@ -11,10 +11,6 @@ module Ctc
           dependent.qualifying_child_relationship? && dependent.meets_qc_age_condition_2020?
         end
 
-        def self.model_for_show_check(current_controller)
-          current_resource_from_params(current_controller.visitor_record, current_controller.params)
-        end
-
         private
 
         def illustration_path; end

--- a/app/controllers/ctc/questions/dependents/child_lived_with_you_controller.rb
+++ b/app/controllers/ctc/questions/dependents/child_lived_with_you_controller.rb
@@ -10,10 +10,6 @@ module Ctc
           dependent.qualifying_child_relationship? && dependent.meets_qc_age_condition_2020? && dependent.meets_qc_misc_conditions?
         end
 
-        def self.model_for_show_check(current_controller)
-          current_resource_from_params(current_controller.visitor_record, current_controller.params)
-        end
-
         def method_name
           'lived_with_more_than_six_months'
         end

--- a/app/controllers/ctc/questions/dependents/child_residence_exceptions_controller.rb
+++ b/app/controllers/ctc/questions/dependents/child_residence_exceptions_controller.rb
@@ -11,10 +11,6 @@ module Ctc
           dependent.qualifying_child_relationship? && dependent.meets_qc_age_condition_2020? && dependent.meets_qc_misc_conditions? && dependent.lived_with_more_than_six_months_no?
         end
 
-        def self.model_for_show_check(current_controller)
-          current_resource_from_params(current_controller.visitor_record, current_controller.params)
-        end
-
         private
 
         def illustration_path; end

--- a/app/controllers/ctc/questions/dependents/claim_child_anyway_controller.rb
+++ b/app/controllers/ctc/questions/dependents/claim_child_anyway_controller.rb
@@ -15,10 +15,6 @@ module Ctc
             dependent.cant_be_claimed_by_other_no?
         end
 
-        def self.model_for_show_check(current_controller)
-          current_resource_from_params(current_controller.visitor_record, current_controller.params)
-        end
-
         def method_name
           'claim_anyway'
         end

--- a/app/controllers/ctc/questions/dependents/does_not_qualify_ctc_controller.rb
+++ b/app/controllers/ctc/questions/dependents/does_not_qualify_ctc_controller.rb
@@ -11,12 +11,8 @@ module Ctc
           !dependent.qualifying_child_2020? && !dependent.qualifying_relative_2020?
         end
 
-        def self.model_for_show_check(current_controller)
-          current_resource_from_params(current_controller.visitor_record, current_controller.params)
-        end
-
         def edit
-          @dependent = current_dependent
+          @dependent = current_resource
           super
         end
 

--- a/app/controllers/ctc/questions/dependents/info_controller.rb
+++ b/app/controllers/ctc/questions/dependents/info_controller.rb
@@ -6,13 +6,11 @@ module Ctc
 
         layout "intake"
 
-        def self.show?(intake)
-          intake.had_dependents_yes?
+        def self.show?(dependent)
+          dependent.intake.had_dependents_yes?
         end
 
-        private
-
-        def current_dependent
+        def current_resource
           @dependent ||= begin
             if params[:id] == 'new'
               current_intake.dependents.new
@@ -21,6 +19,8 @@ module Ctc
             end
           end
         end
+
+        private
 
         def illustration_path; end
       end

--- a/app/controllers/ctc/questions/dependents/qualifying_relative_controller.rb
+++ b/app/controllers/ctc/questions/dependents/qualifying_relative_controller.rb
@@ -14,10 +14,6 @@ module Ctc
             dependent.qualifying_relative_relationship?
         end
 
-        def self.model_for_show_check(current_controller)
-          current_resource_from_params(current_controller.visitor_record, current_controller.params)
-        end
-
         def method_name
           'meets_misc_qualifying_relative_requirements'
         end

--- a/app/controllers/ctc/questions/dependents/tin_controller.rb
+++ b/app/controllers/ctc/questions/dependents/tin_controller.rb
@@ -10,6 +10,10 @@ module Ctc
           intake.had_dependents_yes?
         end
 
+        def self.model_for_show_check(current_controller)
+          current_controller.visitor_record
+        end
+
         private
 
         def illustration_path

--- a/app/controllers/ctc/questions/questions_controller.rb
+++ b/app/controllers/ctc/questions/questions_controller.rb
@@ -3,6 +3,10 @@ module Ctc
     class QuestionsController < ::Questions::QuestionsController
       helper_method :wrapping_layout
 
+      def current_resource
+        nil
+      end
+
       private
 
       def wrapping_layout
@@ -21,7 +25,7 @@ module Ctc
         next_step = form_navigation.next
         options = {}
         if next_step.resource_name.present? && next_step.resource_name == self.class.resource_name
-          options[:id] = current_dependent.id
+          options[:id] = current_resource.id
         end
         next_step.to_path_helper(options)
       end

--- a/spec/features/ctc/complete_intake_spec.rb
+++ b/spec/features/ctc/complete_intake_spec.rb
@@ -123,16 +123,28 @@ RSpec.feature "CTC Intake", :flow_explorer_screenshot, active_job: true do
     click_on I18n.t('general.back')
     click_on I18n.t('general.affirmative')
 
+    dependent_birth_year = 22.years.ago.year
+
     expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.info.title'))
     fill_in I18n.t('views.ctc.questions.dependents.info.first_name'), with: "Jessie"
     fill_in I18n.t('views.ctc.questions.dependents.info.middle_initial'), with: "M"
     fill_in I18n.t('views.ctc.questions.dependents.info.last_name'), with: "Pepper"
     fill_in "ctc_dependents_info_form[birth_date_month]", with: "01"
     fill_in "ctc_dependents_info_form[birth_date_day]", with: "11"
-    fill_in "ctc_dependents_info_form[birth_date_year]", with: "1995"
+    fill_in "ctc_dependents_info_form[birth_date_year]", with: dependent_birth_year
     select I18n.t('general.dependent_relationships.00_daughter'), from: I18n.t('views.ctc.questions.dependents.info.relationship_to_you')
     check I18n.t('views.ctc.questions.dependents.info.full_time_student')
     click_on I18n.t('general.continue')
+
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.child_disqualifiers.title', name: 'Jessie'))
+    check I18n.t('general.none')
+    click_on I18n.t('general.continue')
+
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.child_lived_with_you.title', dependent_name: 'Jessie', tax_year: '2020'))
+    click_on I18n.t('general.affirmative')
+
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.child_can_be_claimed_by_other.title', dependent_name: 'Jessie'))
+    click_on I18n.t('general.affirmative')
 
     expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.tin.title', name: 'Jessie'))
     select "Social Security Number (SSN)"
@@ -141,9 +153,8 @@ RSpec.feature "CTC Intake", :flow_explorer_screenshot, active_job: true do
     click_on I18n.t('general.continue')
 
     expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.confirm_dependents.title'))
-    # Next line skipped for now due to dependent confirmation screen limiting dependents
-    # to the ones that match some criteria.
-    # expect(page).to have_content("Jessie")
+    expect(page).to have_content("Jessie Pepper")
+    expect(page).to have_selector("div", text: "#{I18n.t('general.date_of_birth')}: 1/11/#{dependent_birth_year}")
 
     # Back up to prove that the 'go back' button brings us back to the dependent we were editing
     click_on I18n.t('general.back')


### PR DESCRIPTION
Fixes an issue whereby the ChildDisqualifiersController (and thereafter most of the
dependents questions) would not show up because it was trying to pull the current
dependent from the URL but the url still says /dependents/new.