### PR TITLE
Hub: ClientChange system notes now use the new table formatting from CTC portal notes

### DIFF
--- a/app/controllers/hub/clients_controller.rb
+++ b/app/controllers/hub/clients_controller.rb
@@ -55,10 +55,11 @@ module Hub
     end
 
     def update
+      original_intake = @client.intake.dup
       @form = UpdateClientForm.new(@client, update_client_form_params)
 
       if @form.valid? && @form.save
-        SystemNote::ClientChange.generate!(initiated_by: current_user, intake: @client.intake)
+        SystemNote::ClientChange.generate!(initiated_by: current_user, original_intake: original_intake, intake: @client.intake)
         redirect_to hub_client_path(id: @client.id)
       else
         flash[:alert] = I18n.t("forms.errors.general")

--- a/app/controllers/hub/ctc_clients_controller.rb
+++ b/app/controllers/hub/ctc_clients_controller.rb
@@ -38,10 +38,11 @@ module Hub
 
     def update
       @client = Client.find(params[:id])
+      original_intake = @client.intake.dup
       @form = UpdateCtcClientForm.new(@client, update_client_form_params)
 
       if @form.valid? && @form.save
-        SystemNote::ClientChange.generate!(initiated_by: current_user, intake: @client.intake)
+        SystemNote::ClientChange.generate!(initiated_by: current_user, original_intake: original_intake, intake: @client.intake)
         if @client.tax_returns.last.service_type_online_intake?
           send_email_change_notification if @client.intake.saved_change_to_email_address?
           send_sms_change_notification if @client.intake.saved_change_to_sms_phone_number?

--- a/app/forms/concerns/ctc_client_form_attributes.rb
+++ b/app/forms/concerns/ctc_client_form_attributes.rb
@@ -1,0 +1,48 @@
+module CtcClientFormAttributes
+  extend ActiveSupport::Concern
+
+  def reduce_dirty_attributes(intake, attributes)
+    # For boolean columns that have a default(FALSE) but no 'not null'.
+    # Since these checkboxes sometimes don't appear on the form,
+    # the value from `params` might be nil, which we don't want to go
+    # into the database.
+    # Ensure that we write 'false' on create but retain any existing
+    # value on update.
+    %i(
+      with_general_navigator
+      with_incarcerated_navigator
+      with_limited_english_navigator
+      with_unhoused_navigator
+      with_drivers_license_photo_id
+      with_itin_taxpayer_id
+      with_other_state_photo_id
+      with_passport_photo_id
+      with_social_security_taxpayer_id
+      with_vita_approved_photo_id
+      with_vita_approved_taxpayer_id
+    ).each do |column|
+      if intake&.persisted?
+        attributes[column] ||= intake.send(column)
+      else
+        attributes[column] ||= false
+      end
+    end
+
+    # sms_notification_opt_in will often come in "unfilled" during intake
+    # and we don't want the valet form to flip it to "no" unnecessarily
+    %i(
+      email_notification_opt_in
+      sms_notification_opt_in
+    ).each do |column|
+      if intake&.persisted? && attributes[column] != "yes"
+        attributes[column] = intake.send(column)
+      end
+    end
+
+    # use_spouse_name_for_name_control should treat `nil` and `false` as equivalent
+    # unless we ever make it default(FALSE) and clear out all the nils
+    if intake&.persisted? && attributes[:use_spouse_name_for_name_control] != "true"
+      attributes[:use_spouse_name_for_name_control] = intake.use_spouse_name_for_name_control
+    end
+  end
+end

--- a/app/forms/hub/create_ctc_client_form.rb
+++ b/app/forms/hub/create_ctc_client_form.rb
@@ -1,6 +1,7 @@
 module Hub
   class CreateCtcClientForm < ClientForm
     include BirthDateHelper
+    include CtcClientFormAttributes
     set_attributes_for :intake,
                        :primary_first_name,
                        :primary_last_name,
@@ -123,6 +124,7 @@ module Hub
                         visitor_id: SecureRandom.hex(26)
                       )
         intake_attr[:bank_account_attributes] = attributes_for(:bank_account) if refund_payment_method == "direct_deposit"
