### PR TITLE
CTC intake: use a special "creation_token" instead of /new/ when creating dependents

### DIFF
--- a/app/controllers/ctc/questions/dependents/had_dependents_controller.rb
+++ b/app/controllers/ctc/questions/dependents/had_dependents_controller.rb
@@ -10,7 +10,7 @@ module Ctc
 
         def next_path
           if current_intake.had_dependents_yes?
-            Ctc::Questions::Dependents::InfoController.to_path_helper(id: :new)
+            Ctc::Questions::Dependents::InfoController.to_path_helper(id: current_intake.new_dependent_token)
           else
             super
           end

--- a/app/controllers/ctc/questions/dependents/info_controller.rb
+++ b/app/controllers/ctc/questions/dependents/info_controller.rb
@@ -14,8 +14,10 @@ module Ctc
 
         def current_resource
           @dependent ||= begin
-            if params[:id] == 'new'
-              current_intake.dependents.new
+            verifier = ActiveSupport::MessageVerifier.new(Rails.application.secret_key_base)
+            token = verifier.verified(params[:id])
+            if token
+              current_intake.dependents.find_or_initialize_by(creation_token: token)
             else
               super
             end

--- a/app/models/dependent.rb
+++ b/app/models/dependent.rb
@@ -7,6 +7,7 @@
 #  born_in_2020                                :integer          default("unfilled"), not null
 #  cant_be_claimed_by_other                    :integer          default("unfilled"), not null
 #  claim_anyway                                :integer          default("unfilled"), not null
+#  creation_token                              :string
 #  disabled                                    :integer          default("unfilled"), not null
 #  encrypted_ip_pin                            :string
 #  encrypted_ip_pin_iv                         :string
@@ -40,7 +41,8 @@
 #
 # Indexes
 #
-#  index_dependents_on_intake_id  (intake_id)
+#  index_dependents_on_creation_token  (creation_token)
+#  index_dependents_on_intake_id       (intake_id)
 #
 
 class Dependent < ApplicationRecord

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -578,4 +578,9 @@ class Intake < ApplicationRecord
         needs_to_flush_searchable_data_set_at = NULL
       SQL
   end
+
+  def new_dependent_token
+    verifier = ActiveSupport::MessageVerifier.new(Rails.application.secret_key_base)
+    verifier.generate(SecureRandom.base36(24))
+  end
 end

--- a/app/views/ctc/questions/dependents/confirm_dependents/edit.html.erb
+++ b/app/views/ctc/questions/dependents/confirm_dependents/edit.html.erb
@@ -25,7 +25,7 @@
         <% end %>
       </div>
 
-      <%= link_to Ctc::Questions::Dependents::InfoController.to_path_helper(id: :new), class: "button button--wide text--centered" do %>
+      <%= link_to Ctc::Questions::Dependents::InfoController.to_path_helper(id: current_intake.new_dependent_token), class: "button button--wide text--centered" do %>
         <%= image_tag("add-person.svg", alt: "") %>
         <%= t('views.ctc.questions.dependents.confirm_dependents.add_a_dependent') %>
       <% end %>

--- a/db/migrate/20210818215926_add_creation_token_to_dependents.rb
+++ b/db/migrate/20210818215926_add_creation_token_to_dependents.rb
@@ -1,0 +1,6 @@
+class AddCreationTokenToDependents < ActiveRecord::Migration[6.0]
+  def change
+    add_column :dependents, :creation_token, :string
+    add_index :dependents, :creation_token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_18_163805) do
+ActiveRecord::Schema.define(version: 2021_08_18_215926) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -261,6 +261,7 @@ ActiveRecord::Schema.define(version: 2021_08_18_163805) do
     t.integer "cant_be_claimed_by_other", default: 0, null: false
     t.integer "claim_anyway", default: 0, null: false
     t.datetime "created_at", null: false
+    t.string "creation_token"
     t.integer "disabled", default: 0, null: false
     t.string "encrypted_ip_pin"
     t.string "encrypted_ip_pin_iv"
@@ -290,6 +291,7 @@ ActiveRecord::Schema.define(version: 2021_08_18_163805) do
     t.datetime "updated_at", null: false
     t.integer "was_married", default: 0, null: false
     t.integer "was_student", default: 0, null: false
+    t.index ["creation_token"], name: "index_dependents_on_creation_token"
     t.index ["intake_id"], name: "index_dependents_on_intake_id"
   end
 

--- a/spec/factories/dependents.rb
+++ b/spec/factories/dependents.rb
@@ -7,6 +7,7 @@
 #  born_in_2020                                :integer          default("unfilled"), not null
 #  cant_be_claimed_by_other                    :integer          default("unfilled"), not null
 #  claim_anyway                                :integer          default("unfilled"), not null
+#  creation_token                              :string
 #  disabled                                    :integer          default("unfilled"), not null
 #  encrypted_ip_pin                            :string
 #  encrypted_ip_pin_iv                         :string
@@ -40,7 +41,8 @@
 #
 # Indexes
 #
-#  index_dependents_on_intake_id  (intake_id)
+#  index_dependents_on_creation_token  (creation_token)
+#  index_dependents_on_intake_id       (intake_id)
 #
 
 FactoryBot.define do

--- a/spec/models/dependent_spec.rb
+++ b/spec/models/dependent_spec.rb
@@ -7,6 +7,7 @@
 #  born_in_2020                                :integer          default("unfilled"), not null
 #  cant_be_claimed_by_other                    :integer          default("unfilled"), not null
 #  claim_anyway                                :integer          default("unfilled"), not null
+#  creation_token                              :string
 #  disabled                                    :integer          default("unfilled"), not null
 #  encrypted_ip_pin                            :string
 #  encrypted_ip_pin_iv                         :string
@@ -40,7 +41,8 @@
 #
 # Indexes
 #
-#  index_dependents_on_intake_id  (intake_id)
+#  index_dependents_on_creation_token  (creation_token)
+#  index_dependents_on_intake_id       (intake_id)
 #
 
 require "rails_helper"


### PR DESCRIPTION
The URL for /dependents/:id/info will accept either a signed creation_token
or an actual database id for params[:id]

This will help when users use their browser back button, which previously
was taking them back into /dependents/new/info and potentially creating
too many new dependents.

Co-authored-by: Em Barnard-Shao <ebarnard@codeforamerica.org>