### PR TITLE
Create explicit bank account errors

### DIFF
--- a/app/lib/default_error_messages.rb
+++ b/app/lib/default_error_messages.rb
@@ -30,5 +30,12 @@ class DefaultErrorMessages
       source: :internal,
       expose: false
     )
+    EfileError.find_or_create_by!(
+      code: "BANK-DETAILS",
+      message: "Some of the provided bank account details are incorrect or absent.",
+      source: :intake,
+      expose: true,
+      auto_wait: true
+    )
   end
 end

--- a/app/state_machines/efile_submission_state_machine.rb
+++ b/app/state_machines/efile_submission_state_machine.rb
@@ -53,7 +53,7 @@ class EfileSubmissionStateMachine
   after_transition(to: :failed, after_commit: true) do |submission, transition|
     submission.tax_return.update(status: "file_needs_review")
 
-    Efile::SubmissionErrorParser.new(transition).persist_efile_errors_from_transition_metadata
+    Efile::SubmissionErrorParser.persist_errors(transition)
 
     if transition.efile_errors.any?
       if transition.efile_errors.any?(&:expose)
@@ -72,7 +72,7 @@ class EfileSubmissionStateMachine
   after_transition(to: :rejected, after_commit: true) do |submission, transition|
     submission.tax_return.update(status: "file_rejected")
 
-    Efile::SubmissionErrorParser.new(transition).persist_efile_errors_from_transition_metadata
+    Efile::SubmissionErrorParser.persist_errors(transition)
 
     if transition.efile_errors.any?
       ClientMessagingService.send_system_message_to_all_opted_in_contact_methods(

--- a/spec/factories/efile_submissions.rb
+++ b/spec/factories/efile_submissions.rb
@@ -42,7 +42,7 @@ FactoryBot.define do
       after :create do |submission|
         raw_xml = File.read(File.join(Rails.root, "spec/fixtures/files", "irs_acknowledgement_rejection.xml"))
         submission.efile_submission_transitions.last.update(metadata: { raw_response: raw_xml })
-        Efile::SubmissionErrorParser.new(submission.efile_submission_transitions.last).persist_efile_errors_from_transition_metadata
+        Efile::SubmissionErrorParser.persist_errors(submission.efile_submission_transitions.last)
       end
     end
   end


### PR DESCRIPTION
We're still getting some bank account details are incorrect errors, even after adding validations. Bleh.

It's also just generally creating some other issues in the code to not have these recorded as a specific error type.