### PR TITLE
CTC intake: environment vars to turn off EfileSubmission and ctc_beta link

### DIFF
--- a/app/controllers/ctc/ctc_pages_controller.rb
+++ b/app/controllers/ctc/ctc_pages_controller.rb
@@ -1,7 +1,7 @@
 module Ctc
   class CtcPagesController < CtcController
     def home
-      if params[:ctc_beta] == "1"
+      if params[:ctc_beta] == "1" && ENV['DISABLE_CTC_BETA_PARAM'].blank?
         cookies.permanent[:ctc_intake_ok] = "yes"
         redirect_to Ctc::Questions::OverviewController.to_path_helper
       end

--- a/app/forms/ctc/confirm_legal_form.rb
+++ b/app/forms/ctc/confirm_legal_form.rb
@@ -16,7 +16,12 @@ module Ctc
       @intake.update(attributes_for(:intake))
       efile_attrs = attributes_for(:efile_security_information).merge(timezone_offset: format_timezone_offset(timezone_offset))
       unless @intake.tax_returns.last.efile_submissions.any?
-        EfileSubmission.create(tax_return: @intake.tax_returns.last, efile_security_information_attributes: efile_attrs).transition_to(:preparing)
+        efile_submission = EfileSubmission.create(tax_return: @intake.tax_returns.last, efile_security_information_attributes: efile_attrs)
+        begin
+          efile_submission.transition_to(:preparing)
+        rescue Statesman::GuardFailedError
+          Rails.logger.error "Failed to transition EfileSubmission##{efile_submission.id} to :preparing"
+        end
       end
     end
 

--- a/app/state_machines/efile_submission_state_machine.rb
+++ b/app/state_machines/efile_submission_state_machine.rb
@@ -30,6 +30,10 @@ class EfileSubmissionStateMachine
   transition from: :resubmitted,    to: [:preparing]
   transition from: :waiting,        to: [:resubmitted, :cancelled, :investigating]
 
+  guard_transition(to: :preparing) do |_submission|
+    ENV['HOLD_OFF_NEW_EFILE_SUBMISSIONS'].blank?
+  end
+
   after_transition(to: :preparing) do |submission|
     BuildSubmissionBundleJob.perform_later(submission.id)
     submission.tax_return.update(status: "file_ready_to_file")

--- a/docs/efile-submission-runbook.md
+++ b/docs/efile-submission-runbook.md
@@ -39,5 +39,13 @@ When a crash occurs during a job, we tend to raise an exception so we can see in
 
 If a code change is required, fix the code, then resubmit once the code change is deployed.
 
+## Disabling new submissions temporarily
+
+You can set the HOLD_OFF_NEW_EFILE_SUBMISSIONS environment variable to prevent any EfileSubmission from transitioning to the :preparing state.
+
+Whenever we feel like submitting things again, after the environment variable is removed, you should transition everything that was stuck in 'new' to 'preparing':
+
+`EfileSubmission.in_state(:new).each { |efile_submission| efile_submission.transition_to!(:preparing) }`
+
 ## References
 * The Child Tax Credit is defined in [IRS Revenue Procedure 2021-4.](https://www.irs.gov/pub/irs-drop/rp-21-24.pdf)

--- a/spec/controllers/ctc/ctc_pages_controller_spec.rb
+++ b/spec/controllers/ctc/ctc_pages_controller_spec.rb
@@ -9,6 +9,20 @@ describe Ctc::CtcPagesController do
         expect(cookies[:ctc_intake_ok]).to eq('yes')
         expect(response).to redirect_to Ctc::Questions::OverviewController.to_path_helper
       end
+
+      context "when DISABLE_CTC_BETA_PARAM is set" do
+        around do |example|
+          ENV['DISABLE_CTC_BETA_PARAM'] = '1'
+          example.run
+          ENV.delete('DISABLE_CTC_BETA_PARAM')
+        end
+
+        it "renders the home page without any cookies or redirects" do
+          get :home
+          expect(cookies[:ctc_intake_ok]).to be_nil
+          expect(response).to be_ok
+        end
+      end
     end
 
     context "without the ?ctc_beta=1 query parameter" do

--- a/spec/controllers/ctc/questions/confirm_legal_controller_spec.rb
+++ b/spec/controllers/ctc/questions/confirm_legal_controller_spec.rb
@@ -57,6 +57,22 @@ describe Ctc::Questions::ConfirmLegalController do
             event_name: "ctc_submitted_intake",
           )
         end
+
+        context "when HOLD_OFF_NEW_EFILE_SUBMISSIONS is set" do
+          around do |example|
+            ENV['HOLD_OFF_NEW_EFILE_SUBMISSIONS'] = '1'
+            example.run
+            ENV.delete('HOLD_OFF_NEW_EFILE_SUBMISSIONS')
+          end
+
+          it "create a submission that is still in status 'new'" do
+            post :update, params: params
+
+            expect(response).to redirect_to ctc_portal_root_path
+            efile_submission = client.reload.tax_returns.last.efile_submissions.last
+            expect(efile_submission.current_state).to eq "new"
+          end
+        end
       end
 
       context "when not checking 'I agree'" do

--- a/spec/models/efile_submission_spec.rb
+++ b/spec/models/efile_submission_spec.rb
@@ -97,10 +97,23 @@ describe EfileSubmission do
       allow(ClientPdfDocument).to receive(:create_or_update)
     end
     context "new" do
-      let(:submission) { create :efile_submission }
+      let(:submission) { create :efile_submission, :new }
+
       context "can transition to" do
         it "preparing" do
           expect { submission.transition_to!(:preparing) }.not_to raise_error
+        end
+      end
+
+      context "when HOLD_OFF_NEW_EFILE_SUBMISSIONS is set" do
+        around do |example|
+          ENV['HOLD_OFF_NEW_EFILE_SUBMISSIONS'] = '1'
+          example.run
+          ENV.delete('HOLD_OFF_NEW_EFILE_SUBMISSIONS')
+        end
+
+        it "does not allow transitions from :new to :preparing" do
+          expect { submission.transition_to!(:preparing) }.to raise_error(Statesman::GuardFailedError)
         end
       end
 


### PR DESCRIPTION
DISABLE_CTC_BETA_PARAM makes it so getctc.org?ctc_beta=1 links just render the regular homepage

HOLD_OFF_NEW_EFILE_SUBMISSIONS prevents EfileSubmission state from transitioning to :preparing