### PR TITLE
Move efile submission show page to the client profile

### DIFF
--- a/app/controllers/hub/efile_submissions_controller.rb
+++ b/app/controllers/hub/efile_submissions_controller.rb
@@ -11,10 +11,8 @@ module Hub
       @efile_submissions = @efile_submissions.in_state(params[:status]) if params[:status].present?
     end
 
-    # a little bit unexpectedly, the "show" page actually loads the tax return will all associated submissions
-    # instead of a single submission.
-    # However, efile_submission instance variable for most recent submission is used for access control and
-    # to display information about overall status on the show page.
+    # a little bit unexpectedly, the "show" page actually uses the client id to load the client. Then,
+    # loops through the tax_returns that have efile_submissions.
     def show
       @client = Client.find(params[:id])
       @tax_returns = @client.tax_returns.joins(:efile_submissions) # get all tax returns with submissions

--- a/app/controllers/hub/efile_submissions_controller.rb
+++ b/app/controllers/hub/efile_submissions_controller.rb
@@ -16,8 +16,9 @@ module Hub
     # However, efile_submission instance variable for most recent submission is used for access control and
     # to display information about overall status on the show page.
     def show
-      @tax_return = TaxReturn.joins(:efile_submissions).find(params[:id])
-      @efile_submission = @tax_return.efile_submissions.last
+      @client = Client.find(params[:id])
+      @tax_returns = @client.tax_returns.joins(:efile_submissions) # get all tax returns with submissions
+      redirect_to hub_client_path(id: @client.id) and return unless @tax_returns.present?
     end
 
     def resubmit

--- a/app/controllers/hub/tax_returns_controller.rb
+++ b/app/controllers/hub/tax_returns_controller.rb
@@ -9,7 +9,7 @@ module Hub
     authorize_resource :client, parent: false, only: [:new, :create]
     load_resource only: [:new, :create]
     before_action :prepare_form, only: [:new]
-    before_action :load_assignable_users, except: [:show, :index]
+    before_action :load_assignable_users, except: [:show]
     before_action :load_and_authorize_assignee, only: [:update]
 
     layout "admin"

--- a/app/controllers/hub/tax_returns_controller.rb
+++ b/app/controllers/hub/tax_returns_controller.rb
@@ -9,7 +9,7 @@ module Hub
     authorize_resource :client, parent: false, only: [:new, :create]
     load_resource only: [:new, :create]
     before_action :prepare_form, only: [:new]
-    before_action :load_assignable_users, except: [:show]
+    before_action :load_assignable_users, except: [:show, :index]
     before_action :load_and_authorize_assignee, only: [:update]
 
     layout "admin"

--- a/app/views/hub/clients/_navigation.html.erb
+++ b/app/views/hub/clients/_navigation.html.erb
@@ -3,4 +3,7 @@
   <%= tab_navigation_link(t(".client_messages"), hub_client_messages_path(client_id: @client, anchor: "last-item")) %>
   <%= tab_navigation_link(t(".client_documents"), hub_client_documents_path(client_id: @client)) %>
   <%= tab_navigation_link(t(".client_notes"), hub_client_notes_path(client_id: @client, anchor: "last-item")) %>
+  <% if can?(:manage, EfileSubmission) && @client.tax_returns.joins(:efile_submissions).size.nonzero? %>
+    <%= tab_navigation_link("E-file", efile_hub_client_path(id: @client, anchor: "body")) %>
+  <% end %>
 </section>

--- a/app/views/hub/efile_submissions/index.html.erb
+++ b/app/views/hub/efile_submissions/index.html.erb
@@ -52,10 +52,10 @@
       <% @efile_submissions.each do |submission| %>
         <% tax_return = submission.tax_return %>
           <tr class="index-table__row">
-            <td class="index-table__cell status"><%= link_to submission.current_state, hub_efile_submission_path(id: submission.tax_return.id), class: "underline" %></td>
-            <td class="index-table__cell"><%= link_to submission.irs_submission_id, hub_efile_submission_path(id: submission.tax_return.id) %></td>
+            <td class="index-table__cell status"><%= link_to submission.current_state, efile_hub_client_path(id: submission.client.id, anchor: "body"), class: "underline" %></td>
+            <td class="index-table__cell"><%= link_to submission.irs_submission_id, efile_hub_client_path(id: submission.client.id, anchor: "body") %></td>
             <td class="index-table__cell">
-              <%= link_to submission.client.legal_name, hub_client_path(id: submission.client.id), class: "underline" %>
+              <%= link_to submission.client.legal_name, efile_hub_client_path(id: submission.client.id, anchor: "body"), class: "underline" %>
             </td>
             <td class="index-table__cell">
               <%= tax_return.year %>

--- a/app/views/hub/efile_submissions/show.html.erb
+++ b/app/views/hub/efile_submissions/show.html.erb
@@ -1,32 +1,34 @@
-<% content_for :back_to, "efile" %>
 <% content_for :card do %>
