### PR TITLE
Tell apt-get update that it is OK that a new Debian release was published

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,8 @@ commands:
       - run:
           name: install system dependencies
           command: |
+            # The CircleCI environment is based on Debian buster, which used to be called stable Debian, but is now called oldstable.
+            sudo apt-get update --allow-releaseinfo-change && \
             sudo apt-get update && \
             sudo apt-get install -y pdftk ghostscript
   install_js_dependencies:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM ruby:2.6.5
 
+# The Docker environment is based on Debian buster, which used to be called stable Debian, but is now called oldstable.
+RUN apt-get update --allow-releaseinfo-change
+
 # System prerequisites
 RUN apt-get update \
  && apt-get -y install build-essential libpq-dev pdftk ghostscript poppler-utils curl \


### PR DESCRIPTION
This allows us to keep using Debian 10 (buster) without substantial warnings.

It's smart to upgrade to Debian 11 (bullseye) someday. The best way to do that IMHO is to wait https://github.com/docker-library/ruby pull request number 357 to land. Then we change our base image to one with "buster" in the name, run the tests, and push to prod and cross our fingers. :)