### PR TITLE
CTC portal editing: allow IP PIN for primary, spouse, and dependent to be added even if blank

### DIFF
--- a/app/forms/ctc/portal/dependent_form.rb
+++ b/app/forms/ctc/portal/dependent_form.rb
@@ -28,11 +28,12 @@ module Ctc
 
       validates :ssn, social_security_number: true, if: -> { tin_type == "ssn" && ssn.present? }
 
-      validates :ip_pin, presence: true, ip_pin: true, if: -> { @dependent.has_ip_pin_yes? }
+      validates :ip_pin, ip_pin: true, if: -> { ip_pin.present? }
 
       def save
         @dependent.assign_attributes(attributes_for(:dependent).merge(
-          birth_date: birth_date
+          birth_date: birth_date,
+          has_ip_pin: ip_pin.present? ? "yes" : "no"
         ))
         @dependent.save!
       end

--- a/app/forms/ctc/portal/primary_filer_form.rb
+++ b/app/forms/ctc/portal/primary_filer_form.rb
@@ -12,7 +12,14 @@ module Ctc
       set_attributes_for :birthday, :primary_birth_date_month, :primary_birth_date_day, :primary_birth_date_year
       set_attributes_for :confirmation, :primary_ssn_confirmation
 
-      validates :primary_ip_pin, presence: true, ip_pin: true, if: -> { @intake.has_primary_ip_pin_yes? }
+      validates :primary_ip_pin, ip_pin: true, if: -> { primary_ip_pin.present? }
+
+      def save
+        @intake.assign_attributes(
+          has_primary_ip_pin: primary_ip_pin.present? ? "yes" : "no"
+        )
+        super
+      end
     end
   end
 end

--- a/app/forms/ctc/portal/spouse_form.rb
+++ b/app/forms/ctc/portal/spouse_form.rb
@@ -12,7 +12,14 @@ module Ctc
       set_attributes_for :birthday, :spouse_birth_date_month, :spouse_birth_date_day, :spouse_birth_date_year
       set_attributes_for :confirmation, :spouse_ssn_confirmation
 
-      validates :primary_ip_pin, presence: true, ip_pin: true, if: -> { @intake.has_spouse_ip_pin_yes? }
+      validates :spouse_ip_pin, ip_pin: true, if: -> { spouse_ip_pin.present? }
+
+      def save
+        @intake.assign_attributes(
+          has_spouse_ip_pin: spouse_ip_pin.present? ? "yes" : "no"
+        )
+        super
+      end
     end
   end
 end

--- a/app/views/ctc/portal/dependents/edit.html.erb
+++ b/app/views/ctc/portal/dependents/edit.html.erb
@@ -25,9 +25,7 @@
           <%= f.cfa_select(:tin_type, t("views.ctc.questions.dependents.tin.form_of_identity", name: @form.dependent.first_name), tin_options_for_select(include_atin: true)) %>
           <%= f.cfa_input_field(:ssn, t("views.ctc.questions.dependents.tin.ssn_or_atin", name: @form.dependent.first_name), classes: ["form-width--long"]) %>
           <%= f.cfa_input_field(:ssn_confirmation, t("views.ctc.questions.dependents.tin.ssn_or_atin_confirmation", name: @form.dependent.first_name), classes: ["form-width--long"]) %>
-          <% if @form.dependent.has_ip_pin_yes? %>
-            <%= f.cfa_input_field(:ip_pin, t("views.ctc.questions.ip_pin_entry.label", name: @form.dependent.first_name), classes: ["form-width--long"]) %>
-          <% end %>
+          <%= f.cfa_input_field(:ip_pin, t("views.ctc.questions.ip_pin_entry.label", name: @form.dependent.first_name), classes: ["form-width--long"]) %>
         </div>
 
         <button class="button button--primary button--wide" type="submit">

--- a/app/views/ctc/portal/primary_filer/edit.html.erb
+++ b/app/views/ctc/portal/primary_filer/edit.html.erb
@@ -29,9 +29,7 @@
           <%= f.cfa_select(:primary_tin_type, t('views.ctc.portal.primary_filer.form_of_identity'), tin_options_for_select(include_itin: true), help_text: t('views.ctc.portal.primary_filer.form_of_identity_note')) %>
           <%= f.cfa_input_field(:primary_ssn, t("views.ctc.questions.legal_consent.ssn"), classes: ["form-width--long"]) %>
           <%= f.cfa_input_field(:primary_ssn_confirmation, t("views.ctc.questions.legal_consent.ssn_confirmation"), classes: ["form-width--long"]) %>
-          <% if current_intake.has_primary_ip_pin_yes? %>
-            <%= f.cfa_input_field(:primary_ip_pin, t("views.ctc.questions.ip_pin_entry.label", name: current_intake.primary_full_name), type: "tel", classes: ["form-width--long"]) %>
-          <% end %>
+          <%= f.cfa_input_field(:primary_ip_pin, t("views.ctc.questions.ip_pin_entry.label", name: current_intake.primary_full_name), type: "tel", classes: ["form-width--long"]) %>
         </div>
 
         <button class="button button--primary button--wide" type="submit">

