### PR TITLE
Touch last_seen_at when a client logs in

### DIFF
--- a/app/controllers/portal/client_logins_controller.rb
+++ b/app/controllers/portal/client_logins_controller.rb
@@ -66,6 +66,7 @@ module Portal
       if @form.valid?
         sign_in @form.client
         @form.client.accumulate_total_session_durations
+        @form.client.touch :last_seen_at
         redirect_to session.delete(:after_client_login_path) || portal_root_path
       else
         @clients.each(&:increment_failed_attempts)

--- a/spec/controllers/portal/client_logins_controller_spec.rb
+++ b/spec/controllers/portal/client_logins_controller_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+include ActiveSupport::Testing::TimeHelpers
 
 RSpec.describe Portal::ClientLoginsController, type: :controller do
   let(:client) do
@@ -211,9 +212,9 @@ RSpec.describe Portal::ClientLoginsController, type: :controller do
           end
 
           it "updates the clients last_seen_at" do
-            Timecop.freeze do
-              expect { post :update, params: params }
-                .to change{ client.reload.last_seen_at }.to(Time.now)
+            freeze_time do
+              post :update, params: params
+              expect(client.reload.last_seen_at).to eq Time.zone.now
             end
           end
 

--- a/spec/controllers/portal/client_logins_controller_spec.rb
+++ b/spec/controllers/portal/client_logins_controller_spec.rb
@@ -193,6 +193,7 @@ RSpec.describe Portal::ClientLoginsController, type: :controller do
         before { allow_any_instance_of(ClientLoginService).to receive(:clients_for_token).and_return(client_query) }
 
         context "with a matching ssn/client ID" do
+          before { Timecop.freeze }
           let(:params) do
             {
               id: "raw_token",
@@ -206,6 +207,7 @@ RSpec.describe Portal::ClientLoginsController, type: :controller do
             post :update, params: params
 
             expect(subject.current_client).to eq(client)
+            expect(subject.current_client.last_seen_at).to eq(Time.now)
             expect(response).to redirect_to portal_root_path
           end
 

--- a/spec/controllers/portal/client_logins_controller_spec.rb
+++ b/spec/controllers/portal/client_logins_controller_spec.rb
@@ -1,11 +1,10 @@
 require "rails_helper"
-include ActiveSupport::Testing::TimeHelpers
 
 RSpec.describe Portal::ClientLoginsController, type: :controller do
   let(:client) do
     create(
       :client,
-      last_seen_at: DateTime.new(2021, 4, 20, 16, 21),
+      last_seen_at: nil,
       intake: create(
         :intake,
         email_address: "client@example.com",

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,6 +63,7 @@ RSpec.configure do |config|
   config.include ControllerHelpers, type: :controller
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include ChannelHelpers, type: :channel
+  config.include ActiveSupport::Testing::TimeHelpers
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and


### PR DESCRIPTION
Fixes [this bug](https://www.pivotaltracker.com/story/show/179169548) 🐞

**What was going wrong?**
We want to figure out how long a client spent filling out questions and report it to the IRS. Each time a client signs in, Devise updates `last_sign_in_at`. Each time they answer a question on intake, we update/touch `last_seen_at`. 

When it comes time to either report session time to the IRS, we subtract `last_sign_in_at` from `last_seen_at` because we assume that we saw them sometime after their last login.

However, what if their last action was to login? This would mean that `last_seen_at` was still set to their LAST session's last action and we would get a negative number of milliseconds. The IRS doesn't like negative numbers. Woops.

**How does this fix it?**
We had two options - zero out `last_seen_at` on login or update/touch `last_seen_at` on login. The effect is about the same. I consider logging in to be a "seen" action and so I chose the latter. 

The one tiny downside to this is that there may actually be a few milliseconds between Devise setting their value and us setting ours. Fortunately, neither us nor the IRS requires that level of precision. 