### PR TITLE
Fix signature PIN validation

### DIFF
--- a/app/forms/ctc/confirm_information_form.rb
+++ b/app/forms/ctc/confirm_information_form.rb
@@ -2,9 +2,8 @@ module Ctc
   class ConfirmInformationForm < QuestionsForm
     set_attributes_for :intake, :primary_signature_pin, :spouse_signature_pin
 
-    validates :primary_signature_pin, presence: true, format: { with: /\d{5}/ }, exclusion: { in: %w(00000), message: "00000 is not a valid PIN." }
-    validates :spouse_signature_pin, presence: true, format: { with: /\d{5}/ },  exclusion: { in: %w(00000), message: "00000 is not a valid PIN." },
-              if: -> { @intake.filing_jointly? }
+    validates :primary_signature_pin, presence: true, signature_pin: true
+    validates :spouse_signature_pin, presence: true, signature_pin: true, if: -> { @intake.filing_jointly? }
 
     def save
       @intake.update(attributes_for(:intake))

--- a/app/validators/signature_pin_validator.rb
+++ b/app/validators/signature_pin_validator.rb
@@ -1,0 +1,13 @@
+class SignaturePinValidator < ActiveModel::EachValidator
+  def validate_each(record, attr_name, value)
+    return unless value.present?
+
+    unless /\A\d{5}\z/.match?(value.to_s)
+      record.errors.add(attr_name, I18n.t("validators.signature_pin"))
+    end
+
+    if value.to_s == "00000"
+      record.errors.add(attr_name, I18n.t("validators.signature_pin_zeros"))
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1375,6 +1375,8 @@ en:
     zip: Please enter a valid 5-digit zip code.
     ssn: Please enter a valid social security number.
     itin: Please enter a valid individual taxpayer identification number.
+    signature_pin: Signature PIN must be a 5 digit number.
+    signature_pin_zeros: 00000 is not a valid PIN.
     ip_pin: IP PINs must be a 6 digit number.
     legal_name: Please enter a name that only contains letters, apostrophes, hyphens, periods, and accents.
     pdf_file_type: "%{document_type} must be a PDF file"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1353,8 +1353,11 @@ es:
     file_type: Por favor, sube un tipo de documento válido. Los tipos aceptados incluyen jpg, pdf y png.
     zip: Por favor, introduzca un código postal válido de 5 dígitos.
     ssn: Por favor, ingrese un número de seguro social válido.
-    itin: Por favor ingrese un Número de Identificación Personal del Contribuyente válido
-    ip_pin: IP PINs must be a 6 digit number.
+    itin: Por favor ingrese un Número de Identificación Personal del Contribuyente válido.
+    signature_pin: El PIN debe ser un número de 5 dígitos.
+    signature_pin_zeros: 00000 no es un pin válido
+    ip_pin: IP PINs debe ser un número de 6 dígitos.
+    legal_name: Ingrese un nombre que solo contenga letras, apóstrofos, guiones, puntos y acentos.
     legal_name: Ingrese un nombre que solo contenga letras, apóstrofos, guiones, puntos y acentos.
     file_zero_length: "Sube un archivo válido. El archivo que cargó parece estar vacío."
     pdf_file_type: "%{document_type} debe ser un archivo PDF"

--- a/spec/forms/ctc/confirm_information_form_spec.rb
+++ b/spec/forms/ctc/confirm_information_form_spec.rb
@@ -14,17 +14,31 @@ describe Ctc::ConfirmInformationForm do
       expect(form.errors).to include :primary_signature_pin
     end
 
-    it "requires signature PIN to be five digits" do
-      form = described_class.new(intake, {
-        primary_signature_pin: "123",
-      })
-      expect(form).not_to be_valid
-      expect(form.errors).to include :primary_signature_pin
+    context "length is 5 digits" do
+      it "is valid when 5 digits" do
 
-      form = described_class.new(intake, { primary_signature_pin: "12345" })
-      puts form.errors.keys
-      expect(form).to be_valid
+        form = described_class.new(intake, { primary_signature_pin: "12345" })
+        puts form.errors.keys
+        expect(form).to be_valid
+      end
+
+      it "is invalid when 4 digits" do
+        form = described_class.new(intake, {
+            primary_signature_pin: "1234",
+        })
+        expect(form).not_to be_valid
+        expect(form.errors).to include :primary_signature_pin
+      end
+
+      it "is invalid when 6 digits" do
+        form = described_class.new(intake, {
+            primary_signature_pin: "123456",
+        })
+        expect(form).not_to be_valid
+        expect(form.errors).to include :primary_signature_pin
+      end
     end
+
 
     it "requires signature PIN to be numeric" do
       form = described_class.new(intake, {


### PR DESCRIPTION
The validation prevented less than 5 characters but not more than 5 characters. I also refactored to use a custom validator like we do for ip_pins