### PR TITLE
Stop removing Login Certificate line [#179291421]

### DIFF
--- a/spec/services/efile/gyr_efiler_service_spec.rb
+++ b/spec/services/efile/gyr_efiler_service_spec.rb
@@ -1,6 +1,12 @@
 require "rails_helper"
 
 RSpec.describe Efile::GyrEfilerService do
+  before do
+    # Skip preparing & downloading gyr-efiler since we mock `Process.spawn()` anyway.
+    allow(described_class).to receive(:ensure_config_dir_prepared)
+    allow(described_class).to receive(:ensure_gyr_efiler_downloaded).and_return("/tmp/hypothetical_classes.zip")
+  end
+
   describe ".run_efiler_command" do
     before do
       allow(EnvironmentCredentials).to receive(:dig).with(:irs, :app_sys_id).and_return "asystemidiguess"
@@ -8,7 +14,7 @@ RSpec.describe Efile::GyrEfilerService do
       allow(EnvironmentCredentials).to receive(:dig).with(:irs, :etin).and_return "electronictransmitteridentificationnarwhal"
     end
 
-    xcontext "success" do
+    context "success" do
       let(:zip_data) do
         buf = Zip::OutputStream.write_buffer do |zio|
           zio.put_next_entry("filename.txt")
@@ -37,11 +43,11 @@ RSpec.describe Efile::GyrEfilerService do
       end
     end
 
-    xcontext "command failure" do
+    context "command failure" do
       before do
         allow(Process).to receive(:spawn) do |_argv, chdir:, unsetenv_others:, in:|
           File.open("#{chdir}/output/log/audit_log.txt", 'wb') do |f|
-            f.write("Earlier line\nLogin Certificate: yikesdontsavethis\nLog output")
+            f.write("Earlier line\nLogin Certificate: blahBlahBlah\nLog output")
           end
 
           `false` # Run a command so that $? is set
@@ -52,10 +58,10 @@ RSpec.describe Efile::GyrEfilerService do
         allow(Process).to receive(:wait)
       end
 
-      it "raises an exception with the log output, with Login Certificate line removed" do
+      it "raises an exception with the log output" do
         expect {
           described_class.run_efiler_command
-        }.to raise_error(StandardError, "Earlier line\nLog output")
+        }.to raise_error(StandardError, "Earlier line\nLogin Certificate: blahBlahBlah\nLog output")
       end
     end
   end


### PR DESCRIPTION
## Why

In a previous commit d95d731491dc4992e4d7349d9035844c48fd790d , Jenny and I removed the `Login Certificate` log line since we were afraid it might contain the private key.

I've read the Java code more carefully, and I'm confident it doesn't, so let's leave it in.

The Java code in the SDK copies the `"BinarySecurityToken"` element of the SOAP request, and that's defined as "The binary security token contains the base64binary encoding of the X.509 certificate. This encoding includes the public key that the intended recipient of the SOAP message uses to verify the signature." at https://www.ibm.com/docs/en/cics-ts/5.4?topic=messages-example-signed-soap-message

It's better to make this simpler, so I just removed what we don't need.

While I was at it, I also tried to do the simplest refactor possible that would allow the tests we wrote to pass.