### PR TITLE
Spouse name control should use the spouse name by default

### DIFF
--- a/app/forms/concerns/ctc_client_form_attributes.rb
+++ b/app/forms/concerns/ctc_client_form_attributes.rb
@@ -38,11 +38,5 @@ module CtcClientFormAttributes
         attributes[column] = intake.send(column)
       end
     end
-
-    # use_spouse_name_for_name_control should treat `nil` and `false` as equivalent
-    # unless we ever make it default(FALSE) and clear out all the nils
-    if intake&.persisted? && attributes[:use_spouse_name_for_name_control] != "true"
-      attributes[:use_spouse_name_for_name_control] = intake.use_spouse_name_for_name_control
-    end
   end
 end

--- a/app/forms/hub/update_ctc_client_form.rb
+++ b/app/forms/hub/update_ctc_client_form.rb
@@ -10,7 +10,7 @@ module Hub
                        :primary_prior_year_signature_pin,
                        :spouse_prior_year_agi_amount,
                        :spouse_prior_year_signature_pin,
-                       :use_spouse_name_for_name_control,
+                       :use_primary_name_for_name_control,
                        :preferred_name,
                        :preferred_interview_language,
                        :email_address,

--- a/app/lib/submission_builder/return_header1040.rb
+++ b/app/lib/submission_builder/return_header1040.rb
@@ -197,7 +197,7 @@ module SubmissionBuilder
     end
 
     def spouse_name_control(intake)
-      name = intake.use_spouse_name_for_name_control? ? intake.spouse_last_name : intake.primary_last_name
+      name = intake.use_primary_name_for_name_control ? intake.primary_last_name : intake.spouse_last_name
       person_name_control_type(name)
     end
 

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -205,7 +205,7 @@
 #  street_address2                                      :string
 #  timezone                                             :string
 #  type                                                 :string
-#  use_spouse_name_for_name_control                     :boolean
+#  use_primary_name_for_name_control                    :boolean
 #  viewed_at_capacity                                   :boolean          default(FALSE)
 #  vita_partner_name                                    :string
 #  wants_to_itemize                                     :integer          default(0), not null

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -205,7 +205,7 @@
 #  street_address2                                      :string
 #  timezone                                             :string
 #  type                                                 :string
-#  use_primary_name_for_name_control                    :boolean
+#  use_primary_name_for_name_control                    :boolean          default(FALSE)
 #  viewed_at_capacity                                   :boolean          default(FALSE)
 #  vita_partner_name                                    :string
 #  wants_to_itemize                                     :integer          default(0), not null

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -205,7 +205,7 @@
 #  street_address2                                      :string
 #  timezone                                             :string
 #  type                                                 :string
-#  use_spouse_name_for_name_control                     :boolean
+#  use_primary_name_for_name_control                    :boolean
 #  viewed_at_capacity                                   :boolean          default(FALSE)
 #  vita_partner_name                                    :string
 #  wants_to_itemize                                     :integer          default(0), not null

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -205,7 +205,7 @@
 #  street_address2                                      :string
 #  timezone                                             :string
 #  type                                                 :string
-#  use_primary_name_for_name_control                    :boolean
+#  use_primary_name_for_name_control                    :boolean          default(FALSE)
 #  viewed_at_capacity                                   :boolean          default(FALSE)
 #  vita_partner_name                                    :string
 #  wants_to_itemize                                     :integer          default(0), not null

--- a/app/models/intake/gyr_intake.rb
+++ b/app/models/intake/gyr_intake.rb
@@ -205,7 +205,7 @@
 #  street_address2                                      :string
 #  timezone                                             :string
 #  type                                                 :string
-#  use_spouse_name_for_name_control                     :boolean
+#  use_primary_name_for_name_control                    :boolean
 #  viewed_at_capacity                                   :boolean          default(FALSE)
 #  vita_partner_name                                    :string
 #  wants_to_itemize                                     :integer          default("unfilled"), not null

--- a/app/models/intake/gyr_intake.rb
+++ b/app/models/intake/gyr_intake.rb
@@ -205,7 +205,7 @@
 #  street_address2                                      :string
 #  timezone                                             :string
 #  type                                                 :string
