### PR TITLE
Copy updates and bug fixes for CTC clarity

### DIFF
--- a/app/views/ctc/questions/dependents/child_can_be_claimed_by_other/edit.html.erb
+++ b/app/views/ctc/questions/dependents/child_can_be_claimed_by_other/edit.html.erb
@@ -1,3 +1,3 @@
-<% content_for :form_question, t("views.ctc.questions.dependents.child_can_be_claimed_by_other.title", name: @form.dependent.first_name) %>
+<% content_for :form_question, t("views.ctc.questions.dependents.child_can_be_claimed_by_other.title", name: @form.dependent.first_name&.titleize) %>
 
-<% content_for :form_help_text, t("views.ctc.questions.dependents.child_can_be_claimed_by_other.help_text") %>
+<% content_for :form_help_text, t("views.ctc.questions.dependents.child_can_be_claimed_by_other.help_text_html", name: @form.dependent.first_name&.titleize) %>

--- a/app/views/ctc/questions/dependents/child_disqualifiers/edit.html.erb
+++ b/app/views/ctc/questions/dependents/child_disqualifiers/edit.html.erb
@@ -1,4 +1,4 @@
-<% name = @dependent.first_name.capitalize %>
+<% name = @dependent.first_name&.titleize %>
 <% @main_question = t("views.ctc.questions.dependents.child_disqualifiers.title", name: name) %>
 
 <% content_for :page_title, @main_question %>

--- a/app/views/ctc/questions/dependents/child_lived_with_you/edit.html.erb
+++ b/app/views/ctc/questions/dependents/child_lived_with_you/edit.html.erb
@@ -1,1 +1,1 @@
-<% content_for :form_question, t("views.ctc.questions.dependents.child_lived_with_you.title", name: @form.dependent.first_name, tax_year: 2020) %>
+<% content_for :form_question, t("views.ctc.questions.dependents.child_lived_with_you.title", name: @form.dependent.first_name&.titleize, tax_year: 2020) %>

--- a/app/views/ctc/questions/dependents/child_residence_exceptions/edit.html.erb
+++ b/app/views/ctc/questions/dependents/child_residence_exceptions/edit.html.erb
@@ -1,4 +1,5 @@
-<% content_for :page_title, t("views.ctc.questions.dependents.child_residence_exceptions.title", name: @form.dependent.first_name) %>
+<% content_for :page_title, t("views.ctc.questions.dependents.child_residence_exceptions.title", name: @form.dependent.first_name&.titleize) %>
+<% name = @dependent.first_name&.titleize %>
 
 <% content_for :form_card do %>
   <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder, html: { class: "form-card form-card--long" } do |f| %>
@@ -9,10 +10,10 @@
       <%=t('views.ctc.questions.dependents.child_residence_exceptions.help_text') %>
     </p>
     <div class="form-card__stacked-checkboxes spacing-above-0">
