### PR TITLE
Fix duplicated tax return problem on efile show

### DIFF
--- a/app/controllers/hub/efile_submissions_controller.rb
+++ b/app/controllers/hub/efile_submissions_controller.rb
@@ -15,7 +15,7 @@ module Hub
     # loops through the tax_returns that have efile_submissions.
     def show
       @client = Client.find(params[:id])
-      @tax_returns = @client.tax_returns.joins(:efile_submissions) # get all tax returns with submissions
+      @tax_returns = @client.tax_returns.joins(:efile_submissions).uniq # get all tax returns with submissions
       redirect_to hub_client_path(id: @client.id) and return unless @tax_returns.present?
     end
 

--- a/spec/controllers/hub/efile_submissions_controller_spec.rb
+++ b/spec/controllers/hub/efile_submissions_controller_spec.rb
@@ -36,6 +36,7 @@ describe Hub::EfileSubmissionsController do
 
   describe "#show" do
     let(:submission) { create :efile_submission }
+    let!(:submission_2) { create :efile_submission, tax_return: submission.tax_return }
     let(:params) { { id: submission.client.id } }
     it_behaves_like :an_action_for_admins_only, action: :show, method: :get
 


### PR DESCRIPTION
BERFORE FIX:
![Screen Shot 2021-08-09 at 11 03 27 AM](https://user-images.githubusercontent.com/4494389/128737666-bcb09905-0570-49cd-b976-76feebc3edaa.png)

We were loading in tax returns joined to efile_submissions, which meant that every efile_submissions tax return was loaded. We really want it to be unique tax returns, for all tax returns that have submissions.