### PR TITLE
Aptible: make a 'web' service that will replace the 'cmd' service

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,5 @@
 // Deployment procfile for Aptible
 cmd: bundle exec rails s -b 0.0.0.0 -p 3000
+web: bundle exec rails s -b 0.0.0.0 -p 3000
 worker: bundle exec rails jobs:work
 cron: exec supercronic /app/crontab


### PR DESCRIPTION
'cmd' has a silly name because it is a web service

I'm a bit scared as to what will happen if we just rename it, so for now
maybe we will have both 'cmd' and 'web' running and then remove 'cmd'