### PR TITLE
Remove "outreach" messaging from emails + remove flagging for negative states

### DIFF
--- a/app/state_machines/efile_submission_state_machine.rb
+++ b/app/state_machines/efile_submission_state_machine.rb
@@ -38,14 +38,12 @@ class EfileSubmissionStateMachine
   end
 
   after_transition(to: :failed) do |submission|
-    submission.client.flag!
     submission.tax_return.update(status: "file_needs_review")
   end
 
   after_transition(to: :rejected) do |submission, transition|
     # Add note with rejection reason to client notes
     # Use transition metadata error code and reason to determine whether it is an eng or VITA problem.
-    submission.client.flag!
     submission.tax_return.update(status: "file_rejected")
     client = submission.client
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1216,8 +1216,6 @@ en:
 
             Sign in to see next steps for correcting your tax information: <<Client.LoginLink>>
 
-            If you have any questions, you can go to GetCTC.org and open a chat with a tax expert or email support@getctc.org.
-
             We’re here to help!
             Your tax team at GetCTC.org
           subject: Thank you for filing your taxes with GetCTC!
@@ -1226,8 +1224,7 @@ en:
           Thank you for filing your taxes with GetCTC! Unfortunately, your taxes have been rejected by the IRS for the following reason:
           %{error_code}: %{error_message}
           Sign in to see next steps for correcting your tax information: <<Client.LoginLink>>
-          Respond to this message if you have any questions. We’re here to help!
-
+          We’re here to help!
       preparing:
         email:
           body: |
@@ -1237,15 +1234,13 @@ en:
 
             We are currently processing your information to send it to the IRS. You will receive a confirmation email within 48 hours to let you know if your information has been accepted or rejected.
 
-            If you have any questions, you can go to GetCTC.org and open a chat with a tax expert or email support@getctc.org.
-
             We’re here to help!
             Your tax team at GetCTC.org
           subject: Your tax information has been successfully submitted!
         sms: |
           Hello <<Client.PreferredName>>,
           Your tax information has been successfully submitted to GetCTC! We are currently processing your information to send it to the IRS. You will receive a confirmation email within 48 hours to let you know if your information has been accepted or rejected.
-          Respond to this message if you have any questions. We’re here to help!
+          We’re here to help!
   models:
     intake:
       your_spouse: Your spouse

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1217,8 +1217,6 @@ es:
 
             Inicie sesión para ver los siguientes pasos para corregir su información fiscal: <<Client.LoginLink>>
 
-            Si tiene alguna pregunta, puede ir a GetCTC.org y abrir un chat con un experto en impuestos o enviar un correo electrónico a hello@getctc.org.
-
             ¡Estamos aquí para ayudar!
             Su equipo de impuestos en GetCTC.org
           subject: Atención necesaria para enviar sus impuestos con GetCTC
@@ -1227,7 +1225,7 @@ es:
           ¡Gracias por presentar sus impuestos con GetCTC! Desafortunadamente, sus impuestos han sido rechazados por el IRS por el siguiente motivo:
           %{error_code}: %{error_message}
           Inicie sesión para ver los siguientes pasos para corregir su información fiscal: <<Client.LoginLink>>
-          Responda a este mensaje si tiene alguna pregunta. ¡Estamos aquí para ayudar!
+          ¡Estamos aquí para ayudar!
   models:
     intake:
       your_spouse: Su cónyuge


### PR DESCRIPTION
Looking for ways to streamline workload for customer service at launch, we are removing the outreach sentences from the emails. We also will not be turning on the "flag" for clients when rejected or failed -- this will allow customer service to keep focus on clients who have actively contacted us.