### PR TITLE
Add pause between target snapshots and pr snapshots to script (#177084353)

### DIFF
--- a/bin/percy
+++ b/bin/percy
@@ -18,22 +18,29 @@ FileUtils.chdir APP_ROOT do
   system!({ "PERCY_TOKEN" => Rails.application.credentials.percy_token },
     '
       set -e
+
       if [ -z $PERCY_TOKEN ]; then echo "== 🚨 Please download development.key to access PERCY_TOKEN =="; exit 1; fi
 
       if [ -n "$(git status --porcelain)" ]; then echo "== 🚨 Please commit changes first =="; exit 1; fi
 
-      echo "== 📸 Take baseline images =="
+      echo "== 📸 Take baseline images on %{target_branch} branch =="
       git checkout %{target_branch}
       bundle install
       yarn install
       RAILS_ENV=test bin/webpack
       VITA_MIN_PERCY_ENABLED=1 npx percy exec -- rspec --tag screenshot
-      echo "== 📸 Take new images =="
+
+      echo "== 🕰️  Please wait for %{target_branch} to fully process snapshoots and complete at the provided link above. (Takes a few minutes) =="
+      read -n 1 -p "== 🕰️  Then press any key to continue =="
+
+      current_branch=$(git branch | sed -n -e \'s/^\* \(.*\)/\1/p\')
+      echo "== 📸 Take new images on ${current_branch} branch =="
       git checkout -
       bundle install
       yarn install
       RAILS_ENV=test bin/webpack
       VITA_MIN_PERCY_ENABLED=1 PERCY_TARGET_BRANCH=%{target_branch} PERCY_PULL_REQUEST=%{pr_number} npx percy exec -- rspec --tag screenshot
+      echo "== 🏁 Script complete =="
     ' % { target_branch: target_branch, pr_number: pr_number }
   )
 end


### PR DESCRIPTION
# What does this PR do?

There was an issue with `bin/percy` script. The script creates screenshots for a target branch (usually `main`) and then screenshots for a new branch. But the first screenshots have to be fully processed over on the percy.io service. Otherwise it will use an old reference (or no reference at all).

So to solve for this, after screenshots are created for the target branch, the script will pause and wait for a dev to enter a key to continue on with creating screenshots for the second branch.

## Testing locally

I tested this locally by running the script with these results:

```shell
vita-min ▲ bin/percy
Enter the base branch (press enter to use main)

Enter a 4 digit PR number if available (or press enter)

== 📸 Take baseline images on main branch ==
...
Finished in 1 minute 20.16 seconds (files took 14.14 seconds to load)
3 examples, 0 failures

[percy] Finalized build #13: https://percy.io/Code-for-America/vita-min/builds/12658131
== 🕰️ Please wait for main to fully process snapshoots and complete at the provided link above. (Takes a few minutes) ==
== 🕰️ Then press any key to continue ==
# ℹ️ I went to the URL for build #13, waited for it to finish (about 5 minutes) and then continued the script ℹ️
== 📸 Take new images on main branch ==
...
Finished in 1 minute 18.98 seconds (files took 11.2 seconds to load)
3 examples, 0 failures

[percy] Finalized build #14: https://percy.io/Code-for-America/vita-min/builds/12658235
== 🏁 Script complete ==
```