### PR TITLE
Imperfect return indicator acceptance

### DIFF
--- a/app/models/efile_submission.rb
+++ b/app/models/efile_submission.rb
@@ -55,6 +55,10 @@ class EfileSubmission < ApplicationRecord
     previously_transmitted_submission.efile_submission_transitions.collect(&:efile_errors).flatten.any? { |error| ["SEIC-F1040-501-02", "R0000-504-02"].include? error.code }
   end
 
+  def accepted_as_imperfect_return?
+    current_state == "accepted" && last_transition.metadata["imperfect_return_acceptance"] == true
+  end
+
   def last_client_accessible_transition
     history.reverse.find do |transition|
       !EfileSubmissionStateMachine::CLIENT_INACCESSIBLE_STATUSES.include?(transition.to_state)

--- a/app/models/efile_submission.rb
+++ b/app/models/efile_submission.rb
@@ -56,7 +56,7 @@ class EfileSubmission < ApplicationRecord
   end
 
   def accepted_as_imperfect_return?
-    current_state == "accepted" && last_transition.metadata["imperfect_return_acceptance"] == true
+    current_state == "accepted" && last_transition.metadata.key?("imperfect_return_acceptance")
   end
 
   def last_client_accessible_transition

--- a/app/services/efile/poll_for_acknowledgments_service.rb
+++ b/app/services/efile/poll_for_acknowledgments_service.rb
@@ -42,6 +42,8 @@ module Efile
           EfileSubmission.find_by(irs_submission_id: irs_submission_id).transition_to!(:rejected, raw_response: raw_response)
         elsif status == "Accepted"
           EfileSubmission.find_by(irs_submission_id: irs_submission_id).transition_to!(:accepted, raw_response: raw_response)
+        elsif status == "Exception"
+          EfileSubmission.find_by(irs_submission_id: irs_submission_id).transition_to!(:accepted, raw_response: raw_response, imperfect_return_acceptance: true)
         else
           submission = EfileSubmission.find_by(irs_submission_id: irs_submission_id)
           if submission

--- a/app/views/ctc/portal/portal/home.html.erb
+++ b/app/views/ctc/portal/portal/home.html.erb
@@ -57,7 +57,7 @@
             <%= t("views.ctc.portal.home.status.#{@status}.message") %>
           <% end %>
 
-          <% if @submission.accepted_as_imperfect_return? %>
+          <% if @submission&.accepted_as_imperfect_return? %>
             <h3><%= t("views.ctc.portal.home.next_step_title") %></h3>
             <div class="text--small">
               <%= I18n.t("views.ctc.portal.home.imperfect_return_indicator_text") %>

--- a/app/views/ctc/portal/portal/home.html.erb
+++ b/app/views/ctc/portal/portal/home.html.erb
@@ -57,6 +57,13 @@
             <%= t("views.ctc.portal.home.status.#{@status}.message") %>
           <% end %>
 
+          <% if @submission.accepted_as_imperfect_return? %>
+            <h3><%= t("views.ctc.portal.home.next_step_title") %></h3>
+            <div class="text--small">
+              <%= I18n.t("views.ctc.portal.home.imperfect_return_indicator_text") %>
+            <div>
+          <% end %>
+
           <div class="review-box__cta-button-container spacing-above-35">
             <% if @current_step %>
               <%= link_to t("views.ctc.portal.home.complete_form"), @current_step, class: "button button--wide spacing-below-0" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1426,6 +1426,9 @@ en:
             Reason for this rejection:
           next_step_title: |
             Next steps:
+          imperfect_return_indicator_text: |
+            Your return was accepted by the IRS, inlcuding a request to update one more more of your dependents' legal names in their records.
+            The IRS estimates that it will take 4-8 weeks to process your return. You may also receive a letter confirming your request to update the dependent's legal name.
           status:
             intake_in_progress:
               label: More information needed

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1427,7 +1427,7 @@ en:
           next_step_title: |
             Next steps:
           imperfect_return_indicator_text: |
-            Your return was accepted by the IRS, inlcuding a request to update one more more of your dependents' legal names in their records.
+            Your return was accepted by the IRS, including a request to update one more more of your dependents' legal names in their records.
             The IRS estimates that it will take 4-8 weeks to process your return. You may also receive a letter confirming your request to update the dependent's legal name.
           status:
             intake_in_progress:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1407,6 +1407,9 @@ es:
             Motivo de este rechazo:
           next_step_title: |
             Próximos pasos:
+          imperfect_return_indicator_text: |
+            El IRS aceptó su devolución, incluida una solicitud para actualizar uno más de los nombres legales de sus dependientes en sus registros.
+            El IRS estima que le tomará de 4 a 8 semanas procesar su declaración. También puede recibir una carta confirmando su solicitud para actualizar el nombre legal del dependiente.
           status:
             intake_in_progress:
               label: Necesitamos más información

--- a/spec/factories/efile_submissions.rb
+++ b/spec/factories/efile_submissions.rb
@@ -32,8 +32,8 @@ FactoryBot.define do
 
     EfileSubmissionStateMachine.states.each do |state|
       trait state.to_sym do
-        after :create do |submission|
-          create :efile_submission_transition, state, efile_submission: submission
+        after :create do |submission, evaluator|
+          create :efile_submission_transition, state, efile_submission: submission, metadata: evaluator.metadata
         end
       end
     end

--- a/spec/factories/efile_submissions.rb
+++ b/spec/factories/efile_submissions.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
     transient do
       tax_year { 2020 }
       filing_status { "single" }
-      metadata {}
+      metadata { {} }
     end
     tax_return { create :tax_return, :ctc, year: tax_year, filing_status: filing_status }
 

--- a/spec/models/efile_submission_spec.rb
+++ b/spec/models/efile_submission_spec.rb
@@ -377,6 +377,31 @@ describe EfileSubmission do
     end
   end
 
+  describe "#accepted_as_imperfect_return?" do
+    context "when not accepted status" do
+      let(:efile_submission) { create :efile_submission, :rejected }
+      it "returns false" do
+        expect(efile_submission.accepted_as_imperfect_return?).to eq false
+      end
+    end
+
+    context "when current status is accepted but was not an imperfect return acceptance on metadata" do
+      let(:efile_submission) { create :efile_submission, :accepted }
+
+      it "returns false" do
+        expect(efile_submission.accepted_as_imperfect_return?).to eq false
+
+      end
+    end
+
+    context "when current status is accepted and imperfect return acceptance is present on metadata" do
+      let(:efile_submission) { create :efile_submission, :accepted, metadata: { imperfect_return_acceptance: true } }
+
+      it "returns true" do
+        expect(efile_submission.accepted_as_imperfect_return?).to eq true
+      end
+    end
+  end
   describe "#imperfect_return_resubmission?" do
     context "when the submission's preparing transition has a previous submission id stored" do
       let(:previous_submission) { create(:efile_submission) }

--- a/spec/models/efile_submission_spec.rb
+++ b/spec/models/efile_submission_spec.rb
@@ -402,6 +402,7 @@ describe EfileSubmission do
       end
     end
   end
+
   describe "#imperfect_return_resubmission?" do
     context "when the submission's preparing transition has a previous submission id stored" do
       let(:previous_submission) { create(:efile_submission) }

--- a/spec/services/efile/poll_for_acknowledgments_service_spec.rb
+++ b/spec/services/efile/poll_for_acknowledgments_service_spec.rb
@@ -112,10 +112,10 @@ describe Efile::PollForAcknowledgmentsService do
             end
           end
 
-          context "and it something else" do
+          context "and it is an exception" do
             let(:expected_irs_return_value) { file_fixture("irs_acknowledgement_exception.xml").read }
 
-            it "changes the state from transmitted to investigating" do
+            it "changes the state from transmitted to accepted, with imperfect return acceptance in metadata" do
               Efile::PollForAcknowledgmentsService.run
               expect(efile_submission.current_state).to eq("accepted")
               expect(efile_submission.efile_submission_transitions.last.metadata['raw_response']).to eq(first_ack)

--- a/spec/services/efile/poll_for_acknowledgments_service_spec.rb
+++ b/spec/services/efile/poll_for_acknowledgments_service_spec.rb
@@ -117,8 +117,9 @@ describe Efile::PollForAcknowledgmentsService do
 
             it "changes the state from transmitted to investigating" do
               Efile::PollForAcknowledgmentsService.run
-              expect(efile_submission.current_state).to eq("failed")
+              expect(efile_submission.current_state).to eq("accepted")
               expect(efile_submission.efile_submission_transitions.last.metadata['raw_response']).to eq(first_ack)
+              expect(efile_submission.efile_submission_transitions.last.metadata['imperfect_return_acceptance']).to eq true
             end
           end
         end


### PR DESCRIPTION
We learned last week that "Exception" acknowledgements indicate that the IRS has accepted the return, but with some conditions.

Move "exception" acknowledgement status into accepted instead of failed, and add messaging to explain the implications of this type of acceptance to the clients.