-#  use_primary_name_for_name_control                    :boolean
+#  use_primary_name_for_name_control                    :boolean          default(FALSE)
 #  viewed_at_capacity                                   :boolean          default(FALSE)
 #  vita_partner_name                                    :string
 #  wants_to_itemize                                     :integer          default("unfilled"), not null

--- a/app/views/shared/_client_spouse_info_fields.html.erb
+++ b/app/views/shared/_client_spouse_info_fields.html.erb
@@ -53,11 +53,10 @@
     <% end %>
     <% if is_ctc && !is_dropoff %>
       <div>
-        <%= f.hub_checkbox(:use_spouse_name_for_name_control, "Use spouse last name for spouse name control", options: { checked_value: "true", unchecked_value: "false" }) %>
+        <%= f.hub_checkbox(:use_primary_name_for_name_control, "Use primary last name for spouse name control", options: { checked_value: "true", unchecked_value: "false" }) %>
         <div class="help-text" style="margin-top: -15px;">
-          Only check this box if an efiled return is rejected because spouse name control does not match AND the spouse last name does not match the
-          primary filer's last name. Then, resubmit the return to see if the IRS name control for the spouse is
-          under the spouse's last name.
+          Only check this box if an efiled return is rejected because spouse name control does not match. Then, resubmit the return to see if the IRS name control for the spouse is
+          under the primary's last name.
         </div>
       </div>
     <% end %>

--- a/db/migrate/20210902211714_use_primary_last_name_for_spouse_name_control.rb
+++ b/db/migrate/20210902211714_use_primary_last_name_for_spouse_name_control.rb
@@ -1,0 +1,5 @@
+class UsePrimaryLastNameForSpouseNameControl < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :intakes, :use_spouse_name_for_name_control, :use_primary_name_for_name_control
+  end
+end

--- a/db/migrate/20210902211714_use_primary_last_name_for_spouse_name_control.rb
+++ b/db/migrate/20210902211714_use_primary_last_name_for_spouse_name_control.rb
@@ -1,5 +1,6 @@
 class UsePrimaryLastNameForSpouseNameControl < ActiveRecord::Migration[6.0]
   def change
     rename_column :intakes, :use_spouse_name_for_name_control, :use_primary_name_for_name_control
+    change_column_default :intakes, :use_primary_name_for_name_control, false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -696,7 +696,7 @@ ActiveRecord::Schema.define(version: 2021_09_02_211714) do
     t.string "timezone"
     t.string "type"
     t.datetime "updated_at"
-    t.boolean "use_primary_name_for_name_control"
+    t.boolean "use_primary_name_for_name_control", default: false
     t.boolean "viewed_at_capacity", default: false
     t.string "visitor_id"
     t.bigint "vita_partner_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_29_025358) do
+ActiveRecord::Schema.define(version: 2021_09_02_211714) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -696,7 +696,7 @@ ActiveRecord::Schema.define(version: 2021_08_29_025358) do
     t.string "timezone"
     t.string "type"
     t.datetime "updated_at"
-    t.boolean "use_spouse_name_for_name_control"
+    t.boolean "use_primary_name_for_name_control"
     t.boolean "viewed_at_capacity", default: false
     t.string "visitor_id"
     t.bigint "vita_partner_id"

--- a/spec/controllers/hub/ctc_clients_controller_spec.rb
+++ b/spec/controllers/hub/ctc_clients_controller_spec.rb
@@ -229,6 +229,7 @@ RSpec.describe Hub::CtcClientsController do
           refund_payment_method: "check",
           with_passport_photo_id: "1",
           with_itin_taxpayer_id: "1",
