### PR TITLE
Remove None of the above as an option for Spouse SSN

### DIFF
--- a/app/views/ctc/questions/spouse_info/edit.html.erb
+++ b/app/views/ctc/questions/spouse_info/edit.html.erb
@@ -18,7 +18,7 @@
             help_text: t("hub.clients.show.date_of_birth_help"),
             classes: ["ctc-intake-date-text-input"]
           ) %>
-      <%= f.cfa_select(:spouse_tin_type, t("views.ctc.questions.spouse_info.spouse_identity"), tin_options_for_select(include_itin: true, include_none: true), help_text: t("views.ctc.questions.spouse_info.spouse_identity_help_text")) %>
+      <%= f.cfa_select(:spouse_tin_type, t("views.ctc.questions.spouse_info.spouse_identity"), tin_options_for_select(include_itin: true), help_text: t("views.ctc.questions.spouse_info.spouse_identity_help_text")) %>
       <%= f.cfa_checkbox(:ssn_no_employment, t('views.ctc.questions.legal_consent.ssn_not_valid_for_employment'), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_input_field(:spouse_ssn, t("views.ctc.questions.spouse_info.spouse_ssn_itin"), classes: ["form-width--long"]) %>
       <%= f.cfa_input_field(:spouse_ssn_confirmation, t("views.ctc.questions.spouse_info.spouse_ssn_itin_confirmation"), classes: ["form-width--long"]) %>


### PR DESCRIPTION
We had "None of the above" as an option for spouse identification. It caused a crash when you selected it. See [the story.](https://www.pivotaltracker.com/story/show/179542073)