### PR TITLE
Fix migration file inconsistencies

### DIFF
--- a/db/migrate/20210726181149_rename_eip_payment_columns.rb
+++ b/db/migrate/20210726181149_rename_eip_payment_columns.rb
@@ -2,6 +2,5 @@ class RenameEipPaymentColumns < ActiveRecord::Migration[6.0]
   def change
     rename_column :intakes, :recovery_rebate_credit_amount_1, :eip1_amount_received
     rename_column :intakes, :recovery_rebate_credit_amount_2, :eip2_amount_received
-    rename_column :intakes, :recovery_rebate_credit_amount_confidence, :eip1_and_2_amount_received_confidence
   end
 end

--- a/db/migrate/20210726193720_update_military_column_names.rb
+++ b/db/migrate/20210726193720_update_military_column_names.rb
@@ -1,7 +1,6 @@
 class UpdateMilitaryColumnNames < ActiveRecord::Migration[6.0]
   def change
     rename_column :intakes, :primary_member_of_the_armed_forces, :primary_active_armed_forces
-    rename_column :intakes, :spouse_veteran, :spouse_active_armed_forces
     rename_column :intakes, :tin_type, :primary_tin_type
   end
 end


### PR DESCRIPTION
When doing `db:drop db:create db:migrate` these migrations fail on a clean db fill because of changes made to previous migration files 😬 . I generally don't think we should make it a habit to make changes to migration files like this, but because we made changes to PREVIOUS migration files, we're kind of in a pickle.


