### PR TITLE
Hub emails to CTC clients use the subject "Update from GetCTC"

### DIFF
--- a/app/services/client_messaging_service.rb
+++ b/app/services/client_messaging_service.rb
@@ -4,10 +4,15 @@ class ClientMessagingService
       applied_locale = locale || client.intake.locale
       replacement_args = { body: body, client: client, preparer: user, tax_return: tax_return, locale: applied_locale }
       replaced_body = ReplacementParametersService.new(**replacement_args).process
+
+      service_type = client.intake.is_ctc? ? :ctc : :gyr
+      service = MultiTenantService.new(service_type)
+      subject ||= I18n.t("messages.default_subject_with_service_name", service_name: service.service_name, locale: applied_locale)
+
       OutgoingEmail.create!(
         to: to || client.email_address,
         body: replaced_body,
-        subject: subject || I18n.t("messages.default_subject", locale: applied_locale),
+        subject: subject,
         client: client,
         user: user,
         attachment: attachment,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1073,7 +1073,6 @@ en:
         sent_at: Sent at %{datetime}
       title: Invitations
   messages:
-    default_subject: Update from GetYourRefund
     default_subject_with_service_name: Update from %{service_name}
     sms_opt_in: Welcome to GetYourRefund messages. Msg&data rates may apply.  Msg freq varies. Reply HELP for subscription/privacy info, STOP to stop.
     ctc_sms_opt_in: Welcome to GetCTC messages. Msg&data rates may apply. Msg freq varies. Reply HELP for subscription/privacy info, STOP to stop.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1063,7 +1063,6 @@ es:
         sent_at: Enviado a las %{datetime}
       title: Invitaciones
   messages:
-    default_subject: Actualización de GetYourRefund
     default_subject_with_service_name: Actualización de %{service_name}
     sms_opt_in: Welcome to GetYourRefund messages. Msg&data rates may apply.  Msg freq varies. Reply HELP for subscription/privacy info, STOP to stop.
     ctc_sms_opt_in: Welcome to GetCTC messages. Msg&data rates may apply. Msg freq varies. Reply HELP for subscription/privacy info, STOP to stop.

--- a/spec/services/client_messaging_service_spec.rb
+++ b/spec/services/client_messaging_service_spec.rb
@@ -35,6 +35,19 @@ RSpec.describe ClientMessagingService do
         expect(ClientChannel).to have_received(:broadcast_contact_record).with(outgoing_email)
       end
 
+      context "for a CTC intake" do
+        let(:intake) { create :ctc_intake, email_address: "client@example.com", sms_phone_number: "+14155551212" }
+
+        it "uses the default CTC subject" do
+          expect do
+            described_class.send_email(client: client, user: user, body: "hello, <<Client.PreferredName>>")
+          end.to change(OutgoingEmail, :count).by(1).and have_enqueued_job(SendOutgoingEmailJob)
+
+          outgoing_email = OutgoingEmail.last
+          expect(outgoing_email.subject).to eq("Update from GetCTC")
+        end
+      end
+
       context "with blank body" do
         it "raises an error" do
           expect do


### PR DESCRIPTION
previously it always said "Update from GetYourRefund regardless of status"

Co-authored-by: Catie Talbot <ctalbot@codeforamerica.org>