### PR TITLE
Restrict UserAgent in XML to 150 characters to conform with schema

### DIFF
--- a/app/lib/submission_builder/return_header1040.rb
+++ b/app/lib/submission_builder/return_header1040.rb
@@ -122,7 +122,7 @@ module SubmissionBuilder
               # xml.IPPortNum omitted because we cannot get TCP client port number easily from Aptible.
               xml.DeviceId creation_security_information.device_id || "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
               xml.DeviceTypeCd 1
-              xml.UserAgentTxt creation_security_information.user_agent
+              xml.UserAgentTxt trim(creation_security_information.user_agent, 150)
               xml.BrowserLanguageTxt creation_security_information.browser_language
               xml.PlatformTxt creation_security_information.platform
               xml.TimeZoneOffsetNum creation_security_information.timezone_offset
@@ -135,7 +135,7 @@ module SubmissionBuilder
               }
               xml.DeviceId filing_security_information.device_id || "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
               xml.DeviceTypeCd 1
-              xml.UserAgentTxt filing_security_information.user_agent
+              xml.UserAgentTxt trim(filing_security_information.user_agent, 150)
               xml.BrowserLanguageTxt filing_security_information.browser_language
               xml.PlatformTxt filing_security_information.platform
               xml.TimeZoneOffsetNum filing_security_information.timezone_offset

--- a/spec/lib/submission_builder/return_header1040_spec.rb
+++ b/spec/lib/submission_builder/return_header1040_spec.rb
@@ -297,6 +297,22 @@ describe SubmissionBuilder::ReturnHeader1040 do
       end
     end
 
+    context "efile security information" do
+      context "UserAgentTxt" do
+        before do
+          submission.client.efile_security_information.update(user_agent: "Mozilla/5.0 (Linux; Android 10; SAMSUNG SM-S205DL) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.1 Chrome/79.0.3945.136 Mobile Safari/537.36")
+          submission.efile_security_information.update(user_agent: "Mozilla/5.0 (Linux; Android 10; SAMSUNG SM-S205DL) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.1 Chrome/79.0.3945.136 Mobile Safari/537.36")
+        end
+
+        it "trims long user agent text down to 150 characters, the max acceptable by the schema" do
+          expect(submission.efile_security_information.user_agent.length).to eq 151
+          response = SubmissionBuilder::ReturnHeader1040.build(submission)
+          xml = Nokogiri::XML::Document.parse(response.document.to_xml)
+          expect(xml.at("FilingSecurityInformation AtSubmissionFilingGrp UserAgentTxt").text.length).to eq 150
+          expect(xml.at("FilingSecurityInformation AtSubmissionCreationGrp UserAgentTxt").text.length).to eq 150
+        end
+      end
+    end
     it "conforms to the eFileAttachments schema" do
       expect(SubmissionBuilder::ReturnHeader1040.build(submission)).to be_valid
     end


### PR DESCRIPTION
A submission failed with this error, so we need to fix it. 

This simply trims the user_agent value to 150 characters when writing it into the XML.

(It likely provides the IRS with an invalid user_agent, but that is the fault of their validation TBH)