### PR TITLE
CTC intake: ensure birth date and SSN are loaded in forms when coming back to edit

### DIFF
--- a/app/controllers/ctc/questions/home_controller.rb
+++ b/app/controllers/ctc/questions/home_controller.rb
@@ -9,6 +9,10 @@ module Ctc
       def next_path
         @form.lived_in_territory_or_at_foreign_address? ? questions_use_gyr_path : super
       end
+
+      def tracking_data
+        @form.attributes_for(:misc)
+      end
     end
   end
 end

--- a/app/controllers/ctc/questions/income_controller.rb
+++ b/app/controllers/ctc/questions/income_controller.rb
@@ -21,6 +21,10 @@ module Ctc
       def next_path
         @form.had_reportable_income? ? questions_use_gyr_path : super
       end
+
+      def tracking_data
+        @form.attributes_for(:misc)
+      end
     end
   end
 end

--- a/app/controllers/flows_controller.rb
+++ b/app/controllers/flows_controller.rb
@@ -238,6 +238,7 @@ class FlowsController < ApplicationController
         client.intake.tax_returns.last.update(filing_status: 'married_filing_jointly')
         client.intake.update(
           spouse_tin_type: 'ssn',
+          spouse_birth_date: 31.years.ago + 51.days,
           spouse_ssn: '555113333',
           spouse_last_four_ssn: '3333',
           spouse_first_name: "#{first_name}Spouse",

--- a/app/forms/ctc/dependents/dependent_form.rb
+++ b/app/forms/ctc/dependents/dependent_form.rb
@@ -11,8 +11,12 @@ module Ctc
       end
 
       def self.from_dependent(dependent)
-        attribute_keys = Attributes.new(attribute_names).to_sym
-        new(dependent, existing_attributes(dependent).slice(*attribute_keys))
+        attribute_keys = Attributes.new(scoped_attributes[:dependent]).to_sym
+        new(dependent, existing_attributes(dependent, attribute_keys))
+      end
+
+      def self.existing_attributes(model, attribute_keys)
+        HashWithIndifferentAccess[(attribute_keys || []).map { |k| [k, model.send(k)] }]
       end
     end
   end

--- a/app/forms/ctc/dependents/info_form.rb
+++ b/app/forms/ctc/dependents/info_form.rb
@@ -26,6 +26,18 @@ module Ctc
         @dependent.save
       end
 
+      def self.existing_attributes(dependent, _attribute_keys)
+        if dependent.birth_date.present?
+          super.merge(
+            birth_date_day: dependent.birth_date.day,
+            birth_date_month: dependent.birth_date.month,
+            birth_date_year: dependent.birth_date.year,
+          )
+        else
+          super
+        end
+      end
+
       private
 
       def birth_date

--- a/app/forms/ctc/dependents/tin_form.rb
+++ b/app/forms/ctc/dependents/tin_form.rb
@@ -9,11 +9,14 @@ module Ctc
       set_attributes_for :birthday, :birth_date_month, :birth_date_day, :birth_date_year
       set_attributes_for :misc, :ssn_no_employment
 
-      validates :ssn, confirmation: true, if: -> { ssn.present? && ssn != @dependent.ssn }
+      with_options if: -> { (ssn.present? && ssn != @dependent.ssn) || ssn_confirmation.present? } do
+        validates :ssn, confirmation: true
+        validates :ssn_confirmation, presence: true
+      end
+
       validates :ssn, social_security_number: true, if: -> { tin_type == "ssn" && ssn.present? }
 
       validates_presence_of :tin_type
-      validates_presence_of :ssn_confirmation, if: -> { ssn.present? && ssn != @dependent.ssn }
 
       before_validation do
         if ssn_no_employment == "yes" && tin_type == "ssn"

--- a/app/forms/ctc/direct_deposit_form.rb
+++ b/app/forms/ctc/direct_deposit_form.rb
@@ -10,12 +10,12 @@ module Ctc
       @intake.update(bank_account_attributes: attributes_for(:bank_account))
     end
     
-    def self.existing_attributes(intake)
+    def self.existing_attributes(intake, attribute_keys)
       return super unless intake.bank_account.present?
 
       # bank_name is encrypted, but we want it to be editable for clients
       bank_account_attributes = intake.bank_account.attributes.merge(bank_name: intake.bank_account.bank_name)
-      HashWithIndifferentAccess.new(intake.attributes.merge(bank_account_attributes))
+      super.merge(bank_account_attributes)
     end
   end
 end

--- a/app/forms/ctc/email_verification_form.rb
+++ b/app/forms/ctc/email_verification_form.rb
@@ -1,6 +1,6 @@
 module Ctc
   class EmailVerificationForm < QuestionsForm
-    set_attributes_for :intake, :verification_code
+    set_attributes_for :misc, :verification_code
 
     validates_presence_of :verification_code
 

--- a/app/forms/ctc/home_form.rb
+++ b/app/forms/ctc/home_form.rb
@@ -1,6 +1,6 @@
 module Ctc
   class HomeForm < QuestionsForm
-    set_attributes_for :intake, :lived_in_fifty_states, :lived_at_military_facility, :lived_in_us_territory, :lived_at_foreign_address
+    set_attributes_for :misc, :lived_in_fifty_states, :lived_at_military_facility, :lived_in_us_territory, :lived_at_foreign_address
 
     def save; end
 

--- a/app/forms/ctc/income_form.rb
+++ b/app/forms/ctc/income_form.rb
@@ -1,6 +1,6 @@
 module Ctc
   class IncomeForm < QuestionsForm
-    set_attributes_for :intake, :had_reportable_income
+    set_attributes_for :misc, :had_reportable_income
 
     def save; end
 

--- a/app/forms/ctc/ip_pin_entry_form.rb
+++ b/app/forms/ctc/ip_pin_entry_form.rb
@@ -7,14 +7,6 @@ module Ctc
     validates :primary_ip_pin, presence: true, ip_pin: true, if: -> { @intake.has_primary_ip_pin_yes? }
     validates :spouse_ip_pin, presence: true, ip_pin: true, if: -> { @intake.has_spouse_ip_pin_yes? }
 
-    def self.from_intake(intake)
-      new(intake, existing_attributes(intake, Attributes.new(attribute_names).to_sym))
-    end
-
-    def self.existing_attributes(model, attribute_keys)
-      HashWithIndifferentAccess[attribute_keys.map { |k| [k, model.send(k)] }]
-    end
-
     def dependents
       @intake.assign_attributes(dependents_attributes: dependents_attributes.to_h)
       @intake.dependents.select { |dep| dep.has_ip_pin_yes? }

--- a/app/forms/ctc/phone_verification_form.rb
+++ b/app/forms/ctc/phone_verification_form.rb
@@ -1,6 +1,6 @@
 module Ctc
   class PhoneVerificationForm < QuestionsForm
-    set_attributes_for :intake, :verification_code
+    set_attributes_for :misc, :verification_code
 
     validates_presence_of :verification_code
 

--- a/app/forms/ctc/questions_form.rb
+++ b/app/forms/ctc/questions_form.rb
@@ -1,0 +1,11 @@
+module Ctc
+  class QuestionsForm < ::QuestionsForm
+    def self.from_intake(intake)
+      new(intake, existing_attributes(intake, Attributes.new(scoped_attributes[:intake]).to_sym))
+    end
+
+    def self.existing_attributes(model, attribute_keys)
+      HashWithIndifferentAccess[(attribute_keys || []).map { |k| [k, model.send(k)] }]
+    end
+  end
+end

--- a/app/forms/ctc/spouse_info_form.rb
+++ b/app/forms/ctc/spouse_info_form.rb
@@ -45,7 +45,7 @@ module Ctc
       ))
     end
 