+        reduce_dirty_attributes(nil, intake_attr)
         @client = Client.create!(
           vita_partner_id: attributes_for(:intake)[:vita_partner_id],
           intake_attributes: intake_attr,

--- a/app/forms/hub/update_client_form.rb
+++ b/app/forms/hub/update_client_form.rb
@@ -42,8 +42,6 @@ module Hub
     def initialize(client, params = {})
       @client = client
       super(params)
-      # parent Form class creates setters for each attribute -- won't work til super is called!
-      self.preferred_name = preferred_name.presence || "#{primary_first_name} #{primary_last_name}"
     end
 
     def self.existing_attributes(intake)

--- a/app/forms/hub/update_ctc_client_form.rb
+++ b/app/forms/hub/update_ctc_client_form.rb
@@ -1,6 +1,7 @@
 module Hub
   class UpdateCtcClientForm < ClientForm
     include BirthDateHelper
+    include CtcClientFormAttributes
     set_attributes_for :intake,
                        :primary_first_name,
                        :primary_last_name,
@@ -76,8 +77,6 @@ module Hub
     def initialize(client, params = {})
       @client = client
       super(params)
-      # parent Form class creates setters for each attribute -- won't work til super is called!
-      self.preferred_name = preferred_name.presence || "#{primary_first_name} #{primary_last_name}"
     end
 
     def self.existing_attributes(intake, attribute_keys)
@@ -126,6 +125,7 @@ module Hub
                          dependents_attributes: formatted_dependents_attributes,
                          primary_birth_date: parse_birth_date_params(primary_birth_date_year, primary_birth_date_month, primary_birth_date_day),
                          spouse_birth_date: parse_birth_date_params(spouse_birth_date_year, spouse_birth_date_month, spouse_birth_date_day))
+      reduce_dirty_attributes(@client.intake, intake_attr)
       @client.intake.update(intake_attr)
       # only updates the last tax return because we assume that a CTC client only has a single tax return
       @client.tax_returns.last.update(attributes_for(:tax_return))

--- a/app/lib/interesting_change_arbiter.rb
+++ b/app/lib/interesting_change_arbiter.rb
@@ -1,0 +1,38 @@
+class InterestingChangeArbiter
+  def self.determine_changes(original_model, model)
+    interesting_changes = model.saved_changes.reject do |k, v|
+      k == "updated_at" ||
+        k == "needs_to_flush_searchable_data_set_at" ||
+        encrypted_columns(model).include?(k)
+    end
+
+    # attr_encrypted fields do not correctly report whether they have changed in
+    # saved_changes; the `encrypted_` fields always look like they have changed,
+    # and the old values of the decrypted accessor methods (`ssn_was`, etc)
+    # is always nil, possibly because of this issue:
+    # https://github.com/attr-encrypted/attr_encrypted/pull/337
+    # To work around this, we keep the original model and compare any attr_encrypted
+    # fields manually
+    if encrypted_columns(model).present?
+      encrypted_column_accessors(model).each do |encrypted_column_accessor|
+        if original_model.send(encrypted_column_accessor) != model.send(encrypted_column_accessor)
+          interesting_changes[encrypted_column_accessor.to_s] = ["[REDACTED]", "[REDACTED]"]
+        else
+          interesting_changes.delete(encrypted_column_accessor.to_s)
+        end
+      end
+    end
+
+    interesting_changes
+  end
+
+  def self.encrypted_column_accessors(model)
+    encrypted_columns(model).reject { |column| column.ends_with?('_iv') }.map { |column| column.sub(/^encrypted_/, '').to_sym }
+  end
+  private_class_method :encrypted_column_accessors
+
+  def self.encrypted_columns(model)
+    model.saved_changes.keys.select { |k| k.start_with?("encrypted_") }
+  end
+  private_class_method :encrypted_columns
+end

--- a/app/models/system_note/client_change.rb
+++ b/app/models/system_note/client_change.rb
@@ -22,23 +22,17 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class SystemNote::ClientChange < SystemNote
-  def self.generate!(intake:, initiated_by: )
-    return unless intake.saved_changes.present?
+  def self.generate!(original_intake:, intake:, initiated_by: )
+    interesting_changes = InterestingChangeArbiter.determine_changes(original_intake, intake)
+    return unless interesting_changes.present?
 
