### PR TITLE
Add navigators page with markdown content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ gem 'scenic'
 gem 'rubyzip'
 gem 'intercom', '~> 4.1'
 gem 'statesman', '~> 8.0.3'
+gem 'redcarpet'
 
 group :demo, :development, :test do
   gem 'factory_bot_rails' # added to demo for creating fake data

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -383,6 +383,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (3.5.1)
     regexp_parser (2.1.1)
     request_store (1.5.0)
       rack (>= 1.4)
@@ -616,6 +617,7 @@ DEPENDENCIES
   rails-controller-testing
   rails-i18n
   rails_autolink
+  redcarpet
   rspec-rails
   rspec_junit_formatter
   rubocop (~> 0.82.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -94,6 +94,7 @@
 @import "templates/ctc-home";
 @import "templates/date-text-field";
 @import "templates/flow-explorer";
+@import "templates/navigator-resources";
 
 html {
   background-color: black;

--- a/app/assets/stylesheets/templates/_navigator-resources.scss
+++ b/app/assets/stylesheets/templates/_navigator-resources.scss
@@ -1,0 +1,29 @@
+.navigator-resources {
+  .slab--hero {
+    padding-bottom: 0;
+  }
+
+  .hero-image {
+    margin-top: 3.5rem;
+    max-width: 30rem;
+    @media screen and (min-width: $site-max-up) {
+      margin-top: unset;
+      max-width: unset;
+    }
+    &--family {
+      max-height: 30rem;
+      margin-top: -15rem;
+      margin-right: -6rem;
+      @media screen and (min-width: $site-max-up) {
+        max-height: 39rem;
+        margin-top: unset;
+        margin-right: unset;
+      }
+    }
+  }
+
+  ul {
+    list-style: disc;
+    padding-left: $s35;
+  }
+}

--- a/app/controllers/ctc/ctc_pages_controller.rb
+++ b/app/controllers/ctc/ctc_pages_controller.rb
@@ -12,6 +12,11 @@ module Ctc
       redirect_to root_path(ctc_beta: params[:ctc_beta])
     end
 
+    def navigators
+      markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML)
+      @markdown_content = markdown.render(File.read(Rails.root.join("app", "views", "ctc", "ctc_pages", "navigators.md"))).html_safe
+    end
+
     def privacy_policy
     end
 

--- a/app/views/ctc/ctc_pages/navigators.html.erb
+++ b/app/views/ctc/ctc_pages/navigators.html.erb
@@ -1,0 +1,21 @@
+<div class="navigator-resources">
+  <div class="slab slab--hero slab--blue">
+    <div class="grid-flex contained column-row space-between">
+      <div class="grid-flex column-column spacing-below-35">
+        <h1>GetCTC.org Navigator Resources</h1>
+        <p class="help-text">Guidance for community-based navigators seeking to help hard-to-reach clients access the Advance Child Tax Credit (AdvCTC) or Economic Impact Payment (EIP or Stimulus).</p>
+      </div>
+
+      <div class="grid-flex align-flex-end justify-flex-end">
+        <%= image_tag "hero-family.png", alt: "", class: "hero-image hero-image--family" %>
+      </div>
+    </div>
+  </div>
+  <section class="slab slab--white slab--half-padded">
+    <div class="grid">
+      <div class="grid__item width-one-whole">
+        <%= @markdown_content %>
+      </div>
+    </div>
+  </section>
+</div>

--- a/app/views/ctc/ctc_pages/navigators.md
+++ b/app/views/ctc/ctc_pages/navigators.md
@@ -1,0 +1,46 @@
+These resources are evolving quickly. **Sign up [here](https://airtable.com/shr4eDAcMdLgjOTjJ) for updates.**
+
+### **Step 1: Complete navigator orientation**
+
+- **Learn the essential responsibilities of a Navigator by reviewing this [slide deck](https://docs.google.com/presentation/d/19m9IjerdB14yBQ9HqhIpp2lDi_sQPO7c4F1qUMUtlOw/edit?usp=sharing).** These resources will introduce you to the navigator role and help you determine next steps (if any) for your clients.
+- **Get ready to use the GetCTC Simplified Filing Portal (coming soon)** by watching our demo video [**here**](https://youtu.be/nGoyN_M9SfQ).
+- A complete guide to using the GetCTC Simplified Tax Filing Portal is coming soon.
+
+### **Step 2: Familiarize yourself with resources**
+
+**Client-facing resources:**
+
+- [GetCTC.org](http://www.GetCTC.org) landing page with up-to-date information, clear next steps, and FAQs, in English and Spanish. Future home of Code for America's simplified tax filing portal.
+- [GetYourRefund.org](https://www.getyourrefund.org/en) free tax prep services and [FAQ](https://www.getyourrefund.org/en/faq) for clients who want to file a full return, in English and Spanish
+- [How to fill out the IRS Non-filer form](https://www.eitcoutreach.org/tax-filing/coronavirus/how-to-fill-out-the-irs-non-filer-form/) provides step-by-step instructions and other helpful tips to complete the IRS non-filer form, presented by the Center on Budget and Policy Priorities' Get It Back Campaign. The site also features several other helpful toolkits!
+- [How to use the IRS Child Tax Credit Update Portal (CTC UP)](https://www.taxoutreach.org/tax-filing/coronavirus/how-to-use-the-irs-child-tax-credit-update-portal-ctc-up/) provides step-by-step instructions and helpful tips to utilize the CTC Update Portal, presented by Center on Budget and Policy Priorities' Get It Back Campaign.
+- IRS CTC Helpline: (800) 908-4184 The helpline connects clients to an IRS operator to get answers to basic CTC questions and is available in English and Spanish. The operators can only provide general information and are not able to access individual accounts.
+
+🎉  **GetCTC.org’s Simplified Filing Portal for claiming the Child Tax Credit and stimulus payments is coming soon! We need beta testers. (click arrow for more info)**
+
+Code for America is looking for partner organizations willing to use the [new simplified filing portal](https://www.codeforamerica.org/news/ensuring-families-who-qualify-for-the-child-tax-credit-arent-left-behind/) with real clients and provide us with feedback on the beta version. Submissions received through the beta testing process will be filed with the IRS so the client can receive their Child Tax Credit and any missing stimulus payments. We are primarily looking for feedback on how we ask clients each of the questions, with the goal of making it easier for any client to use the portal without navigator assistance. 
+
+- Feel free to experiment with the portal yourself with this [demo link.](https://ctc.demo.getyourrefund.org/en/questions/overview) Please note the exact copy may change between now and when you are using the live tool, but this link will give you a general sense of the questions and possible outcomes. *Information submitted via the demo link will not be submitted to the IRS.*
+- You can see a full demo of the simplified filing portal [here](https://codeforamerica.zoom.us/rec/share/ozvymqA79_b5SKxZ-q8OTYXXKHyOhQQT5dzP1HPo00Lw9BRBLeqpgAsTh0QimlDs.8cEtMTwZwcsjsxuB). Passcode: FJ2!y5@a
+- If your organization is interested in helping us with beta testing, please review this [slide deck](https://docs.google.com/presentation/d/1oVB7JvJZ32wRrM639nPDa51qRWIS98v7E8Ny28iu7vU/edit#slide=id.gd8f53294e4_0_316), which provides more info on the role. You can also review our [quick guide for beta testers](https://docs.google.com/document/d/19KgzhsRfUY6b3WV8XdQ-td8aOaADrpCZAZp4KuFFaBw/edit).
+- [Fill out this form to become a beta tester](https://airtable.com/shrp6sbV3mn3bFrfG) and receive early access to the portal.
+
+**Advanced Navigator guides:**
+
+- [Determining client's next steps](https://drive.google.com/file/d/1m3ysogunU8Va8cQQ8mOTwSCWi_ZCoz9y/view?usp=sharing): This decision tree is designed to help you know which resource, if any, a client should use based on their tax filing history and needs.
+- [Calculating Recovery Rebate Credit:](https://drive.google.com/file/d/1bx2jVMlc8nKhxMmwP2nCOP5EkZPRBH5m/view?usp=sharing) Clients who missed out on their full 1st or 2nd Economic Impact Payments (EIP) will have the opportunity to claim the missing payments when entering the Recovery Rebate Credit (RRC) as part of the IRS non-filer form. If the RRC entered does not match IRS records, the IRS will delay processing the refund in order to correct the issue. Use this guide to help a client accurately complete this section and claim all eligible benefits.
+- [Reasons to opt-out of the Advance CTC](https://drive.google.com/file/d/1YjLTLG4nUo0MC9AhNuTXwKVFis457CL-/view?usp=sharing): Learn more about Advance Child Tax Credit payments, tax year 2021 reporting process, and why some clients may want to opt-out of these payments.
+- [Common rejects for non-filers and next steps](https://drive.google.com/file/d/1JMSdcLLVFDGsXih7MYSPm0JKuyu4ty_L/view?usp=sharing): After filing the non-filer form, clients will receive an email letting them know if their return was accepted or rejected. This guide explains common reasons a client's return is rejected and possible next steps.
+
+**Recorded Webinars:**
+
+- [Ensuring Families Receive the Child Tax Credit](https://youtu.be/hs1xVN13KnA): Watch the Automatic Benefit of Children (ABC) Coalition's webinar to learn from state and local community-based organizations who serve families about innovate outreach strategies to raise awareness about the CTC and get families sign up.
+- [Becoming a CTC Navigator and Non-filer & CTC Update Portal Walk-through](https://www.taxoutreach.org/blog/training-becoming-a-ctc-navigator-and-non-filer-portal-walk-through/): This training, co-hosted by Center on Budget and Policy Priorities, will help you become a CTC Navigator for your community.
+
+### **Step 3: Learn more about common client barriers**
+
+Read [Code for America and GetYourRefund.org Non-filer Learnings and Recommendations](https://files.codeforamerica.org/2021/06/16174016/filer-learnings-and-recommendations-april-2021.pdf) for more info about the barriers non-filers face in accessing the tax benefits they deserve.
+
+Read [Code for America and GetYourRefund.org Earned Income Tax Credit Research](https://files.codeforamerica.org/2021/07/09131827/EITC-Research-Findings-Report-_-January-July-2019-_-GetYourRefund.pdf) for more info about the people in the Earned Income Tax Credit (EITC) participation gap. 
+
+Read New America's [Talking to Non-Filers Report](https://www.newamerica.org/new-practice-lab/blog/talking-to-non-filers/) for qualitative research about families who don't regularly file tax returns.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -316,6 +316,7 @@ Rails.application.routes.draw do
           get "/confirmation", to: "signups#confirmation", on: :collection
         end
         get "/privacy", to: "ctc_pages#privacy_policy"
+        get "/navigators", to: "ctc_pages#navigators"
         scope "common-questions" do
           get "/what-will-i-need-to-submit", to: "ctc_pages#what_will_i_need_to_submit"
           get "/check-payment-status", to: "ctc_pages#check_payment_status"

--- a/spec/controllers/ctc/ctc_pages_controller_spec.rb
+++ b/spec/controllers/ctc/ctc_pages_controller_spec.rb
@@ -32,4 +32,14 @@ describe Ctc::CtcPagesController do
       end
     end
   end
+
+  describe "#navigators" do
+    render_views
+
+    it "renders the content" do
+      get :navigators
+
+      expect(response.body).to include "Step 1: Complete navigator orientation"
+    end
+  end
 end


### PR DESCRIPTION
we made a page that renders markdown! the goal is that non-engineers will have an easier time of updating the contents (and we can workshop a way to get these changes in with minimal but sufficient eng review)

![image](https://user-images.githubusercontent.com/43800769/130158732-11103b54-0ac1-4355-88dc-b3aeb9591bd5.png)


Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>