### PR TITLE
Fix dependent yes no bug

### DIFF
--- a/app/assets/stylesheets/components/_review-box.scss
+++ b/app/assets/stylesheets/components/_review-box.scss
@@ -19,7 +19,11 @@
     &:first-child {
       margin-top: 0;
     }
+    &-tighter {
+      margin-bottom: 1.5rem;
+    }
   }
+
 
   &__space-between {
     display: flex;

--- a/app/controllers/ctc/questions/dependents/had_dependents_controller.rb
+++ b/app/controllers/ctc/questions/dependents/had_dependents_controller.rb
@@ -9,10 +9,12 @@ module Ctc
         private
 
         def next_path
-          if current_intake.had_dependents_yes?
-            Ctc::Questions::Dependents::InfoController.to_path_helper(id: current_intake.new_dependent_token)
-          else
+          if current_intake.dependents.count > 0 # If the client has already added dependents, take them to the confirmation page to add more or continue.
+            questions_confirm_dependents_path
+          elsif current_intake.had_dependents_no?
             super
+          else
+            Ctc::Questions::Dependents::InfoController.to_path_helper(id: current_intake.new_dependent_token)
           end
         end
 

--- a/app/views/ctc/questions/dependents/confirm_dependents/edit.html.erb
+++ b/app/views/ctc/questions/dependents/confirm_dependents/edit.html.erb
@@ -9,28 +9,34 @@
 
     <div class="review-box spacing-below-35">
       <div data-automation="ctc-dependents">
-        <div class="review-box__title">
+        <div class="review-box__title review-box__title-tighter">
           <h2><%= t("views.ctc.questions.dependents.confirm_dependents.qualifying_for_ctc") %></h2>
         </div>
-        <% current_intake.dependents.select { |dep| dep.eligible_for_child_tax_credit_2020? }.each do |dependent| %>
-          <%= render 'dependent', dependent: dependent %>
-        <% end %>
+        <div class="spacing-below-15">
+          <%= render(
+                  partial: 'dependent',
+                  collection: current_intake.dependents.select { |dep| dep.eligible_for_child_tax_credit_2020? }
+              ) || t('views.ctc.questions.dependents.confirm_dependents.no_qualifying_dependents') %>
+        </div>
       </div>
       <div data-automation="other-credits-dependents">
-        <div class="review-box__title">
+        <div class="review-box__title review-box__title-tighter">
           <h2><%= t("views.ctc.questions.dependents.confirm_dependents.qualifying_for_other_credits") %></h2>
         </div>
-        <% current_intake.dependents.select { |dep| !dep.eligible_for_child_tax_credit_2020? && (dep.qualifying_child_2020? || dep.qualifying_relative_2020?) }.each do |dependent| %>
-          <%= render 'dependent', dependent: dependent %>
-        <% end %>
+        <div class="spacing-below-35">
+          <%= render(partial: 'dependent', collection:
+              current_intake.dependents.select { |dep| !dep.eligible_for_child_tax_credit_2020? && (dep.qualifying_child_2020? || dep.qualifying_relative_2020?) }
+              ) || t('views.ctc.questions.dependents.confirm_dependents.no_qualifying_dependents') %>
+        </div>
       </div>
 
-      <%= link_to Ctc::Questions::Dependents::InfoController.to_path_helper(id: current_intake.new_dependent_token), class: "button button--wide text--centered" do %>
-        <%= image_tag("add-person.svg", alt: "") %>
-        <%= t('views.ctc.questions.dependents.confirm_dependents.add_a_dependent') %>
-      <% end %>
+      <div class="review-box__cta-button-container">
+        <%= link_to Ctc::Questions::Dependents::InfoController.to_path_helper(id: current_intake.new_dependent_token), class: "button button--wide text--centered" do %>
+          <%= image_tag("add-person.svg", alt: "") %>
+          <%= t('views.ctc.questions.dependents.confirm_dependents.add_a_dependent') %>
+        <% end %>
+      </div>
     </div>
-
     <button class="button button--primary button--wide" type="submit">
       <%= t("views.ctc.questions.dependents.confirm_dependents.done_adding") %>
     </button>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1488,6 +1488,7 @@ en:
             title: "Let’s confirm your dependents!"
             qualifying_for_ctc: "Dependents qualifying for CTC and stimulus payments"
             qualifying_for_other_credits: "Dependents qualifying for stimulus payments only"
+            no_qualifying_dependents: "No qualifying dependents"
             birthday: "Date of birth: %{dob}"
             ssn: "SSN: XXX-XX-%{ssn}"
             ssn_na: "SSN: N/A"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1472,6 +1472,7 @@ es:
             title: "Confirmemos sus dependientes"
             qualifying_for_ctc: "Dependientes que califican para CTC y los pagos de estímulo"
             qualifying_for_other_credits: "Dependientes que califican para los pagos de estímulo solor"
+            no_qualifying_dependents: "No dependientes que califican"
             birthday: "Fecha de nacimiento: %{dob}"
             ssn: "Número de Seguro Social: XXX-XX-%{ssn}"
             ssn_na: "Número de Seguro Social: N/A"

--- a/spec/controllers/ctc/questions/dependents/had_dependents_controller_spec.rb
+++ b/spec/controllers/ctc/questions/dependents/had_dependents_controller_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe Ctc::Questions::Dependents::HadDependentsController do
+  let(:had_dependents) { "unfilled" }
+  let(:intake) { create :ctc_intake, had_dependents: had_dependents }
+  before { sign_in intake.client }
+
+  describe "#next_path" do
+    context "when the client has already added some dependents" do
+      let(:intake) { create :ctc_intake, :with_dependents, had_dependents: had_dependents }
+
+      context "when the client answers yes" do
+        it "returns the confirm dependents page" do
+          put :update, params: { ctc_had_dependents_form: { had_dependents: "yes" } }
+
+          expect(response).to redirect_to questions_confirm_dependents_path
+        end
+      end
+
+      context "when the client answers no" do
+        it "returns the confirm dependents page" do
+          put :update, params: { ctc_had_dependents_form: { had_dependents: "no" } }
+
+          expect(response).to redirect_to questions_confirm_dependents_path
+        end
+      end
+    end
+
+    context "when the client has not added any dependents yet" do
+
+      context "when the client answers yes" do
+        let(:info_controller_path) { double }
+
+        before do
+          allow_any_instance_of(Intake).to receive(:new_dependent_token).and_return("new")
+        end
+
+        it "returns the dependents path" do
+          put :update, params: { ctc_had_dependents_form: { had_dependents: "yes" } }
+
+          expect(response).to redirect_to Ctc::Questions::Dependents::InfoController.to_path_helper(id: "new")
+        end
+      end
+
+      context "when the client answers no" do
+        let(:had_dependents) { "no" }
+
+        it "returns the default next navigation path" do
+          put :update, params: { ctc_had_dependents_form: { had_dependents: "no" } }
+
+          expect(response).to redirect_to questions_stimulus_payments_path
+        end
+      end
+    end
+  end
+end
+

--- a/spec/controllers/questions/had_dependents_controller_spec.rb
+++ b/spec/controllers/questions/had_dependents_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Questions::HadDependentsController do
   before { sign_in intake.client }
 
   describe "#next_path" do
-    context "when the user answers that they had dependents" do
+    context "when the user had dependents" do
       let(:had_dependents) { "yes" }
 
       it "returns the dependents path" do
@@ -14,7 +14,7 @@ RSpec.describe Questions::HadDependentsController do
       end
     end
 
-    context "when the user didn't didn't have dependents" do
+    context "when the user didn't have dependents" do
       let(:had_dependents) { "no" }
 
       it "returns the default next navigation path" do

--- a/spec/controllers/questions/had_dependents_controller_spec.rb
+++ b/spec/controllers/questions/had_dependents_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Questions::HadDependentsController do
   before { sign_in intake.client }
 
   describe "#next_path" do
-    context "when the user had dependents" do
+    context "when the user answers that they had dependents" do
       let(:had_dependents) { "yes" }
 
       it "returns the dependents path" do
@@ -14,7 +14,7 @@ RSpec.describe Questions::HadDependentsController do
       end
     end
 
-    context "when the user didn't have dependents" do
+    context "when the user didn't didn't have dependents" do
       let(:had_dependents) { "no" }
 
       it "returns the default next navigation path" do


### PR DESCRIPTION
Skipping to the confirm page if you've already answered this question seemed like the simplest way to navigate this because that page allows people to add and remove dependents if they need to.

This means that if you go back through and answer yes, you won't be forced to add a whole new dependents.

This means that if you go back through and answer no, we won't break the site for you.

I also took some liberties to add a "No qualifying dependents" state for this page so that its more clear to clients what their situation is when they land on this page.

<img width="578" alt="Screen Shot 2021-08-24 at 2 57 55 PM" src="https://user-images.githubusercontent.com/4494389/130685275-db7f4cf6-e15f-4150-a2bc-85ce88fb39a7.png">
