### PR TITLE
CTC intake: add mixpanel events for some controllers and efile transitions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -139,7 +139,7 @@ class ApplicationController < ActionController::Base
     invalid_field_flags = errors.keys.map { |key| ["invalid_#{key}".to_sym, true] }.to_h
 
     MixpanelService.send_event(
-      event_id: visitor_id,
+      distinct_id: visitor_id,
       event_name: 'validation_error',
       data: invalid_field_flags.merge(additional_data),
       subject: current_intake,
@@ -152,7 +152,7 @@ class ApplicationController < ActionController::Base
     return if user_agent.bot?
 
     MixpanelService.send_event(
-      event_id: visitor_id,
+      distinct_id: visitor_id,
       event_name: event_name,
       data: data,
       subject: subject || visitor_record,

--- a/app/controllers/ctc/questions/confirm_legal_controller.rb
+++ b/app/controllers/ctc/questions/confirm_legal_controller.rb
@@ -11,6 +11,10 @@ module Ctc
 
       private
 
+      def after_update_success
+        send_mixpanel_event(event_name: "ctc_submitted_intake")
+      end
+
       def next_path
         ctc_portal_root_path
       end

--- a/app/controllers/ctc/questions/email_verification_controller.rb
+++ b/app/controllers/ctc/questions/email_verification_controller.rb
@@ -20,6 +20,7 @@ module Ctc
       end
 
       def after_update_success
+        send_mixpanel_event(event_name: "ctc_contact_verified")
         sign_in current_intake.client
 
         ClientMessagingService.send_system_message_to_all_opted_in_contact_methods(

--- a/app/controllers/ctc/questions/legal_consent_controller.rb
+++ b/app/controllers/ctc/questions/legal_consent_controller.rb
@@ -12,6 +12,10 @@ module Ctc
 
       private
 
+      def after_update_success
+        send_mixpanel_event(event_name: "ctc_provided_personal_info")
+      end
+
       def illustration_path; end
     end
   end

--- a/app/controllers/ctc/questions/overview_controller.rb
+++ b/app/controllers/ctc/questions/overview_controller.rb
@@ -6,6 +6,10 @@ module Ctc
 
       private
 
+      def after_update_success
+        send_mixpanel_event(event_name: "ctc_started_flow")
+      end
+
       def illustration_path; end
 
       def form_class

--- a/app/controllers/ctc/questions/phone_verification_controller.rb
+++ b/app/controllers/ctc/questions/phone_verification_controller.rb
@@ -21,6 +21,7 @@ module Ctc
       end
 
       def after_update_success
+        send_mixpanel_event(event_name: "ctc_contact_verified")
         sign_in current_intake.client
 
         ClientMessagingService.send_system_message_to_all_opted_in_contact_methods(

--- a/app/controllers/documents/intro_controller.rb
+++ b/app/controllers/documents/intro_controller.rb
@@ -6,7 +6,7 @@ module Documents
       data = MixpanelService.data_from([current_intake.client, current_intake])
 
       MixpanelService.send_event(
-        event_id: current_intake.visitor_id,
+        distinct_id: current_intake.visitor_id,
         event_name: "intake_ids_uploaded",
         data: data
       )

--- a/app/controllers/questions/final_info_controller.rb
+++ b/app/controllers/questions/final_info_controller.rb
@@ -11,7 +11,7 @@ module Questions
       IntakePdfJob.perform_later(current_intake.id, "Original 13614-C.pdf")
 
       MixpanelService.send_event(
-        event_id: current_intake.visitor_id,
+        distinct_id: current_intake.visitor_id,
         event_name: "intake_finished",
         data: MixpanelService.data_from([current_intake.client, current_intake])
       )

--- a/app/forms/backtaxes_form.rb
+++ b/app/forms/backtaxes_form.rb
@@ -11,7 +11,7 @@ class BacktaxesForm < QuestionsForm
     data = MixpanelService.data_from([@intake.client, @intake])
 
     MixpanelService.send_event(
-      event_id: @intake.visitor_id,
+      distinct_id: @intake.visitor_id,
       event_name: "intake_started",
       data: data
     )

--- a/app/forms/hub/create_client_form.rb
+++ b/app/forms/hub/create_client_form.rb
@@ -74,7 +74,7 @@ module Hub
 
       @client.tax_returns.each do |tax_return|
         MixpanelService.send_event(
-          event_id: @client.intake.visitor_id,
+          distinct_id: @client.intake.visitor_id,
           event_name: "drop_off_submitted",
           data: MixpanelService.data_from([@client, tax_return, current_user])
         )

--- a/app/forms/hub/create_ctc_client_form.rb
+++ b/app/forms/hub/create_ctc_client_form.rb
@@ -155,7 +155,7 @@ module Hub
     def send_mixpanel_data
       client.tax_returns.each do |tax_return|
         MixpanelService.send_event(
-          event_id: @client.intake.visitor_id,
+          distinct_id: @client.intake.visitor_id,
           event_name: "drop_off_submitted",
           data: MixpanelService.data_from([client, tax_return, @current_user])
         )

--- a/app/jobs/scrape_vita_providers_job.rb
+++ b/app/jobs/scrape_vita_providers_job.rb
@@ -24,7 +24,7 @@ class ScrapeVitaProvidersJob < ApplicationJob
     }
 
     MixpanelService.send_event(
-      event_id: MIXPANEL_ROBOT_ID,
+      distinct_id: MIXPANEL_ROBOT_ID,
       event_name: "scrape_vita_providers",
       data: data,
     )

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -530,7 +530,7 @@ RSpec.describe ApplicationController do
       }
 
       expect(mixpanel_spy).to have_received(:run).with(
-        unique_id: "123",
+        distinct_id: "123",
         event_name: "beep",
         data: expected_mixpanel_data
       )
@@ -568,7 +568,7 @@ RSpec.describe ApplicationController do
         get :index
 
         expect(mixpanel_spy).to have_received(:run).with(
-          unique_id: "current_intake_visitor_id",
+          distinct_id: "current_intake_visitor_id",
           event_name: "page_view",
           data: hash_including(
             intake_source: "horse-ad-campaign-26",
@@ -588,9 +588,9 @@ RSpec.describe ApplicationController do
         get :index, params: { locale: 'es' }
 
         expect(mixpanel_spy).to have_received(:run).with(
-            unique_id: "123",
-            event_name: "page_view",
-            data: hash_including(locale: "es")
+          distinct_id: "123",
+          event_name: "page_view",
+          data: hash_including(locale: "es")
         )
       end
     end

--- a/spec/controllers/ctc/questions/email_verification_controller_spec.rb
+++ b/spec/controllers/ctc/questions/email_verification_controller_spec.rb
@@ -27,10 +27,10 @@ describe Ctc::Questions::EmailVerificationController do
 
   describe "#after_update_success" do
     let(:locale) { "en" }
-    let(:current_user) { create :user }
 
     before do
       allow(ClientMessagingService).to receive(:send_system_message_to_all_opted_in_contact_methods)
+      allow(MixpanelService).to receive(:send_event)
     end
 
     context "they successfully verify their email" do
@@ -41,6 +41,15 @@ describe Ctc::Questions::EmailVerificationController do
           client: client,
           message: instance_of(AutomatedMessage::CtcGettingStarted),
           locale: 'en'
+        )
+      end
+
+      it "sends a mixpanel event" do
+        subject.after_update_success
+
+        expect(MixpanelService).to have_received(:send_event).with hash_including(
+          distinct_id: visitor_id,
+          event_name: "ctc_contact_verified",
         )
       end
     end

--- a/spec/controllers/ctc/questions/legal_consent_controller_spec.rb
+++ b/spec/controllers/ctc/questions/legal_consent_controller_spec.rb
@@ -68,6 +68,14 @@ describe Ctc::Questions::LegalConsentController do
         expect(client.efile_security_information.user_agent).to eq "GeckoFox"
         expect(client.efile_security_information.ip_address).to eq ip_address
       end
+
+      it "sends a Mixpanel event" do
+        post :update, params: params
+        expect(MixpanelService).to have_received(:send_event).with hash_including(
+          distinct_id: "visitor-id",
+          event_name: "ctc_provided_personal_info"
+        )
+      end
     end
   end
 end

--- a/spec/controllers/ctc/questions/overview_controller_spec.rb
+++ b/spec/controllers/ctc/questions/overview_controller_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+describe Ctc::Questions::OverviewController do
+  context '#update' do
+    let(:params) { {} }
+
+    before do
+      cookies[:visitor_id] = "visitor_id"
+      allow(MixpanelService).to receive(:send_event)
+    end
+
+    it "sends an event to mixpanel" do
+      post :update, params: params
+
+      expect(MixpanelService).to have_received(:send_event).with(hash_including(
+        event_name: "ctc_started_flow",
+        distinct_id: "visitor_id",
+      ))
+    end
+  end
+end

--- a/spec/controllers/ctc/questions/phone_verification_controller_spec.rb
+++ b/spec/controllers/ctc/questions/phone_verification_controller_spec.rb
@@ -27,9 +27,9 @@ describe Ctc::Questions::PhoneVerificationController do
 
   describe "#after_update_success" do
     let(:locale) { "es" }
-    let(:current_user) { create :user }
 
     before do
+      allow(MixpanelService).to receive(:send_event)
       allow(ClientMessagingService).to receive(:send_system_message_to_all_opted_in_contact_methods)
     end
 
@@ -41,6 +41,15 @@ describe Ctc::Questions::PhoneVerificationController do
           client: client,
           message: instance_of(AutomatedMessage::CtcGettingStarted),
           locale: 'es'
+        )
+      end
+
+      it "sends a mixpanel event" do
+        subject.after_update_success
+
+        expect(MixpanelService).to have_received(:send_event).with hash_including(
+          distinct_id: visitor_id,
+          event_name: "ctc_contact_verified",
         )
       end
     end

--- a/spec/controllers/documents/intro_controller_spec.rb
+++ b/spec/controllers/documents/intro_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Documents::IntroController do
         get :edit
 
         expect(MixpanelService).to have_received(:send_event).with(
-          event_id: intake.visitor_id,
+          distinct_id: intake.visitor_id,
           event_name: "intake_ids_uploaded",
           data: fake_mixpanel_data
         )

--- a/spec/controllers/questions/final_info_controller_spec.rb
+++ b/spec/controllers/questions/final_info_controller_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Questions::FinalInfoController do
           post :update, params: params
 
           expect(MixpanelService).to have_received(:send_event).with(
-            event_id: intake.visitor_id,
+            distinct_id: intake.visitor_id,
             event_name: "intake_finished",
             data: fake_mixpanel_data
           )

--- a/spec/forms/backtaxes_form_spec.rb
+++ b/spec/forms/backtaxes_form_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe BacktaxesForm do
         form.save
 
         expect(MixpanelService).to have_received(:send_event).with(
-          event_id: intake.visitor_id,
+          distinct_id: intake.visitor_id,
           event_name: "intake_started",
           data: fake_mixpanel_data
         )

--- a/spec/forms/hub/create_client_form_spec.rb
+++ b/spec/forms/hub/create_client_form_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe Hub::CreateClientForm do
           tax_returns = Client.last.tax_returns
 
           expect(MixpanelService).to have_received(:send_event).with(
-            event_id: Client.last.intake.visitor_id,
+            distinct_id: Client.last.intake.visitor_id,
             event_name: "drop_off_submitted",
             data: fake_mixpanel_data
           ).exactly(3).times

--- a/spec/forms/hub/create_ctc_client_form_spec.rb
+++ b/spec/forms/hub/create_ctc_client_form_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe Hub::CreateCtcClientForm do
           tax_return = Client.last.tax_returns.first
 
           expect(MixpanelService).to have_received(:send_event).with(
-            event_id: Client.last.intake.visitor_id,
+            distinct_id: Client.last.intake.visitor_id,
             event_name: "drop_off_submitted",
             data: fake_mixpanel_data
           ).exactly(1).times

--- a/spec/jobs/scrape_vita_providers_job_spec.rb
+++ b/spec/jobs/scrape_vita_providers_job_spec.rb
@@ -104,7 +104,7 @@ describe ScrapeVitaProvidersJob do
         archived_provider_count: 1,
       }
       expect(MixpanelService).to have_received(:send_event).with(
-        event_id: ScrapeVitaProvidersJob::MIXPANEL_ROBOT_ID,
+        distinct_id: ScrapeVitaProvidersJob::MIXPANEL_ROBOT_ID,
         event_name: "scrape_vita_providers",
         data: data,
       )

--- a/spec/models/efile_submission_spec.rb
+++ b/spec/models/efile_submission_spec.rb
@@ -158,6 +158,7 @@ describe EfileSubmission do
 
     context "transmitted" do
       let(:submission) { create :efile_submission, :transmitted }
+
       context "can transition to" do
         it "accepted" do
           expect { submission.transition_to!(:accepted) }.not_to raise_error
@@ -173,6 +174,55 @@ describe EfileSubmission do
           it state.to_s do
             expect { submission.transition_to!(state) }.to raise_error(Statesman::TransitionFailedError)
           end
+        end
+      end
+
+      context "after transition to" do
+        before { allow(MixpanelService).to receive(:send_event) }
+        let!(:submission) { create(:efile_submission, :queued, submission_bundle: { filename: 'picture_id.jpg', io: File.open(Rails.root.join("spec", "fixtures", "attachments", "picture_id.jpg"), 'rb') }) }
+
+        it "sends a mixpanel event" do
+          submission.transition_to!(:transmitted)
+
+          expect(MixpanelService).to have_received(:send_event).with hash_including(
+            distinct_id: submission.client.intake.visitor_id,
+            event_name: "ctc_efile_return_transmitted",
+            subject: submission.intake,
+          )
+        end
+      end
+    end
+
+    context "accepted" do
+      context "after transition to" do
+        before { allow(MixpanelService).to receive(:send_event) }
+        let!(:submission) { create(:efile_submission, :transmitted, submission_bundle: { filename: 'picture_id.jpg', io: File.open(Rails.root.join("spec", "fixtures", "attachments", "picture_id.jpg"), 'rb') }) }
+
+        it "sends a mixpanel event" do
+          submission.transition_to!(:accepted)
+
+          expect(MixpanelService).to have_received(:send_event).with hash_including(
+            distinct_id: submission.client.intake.visitor_id,
+            event_name: "ctc_efile_return_accepted",
+            subject: submission.intake,
+          )
+        end
+      end
+    end
+
+    context "rejected" do
+      context "after transition to" do
+        before { allow(MixpanelService).to receive(:send_event) }
+        let!(:submission) { create(:efile_submission, :transmitted, submission_bundle: { filename: 'picture_id.jpg', io: File.open(Rails.root.join("spec", "fixtures", "attachments", "picture_id.jpg"), 'rb') }) }
+
+        it "sends a mixpanel event" do
+          submission.transition_to!(:rejected)
+
+          expect(MixpanelService).to have_received(:send_event).with hash_including(
+            distinct_id: submission.client.intake.visitor_id,
+            event_name: "ctc_efile_return_rejected",
+            subject: submission.intake,
+          )
         end
       end
     end

--- a/spec/state_machines/efile_submission_state_machine_spec.rb
+++ b/spec/state_machines/efile_submission_state_machine_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 describe EfileSubmissionStateMachine do
-
   before do
     allow(ClientPdfDocument).to receive(:create_or_update)
   end


### PR DESCRIPTION
- ctc_started_flow: clicked "continue" on en/questions/overview
- ctc_provided_personal_info: clicked "continue" on en/questions/consent
- ctc_contact_verified: successfully verifies their contact info on /verify
- ctc_submitted_intake: click "file my return" on /confirm-legal
- ctc_efile_return_transmitted: we transmitted the return to the IRS
- ctc_efile_return_accepted: when submission status is changed to accepted
- ctc_efile_return_rejected: one event when the submission status is changed to rejected

ALSO we renamed MixpanelService's "event_id" param to "distinct_id" because
that is what it represented in mixpanel (a person, not an event)

Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>