### PR TITLE
Format Name Line 1 for the IRS

### DIFF
--- a/app/lib/submission_builder/formatting_methods.rb
+++ b/app/lib/submission_builder/formatting_methods.rb
@@ -14,22 +14,51 @@ module SubmissionBuilder
       date.strftime("%F")
     end
 
-    def person_name_type(string)
-      name = string.gsub(" ", "<")
-      trim(name, 35)
+    def name_line_1_type(primary_first, primary_middle, primary_last, spouse_first, spouse_middle, spouse_last)
+      name_line = formatted_first_name(primary_first)
+      name_line << " #{primary_middle.upcase}" if primary_middle
+
+      if spouse_last == primary_last # spouse with same last name
+        name_line << " & #{formatted_first_name(spouse_first)}"
+        name_line << " #{spouse_middle.upcase}" if spouse_middle
+      end
+
+      if spouse_last && spouse_last != primary_last # spouse with different last name
+        name_line << "<#{formatted_last_name(primary_last)}"
+        name_line << "<& #{formatted_first_name(spouse_first)}"
+        name_line << " #{spouse_middle.upcase}" if spouse_middle
+        name_line << " #{formatted_last_name(spouse_last)}"
+        return name_line
+      end
+
+      # single or spouse with same last name
+      name_line << "<#{formatted_last_name(primary_last)}"
+
+      # add in support for formatting JR/2nd/II
+      # add in support for 35+ char names
     end
 
     # Limit to max 4 chars uppercased
     def person_name_control_type(string)
       return "" unless string.present?
 
-      string.upcase.first(4)
+      string.first(4).upcase
     end
 
     # phone number without country code or formatting
     # results in 10 digit number for transmitting to the IRS
     def phone_type(string)
       Phonelib.parse(string, "US").national(false)
+    end
+
+    private
+
+    def formatted_first_name(name)
+      I18n.transliterate(name).upcase.gsub(/[^A-Z]/, '')
+    end
+
+    def formatted_last_name(name)
+      I18n.transliterate(name).upcase.gsub(/[^A-Z\-]/, '')
     end
   end
 end

--- a/app/lib/submission_builder/formatting_methods.rb
+++ b/app/lib/submission_builder/formatting_methods.rb
@@ -15,15 +15,15 @@ module SubmissionBuilder
     end
 
     def name_line_1_type(primary_first, primary_middle, primary_last, spouse_first, spouse_middle, spouse_last)
+      # add in support for formatting JR/2nd/II
+      # add in support for 35+ char names
       name_line = formatted_first_name(primary_first)
       name_line << " #{primary_middle.upcase}" if primary_middle
 
       if spouse_last == primary_last # spouse with same last name
         name_line << " & #{formatted_first_name(spouse_first)}"
         name_line << " #{spouse_middle.upcase}" if spouse_middle
-      end
-
-      if spouse_last && spouse_last != primary_last # spouse with different last name
+      elsif spouse_last && spouse_last != primary_last # spouse with different last name
         name_line << "<#{formatted_last_name(primary_last)}"
         name_line << "<& #{formatted_first_name(spouse_first)}"
         name_line << " #{spouse_middle.upcase}" if spouse_middle
@@ -33,9 +33,6 @@ module SubmissionBuilder
 
       # single or spouse with same last name
       name_line << "<#{formatted_last_name(primary_last)}"
-
-      # add in support for formatting JR/2nd/II
-      # add in support for 35+ char names
     end
 
     # Limit to max 4 chars uppercased

--- a/app/lib/submission_builder/formatting_methods.rb
+++ b/app/lib/submission_builder/formatting_methods.rb
@@ -78,13 +78,13 @@ module SubmissionBuilder
     private
 
     def formatted_first_name(name)
-      # removes accented characters and any special characters
-      I18n.transliterate(name).upcase.gsub(/[^A-Z]/, '')
+      # removes accented characters and any special characters, except space
+      I18n.transliterate(name).strip.upcase.gsub(/[^A-Z\s]/, '')
     end
 
     def formatted_last_name(name)
-      # removes accented characters and any special characters, except hyphens
-      I18n.transliterate(name).upcase.gsub(/[^A-Z\-]/, '')
+      # removes accented characters and any special characters, except space and hyphens
+      I18n.transliterate(name).strip.upcase.gsub(/[^A-Z\-\s]/, '')
     end
   end
 end

