### PR TITLE
Do not expose "investigating" status in client portal.

### DIFF
--- a/app/controllers/ctc/portal/portal_controller.rb
+++ b/app/controllers/ctc/portal/portal_controller.rb
@@ -5,8 +5,9 @@ class Ctc::Portal::PortalController < ApplicationController
   def home
     if current_client.efile_submissions.any?
       submission = current_client.efile_submissions.last
-      @status = submission.current_state
-      @exposed_error = submission.last_transition ? submission.last_transition.client_facing_errors.first : nil
+      latest_transition = submission.last_client_accessible_transition
+      @status = latest_transition.to_state
+      @exposed_error = latest_transition ? latest_transition.client_facing_errors.first : nil
       @current_step = nil
     else
       @status = "intake_in_progress"

--- a/app/controllers/ctc/portal/portal_controller.rb
+++ b/app/controllers/ctc/portal/portal_controller.rb
@@ -6,8 +6,8 @@ class Ctc::Portal::PortalController < ApplicationController
     if current_client.efile_submissions.any?
       submission = current_client.efile_submissions.last
       latest_transition = submission.last_client_accessible_transition
-      @status = latest_transition.to_state
-      @exposed_error = latest_transition ? latest_transition.client_facing_errors.first : nil
+      @status = latest_transition.present? ? latest_transition.to_state : EfileSubmissionStateMachine.initial_state
+      @exposed_error = latest_transition.present? ? latest_transition.client_facing_errors.first : nil
       @current_step = nil
     else
       @status = "intake_in_progress"

--- a/app/models/efile_submission.rb
+++ b/app/models/efile_submission.rb
@@ -52,6 +52,14 @@ class EfileSubmission < ApplicationRecord
     false
   end
 
+  def last_client_accessible_transition
+    return nil unless last_transition.present?
+
+    return last_transition unless last_transition.to_state == "investigating"
+
+    efile_submission_transitions.where('id < ?', last_transition.id).last
+  end
+
   def resubmission?
     previously_transmitted_submission.present?
   end

--- a/app/state_machines/efile_submission_state_machine.rb
+++ b/app/state_machines/efile_submission_state_machine.rb
@@ -24,7 +24,7 @@ class EfileSubmissionStateMachine
   transition from: :failed,       to: [:resubmitted, :cancelled, :investigating]
   transition from: :rejected,     to: [:resubmitted, :cancelled, :investigating]
   transition from: :investigating, to: [:resubmitted, :cancelled]
-  transition from: :resubmitted,  to: [:preparing]
+  transition from: :resubmitted, to: [:preparing]
 
   after_transition(to: :preparing) do |submission|
     BuildSubmissionBundleJob.perform_later(submission.id)

--- a/spec/controllers/hub/efile_errors_controller_spec.rb
+++ b/spec/controllers/hub/efile_errors_controller_spec.rb
@@ -50,7 +50,7 @@ describe Hub::EfileErrorsController do
       before do
         sign_in user
       end
-      
+
       it "updates the object based on passed logic" do
         expect(efile_error.expose).to eq true
         put :update, params: params

--- a/spec/features/ctc/portal_spec.rb
+++ b/spec/features/ctc/portal_spec.rb
@@ -142,6 +142,37 @@ RSpec.feature "CTC Intake", active_job: true do
     end
   end
 
+  context "whhen the client has verified the contact, efile submission is status investigating" do
+    before do
+      intake.update(email_address_verified_at: DateTime.now)
+      es = create(:efile_submission, :failed, tax_return: create(:tax_return, client: intake.client, year: 2020))
+      es.transition_to!(:investigating)
+
+    end
+    scenario "a client sees information about the previous transition to failed" do
+      visit "/en/portal/login"
+
+      expect(page).to have_selector("h1", text: "To view your progress, we’ll send you a secure code.")
+      fill_in "Email address", with: "mango@example.com"
+      click_on "Send code"
+
+      perform_enqueued_jobs
+      mail = ActionMailer::Base.deliveries.last
+      expect(mail.html_part.body.to_s).to have_text("Your 6-digit GetCTC verification code is: ")
+      code = mail.html_part.body.to_s.match(/Your 6-digit GetCTC verification code is: (\d+)/)[1]
+      fill_in "Enter 6 digit code", with: code
+      click_on "Verify"
+      expect(page).to have_selector("h1", text: "Authentication needed to continue.")
+      fill_in "Client ID or Last 4 of SSN/ITIN", with: intake.client.id
+      click_on "Continue"
+
+      expect(page).to have_selector("h1", text: "Thank you for filing with GetCTC!")
+      expect(page).to have_text "Submission error"
+      expect(page).to have_text "We encountered some errors transmitting your return to the IRS. Information about next steps were sent to your contact info."
+    end
+
+  end
+
   context "when the client has verified the contact, efile submission is status transmitted" do
     before do
       intake.update(email_address_verified_at: DateTime.now)

--- a/spec/features/ctc/portal_spec.rb
+++ b/spec/features/ctc/portal_spec.rb
@@ -142,7 +142,7 @@ RSpec.feature "CTC Intake", active_job: true do
     end
   end
 
-  context "whhen the client has verified the contact, efile submission is status investigating" do
+  context "when the client has verified the contact, efile submission is status investigating" do
     before do
       intake.update(email_address_verified_at: DateTime.now)
       es = create(:efile_submission, :failed, tax_return: create(:tax_return, client: intake.client, year: 2020))

--- a/spec/models/efile_submission_spec.rb
+++ b/spec/models/efile_submission_spec.rb
@@ -217,4 +217,30 @@ describe EfileSubmission do
       end
     end
   end
+
+  describe "last_client_accessible_transition" do
+    context "when the status of the last_transition is investigating" do
+      let(:efile_submission) { create :efile_submission, :rejected }
+      before do
+        efile_submission.transition_to!(:investigating)
+      end
+      it "returns last_transition" do
+        expect(efile_submission.last_client_accessible_transition).to eq (efile_submission.efile_submission_transitions.where(to_state: 'rejected').last)
+      end
+    end
+
+    context "when the status of the last_transition is not investigating" do
+      let(:efile_submission) { create :efile_submission, :preparing }
+      it "returns last_transition" do
+        expect(efile_submission.last_client_accessible_transition).to eq (efile_submission.last_transition)
+      end
+    end
+
+    context "when there is no last_transition" do
+      let(:efile_submission) { create :efile_submission }
+      it "returns nil" do
+        expect(efile_submission.last_client_accessible_transition).to eq nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
Investigating is a status that we'll use internally, but we should expose to the client the actionable previous status in the portal.