### PR TITLE
Allow clients to resubmit their own returns

### DIFF
--- a/app/controllers/ctc/portal/portal_controller.rb
+++ b/app/controllers/ctc/portal/portal_controller.rb
@@ -16,15 +16,18 @@ class Ctc::Portal::PortalController < Ctc::Portal::BaseAuthenticatedController
     end
   end
 
-  def edit_info; end
+  def edit_info
+    @current_submission = current_intake.client.efile_submissions.last
+  end
 
   def resubmit
     @submission = current_client.efile_submissions.last
-    if @submission.can_transition_to?(:ready_to_resubmit)
-      @submission.transition_to(:ready_to_resubmit)
+    if @submission.can_transition_to?(:resubmitted)
+      current_client.efile_security_informations.create(params.require(:ctc_resubmit_form).permit!)
+      @submission.transition_to(:resubmitted)
       SystemNote::CtcPortalAction.generate!(
         model: @submission,
-        action: 'ready_to_resubmit',
+        action: 'resubmitted',
         client: current_client
       )
     end

--- a/app/controllers/flows_controller.rb
+++ b/app/controllers/flows_controller.rb
@@ -234,7 +234,7 @@ class FlowsController < ApplicationController
       }
       client = Client.create!(
         intake_attributes: intake_attributes,
-        efile_security_information_attributes: {
+        efile_security_informations_attributes: [{
           ip_address: '127.0.0.1',
           device_id: "7BA1E530D6503F380F1496A47BEB6F33E40403D1",
           user_agent: "GeckoFox",
@@ -242,7 +242,7 @@ class FlowsController < ApplicationController
           platform: "iPad",
           timezone_offset: "+240",
           client_system_time: "2021-07-28T21:21:32.306Z"
-        },
+        }],
         tax_returns_attributes: [{ year: 2020, is_ctc: true, filing_status: 'single' }],
       )
 

--- a/app/forms/ctc/confirm_legal_form.rb
+++ b/app/forms/ctc/confirm_legal_form.rb
@@ -17,7 +17,8 @@ module Ctc
       @intake.update(attributes_for(:intake))
       efile_attrs = attributes_for(:efile_security_information).merge(timezone_offset: format_timezone_offset(timezone_offset))
       unless @intake.tax_returns.last.efile_submissions.any?
-        efile_submission = EfileSubmission.create(tax_return: @intake.tax_returns.last, efile_security_information_attributes: efile_attrs)
+        EfileSecurityInformation.create(efile_attrs.merge(client: @intake.client))
+        efile_submission = EfileSubmission.create(tax_return: @intake.tax_returns.last)
         begin
           efile_submission.transition_to(:preparing)
         rescue Statesman::GuardFailedError

--- a/app/forms/ctc/income_form.rb
+++ b/app/forms/ctc/income_form.rb
@@ -17,7 +17,7 @@ module Ctc
       @intake.assign_attributes(attributes_for(:intake).merge(locale: I18n.locale))
       @intake.build_client(
         tax_returns_attributes: [{ year: 2020, is_ctc: true }],
-        efile_security_information_attributes: attributes_for(:efile_security_information).merge(timezone_offset: format_timezone_offset(timezone_offset))
+        efile_security_informations_attributes: [attributes_for(:efile_security_information).merge(timezone_offset: format_timezone_offset(timezone_offset))]
       )
       @intake.save!
     end

