### PR TITLE
Efiling: pad timezones like "-60" with zeroes to match schema

### DIFF
--- a/app/lib/submission_builder/formatting_methods.rb
+++ b/app/lib/submission_builder/formatting_methods.rb
@@ -96,6 +96,17 @@ module SubmissionBuilder
       Phonelib.parse(string, "US").national(false)
     end
 
+    # Timezones like '-60' need to be padded to '-060' to validate schema
+    # These timezones are all a little suspicious, but it's better to handle
+    # their suspiciousness somewhere else rather than crash on bundle
+    def time_zone_offset_type(string)
+      if (match = string.match(/\A([+-])([0-9]{1,2})\z/))
+        "#{match[1]}#{"%03d" % match[2]}"
+      else
+        string
+      end
+    end
+
     private
 
     def formatted_first_name(name)

--- a/app/lib/submission_builder/return_header1040.rb
+++ b/app/lib/submission_builder/return_header1040.rb
@@ -137,7 +137,7 @@ module SubmissionBuilder
               xml.UserAgentTxt trim(creation_security_information.user_agent, 150)
               xml.BrowserLanguageTxt trim(creation_security_information.browser_language, 5)
               xml.PlatformTxt trim(creation_security_information.platform, 15)
-              xml.TimeZoneOffsetNum creation_security_information.timezone_offset
+              xml.TimeZoneOffsetNum time_zone_offset_type(creation_security_information.timezone_offset)
               xml.SystemTs datetime_type(creation_security_information.client_system_datetime)
             }
             xml.AtSubmissionFilingGrp {
@@ -150,7 +150,7 @@ module SubmissionBuilder
               xml.UserAgentTxt trim(filing_security_information.user_agent, 150)
               xml.BrowserLanguageTxt trim(filing_security_information.browser_language, 5)
               xml.PlatformTxt trim(filing_security_information.platform, 15)
-              xml.TimeZoneOffsetNum filing_security_information.timezone_offset
+              xml.TimeZoneOffsetNum time_zone_offset_type(filing_security_information.timezone_offset)
               xml.SystemTs datetime_type(filing_security_information.client_system_datetime)
             }
             if submission.resubmission?


### PR DESCRIPTION
they must have at least three digits, e.g. "-060"