### PR TITLE
Fix child tax credit calculation for people under 6

### DIFF
--- a/app/lib/child_tax_credit_calculator.rb
+++ b/app/lib/child_tax_credit_calculator.rb
@@ -1,5 +1,5 @@
 class ChildTaxCreditCalculator
-  PER_DEPENDENT_UNDER_SIX_PAYMENT = 600
+  PER_DEPENDENT_UNDER_SIX_PAYMENT = 300
   PER_DEPENDENT_OVER_SIX_PAYMENT = 250
 
   def self.monthly_payment_due(dependents_under_six_count:, dependents_over_six_count:)
@@ -12,5 +12,4 @@ class ChildTaxCreditCalculator
   def self.total_payment_due(dependents_under_six_count:, dependents_over_six_count:)
     monthly_payment_due(dependents_under_six_count: dependents_under_six_count, dependents_over_six_count: dependents_over_six_count) * 12
   end
-
 end

--- a/spec/lib/child_tax_credit_calculator_spec.rb
+++ b/spec/lib/child_tax_credit_calculator_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 describe ChildTaxCreditCalculator do
   describe ".monthly_payment_due" do
-    it "should return the correct payment amount based on dependent counts" do
-      expected_payment = 850
+    it "returns the correct payment amount based on dependent counts" do
+      expected_payment = 550
       monthly_payment_amount = described_class.monthly_payment_due(dependents_under_six_count: 1, dependents_over_six_count: 1)
 
       expect(monthly_payment_amount).to eq(expected_payment)
@@ -11,8 +11,8 @@ describe ChildTaxCreditCalculator do
   end
 
   describe ".total_payment_due" do
-    it "should return the correct payment amount based on dependent counts" do
-      expected_payment = 10200
+    it "returns the correct payment amount based on dependent counts" do
+      expected_payment = 6600
       total_payment_amount = described_class.total_payment_due(dependents_under_six_count: 1, dependents_over_six_count: 1)
 
       expect(total_payment_amount).to eq(expected_payment)


### PR DESCRIPTION
the original calculation was incorrect. we weren't using it actively anywhere, so its fine. but it would be better ifit is correct.