### PR TITLE
Validate birth dates are between 1900 and current year [#179284291]

### DIFF
--- a/app/controllers/dependents_controller.rb
+++ b/app/controllers/dependents_controller.rb
@@ -90,10 +90,16 @@ class DependentsController < ApplicationController
     birth_date_values = birth_date_params.values
     return nil if birth_date_values.any?(&:blank?)
     begin
-      Date.new(*birth_date_params.values.map(&:to_i))
+      parsed_birth_date = Date.new(*birth_date_params.values.map(&:to_i))
     rescue ArgumentError => error
       raise error unless error.to_s == "invalid date"
-      nil
+      return nil
     end
+
+    if parsed_birth_date.year < 1900 || parsed_birth_date.year > Date.today.year
+      return nil
+    end
+
+    parsed_birth_date
   end
 end

--- a/app/helpers/birth_date_helper.rb
+++ b/app/helpers/birth_date_helper.rb
@@ -13,6 +13,12 @@ module BirthDateHelper
       self.errors.add(:birth_date, I18n.t("helpers.birth_date_helper.valid_birth_date"))
       return false
     end
+
+    if parsed_birth_date.year < 1900 || parsed_birth_date.year > Date.today.year
+      self.errors.add(key, I18n.t('errors.attributes.birth_date.blank'))
+      return false
+    end
+
     true
   end
 
@@ -22,6 +28,12 @@ module BirthDateHelper
       self.errors.add(key, I18n.t('errors.attributes.birth_date.blank'))
       return false
     end
+
+    if parsed_birth_date.year < 1900 || parsed_birth_date.year > Date.today.year
+      self.errors.add(key, I18n.t('errors.attributes.birth_date.blank'))
+      return false
+    end
+
     true
   end
 

--- a/spec/controllers/dependents_controller_spec.rb
+++ b/spec/controllers/dependents_controller_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe DependentsController do
               first_name: "Kylie",
               birth_date_month: "12",
               birth_date_day: "2",
-              birth_date_year: "",
+              birth_date_year: "96",
               relationship: "Nibling",
               months_in_home: "12",
               was_student: "no",

--- a/spec/forms/ctc/legal_consent_form_spec.rb
+++ b/spec/forms/ctc/legal_consent_form_spec.rb
@@ -179,6 +179,26 @@ describe Ctc::LegalConsentForm do
         expect(described_class.new(intake, params)).not_to be_valid
       end
     end
+
+    context "when the year is before 1900" do
+      before do
+        params[:primary_birth_date_year] = "1492"
+      end
+
+      it "is not valid" do
+        expect(described_class.new(intake, params)).not_to be_valid
+      end
+    end
+
+    context "when the year is in the future" do
+      before do
+        params[:primary_birth_date_year] = "2035"
+      end
+
+      it "is not valid" do
+        expect(described_class.new(intake, params)).not_to be_valid
+      end
+    end
   end
 
   describe "#save" do


### PR DESCRIPTION
Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>

## Why

People are entering two digit numbers like `96` as a birth year and it's causing problems.

## Notes for reviewers

I'm only adding tests for one consumer of BirthDateHelper. I think that's OK. Later we can refactor it into a custom validator.

I added the same rule to GYR birthdays for consistency.

This will result in some birthdays becoming invalid. Shannon and Catie plan to look into those.