### PR TITLE
When looking for testing-only config settings, use `.try()` to avoid crash outside of tests

### DIFF
--- a/app/controllers/ctc/questions/confirm_legal_controller.rb
+++ b/app/controllers/ctc/questions/confirm_legal_controller.rb
@@ -7,7 +7,7 @@ module Ctc
 
       def form_params
         super.merge(ip_address: request.remote_ip).merge(
-          Rails.application.config.efile_security_information_for_testing.presence || {}
+          Rails.application.config.try(:efile_security_information_for_testing).presence || {}
         )
       end
 

--- a/app/controllers/ctc/questions/legal_consent_controller.rb
+++ b/app/controllers/ctc/questions/legal_consent_controller.rb
@@ -8,7 +8,7 @@ module Ctc
 
       def form_params
         super.merge(ip_address: request.remote_ip).merge(
-          Rails.application.config.efile_security_information_for_testing.presence || {}
+          Rails.application.config.try(:efile_security_information_for_testing).presence || {}
         )
       end
 


### PR DESCRIPTION
Fixes https://sentry.io/organizations/codeforamerica/issues/2572625680/?referrer=alert_email&environment=demo