### PR TITLE
Display cancelled returns with text rejected and cancelled message

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1412,7 +1412,7 @@ en:
               label: Rejected
               message: Your return has not been accepted by the IRS. We will need to correct your info and resubmit. Please contact your tax preparer to make corrections.
             cancelled:
-              label: Cancelled
+              label: Rejected
               message: We will no longer attempt to submit this return to the IRS. This may be because you requested that we do not submit the return, or because a rejection from the IRS indicated that we can not resubmit on your behalf.
       questions:
         returning_client:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1393,7 +1393,7 @@ es:
               label: Rechazada
               message: Su declaración no ha sido aceptada por el IRS. Tendremos que corregir su información y volver a enviarla. Favor de comunicarse con su preparador de impuestos para hacer las correcciones.
             cancelled:
-              label: Cancelado
+              label: Rechazada
               message: Ya no intentaremos enviar esta declaración al IRS. Esto puede deberse a que solicitó que no enviemos la declaración o porque un rechazo del IRS indicó que no podemos volver a enviarla en su nombre.
       questions:
         returning_client:


### PR DESCRIPTION
We realized it's sort of rude to change the status to cancelled while we're working with clients, so we're just going to display Rejected with the cancelled reason for now.

