### PR TITLE
Add .svg to icons for asset pipeline happiness

### DIFF
--- a/app/views/hub/efile_errors/index.html.erb
+++ b/app/views/hub/efile_errors/index.html.erb
@@ -34,7 +34,7 @@
       <% @efile_errors.each do |error| %>
         <tr class="index-table__row">
           <td class="index-table__cell index-table__cell--center">
-            <%= image_tag error.expose ? "icons/check" : "icons/cancelled", alt: error.expose ? "yes" : "no" %>
+            <%= image_tag error.expose ? "icons/check.svg" : "icons/cancelled.svg", alt: error.expose ? "yes" : "no" %>
           </td>
           <td class="index-table__cell status">
             <%= link_to error.source, hub_efile_error_path(id: error.id) %>


### PR DESCRIPTION
Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>

## Why

I have a hunch it'll fix https://sentry.io/organizations/codeforamerica/issues/2567547227/?project=1880321&referrer=slack

That error doesn't repro locally but I know the asset pipeline acts differently in local dev vs. prod-like environments, so I thought I'd just try rolling with this.

## Testing performed

It works locally at least:

![image](https://user-images.githubusercontent.com/67708639/128951971-fd5acc62-2f63-431e-b604-d2e4d82eb08f.png)
