### PR TITLE
Remove miniracer gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,6 @@ gem 'rails', '>= 6.0.3.7'
 gem 'puma', '>= 5.3.2'
 gem 'sass-rails', '~> 5.0'
 gem 'cfa-styleguide', git: 'https://github.com/codeforamerica/honeycrisp-gem', branch: 'main'
-# See https://github.com/rails/execjs#readme for more supported runtimes
-gem 'mini_racer', platforms: :ruby
 gem 'nokogiri', '>= 1.10.8'
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,7 +264,6 @@ GEM
       addressable (~> 2.7)
     letter_opener (1.7.0)
       launchy (~> 2.2)
-    libv8 (8.4.255.0)
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -290,8 +289,6 @@ GEM
     mini_magick (4.11.0)
     mini_mime (1.1.0)
     mini_portile2 (2.5.3)
-    mini_racer (0.3.1)
-      libv8 (~> 8.4.255)
     minitest (5.14.4)
     mixpanel-ruby (2.2.2)
     msgpack (1.3.3)
@@ -600,7 +597,6 @@ DEPENDENCIES
   lograge
   mailgun-ruby
   memory_profiler
-  mini_racer
   mixpanel-ruby
   nokogiri (>= 1.10.8)
   parallel_tests


### PR DESCRIPTION
As far as I know, in most cases when Rails wants to do something javascripty
it can just hunt around on your computer for a JS runtime (usually node)
so it's easier to do that than specifying some other (possibly old)
JS runtime installed with a gem.