-    changes_list = ""
-    intake.saved_changes.each do |k, v|
-      next if k == "updated_at"
-      next if k == "needs_to_flush_searchable_data_set_at"
-      next if k.include?("encrypted")
-
-      changes_list += "\n\u2022 #{k.tr('_', ' ')} from #{v[0]} to #{v[1]}"
-    end
-    if changes_list.present?
-      create!(
-        body: "#{initiated_by.name} changed: #{changes_list}",
-        client: intake.client,
-        user: initiated_by
-      )
-    end
+    create!(
+      data: {
+        model: intake.to_global_id.to_s,
+        changes: interesting_changes
+      },
+      client: intake.client,
+      user: initiated_by
+    )
   end
 end

--- a/app/models/system_note/ctc_portal_update.rb
+++ b/app/models/system_note/ctc_portal_update.rb
@@ -23,29 +23,7 @@
 #
 class SystemNote::CtcPortalUpdate < SystemNote
   def self.generate!(original_model:, model:, client:)
-    interesting_changes = model.saved_changes.reject do |k, v|
-      k == "updated_at" ||
-        k == "needs_to_flush_searchable_data_set_at" ||
-        encrypted_columns(model).include?(k)
-    end
-
-    # attr_encrypted fields do not correctly report whether they have changed in
-    # saved_changes; the `encrypted_` fields always look like they have changed,
-    # and the old values of the decrypted accessor methods (`ssn_was`, etc)
-    # is always nil, possibly because of this issue:
-    # https://github.com/attr-encrypted/attr_encrypted/pull/337
-    # To work around this, we keep the original model and compare any attr_encrypted
-    # fields manually
-    if encrypted_columns(model).present?
-      encrypted_column_accessors(model).each do |encrypted_column_accessor|
-        if original_model.send(encrypted_column_accessor) != model.send(encrypted_column_accessor)
-          interesting_changes[encrypted_column_accessor.to_s] = ["[REDACTED]", "[REDACTED]"]
-        else
-          interesting_changes.delete(encrypted_column_accessor.to_s)
-        end
-      end
-    end
-
+    interesting_changes = InterestingChangeArbiter.determine_changes(original_model, model)
     return unless interesting_changes.present?
 
     create!(
@@ -55,15 +33,5 @@ class SystemNote::CtcPortalUpdate < SystemNote
       },
       client: client
     )
-  end
-
-  private
-
-  def self.encrypted_column_accessors(model)
-    encrypted_columns(model).reject { |column| column.ends_with?('_iv') }.map { |column| column.sub(/^encrypted_/, '').to_sym }
-  end
-
-  def self.encrypted_columns(model)
-    model.saved_changes.keys.select { |k| k.start_with?("encrypted_") }
   end
 end

--- a/app/views/hub/notes/_note.html.erb
+++ b/app/views/hub/notes/_note.html.erb
@@ -13,8 +13,8 @@
       <%= render "system_note_document_help", note: note %>
     <% elsif note.is_a? SystemNote::CtcPortalAction %>
       <%= render "system_note_ctc_portal_action", note: note %>
-    <% elsif note.is_a? SystemNote::CtcPortalUpdate %>
-      <%= render "system_note_ctc_portal_update", note: note %>
+    <% elsif note.is_a?(SystemNote::CtcPortalUpdate) || (note.is_a?(SystemNote::ClientChange) && note.data.present?) %>
+      <%= render "system_note_model_update", note: note %>
     <% else %>
       <%= format_text(note.body) %>
     <% end %>

--- a/app/views/hub/notes/_system_note_model_update.erb
+++ b/app/views/hub/notes/_system_note_model_update.erb
@@ -1,5 +1,9 @@
 <% model_gid = GlobalID.parse(note.data['model']) %>
-<strong>Client updated <%= model_gid.model_name %> #<%= model_gid.model_id %>:</strong>
+<% if note.is_a?(SystemNote::CtcPortalUpdate) %>
+  <strong>Client updated <%= model_gid.model_name %> #<%= model_gid.model_id %>:</strong>
+<% elsif note.is_a?(SystemNote::ClientChange) %>
+  <strong><%= note.user.name %> changed <%= model_gid.model_name %> #<%= model_gid.model_id %>:</strong>
+<% end %>
 
 <table class="spacing-above-15 spacing-below-0 changes-table">
   <thead>

