### PR TITLE
Sort the Status Logs by time

### DIFF
--- a/app/models/efile_submission.rb
+++ b/app/models/efile_submission.rb
@@ -18,7 +18,7 @@ class EfileSubmission < ApplicationRecord
   has_one :client, through: :tax_return
   has_many :dependents, through: :intake
   has_one :address, as: :record
-  has_many :efile_submission_transitions, class_name: "EfileSubmissionTransition", autosave: false, dependent: :destroy
+  has_many :efile_submission_transitions, -> { order(id: :asc) }, class_name: "EfileSubmissionTransition", autosave: false, dependent: :destroy
   has_one_attached :submission_bundle
   has_one :efile_security_information
   accepts_nested_attributes_for :efile_security_information
@@ -36,6 +36,8 @@ class EfileSubmission < ApplicationRecord
   scope :most_recent_by_tax_return, lambda {
     joins(:tax_return).where("efile_submissions.id = (SELECT MAX(efile_submissions.id) FROM efile_submissions WHERE efile_submissions.tax_return_id = tax_returns.id)")
   }
+
+  default_scope { order(id: :asc) }
 
   def state_machine
     @state_machine ||= EfileSubmissionStateMachine.new(self, transition_class: EfileSubmissionTransition)

--- a/app/models/efile_submission_transition.rb
+++ b/app/models/efile_submission_transition.rb
@@ -28,6 +28,8 @@ class EfileSubmissionTransition < ApplicationRecord
   after_destroy :update_most_recent, if: :most_recent?
   after_create_commit :persist_efile_error_from_metadata
 
+  default_scope { order(id: :asc) }
+
   def initiated_by
     return nil unless metadata["initiated_by_id"]
 


### PR DESCRIPTION
Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>

## Why

I was looking at https://demo.getyourrefund.org/en/hub/clients/34490/efile and stuff was all in arbitrary orders and it was confusing me so I figure the logs can be sorted by time.