### PR TITLE
Rename total_session_active_seconds to previous_sessions_active_seconds

### DIFF
--- a/app/lib/submission_builder/return_header1040.rb
+++ b/app/lib/submission_builder/return_header1040.rb
@@ -182,7 +182,7 @@ module SubmissionBuilder
 
     def total_active_preparation_minutes
       current_session_duration = submission.client.last_seen_at.to_i - submission.client.current_sign_in_at.to_i
-      ((submission.client.total_session_active_seconds || 0) + current_session_duration) / 60
+      ((submission.client.previous_sessions_active_seconds || 0) + current_session_duration) / 60
     end
   end
 end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -21,10 +21,10 @@
 #  locked_at                                :datetime
 #  login_requested_at                       :datetime
 #  login_token                              :string
+#  previous_sessions_active_seconds         :integer
 #  routing_method                           :integer
 #  sign_in_count                            :integer          default(0), not null
 #  still_needs_help                         :integer          default("unfilled"), not null
-#  total_session_active_seconds             :integer
 #  triggered_still_needs_help_at            :datetime
 #  created_at                               :datetime         not null
 #  updated_at                               :datetime         not null
@@ -185,7 +185,7 @@ class Client < ApplicationRecord
 
     previous_session_duration = last_seen_at - last_sign_in_at
 
-    update!(total_session_active_seconds: (total_session_active_seconds || 0) + previous_session_duration)
+    update!(previous_sessions_active_seconds: (previous_sessions_active_seconds || 0) + previous_session_duration)
   end
 
   def legal_name

--- a/db/migrate/20210803225320_rename_total_active_seconds.rb
+++ b/db/migrate/20210803225320_rename_total_active_seconds.rb
@@ -1,0 +1,5 @@
+class RenameTotalActiveSeconds < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :clients, :total_session_active_seconds, :previous_sessions_active_seconds
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_03_223047) do
+ActiveRecord::Schema.define(version: 2021_08_03_225320) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -187,10 +187,10 @@ ActiveRecord::Schema.define(version: 2021_08_03_223047) do
     t.datetime "locked_at"
     t.datetime "login_requested_at"
     t.string "login_token"
+    t.integer "previous_sessions_active_seconds"
     t.integer "routing_method"
     t.integer "sign_in_count", default: 0, null: false
     t.integer "still_needs_help", default: 0, null: false
-    t.integer "total_session_active_seconds"
     t.datetime "triggered_still_needs_help_at"
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "vita_partner_id"

--- a/spec/factories/clients.rb
+++ b/spec/factories/clients.rb
@@ -21,10 +21,10 @@
 #  locked_at                                :datetime
 #  login_requested_at                       :datetime
 #  login_token                              :string
+#  previous_sessions_active_seconds         :integer
 #  routing_method                           :integer
 #  sign_in_count                            :integer          default(0), not null
 #  still_needs_help                         :integer          default("unfilled"), not null
-#  total_session_active_seconds             :integer
 #  triggered_still_needs_help_at            :datetime
 #  created_at                               :datetime         not null
 #  updated_at                               :datetime         not null

--- a/spec/features/ctc/client_session_duration_spec.rb
+++ b/spec/features/ctc/client_session_duration_spec.rb
@@ -87,14 +87,14 @@ RSpec.feature "Session duration" do
           authenticate_client(client)
           expect(page).to have_text(I18n.t('views.ctc.questions.dependents.had_dependents.title'))
         end
-        expect(client.reload.total_session_active_seconds).to eq(0) # last session occurred in one instant
+        expect(client.reload.previous_sessions_active_seconds).to eq(0) # last session occurred in one instant
         expect(client.reload.last_seen_at).to eq(fake_time)
 
         Timecop.freeze(fake_time + 1.minutes) do
           visit Ctc::Questions::Dependents::HadDependentsController.to_path_helper
         end
         expect(client.reload.last_seen_at).to eq(fake_time + 1.minutes)
-        expect(client.reload.total_session_active_seconds).to eq(0) # still w/r/t the previous login
+        expect(client.reload.previous_sessions_active_seconds).to eq(0) # still w/r/t the previous login
         Capybara.current_session.reset!
 
         Timecop.freeze(fake_time + 2.minutes) do
@@ -103,7 +103,7 @@ RSpec.feature "Session duration" do
           expect(page).to have_text(I18n.t('views.ctc.questions.dependents.had_dependents.title'))
         end
         expect(client.reload.last_seen_at).to eq(fake_time + 2.minutes)
-        expect(client.reload.total_session_active_seconds).to eq(1.minutes)
+        expect(client.reload.previous_sessions_active_seconds).to eq(1.minutes)
       end
     end
   end

--- a/spec/lib/submission_builder/return_header1040_spec.rb
+++ b/spec/lib/submission_builder/return_header1040_spec.rb
@@ -20,7 +20,7 @@ describe SubmissionBuilder::ReturnHeader1040 do
         current_sign_in_at: DateTime.new(2021, 4, 20, 16, 20),
         last_seen_at: DateTime.new(2021, 4, 20, 16, 21),
         # Previous sessions have lasted 20 minutes
-        total_session_active_seconds: 20 * 60,
+        previous_sessions_active_seconds: 20 * 60,
       )
     end
 

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -21,10 +21,10 @@
 #  locked_at                                :datetime
 #  login_requested_at                       :datetime
 #  login_token                              :string
+#  previous_sessions_active_seconds         :integer
 #  routing_method                           :integer
 #  sign_in_count                            :integer          default(0), not null
 #  still_needs_help                         :integer          default("unfilled"), not null
-#  total_session_active_seconds             :integer
 #  triggered_still_needs_help_at            :datetime
 #  created_at                               :datetime         not null
 #  updated_at                               :datetime         not null
@@ -821,7 +821,7 @@ describe Client do
     end
   end
 
-  describe '#total_session_active_seconds' do
+  describe '#previous_sessions_active_seconds' do
     let(:fake_time) { Time.utc(2021, 2, 6, 0, 0, 0) }
     let(:client) { create :client, last_sign_in_at: fake_time - 5.minutes, last_seen_at: fake_time }
 
@@ -832,7 +832,7 @@ describe Client do
     it 'accumulates the last session length on every login' do
       expect do
         client.accumulate_total_session_durations
-      end.to change { client.reload.total_session_active_seconds }.from(nil).to(5 * 60)
+      end.to change { client.reload.previous_sessions_active_seconds }.from(nil).to(5 * 60)
     end
   end
 end


### PR DESCRIPTION
This trivial follow-up to #1378 improves a column name.

We used to call something a "total" that wasn't actually a total.