### PR TITLE
CTC portal updates: disable 'Resubmit' button until some changes have been made

### DIFF
--- a/app/controllers/ctc/portal/portal_controller.rb
+++ b/app/controllers/ctc/portal/portal_controller.rb
@@ -18,7 +18,9 @@ class Ctc::Portal::PortalController < Ctc::Portal::BaseAuthenticatedController
     end
   end
 
-  def edit_info; end
+  def edit_info
+    @intake_updated_since_last_submission = SystemNote.where('created_at > ?', @submission.created_at).where(type: [SystemNote::CtcPortalAction, SystemNote::CtcPortalUpdate].map(&:to_s)).any?
+  end
 
   def resubmit
     if @submission.can_transition_to?(:resubmitted)

--- a/app/views/ctc/portal/portal/edit_info.html.erb
+++ b/app/views/ctc/portal/portal/edit_info.html.erb
@@ -52,9 +52,9 @@
           <p>
             <%= t("views.ctc.portal.edit_info.help_text") %>
           </p>
-          <button class="button button--primary button--full-width" type="submit">
+          <%= button_tag(class: "button button--primary button--full-width", type: "submit", disabled: !@intake_updated_since_last_submission) do %>
             <%= t("views.ctc.portal.edit_info.resubmit") %>
-          </button>
+          <% end %>
         <% else %>
           <p>
             <%= t("views.ctc.portal.edit_info.help_text_cant_submit") %>

--- a/spec/features/ctc/portal_spec.rb
+++ b/spec/features/ctc/portal_spec.rb
@@ -195,6 +195,9 @@ RSpec.feature "CTC Intake", :js, :active_job do
 
       click_on I18n.t("views.ctc.portal.home.correct_info")
 
+      # Can't resubmit until you have made a meaningful edit
+      expect(page).to have_selector("button:disabled", text: I18n.t('views.ctc.portal.edit_info.resubmit'))
+
       within ".primary-info" do
         click_on I18n.t('general.edit').downcase
       end


### PR DESCRIPTION
otherwise clients can continue to resubmit the same thing forever

Co-authored-by: Em Barnard-Shao <ebarnard@codeforamerica.org>