### PR TITLE
Add feature spec for some dependents flow cases [#179017128]

### DIFF
--- a/app/views/ctc/questions/dependents/child_can_be_claimed_by_other/edit.html.erb
+++ b/app/views/ctc/questions/dependents/child_can_be_claimed_by_other/edit.html.erb
@@ -1,1 +1,1 @@
-<% content_for :form_question, t("views.ctc.questions.dependents.child_can_be_claimed_by_other.title", dependent_name: @form.dependent.first_name) %>
+<% content_for :form_question, t("views.ctc.questions.dependents.child_can_be_claimed_by_other.title", name: @form.dependent.first_name) %>

--- a/app/views/ctc/questions/dependents/child_lived_with_you/edit.html.erb
+++ b/app/views/ctc/questions/dependents/child_lived_with_you/edit.html.erb
@@ -1,1 +1,1 @@
-<% content_for :form_question, t("views.ctc.questions.dependents.child_lived_with_you.title", dependent_name: @form.dependent.first_name, tax_year: 2020) %>
+<% content_for :form_question, t("views.ctc.questions.dependents.child_lived_with_you.title", name: @form.dependent.first_name, tax_year: 2020) %>

--- a/app/views/ctc/questions/dependents/child_residence_exceptions/edit.html.erb
+++ b/app/views/ctc/questions/dependents/child_residence_exceptions/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t("views.ctc.questions.dependents.child_residence_exceptions.title", dependent_name: @form.dependent.first_name) %>
+<% content_for :page_title, t("views.ctc.questions.dependents.child_residence_exceptions.title", name: @form.dependent.first_name) %>
 
 <% content_for :form_card do %>
   <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder, html: { class: "form-card form-card--long" } do |f| %>
@@ -9,10 +9,10 @@
       <%=t('views.ctc.questions.dependents.child_residence_exceptions.help_text') %>
     </p>
     <div class="form-card__stacked-checkboxes spacing-above-0">
-      <%= f.cfa_checkbox(:born_in_2020, t('views.ctc.questions.dependents.child_residence_exceptions.born_in_2020', dependent_name: @form.dependent.first_name), options: { checked_value: "yes", unchecked_value: "no" }) %>
-      <%= f.cfa_checkbox(:passed_away_2020, t('views.ctc.questions.dependents.child_residence_exceptions.passed_away_2020', dependent_name: @form.dependent.first_name), options: { checked_value: "yes", unchecked_value: "no" }) %>
-      <%= f.cfa_checkbox(:placed_for_adoption, t('views.ctc.questions.dependents.child_residence_exceptions.placed_for_adoption', dependent_name: @form.dependent.first_name), options: { checked_value: "yes", unchecked_value: "no" }) %>
-      <%= f.cfa_checkbox(:permanent_residence_with_client, t('views.ctc.questions.dependents.child_residence_exceptions.permanent_residence_with_client', dependent_name: @form.dependent.first_name), options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <%= f.cfa_checkbox(:born_in_2020, t('views.ctc.questions.dependents.child_residence_exceptions.born_in_2020', name: @form.dependent.first_name), options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <%= f.cfa_checkbox(:passed_away_2020, t('views.ctc.questions.dependents.child_residence_exceptions.passed_away_2020', name: @form.dependent.first_name), options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <%= f.cfa_checkbox(:placed_for_adoption, t('views.ctc.questions.dependents.child_residence_exceptions.placed_for_adoption', name: @form.dependent.first_name), options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <%= f.cfa_checkbox(:permanent_residence_with_client, t('views.ctc.questions.dependents.child_residence_exceptions.permanent_residence_with_client', name: @form.dependent.first_name), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox(:none, t("general.none_of_the_above"), options: { id: "none__checkbox", checked_value: "yes", unchecked_value: "no" }) %>
     </div>
 

--- a/app/views/ctc/questions/dependents/claim_child_anyway/edit.html.erb
+++ b/app/views/ctc/questions/dependents/claim_child_anyway/edit.html.erb
@@ -1,6 +1,6 @@
-<% content_for :form_question, t("views.ctc.questions.dependents.claim_child_anyway.title", dependent_name: @form.dependent.first_name) %>
+<% content_for :form_question, t("views.ctc.questions.dependents.claim_child_anyway.title", name: @form.dependent.first_name) %>
 <% content_for :form_help_text do %>
-  <%= t("views.ctc.questions.dependents.claim_child_anyway.help_text", dependent_name: @form.dependent.first_name) %>
+  <%= t("views.ctc.questions.dependents.claim_child_anyway.help_text", name: @form.dependent.first_name) %>
 
   <%= render('components/molecules/reveal', title: t("views.ctc.questions.dependents.claim_child_anyway.not_sure_reveal.title")) do %>
     <p> <%= t("views.ctc.questions.dependents.claim_child_anyway.not_sure_reveal.p") %> </p>

--- a/app/views/ctc/questions/dependents/confirm_dependents/edit.html.erb
+++ b/app/views/ctc/questions/dependents/confirm_dependents/edit.html.erb
@@ -8,18 +8,22 @@
     <h1 class="h2"><%= @main_question %></h1>
 
     <div class="review-box spacing-below-35">
-      <div class="review-box__title">
-        <h2><%= t("views.ctc.questions.dependents.confirm_dependents.qualifying_for_ctc") %></h2>
+      <div data-automation="ctc-dependents">
+        <div class="review-box__title">
+          <h2><%= t("views.ctc.questions.dependents.confirm_dependents.qualifying_for_ctc") %></h2>
+        </div>
+        <% current_intake.dependents.select { |dep| dep.eligible_for_child_tax_credit_2020? }.each do |dependent| %>
+          <%= render 'dependent', dependent: dependent %>
+        <% end %>
       </div>
-      <% current_intake.dependents.select { |dep| dep.eligible_for_child_tax_credit_2020? }.each do |dependent| %>
-        <%= render 'dependent', dependent: dependent %>
-      <% end %>
-      <div class="review-box__title">
-        <h2><%= t("views.ctc.questions.dependents.confirm_dependents.qualifying_for_other_credits") %></h2>
+      <div data-automation="other-credits-dependents">
+        <div class="review-box__title">
+          <h2><%= t("views.ctc.questions.dependents.confirm_dependents.qualifying_for_other_credits") %></h2>
+        </div>
+        <% current_intake.dependents.select { |dep| !dep.eligible_for_child_tax_credit_2020? && (dep.qualifying_child_2020? || dep.qualifying_relative_2020?) }.each do |dependent| %>
+          <%= render 'dependent', dependent: dependent %>
+        <% end %>
       </div>
-      <% current_intake.dependents.select { |dep| !dep.eligible_for_child_tax_credit_2020? && (dep.qualifying_child_2020? || dep.qualifying_relative_2020?) }.each do |dependent| %>
-        <%= render 'dependent', dependent: dependent %>
-      <% end %>
 
       <%= render('components/molecules/reveal', title: t("views.ctc.questions.dependents.confirm_dependents.reveal_title")) do %>
         <p><%= t("views.ctc.questions.dependents.confirm_dependents.reveal_body_title") %></p>

--- a/app/views/ctc/questions/dependents/does_not_qualify_ctc/edit.html.erb
+++ b/app/views/ctc/questions/dependents/does_not_qualify_ctc/edit.html.erb
@@ -1,4 +1,4 @@
-<% @main_question = t("views.ctc.questions.dependents.does_not_qualify_ctc.title", dependent:  @dependent.first_name.capitalize) %>
+<% @main_question = t("views.ctc.questions.dependents.does_not_qualify_ctc.title", name:  @dependent.first_name.capitalize) %>
 
 <% content_for :page_title, @main_question %>
 

--- a/app/views/ctc/questions/dependents/qualifying_relative/edit.html.erb
+++ b/app/views/ctc/questions/dependents/qualifying_relative/edit.html.erb
@@ -2,9 +2,9 @@
 
 <% content_for :form_help_text do %>
   <ul class="list--bulleted">
-    <li><%=t("views.ctc.questions.dependents.qualifying_relative.help_text.li1", dependent_name: @form.dependent.first_name) %></li>
-    <li><%=t("views.ctc.questions.dependents.qualifying_relative.help_text.li2", dependent_name: @form.dependent.first_name) %></li>
-    <li><%=t("views.ctc.questions.dependents.qualifying_relative.help_text.li3", dependent_name: @form.dependent.first_name) %></li>
-    <li><%=t("views.ctc.questions.dependents.qualifying_relative.help_text.li4", dependent_name: @form.dependent.first_name) %></li>
+    <li><%=t("views.ctc.questions.dependents.qualifying_relative.help_text.li1", name: @form.dependent.first_name) %></li>
+    <li><%=t("views.ctc.questions.dependents.qualifying_relative.help_text.li2", name: @form.dependent.first_name) %></li>
+    <li><%=t("views.ctc.questions.dependents.qualifying_relative.help_text.li3", name: @form.dependent.first_name) %></li>
+    <li><%=t("views.ctc.questions.dependents.qualifying_relative.help_text.li4", name: @form.dependent.first_name) %></li>
   </ul>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1375,26 +1375,26 @@ en:
             help_text: "Someone who lives with you for a majority of the year or who you support financially could qualify as a dependent."
             what_relationships_reveal: "What relationships qualify?"
           child_lived_with_you:
-            title: "Did %{dependent_name} live with you for more than 6 months in %{tax_year}?"
+            title: "Did %{name} live with you for more than 6 months in %{tax_year}?"
           child_residence_exceptions:
-            title: "Were any of the following true for %{dependent_name}?"
+            title: "Were any of the following true for %{name}?"
             help_text: "They could still qualify for payments if they lived with you for less than 6 months and any of the following were true."
-            born_in_2020: "%{dependent_name} was born in 2020"
-            passed_away_2020: "%{dependent_name} was lawfully placed with you for adoption in 2020"
-            placed_for_adoption: "%{dependent_name} passed away in 2020"
-            permanent_residence_with_client: "%{dependent_name}’s permanent residence was with you for at least six months, even if they were away for part of that time"
+            born_in_2020: "%{name} was born in 2020"
+            passed_away_2020: "%{name} was lawfully placed with you for adoption in 2020"
+            placed_for_adoption: "%{name} passed away in 2020"
+            permanent_residence_with_client: "%{name}’s permanent residence was with you for at least six months, even if they were away for part of that time"
           qualifying_relative:
             title: "Were all of the following true in 2020?"
             help_text:
-              li1: "You paid for more than half of %{dependent_name}'s expenses."
-              li2: "%{dependent_name} earned less than $4,300."
-              li3: "%{dependent_name} has a SSN or ATIN."
-              li4: "%{dependent_name} did not live with someone else who could claim them."
+              li1: "You paid for more than half of %{name}'s expenses."
+              li2: "%{name} earned less than $4,300."
+              li3: "%{name} has a SSN or ATIN."
+              li4: "%{name} did not live with someone else who could claim them."
           child_can_be_claimed_by_other:
-            title: "Are you the only person who can claim %{dependent_name}?"
+            title: "Are you the only person who can claim %{name}?"
           claim_child_anyway:
-            title: "Would you like to claim %{dependent_name} anyway?"
-            help_text: "If you and someone else are eligible to claim %{dependent_name}, you should follow any existing agreement with the other person about who claims them."
+            title: "Would you like to claim %{name} anyway?"
+            help_text: "If you and someone else are eligible to claim %{name}, you should follow any existing agreement with the other person about who claims them."
             not_sure_reveal:
               title: "I’m unsure. Should I claim them?"
               p: "You should claim the dependent if one of these situations is true:"
@@ -1428,7 +1428,7 @@ en:
             filed_joint_return: "%{name} is married and filed taxes with their spouse"
             error: "Please select at least one option"
           does_not_qualify_ctc:
-            title: "%{dependent} can’t be claimed as a dependent."
+            title: "%{name} can’t be claimed as a dependent."
             body_html: |
               <p>For a dependent to qualify they would need to meet the following conditions:</p>
               <ul class="list--bulleted">

--- a/spec/features/ctc/complete_intake_spec.rb
+++ b/spec/features/ctc/complete_intake_spec.rb
@@ -140,10 +140,10 @@ RSpec.feature "CTC Intake", :flow_explorer_screenshot, active_job: true do
     check I18n.t('general.none')
     click_on I18n.t('general.continue')
 
-    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.child_lived_with_you.title', dependent_name: 'Jessie', tax_year: '2020'))
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.child_lived_with_you.title', name: 'Jessie', tax_year: '2020'))
     click_on I18n.t('general.affirmative')
 
-    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.child_can_be_claimed_by_other.title', dependent_name: 'Jessie'))
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.child_can_be_claimed_by_other.title', name: 'Jessie'))
     click_on I18n.t('general.affirmative')
 
     expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.tin.title', name: 'Jessie'))

--- a/spec/features/ctc/dependents_spec.rb
+++ b/spec/features/ctc/dependents_spec.rb
@@ -1,0 +1,149 @@
+require "rails_helper"
+
+def fill_in_dependent_info(dependent_birth_year)
+  expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.info.title'))
+  fill_in I18n.t('views.ctc.questions.dependents.info.first_name'), with: "Jessie"
+  fill_in I18n.t('views.ctc.questions.dependents.info.middle_initial'), with: "M"
+  fill_in I18n.t('views.ctc.questions.dependents.info.last_name'), with: "Pepper"
+  fill_in "ctc_dependents_info_form[birth_date_month]", with: "01"
+  fill_in "ctc_dependents_info_form[birth_date_day]", with: "11"
+  fill_in "ctc_dependents_info_form[birth_date_year]", with: dependent_birth_year
+end
+
+RSpec.feature "Dependents in CTC intake", :flow_explorer_screenshot, active_job: true do
+  let(:client) { create :client, intake: create(:ctc_intake), tax_returns: [create(:tax_return, year: 2020)] }
+
+  before do
+    login_as client, scope: :client
+    allow_any_instance_of(Routes::CtcDomain).to receive(:matches?).and_return(true)
+
+    visit "/questions/had-dependents"
+    click_on I18n.t('general.affirmative')
+  end
+
+  context "adding people who count as dependents" do
+    scenario "a minor child" do
+      dependent_birth_year = 15.years.ago.year
+      fill_in_dependent_info(dependent_birth_year)
+      select I18n.t('general.dependent_relationships.00_daughter'), from: I18n.t('views.ctc.questions.dependents.info.relationship_to_you')
+      click_on I18n.t('general.continue')
+
+      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.child_disqualifiers.title', name: 'Jessie'))
+      check I18n.t('general.none')
+      click_on I18n.t('general.continue')
+
+      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.child_lived_with_you.title', name: 'Jessie', tax_year: '2020'))
+      click_on I18n.t('general.affirmative')
+
+      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.child_can_be_claimed_by_other.title', name: 'Jessie'))
+      click_on I18n.t('general.affirmative')
+
+      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.tin.title', name: 'Jessie'))
+      select "Social Security Number (SSN)"
+      fill_in I18n.t('views.ctc.questions.dependents.tin.ssn_or_atin', name: "Jessie"), with: "222-33-4445"
+      fill_in I18n.t('views.ctc.questions.dependents.tin.ssn_or_atin_confirmation', name: "Jessie"), with: "222-33-4445"
+      click_on I18n.t('general.continue')
+
+      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.confirm_dependents.title'))
+      within "[data-automation='ctc-dependents']" do
+        expect(page).to have_content("Jessie Pepper")
+        expect(page).to have_selector("div", text: "#{I18n.t('general.date_of_birth')}: 1/11/#{dependent_birth_year}")
+      end
+    end
+
+    scenario "a child over 18 who qualifies as a dependent by being a student" do
+      dependent_birth_year = 20.years.ago.year
+      fill_in_dependent_info(dependent_birth_year)
+      select I18n.t('general.dependent_relationships.00_daughter'), from: I18n.t('views.ctc.questions.dependents.info.relationship_to_you')
+      check I18n.t('views.ctc.questions.dependents.info.full_time_student')
+      click_on I18n.t('general.continue')
+
+      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.child_disqualifiers.title', name: 'Jessie'))
+      check I18n.t('general.none')
+      click_on I18n.t('general.continue')
+
+      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.child_lived_with_you.title', name: 'Jessie', tax_year: '2020'))
+      click_on I18n.t('general.affirmative')
+
+      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.child_can_be_claimed_by_other.title', name: 'Jessie'))
+      click_on I18n.t('general.affirmative')
+
+      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.tin.title', name: 'Jessie'))
+      select "Social Security Number (SSN)"
+      fill_in I18n.t('views.ctc.questions.dependents.tin.ssn_or_atin', name: "Jessie"), with: "222-33-4445"
+      fill_in I18n.t('views.ctc.questions.dependents.tin.ssn_or_atin_confirmation', name: "Jessie"), with: "222-33-4445"
+      click_on I18n.t('general.continue')
+
+      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.confirm_dependents.title'))
+      within "[data-automation='other-credits-dependents']" do
+        expect(page).to have_content("Jessie Pepper")
+        expect(page).to have_selector("div", text: "#{I18n.t('general.date_of_birth')}: 1/11/#{dependent_birth_year}")
+      end
+    end
+
+    scenario "a disabled adult" do
+      dependent_birth_year = 40.years.ago.year
+      fill_in_dependent_info(dependent_birth_year)
+      select I18n.t('general.dependent_relationships.08_uncle'), from: I18n.t('views.ctc.questions.dependents.info.relationship_to_you')
+      check I18n.t('views.ctc.questions.dependents.info.permanently_totally_disabled')
+      click_on I18n.t('general.continue')
+
+      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.qualifying_relative.title'))
+      click_on I18n.t('general.affirmative')
+
+      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.tin.title', name: 'Jessie'))
+      select "Social Security Number (SSN)"
+      fill_in I18n.t('views.ctc.questions.dependents.tin.ssn_or_atin', name: "Jessie"), with: "222-33-4445"
+      fill_in I18n.t('views.ctc.questions.dependents.tin.ssn_or_atin_confirmation', name: "Jessie"), with: "222-33-4445"
+      click_on I18n.t('general.continue')
+
+      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.confirm_dependents.title'))
+      within "[data-automation='other-credits-dependents']" do
+        expect(page).to have_content("Jessie Pepper")
+        expect(page).to have_selector("div", text: "#{I18n.t('general.date_of_birth')}: 1/11/#{dependent_birth_year}")
+      end
+    end
+
+    scenario "a middle-aged adult who earns little money, lives with the client, and has a SSN" do
+      dependent_birth_year = 40.years.ago.year
+      fill_in_dependent_info(dependent_birth_year)
+      select I18n.t('general.dependent_relationships.08_uncle'), from: I18n.t('views.ctc.questions.dependents.info.relationship_to_you')
+      click_on I18n.t('general.continue')
+
+      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.qualifying_relative.title'))
+      click_on I18n.t('general.affirmative')
+
+      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.tin.title', name: 'Jessie'))
+      select "Social Security Number (SSN)"
+      fill_in I18n.t('views.ctc.questions.dependents.tin.ssn_or_atin', name: "Jessie"), with: "222-33-4445"
+      fill_in I18n.t('views.ctc.questions.dependents.tin.ssn_or_atin_confirmation', name: "Jessie"), with: "222-33-4445"
+      click_on I18n.t('general.continue')
+
+      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.confirm_dependents.title'))
+      within "[data-automation='other-credits-dependents']" do
+        expect(page).to have_content("Jessie Pepper")
+        expect(page).to have_selector("div", text: "#{I18n.t('general.date_of_birth')}: 1/11/#{dependent_birth_year}")
+      end
+    end
+  end
+
+  context "adding people who don't count as dependents" do
+    xscenario "a middle-aged adult who earns a bunch of money and isn't disabled" do
+      dependent_birth_year = 40.years.ago.year
+      fill_in_dependent_info(dependent_birth_year)
+      select I18n.t('general.dependent_relationships.08_uncle'), from: I18n.t('views.ctc.questions.dependents.info.relationship_to_you')
+      click_on I18n.t('general.continue')
+
+      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.qualifying_relative.title'))
+      click_on I18n.t('general.negative')
+
+      expect(page).to have_selector("h1", text: I18n.t("views.ctc.questions.dependents.does_not_qualify_ctc.title", name: "Jessie"))
+      click_on I18n.t("views.ctc.questions.dependents.confirm_dependents.done_adding")
+
+      # NOTE: currently it will show the Tin page for this dependent which is wrong!
+
+      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.confirm_dependents.title'))
+      expect(page).not_to have_content("Jessie Pepper")
+    end
+  end
+end


### PR DESCRIPTION
Also rename inconsistent I18n variables for conciseness and consistency.

Now `name`, `dependent`, or `dependent_name` are always `name`.