### PR TITLE
Always show the tin/ssn page regardless of had_dependents

### DIFF
--- a/app/controllers/ctc/questions/dependents/tin_controller.rb
+++ b/app/controllers/ctc/questions/dependents/tin_controller.rb
@@ -8,7 +8,6 @@ module Ctc
 
         def self.show?(dependent)
           return false unless dependent&.relationship
-          return false unless dependent.intake.had_dependents_yes?
 
           dependent.qualifying_child_2020? || dependent.qualifying_relative_2020?
         end


### PR DESCRIPTION
See [this ticket](https://www.pivotaltracker.com/story/show/179349294) and [this thread](https://cfa.slack.com/archives/C02BZ51TB1S/p1629925717099600) for discussion

If you start to add a dependent and then go back and select "no" to had_dependents then we don't ask you for their SSN. That's wrong.

A better fix would be to move the ssn/itin info to the initial information page for dependents. That way we never make dependents without SSN/TINS. We can do that later. This should stop some of the occurrences of dependents without SSN/ITIN.