### PR TITLE
Ensure all CTC controllers put their keys in "views.#{controller_path}" or specify an alternate i18n_base_key

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,10 @@ class ApplicationController < ActionController::Base
     { locale: I18n.locale }.merge(super)
   end
 
+  def self.i18n_base_path
+    "views.#{controller_path.tr('/', '.')}"
+  end
+
   def canonical_url(locale=I18n.locale)
     # Leave the locale out of canonical URLs in the default locale (works ok either way but needs to be consistent)
     url_for(only_path: false, locale: locale)

--- a/app/controllers/ctc/questions/direct_deposit_controller.rb
+++ b/app/controllers/ctc/questions/direct_deposit_controller.rb
@@ -9,6 +9,10 @@ module Ctc
         intake.refund_payment_method_direct_deposit?
       end
 
+      def self.i18n_base_path
+        "views.questions.bank_details"
+      end
+
       private
 
       def illustration_path

--- a/app/controllers/ctc/questions/email_verification_controller.rb
+++ b/app/controllers/ctc/questions/email_verification_controller.rb
@@ -14,6 +14,10 @@ module Ctc
         intake.email_address.present? && intake.email_notification_opt_in_yes? && intake.email_address_verified_at.present?
       end
 
+      def self.i18n_base_path
+        "views.ctc.questions.verification"
+      end
+
       def after_update_success
         sign_in current_intake.client
       end

--- a/app/controllers/ctc/questions/phone_verification_controller.rb
+++ b/app/controllers/ctc/questions/phone_verification_controller.rb
@@ -15,6 +15,10 @@ module Ctc
         intake.sms_phone_number.present? && intake.sms_notification_opt_in_yes? && !intake.sms_phone_number_verified_at.present?
       end
 
+      def self.i18n_base_path
+        "views.ctc.questions.verification"
+      end
+
       def after_update_success
         sign_in current_intake.client
       end

--- a/app/controllers/ctc/questions/returning_client_controller.rb
+++ b/app/controllers/ctc/questions/returning_client_controller.rb
@@ -5,6 +5,10 @@ module Ctc
       skip_before_action :set_current_step
       layout "intake"
 
+      def self.i18n_base_path
+        "views.questions.returning_client"
+      end
+
       private
 
       def redirect_to_next_if_already_authenticated

--- a/app/controllers/flows_controller.rb
+++ b/app/controllers/flows_controller.rb
@@ -130,14 +130,10 @@ class FlowsController < ApplicationController
       end
 
       def navigation_entry_action_title(i18n_params = {})
-        base_path = "views.#{controller_path.tr('/', '.')}"
         possible_paths = %W(
-          #{base_path}.#{navigation_entry_action}.title
-          #{base_path}.#{navigation_entry_action}.title_html
-          #{base_path}.#{navigation_entry_action}.page_title
-          #{base_path}.title
-          #{base_path}.title_html
-          #{base_path}.page_title
+          #{i18n_base_path}.title
+          #{i18n_base_path}.title_html
+          #{i18n_base_path}.page_title
         )
 
         existing_path = possible_paths.find { |path| I18n.exists?(path) }
@@ -148,7 +144,11 @@ class FlowsController < ApplicationController
             e.string
           end
         else
-          controller_name.titleize.singularize
+          if controller_path.start_with?('ctc')
+            raise "Could not find title for: #{controller_path}"
+          else
+            controller_name.titleize.singularize
+          end
         end
       end
 

--- a/app/views/ctc/questions/consent/edit.html.erb
+++ b/app/views/ctc/questions/consent/edit.html.erb
@@ -1,4 +1,4 @@
-<% @main_question = t("views.ctc.questions.legal_consent.title") %>
+<% @main_question = t("views.ctc.questions.consent.title") %>
 
 <% content_for :page_title, @main_question %>
 
@@ -7,16 +7,16 @@
     <h1 class="h2"><%= @main_question %></h1>
 
     <p>
-      <%= t("views.ctc.questions.legal_consent.body.p1") %>
+      <%= t("views.ctc.questions.consent.body.p1") %>
     </p>
     <p>
