### PR TITLE
Fix EIP Go back bug by resetting values to defaults when clicking i havent received all of my stimulus

### DIFF
--- a/app/controllers/ctc/questions/stimulus_reset_controller.rb
+++ b/app/controllers/ctc/questions/stimulus_reset_controller.rb
@@ -1,0 +1,22 @@
+module Ctc
+  module Questions
+    class StimulusResetController < QuestionsController
+      include AuthenticatedCtcClientConcern
+
+      layout "intake"
+
+      def self.show?(intake)
+        false
+      end
+
+      # there is no edit page for this endpoint
+      def edit
+        redirect_back(fallback_location: prev_path)
+      end
+
+      private
+
+      def illustration_path;end
+    end
+  end
+end

--- a/app/controllers/flows_controller.rb
+++ b/app/controllers/flows_controller.rb
@@ -144,7 +144,7 @@ class FlowsController < ApplicationController
             e.string
           end
         else
-          if controller_path.start_with?('ctc')
+          if controller_path.start_with?('ctc') && !unreachable?(@current_controller)
             raise "Could not find title for: #{controller_path}"
           else
             controller_name.titleize.singularize

--- a/app/forms/ctc/stimulus_reset_form.rb
+++ b/app/forms/ctc/stimulus_reset_form.rb
@@ -1,0 +1,12 @@
+module Ctc
+  class StimulusResetForm < QuestionsForm
+    def save
+      @intake.update(
+        eip1_amount_received: nil,
+        eip2_amount_received: nil,
+        eip1_entry_method: "unfilled",
+        eip2_entry_method: "unfilled"
+      )
+    end
+  end
+end

--- a/app/lib/ctc_question_navigation.rb
+++ b/app/lib/ctc_question_navigation.rb
@@ -42,6 +42,7 @@ class CtcQuestionNavigation
 
     # RRC
     Ctc::Questions::StimulusPaymentsController,
+    Ctc::Questions::StimulusResetController,
     Ctc::Questions::StimulusOneController,
     Ctc::Questions::StimulusOneReceivedController,
     Ctc::Questions::StimulusTwoController,

--- a/app/views/ctc/questions/stimulus_payments/edit.html.erb
+++ b/app/views/ctc/questions/stimulus_payments/edit.html.erb
@@ -29,7 +29,7 @@
         <%= t("views.ctc.questions.stimulus_payments.yes_received") %>
       <% end %>
 
-      <%= link_to questions_stimulus_one_path, class: "button button--wide text--centered" do %>
+      <%= link_to questions_stimulus_reset_path, method: :put, class: "button button--wide text--centered" do %>
         <%= t("views.ctc.questions.stimulus_payments.no_did_not_receive") %>
       <% end %>
     </div>

--- a/spec/features/ctc/rrc_intake_questions_spec.rb
+++ b/spec/features/ctc/rrc_intake_questions_spec.rb
@@ -59,6 +59,32 @@ RSpec.feature "CTC Intake", :flow_explorer_screenshot_i18n_friendly, active_job:
     end
   end
 
+  context "when a client clicks that they recieved less than the stimulus amount after previously saying that was the amount they received, it should reset the amounts" do
+    scenario do
+      visit "en/questions/stimulus-payments"
+      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_payments.title'))
+      click_on I18n.t('views.ctc.questions.stimulus_payments.yes_received')
+
+      expect(page).to have_text("EIP 1: $2,400")
+      expect(page).to have_text("EIP 2: $1,200")
+      click_on I18n.t("general.back")
+      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_payments.title'))
+      click_on I18n.t('views.ctc.questions.stimulus_payments.no_did_not_receive')
+      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_one.title'))
+      click_on I18n.t('general.affirmative')
+      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_one_received.title'))
+      fill_in I18n.t('views.ctc.questions.stimulus_one_received.eip1_amount_received_label'), with: "800"
+      click_on I18n.t('general.continue')
+      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_two.title'))
+      click_on I18n.t('general.affirmative')
+      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_two_received.title'))
+      fill_in I18n.t('views.ctc.questions.stimulus_two_received.eip2_amount_received_label'), with: "400"
+      click_on I18n.t('general.continue')
+      expect(page).to have_text("EIP 1: $800")
+      expect(page).to have_text("EIP 2: $400")
+    end
+  end
+
   context "client ends up on /stimulus-owed" do
     before do
       client.intake.update(eip1_amount_received: 0, eip2_amount_received: 0)


### PR DESCRIPTION
This adds a new entry to QuestionNavigation. It is a no-op for edit (it never responds true to show), but we link to the update page from the link so that we can have a form action that clears the EIP data. 

