### PR TITLE
Log metrics when polling for acks

### DIFF
--- a/app/models/efile_submission.rb
+++ b/app/models/efile_submission.rb
@@ -2,11 +2,12 @@
 #
 # Table name: efile_submissions
 #
-#  id                :bigint           not null, primary key
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  irs_submission_id :string
-#  tax_return_id     :bigint
+#  id                      :bigint           not null, primary key
+#  last_checked_for_ack_at :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  irs_submission_id       :string
+#  tax_return_id           :bigint
 #
 # Indexes
 #

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -178,7 +178,7 @@
 #  spouse_active_armed_forces                           :integer          default("unfilled")
 #  spouse_auth_token                                    :string
 #  spouse_birth_date                                    :date
-#  spouse_can_be_claimed_as_dependent                   :integer          default(0)
+#  spouse_can_be_claimed_as_dependent                   :integer          default("unfilled")
 #  spouse_consented_to_service                          :integer          default(0), not null
 #  spouse_consented_to_service_at                       :datetime
 #  spouse_consented_to_service_ip                       :inet

--- a/app/services/efile/poll_for_acknowledgments_service.rb
+++ b/app/services/efile/poll_for_acknowledgments_service.rb
@@ -1,10 +1,27 @@
 module Efile
   class PollForAcknowledgmentsService
     def self.run
-      transmitted_submissions = EfileSubmission.in_state(:transmitted).limit(100)
-      response = Efile::GyrEfilerService.run_efiler_command(Rails.application.config.efile_environment, "acks", *transmitted_submissions.pluck(:irs_submission_id))
+      ack_count = 0
+      submission_ids = transmitted_submission_ids
+      submission_ids.each_slice(100) do |submission_ids|
+        ack_count = _handle_response(Efile::GyrEfilerService.run_efiler_command(Rails.application.config.efile_environment, "acks", *submission_ids))
+      end
+      DatadogApi.gauge("efile.poll_for_acks.requested", submission_ids.size)
+      DatadogApi.gauge("efile.poll_for_acks.received", ack_count)
+      DatadogApi.increment("efile.poll_for_acks")
+    end
+
+    def self.transmitted_submission_ids
+      transmitted_submissions = EfileSubmission.in_state(:transmitted)
+      transmitted_submissions.touch_all(:last_checked_for_ack_at)
+      transmitted_submissions.pluck(:irs_submission_id)
+    end
+
+    def self._handle_response(response)
       doc = Nokogiri::XML(response)
+      ack_count = 0
       doc.css('AcknowledgementList Acknowledgement').each do |ack|
+        ack_count += 1
         irs_submission_id = ack.css("SubmissionId").text.strip
         status = ack.css("AcceptanceStatusTxt").text.strip
         raw_response = ack.to_xml
@@ -17,6 +34,7 @@ module Efile
           raise StandardError.new("Submission acknowledgement has an unknown status: #{status} for submission ID #{irs_submission_id}")
         end
       end
+      ack_count
     end
   end
 end

--- a/db/migrate/20210812213057_add_last_checked_for_ack_at_to_efile_submission.rb
+++ b/db/migrate/20210812213057_add_last_checked_for_ack_at_to_efile_submission.rb
@@ -1,0 +1,5 @@
+class AddLastCheckedForAckAtToEfileSubmission < ActiveRecord::Migration[6.0]
+  def change
+    add_column :efile_submissions, :last_checked_for_ack_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_11_005744) do
+ActiveRecord::Schema.define(version: 2021_08_12_213057) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -377,6 +377,7 @@ ActiveRecord::Schema.define(version: 2021_08_11_005744) do
   create_table "efile_submissions", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.string "irs_submission_id"
+    t.datetime "last_checked_for_ack_at"
     t.bigint "tax_return_id"
     t.datetime "updated_at", precision: 6, null: false
     t.index ["tax_return_id"], name: "index_efile_submissions_on_tax_return_id"

--- a/spec/factories/efile_submissions.rb
+++ b/spec/factories/efile_submissions.rb
@@ -2,11 +2,12 @@
 #
 # Table name: efile_submissions
 #
-#  id                :bigint           not null, primary key
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  irs_submission_id :string
-#  tax_return_id     :bigint
+#  id                      :bigint           not null, primary key
+#  last_checked_for_ack_at :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  irs_submission_id       :string
+#  tax_return_id           :bigint
 #
 # Indexes
 #

--- a/spec/models/efile_submission_spec.rb
+++ b/spec/models/efile_submission_spec.rb
@@ -2,11 +2,12 @@
 #
 # Table name: efile_submissions
 #
-#  id                :bigint           not null, primary key
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  irs_submission_id :string
-#  tax_return_id     :bigint
+#  id                      :bigint           not null, primary key
+#  last_checked_for_ack_at :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  irs_submission_id       :string
+#  tax_return_id           :bigint
 #
 # Indexes
 #

--- a/spec/services/efile/poll_for_acknowledgments_service_spec.rb
+++ b/spec/services/efile/poll_for_acknowledgments_service_spec.rb
@@ -10,6 +10,7 @@ describe Efile::PollForAcknowledgmentsService do
   describe ".run" do
     context "when there are no EfileSubmissions" do
       it "quietly runs and does nothing" do
+        expect(EfileSubmission.count).to eq 0
         expect{ Efile::PollForAcknowledgmentsService.run }.to_not raise_error
       end
 

--- a/spec/services/efile/poll_for_acknowledgments_service_spec.rb
+++ b/spec/services/efile/poll_for_acknowledgments_service_spec.rb
@@ -8,6 +8,17 @@ describe Efile::PollForAcknowledgmentsService do
   end
 
   describe ".run" do
+    context "when there are no EfileSubmissions" do
+      it "quietly runs and does nothing" do
+        expect{ Efile::PollForAcknowledgmentsService.run }.to_not raise_error
+      end
+
+      it "sends a metric to Datadog" do
+        Efile::PollForAcknowledgmentsService.run
+        expect(DatadogApi).to have_received(:increment).with("efile.poll_for_acks")
+      end
+    end
+
     context "when there is 101 EfileSubmissions" do
       let(:efile_submission_ids) { (1..101).to_a.map(&:to_s) }
 


### PR DESCRIPTION
AL and I decided on an approach for storing data about the acks cron job

- check for ACKs on all outstanding returns, but in batches of 100, log in datadog how many outstanding returns there are when the job runs and how many we heard back about from the IRS
- add a column for last_checked_for_ack_at on submission
- add datadog alert if the chron job hasn't run, so add a measurement/logging of the chron job running and then config the alert in datadog if it doesn't happen in some reasonable timeframe

I still have to add the datadog alert -- that'll happen after merging