-      <%= t("views.ctc.questions.legal_consent.body.p2") %>
+      <%= t("views.ctc.questions.consent.body.p2") %>
     </p>
 
     <div class="form-card__content">
-      <%= f.cfa_input_field(:primary_first_name, t("views.ctc.questions.legal_consent.first_name"), classes: ["form-width--long"]) %>
-      <%= f.cfa_input_field(:primary_middle_initial, t("views.ctc.questions.legal_consent.middle_initial"), classes: ["form-width--short"]) %>
-      <%= f.cfa_input_field(:primary_last_name, t("views.ctc.questions.legal_consent.last_name"), classes: ["form-width--long"]) %>
+      <%= f.cfa_input_field(:primary_first_name, t("views.ctc.questions.consent.first_name"), classes: ["form-width--long"]) %>
+      <%= f.cfa_input_field(:primary_middle_initial, t("views.ctc.questions.consent.middle_initial"), classes: ["form-width--short"]) %>
+      <%= f.cfa_input_field(:primary_last_name, t("views.ctc.questions.consent.last_name"), classes: ["form-width--long"]) %>
       <%= f.vita_min_date_text_fields(
             :primary_birth_date,
             t("hub.clients.show.date_of_birth"),
@@ -24,9 +24,9 @@
             classes: ["ctc-intake-date-text-input"]
             ) %>
       <%= f.cfa_select(:primary_tin_type, "Identification Type", tin_options_for_select(include_itin: true)) %>
-      <%= f.cfa_input_field(:primary_ssn, t("views.ctc.questions.legal_consent.ssn"), classes: ["form-width--long"]) %>
-      <%= f.cfa_input_field(:primary_ssn_confirmation, t("views.ctc.questions.legal_consent.ssn_confirmation"), classes: ["form-width--long"]) %>
-      <%= f.cfa_input_field(:phone_number, t("views.ctc.questions.legal_consent.sms_phone_number"), classes: ["form-width--long"]) %>
+      <%= f.cfa_input_field(:primary_ssn, t("views.ctc.questions.consent.ssn"), classes: ["form-width--long"]) %>
+      <%= f.cfa_input_field(:primary_ssn_confirmation, t("views.ctc.questions.consent.ssn_confirmation"), classes: ["form-width--long"]) %>
+      <%= f.cfa_input_field(:phone_number, t("views.ctc.questions.consent.sms_phone_number"), classes: ["form-width--long"]) %>
       <%= f.hidden_field(:timezone) %>
       <%= f.hidden_field(:device_id) %>
       <%= f.hidden_field(:user_agent) %>

--- a/app/views/ctc/questions/filed2019/edit.html.erb
+++ b/app/views/ctc/questions/filed2019/edit.html.erb
@@ -1,2 +1,2 @@
-<% content_for :form_question, t("views.ctc.questions.filed_2019.title") %>
-<% content_for :form_help_text, t("views.ctc.questions.filed_2019.help_text_html") %>
+<% content_for :form_question, t("views.ctc.questions.filed2019.title") %>
+<% content_for :form_help_text, t("views.ctc.questions.filed2019.help_text_html") %>

--- a/app/views/ctc/questions/filed2020/edit.html.erb
+++ b/app/views/ctc/questions/filed2020/edit.html.erb
@@ -1,2 +1,2 @@
-<% content_for :form_question, t("views.ctc.questions.filed_2020.title") %>
-<% content_for :form_help_text, t("views.ctc.questions.filed_2020.help_text_html") %>
+<% content_for :form_question, t("views.ctc.questions.filed2020.title") %>
+<% content_for :form_help_text, t("views.ctc.questions.filed2020.help_text_html") %>

--- a/app/views/ctc/questions/filed2020_yes/edit.html.erb
+++ b/app/views/ctc/questions/filed2020_yes/edit.html.erb
@@ -1,4 +1,4 @@
-<% @main_question = t("views.ctc.questions.filed_2020_yes.title") %>
+<% @main_question = t("views.ctc.questions.filed2020_yes.title") %>
 
 <% content_for :page_title, @main_question %>
 
