### PR TITLE
Log full errors when transitioning to :failed

### DIFF
--- a/app/jobs/build_submission_bundle_job.rb
+++ b/app/jobs/build_submission_bundle_job.rb
@@ -10,14 +10,14 @@ class BuildSubmissionBundleJob < ApplicationJob
     begin
       submission.generate_form_1040_pdf
     rescue StandardError => e
-      submission.transition_to!(:failed, error_code: 'PDF-1040-FAIL', raw_response: "Engineers should look in Sentry for an exception\n\nEfileSubmission ID #{submission_id}\n\nException class: #{e.class.name}")
+      submission.transition_to!(:failed, error_code: 'PDF-1040-FAIL', raw_response: e.inspect)
       raise
     end
 
     begin
       response = SubmissionBundle.build(submission, documents: ["adv_ctc_irs1040"])
     rescue StandardError => e
-      submission.transition_to!(:failed, error_code: 'BUNDLE-FAIL', raw_response: "Engineers should look in Sentry for an exception\n\nEfileSubmission ID #{submission_id}\n\nException class: #{e.class.name}")
+      submission.transition_to!(:failed, error_code: 'BUNDLE-FAIL', raw_response: e.inspect)
       raise
     end
 


### PR DESCRIPTION
Before this change:

* On submission fail, we would look the full error: `      submission.transition_to!(:failed, error_code: "TRANSMISSION-SERVICE", raw_response: e.inspect)`
* On _bundle_ fail, we would show a frustratingly low-information error message

After this change:

* Submission and bundle fail show the full error.