-      <%= f.cfa_checkbox(:born_in_2020, t('views.ctc.questions.dependents.child_residence_exceptions.born_in_2020', name: @form.dependent.first_name), options: { checked_value: "yes", unchecked_value: "no" }) %>
-      <%= f.cfa_checkbox(:passed_away_2020, t('views.ctc.questions.dependents.child_residence_exceptions.passed_away_2020', name: @form.dependent.first_name), options: { checked_value: "yes", unchecked_value: "no" }) %>
-      <%= f.cfa_checkbox(:placed_for_adoption, t('views.ctc.questions.dependents.child_residence_exceptions.placed_for_adoption', name: @form.dependent.first_name), options: { checked_value: "yes", unchecked_value: "no" }) %>
-      <%= f.cfa_checkbox(:permanent_residence_with_client, t('views.ctc.questions.dependents.child_residence_exceptions.permanent_residence_with_client', name: @form.dependent.first_name), options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <%= f.cfa_checkbox(:born_in_2020, t('views.ctc.questions.dependents.child_residence_exceptions.born_in_2020', name: name), options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <%= f.cfa_checkbox(:passed_away_2020, t('views.ctc.questions.dependents.child_residence_exceptions.passed_away_2020', name: name), options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <%= f.cfa_checkbox(:placed_for_adoption, t('views.ctc.questions.dependents.child_residence_exceptions.placed_for_adoption', name: name), options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <%= f.cfa_checkbox(:permanent_residence_with_client, t('views.ctc.questions.dependents.child_residence_exceptions.permanent_residence_with_client', name: name), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox(:none, t("general.none_of_the_above"), options: { id: "none__checkbox", checked_value: "yes", unchecked_value: "no" }) %>
     </div>
 

--- a/app/views/ctc/questions/dependents/claim_child_anyway/edit.html.erb
+++ b/app/views/ctc/questions/dependents/claim_child_anyway/edit.html.erb
@@ -1,6 +1,6 @@
-<% content_for :form_question, t("views.ctc.questions.dependents.claim_child_anyway.title", name: @form.dependent.first_name) %>
+<% content_for :form_question, t("views.ctc.questions.dependents.claim_child_anyway.title", name: @form.dependent.first_name&.titleize) %>
 <% content_for :form_help_text do %>
-  <%= t("views.ctc.questions.dependents.claim_child_anyway.help_text", name: @form.dependent.first_name) %>
+  <%= t("views.ctc.questions.dependents.claim_child_anyway.help_text_html", name: @form.dependent.first_name&.titleize) %>
 
   <%= render('components/molecules/reveal', title: t("views.ctc.questions.dependents.claim_child_anyway.not_sure_reveal.title")) do %>
     <p> <%= t("views.ctc.questions.dependents.claim_child_anyway.not_sure_reveal.p") %> </p>

--- a/app/views/ctc/questions/dependents/does_not_qualify_ctc/edit.html.erb
+++ b/app/views/ctc/questions/dependents/does_not_qualify_ctc/edit.html.erb
@@ -13,7 +13,7 @@
   </ul>
 
   <div class="spacing-above-60">
-    <%= link_to Ctc::Questions::Dependents::InfoController.to_path_helper(id: :new), class: "button button--wide button--primary text--centered button--wide" do %>
+    <%= link_to Ctc::Questions::Dependents::InfoController.to_path_helper(id: current_intake.new_dependent_token), class: "button button--wide button--primary text--centered button--wide" do %>
       <%= image_tag("add-person--white.svg", alt: "") %>
       <%= t("views.ctc.questions.dependents.does_not_qualify_ctc.add_button") %>
     <% end %>

--- a/app/views/ctc/questions/dependents/qualifying_relative/edit.html.erb
+++ b/app/views/ctc/questions/dependents/qualifying_relative/edit.html.erb
@@ -1,13 +1,13 @@
 <% content_for :form_question, t("views.ctc.questions.dependents.qualifying_relative.title_html") %>
-
+<% name = @form.dependent.first_name&.titleize %>
 <% content_for :form_help_text do %>
   <ul class="checkmark-list teal">
-    <li><%=t("views.ctc.questions.dependents.qualifying_relative.help_text.li1", name: @form.dependent.first_name) %></li>
-    <li><%=t("views.ctc.questions.dependents.qualifying_relative.help_text.li2", name: @form.dependent.first_name) %></li>
-    <li><%=t("views.ctc.questions.dependents.qualifying_relative.help_text.li3", name: @form.dependent.first_name) %></li>
+    <li><%=t("views.ctc.questions.dependents.qualifying_relative.help_text.li1", name: name) %></li>
+    <li><%=t("views.ctc.questions.dependents.qualifying_relative.help_text.li2", name: name) %></li>
+    <li><%=t("views.ctc.questions.dependents.qualifying_relative.help_text.li3", name: name) %></li>
   </ul>
   <ul class="crossmark-list">
-    <li><%=t("views.ctc.questions.dependents.qualifying_relative.help_text.li4", name: @form.dependent.first_name) %></li>
-    <li><%=t("views.ctc.questions.dependents.qualifying_relative.help_text.li5", name: @form.dependent.first_name) %></li>
+    <li><%=t("views.ctc.questions.dependents.qualifying_relative.help_text.li4", name: name) %></li>
+    <li><%=t("views.ctc.questions.dependents.qualifying_relative.help_text.li5", name: name) %></li>
   </ul>
 <% end %>

--- a/app/views/ctc/questions/dependents/remove_dependent/edit.html.erb
+++ b/app/views/ctc/questions/dependents/remove_dependent/edit.html.erb
@@ -1,4 +1,4 @@
-<% @main_heading = t("views.ctc.questions.dependents.remove_dependent.title_html", dependent_name: @form.dependent.first_name) %>
+<% @main_heading = t("views.ctc.questions.dependents.remove_dependent.title_html", dependent_name: @form.dependent.first_name&.titleize) %>
 <% content_for :form_question, @main_heading %>
 
 <% content_for :form_card do %>

--- a/app/views/ctc/questions/dependents/tin/edit.html.erb
+++ b/app/views/ctc/questions/dependents/tin/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t("views.ctc.questions.dependents.tin.title", name: @form.dependent.first_name) %>
+<% content_for :page_title, t("views.ctc.questions.dependents.tin.title", name: @form.dependent.first_name&.titleize) %>
 
 <% content_for :form_card do %>
   <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder, html: { class: "form-card form-card--long" } do |f| %>
@@ -6,12 +6,12 @@
     <p>
       <%=t("views.ctc.questions.dependents.tin.help_text") %>
     </p>
-
+    <% name = @form.dependent.first_name&.titleize %>
     <div class="form-card__content">
-      <%= f.cfa_select(:tin_type, t("views.ctc.questions.dependents.tin.form_of_identity", name: @form.dependent.first_name), tin_options_for_select(include_atin: true)) %>
+      <%= f.cfa_select(:tin_type, t("views.ctc.questions.dependents.tin.form_of_identity", name: name), tin_options_for_select(include_atin: true)) %>
       <%= f.cfa_checkbox(:ssn_no_employment, t('views.ctc.questions.legal_consent.ssn_not_valid_for_employment'), options: { checked_value: "yes", unchecked_value: "no" }) %>
-      <%= f.cfa_input_field(:ssn, t("views.ctc.questions.dependents.tin.ssn_or_atin", name: @form.dependent.first_name), classes: ["form-width--long"]) %>
-      <%= f.cfa_input_field(:ssn_confirmation, t("views.ctc.questions.dependents.tin.ssn_or_atin_confirmation", name: @form.dependent.first_name), classes: ["form-width--long"]) %>
+      <%= f.cfa_input_field(:ssn, t("views.ctc.questions.dependents.tin.ssn_or_atin", name: name), classes: ["form-width--long"]) %>
+      <%= f.cfa_input_field(:ssn_confirmation, t("views.ctc.questions.dependents.tin.ssn_or_atin_confirmation", name: name), classes: ["form-width--long"]) %>
     </div>
 
     <button class="button button--primary spacing-below-15 button--wide" type="submit">

--- a/app/views/ctc/questions/file_full_return/edit.html.erb
+++ b/app/views/ctc/questions/file_full_return/edit.html.erb
@@ -14,11 +14,11 @@
     <% end %>
   </ul>
 
-  <%= link_to next_path, class: "button button--wide text--centered spacing-above-60 button--primary" do %>
+  <%= link_to next_path, class: "button button--full-width text--centered spacing-above-60 button--primary" do %>
     <%= t("views.ctc.questions.file_full_return.simplified_btn") %>
   <% end %>
 
-  <%= link_to url_for(host: Rails.application.config.gyr_domains[Rails.env.to_sym], controller: "/public_pages", action: 'diy'), class: "button button--wide text--centered" do %>
+  <%= link_to url_for(host: Rails.application.config.gyr_domains[Rails.env.to_sym], controller: "/public_pages", action: 'diy'), class: "button button--full-width text--centered" do %>
     <%= t("views.ctc.questions.file_full_return.full_btn") %>
   <% end %>
 <% end %>

--- a/app/views/ctc/questions/filed2019/edit.html.erb
+++ b/app/views/ctc/questions/filed2019/edit.html.erb
@@ -15,6 +15,8 @@
           ]
       )
   %>
-    <%= f.submit t("general.continue"), class: "button button--primary button--wide" %>
+    <div class="spacing-above-60">
+      <%= f.submit t("general.continue"), class: "button button--primary button--wide" %>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/ctc/questions/filed2020_yes/edit.html.erb
+++ b/app/views/ctc/questions/filed2020_yes/edit.html.erb
@@ -11,9 +11,13 @@
   <p>
     <%= t("views.ctc.questions.filed2020_yes.p2_html") %>
   </p>
-
-  <%= link_to t("views.ctc.questions.filed2020_yes.visit_ctc_faq"), root_path(anchor: 'ctc_faq'), class: "button button--wide text--centered" %>
-  <%= link_to url_for(host: Rails.application.config.gyr_domains[Rails.env.to_sym], controller: "/public_pages", action: 'stimulus'), class: "button button--wide text--centered" do %>
-    <%=t("views.ctc.questions.filed2020_yes.visit_stimulus_faq") %>
-  <% end %>
+  <p>
+    <%= t("views.ctc.questions.filed2020_yes.p3") %>
+  </p>
+  <div class="spacing-above-60">
+    <%= link_to t("views.ctc.questions.filed2020_yes.contact_vita"), url_for(host: Rails.application.config.gyr_domains[Rails.env.to_sym], controller: "/vita_providers", action: 'index'), class: "button button--full-width text--centered" %>
+    <%= link_to "https://www.taxpayeradvocate.irs.gov/contact-us/", target: "_blank", rel: "noopener nofollow", class: "button button--full-width text--centered" do %>
+      <%=t("views.ctc.questions.filed2020_yes.contact_ta") %>
+    <% end %>
+  </div>
 <% end %>

--- a/app/views/ctc/questions/life_situations2019/edit.html.erb
+++ b/app/views/ctc/questions/life_situations2019/edit.html.erb
@@ -20,6 +20,6 @@
   <%= link_to t("general.continue"), next_path, class: "button button--primary button--wide text--centered spacing-above-60" %>
   <%= link_to t("views.ctc.questions.life_situations2019.visit_ctc_faq"), root_path(anchor: 'ctc_faq'), class: "button button--wide text--centered" %>
   <%= link_to url_for(host: Rails.application.config.gyr_domains[Rails.env.to_sym], controller: "/public_pages", action: 'stimulus'), class: "button button--wide text--centered" do %>
-    <%=t("views.ctc.questions.filed2020_yes.visit_stimulus_faq") %>
+    <%=t("views.ctc.questions.life_situations2019.visit_stimulus_faq") %>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1474,10 +1474,15 @@ en:
               li5: "%{name} did not file jointly on a separate tax return"
           child_can_be_claimed_by_other:
             title: "Are you the only person who can claim %{name}?"
-            help_text: "You might say no if you share caregiving responsibilities with someone else."
+            help_text_html: |
+              <p>You might say no if you share caregiving responsibilities with someone else.</p>
+              <p>Keep in mind, if someone else has claimed %{name} and you claim them too, your return will be rejected</p>
+              <p>Think carefully about whether there is someone else who might have claimed them. If there could be someone else, select "No" and we'll help you decide whether you can claim %{name} or not.</p>
           claim_child_anyway:
             title: "Would you like to claim %{name} anyway?"
-            help_text: "If you and someone else are eligible to claim %{name}, you should follow any existing agreement with the other person about who claims them."
+            help_text_html: |
+              <p>If you and someone else are eligible to claim %{name}, you should follow any existing agreement with the other person about who claims them.</p>
+              <p>Remember, if someone else has already claimed %{name} your return will be rejected. If that happens, we can guide you through the process of appealing the other claim, but it's not easy. You may choose to check first with the other caregivers.</p>
             not_sure_reveal:
               title: "I’m unsure. Should I claim them?"
               p: "You should claim the dependent if one of these situations is true:"
@@ -1631,13 +1636,15 @@ en:
           title: Did you file a 2020 tax return this year?
           help_text_html: |
             <p>Did you file a tax return this year, after January 1, 2021, for the 2020 tax year?</p>
-            <p>Answer yes even if you are still waiting for your stimulus payments, or if you used the Non-filers Sign-Up Tool.</p>
+            <p>Answer yes even if you are still waiting for your stimulus payments, or if you used the Non-filers Sign-Up Tool. If you did, we'll give you more guidance about your options on the next page.</p>
+            <p class="text--bold">If you already filed a 2020 tax return, the return you file with this tool with be rejected by the IRS.</p>
         filed2020_yes:
-          title: Great! The IRS has the information they need to process your return.
-          p1: If you’ve filed a 2020 tax return, the IRS will have the information it needs to process your Child Tax Credit (CTC) and any stimulus payments.
-          p2_html: You can visit the <a href="https://www.irs.gov/credits-deductions/child-tax-credit-update-portal" target="_blank" rel="noopener noreferrer">IRS Child Tax Credit Update Portal</a> to check your CTC payment status. Visit <a href="https://www.irs.gov/coronavirus/get-my-payment" target="_blank" rel="noopener noreferrer">Get My Payment</a> to check your stimulus status.
-          visit_ctc_faq: Visit the Child Tax Credit FAQ
-          visit_stimulus_faq: Visit the Stimulus FAQ
+          title: Unfortunately, you can't use GetCTC.
+          p1: Like the IRS non-filer sign up tool, GetCTC helps you e-file a simplified 2020 tax return. If you've already filed a 2020 return, the IRS will reject this return without reviewing it, even if your first return was wrong or processed incorrectly.
+          p2_html: If the information on your 2020 return has changed and you want to update your CTC payments, you can use the IRS's <a href="https://www.irs.gov/credits-deductions/child-tax-credit-update-portal" target="_blank" rel="noopener noreferrer">CTC Update Portal</a>.
+          p3: If you think your 2020 return was never processed and you don't know what happened, you'll need direct assistance to help resolve your case. You can reach out to a Volunteer Income Tax Assistance (VITA) site or the Taxpayer Advocate Service.
+          contact_vita: Contact a VITA Site
+          contact_ta: Contact a Taxpayer Advocate
         filed2019:
           title: Did you file a 2019 tax return?
           help_text: Did you file a tax return for the 2019 tax year? This tax return would have originally been due on April 15, 2020.
@@ -1645,6 +1652,7 @@ en:
           filed_non_filer: Yes, I filed using the IRS non-filer portal
           did_not_file: No, I didn't file a 2019 tax return
         life_situations2019:
+          visit_stimulus_faq: "Visit Stimulus FAQ"
           title: Let’s make sure this tool is right for you!
           p1: |
             If any of the following are true, you should continue with our simplified tool:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1458,10 +1458,15 @@ es:
               li5: "%{name} conjuntamente una declaración de impuestos por separado"
           child_can_be_claimed_by_other:
             title: "¿Es usted la única persona que puede declarar a %{name}?"
-            help_text: "Puede decir que no si comparte las responsabilidades de cuidado con otra persona."
+            help_text_html: |
+              <p>Puede decir que no si comparte las responsabilidades de cuidado con otra persona.</p>
+              <p>Tenga en cuenta que si otra persona ha reclamado %{name} y usted también los reclama, su devolución será rechazada. Piense detenidamente si hay alguien más que pueda haberlos reclamado.</p>
+              <p>Si pudiera haber otra persona, seleccione "No" y lo ayudaremos a decidir si puede reclamar %{name} o no.</p>
           claim_child_anyway:
             title: "¿Le gustaría declarar a %{name} de todas maneras?"
-            help_text: "Si usted y otra persona tienen derecho a declarar a %{name}, debe seguir el acuerdo que tiene con la otra persona sobre quién lo declara."
+            help_text_html: |
+              <p>Si usted y otra persona tienen derecho a declarar a %{name}, debe seguir el acuerdo que tiene con la otra persona sobre quién lo declara.</p>
+              <p>Recuerde, si alguien más ya reclamó %{name}, su devolución será rechazada. Si eso sucede, podemos guiarlo a través del proceso de apelar el otro reclamo, pero no es fácil. Puede optar por consultar primero con los demás cuidadores.</p>
             not_sure_reveal:
               title: "No estoy seguro/a. ¿Debería declararlo/a?"
               p: "Debe declarar al dependiente si una de estas situaciones es válida:"
@@ -1616,20 +1621,23 @@ es:
           title: "¿Presentó su declaración de impuestos de 2020 este año?"
           help_text_html: |
             <p>Presentó una declaración de impuestos este año, después del 1o de enero de 2021, para el año fiscal 2020?</p>
-            <p>Conteste que sí, incluso si todavía está esperando los pagos del estímulo, o si utilizó la Herramienta de inscripción para No Declarantes.</p>
+            <p>Conteste que sí, incluso si todavía está esperando los pagos del estímulo, o si utilizó la Herramienta de inscripción para No Declarantes. Si lo hizo, le brindaremos más orientación sobre sus opciones en la página siguiente.</p>
+            <p class="text--bold">If you already filed a 2020 tax return, the return you file with this tool with be rejected by the IRS.</p>
         filed2020_yes:
           title: ¡Magnífico! El IRS tiene la información que necesita para procesar su declaración.
-          p1: "Si ha presentado una declaración de impuestos de 2020, el IRS tendrá la información que necesita para procesar su Crédito Fiscal por Hijos (CTC) y cualquier pago de estímulo."
-          p2_html: "Puede visitar el <a href=\"https://www.irs.gov/credits-deductions/child-tax-credit-update-portal\" target=\"_blank\" rel=\"noopener noreferrer\">Portal de Actualización del Crédito Fiscal por Hijos del IRS</a> para revisar el estado de su pago del CTC. Visite <a href=\"https://www.irs.gov/coronavirus/get-my-payment\" target=\"_blank\" rel=\"noopener noreferrer\">Get My Payment</a> para revisar el estado de su estímulo."
-          visit_ctc_faq: Visite las Preguntas Frecuentes sobre el Crédito Fiscal por Hijos
-          visit_stimulus_faq: Visite las Preguntas Frecuentes sobre el Estímulo
+          p1: Al igual que la herramienta de registro de no contribuyentes del IRS, GetCTC le ayuda a presentar electrónicamente una declaración de impuestos simplificada de 2020. Si ya presentó una declaración de 2020, el IRS rechazará esta declaración sin revisarla, incluso si su primera declaración fue incorrecta o se procesó incorrectamente.
+          p2_html: "Si la información de su declaración de 2020 ha cambiado y desea actualizar sus pagos de CTC, puede usar el <a href=\"https://www.irs.gov/credits-deductions/child-tax-credit-update-portal\" target=\"_blank\" rel=\"noopener noreferrer\">Portal de Actualización del Crédito Fiscal por Hijos del IRS</a>."
+          p3: Si cree que su declaración de 2020 nunca se procesó y no sabe qué sucedió, necesitará asistencia directa para ayudarlo a resolver su caso. Puede comunicarse con un sitio de Asistencia Voluntaria de Impuestos sobre la Renta (VITA) o con el Servicio de Defensa del Contribuyente.
+          contact_vita: Contactar un sitio de VITA
+          contact_ta: Contactar Defensores del Contribuyente
         filed2019:
           title: "¿Ha presentado la declaración de impuestos de 2019?"
-          help_text: "¿Presentó una declaración de impuestos después del 1 de enero de 2020 para el año fiscal 2019?"
+          help_text: "¿Presentó una declaración de impuestos para el año fiscal 2019? Esta declaración de impuestos se debió presentar originalmente el 15 de abril de 2020."
           filed_full: Sí, presenté una declaración completa
           filed_non_filer: Sí, presenté a través del portal de no contribuyentes del IRS
           did_not_file: No, no presenté una declaración de impuestos de 2019
         life_situations2019:
+          visit_stimulus_faq: Visita preguntas frecuentes sobre estímulos
           title: ¡Asegurémonos de que esta herramienta es la adecuada para usted!
           p1: |
             Si cualquiera de los siguientes puntos es válido, debe continuar con nuestra herramienta simplificada:


### PR DESCRIPTION
- Change all copy as requested in ticket
- Makes buttons full width on offboarding pages because buttons with two lines of text skeeve me out
- consistently titleizes dependent name for polish
- Fixes bug where "Add a new dependent" on dependent offboarding page used an old pattern.