--- a/spec/controllers/hub/ctc_clients_controller_spec.rb
+++ b/spec/controllers/hub/ctc_clients_controller_spec.rb
@@ -280,16 +280,7 @@ RSpec.describe Hub::CtcClientsController do
           "spouse_email_address" => ["eva@hesse.com", "san@diego.com"],
           "spouse_last_four_ssn" => ["[REDACTED]", "[REDACTED]"],
           "primary_last_four_ssn" => ["[REDACTED]", "[REDACTED]"],
-          "with_general_navigator" => [false, nil],
-          "with_unhoused_navigator" => [false, nil],
-          "with_other_state_photo_id" => [false, nil],
-          "with_incarcerated_navigator" => [false, nil],
-          "with_vita_approved_photo_id" => [false, nil],
           "preferred_interview_language" => ["en", nil],
-          "with_drivers_license_photo_id" => [false, nil],
-          "with_limited_english_navigator" => [false, nil],
-          "with_vita_approved_taxpayer_id" => [false, nil],
-          "with_social_security_taxpayer_id" => [false, nil]
         })
       end
 

--- a/spec/controllers/hub/ctc_clients_controller_spec.rb
+++ b/spec/controllers/hub/ctc_clients_controller_spec.rb
@@ -245,7 +245,6 @@ RSpec.describe Hub::CtcClientsController do
 
       before do
         sign_in user
-        allow(SystemNote::ClientChange).to receive(:generate!)
       end
 
       it "updates the clients intake and creates a system note" do
@@ -263,7 +262,35 @@ RSpec.describe Hub::CtcClientsController do
         expect(first_dependent.reload.first_name).to eq "Updated Dependent"
         expect(client.intake.dependents.count).to eq 1
         expect(response).to redirect_to hub_client_path(id: client.id)
-        expect(SystemNote::ClientChange).to have_received(:generate!).with(initiated_by: user, intake: intake)
+
+        system_note = SystemNote::ClientChange.last
+        expect(system_note.client).to eq(client)
+        expect(system_note.user).to eq(user)
+        expect(system_note.data['changes']).to match({
+          "spouse_ssn" => ["[REDACTED]", "[REDACTED]"],
+          "primary_ssn" => ["[REDACTED]", "[REDACTED]"],
+          "email_address" => ["cher@example.com", "san@mateo.com"],
+          "primary_tin_type" => ["ssn", nil],
+          "spouse_last_name" => ["Hesse", "Diego"],
+          "primary_last_name" => ["Cherimoya", "Mateo"],
+          "spouse_birth_date" => ["1929-09-02", "1980-01-11"],
+          "spouse_first_name" => ["Eva", "San"],
+          "primary_first_name" => ["Cher", "San"],
+          "eip1_amount_received" => [1000, 9000],
+          "spouse_email_address" => ["eva@hesse.com", "san@diego.com"],
+          "spouse_last_four_ssn" => ["[REDACTED]", "[REDACTED]"],
+          "primary_last_four_ssn" => ["[REDACTED]", "[REDACTED]"],
+          "with_general_navigator" => [false, nil],
+          "with_unhoused_navigator" => [false, nil],
+          "with_other_state_photo_id" => [false, nil],
+          "with_incarcerated_navigator" => [false, nil],
+          "with_vita_approved_photo_id" => [false, nil],
+          "preferred_interview_language" => ["en", nil],
+          "with_drivers_license_photo_id" => [false, nil],
+          "with_limited_english_navigator" => [false, nil],
+          "with_vita_approved_taxpayer_id" => [false, nil],
+          "with_social_security_taxpayer_id" => [false, nil]
+        })
       end
 
       context "when the client's email address has changed" do

--- a/spec/features/ctc/complete_intake_spec.rb
+++ b/spec/features/ctc/complete_intake_spec.rb
@@ -1,13 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "CTC Intake", :flow_explorer_screenshot_i18n_friendly, active_job: true do
-  def strip_inner_newlines(text)
-    text.gsub(/\n/, '')
-  end
-
-  def strip_html_tags(text)
-    ActionController::Base.helpers.strip_tags(text)
-  end
+  include FeatureTestHelpers
 
   before do
     allow_any_instance_of(Routes::CtcDomain).to receive(:matches?).and_return(true)
