### PR TITLE
Use soft deletion logic to create calculations

### DIFF
--- a/app/models/tax_return.rb
+++ b/app/models/tax_return.rb
@@ -103,14 +103,14 @@ class TaxReturn < ApplicationRecord
   def expected_recovery_rebate_credit_one
     EconomicImpactPaymentOneCalculator.payment_due(
       filer_count: rrc_eligible_filer_count,
-      dependent_count: intake.dependents.count(&:eligible_for_eip1?)
+      dependent_count: qualifying_dependents.count(&:eligible_for_eip1?)
     )
   end
 
   def expected_recovery_rebate_credit_two
     EconomicImpactPaymentTwoCalculator.payment_due(
       filer_count: rrc_eligible_filer_count,
-      dependent_count: intake.dependents.count(&:eligible_for_eip2?)
+      dependent_count: qualifying_dependents.count(&:eligible_for_eip2?)
     )
   end
 

--- a/spec/models/tax_return_spec.rb
+++ b/spec/models/tax_return_spec.rb
@@ -123,6 +123,7 @@ describe TaxReturn do
     let(:intake) { tax_return.intake }
     before do
       allow(tax_return).to receive(:rrc_eligible_filer_count).and_return(1)
+      allow_any_instance_of(Dependent).to receive(:qualifying_child_2020?).and_return true
       allow_any_instance_of(Dependent).to receive(:eligible_for_eip1?).and_return true
       allow(EconomicImpactPaymentOneCalculator).to receive(:payment_due)
     end
@@ -139,6 +140,7 @@ describe TaxReturn do
     let(:intake) { tax_return.intake }
     before do
       allow(tax_return).to receive(:rrc_eligible_filer_count).and_return(1)
+      allow_any_instance_of(Dependent).to receive(:qualifying_child_2020?).and_return true
       allow_any_instance_of(Dependent).to receive(:eligible_for_eip2?).and_return true
       allow(EconomicImpactPaymentTwoCalculator).to receive(:payment_due)
     end


### PR DESCRIPTION
Soft delete logic was only implemented on the qualifying_dependents logic, but we were making $$ calculations for those dependents even though they'd been removed from the return..