-    def self.existing_attributes(intake)
+    def self.existing_attributes(intake, attributes)
       super.merge(ssn_attributes(intake)).merge(date_of_birth_attributes(intake))
     end
 

--- a/app/forms/null_form.rb
+++ b/app/forms/null_form.rb
@@ -1,5 +1,5 @@
 class NullForm < QuestionsForm
-  def self.existing_attributes(_)
+  def self.existing_attributes(*_args)
     {}
   end
 

--- a/spec/forms/ctc/direct_deposit_form_spec.rb
+++ b/spec/forms/ctc/direct_deposit_form_spec.rb
@@ -60,7 +60,7 @@ describe Ctc::DirectDepositForm do
     context "with an existing bank account" do
       let(:intake) { create :ctc_intake, bank_account: create(:bank_account, bank_name: "Bank Name") }
       it "pushes the bank names into the existing attributes" do
-        expect(described_class.existing_attributes(intake)[:bank_name]).to eq "Bank Name"
+        expect(described_class.existing_attributes(intake, described_class.scoped_attributes[:intake])[:bank_name]).to eq "Bank Name"
       end
     end
   end

--- a/spec/forms/ctc/spouse_info_form_spec.rb
+++ b/spec/forms/ctc/spouse_info_form_spec.rb
@@ -45,7 +45,7 @@ describe Ctc::SpouseInfoForm do
     let(:populated_intake) { build :ctc_intake, spouse_birth_date: Date.new(1983, 5, 10), spouse_ssn: "123456789" }
 
     it "returns a hash with the date fields populated" do
-      attributes = Ctc::SpouseInfoForm.existing_attributes(populated_intake)
+      attributes = Ctc::SpouseInfoForm.existing_attributes(populated_intake, Ctc::SpouseInfoForm.scoped_attributes[:intake])
 
       expect(attributes[:spouse_birth_date_year]).to eq 1983
       expect(attributes[:spouse_birth_date_month]).to eq 5

--- a/spec/forms/ctc/spouse_info_form_spec.rb
+++ b/spec/forms/ctc/spouse_info_form_spec.rb
@@ -51,7 +51,6 @@ describe Ctc::SpouseInfoForm do
       expect(attributes[:spouse_birth_date_month]).to eq 5
       expect(attributes[:spouse_birth_date_day]).to eq 10
       expect(attributes[:spouse_ssn]).to eq "123456789"
-      expect(attributes[:spouse_ssn_confirmation]).to eq "123456789"
     end
   end
 


### PR DESCRIPTION
Also only require SSN confirmation when the SSN has changed (previously
only worked like this in the dependents flow)

This attempts to provide a consistent experience for entering birth date
and TIN no matter whether you are doing it for the primary, spouse, or
dependent. These fields should always show up when reloading persisted
data and not require confirmation unless the values have changed.

Previously, birth date and SSN were always blank when editing persisted
data, because `existing_attributes` relies on `model.attributes`
and the values don't show up there (for SSN, because they are encrypted,
and for birth date, because the form has more fields than the model)