### PR TITLE
Fix efile security on resubmission

### DIFF
--- a/app/forms/ctc/confirm_legal_form.rb
+++ b/app/forms/ctc/confirm_legal_form.rb
@@ -15,7 +15,7 @@ module Ctc
 
     def save
       @intake.update(attributes_for(:intake))
-      efile_attrs = attributes_for(:efile_security_information).merge(timezone_offset: format_timezone_offset(timezone_offset))
+      efile_attrs = attributes_for(:efile_security_information)
       unless @intake.tax_returns.last.efile_submissions.any?
         EfileSecurityInformation.create(efile_attrs.merge(client: @intake.client))
         efile_submission = EfileSubmission.create(tax_return: @intake.tax_returns.last)
@@ -25,14 +25,6 @@ module Ctc
           Rails.logger.error "Failed to transition EfileSubmission##{efile_submission.id} to :preparing"
         end
       end
-    end
-
-    private
-
-    def format_timezone_offset(tz_offset)
-      return unless tz_offset.present?
-
-      return (tz_offset.include?("-") || tz_offset.include?("+")) ? tz_offset : "+" + tz_offset
     end
   end
 end

--- a/app/forms/ctc/income_form.rb
+++ b/app/forms/ctc/income_form.rb
@@ -17,19 +17,13 @@ module Ctc
       @intake.assign_attributes(attributes_for(:intake).merge(locale: I18n.locale))
       @intake.build_client(
         tax_returns_attributes: [{ year: 2020, is_ctc: true }],
-        efile_security_informations_attributes: [attributes_for(:efile_security_information).merge(timezone_offset: format_timezone_offset(timezone_offset))]
+        efile_security_informations_attributes: [attributes_for(:efile_security_information)]
       )
       @intake.save!
     end
 
     def had_reportable_income?
       had_reportable_income == "yes"
-    end
-
-    def format_timezone_offset(tz_offset)
-      return unless tz_offset.present?
-
-      (tz_offset.include?("-") || tz_offset.include?("+")) ? tz_offset : "+" + tz_offset
     end
   end
 end

--- a/app/javascript/lib/efile_security_information.js
+++ b/app/javascript/lib/efile_security_information.js
@@ -9,13 +9,15 @@ export function getEfileSecurityInformation(formName) {
         let concatenatedAndHashed = CryptoJS.SHA1(concatenated).toString().toUpperCase();
 
         let now = new Date();
+        let timezoneOffset = now.getTimezoneOffset();
+        let timezoneOffsetString = timezoneOffset < 0 ? (timezoneOffset.toString()) : ("+" + timezoneOffset);
         let securityAttributes = {
             device_id: concatenatedAndHashed,
             user_agent: navigator.userAgent,
             browser_language: navigator.language,
             platform: navigator.platform,
             client_system_time: now,
-            timezone_offset: now.getTimezoneOffset()
+            timezone_offset: timezoneOffsetString
         };
 
         for (const attr in securityAttributes) {

--- a/app/models/efile_security_information.rb
+++ b/app/models/efile_security_information.rb
@@ -27,7 +27,13 @@
 #
 class EfileSecurityInformation < ApplicationRecord
   belongs_to :client
-
+  validates_presence_of :device_id,
+                     :user_agent,
+                     :browser_language,
+                     :platform,
+                     :timezone_offset,
+                     :client_system_time,
+                     :ip_address
   # storing client_system_time as a string and then transforming it into DateTime for the return_header1040
   # b/c the db would record the date in UTC and we would lose the client's timezone
   def client_system_datetime

--- a/spec/forms/ctc/confirm_legal_form_spec.rb
+++ b/spec/forms/ctc/confirm_legal_form_spec.rb
@@ -10,7 +10,7 @@ describe Ctc::ConfirmLegalForm do
       user_agent: "GeckoFox",
       browser_language: "en-US",
       platform: "iPad",
-      timezone_offset: "240",
+      timezone_offset: "+240",
       client_system_time: "Mon Aug 02 2021 18:55:41 GMT-0400 (Eastern Daylight Time)",
       ip_address: "1.1.1.1",
     }

--- a/spec/forms/ctc/income_form_spec.rb
+++ b/spec/forms/ctc/income_form_spec.rb
@@ -42,7 +42,7 @@ describe Ctc::IncomeForm do
         user_agent: "GeckoFox",
         browser_language: "en-US",
         platform: "iPad",
-        timezone_offset: "240",
+        timezone_offset: "+240",
         client_system_time: "Mon Aug 02 2021 18:55:41 GMT-0400 (Eastern Daylight Time)",
         ip_address: "1.1.1.1",
       }


### PR DESCRIPTION
The +/- for timezone offset was happening at a form level, but this now does it in the JS so we only have to do it in one place.

It also adds model level validations for efile submission things since we ultimately require them anyway.