### PR TITLE
Do not resend the preparing email on a resubmission

### DIFF
--- a/app/lib/submission_builder/return_header1040.rb
+++ b/app/lib/submission_builder/return_header1040.rb
@@ -141,7 +141,7 @@ module SubmissionBuilder
               xml.TimeZoneOffsetNum filing_security_information.timezone_offset
               xml.SystemTs datetime_type(filing_security_information.client_system_datetime)
             }
-            if submission.resubmission?
+            if submission.irs_resubmission?
               xml.FederalOriginalSubmissionId submission.previously_transmitted_submission.irs_submission_id
               xml.FederalOriginalSubmissionIdDt date_type(submission.previously_transmitted_submission.created_at)
             end

--- a/app/models/efile_submission.rb
+++ b/app/models/efile_submission.rb
@@ -60,7 +60,12 @@ class EfileSubmission < ApplicationRecord
     end
   end
 
+  # There are two types of resubmissions: One
   def resubmission?
+    irs_resubmission? || last_transition_to(:resubmitted).present?
+  end
+
+  def irs_resubmission?
     previously_transmitted_submission.present?
   end
 

--- a/app/state_machines/efile_submission_state_machine.rb
+++ b/app/state_machines/efile_submission_state_machine.rb
@@ -76,12 +76,14 @@ class EfileSubmissionStateMachine
   end
 
   after_transition(from: :new, to: :preparing) do |submission|
-    client = submission.client
-    ClientMessagingService.send_system_message_to_all_opted_in_contact_methods(
-      client: client,
-      message: AutomatedMessage::EfilePreparing.new,
-      locale: client.intake.locale
-    )
+    unless submission.resubmission?
+      client = submission.client
+      ClientMessagingService.send_system_message_to_all_opted_in_contact_methods(
+        client: client,
+        message: AutomatedMessage::EfilePreparing.new,
+        locale: client.intake.locale
+      )
+    end
   end
 
   after_transition(to: :investigating) do |submission|

--- a/spec/models/efile_submission_spec.rb
+++ b/spec/models/efile_submission_spec.rb
@@ -283,6 +283,38 @@ describe EfileSubmission do
     end
   end
 
+  describe "#resubmission?" do
+    context "when there was a previous submission to the irs" do
+      let(:previous_submission) { create :efile_submission }
+      let(:submission) { create :efile_submission }
+      before do
+        submission.transition_to!(:preparing, previous_submission_id: previous_submission.id)
+      end
+
+      it "returns true" do
+        expect(submission.resubmission?).to eq true
+      end
+    end
+
+    context "when there was a previous status transition of the existing submission to resubmitted" do
+      let(:submission) { create :efile_submission, :rejected }
+      before do
+        submission.transition_to!(:resubmitted)
+      end
+
+      it "returns true" do
+        expect(submission.resubmission?).to eq true
+      end
+    end
+
+    context "when the submission is not a resubmission" do
+      let(:submission) { create :efile_submission, :preparing }
+      it "returns false" do
+        expect(submission.resubmission?).to eq false
+      end
+    end
+  end
+
   describe "#previously_transmitted_submission" do
     context "when the submission's preparing transition has a previous submission id stored" do
       let(:previous_submission) { create :efile_submission }

--- a/spec/state_machines/efile_submission_state_machine_spec.rb
+++ b/spec/state_machines/efile_submission_state_machine_spec.rb
@@ -25,14 +25,27 @@ describe EfileSubmissionStateMachine do
           allow(ClientMessagingService).to receive(:send_system_message_to_all_opted_in_contact_methods)
         end
 
-        it "sends a message to the client" do
-          submission.transition_to!(:preparing)
+        context "when the submission is not a resubmission" do
+          it "sends a message to the client" do
+            submission.transition_to!(:preparing)
 
-          expect(ClientMessagingService).to have_received(:send_system_message_to_all_opted_in_contact_methods).with(
-            client: submission.client.reload,
-            message: instance_of(AutomatedMessage::EfilePreparing),
-            locale: submission.client.intake.locale
-          )
+            expect(ClientMessagingService).to have_received(:send_system_message_to_all_opted_in_contact_methods).with(
+                client: submission.client.reload,
+                message: instance_of(AutomatedMessage::EfilePreparing),
+                locale: submission.client.intake.locale
+            )
+          end
+        end
+
+        context "when the submission is a resubmission" do
+          before do
+            allow(submission).to receive(:resubmission?).and_return true
+          end
+
+          it "does not send the email" do
+            submission.transition_to!(:preparing)
+            expect(ClientMessagingService).not_to have_received(:send_system_message_to_all_opted_in_contact_methods)
+          end
         end
       end
     end


### PR DESCRIPTION
Because we create new efile submissions after the return has been submitted to the IRS, we end up resending the preparing email every time we resubmit.

I actually think some alternatives may be better:

- Move the email to the place where we finish intake / create the submission
- Consider a larger refactor so that there are not two diverging ways of dealing with resubmissions (for example, do not create the IRS transmission ID until the point at which we are ready to transmit to the IRS. That way the presence of a submission ID means that it is a resubmission?)
- Store an attribute on the client so that we can detect if the client's already gotten this email.
- Basically anything other than this implementation, pretty much.