### PR TITLE
Move navigator things into its own section

### DIFF
--- a/app/assets/stylesheets/_honeycrisp-compact.scss
+++ b/app/assets/stylesheets/_honeycrisp-compact.scss
@@ -17,6 +17,10 @@
     list-style-type: initial;
   }
 
+  ul.no-bullets {
+    list-style-type: none;
+  }
+
   ol {
     list-style-type: decimal;
   }

--- a/app/helpers/filing_status_helper.rb
+++ b/app/helpers/filing_status_helper.rb
@@ -1,9 +1,9 @@
 module FilingStatusHelper
   def filing_status(client)
     if client.tax_returns.map(&:filing_status).any?
-      content_tag :ul do
+      content_tag :ul, class: 'no-bullets' do
         client.tax_returns.collect do |tax_return|
-          content_tag( :li, filing_status_tax_return(tax_return)) if tax_return.filing_status.present?
+          content_tag(:li, filing_status_tax_return(tax_return)) if tax_return.filing_status.present?
         end.compact.join.html_safe
       end
     else
@@ -14,8 +14,8 @@ module FilingStatusHelper
   def filing_status_tax_return(tax_return)
     return nil unless tax_return.filing_status?
 
-    content = content_tag(:strong, I18n.t("general.filing_status.#{tax_return.filing_status}"))
-    content << content_tag(:span, " (#{tax_return.year})")
+    content = content_tag(:span, "#{tax_return.year}: ", class: "form-question")
+    content << content_tag(:span, I18n.t("general.filing_status.#{tax_return.filing_status}"))
     content << content_tag(:div, (content_tag :i, tax_return.filing_status_note)) if tax_return.filing_status_note?
     content
   end

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -548,6 +548,10 @@ class Intake < ApplicationRecord
     self.update(navigator_type[:field_name] => true)
   end
 
+  def drop_off?
+    tax_returns.pluck(:service_type).any? "drop_off"
+  end
+
   def navigator_display_names
     names = []
     NAVIGATOR_TYPES.each do |_, type|

--- a/app/views/hub/clients/show.html.erb
+++ b/app/views/hub/clients/show.html.erb
@@ -101,37 +101,12 @@
             <div class="field-display">
               <span class="form-question"><%= t("general.dependents") %>:</span>
               <span class="label-value"><%= @client.intake&.dependents.count %></span>
-              <ul id="dependents-list">
+              <ul id="dependents-list" class="no-bullets">
                 <%= render @client.intake.dependents %>
               </ul>
             </div>
 
           </div>
-
-          <div class="client-profile__field-group">
-            <h2 class="text--bold"><%= t(".navigator_types") %></h2>
-            <div class="field-display">
-              <span class="label-value"><%= @client.intake.navigator_display_names.present? ? @client.intake.navigator_display_names : t(".navigator_types_empty") %></span>
-            </div>
-          </div>
-
-          <% if @client.intake.is_ctc? %>
-            <!-- Photo ID info-->
-            <div class="client-profile__field-group">
-              <h2 class="text--bold"><%= t(".photo_id_types") %></h2>
-              <div class="field-display">
-                <span class="label-value"><%= @client.intake.photo_id_display_names %></span>
-              </div>
-            </div>
-
-            <!-- Taxpayer ID info-->
-            <div class="client-profile__field-group">
-              <h2 class="text--bold"><%= t(".taxpayer_id_types") %></h2>
-              <div class="field-display">
-                <span class="label-value"><%= @client.intake.taxpayer_id_display_names %></span>
-              </div>
-            </div>
-          <% end %>
 
           <!-- Payment info-->
           <div class="client-profile__field-group client-bank-account-info">
@@ -252,29 +227,55 @@
           <div class="client-profile__field-group">
             <h2 class="text--bold"><%= t(".other_info") %></h2>
             <div class="field-display">
+              <span class="form-question">Intake type:</span>
+              <span class="label-value">
+                <%= @client.intake.drop_off? ? "Drop off" : "Online" %>
+              </span>
+            </div>
+            <div class="field-display">
               <span class="form-question"><%= t(".routing_method") %>:</span>
               <span class="label-value">
-              <%= readable_routing_method(@client) || t("general.NA") %>
-            </span>
+                <%= readable_routing_method(@client) || t("general.NA") %>
+              </span>
             </div>
             <div class="field-display">
               <span class="form-question"><%= t(".source_param") %>:</span>
               <span class="label-value">
-              <%= @client.intake&.source || t("general.NA") %>
-            </span>
+                <%= @client.intake&.source || t("general.NA") %>
+              </span>
+            </div>
+            <div class="field-display">
+              <span class="form-question">Current Intake Step:</span>
+              <span class="label-value">
+                <%= @client.intake.current_step || t("general.NA") %>
+              </span>
             </div>
           </div>
 
           <!-- Identity verification -->
-          <% if @client.intake.is_ctc? %>
-            <div class="client-profile__field-group">
-              <h2 class="text--bold">Navigator Name</h2>
-              <div class="field-display">
-                <span class="form-question">Legal Name:</span>
-                <span class="label-value"><%= @client.intake.navigator_name %> </span>
-              </div>
+          <div class="client-profile__field-group">
+            <h2 class="text--bold">Navigator Info</h2>
+            <div class="field-display">
+              <span class="form-question">Navigator type:</span>
+              <span class="label-value"><%= @client.intake.navigator_display_names.present? ? @client.intake.navigator_display_names : t(".navigator_types_empty") %></span>
             </div>