@@ -6,12 +6,12 @@
   <h1 class="h2"><%= @main_question %></h1>
 
   <p>
-    <%= t("views.ctc.questions.filed_2020_yes.p1") %>
+    <%= t("views.ctc.questions.filed2020_yes.p1") %>
   </p>
   <p>
-    <%= t("views.ctc.questions.filed_2020_yes.p2") %>
+    <%= t("views.ctc.questions.filed2020_yes.p2") %>
   </p>
 
-  <%= link_to t("views.ctc.questions.filed_2020_yes.visit_ctc_portal"), "https://www.irs.gov/credits-deductions/child-tax-credit-update-portal", class: "button button--primary button--wide text--centered spacing-above-60" %>
-  <%= link_to t("views.ctc.questions.filed_2020_yes.visit_ctc_faq"), root_path, class: "button button--wide text--centered" %>
+  <%= link_to t("views.ctc.questions.filed2020_yes.visit_ctc_portal"), "https://www.irs.gov/credits-deductions/child-tax-credit-update-portal", class: "button button--primary button--wide text--centered spacing-above-60" %>
+  <%= link_to t("views.ctc.questions.filed2020_yes.visit_ctc_faq"), root_path, class: "button button--wide text--centered" %>
 <% end %>

--- a/app/views/ctc/questions/life_situations2019/edit.html.erb
+++ b/app/views/ctc/questions/life_situations2019/edit.html.erb
@@ -1,4 +1,4 @@
-<% @main_question = t("views.ctc.questions.life_situations_2019.title") %>
+<% @main_question = t("views.ctc.questions.life_situations2019.title") %>
 
 <% content_for :page_title, @main_question %>
 
@@ -6,17 +6,17 @@
   <h1 class="h2"><%= @main_question %></h1>
 
   <p>
-    <%= t("views.ctc.questions.life_situations_2019.p1") %>
+    <%= t("views.ctc.questions.life_situations2019.p1") %>
   </p>
   <ul class="checkmark-list teal">
-    <li><%= t("views.ctc.questions.life_situations_2019.item1" )%></li>
-    <li><%= t("views.ctc.questions.life_situations_2019.item2" )%></li>
-    <li><%= t("views.ctc.questions.life_situations_2019.item3" )%></li>
+    <li><%= t("views.ctc.questions.life_situations2019.item1" )%></li>
+    <li><%= t("views.ctc.questions.life_situations2019.item2" )%></li>
+    <li><%= t("views.ctc.questions.life_situations2019.item3" )%></li>
   </ul>
   <p>
-    <%= t("views.ctc.questions.life_situations_2019.p2") %>
+    <%= t("views.ctc.questions.life_situations2019.p2") %>
   </p>
 
   <%= link_to t("general.continue"), next_path, class: "button button--primary button--wide text--centered spacing-above-60" %>
-  <%= link_to t("views.ctc.questions.life_situations_2019.visit_ctc_faq"), root_path, class: "button button--wide text--centered" %>
+  <%= link_to t("views.ctc.questions.life_situations2019.visit_ctc_faq"), root_path, class: "button button--wide text--centered" %>
 <% end %>

--- a/app/views/ctc/questions/life_situations2020/edit.html.erb
+++ b/app/views/ctc/questions/life_situations2020/edit.html.erb
@@ -1,21 +1,21 @@
-<% @main_question = t("views.ctc.questions.life_situations_2020.title") %>
+<% @main_question = t("views.ctc.questions.life_situations2020.title") %>
 
 <% content_for :page_title, @main_question %>
 
 <% content_for :form_card do %>
   <h1 class="h2"><%= @main_question %></h1>
 
-  <p class="spacing-below-15"><%= t("views.ctc.questions.life_situations_2020.p1") %></p>
+  <p class="spacing-below-15"><%= t("views.ctc.questions.life_situations2020.p1") %></p>
 
   <%= form_with model: @form, url: current_path, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
     <div class="form-card__stacked-checkboxes spacing-above-0 spacing-below-15">
