### PR TITLE
Fix screenshot test failure and point to target branch in percy

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ COVERAGE=y rspec
 
 #### Percy visual diff tests
 
+As an engineer, if you've made changes that _should_ not result in visual changes, but you are afraid they will, Percy can help. Create a pull request in GitHub, then run `bin/percy` locally. This will run the feature specs twice locally -- once on main, then once on your pull request -- and upload both collections to Percy. Percy will add a check in the pull request with a link to the visual comparison as well as print the URL to your console.
+
 [Percy](https://percy.io/) allows us to automatically compare visual changes with screenshots.
 
 We access a `PERCY_TOKEN` from Rails `development` credentials. Ask a teammate about access to development credentials.

--- a/bin/percy
+++ b/bin/percy
@@ -10,24 +10,31 @@ def system!(*args)
 end
 
 FileUtils.chdir APP_ROOT do
+  puts "Enter the base branch (press enter to use main)"
+  target_branch = gets.chomp.presence || 'main'
+  puts "Enter a 4 digit PR number if available (or press enter)"
+  pr_number = gets.chomp
+
   system!({ "PERCY_TOKEN" => Rails.application.credentials.percy_token },
     '
+      set -e
       if [ -z $PERCY_TOKEN ]; then echo "== 🚨 Please download development.key to access PERCY_TOKEN =="; exit 1; fi
 
-      if [ -z "$(git status --porcelain)" ]; then
-        echo "== 📸 Take baseline images =="
-        git checkout main
-        bundle install
-        npx percy exec -- rspec --tag screenshot
-        echo "== 📸 Take new images =="
-        git checkout -
-        bundle install
-        npx percy exec -- rspec --tag screenshot
-      else
-       echo "== 🚨 Please commit changes first =="
-       exit 1
-      fi
-    '
+      if [ -n "$(git status --porcelain)" ]; then echo "== 🚨 Please commit changes first =="; exit 1; fi
+
+      echo "== 📸 Take baseline images =="
+      git checkout %{target_branch}
+      bundle install
+      yarn install
+      RAILS_ENV=test bin/webpack
+      VITA_MIN_PERCY_ENABLED=1 npx percy exec -- rspec --tag screenshot
+      echo "== 📸 Take new images =="
+      git checkout -
+      bundle install
+      yarn install
+      RAILS_ENV=test bin/webpack
+      VITA_MIN_PERCY_ENABLED=1 PERCY_TARGET_BRANCH=%{target_branch} PERCY_PULL_REQUEST=%{pr_number} npx percy exec -- rspec --tag screenshot
+    ' % { target_branch: target_branch, pr_number: pr_number }
   )
 end
 

--- a/spec/support/helpers/feature_helpers.rb
+++ b/spec/support/helpers/feature_helpers.rb
@@ -4,7 +4,7 @@ module FeatureHelpers
   def screenshot_after
     yield
 
-    if @metadata_screenshot
+    if @metadata_screenshot && ENV["VITA_MIN_PERCY_ENABLED"].present?
       @screenshot_index = defined?(@screenshot_index) ? @screenshot_index + 1 : 1
       example_text, spec_path = inspect.match(/"(.*)" \(\.\/spec\/features\/(.*)_spec\.rb/)[1, 2]
 


### PR DESCRIPTION
# What does this PR do?

- Fixes `new_joint_filers_spec.rb` test, since it was updated to use the `js` driver, the `upload` button needed to be pressed when uploading files.
- Improve `bin/percy` script to:
  - Target `main` branch
  - Associate a PR if it's already opened ([this is optional](https://docs.percy.io/docs/environment-variables#optional))