### PR TITLE
Updated honeycrisp to version 0.10.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rack', '>= 2.0.8'
 gem 'rails', '>= 6.0.3.7'
 gem 'puma', '>= 5.3.2'
 gem 'sass-rails', '~> 5.0'
-gem 'cfa-styleguide', '0.10.4', git: 'https://github.com/codeforamerica/honeycrisp-gem', branch: 'main'
+gem 'cfa-styleguide', '0.10.5', git: 'https://github.com/codeforamerica/honeycrisp-gem', branch: 'main'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 gem 'mini_racer', '~> 0.4.0', platforms: :ruby
 gem 'nokogiri', '>= 1.10.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/codeforamerica/honeycrisp-gem
-  revision: af7cd9db0f25fc593914688a76d64100c5e375b6
+  revision: 4c6f873f55704ec34fd518906f131133b290e56a
   branch: main
   specs:
-    cfa-styleguide (0.10.4)
+    cfa-styleguide (0.10.5)
       autoprefixer-rails
       bourbon
       jquery-rails
@@ -82,7 +82,7 @@ GEM
       encryptor (~> 3.0.0)
     auto_strip_attributes (2.6.0)
       activerecord (>= 4.0)
-    autoprefixer-rails (10.3.1.0)
+    autoprefixer-rails (10.3.3.0)
       execjs (~> 2)
     awesome_print (1.9.2)
     aws-eventstream (1.1.1)
@@ -574,7 +574,7 @@ DEPENDENCIES
   byebug
   cancancan
   capybara (>= 2.15)
-  cfa-styleguide (= 0.10.4)!
+  cfa-styleguide (= 0.10.5)!
   combine_pdf
   database_cleaner
   ddtrace


### PR DESCRIPTION
# What does this PR do?

* Updated honeycrisp to version 0.10.5, [which fixes honeycrisp dependency security alerts](https://github.com/codeforamerica/honeycrisp-gem/compare/v0.9.4...v0.10.4).

## Visual diff testing

Percy [ran with no issues (aside from false positives in Edge)](https://percy.io/Code-for-America/vita-min/builds/12741890/changed/719949632?browser=edge&browser_ids=19%2C20%2C21&subcategories=approved&viewLayout=overlay&viewMode=new&width=1280&widths=375%2C1280).