### PR TITLE
Update node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update --allow-releaseinfo-change
 # System prerequisites
 RUN apt-get update \
  && apt-get -y install build-essential libpq-dev pdftk ghostscript poppler-utils curl \
- && curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+ && curl -sL https://deb.nodesource.com/setup_12.x | bash - \
  && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
  && apt-get update && apt-get install -y nodejs yarn \

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "jest-junit": "^12.0.0",
     "webpack-dev-server": "^3.11.0"
   },
+  "engines": {
+    "node": ">=12.16"
+  },
   "scripts": {
     "test": "jest"
   },


### PR DESCRIPTION
- This bumps the Aptible node version from 10 to 12, which is required for being able to list percy/cli as a dev dependency.
- It also requires that anything running yarn has at least Node 12. This will require developers to upgrade node locally in rare cases