### PR TITLE
Replace flaky Capybara `within('h1')... have_text` with `have_selector`

### DIFF
--- a/spec/features/hub/create_client_spec.rb
+++ b/spec/features/hub/create_client_spec.rb
@@ -13,9 +13,7 @@ RSpec.feature "Creating new drop off clients" do
       visit hub_clients_path
       click_on "Add client"
 
-      within("h1") do
-        expect(page).to have_text "Add a new client"
-      end
+      expect(page).to have_selector "h1", text: "Add a new client"
 
       expect(page).to have_text "Drop off"
       select "Floret Financial Readiness", from: "Assign to"

--- a/spec/features/hub/create_ctc_client_spec.rb
+++ b/spec/features/hub/create_ctc_client_spec.rb
@@ -13,9 +13,7 @@ RSpec.feature "Creating new drop off clients" do
       visit hub_clients_path
       click_on "Add CTC client"
 
-      within("h1") do
-        expect(page).to have_text "Add a new CTC client"
-      end
+      expect(page).to have_selector "h1", text: "Add a new CTC client"
 
       expect(page.find("#hub_create_ctc_client_form_vita_partner_id").all('option').collect(&:text)).to include "Floret Financial Readiness"
       expect(page.find("#hub_create_ctc_client_form_vita_partner_id").all('option').collect(&:text)).not_to include "Brassica Asset Builders"

--- a/spec/features/hub/invitations/admin_spec.rb
+++ b/spec/features/hub/invitations/admin_spec.rb
@@ -12,9 +12,7 @@ RSpec.feature "Inviting admin users" do
       click_on "Invitations"
 
       # Invitations page
-      within("h1") do
-        expect(page).to have_text "Invitations"
-      end
+      expect(page).to have_selector "h1", text: "Invitations"
       click_on "Invite a new admin"
 
       # new invitation page

--- a/spec/features/hub/invitations/client_success_spec.rb
+++ b/spec/features/hub/invitations/client_success_spec.rb
@@ -12,9 +12,7 @@ RSpec.feature "Inviting client success" do
       click_on "Invitations"
 
       # Invitations page
-      within("h1") do
-        expect(page).to have_text "Invitations"
-      end
+      expect(page).to have_selector "h1", text: "Invitations"
       click_on "Invite a new client success"
 
       # new invitation page

--- a/spec/features/hub/invitations/coalition_lead_spec.rb
+++ b/spec/features/hub/invitations/coalition_lead_spec.rb
@@ -13,9 +13,7 @@ RSpec.feature "Inviting coalition leads" do
       click_on "Invitations"
 
       # Invitations page
-      within("h1") do
-        expect(page).to have_text "Invitations"
-      end
+      expect(page).to have_selector "h1", text: "Invitations"
       click_on "Invite a new coalition lead"
 
       # new invitation page

--- a/spec/features/hub/invitations/greeter_spec.rb
+++ b/spec/features/hub/invitations/greeter_spec.rb
@@ -13,9 +13,7 @@ RSpec.feature "Inviting greeters" do
       click_on "Invitations"
 
       # Invitations page
-      within("h1") do
-        expect(page).to have_text "Invitations"
-      end
+      expect(page).to have_selector "h1", text: "Invitations"
       click_on "Invite a new greeter"
 
       # new invitation page

--- a/spec/features/hub/invitations/org_lead_spec.rb
+++ b/spec/features/hub/invitations/org_lead_spec.rb
@@ -13,9 +13,7 @@ RSpec.feature "Inviting organization leads" do
       click_on "Invitations"
 
       # Invitations page
-      within("h1") do
-        expect(page).to have_text "Invitations"
-      end
+      expect(page).to have_selector "h1", text: "Invitations"
       click_on "Invite a new organization lead"
 
       # new invitation page

--- a/spec/features/hub/invitations/site_coordinator_spec.rb
+++ b/spec/features/hub/invitations/site_coordinator_spec.rb
@@ -13,9 +13,7 @@ RSpec.feature "Inviting site coordinator" do
       click_on "Invitations"
 
       # Invitations page
-      within("h1") do
-        expect(page).to have_text "Invitations"
-      end
+      expect(page).to have_selector "h1", text: "Invitations"
       click_on "Invite a new site coordinator"
 
       # new invitation page

--- a/spec/features/hub/invitations/team_member_spec.rb
+++ b/spec/features/hub/invitations/team_member_spec.rb
@@ -15,9 +15,7 @@ RSpec.feature "Inviting team members" do
       click_on "Invitations"
 
       # Invitations page
-      within("h1") do
-        expect(page).to have_text "Invitations"
-      end
+      expect(page).to have_selector "h1", text: "Invitations"
       click_on "Invite a new team member"
 
       # new invitation page


### PR DESCRIPTION
I believe this is flaky because once the wrapping `within` block finds a match, it will not refresh if a navigation/refresh happens.

It looks like `have_selector` is the typical usage across the codebase, so these are just a few outliers.