+          use_primary_name_for_name_control: false,
           primary_ip_pin: intake.primary_ip_pin,
           spouse_ip_pin: intake.spouse_ip_pin,
           dependents_attributes: {

--- a/spec/factories/intakes.rb
+++ b/spec/factories/intakes.rb
@@ -205,7 +205,7 @@
 #  street_address2                                      :string
 #  timezone                                             :string
 #  type                                                 :string
-#  use_spouse_name_for_name_control                     :boolean
+#  use_primary_name_for_name_control                    :boolean
 #  viewed_at_capacity                                   :boolean          default(FALSE)
 #  vita_partner_name                                    :string
 #  wants_to_itemize                                     :integer          default(0), not null

--- a/spec/factories/intakes.rb
+++ b/spec/factories/intakes.rb
@@ -205,7 +205,7 @@
 #  street_address2                                      :string
 #  timezone                                             :string
 #  type                                                 :string
-#  use_primary_name_for_name_control                    :boolean
+#  use_primary_name_for_name_control                    :boolean          default(FALSE)
 #  viewed_at_capacity                                   :boolean          default(FALSE)
 #  vita_partner_name                                    :string
 #  wants_to_itemize                                     :integer          default(0), not null

--- a/spec/lib/submission_builder/return_header1040_spec.rb
+++ b/spec/lib/submission_builder/return_header1040_spec.rb
@@ -375,14 +375,14 @@ describe SubmissionBuilder::ReturnHeader1040 do
     end
 
     context "spouse name control" do
-      context "when use_spouse_name_for_name_control is true" do
+      context "when use_primary_name_for_name_control is true" do
         before do
-          submission.intake.update(use_spouse_name_for_name_control: true)
+          submission.intake.update(use_primary_name_for_name_control: true)
         end
-        it "uses the spouses last name to create the name control" do
+        it "uses the primary last name to create the name control" do
           response = SubmissionBuilder::ReturnHeader1040.build(submission)
           xml = Nokogiri::XML::Document.parse(response.document.to_xml)
-          expect(xml.at("SpouseNameControlTxt").text).to eq "FRAN"
+          expect(xml.at("SpouseNameControlTxt").text).to eq "DIWO"
         end
       end
     end

--- a/spec/lib/submission_builder/return_header1040_spec.rb
+++ b/spec/lib/submission_builder/return_header1040_spec.rb
@@ -95,7 +95,7 @@ describe SubmissionBuilder::ReturnHeader1040 do
         expect(xml.at("SpouseSSN").text).to eq submission.intake.spouse_ssn
         expect(xml.at("NameLine1Txt").text).to eq "HUBERT BLAINE<D<& LISA F" # trimmed to 35 characters
         expect(xml.at("PrimaryNameControlTxt").text).to eq "DIWO"
-        expect(xml.at("SpouseNameControlTxt").text).to eq "DIWO"
+        expect(xml.at("SpouseNameControlTxt").text).to eq "FRAN"
         expect(xml.at("AddressLine1Txt").text).to eq "23627 HAWKINS CREEK CT"
         expect(xml.at("CityNm").text).to eq "KATY"
         expect(xml.at("StateAbbreviationCd").text).to eq "TX"

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -205,7 +205,7 @@
 #  street_address2                                      :string
 #  timezone                                             :string
 #  type                                                 :string
-#  use_spouse_name_for_name_control                     :boolean
+#  use_primary_name_for_name_control                    :boolean
 #  viewed_at_capacity                                   :boolean          default(FALSE)
 #  vita_partner_name                                    :string
 #  wants_to_itemize                                     :integer          default(0), not null

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -205,7 +205,7 @@
 #  street_address2                                      :string
 #  timezone                                             :string
 #  type                                                 :string
-#  use_primary_name_for_name_control                    :boolean
+#  use_primary_name_for_name_control                    :boolean          default(FALSE)
 #  viewed_at_capacity                                   :boolean          default(FALSE)
 #  vita_partner_name                                    :string
 #  wants_to_itemize                                     :integer          default(0), not null


### PR DESCRIPTION
The IRS documentation specifies that SpouseNameControl should use the primary last name. This guidance seems to be outdated (both technically - and frankly, culturally) based on our interactions with their systems, ie we've run into a lot of issues with partners with different last names.

So the fix is to try and use the spouse's own last name by default. This matches the guidance provided by Courtney, as well.

This also flips the override to use the primary name, rather than the spouse name, and sets it to `false` by default.