-  <div class="slab slab--not-padded spacing-above-25 submission">
-    <div style="display: flex;">
-      <h1 class="h2 spacing-below-5">
-        <%= link_to @tax_return.client.legal_name, hub_client_path(id: @tax_return.client.id) %> (<%= @efile_submission.current_state %>)
-      </h1>
+  <%= render "hub/clients/client_header" %>
+  <%= render "hub/clients/navigation" %>
+  <% @tax_returns.each do |tax_return| %>
+    <% latest_efile_submission = tax_return.efile_submissions.last  %>
+    <div class="slab slab--not-padded spacing-above-25 submission" id="body">
 
-      <div style="margin-left: 10px;">
+      <div style="display: flex;">
+        <h1><%= tax_return.year %> Tax Return (<%= latest_efile_submission.current_state %>)</h1>
+
+        <div style="margin-left: 10px;">
         <%= link_to("Resubmit return",
-                    resubmit_hub_efile_submission_path(id: @efile_submission.id),
+                    resubmit_hub_efile_submission_path(id: latest_efile_submission.id),
                     method: :patch,
-                    data: { confirm: "Have you updated the necessary information for #{@tax_return.client.legal_name}?" },
-                    class: "button button--small") if @efile_submission.can_transition_to?(:resubmitted)
+                    data: { confirm: "Have you updated the necessary information for #{@client.legal_name}?" },
+                    class: "button button--small") if latest_efile_submission.can_transition_to?(:resubmitted)
         %>
       </div>
 
       <div style="margin-left: 10px">
         <%= link_to("Do not file",
-                    cancel_hub_efile_submission_path(id: @efile_submission.id),
+                    cancel_hub_efile_submission_path(id: latest_efile_submission.id),
                     method: :patch,
-                    data: { confirm: "Are you sure you want to mark this tax return submission for # #{@tax_return.client.legal_name}? as 'Not filing'?" },
-                    class: "button button--danger button--small") if @efile_submission.can_transition_to?(:cancelled) %>
+                    data: { confirm: "Are you sure you want to mark this tax return submission for # #{@client.legal_name}? as 'Not filing'?" },
+                    class: "button button--danger button--small") if latest_efile_submission.can_transition_to?(:cancelled) %>
       </div>
     </div>
 
     <div class="log-wrapper">
-      <h4 class="spacing-above-25 spacing-below-10">Status Logs</h4>
-      <% @tax_return.efile_submissions.each_with_index do |efile_submission, i| %>
+      <h4 class="spacing-below-10">Status Logs</h4>
+      <% tax_return.efile_submissions.each_with_index do |efile_submission, i| %>
         <hr/>
         <div>
           <%= i.zero? ? "Submission" : "Resubmission" %>
@@ -39,4 +41,5 @@
       <% end %>
     </div>
   </div>
+  <% end %>
 <% end %>

--- a/app/views/shared/_tax_return_list.html.erb
+++ b/app/views/shared/_tax_return_list.html.erb
@@ -45,13 +45,7 @@
           <% end %>
         <% else %>
           <div>
-            <% if tax_return.has_submissions? %>
-             <%= link_to hub_efile_submission_path(id: tax_return.id) do %>
-                <%= render 'shared/tax_return_status_label', tax_return: tax_return %>
-             <% end %>
-            <% else %>
              <%= render 'shared/tax_return_status_label', tax_return: tax_return %>
-            <% end %>
           </div>
         <% end %>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -187,6 +187,7 @@ Rails.application.routes.draw do
           end
           resources :notes, only: [:create, :index]
           resources :messages, only: [:index]
+          get "/efile", to: "efile_submissions#show", on: :member, as: :efile
           resources :outgoing_text_messages, only: [:create]
           resources :outgoing_emails, only: [:create]
           resources :outbound_calls, only: [:new, :create, :show, :update]

--- a/spec/controllers/hub/efile_submissions_controller_spec.rb
+++ b/spec/controllers/hub/efile_submissions_controller_spec.rb
@@ -36,7 +36,7 @@ describe Hub::EfileSubmissionsController do
 
   describe "#show" do
     let(:submission) { create :efile_submission }
-    let(:params) { { id: submission.tax_return  } }
+    let(:params) { { id: submission.client.id } }
     it_behaves_like :an_action_for_admins_only, action: :show, method: :get
 
     context "as an authenticated admin" do
@@ -45,9 +45,8 @@ describe Hub::EfileSubmissionsController do
 
       it "loads the tax return by id and latest submission as instance variables" do
         get :show, params: params
-
-        expect(assigns(:tax_return)).to eq submission.tax_return
-        expect(assigns(:efile_submission)).to eq submission
+        expect(assigns(:client)).to eq submission.client
+        expect(assigns(:tax_returns)).to eq [submission.tax_return]
       end
     end
   end


### PR DESCRIPTION
Third (fourth?) times a charm in reconfiguring where this page is and what it displays. Better than ever!

All of the links on the efile index now link to this page, which simplifies things quite nicely. 

<img width="1351" alt="Screen Shot 2021-08-03 at 9 14 26 PM" src="https://user-images.githubusercontent.com/4494389/128111107-eb6eb7bb-f7e5-401f-be50-4677213a99fc.png">