-          <% end %>
+            <% if @client.intake.is_ctc? %>
+              <div class="field-display">
+                <span class="form-question">Navigator Name:</span>
+                <span class="label-value"><%= @client.intake.navigator_name || "N/A" %> </span>
+              </div>
+            <% end %>
+            <% if @client.intake.drop_off? %>
+              <div class="field-display">
+                <span class="form-question">Photo ID Used:</span>
+                <span class="label-value"><%= @client.intake.photo_id_display_names || "N/A"%></span>
+              </div>
+              <div class="field-display">
+                <span class="form-question">Taxpayer ID Used:</span>
+                <span class="label-value"><%= @client.intake.taxpayer_id_display_names || "N/A" %></span>
+              </div>
+            <% end %>
+          </div>
         </div>
       </div>
       <div class="client-profile__actions"><%= link_to(t("general.edit_info"), @client.intake.is_ctc? ? edit_hub_ctc_client_path : edit_hub_client_path, class: "button hc-button--wide") %></div>

--- a/app/views/hub/clients/show.html.erb
+++ b/app/views/hub/clients/show.html.erb
@@ -264,17 +264,19 @@
                 <span class="form-question">Navigator Name:</span>
                 <span class="label-value"><%= @client.intake.navigator_name || "N/A" %> </span>
               </div>
-            <% end %>
-            <% if @client.intake.drop_off? %>
-              <div class="field-display">
-                <span class="form-question">Photo ID Used:</span>
-                <span class="label-value"><%= @client.intake.photo_id_display_names || "N/A"%></span>
-              </div>
-              <div class="field-display">
-                <span class="form-question">Taxpayer ID Used:</span>
-                <span class="label-value"><%= @client.intake.taxpayer_id_display_names || "N/A" %></span>
-              </div>
-            <% end %>
+
+              <% if @client.intake.drop_off? %>
+                <div class="field-display">
+                  <span class="form-question">Photo ID Used:</span>
+                  <span class="label-value"><%= @client.intake.photo_id_display_names || "N/A"%></span>
+                </div>
+                <div class="field-display">
+                  <span class="form-question">Taxpayer ID Used:</span>
+                  <span class="label-value"><%= @client.intake.taxpayer_id_display_names || "N/A" %></span>
+                </div>
+              <% end %>
+
+          <% end %>
           </div>
         </div>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -175,10 +175,7 @@ en:
         spouse_contact_info: Spouse Contact Info
         texting_phone: Phone For Texting
         tax_info: Tax Info
-        navigator_types: Type of navigator used
         navigator_types_empty: No navigator used
-        photo_id_types: Type of photo ID used
-        taxpayer_id_types: Type of taxpayer ID used
         basic_info: Basic Info
         other_info: Other Info
         routing_method: Initial Routing Method

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -157,10 +157,7 @@ es:
         spouse_contact_info: Información de contacto del cónyuge
         texting_phone: Número celular
         tax_info: Información de impuestos
-        navigator_types: Tipo de navegador utilizada
         navigator_types_empty: No se utiliza navegador
-        photo_id_types: Type of photo ID used
-        taxpayer_id_types: Type of taxpayer ID used
         basic_info: Información básica
         other_info: Other info
         routing_method: Método de enrutamiento inicial

--- a/spec/features/ctc/edit_ctc_client_spec.rb
+++ b/spec/features/ctc/edit_ctc_client_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe "a user editing a clients intake fields" do
         expect(page).to have_text "Laura Peaches"
         expect(page).to have_text "12/1/2008"
       end
-      expect(page).to have_text "Type of navigator used"
+      expect(page).to have_text "Navigator type"
       expect(page).to have_text "General, Incarcerated/reentry, Unhoused"
       expect(page).to have_text "hello@cauliflower.com"
       expect(page).to have_text "+15005550006"

--- a/spec/features/hub/edit_client_spec.rb
+++ b/spec/features/hub/edit_client_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe "a user editing a clients intake fields" do
         expect(page).to have_text "Cranberry Chung"
         expect(page).to have_text "11/25/2019"
       end
-      expect(page).to have_text "Type of navigator used"
+      expect(page).to have_text "Navigator type"
       expect(page).to have_text "General, Incarcerated/reentry, Unhoused"
       expect(page).to have_text "hello@cauliflower.com"
       expect(page).to have_text "+15005550006"

--- a/spec/helpers/filing_status_helper_spec.rb
+++ b/spec/helpers/filing_status_helper_spec.rb
@@ -59,9 +59,8 @@ describe FilingStatusHelper do
 
       it "returns formatted filing statuses with notes, if applicable" do
         result = <<-RESULT
-        <ul><li><strong>Head of household</strong><span> (2019)</span><div><i>Married early 2020, qualifying dependent born late 2019.</i></div></li><li><strong>Married filing jointly</strong><span> (2020)</span></li></ul>
+        <ul class="no-bullets"><li><span class="form-question">2019: </span><span>Head of household</span><div><i>Married early 2020, qualifying dependent born late 2019.</i></div></li><li><span class="form-question">2020: </span><span>Married filing jointly</span></li></ul>
         RESULT
-
         expect(helper.filing_status(client)).to eq result.strip_heredoc.chomp
       end
     end


### PR DESCRIPTION
Format output navigator-relevant fields was inconsistent with the established pattern for putting data into sections on the client show page. This attempts to group the data into a navigator section.

For "driving" purposes, I also am outputting the current step so that i can see where clients get stuck in the flow.