### PR TITLE
Send data to Mixpanel in background job

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -144,7 +144,8 @@ class ApplicationController < ActionController::Base
       data: invalid_field_flags.merge(additional_data),
       subject: current_intake,
       request: request,
-      source: self
+      source: self,
+      synchronous: true # Run synchronously to avoid having to serialize a ActionDispatch::Http::UploadedFile
     )
   end
 

--- a/app/jobs/mixpanel_job.rb
+++ b/app/jobs/mixpanel_job.rb
@@ -1,0 +1,9 @@
+class MixpanelJob < ApplicationJob
+  def priority
+    100 # lower numbers run first, see https://github.com/collectiveidea/delayed_job
+  end
+
+  def perform(distinct_id:, event_name:, data: {})
+    MixpanelService.instance.run(distinct_id: distinct_id, event_name: event_name, data: data)
+  end
+end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe ApplicationController do
+RSpec.describe ApplicationController, active_job: true do
   let(:user_agent_string) { "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.360" }
 
   controller do
@@ -485,10 +485,7 @@ RSpec.describe ApplicationController do
   end
 
   describe "#send_mixpanel_event" do
-    let(:mixpanel_spy) { spy(MixpanelService) }
-
     before do
-      allow(MixpanelService).to receive(:instance).and_return(mixpanel_spy)
       cookies[:visitor_id] = "123"
       session[:source] = "vdss"
       session[:utm_state] = "CA"
@@ -529,7 +526,7 @@ RSpec.describe ApplicationController do
         controller_action_name: "index",
       }
 
-      expect(mixpanel_spy).to have_received(:run).with(
+      expect(MixpanelJob).to have_been_enqueued.with(
         distinct_id: "123",
         event_name: "beep",
         data: expected_mixpanel_data
@@ -540,9 +537,10 @@ RSpec.describe ApplicationController do
       let(:user_agent_string) { "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)" }
 
       it "sends nothing to mixpanel" do
+        clear_enqueued_jobs
         get :index
 
-        expect(mixpanel_spy).not_to have_received(:run)
+        expect(MixpanelJob).not_to have_been_enqueued
       end
     end
 
@@ -567,7 +565,7 @@ RSpec.describe ApplicationController do
       it "sends fields about the intake" do
         get :index
 
-        expect(mixpanel_spy).to have_received(:run).with(
+        expect(MixpanelJob).to have_been_enqueued.with(
           distinct_id: "current_intake_visitor_id",
           event_name: "page_view",
           data: hash_including(
@@ -587,7 +585,7 @@ RSpec.describe ApplicationController do
       it "sends the new locale" do
         get :index, params: { locale: 'es' }
 
-        expect(mixpanel_spy).to have_received(:run).with(
+        expect(MixpanelJob).to have_been_enqueued.with(
           distinct_id: "123",
           event_name: "page_view",
           data: hash_including(locale: "es")

--- a/spec/jobs/mixpanel_job_spec.rb
+++ b/spec/jobs/mixpanel_job_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+describe MixpanelJob do
+  describe "#perform" do
+    before do
+      allow(MixpanelService.instance).to receive(:run)
+    end
+
+    it "calls Mixpanel" do
+      subject.perform(distinct_id: "id", event_name: "evt", data: {"data": "yes"})
+
+      expect(MixpanelService.instance).to have_received(:run).with(distinct_id: "id", event_name: "evt", data: {"data": "yes"})
+    end
+  end
+end


### PR DESCRIPTION
Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>

## Why

By moving Mixpanel data sending to a background job, I hope we save approx 50 milliseconds per page load. I admit I haven't tested this theory.