### PR TITLE
CTC portal updating: create a SystemNote when bank account is changed

### DIFF
--- a/app/controllers/ctc/portal/bank_account_controller.rb
+++ b/app/controllers/ctc/portal/bank_account_controller.rb
@@ -14,4 +14,9 @@ class Ctc::Portal::BankAccountController < Ctc::Portal::BaseIntakeRevisionContro
   def form_class
     Ctc::Portal::BankAccountForm
   end
+
+  def current_model
+    @_current_model ||= current_intake.bank_account
+  end
+  helper_method :current_model
 end

--- a/app/forms/ctc/portal/bank_account_form.rb
+++ b/app/forms/ctc/portal/bank_account_form.rb
@@ -17,12 +17,12 @@ module Ctc
       validates :my_bank_account, acceptance: { accept: "yes", message: -> (_object, _data) { I18n.t("views.ctc.questions.direct_deposit.my_bank_account.error_message") }}
 
       def initialize(intake, params = {})
-        @intake = intake
+        @bank_account = intake
         super(params)
       end
 
       def save
-        bank_account = @intake.bank_account || @intake.build_bank_account
+        bank_account = @bank_account
         bank_account.assign_attributes(attributes_for(:bank_account))
         bank_account.save if bank_account.valid?
       end

--- a/app/views/hub/notes/_system_note_model_update.erb
+++ b/app/views/hub/notes/_system_note_model_update.erb
@@ -5,7 +5,7 @@
   <strong><%= note.user.name %> changed <%= model_gid.model_name %> #<%= model_gid.model_id %>:</strong>
 <% end %>
 
-<table class="spacing-above-15 spacing-below-0 changes-table">
+<table class="spacing-above-15 spacing-below-0 changes-table changes-note-<%= note.id %>">
   <thead>
     <th></th>
     <th>Was</th>

--- a/spec/forms/ctc/portal/bank_account_form_spec.rb
+++ b/spec/forms/ctc/portal/bank_account_form_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 describe Ctc::Portal::BankAccountForm do
+  let!(:bank_account) { create(:bank_account, intake: intake) }
   let(:intake) { create :ctc_intake }
   let(:bank_name) { "Bank of America" }
   let(:account_type) { "checking" }
@@ -25,7 +26,7 @@ describe Ctc::Portal::BankAccountForm do
       context "when not present" do
         let(:bank_name) { nil }
         it "is not valid" do
-          expect(described_class.new(intake, params)).not_to be_valid
+          expect(described_class.new(bank_account, params)).not_to be_valid
         end
       end
     end
@@ -34,7 +35,7 @@ describe Ctc::Portal::BankAccountForm do
       context "when not present" do
         let(:account_type) { nil }
         it "is not valid" do
-          expect(described_class.new(intake, params)).not_to be_valid
+          expect(described_class.new(bank_account, params)).not_to be_valid
         end
       end
     end
@@ -43,7 +44,7 @@ describe Ctc::Portal::BankAccountForm do
       context "when not checked yes" do
         let(:my_bank_account) { "no" }
         it "is not valid" do
-          expect(described_class.new(intake, params)).not_to be_valid
+          expect(described_class.new(bank_account, params)).not_to be_valid
         end
       end
     end
@@ -53,7 +54,7 @@ describe Ctc::Portal::BankAccountForm do
       let(:routing_number_confirmation) { "12345678" }
       it "is not valid" do
         expect(
-            described_class.new(intake, params)
+            described_class.new(bank_account, params)
         ).not_to be_valid
       end
     end
@@ -63,7 +64,7 @@ describe Ctc::Portal::BankAccountForm do
       let(:routing_number_confirmation) { "12345678" }
       it "is not valid" do
         expect(
-            described_class.new(intake, params)
+            described_class.new(bank_account, params)
         ).not_to be_valid
       end
     end
@@ -74,7 +75,7 @@ describe Ctc::Portal::BankAccountForm do
 
       it "is not valid" do
         expect(
-          described_class.new(intake, params)
+          described_class.new(bank_account, params)
         ).not_to be_valid
       end
     end
@@ -84,7 +85,7 @@ describe Ctc::Portal::BankAccountForm do
       let(:account_number_confirmation) { "123456789012345678" }
       it "is not valid" do
         expect(
-            described_class.new(intake, params)
+            described_class.new(bank_account, params)
         ).not_to be_valid
       end
     end
@@ -94,7 +95,7 @@ describe Ctc::Portal::BankAccountForm do
       let(:account_number_confirmation) { "12345678" }
       it "is not valid" do
         expect(
-          described_class.new(intake, params)
+          described_class.new(bank_account, params)
         ).not_to be_valid
       end
     end
@@ -105,34 +106,20 @@ describe Ctc::Portal::BankAccountForm do
 
       it "is not valid" do
         expect(
-            described_class.new(intake, params)
+            described_class.new(bank_account, params)
         ).not_to be_valid
       end
     end
   end
 
   context '#save' do
-    context "when there is no existing bank account object" do
-      it 'creates a bank account object and associates it with the intake' do
-        expect {
-          described_class.new(intake, params).save
-          intake.reload
-        }.to change(BankAccount, :count).by(1)
-        bank_account = BankAccount.last
-        expect(bank_account.bank_name).to eq "Bank of America"
-        expect(bank_account.account_type).to eq "checking"
-        expect(bank_account.intake).to eq intake
-      end
-    end
-
     context "when there is an existing bank account object" do
       before do
-        create(:bank_account, intake: intake)
       end
 
       it "updates the existing bank account object" do
         expect {
-          described_class.new(intake, params).save
+          described_class.new(bank_account, params).save
           intake.reload
         }.to change(BankAccount, :count).by(0)
         bank_account = intake.bank_account


### PR DESCRIPTION
the account_number, routing_number, and bank_name will all be [REDACTED],
so the system note may not be very informative, but it at least will be there.

Co-authored-by: Em Barnard-Shao <ebarnard@codeforamerica.org>

![Screen Shot 2021-09-15 at 11 02 51 AM](https://user-images.githubusercontent.com/30675659/133485828-8e88b889-9fd8-46b0-951e-7a8342dd76f9.png)
