### PR TITLE
Fix issue with efile 1040 values and bolster adv ctc 1040 tests

### DIFF
--- a/app/lib/submission_builder/documents/adv_ctc_irs1040.rb
+++ b/app/lib/submission_builder/documents/adv_ctc_irs1040.rb
@@ -49,7 +49,7 @@ module SubmissionBuilder
             xml.TaxableIncomeAmt 0
             xml.RecoveryRebateCreditAmt tax_return.claimed_recovery_rebate_credit
             xml.RefundableCreditsAmt tax_return.claimed_recovery_rebate_credit
-            xml.TotalPaymentsAmt 0
+            xml.TotalPaymentsAmt tax_return.claimed_recovery_rebate_credit
             xml.OverpaidAmt 0
             xml.RefundAmt tax_return.claimed_recovery_rebate_credit
             if bank_account.present? && intake.refund_payment_method_direct_deposit?


### PR DESCRIPTION
The paper 1040 PDF was correct, but the efiled 1040 was providing the incorrect amount (0 instead of the rrc amount, thinking it was supposed to be a value for payments MADE instead of expected payments TO the client), which resulted in a rejected tax return.