### PR TITLE
Change crontab command to include "rake"/"rails" [#179135032]

### DIFF
--- a/crontab
+++ b/crontab
@@ -1,4 +1,4 @@
 0 0 * * 0 bundle exec rake vita_providers:scrape_vita_providers
 * * * * * bundle exec rake search:refresh
 20 21 * * 1-5 bundle exec rake client_surveys:send_client_in_progress_surveys
-*/10 * * * * bundle exec efile:poll_and_get_acknowledgments
+*/10 * * * * bundle exec rake efile:poll_and_get_acknowledgments


### PR DESCRIPTION
This should fix an error we were seeing in the logs:

> time="2021-08-05T17:30:00Z" level=error msg="error running command: exit status 127" iteration=0 job.command="bundle exec efile:poll_and_get_acknowledgments" job.position=3 job.schedule="*/10 * * * *"
