### PR TITLE
Replace &nbsp; with empty div

### DIFF
--- a/app/views/public_pages/maintenance.html.erb
+++ b/app/views/public_pages/maintenance.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, t("views.ctc.questions.at_capacity.title") %>
 <% content_for :header do %>
-  <div></div>
+  <%= render 'shared/header', title: "GetCTC", home_link: ctc_root_path %>
 <% end %>
 <% content_for :footer do %>
   <footer class="footer">
@@ -18,7 +18,6 @@
       </div>
     </div>
   </footer>
-
 <% end %>
 
 <main role="main">

--- a/app/views/public_pages/maintenance.html.erb
+++ b/app/views/public_pages/maintenance.html.erb
@@ -1,5 +1,7 @@
 <% content_for :page_title, t("views.ctc.questions.at_capacity.title") %>
-<% content_for :header, "&nbsp;" %>
+<% content_for :header do %>
+  <div></div>
+<% end %>
 <% content_for :footer do %>
   <footer class="footer">
     <div class="slab slab--footer">


### PR DESCRIPTION
the profiler strikes again! i think we didn't notice there was a visible "\&nbsp;" because it was blocked

this is what demo looks like:
![image](https://user-images.githubusercontent.com/43800769/131197371-f5f9e251-c986-4a2f-8fd9-0a18f8cc9f1b.png)

with this change it looks like:
![image](https://user-images.githubusercontent.com/43800769/131197388-c81aec55-a11b-41b6-b464-dc1a7b47fd84.png)

but the empty div feels janky, please lmk if you have other ideas