--- a/app/views/ctc/portal/spouse/edit.html.erb
+++ b/app/views/ctc/portal/spouse/edit.html.erb
@@ -23,9 +23,7 @@
       <%= f.cfa_checkbox(:ssn_no_employment, t('views.ctc.questions.legal_consent.ssn_not_valid_for_employment'), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_input_field(:spouse_ssn, t("views.ctc.questions.spouse_info.spouse_ssn_itin"), classes: ["form-width--long"]) %>
       <%= f.cfa_input_field(:spouse_ssn_confirmation, t("views.ctc.questions.spouse_info.spouse_ssn_itin_confirmation"), classes: ["form-width--long"]) %>
-      <% if current_intake.has_spouse_ip_pin_yes? %>
-        <%= f.cfa_input_field(:spouse_ip_pin, t("views.ctc.questions.ip_pin_entry.label", name: current_intake.spouse_full_name), type: "tel", classes: ["form-width--long"]) %>
-      <% end %>
+      <%= f.cfa_input_field(:spouse_ip_pin, t("views.ctc.questions.ip_pin_entry.label", name: current_intake.spouse_full_name), type: "tel", classes: ["form-width--long"]) %>
     </div>
 
     <button class="button button--primary button--wide spacing-below-15" type="submit">

--- a/spec/controllers/ctc/portal/dependents_controller_spec.rb
+++ b/spec/controllers/ctc/portal/dependents_controller_spec.rb
@@ -12,7 +12,8 @@ describe Ctc::Portal::DependentsController do
         last_name: "Mango",
         birth_date: Date.parse("2012-05-01"),
         tin_type: "ssn",
-        ssn: '111-22-9999'
+        ssn: '111-22-9999',
+        has_ip_pin: "no"
       )
     end
 
@@ -47,6 +48,16 @@ describe Ctc::Portal::DependentsController do
       expect do
         put :update, params: params
       end.not_to change(SystemNote::CtcPortalUpdate, :count)
+    end
+
+    it "changes has_ip_pin if an ip pin is provided" do
+      params[:ctc_portal_dependent_form].merge!(
+        ip_pin: '123456',
+      )
+      expect do
+        put :update, params: params
+      end.to change { dependent.reload.has_ip_pin }.from("no").to("yes")
+      expect(dependent.ip_pin).to eq('123456')
     end
 
     context "when there are changes of note" do

--- a/spec/controllers/ctc/portal/primary_filer_controller_spec.rb
+++ b/spec/controllers/ctc/portal/primary_filer_controller_spec.rb
@@ -10,7 +10,8 @@ describe Ctc::Portal::PrimaryFilerController do
              primary_birth_date: Date.parse("1963-09-10"),
              primary_ssn: "111-22-8888",
              primary_last_four_ssn: "8888",
-             primary_tin_type: "ssn"
+             primary_tin_type: "ssn",
+             has_primary_ip_pin: "no"
     end
 
     let(:params) {
@@ -37,6 +38,16 @@ describe Ctc::Portal::PrimaryFilerController do
       expect do
         put :update, params: params
       end.not_to change(SystemNote::CtcPortalUpdate, :count)
+    end
+
+    it "changes has_primary_ip_pin if an ip pin is provided" do
+      params[:ctc_portal_primary_filer_form].merge!(
+        primary_ip_pin: '123456',
+      )
+      expect do
+        put :update, params: params
+      end.to change { intake.reload.has_primary_ip_pin }.from("no").to("yes")
+      expect(intake.primary_ip_pin).to eq('123456')
     end
 
     context "when there are changes of note" do

--- a/spec/controllers/ctc/portal/spouse_controller_spec.rb
+++ b/spec/controllers/ctc/portal/spouse_controller_spec.rb
@@ -10,7 +10,8 @@ describe Ctc::Portal::SpouseController do
              spouse_birth_date: Date.parse("1963-09-10"),
              spouse_ssn: "111-22-8888",
              spouse_last_four_ssn: "8888",
-             spouse_tin_type: "ssn"
+             spouse_tin_type: "ssn",
+             has_spouse_ip_pin: "no"
     end
 
     let(:params) {
@@ -37,6 +38,16 @@ describe Ctc::Portal::SpouseController do
       expect do
         put :update, params: params
       end.not_to change(SystemNote::CtcPortalUpdate, :count)
+    end
+
+    it "changes has_spouse_ip_pin if an ip pin is provided" do
+      params[:ctc_portal_spouse_form].merge!(
+        spouse_ip_pin: '123456',
+      )
+      expect do
+        put :update, params: params
+      end.to change { intake.reload.has_spouse_ip_pin }.from("no").to("yes")
+      expect(intake.spouse_ip_pin).to eq('123456')
     end
 
     context "when there are changes of note" do


### PR DESCRIPTION
tries to keep `has_ip_pin` fields up to date, for whatever it's worth