### PR TITLE
Update gem for M1 chip compatibility 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'puma', '>= 5.3.2'
 gem 'sass-rails', '~> 5.0'
 gem 'cfa-styleguide', git: 'https://github.com/codeforamerica/honeycrisp-gem', branch: 'main'
 # See https://github.com/rails/execjs#readme for more supported runtimes
-gem 'mini_racer', '0.4.0', platforms: :ruby
+gem 'mini_racer', '~> 0.4.0', platforms: :ruby
 gem 'nokogiri', '>= 1.10.8'
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -600,7 +600,7 @@ DEPENDENCIES
   lograge
   mailgun-ruby
   memory_profiler
-  mini_racer (= 0.4.0)
+  mini_racer (~> 0.4.0)
   mixpanel-ruby
   nokogiri (>= 1.10.8)
   parallel_tests


### PR DESCRIPTION
In Gemfile updated mini-racer to use libv8-node to be able to run on M1 computers.