### PR TITLE
Efiling: squish internal spaces in user agent string to meet IRS schema

### DIFF
--- a/app/lib/submission_builder/formatting_methods.rb
+++ b/app/lib/submission_builder/formatting_methods.rb
@@ -3,7 +3,7 @@ module SubmissionBuilder
     extend ActiveSupport::Concern
 
     def trim(string, length)
-      string.first(length)&.strip
+      string.squish.first(length)&.strip
     end
 
     def datetime_type(datetime)


### PR DESCRIPTION
The current version of Firefox on iOS has a double-space in the user agent string, which isn't accepted by the schema. It looks like this (see after FxIos/36.0):

Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/36.0  Mobile/15E148 Safari/605.1.15