### PR TITLE
Use CTC domain when sending emails from getctc.org [179186159]

### DIFF
--- a/app/mailers/ctc_signup_mailer.rb
+++ b/app/mailers/ctc_signup_mailer.rb
@@ -1,18 +1,4 @@
 class CtcSignupMailer < ApplicationMailer
-  default from: Rails.configuration.email_from[:noreply][:ctc]
-
-  def beta_navigation(email_address:, name:)
-    @name = name
-    @subject = "GetCTC Child Tax Credit Assistance now available"
-    ctc_service = MultiTenantService.new(:ctc)
-    mail(
-      to: email_address,
-      subject: @subject,
-      from: ctc_service.default_email,
-      delivery_method_options: ctc_service.delivery_method_options,
-    )
-  end
-
   def launch_announcement(email_address:, name:)
     @name = name
     subject = "Thank you for signing up to receive updates regarding GetCTC! / ¡Gracias por registrarse para recibir las actualizaciones de GetCTC!"
@@ -20,7 +6,7 @@ class CtcSignupMailer < ApplicationMailer
     mail(
       to: email_address,
       subject: subject,
-      from: ctc_service.default_email,
+      from: ctc_service.noreply_email,
       delivery_method_options: ctc_service.delivery_method_options,
     )
   end

--- a/app/mailers/ctc_signup_mailer.rb
+++ b/app/mailers/ctc_signup_mailer.rb
@@ -4,20 +4,24 @@ class CtcSignupMailer < ApplicationMailer
   def beta_navigation(email_address:, name:)
     @name = name
     @subject = "GetCTC Child Tax Credit Assistance now available"
-    @service_type = :ctc
+    ctc_service = MultiTenantService.new(:ctc)
     mail(
       to: email_address,
       subject: @subject,
+      from: ctc_service.default_email,
+      delivery_method_options: ctc_service.delivery_method_options,
     )
   end
 
   def launch_announcement(email_address:, name:)
     @name = name
     subject = "Thank you for signing up to receive updates regarding GetCTC! / ¡Gracias por registrarse para recibir las actualizaciones de GetCTC!"
-    @service_type = :ctc
+    ctc_service = MultiTenantService.new(:ctc)
     mail(
       to: email_address,
       subject: subject,
+      from: ctc_service.default_email,
+      delivery_method_options: ctc_service.delivery_method_options,
     )
   end
 end


### PR DESCRIPTION
Before this change, the email I got in production was marked as spam with this in the headers:

```
ARC-Authentication-Results: i=1; mx.google.com;
       dkim=pass header.i=@mg.getyourrefund.org header.s=pic header.b=ARqWBbhe;
       spf=pass (google.com: domain of bounce+0ca7ff.b8d535-alaroia=codeforamerica.org@mg.getyourrefund.org designates 209.61.151.230 as permitted sender) smtp.mailfrom="bounce+0ca7ff.b8d535-alaroia=codeforamerica.org@mg.getyourrefund.org";
       dmarc=fail (p=QUARANTINE sp=NONE dis=QUARANTINE) header.from=getctc.org
```

We used a "From" header of getctc.org but were using the getyourrefund.org mailgun key, which meant our "envelope from" was mg.getyourrefund.org. This mismatch caused it to be marked as spam.

The change in this pull request adjusts the delivery options to use the GetCTC delivery options.