### PR TITLE
Auto re-submit on IRS data loss [#178855164]

### DIFF
--- a/app/models/efile_error.rb
+++ b/app/models/efile_error.rb
@@ -19,4 +19,11 @@ class EfileError < ApplicationRecord
   has_rich_text :description_es
   has_rich_text :resolution_en
   has_rich_text :resolution_es
+
+  def self.error_codes_to_retry_once
+    # These error codes indicate that the IRS had trouble parsing our data. When we see this, it
+    # is usually correlated with IRS downtime. The implication seems to be that the IRS didn't process
+    # our submission correctly during the downtime period, and that re-submitting is a good idea.
+    %w[X0000-010 X0000-032]
+  end
 end

--- a/app/state_machines/efile_submission_state_machine.rb
+++ b/app/state_machines/efile_submission_state_machine.rb
@@ -82,6 +82,13 @@ class EfileSubmissionStateMachine
       )
       submission.transition_to!(:cancelled) if transition.efile_errors.any?(&:auto_cancel)
       submission.transition_to!(:waiting) if transition.efile_errors.all?(&:auto_wait)
+      if transition.efile_errors.all? { |efile_error| EfileError.error_codes_to_retry_once.include?(efile_error.code) }
+        already_auto_resubmitted = submission.previously_transmitted_submission && submission.previously_transmitted_submission.efile_submission_transitions.where(to_state: :resubmitted
+          ).any? { |transition| puts(transition.metadata); transition.metadata.dig("auto_resubmitted") }
+        unless already_auto_resubmitted
+          submission.transition_to!(:resubmitted, {auto_resubmitted: true})
+        end
+      end
     end
 
     send_mixpanel_event(submission, "ctc_efile_return_rejected")


### PR DESCRIPTION
For the two IRS errors that indicate that they had trouble parsing our data, let's resubmit. We saw these when there was an IRS outage.

* https://www.getyourrefund.org/en/hub/errors/33
* https://www.getyourrefund.org/en/hub/errors/34

It's probably good to only resubmit once like this, to avoid creating an infinite loop.