@@ -337,6 +331,33 @@ RSpec.feature "CTC Intake", :flow_explorer_screenshot_i18n_friendly, active_job:
     # =========== PORTAL ===========
     expect(page).to have_selector("h1", text: I18n.t("views.ctc.portal.home.title"))
     expect(page).to have_text(I18n.t("views.ctc.portal.home.status.preparing.label"))
+
+    # ========= ADMIN HUB EDITING ======
+    # Prove that making a simple edit in the hub to an intake that was
+    # created in the normal flow only shows a minimal amount
+    # of changes in the SystemNote
+    Capybara.current_session.reset!
+
+    allow_any_instance_of(Routes::CtcDomain).to receive(:matches?).and_return(false)
+    login_as create :admin_user
+
+    visit hub_client_path(id: Client.last.id)
+    within ".client-profile" do
+      click_on "Edit"
+    end
+
+    within "#primary-info" do
+      fill_in "Legal first name", with: "Garnet"
+      fill_in "Preferred full name", with: "Garnet Mango"
+    end
+
+    click_on "Save"
+    click_on "Notes"
+
+    expect(changes_table_contents('.changes-table')).to match({
+      "preferred_name" => ["nil", "Garnet Mango"],
+      "primary_first_name" => ["Gary", "Garnet"],
+    })
   end
 
   scenario "client who has filed in 2019" do

--- a/spec/features/ctc/ctc_intake_offboard_duplicates_spec.rb
+++ b/spec/features/ctc/ctc_intake_offboard_duplicates_spec.rb
@@ -1,13 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "CTC Intake", :flow_explorer_screenshot_i18n_friendly, active_job: true do
-  def strip_inner_newlines(text)
-    text.gsub(/\n/, '')
-  end
-
-  def strip_html_tags(text)
-    ActionController::Base.helpers.strip_tags(text)
-  end
+  include FeatureTestHelpers
 
   before do
     # create duplicated intake

--- a/spec/features/ctc/edit_ctc_client_spec.rb
+++ b/spec/features/ctc/edit_ctc_client_spec.rb
@@ -165,17 +165,8 @@ RSpec.describe "a user editing a clients intake fields" do
       expect(changes_table_contents('.changes-table')).to match({
         "eip1_and_2_amount_received_confidence" => ["sure", "nil"],
         "preferred_name" => ["Colleen Cauliflower", "Colly Cauliflower"],
-        "sms_notification_opt_in" => ["unfilled", "no"],
         "spouse_last_four_ssn" => ["[REDACTED]", "[REDACTED]"],
         "spouse_tin_type" => ["nil", "ssn"],
-        "use_spouse_name_for_name_control" => ["nil", "false"],
-        "with_drivers_license_photo_id" => ["false", "nil"],
-        "with_itin_taxpayer_id" => ["false", "nil"],
-        "with_other_state_photo_id" => ["false", "nil"],
-        "with_passport_photo_id" => ["false", "nil"],
-        "with_social_security_taxpayer_id" => ["false", "nil"],
-        "with_vita_approved_photo_id" => ["false", "nil"],
-        "with_vita_approved_taxpayer_id" => ["false", "nil"]
       })
     end
   end

--- a/spec/features/ctc/edit_ctc_client_spec.rb
+++ b/spec/features/ctc/edit_ctc_client_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "a user editing a clients intake fields" do
+  include FeatureTestHelpers
+
   context "as an admin user" do
     let(:organization) { create(:organization, name: "Assigned Org") }
     let!(:new_site) { create(:site, name: "Other Site") }