-      <%= f.cfa_checkbox(:cannot_claim_me_as_a_dependent, t("views.ctc.questions.life_situations_2020.cannot_claim_me_as_a_dependent"), options: { checked_value: "yes", unchecked_value: "no" }) %>
-      <%= f.cfa_checkbox(:primary_active_armed_forces, t("views.ctc.questions.life_situations_2020.primary_active_armed_forces"), options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <%= f.cfa_checkbox(:cannot_claim_me_as_a_dependent, t("views.ctc.questions.life_situations2020.cannot_claim_me_as_a_dependent"), options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <%= f.cfa_checkbox(:primary_active_armed_forces, t("views.ctc.questions.life_situations2020.primary_active_armed_forces"), options: { checked_value: "yes", unchecked_value: "no" }) %>
     </div>
     <div class="reveal" style="max-width: 47.5rem;">
-      <span class="text--small"><a href="#" class="reveal__link"><%= t("views.ctc.questions.life_situations_2020.reveal_label") %></a></span>
+      <span class="text--small"><a href="#" class="reveal__link"><%= t("views.ctc.questions.life_situations2020.reveal_label") %></a></span>
       <div class="reveal__content">
-        <%= t("views.ctc.questions.life_situations_2020.reveal_content") %>
+        <%= t("views.ctc.questions.life_situations2020.reveal_content") %>
       </div>
     </div>
     <%= f.submit t("general.continue"), class: "button button--primary button--wide text--centered spacing-above-60" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1532,7 +1532,7 @@ en:
             - You have not filed a tax return the last two years
             - You have kids or dependents
             - You didn't receive the full amount of stimulus you were owed
-        legal_consent:
+        consent:
           title: In order to file, we’ll need some additional information.
           body:
             p1: To submit your tax return and receive either your child tax credit or your stimulus payments, we’ll need some of your personal information.
@@ -1592,23 +1592,23 @@ en:
           title_html: You're about to remove %{spouse_name}.<br><br>Is that okay?
           remove_button: Yes, remove them
           nevermind_button: Nevermind, let's save them
-        filed_2020:
+        filed2020:
           title: Did you file a 2020 tax return this year?
           help_text_html: |
             <p>Did you file a tax return this year, after January 1, 2021, for the 2020 tax year?</p>
             <p>You can answer yes if you filed a return and are still waiting for your stimulus payments or if you used the Non-filers Sign-up tool.</p>
-        filed_2020_yes:
+        filed2020_yes:
           title: Great! The IRS can process your return and determine your Child Tax Credit.
           p1: If you've filed a 2020 tax return, the IRS will have the information it needs to process your Child Tax Credit (CTC).
           p2: You can visit the IRS Child Tax Credit Update Portal to update your information.
           visit_ctc_portal: Visit the CTC Update Portal
           visit_ctc_faq: Visit CTC FAQ
-        filed_2019:
+        filed2019:
           title: Did you either file a 2019 tax return or receive any stimulus payments?
           help_text_html: |
             <p>If you filed a 2019 return or received stimulus payments, if eligible you will receive your Child Tax Credit based on the information in that return. You don't need to file a 2020 tax return to receive the benefits you are due.</p>
             <p>If you do have changes to your personal situation you can visit the <a href="https://www.irs.gov/credits-deductions/child-tax-credit-update-portal" target="_blank" rel="noopener noreferrer">IRS Child Tax Credit Update Portal</a> to update your tax information.<p>
-        life_situations_2019:
+        life_situations2019:
           title: Let's check one more thing.
           p1: |
             If any of the following are true, you should continue with our simplified CTC tool:
@@ -1700,7 +1700,7 @@ en:
           title: How will you be filing your tax return?
           reveal_title: I'm unsure how to file
           reveal_body: If you normally file as head of household or married filing separately, select ‘single’ for the purpose of this return.
-        life_situations_2020:
+        life_situations2020:
           title: "Select any situations that were true for you in 2020"
           p1: "These answers help us determine what tax credits you qualify for."
           cannot_claim_me_as_a_dependent: "No one can claim me as a dependent"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1414,7 +1414,7 @@ es:
             Por favor, proporcione un número de teléfono en el que pueda recibir mensajes de texto, o bien<a href=%{email_link}>, proporcione una dirección de correo electrónico</a>
         email_address:
           title: Por favor comparte tu dirección de correo electrónico.
-        legal_consent:
+        consent:
           title: "Para realizar la solicitud, necesitaremos un poco de más de información."
           body:
             p1: "Para presentar su declaración de impuestos y recibir su crédito fiscal por hijos o sus pagos de estímulo, necesitaremos algunos de sus datos personales."
@@ -1451,24 +1451,24 @@ es:
           spouse_active_armed_forces_reveal: "¿Por qué me preguntan esto?"
           spouse_active_armed_forces_reveal_content: El ser miembro de las Fuerzas Armadas nos ayudará a calcular mejor su crédito de Reembolso por Recuperación o Recovery Rebate Credit
           ssn_required_message: "Necesitamos un SSN/ITIN para continuar. Si su cónyuge no tiene uno, declare sus impuestos gratis con <a href=\"https://www.getyourrefund.org/\">GetYourRefund</a>."
-        filed_2020:
+        filed2020:
           title: "¿Presentó su declaración de impuestos de 2020 este año?"
           help_text_html: |
             <p>¿Presentó una declaración de impuestos este año, después del 1 de enero de 2021, para el año fiscal 2020?</p>
             <p>Puede responder afirmativamente si presentó una declaración y aún está esperando los pagos del estímulo o si utilizó la herramienta de inscripción para las personas que no declararon o Non-filers Sign-up.</p>
-        filed_2020_yes:
+        filed2020_yes:
           title: ¡Fabuloso! El IRS puede procesar su declaración y determinar su Crédito Fiscal por Hijos.
           p1: "Si presentó su declaración de impuestos de 2020, el IRS tendrá la información que necesita para tramitar su Crédito Fiscal por Hijos (CTC)."
           p2: "Puede visitar el sitio web del IRS de Crédito Fiscal por Hijos o en inglés: \"Child Tax Credit Update Portal\" para actualizar su información."
           visit_ctc_portal: Visite el sitio de web de actualizaciones del CTC
           visit_ctc_faq: "Visite Preguntas y Respuestas o FAQ en inglés de CTC "
-        filed_2019:
+        filed2019:
           title: "¿Ha presentado la declaración de impuestos de 2019 o ha recibido algún pago de estímulo?"
           help_text_html: |+
             <p>Si presentó una declaración de 2019 o recibió pagos de estímulo, de ser elegible, recibirá su Crédito Fiscal por Hijos basado en la información de esa declaración. No necesita presentar una declaración de impuestos de 2020 para recibir los beneficios que le corresponden.</p>
             <p>Si hay cambios en su situación personal puede visitar el <a href="https://www.irs.gov/credits-deductions/child-tax-credit-update-portal" target="_blank" rel="noopener noreferrer">Portal de Actualización del Crédito Fiscal por Hijos IRS</a> para actualizar su información fiscal.
 
-        life_situations_2019:
+        life_situations2019:
           title: Revisemos una cosa más.
           p1: |
             Si cualesquiera de los siguientes puntos son válidos para usted, debe continuar con nuestra herramienta simplificada de CTC:
@@ -1561,7 +1561,7 @@ es:
           title: "¿Cómo desea presentar su declaración de impuestos?"
           reveal_title: No estoy seguro de cómo solicitar
           reveal_body: "Si normalmente declara como jefe de familia o casado que presenta la declaración por separado, seleccione \"soltero\" a efectos de esta declaración."
-        life_situations_2020:
+        life_situations2020:
           title: "Seleccione cualquier situación válida para usted en 2020"
           p1: "Estas respuestas nos ayudan a determinar para qué créditos fiscales califica."
           cannot_claim_me_as_a_dependent: "Nadie puede declararme como dependiente"

--- a/spec/features/ctc/client_session_duration_spec.rb
+++ b/spec/features/ctc/client_session_duration_spec.rb
@@ -29,16 +29,16 @@ RSpec.feature "Session duration" do
     click_on I18n.t('general.negative')
     click_on I18n.t("views.ctc.questions.file_full_return.full_btn")
 
-    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.legal_consent.title'))
-    fill_in I18n.t('views.ctc.questions.legal_consent.first_name'), with: "Gary"
-    fill_in I18n.t('views.ctc.questions.legal_consent.middle_initial'), with: "H"
-    fill_in I18n.t('views.ctc.questions.legal_consent.last_name'), with: "Mango"
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.consent.title'))
+    fill_in I18n.t('views.ctc.questions.consent.first_name'), with: "Gary"
+    fill_in I18n.t('views.ctc.questions.consent.middle_initial'), with: "H"
+    fill_in I18n.t('views.ctc.questions.consent.last_name'), with: "Mango"
     fill_in "ctc_consent_form_primary_birth_date_month", with: "08"
     fill_in "ctc_consent_form_primary_birth_date_day", with: "24"
     fill_in "ctc_consent_form_primary_birth_date_year", with: "1996"
-    fill_in I18n.t('views.ctc.questions.legal_consent.ssn'), with: "111-22-8888"
-    fill_in I18n.t('views.ctc.questions.legal_consent.ssn_confirmation'), with: "111-22-8888"
-    fill_in I18n.t('views.ctc.questions.legal_consent.sms_phone_number'), with: "831-234-5678"
+    fill_in I18n.t('views.ctc.questions.consent.ssn'), with: "111-22-8888"
+    fill_in I18n.t('views.ctc.questions.consent.ssn_confirmation'), with: "111-22-8888"
+    fill_in I18n.t('views.ctc.questions.consent.sms_phone_number'), with: "831-234-5678"
     click_on I18n.t('general.continue')
 
     expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.contact_preference.title'))

--- a/spec/features/ctc/complete_intake_spec.rb
+++ b/spec/features/ctc/complete_intake_spec.rb
@@ -29,16 +29,16 @@ RSpec.feature "CTC Intake", :flow_explorer_screenshot_i18n_friendly, active_job:
     expect(page).to have_selector("h1", text: I18n.t("views.ctc.questions.file_full_return.title"))
     click_on I18n.t("views.ctc.questions.file_full_return.full_btn")
 
-    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.legal_consent.title'))
-    fill_in I18n.t('views.ctc.questions.legal_consent.first_name'), with: "Gary"
-    fill_in I18n.t('views.ctc.questions.legal_consent.middle_initial'), with: "H"
-    fill_in I18n.t('views.ctc.questions.legal_consent.last_name'), with: "Mango"
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.consent.title'))
+    fill_in I18n.t('views.ctc.questions.consent.first_name'), with: "Gary"
+    fill_in I18n.t('views.ctc.questions.consent.middle_initial'), with: "H"
+    fill_in I18n.t('views.ctc.questions.consent.last_name'), with: "Mango"
     fill_in "ctc_consent_form_primary_birth_date_month", with: "08"
     fill_in "ctc_consent_form_primary_birth_date_day", with: "24"
     fill_in "ctc_consent_form_primary_birth_date_year", with: "1996"
-    fill_in I18n.t('views.ctc.questions.legal_consent.ssn'), with: "111-22-8888"
-    fill_in I18n.t('views.ctc.questions.legal_consent.ssn_confirmation'), with: "111-22-8888"
-    fill_in I18n.t('views.ctc.questions.legal_consent.sms_phone_number'), with: "831-234-5678"
+    fill_in I18n.t('views.ctc.questions.consent.ssn'), with: "111-22-8888"
+    fill_in I18n.t('views.ctc.questions.consent.ssn_confirmation'), with: "111-22-8888"
+    fill_in I18n.t('views.ctc.questions.consent.sms_phone_number'), with: "831-234-5678"
     click_on I18n.t('general.continue')
 
     expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.contact_preference.title'))
@@ -74,11 +74,11 @@ RSpec.feature "CTC Intake", :flow_explorer_screenshot_i18n_friendly, active_job:
     click_on I18n.t('general.continue')
 
     # =========== LIFE SITUATIONS ===========
-    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.filed_2020.title'))
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.filed2020.title'))
     click_on I18n.t('general.negative')
-    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.filed_2019.title'))
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.filed2019.title'))
     click_on I18n.t('general.affirmative')
-    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.life_situations_2019.title'))
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.life_situations2019.title'))
     click_on I18n.t('general.continue')
 
     expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.home.title'))
@@ -91,8 +91,8 @@ RSpec.feature "CTC Intake", :flow_explorer_screenshot_i18n_friendly, active_job:
     check I18n.t('views.ctc.questions.home.options.fifty_states')
     check I18n.t('views.ctc.questions.home.options.military_facility')
     click_on I18n.t('general.continue')
-    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.life_situations_2020.title'))
-    check I18n.t('views.ctc.questions.life_situations_2020.cannot_claim_me_as_a_dependent')
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.life_situations2020.title'))
+    check I18n.t('views.ctc.questions.life_situations2020.cannot_claim_me_as_a_dependent')
     click_on I18n.t('general.continue')
 
     # =========== FILING STATUS ===========

--- a/spec/features/ctc/ctc_intake_offboard_duplicates_spec.rb
+++ b/spec/features/ctc/ctc_intake_offboard_duplicates_spec.rb
@@ -29,16 +29,16 @@ RSpec.feature "CTC Intake", :flow_explorer_screenshot_i18n_friendly, active_job:
     click_on I18n.t('general.negative')
     click_on I18n.t("views.ctc.questions.file_full_return.full_btn")
 
-    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.legal_consent.title'))
-    fill_in I18n.t('views.ctc.questions.legal_consent.first_name'), with: "Gary"
-    fill_in I18n.t('views.ctc.questions.legal_consent.middle_initial'), with: "H"
-    fill_in I18n.t('views.ctc.questions.legal_consent.last_name'), with: "Mango"
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.consent.title'))
+    fill_in I18n.t('views.ctc.questions.consent.first_name'), with: "Gary"
+    fill_in I18n.t('views.ctc.questions.consent.middle_initial'), with: "H"
+    fill_in I18n.t('views.ctc.questions.consent.last_name'), with: "Mango"
     fill_in "ctc_consent_form_primary_birth_date_month", with: "08"
     fill_in "ctc_consent_form_primary_birth_date_day", with: "24"
     fill_in "ctc_consent_form_primary_birth_date_year", with: "1996"
-    fill_in I18n.t('views.ctc.questions.legal_consent.ssn'), with: "111-22-8888"
-    fill_in I18n.t('views.ctc.questions.legal_consent.ssn_confirmation'), with: "111-22-8888"
-    fill_in I18n.t('views.ctc.questions.legal_consent.sms_phone_number'), with: "831-234-5678"
+    fill_in I18n.t('views.ctc.questions.consent.ssn'), with: "111-22-8888"
+    fill_in I18n.t('views.ctc.questions.consent.ssn_confirmation'), with: "111-22-8888"
+    fill_in I18n.t('views.ctc.questions.consent.sms_phone_number'), with: "831-234-5678"
     click_on I18n.t('general.continue')
 
     expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.contact_preference.title'))


### PR DESCRIPTION
Notably for things with numbers like Filed2020Controller, `controller_path`
is `ctc/questions/filed2019`, not `ctc/questions/filed_2019`

A couple of controllers in CTC land take all their keys from GYR land,
which is fine, but it means they need to override `i18n_base_key`
to something like `views.questions.bank_details` or whatever.

Flow explorer will raise if it can't find a title at the expected path
This should be caught for any new controllers by the flow explorer spec