--- a/app/lib/submission_builder/return_header1040.rb
+++ b/app/lib/submission_builder/return_header1040.rb
@@ -53,7 +53,7 @@ module SubmissionBuilder
           xml.Filer {
             xml.PrimarySSN intake.primary_ssn
             xml.SpouseSSN intake.spouse_ssn if tax_return.filing_jointly?
-            xml.NameLine1Txt person_name_type(client.legal_name)
+            xml.NameLine1Txt name_line_1_type(intake.primary_first_name, intake.primary_middle_initial, intake.primary_last_name, intake.spouse_first_name, intake.spouse_middle_initial, intake.spouse_last_name)
             xml.PrimaryNameControlTxt person_name_control_type(client.legal_name)
             xml.SpouseNameControlTxt person_name_control_type(client.spouse_legal_name) if tax_return.filing_jointly?
             xml.USAddress {

--- a/docs/2021-08-03-irs-name-line-1.md
+++ b/docs/2021-08-03-irs-name-line-1.md
@@ -1,0 +1,34 @@
+# IRS Name Line 1 Formatting for EFiling
+The IRS has specific rules for how NameLine1 needs to be formatted for the Return 1040 Header.
+
+They are outlined on page 189 of https://www.irs.gov/pub/irs-pdf/p4164.pdf
+
+I[CT] make sense of them as the following:
+
+- There is a maximum of 2 <
+- First name and middle initial are always concatenated without <.
+
+**Single filers**
+
+- Between a first/middle and the last name add a `<`.
+- Between last name and suffix add a `<`.
+
+**Filers with same last name**
+- Concatenate the first/middles, building them the same as single filer and concatenate with `&`
+- Add `<` then last name then `<` then suffix (so these last two steps are shared with the single filers)
+
+**Filers with different last names**
+- Build the single filer name, if no suffix then add `<` between last and `&`, otherwise if there is a suffix, you've reached your 2 `<` limit and so don't add one before the ampersand.
+- Concatenate the first/middle/last of the spouse without special formatting.
+
+This logic is used to implement `SubmissionBuilder::FormattingMethods#name_line_1_type`
+
+There is also logic to truncate lines > 35 which is outlined on page 189 of https://www.irs.gov/pub/irs-pdf/p4164.pdf
+
+Truncate components of the line in the following order until <= 35:
+- Spouse last
+- Primary last
+- Remove spouse middle
+- Remove primary middle
+- Spouse first
+- Primary first

--- a/spec/lib/submission_builder/formatting_methods_spec.rb
+++ b/spec/lib/submission_builder/formatting_methods_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+describe SubmissionBuilder::FormattingMethods do
+  let(:dummy_class) { Class.new() { extend SubmissionBuilder::FormattingMethods } }
+
+  describe '#name_line_1_type' do
+    subject(:formatted_name) { dummy_class.name_line_1_type(primary_first, primary_middle, primary_last, spouse_first, spouse_middle, spouse_last) }
+
+    let(:primary_first) { "Samantha" }
+    let(:primary_middle) { nil }
+    let(:primary_last) { "Seashells" }
+    let(:spouse_first) { nil }
+    let(:spouse_middle) { nil }
+    let(:spouse_last) { nil }
+
+    context 'when there is only a primary name' do
+      context 'with a middle initial' do
+        let(:primary_middle) { "C" }
+        it 'formats it correctly' do
+          expect(formatted_name).to eq("SAMANTHA C<SEASHELLS")
+        end
+      end
+
+      context 'with an accent' do
+        let(:primary_first) { "Sám" }
+        it 'formats it correctly' do
+          expect(formatted_name).to eq("SAM<SEASHELLS")
+        end
+      end
+
+      context 'with an apostrophe' do
+        let(:primary_last) { "S/'shells" }
+        it 'formats it correctly' do
+          expect(formatted_name).to eq("SAMANTHA<SSHELLS")
+        end
+      end
+
+      context 'with a hyphenated last name' do
+        let(:primary_last) { "Sea-shells" }
+        it 'formats it correctly' do
+          expect(formatted_name).to eq("SAMANTHA<SEA-SHELLS")
+        end
+      end
+    end
+
+    context 'when there is a spouse name' do
+      let(:spouse_first) { "Cora" }
+      let(:spouse_middle) { "O" }
+
+      context "with a different last name" do
+        let(:spouse_last) { "Coconuts" }
+        it 'formats it correctly' do
+          expect(formatted_name).to eq("SAMANTHA<SEASHELLS<& CORA O COCONUTS")
+        end
+      end
+
+      context "with the same last name" do
+        let(:spouse_last) { "Seashells" }
+        it 'formats it correctly' do
+          expect(formatted_name).to eq("SAMANTHA & CORA O<SEASHELLS")
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/submission_builder/formatting_methods_spec.rb
+++ b/spec/lib/submission_builder/formatting_methods_spec.rb
@@ -41,6 +41,23 @@ describe SubmissionBuilder::FormattingMethods do
           expect(formatted_name).to eq("SAMANTHA<SEA-SHELLS")
         end
       end
+
+      context "when the name line is > 35" do
+        context "due to a long first name" do
+          let(:primary_first) { "Sssssaaaaaammmaaaannnthhhhaaaaaaaaaa"}
+          it "truncates it correctly" do
+            expect(formatted_name).to eq("S<S")
+          end
+        end
+
+        context "due to a long last name" do
+          let(:primary_last) { "Seeeeeeeeeeeeaaashhhhhhhhhhhhellllls"}
+          let(:primary_middle) { "C" }
+          it "truncates it correctly" do
+            expect(formatted_name).to eq("SAMANTHA C<S")
+          end
+        end
+      end
     end
 
     context 'when there is a spouse name' do
@@ -48,9 +65,25 @@ describe SubmissionBuilder::FormattingMethods do
       let(:spouse_middle) { "O" }
 
       context "with a different last name" do
-        let(:spouse_last) { "Coconuts" }
+        let(:spouse_last) { "Coconut" }
         it 'formats it correctly' do
-          expect(formatted_name).to eq("SAMANTHA<SEASHELLS<& CORA O COCONUTS")
+          expect(formatted_name).to eq("SAMANTHA<SEASHELLS<& CORA O COCONUT")
+        end
+
+        context "when the name line is > 35" do
+          context "due to a long first name" do
+            let(:spouse_first) { "Coooooooooooooooooooooooooooooooooora"}
+            it "truncates it correctly" do
+              expect(formatted_name).to eq("SAMANTHA<S<& C C")
+            end
+          end
+
+          context "due to a long last name" do
+            let(:spouse_last) { "Coooooooocoooooooooooonut" }
+            it "truncates it correctly" do
+              expect(formatted_name).to eq("SAMANTHA<SEASHELLS<& CORA O C")
+            end
+          end
         end
       end
 
@@ -58,6 +91,13 @@ describe SubmissionBuilder::FormattingMethods do
         let(:spouse_last) { "Seashells" }
         it 'formats it correctly' do
           expect(formatted_name).to eq("SAMANTHA & CORA O<SEASHELLS")
+        end
+
+        context "when the name line is > 35" do
+          let(:spouse_first) { "Coooooooooooooooooooooooooooooooooora"}
+          it "truncates it correctly" do
+            expect(formatted_name).to eq("SAMANTHA & C<S")
+          end
         end
       end
     end

--- a/spec/lib/submission_builder/return_header1040_spec.rb
+++ b/spec/lib/submission_builder/return_header1040_spec.rb
@@ -77,7 +77,7 @@ describe SubmissionBuilder::ReturnHeader1040 do
         expect(xml.at('ReturnTypeCd').text).to eq "1040"
         expect(xml.at("PrimarySSN").text).to eq submission.intake.primary_ssn
         expect(xml.at("SpouseSSN").text).to eq submission.intake.spouse_ssn
-        expect(xml.at("NameLine1Txt").text).to eq "HUBERTBLAINE<W<& LISA F" # trimmed to 35 characters
+        expect(xml.at("NameLine1Txt").text).to eq "HUBERT BLAINE<W<& LISA F" # trimmed to 35 characters
         expect(xml.at("PrimaryNameControlTxt").text).to eq "HUBE"
         expect(xml.at("SpouseNameControlTxt").text).to eq "LISA"
         expect(xml.at("AddressLine1Txt").text).to eq "23627 HAWKINS CREEK CT"

--- a/spec/lib/submission_builder/return_header1040_spec.rb
+++ b/spec/lib/submission_builder/return_header1040_spec.rb
@@ -77,7 +77,7 @@ describe SubmissionBuilder::ReturnHeader1040 do
         expect(xml.at('ReturnTypeCd').text).to eq "1040"
         expect(xml.at("PrimarySSN").text).to eq submission.intake.primary_ssn
         expect(xml.at("SpouseSSN").text).to eq submission.intake.spouse_ssn
-        expect(xml.at("NameLine1Txt").text).to eq "Hubert<Blaine<Wolfeschlegelsteinhau" # trimmed to 35 characters
+        expect(xml.at("NameLine1Txt").text).to eq "HUBERTBLAINE<W<& LISA F" # trimmed to 35 characters
         expect(xml.at("PrimaryNameControlTxt").text).to eq "HUBE"
         expect(xml.at("SpouseNameControlTxt").text).to eq "LISA"
         expect(xml.at("AddressLine1Txt").text).to eq "23627 HAWKINS CREEK CT"


### PR DESCRIPTION
This just adds better support for name line 1 of the 1040 header, as outlined on [page 189 of this doc](https://www.irs.gov/pub/irs-pdf/p4164.pdf)

To-do:
- Have a conversation with design and add validation?? for special characters (though we strip them all out anyways so maybe this step isn't entirely necessary but it could lead to heavy manipulation if we dont)
- Support for suffixes like JR, II
- Before doing that, take a peek at prod data for occurrences of those cases and what format they are usually in because who knows maybe we can simplify things