@@ -11,6 +13,7 @@ RSpec.describe "a user editing a clients intake fields" do
              vita_partner: organization,
              tax_returns: [create(:tax_return, filing_status: "married_filing_jointly")],
              intake: create(:ctc_intake,
+                            :with_ssns,
                             email_address: "colleen@example.com",
                             filing_joint: "yes",
                             primary_first_name: "Colleen",
@@ -144,6 +147,36 @@ RSpec.describe "a user editing a clients intake fields" do
         expect(page).to have_text "Economic Impact Payment 1 received: $1200"
         expect(page).to have_text "Economic Impact Payment 2 received: $1300"
       end
+    end
+
+    it "creates a system note for client profile change" do
+      visit hub_client_path(id: client.id)
+      within ".client-profile" do
+        click_on "Edit"
+      end
+
+      within "#primary-info" do
+        fill_in "Preferred full name", with: "Colly Cauliflower"
+      end
+
+      click_on "Save"
+      click_on "Notes"
+
+      expect(changes_table_contents('.changes-table')).to match({
+        "eip1_and_2_amount_received_confidence" => ["sure", "nil"],
+        "preferred_name" => ["Colleen Cauliflower", "Colly Cauliflower"],
+        "sms_notification_opt_in" => ["unfilled", "no"],
+        "spouse_last_four_ssn" => ["[REDACTED]", "[REDACTED]"],
+        "spouse_tin_type" => ["nil", "ssn"],
+        "use_spouse_name_for_name_control" => ["nil", "false"],
+        "with_drivers_license_photo_id" => ["false", "nil"],
+        "with_itin_taxpayer_id" => ["false", "nil"],
+        "with_other_state_photo_id" => ["false", "nil"],
+        "with_passport_photo_id" => ["false", "nil"],
+        "with_social_security_taxpayer_id" => ["false", "nil"],
+        "with_vita_approved_photo_id" => ["false", "nil"],
+        "with_vita_approved_taxpayer_id" => ["false", "nil"]
+      })
     end
   end
 

--- a/spec/features/hub/edit_client_spec.rb
+++ b/spec/features/hub/edit_client_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "a user editing a clients intake fields" do
+  include FeatureTestHelpers
+
   context "as an admin user" do
     let(:organization) { create(:organization, name: "Assigned Org") }
     let!(:new_site) { create(:site, name: "Other Site") }
@@ -233,7 +235,15 @@ RSpec.describe "a user editing a clients intake fields" do
       click_on "Save"
       click_on "Notes"
 
-      expect(page).to have_text "#{user.name} changed: \u2022 preferred name from Colleen Cauliflower to Colly Cauliflower"
+      expect(changes_table_contents('.changes-table')).to match({
+        "divorced" => ["unfilled", "no"],
+        "lived_with_spouse" => ["unfilled", "no"],
+        "married" => ["unfilled", "no"],
+        "preferred_name" => ["Colleen Cauliflower", "Colly Cauliflower"],
+        "separated" => ["unfilled", "no"],
+        "sms_notification_opt_in" => ["unfilled", "no"],
+        "widowed" => ["unfilled", "no"]
+      })
     end
   end
 end

--- a/spec/support/feature_test_helpers.rb
+++ b/spec/support/feature_test_helpers.rb
@@ -9,4 +9,12 @@ module FeatureTestHelpers
 
     contents
   end
+
+  def strip_inner_newlines(text)
+    text.gsub(/\n/, '')
+  end
+
+  def strip_html_tags(text)
+    ActionController::Base.helpers.strip_tags(text)
+  end
 end

--- a/spec/support/feature_test_helpers.rb
+++ b/spec/support/feature_test_helpers.rb
@@ -1,0 +1,12 @@
+module FeatureTestHelpers
+  def changes_table_contents(selector)
+    contents = {}
+
+    all("#{selector} > tbody > tr").map do |tr|
+      column, was, is = tr.find_xpath("td").map(&:visible_text)
+      contents[column] = [was, is]
+    end
+
+    contents
+  end
+end


### PR DESCRIPTION
old ClientChange notes that baked all their presentation into the 'body'
attribute will still display how they used to

Also another commit is on here that tries to clean up the extra cruft you get when you edit an Intake::CtcIntake in the hub for the first time. Check it out!!

## bad

<img width="815" alt="Screen Shot 2021-08-31 at 1 52 10 AM" src="https://user-images.githubusercontent.com/30675659/131464639-adda1e5d-e811-4134-adb9-79d7b2d22ad2.png">

## good ?

<img width="811" alt="Screen Shot 2021-08-31 at 1 53 18 AM" src="https://user-images.githubusercontent.com/30675659/131464659-35ade50f-ee2c-4ec1-af03-cdee932858d1.png">
