### PR TITLE
If submission generation raises an error, switch to failed [#179170521]

### DIFF
--- a/app/jobs/build_submission_bundle_job.rb
+++ b/app/jobs/build_submission_bundle_job.rb
@@ -9,16 +9,15 @@ class BuildSubmissionBundleJob < ApplicationJob
 
     begin
       submission.generate_form_1040_pdf
-    rescue
-      submission.transition_to!(:failed, error_code: 'PDF-1040-FAIL', raw_response: ['Engineers should look in Sentry for a crash'])
+    rescue StandardError => e
+      submission.transition_to!(:failed, error_code: 'PDF-1040-FAIL', raw_response: ["Engineers should look in Sentry for an exception", "EfileSubmission #{submission_id}", e.class.name])
       raise
     end
 
     begin
       response = SubmissionBundle.build(submission, documents: ["adv_ctc_irs1040"])
-    rescue
-      submission.transition_to!(:failed, error_code: 'BUNDLE-FAIL', raw_response: ['Engineers should look in Sentry for a crash'])
-      raise
+    rescue StandardError => e
+      submission.transition_to!(:failed, error_code: 'BUNDLE-FAIL', raw_response: ["Engineers should look in Sentry for an exception", "EfileSubmission #{submission_id}", e.class.name])
     end
 
     if response.valid?

--- a/app/jobs/build_submission_bundle_job.rb
+++ b/app/jobs/build_submission_bundle_job.rb
@@ -14,7 +14,13 @@ class BuildSubmissionBundleJob < ApplicationJob
       raise
     end
 
-    response = SubmissionBundle.build(submission, documents: ["adv_ctc_irs1040"])
+    begin
+      response = SubmissionBundle.build(submission, documents: ["adv_ctc_irs1040"])
+    rescue
+      submission.transition_to!(:failed, error_code: 'BUNDLE-FAIL')
+      raise
+    end
+
     if response.valid?
       submission.transition_to!(:queued)
     else

--- a/app/jobs/build_submission_bundle_job.rb
+++ b/app/jobs/build_submission_bundle_job.rb
@@ -10,14 +10,15 @@ class BuildSubmissionBundleJob < ApplicationJob
     begin
       submission.generate_form_1040_pdf
     rescue StandardError => e
-      submission.transition_to!(:failed, error_code: 'PDF-1040-FAIL', raw_response: ["Engineers should look in Sentry for an exception", "EfileSubmission #{submission_id}", e.class.name])
+      submission.transition_to!(:failed, error_code: 'PDF-1040-FAIL', raw_response: "Engineers should look in Sentry for an exception\n\nEfileSubmission ID #{submission_id}\n\nException class: #{e.class.name}")
       raise
     end
 
     begin
       response = SubmissionBundle.build(submission, documents: ["adv_ctc_irs1040"])
     rescue StandardError => e
-      submission.transition_to!(:failed, error_code: 'BUNDLE-FAIL', raw_response: ["Engineers should look in Sentry for an exception", "EfileSubmission #{submission_id}", e.class.name])
+      submission.transition_to!(:failed, error_code: 'BUNDLE-FAIL', raw_response: "Engineers should look in Sentry for an exception\n\nEfileSubmission ID #{submission_id}\n\nException class: #{e.class.name}")
+      raise
     end
 
     if response.valid?

--- a/app/jobs/build_submission_bundle_job.rb
+++ b/app/jobs/build_submission_bundle_job.rb
@@ -10,14 +10,14 @@ class BuildSubmissionBundleJob < ApplicationJob
     begin
       submission.generate_form_1040_pdf
     rescue
-      submission.transition_to!(:failed, error_code: 'PDF-1040-FAIL')
+      submission.transition_to!(:failed, error_code: 'PDF-1040-FAIL', raw_response: ['Engineers should look in Sentry for a crash'])
       raise
     end
 
     begin
       response = SubmissionBundle.build(submission, documents: ["adv_ctc_irs1040"])
     rescue
-      submission.transition_to!(:failed, error_code: 'BUNDLE-FAIL')
+      submission.transition_to!(:failed, error_code: 'BUNDLE-FAIL', raw_response: ['Engineers should look in Sentry for a crash'])
       raise
     end
 

--- a/spec/jobs/build_submission_bundle_job_spec.rb
+++ b/spec/jobs/build_submission_bundle_job_spec.rb
@@ -63,5 +63,18 @@ describe BuildSubmissionBundleJob do
         expect(submission.reload.current_state).to eq "failed"
       end
     end
+
+    context "when the build raises an unhandled exception" do
+      before do
+        allow(SubmissionBundle).to receive(:build).and_raise StandardError
+      end
+
+      it "transitions the submission into :failed" do
+        expect do
+          described_class.perform_now(submission.id)
+        end.to raise_error(StandardError)
+        expect(submission.reload.current_state).to eq "failed"
+      end
+    end
   end
 end


### PR DESCRIPTION
Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>

## Why this is needed

In the case of https://demo.getyourrefund.org/en/hub/clients/34487/efile#body , we ran into an exception while generating the submission bundle.

If this happens in the future, we'll have to look in Sentry for the details of the exception, so I added that remark here.

In this case, the codebase already has a fix for the issue; however, the EfileSubmission is in the wrong state. Once this pull request is approved, I'll mark the EfileSubmission as `:failed` which will allow it to be resubmitted within the Hub.