### PR TITLE
Use FederalOriginalSubmissionIdDt for resubmission timestamp in 1040 XML header [#179170521]

### DIFF
--- a/app/lib/submission_builder/return_header1040.rb
+++ b/app/lib/submission_builder/return_header1040.rb
@@ -143,7 +143,7 @@ module SubmissionBuilder
             }
             if submission.resubmission?
               xml.FederalOriginalSubmissionId submission.previously_transmitted_submission.irs_submission_id
-              xml.FederalOriginalSubmissionDt date_type(submission.previously_transmitted_submission.created_at)
+              xml.FederalOriginalSubmissionIdDt date_type(submission.previously_transmitted_submission.created_at)
             end
             xml.TotalPreparationSubmissionTs total_preparation_submission_minutes
             xml.TotActiveTimePrepSubmissionTs total_active_preparation_minutes


### PR DESCRIPTION
This is important because the old XML tag name did not match the IRS schema,
which meant we could not re-submit a return if it had already been transmitted
once to the IRS.

Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>