### PR TITLE
Disable the resubmit button after the initial button press

### DIFF
--- a/app/views/ctc/portal/portal/edit_info.html.erb
+++ b/app/views/ctc/portal/portal/edit_info.html.erb
@@ -53,7 +53,7 @@
             <%= t("views.ctc.portal.edit_info.help_text") %>
           </p>
           <%= recaptcha_v3(action: 'resubmit') %>
-          <%= button_tag(class: "button button--primary button--full-width", type: "submit", disabled: !@intake_updated_since_last_submission) do %>
+          <%= button_tag(class: "button button--primary button--full-width", type: "submit", data: { disable_with: t("general.please_wait") }, disabled: !@intake_updated_since_last_submission) do %>
             <%= t("views.ctc.portal.edit_info.resubmit") %>
           <% end %>
         <% else %>


### PR DESCRIPTION
This just makes it so that after the user presses the button, they can't press it again while it loads the next page.

We already did this to the button on the confirm-legal page, going to do it here because it is causing timeout/duplicate errors for Recaptcha (no user impact, but noisy on Sentry)