--- a/app/javascript/listeners/index.js
+++ b/app/javascript/listeners/index.js
@@ -50,6 +50,10 @@ const Listeners =  (function(){
                     getEfileSecurityInformation('ctc_confirm_legal_form');
                 }
 
+                if(window.appData.controller_action == "Ctc::Portal::PortalController#edit_info" || window.appData.controller_action == "Ctc::Portal::PortalController#resubmit") {
+                    getEfileSecurityInformation('ctc_resubmit_form');
+                }
+
                 if (document.querySelector('.taggable-note')) {
                     initTaggableNote();
                 }

--- a/app/jobs/build_submission_bundle_job.rb
+++ b/app/jobs/build_submission_bundle_job.rb
@@ -1,6 +1,6 @@
 class BuildSubmissionBundleJob < ApplicationJob
   def perform(submission_id)
-    submission = EfileSubmission.includes(:intake, :dependents, :client, :address, :tax_return).find(submission_id)
+    submission = EfileSubmission.includes(:intake, :dependents, :address, :tax_return, client: :efile_security_informations).find(submission_id)
     address_creation = submission.generate_irs_address
     unless address_creation.valid?
       submission.transition_to!(:failed, error_source: :usps, error_code: address_creation.error_code, error_message: address_creation.error_message)

--- a/app/lib/submission_builder/return_header1040.rb
+++ b/app/lib/submission_builder/return_header1040.rb
@@ -16,8 +16,8 @@ module SubmissionBuilder
       tax_return = submission.tax_return
       intake = submission.intake
       client = submission.client
-      creation_security_information = client.efile_security_information
-      filing_security_information = submission.efile_security_information
+      creation_security_information = client.efile_security_informations.first
+      filing_security_information = client.efile_security_informations.last
       address = submission.address
 
       Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -61,10 +61,10 @@ class Client < ApplicationRecord
   has_many :outbound_calls, dependent: :destroy
   has_many :users_assigned_to_tax_returns, through: :tax_returns, source: :assigned_user
   has_many :efile_submissions, through: :tax_returns
-  has_one :efile_security_information, dependent: :destroy
+  has_many :efile_security_informations, dependent: :destroy
   accepts_nested_attributes_for :tax_returns
   accepts_nested_attributes_for :intake
-  accepts_nested_attributes_for :efile_security_information
+  accepts_nested_attributes_for :efile_security_informations
   attr_accessor :change_initiated_by
   enum routing_method: { most_org_leads: 0, source_param: 1, zip_code: 2, national_overflow: 3, state: 4, at_capacity: 5 }
   enum still_needs_help: { unfilled: 0, yes: 1, no: 2 }, _prefix: :still_needs_help

--- a/app/models/efile_security_information.rb
+++ b/app/models/efile_security_information.rb
@@ -26,8 +26,7 @@
 #  fk_rails_...  (efile_submission_id => efile_submissions.id)
 #
 class EfileSecurityInformation < ApplicationRecord
-  belongs_to :client, optional: true
-  belongs_to :efile_submission, optional: true
+  belongs_to :client
 
   # storing client_system_time as a string and then transforming it into DateTime for the return_header1040
   # b/c the db would record the date in UTC and we would lose the client's timezone

--- a/app/models/efile_submission.rb
+++ b/app/models/efile_submission.rb
@@ -22,8 +22,6 @@ class EfileSubmission < ApplicationRecord
   has_one :address, as: :record
   has_many :efile_submission_transitions, -> { order(id: :asc) }, class_name: "EfileSubmissionTransition", autosave: false, dependent: :destroy
   has_one_attached :submission_bundle
-  has_one :efile_security_information, required: true
-  accepts_nested_attributes_for :efile_security_information
 
   before_validation :generate_irs_submission_id
   validates_format_of :irs_submission_id, with: /\A[0-9]{6}[0-9]{7}[0-9a-z]{7}\z/

--- a/app/state_machines/efile_submission_state_machine.rb
+++ b/app/state_machines/efile_submission_state_machine.rb
@@ -127,10 +127,7 @@ class EfileSubmissionStateMachine
       submission.transition_to!(:preparing)
     else
       # Re-submission doesn't involve client interaction so we use e-file security information from the last interaction
-      @new_submission = submission.tax_return.efile_submissions.create!(
-        efile_security_information_attributes:
-          submission.efile_security_information.attributes.except("efile_submission_id", "id", "created_at", "updated_at")
-      )
+      @new_submission = submission.tax_return.efile_submissions.create
       @new_submission.transition_to!(:preparing, previous_submission_id: submission.id)
     end
   end

--- a/app/views/ctc/portal/portal/edit_info.html.erb
+++ b/app/views/ctc/portal/portal/edit_info.html.erb
@@ -9,7 +9,7 @@
       <%= link_to t("general.back"), :back %>
     </div>
     <div class="question-wrapper">
-      <%= form_with model: @form, url: ctc_portal_resubmit_path, local: true, method: "put", builder: VitaMinFormBuilder, html: { class: "form-card form-card--long" } do |f| %>
+      <%= form_with url: ctc_portal_resubmit_path, local: true, method: "put", builder: VitaMinFormBuilder, html: { class: "form-card form-card--long" } do |f| %>
 
         <h1 class="h2"><%= @main_question %></h1>
 
@@ -43,12 +43,21 @@
             %>
           <% end %>
         </div>
-        <p>
-          <%= t("views.ctc.portal.edit_info.help_text") %>
-        </p>
-        <button class="button button--primary button--full-width" type="submit">
-          <%= t("views.ctc.portal.edit_info.resubmit") %>
-        </button>
+        <% if @current_submission.can_transition_to?(:resubmitted) %>
+          <p>
+            <%= t("views.ctc.portal.edit_info.help_text") %>
+          </p>
+          <button class="button button--primary button--full-width" type="submit">
+            <%= t("views.ctc.portal.edit_info.resubmit") %>
+          </button>
+        <% else %>
+          <p>
+            <%= t("views.ctc.portal.edit_info.help_text_cant_submit") %>
+          </p>
+          <button disabled class="button button--primary button--full-width button--disabled" type="submit">
+            <%= t("views.ctc.portal.edit_info.resubmit") %>
+          </button>
+        <% end %>
         <%= link_to t("views.ctc.portal.home.contact_us"), new_portal_message_path, class: "button button--full-width" %>
       <% end %>
     </div>

--- a/app/views/hub/notes/_system_note_ctc_portal_action.erb
+++ b/app/views/hub/notes/_system_note_ctc_portal_action.erb
@@ -3,4 +3,6 @@
   <strong>Client removed <%= model_gid.model_name %> #<%= model_gid.model_id %></strong>
 <% elsif note.data['action'] == 'ready_to_resubmit' %>
   <strong>Client marked <%= model_gid.model_name %> #<%= model_gid.model_id %> ready to submit</strong>
+<% elsif note.data['action'] == 'resubmitted' %>
+  <strong>Client initiated resubmission of their tax return.</strong>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1453,6 +1453,7 @@ en:
           correct_info: "Correct my information"
         edit_info:
           help_text: Please ensure that all of your information is correct prior to submitting your tax return. Once you resubmit, your tax return will be transmitted to the IRS and you will not be able to make any additional changes.
+          help_text_cant_submit: Please wait to submit any additional changes to your submission. We are waiting on a response to your previous submission from the IRS.
           title: Correct your submitted information
           resubmit: Resubmit my tax return
         primary_filer:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1437,6 +1437,7 @@ es:
           correct_info: "Corrija mi información"
         edit_info:
           help_text: Asegúrese de que toda su información sea correcta antes de enviar su declaración de impuestos. Una vez que vuelva a enviarla, su declaración de impuestos se transmitirá al IRS y no podrá realizar ningún cambio adicional.
+          help_text_cant_submit: Espere a enviar cambios adicionales a su envío. Estamos esperando una respuesta a su presentación anterior del IRS.
           title: Corrija su información enviada
           resubmit: Volver a enviar mi declaración de impuestos
         primary_filer:

--- a/spec/controllers/ctc/questions/confirm_legal_controller_spec.rb
+++ b/spec/controllers/ctc/questions/confirm_legal_controller_spec.rb
@@ -41,12 +41,15 @@ describe Ctc::Questions::ConfirmLegalController do
     context "when submitting the form" do
       context "when checking 'I agree'" do
         it "create a submission with the status of 'preparing' and send client a message and redirect to portal home" do
-          post :update, params: params
+          expect {
+            post :update, params: params
+          }.to change(client.efile_security_informations, :count).by 1
+
 
           expect(response).to redirect_to ctc_portal_root_path
           efile_submission = client.reload.tax_returns.last.efile_submissions.last
           expect(efile_submission.current_state).to eq "preparing"
-          expect(efile_submission.efile_security_information.ip_address).to eq ip_address
+          expect(client.efile_security_informations.last.ip_address).to eq ip_address
         end
 
         it "sends a Mixpanel event" do

--- a/spec/controllers/ctc/questions/income_controller_spec.rb
+++ b/spec/controllers/ctc/questions/income_controller_spec.rb
@@ -37,11 +37,14 @@ describe Ctc::Questions::IncomeController do
     end
 
     it "updates client with intake security information" do
+      expect {
+        post :update, params: params
+      }.to change(EfileSecurityInformation, :count).by 1
       post :update, params: params
 
-      client = Client.last
-      expect(client.efile_security_information.user_agent).to eq "GeckoFox"
-      expect(client.efile_security_information.ip_address).to eq ip_address
+      efile_security = Client.last.efile_security_informations.last
+      expect(efile_security.user_agent).to eq "GeckoFox"
+      expect(efile_security.ip_address).to eq ip_address
     end
 
     context "when answer is yes" do

--- a/spec/factories/clients.rb
+++ b/spec/factories/clients.rb
@@ -42,7 +42,7 @@
 #
 FactoryBot.define do
   factory :client do
-    efile_security_information { build :efile_security_information }
+    efile_security_informations { [build(:efile_security_information)] }
 
     trait :with_return do
       transient do

--- a/spec/factories/efile_submissions.rb
+++ b/spec/factories/efile_submissions.rb
@@ -22,7 +22,6 @@ FactoryBot.define do
       metadata {}
     end
     tax_return { create :tax_return, :ctc, year: tax_year, filing_status: filing_status }
-    efile_security_information { build(:efile_security_information) }
 
     trait :ctc do
       after :create do |submission|

--- a/spec/features/ctc/ctc_intake_js_integration_spec.rb
+++ b/spec/features/ctc/ctc_intake_js_integration_spec.rb
@@ -14,6 +14,7 @@ RSpec.feature "CTC Intake Javascript Integrations", :js, active_job: true do
     click_on I18n.t('general.negative')
     intake = Intake::CtcIntake.last
     expect(intake.timezone).to be_present
-    expect(intake.client.efile_security_information.client_system_time).to be_present
+    expect(intake.client.efile_security_informations.last.client_system_time).to be_present
+    expect(intake.client.efile_security_informations.last.device_id).to be_present
   end
 end

--- a/spec/features/ctc/portal_spec.rb
+++ b/spec/features/ctc/portal_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "CTC Intake", active_job: true do
+RSpec.feature "CTC Intake", :js, :active_job do
   module CtcPortalHelper
     def log_in_to_ctc_portal
       visit "/en/portal/login"
@@ -241,7 +241,7 @@ RSpec.feature "CTC Intake", active_job: true do
       click_on I18n.t('views.ctc.portal.edit_info.resubmit')
 
       expect(page).to have_selector("h1", text: I18n.t('views.ctc.portal.home.title'))
-      expect(page).to have_text I18n.t('views.ctc.portal.home.status.ready_to_resubmit.label')
+      expect(page).to have_text I18n.t('views.ctc.portal.home.status.preparing.label')
 
       # Go look for the note as an admin
       Capybara.current_session.reset!
@@ -263,7 +263,7 @@ RSpec.feature "CTC Intake", active_job: true do
       expect(page).to have_content("123 Sandwich Lane")
 
       expect(page).to have_content("Client removed Dependent ##{dependent_to_delete.id}")
-      expect(page).to have_content("Client marked EfileSubmission ##{efile_submission.id} ready to submit")
+      expect(page).to have_content("Client initiated resubmission of their tax return.")
     end
 
     scenario "a client sees and can click on a link to continue their intake" do

--- a/spec/forms/ctc/confirm_legal_form_spec.rb
+++ b/spec/forms/ctc/confirm_legal_form_spec.rb
@@ -57,9 +57,9 @@ describe Ctc::ConfirmLegalForm do
                                                       .and change(intake.tax_returns.last.efile_submissions, :count).by(1)
     end
 
-    it "persists efile_security_information as a record linked to the efile submission" do
+    it "persists efile_security_information as a record linked to the client" do
       expect { described_class.new(intake, params).save }.to change(EfileSecurityInformation, :count).by(1)
-      efile_security_information = intake.tax_returns.last.efile_submissions.last.efile_security_information
+      efile_security_information = intake.client.reload.efile_security_informations.last
       expect(efile_security_information.ip_address).to eq "1.1.1.1"
       expect(efile_security_information.device_id).to eq "7BA1E530D6503F380F1496A47BEB6F33E40403D1"
       expect(efile_security_information.user_agent).to eq "GeckoFox"

--- a/spec/forms/ctc/income_form_spec.rb
+++ b/spec/forms/ctc/income_form_spec.rb
@@ -66,13 +66,14 @@ describe Ctc::IncomeForm do
       expect(intake.visitor_id).to eq "something"
       expect(intake.source).to eq "some-source"
       expect(intake.type).to eq "Intake::CtcIntake"
-      expect(intake.client.efile_security_information.ip_address).to eq "1.1.1.1"
-      expect(intake.client.efile_security_information.device_id).to eq "7BA1E530D6503F380F1496A47BEB6F33E40403D1"
-      expect(intake.client.efile_security_information.user_agent).to eq "GeckoFox"
-      expect(intake.client.efile_security_information.browser_language).to eq "en-US"
-      expect(intake.client.efile_security_information.platform).to eq "iPad"
-      expect(intake.client.efile_security_information.timezone_offset).to eq "+240"
-      expect(intake.client.efile_security_information.client_system_time).to eq "Mon Aug 02 2021 18:55:41 GMT-0400 (Eastern Daylight Time)"
+      efile_security_information = intake.client.efile_security_informations.first
+      expect(efile_security_information.ip_address).to eq "1.1.1.1"
+      expect(efile_security_information.device_id).to eq "7BA1E530D6503F380F1496A47BEB6F33E40403D1"
+      expect(efile_security_information.user_agent).to eq "GeckoFox"
+      expect(efile_security_information.browser_language).to eq "en-US"
+      expect(efile_security_information.platform).to eq "iPad"
+      expect(efile_security_information.timezone_offset).to eq "+240"
+      expect(efile_security_information.client_system_time).to eq "Mon Aug 02 2021 18:55:41 GMT-0400 (Eastern Daylight Time)"
     end
   end
 end

--- a/spec/lib/submission_builder/return_header1040_spec.rb
+++ b/spec/lib/submission_builder/return_header1040_spec.rb
@@ -359,12 +359,13 @@ describe SubmissionBuilder::ReturnHeader1040 do
     context "efile security information" do
       context "UserAgentTxt" do
         before do
-          submission.client.efile_security_information.update(user_agent: "Mozilla/5.0 (Linux; Android 10; SAMSUNG SM-S205DL) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.1 Chrome/79.0.3945.136 Mobile Safari/537.36")
-          submission.efile_security_information.update(user_agent: "Mozilla/5.0 (Linux; Android 10; SAMSUNG SM-S205DL) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.1 Chrome/79.0.3945.136 Mobile Safari/537.36")
+          submission.client.efile_security_informations.first.update(user_agent: "Mozilla/5.0 (Linux; Android 10; SAMSUNG SM-S205DL) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.1 Chrome/79.0.3945.136 Mobile Safari/537.36")
+          submission.client.efile_security_informations.last.update(user_agent: "Mozilla/5.0 (Linux; Android 10; SAMSUNG SM-S205DL) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.1 Chrome/79.0.3945.136 Mobile Safari/537.36")
         end
 
         it "trims long user agent text down to 150 characters, the max acceptable by the schema" do
-          expect(submission.efile_security_information.user_agent.length).to eq 151
+          expect(submission.client.efile_security_informations.first.user_agent.length).to eq 151
+          expect(submission.client.efile_security_informations.last.user_agent.length).to eq 151
           response = SubmissionBuilder::ReturnHeader1040.build(submission)
           xml = Nokogiri::XML::Document.parse(response.document.to_xml)
           expect(xml.at("FilingSecurityInformation AtSubmissionFilingGrp UserAgentTxt").text.length).to eq 150
@@ -372,6 +373,7 @@ describe SubmissionBuilder::ReturnHeader1040 do
         end
       end
     end
+
     context "spouse name control" do
       context "when use_spouse_name_for_name_control is true" do
         before do

--- a/spec/models/efile_submission_spec.rb
+++ b/spec/models/efile_submission_spec.rb
@@ -27,30 +27,6 @@ describe EfileSubmission do
     allow(address_service_double).to receive(:city).and_return "Katy"
   end
 
-  context "validation" do
-    describe ".efile_security_information" do
-      let(:tax_return) { build(:tax_return) }
-      let(:efile_submission) { EfileSubmission.new(tax_return: tax_return, efile_security_information: efile_security_information) }
-
-      context "without the field" do
-        let(:efile_security_information) { nil }
-
-        it "is invalid" do
-          expect(efile_submission).not_to be_valid
-          expect(efile_submission.errors).to include(:efile_security_information)
-        end
-      end
-
-      context "with the field" do
-        let(:efile_security_information) { build(:efile_security_information) }
-
-        it "is valid" do
-          expect(efile_submission).to be_valid
-        end
-      end
-    end
-  end
-
   context "generating an irs_submission_id before create" do
     context "adhering to IRS format" do
       around do |example|

--- a/spec/state_machines/efile_submission_state_machine_spec.rb
+++ b/spec/state_machines/efile_submission_state_machine_spec.rb
@@ -167,9 +167,6 @@ describe EfileSubmissionStateMachine do
           new_submission = EfileSubmission.last
           expect(new_submission.current_state).to eq "preparing"
           expect(new_submission.last_transition.metadata["previous_submission_id"]).to eq efile_submission.id
-          old_efile_security_information_data = efile_submission.efile_security_information.attributes.except("efile_submission_id", "id", "created_at", "updated_at")
-          new_efile_security_information_data = new_submission.efile_security_information.attributes.except("efile_submission_id", "id", "created_at", "updated_at")
-          expect(old_efile_security_information_data).to eq(new_efile_security_information_data)
         end
       end
 


### PR DESCRIPTION
I moved security information entirely to client because passing the efile submission stuff through onto the efile submission, tracking whether its changed, etc. It simplifies things in a lot of ways and allows us to just grab first and last on the submission.