### PR TITLE
GyrEfiler: raise RetryableError if we get a redirect on login

### DIFF
--- a/app/services/efile/gyr_efiler_service.rb
+++ b/app/services/efile/gyr_efiler_service.rb
@@ -38,6 +38,8 @@ module Efile
           log_contents = File.read(File.join(working_directory, 'output/log/audit_log.txt'))
           if log_contents.split("\n").include?("Transaction Result: java.net.SocketTimeoutException: Read timed out")
             raise RetryableError, log_contents
+          elsif log_contents.match(/Transaction Result: The server sent HTTP status code 302: Moved Temporarily/)
+            raise RetryableError, log_contents
           else
             raise Error, log_contents
           end

--- a/spec/services/efile/gyr_efiler_service_spec.rb
+++ b/spec/services/efile/gyr_efiler_service_spec.rb
@@ -78,6 +78,29 @@ RSpec.describe Efile::GyrEfilerService do
           }.to raise_error(Efile::GyrEfilerService::RetryableError)
         end
       end
+
+      context "when the cause is a gyr-efiler login moved temporarily" do
+        let(:log_output) do
+          <<~AUDIT_LOG
+            Name of Service Call: Login
+            Message ID of Service Call: abcdefg
+            Transaction Submission Date/Time: 2021-09-11T11:58:02Z
+            ETIN of Service Call: 1234
+            ASID: 121212
+            Toolkit Version: 2020v11.1
+            Request data: N/A
+            Name of Service Call: Login
+            Message ID of Service Call: abcdefg
+            Transaction Result: The server sent HTTP status code 302: Moved Temporarily
+          AUDIT_LOG
+        end
+
+        it "raises a RetryableError" do
+          expect {
+            described_class.run_efiler_command
+          }.to raise_error(Efile::GyrEfilerService::RetryableError)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
historically this has happened over the weekend during some IRS downtime

one example is https://www.getyourrefund.org/en/hub/clients/582739/efile