### PR TITLE
Dependent has a default_scope to omit soft-deleted records

### DIFF
--- a/app/models/concerns/soft_deletable.rb
+++ b/app/models/concerns/soft_deletable.rb
@@ -1,0 +1,10 @@
+module SoftDeletable
+  extend ActiveSupport::Concern
+
+  included do
+    default_scope { where(soft_deleted_at: nil) }
+
+    scope :with_deleted, -> { unscope(where: :soft_deleted_at) }
+    scope :only_deleted, -> { unscope(where: :soft_deleted_at).where.not(soft_deleted_at: nil) }
+  end
+end

--- a/app/models/dependent.rb
+++ b/app/models/dependent.rb
@@ -47,6 +47,8 @@
 #
 
 class Dependent < ApplicationRecord
+  include SoftDeletable
+
   belongs_to :intake, inverse_of: :dependents
 
   attr_encrypted :ssn, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }

--- a/app/models/tax_return.rb
+++ b/app/models/tax_return.rb
@@ -67,7 +67,7 @@ class TaxReturn < ApplicationRecord
   def qualifying_dependents
     raise StandardError, "Qualifying dependent logic is only valid for 2020.  Define new rules for #{year}." unless year == 2020
 
-    intake.dependents.reject(&:soft_deleted_at).filter { |d| d.qualifying_child_2020? || d.qualifying_relative_2020? }
+    intake.dependents.filter { |d| d.qualifying_child_2020? || d.qualifying_relative_2020? }
   end
 
   def filing_status_code

--- a/app/views/hub/clients/show.html.erb
+++ b/app/views/hub/clients/show.html.erb
@@ -100,9 +100,9 @@
             </div>
             <div class="field-display">
               <span class="form-question"><%= t("general.dependents") %>:</span>
-              <span class="label-value"><%= @client.intake&.dependents.count %></span>
+              <span class="label-value"><%= @client.intake&.dependents.with_deleted.length %></span>
               <ul id="dependents-list" class="no-bullets">
-                <%= render @client.intake.dependents %>
+                <%= render @client.intake.dependents.with_deleted %>
               </ul>
             </div>
           </div>

--- a/spec/controllers/ctc/portal/dependents_controller_spec.rb
+++ b/spec/controllers/ctc/portal/dependents_controller_spec.rb
@@ -99,8 +99,10 @@ describe Ctc::Portal::DependentsController do
 
     it "removes a dependent and leaves a system note" do
       expect do
-        put :destroy, params: { id: dependent.id }
-      end.not_to change(Dependent, :count)
+        expect do
+          put :destroy, params: { id: dependent.id }
+        end.to change(Dependent, :count).by(-1)
+      end.not_to change { Dependent.with_deleted.count }
 
       expect(dependent.reload.soft_deleted_at).to be_truthy
 


### PR DESCRIPTION
adds a concern that also provides scopes for .with_deleted
or .only_deleted