### PR TITLE
Demo: Heroku Review App configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 /config/master.key
 /config/credentials/development.key
 /config/credentials/staging.key
+/config/credentials/heroku.key
 /config/credentials/demo.key
 /config/credentials/production.key
 /config/credentials/*.key

--- a/Procfile
+++ b/Procfile
@@ -2,3 +2,5 @@
 cmd: bundle exec rails s -b 0.0.0.0 -p 3000
 worker: bundle exec rails jobs:work
 cron: exec supercronic /app/crontab
+release: bin/rails heroku:release
+web: bundle exec rails server

--- a/app.json
+++ b/app.json
@@ -1,16 +1,48 @@
 {
-  "name": "VitaMin",
+  "name": "My Rails Application",
   "description": "Heroku review apps from GitHub PRs",
-  "addons": [
-    "heroku-postgresql"
-  ],
-  "stack": "heroku-16",
+  "scripts": {
+    "postdeploy": "bin/rails heroku:postdeploy"
+  },
+  "formation": {
+    "web": {
+      "quantity": 1
+    },
+    "worker": {
+      "quantity": 1
+    }
+  },
+  "stack": "heroku-18",
   "buildpacks": [
     {
-      "url": "https://github.com/fxtentacle/heroku-pdftk-buildpack.git"
+      "url": "heroku/ruby"
     },
     {
-      "url": "heroku/ruby"
+      "url": "https://github.com/heroku/heroku-buildpack-activestorage-preview"
+    },
+    {
+      "url": "https://github.com/fxtentacle/heroku-pdftk-buildpack.git"
     }
+  ],
+  "env": {
+    "LOG_LEVEL": {
+      "value": "info"
+    },
+    "RACK_ENV": {
+      "value": "production"
+    },
+    "RAILS_ENV": {
+      "value": "heroku"
+    },
+    "RAILS_SERVE_STATIC_FILES": {
+      "value": "enabled"
+    },
+    "SECRET_KEY_BASE": {
+      "description": "Secret key base for Rails.",
+      "generator": "secret"
+    }
+  },
+  "addons": [
+    "heroku-postgresql"
   ]
 }

--- a/app/lib/routes/ctc_domain.rb
+++ b/app/lib/routes/ctc_domain.rb
@@ -1,7 +1,9 @@
 module Routes
   class CtcDomain
     def matches?(request)
-      Rails.application.config.ctc_domains.values.include?(request.host)
+      Rails.application.config.ctc_domains.values.any? do |matcher|
+        matcher.is_a?(Regexp) ? matcher.match?(request.host) : matcher == request.host
+      end
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,12 +38,14 @@ module VitaMin
     config.gyr_domains = {
       development: "localhost",
       demo: "demo.getyourrefund.org",
+      heroku_review: /gyr-vita-min-.*\.herokuapp\.com/,
       staging: "staging.getyourrefund.org",
       production: "www.getyourrefund.org"
     }
     config.ctc_domains = {
       development: "ctc.localhost",
       demo: "ctc.demo.getyourrefund.org",
+      heroku_review: /ctc-vita-min-.*\.herokuapp\.com/,
       staging: "ctc.staging.getyourrefund.org",
       production: "www.getctc.org"
     }

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -4,6 +4,9 @@ development:
 staging:
   adapter: postgresql
 
+heroku:
+  adapter: postgresql
+
 demo:
   adapter: postgresql
 

--- a/config/credentials/heroku.yml.enc
+++ b/config/credentials/heroku.yml.enc
@@ -1,0 +1,1 @@
+OVbe5IvKyR/HmTzsfpHee9uCgRix6qGnI+OETWHsa4SSRpYOSt/HjQJ4Dsvk80A1kGC67cqR5Q9ZAYU=--cKlxViy1BgUjSsXA--des/MUpxs16QjutVEbu0jg==

--- a/config/database.yml
+++ b/config/database.yml
@@ -30,3 +30,7 @@ staging:
 
 demo:
   <<: *deploy_default
+
+heroku:
+  <<: *deploy_default
+  url: <%= ENV.fetch("DATABASE_URL", "").sub('postgres://', 'postgis://') %>

--- a/config/environments/heroku.rb
+++ b/config/environments/heroku.rb
@@ -1,0 +1,25 @@
+require Rails.root.join('config/environments/demo')
+
+Rails.application.configure do
+  # TODO: have an S3 bucket
+  config.active_storage.service = :local
+
+  heroku_host = "#{ENV['HEROKU_APP_NAME']}.herokuapp.com"
+  heroku_url = "https://#{heroku_host}"
+  config.ctc_url = heroku_url.sub("gyr-", "ctc-")
+  config.gyr_url = heroku_url.sub("ctc-", "gyr-")
+
+  ctc_email_from_domain = "mg-staging-ctc.getyourrefund-testing.org"
+  gyr_email_from_domain = "mg-staging.getyourrefund-testing.org"
+  config.email_from = {
+    default: {ctc: "hello@#{ctc_email_from_domain}", gyr: "hello@#{gyr_email_from_domain}"},
+    noreply: {ctc: "no-reply@#{ctc_email_from_domain}", gyr: "no-reply@#{gyr_email_from_domain}"}
+  }
+  config.action_mailer.default_url_options = { host: heroku_host }
+  config.action_mailer.asset_host = heroku_url
+  config.offseason = false
+  config.hide_ctc = false
+
+  Rails.application.default_url_options = config.action_mailer.default_url_options
+  config.efile_environment = "test"
+end

--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -1,0 +1,16 @@
+namespace :heroku do
+  desc 'Heroku release task (runs on every code push; on review app creation, runs before postdeploy task)'
+  task release: :environment do
+    if ActiveRecord::SchemaMigration.table_exists?
+      Rake::Task['db:migrate'].invoke
+    else
+      Rails.logger.info "Database not initialized, skipping database migration."
+    end
+  end
+
+  desc 'Heroku postdeploy task (runs once on review app creation, after release task)'
+  task postdeploy: :environment do
+    Rake::Task['db:schema:load'].invoke
+    Rake::Task['db:seed'].invoke
+  end
+end

--- a/spec/lib/routes/ctc_domain_spec.rb
+++ b/spec/lib/routes/ctc_domain_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe Routes::CtcDomain do
   let(:ctc_localhost) { instance_double(ActionDispatch::Request, host: "ctc.localhost") }
+  let(:ctc_heroku) { instance_double(ActionDispatch::Request, host: "ctc-vita-min-pr-42.herokuapp.com") }
   let(:ctc_prod) { instance_double(ActionDispatch::Request, host: "www.getctc.org") }
   let(:root_demo) { instance_double(ActionDispatch::Request, host: "demo.getyourrefund.org") }
   let(:root_localhost) { instance_double(ActionDispatch::Request, host: "localhost") }
@@ -11,6 +12,7 @@ describe Routes::CtcDomain do
   describe "#matches?" do
     it 'returns true if the request host is a ctc domain' do
       expect(subject.matches?(ctc_localhost)).to be_truthy
+      expect(subject.matches?(ctc_heroku)).to be_truthy
       expect(subject.matches?(ctc_prod)).to be_truthy
       expect(subject.matches?(root_demo)).to be_falsey
       expect(subject.matches?(root_localhost)).to be_falsey


### PR DESCRIPTION
This will be demoed/discussed/recreated during Computer Gardening. Check out the [Notion Document](https://www.notion.so/cfa/Heroku-Review-Apps-d7bcef5d33114348bad8b343f736175c) for high-level benefits and drawbacks.

Notes:
- Creates a new "heroku" Rails environment, and ensures that Rails mailer hostnames are set dynamically because every Heroku Review app will each have its own domain.
- Creates a new credentials file for the `heroku` Rails environment. Currently, it only has a value for `attr_encrypted`, but could eventually have S3, Mailgun, Twilio, etc credentials. The `RAILS_MASTER_KEY` is added via the Heroku Dashboard.
- Adds an `app.json` which is Heroku's configuration file
- Adds some Rake tasks for ensuring that Heroku's databases are set up and seeded
- Updates the Domain Matcher to recognize Heroku's dynamic hostnames. There will need to actually be 2 separate "Pipelines"/Review App configurations, one for each of `gyr` and `ctc` domains.

Further work:

- Add credentials for S3, Mailgun, Twilio, etc. to the `heroku.yml.enc` credentials file so that the Review Apps can handle uploads, send email/SMS, etc. 