### PR TITLE
De-flake some tests by removing apostrophes from Faker::Name.last_name names

### DIFF
--- a/spec/factories/intakes.rb
+++ b/spec/factories/intakes.rb
@@ -321,7 +321,7 @@ FactoryBot.define do
 
   trait :with_faker_contact_info do
     primary_first_name { Faker::Name.first_name }
-    primary_last_name { Faker::Name.last_name }
+    primary_last_name { Faker::Name.last_name.gsub("'", '') }
     preferred_name { primary_first_name }
     phone_number { "+14155551212" }
     sms_phone_number { "+14155551212" }


### PR DESCRIPTION
One example of a failing test is adv_ctc_irs1040_pdf_spec; if a name like
O'Connor is used, the assertion that the PDF includes "O'Connor" will fail
because it actually contains `O&apos;Connor`. I've confirmed that the
content of the PDF looks right in practice, it's just a testing problem.

Let us not be burdened by these flakes any more!