### PR TITLE
Turn off imperfect return indicator

### DIFF
--- a/app/models/efile_submission.rb
+++ b/app/models/efile_submission.rb
@@ -51,8 +51,8 @@ class EfileSubmission < ApplicationRecord
   # This election can only be made if the original return rejected with reject code SEIC-F1040-501-02 or R0000-504-02.
   def imperfect_return_resubmission?
     return false unless previously_transmitted_submission.present?
-
-    previously_transmitted_submission.efile_submission_transitions.collect(&:efile_errors).flatten.any? { |error| ["SEIC-F1040-501-02", "R0000-504-02"].include? error.code }
+    return false # turn off imperfect return indicator as this means CAN retransmit and accept, not MUST.
+    # previously_transmitted_submission.efile_submission_transitions.collect(&:efile_errors).flatten.any? { |error| ["SEIC-F1040-501-02", "R0000-504-02"].include? error.code }
   end
 
   def last_client_accessible_transition

--- a/spec/models/efile_submission_spec.rb
+++ b/spec/models/efile_submission_spec.rb
@@ -360,10 +360,16 @@ describe EfileSubmission do
       context "and the previous submission had a R0000-504-02 error" do
         let!(:efile_error) { create(:efile_error, code: "R0000-504-02") }
 
-        it "returns true" do
+        xit "returns true" do
           expect(submission.imperfect_return_resubmission?).to eq(true)
         end
+
+        it "returns false" do
+          expect(submission.imperfect_return_resubmission?).to eq (false)
+        end
       end
+
+
     end
   end
 


### PR DESCRIPTION
Turn off the imperfect return indicator that allows for auto-acceptance on any name control errors we get for Dependents.

We will reassess how to handle IRI returns on Tuesday, but for now we don't want to risk submitting inaccurate information to the IRS that may create more problems for the client in the future.