### PR TITLE
Add phone number to CTC client Update/New form

### DIFF
--- a/app/views/shared/_client_primary_info_fields.html.erb
+++ b/app/views/shared/_client_primary_info_fields.html.erb
@@ -40,6 +40,8 @@
       <%= f.hub_checkbox(:sms_notification_opt_in, t("general.opt_in_sms"), options: { checked_value: "yes", unchecked_value: "no" }) %>
     </div>
 
+    <%= f.cfa_input_field(:phone_number, t("general.phone_number"),  classes: ["form-width--phone"]) %>
+
     <% if is_ctc %>
       <%= f.vita_min_date_text_fields(
             :primary_birth_date,
@@ -62,7 +64,6 @@
           ) %>
       <%= f.cfa_input_field(:primary_ip_pin, t("general.ip_pin")) %>
     <% else %>
-      <%= f.cfa_input_field(:phone_number, t("general.phone_number"),  classes: ["form-width--phone"]) %>
       <%= f.cfa_input_field(
             :primary_last_four_ssn,
             t("general.last_four_ssn"),

--- a/spec/features/ctc/edit_ctc_client_spec.rb
+++ b/spec/features/ctc/edit_ctc_client_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "a user editing a clients intake fields" do
                             filing_joint: "yes",
                             primary_first_name: "Colleen",
                             primary_last_name: "Cauliflower",
+                            phone_number: "+14404093500",
                             state_of_residence: "CA",
                             preferred_name: "Colleen Cauliflower",
                             email_notification_opt_in: "yes",
@@ -115,7 +116,7 @@ RSpec.describe "a user editing a clients intake fields" do
       expect(page).to have_text "Type of navigator used"
       expect(page).to have_text "General, Incarcerated/reentry, Unhoused"
       expect(page).to have_text "hello@cauliflower.com"
-      expect(page).to have_text "+15005550006"
+      expect(page).to have_text "+14404093500"
       expect(page).to have_text "+15005550006"
       expect(page).to have_text "123 Garden Ln"
       expect(page).to have_text "Brassicaville, CA 95032"


### PR DESCRIPTION
We send it to the IRS and ask it on the legal-consent page, so it should be edit-table on the form.

It fixes this issue (https://www.pivotaltracker.com/story/show/179238903)