### PR TITLE
Move confirm information so that people with unexposed errors can update their information

### DIFF
--- a/app/views/ctc/portal/portal/home.html.erb
+++ b/app/views/ctc/portal/portal/home.html.erb
@@ -50,9 +50,6 @@
                 <%= t("views.ctc.portal.home.default_next_steps") %>
               <% end %>
             </div>
-            <div class="review-box__cta-button-container spacing-above-35">
-              <%= link_to t("views.ctc.portal.home.correct_info"), ctc_portal_edit_info_path, class: "button button--wide button--primary spacing-below-0" %>
-            </div>
           <% else %>
             <%= t("views.ctc.portal.home.status.#{@status}.message") %>
           <% end %>
@@ -65,6 +62,11 @@
           <% end %>
 
           <div class="review-box__cta-button-container spacing-above-35">
+            <% if @submission.can_transition_to?(:resubmitted) %>
+              <div class="review-box__cta-button-container spacing-above-35">
+                <%= link_to t("views.ctc.portal.home.correct_info"), ctc_portal_edit_info_path, class: "button button--wide button--primary spacing-below-0" %>
+              </div>
+            <% end %>
             <% if @current_step %>
               <%= link_to t("views.ctc.portal.home.complete_form"), @current_step, class: "button button--wide spacing-below-0" %>
             <% end %>

--- a/app/views/ctc/portal/portal/home.html.erb
+++ b/app/views/ctc/portal/portal/home.html.erb
@@ -62,7 +62,7 @@
           <% end %>
 
           <div class="review-box__cta-button-container spacing-above-35">
-            <% if @submission.can_transition_to?(:resubmitted) %>
+            <% if @submission.present? && @submission.can_transition_to?(:resubmitted) %>
               <div class="review-box__cta-button-container spacing-above-35">
                 <%= link_to t("views.ctc.portal.home.correct_info"), ctc_portal_edit_info_path, class: "button button--wide button--primary spacing-below-0" %>
               </div>


### PR DESCRIPTION
Limiting showing this button to only people who have an exposed error means that the people affected by bank account bundle fails couldn't get to the update info page.