### PR TITLE
Add timezone to efile security informations

### DIFF
--- a/app/forms/ctc/confirm_legal_form.rb
+++ b/app/forms/ctc/confirm_legal_form.rb
@@ -9,10 +9,11 @@ module Ctc
                        :timezone_offset,
                        :client_system_time,
                        :ip_address,
-                       :recaptcha_score
+                       :recaptcha_score,
+                       :timezone
 
     validates :consented_to_legal, acceptance: { accept: 'yes', message: I18n.t("views.ctc.questions.confirm_legal.error") }
-    validates_presence_of :device_id, :user_agent, :browser_language, :platform, :timezone_offset, :client_system_time, :ip_address
+    validates_presence_of :device_id, :user_agent, :browser_language, :platform, :timezone_offset, :client_system_time, :ip_address, :timezone
 
     def save
       intake_attributes = attributes_for(:intake)

--- a/app/forms/ctc/income_form.rb
+++ b/app/forms/ctc/income_form.rb
@@ -8,13 +8,14 @@ module Ctc
                        :platform,
                        :timezone_offset,
                        :client_system_time,
-                       :ip_address
+                       :ip_address,
+                       :timezone
     set_attributes_for :misc, :had_reportable_income
 
-    validates_presence_of :device_id, :user_agent, :browser_language, :platform, :timezone_offset, :client_system_time, :ip_address
+    validates_presence_of :device_id, :user_agent, :browser_language, :platform, :timezone_offset, :client_system_time, :ip_address, :timezone
 
     def save
-      @intake.assign_attributes(attributes_for(:intake).merge(locale: I18n.locale))
+      @intake.assign_attributes(attributes_for(:intake).merge(locale: I18n.locale, timezone: timezone))
       @intake.build_client(
         tax_returns_attributes: [{ year: 2020, is_ctc: true }],
         efile_security_informations_attributes: [attributes_for(:efile_security_information)]

--- a/app/javascript/lib/efile_security_information.js
+++ b/app/javascript/lib/efile_security_information.js
@@ -7,7 +7,7 @@ export function getEfileSecurityInformation(formName) {
     Fingerprint2.get(function(components) {
         let concatenated = components.map(function (pair) { return pair.value }).join('###')
         let concatenatedAndHashed = CryptoJS.SHA1(concatenated).toString().toUpperCase();
-
+        let timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
         let now = new Date();
         let timezoneOffset = now.getTimezoneOffset();
         let timezoneOffsetString = timezoneOffset < 0 ? (timezoneOffset.toString()) : ("+" + timezoneOffset);
@@ -17,7 +17,8 @@ export function getEfileSecurityInformation(formName) {
             browser_language: navigator.language,
             platform: navigator.platform,
             client_system_time: now,
-            timezone_offset: timezoneOffsetString
+            timezone_offset: timezoneOffsetString,
+            timezone: timezone,
         };
 
         for (const attr in securityAttributes) {

--- a/app/models/efile_security_information.rb
+++ b/app/models/efile_security_information.rb
@@ -8,6 +8,7 @@
 #  ip_address          :inet
 #  platform            :string
 #  recaptcha_score     :decimal(, )
+#  timezone            :string
 #  timezone_offset     :string
 #  user_agent          :string
 #  created_at          :datetime         not null

--- a/app/views/ctc/questions/income/edit.html.erb
+++ b/app/views/ctc/questions/income/edit.html.erb
@@ -9,18 +9,3 @@
     <% end %>
   </ul>
 <% end %>
-
-<% content_for :script do %>
-  <script>
-    document.addEventListener("DOMContentLoaded", function() {
-      var hiddenField = document.createElement('input');
-      hiddenField.setAttribute('type', 'hidden')
-      hiddenField.setAttribute('name', 'ctc_income_form[timezone]')
-      hiddenField.setAttribute('id', 'ctc_income_form_timezone')
-      document.querySelector('main form').appendChild(hiddenField);
-
-      var timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-      document.getElementById('ctc_income_form_timezone').value = timezone;
-    });
-  </script>
-<% end %>

--- a/db/migrate/20210928153248_add_timezone_to_efile_security_information.rb
+++ b/db/migrate/20210928153248_add_timezone_to_efile_security_information.rb
@@ -1,0 +1,5 @@
+class AddTimezoneToEfileSecurityInformation < ActiveRecord::Migration[6.0]
+  def change
+    add_column :efile_security_informations, :timezone, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_16_110729) do
+ActiveRecord::Schema.define(version: 2021_09_28_153248) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -374,6 +374,7 @@ ActiveRecord::Schema.define(version: 2021_09_16_110729) do
     t.inet "ip_address"
     t.string "platform"
     t.decimal "recaptcha_score"
+    t.string "timezone"
     t.string "timezone_offset"
     t.datetime "updated_at", precision: 6, null: false
     t.string "user_agent"

--- a/lib/tasks/backfill_timezones_to_efile_security_information.rake
+++ b/lib/tasks/backfill_timezones_to_efile_security_information.rake
@@ -1,0 +1,10 @@
+namespace :timezones do
+  desc "Backfill timezones onto efile security information objects"
+  task backfill: :environment do
+    EfileSecurityInformation.where(timezone: nil).find_each do |esi|
+      esi.update(timezone: esi&.client&.intake&.timezone)
+      print "." if esi.timezone.present?
+      print "-" if esi.timezone.nil?
+    end
+  end
+end

--- a/spec/controllers/ctc/questions/confirm_legal_controller_spec.rb
+++ b/spec/controllers/ctc/questions/confirm_legal_controller_spec.rb
@@ -35,6 +35,7 @@ describe Ctc::Questions::ConfirmLegalController do
           platform: "iPad",
           timezone_offset: "+240",
           client_system_time: "2021-07-28T21:21:32.306Z",
+          timezone: "America/Chicago"
         }
       }
     end

--- a/spec/controllers/ctc/questions/income_controller_spec.rb
+++ b/spec/controllers/ctc/questions/income_controller_spec.rb
@@ -40,10 +40,11 @@ describe Ctc::Questions::IncomeController do
       expect {
         post :update, params: params
       }.to change(EfileSecurityInformation, :count).by 1
-      post :update, params: params
 
+      expect(Client.last.intake.timezone).to eq "America/Chicago"
       efile_security = Client.last.efile_security_informations.last
       expect(efile_security.user_agent).to eq "GeckoFox"
+      expect(efile_security.timezone).to eq "America/Chicago"
       expect(efile_security.ip_address).to eq ip_address
     end
 

--- a/spec/factories/efile_security_informations.rb
+++ b/spec/factories/efile_security_informations.rb
@@ -8,6 +8,7 @@
 #  ip_address          :inet
 #  platform            :string
 #  recaptcha_score     :decimal(, )
+#  timezone            :string
 #  timezone_offset     :string
 #  user_agent          :string
 #  created_at          :datetime         not null
@@ -35,5 +36,6 @@ FactoryBot.define do
     timezone_offset { "+240" }
     client_system_time { "Mon Aug 02 2021 18:55:41 GMT-0400 (Eastern Daylight Time)" }
     ip_address { IPAddr.new("1.1.1.1") }
+    timezone { "America/New_York" }
   end
 end

--- a/spec/forms/ctc/confirm_legal_form_spec.rb
+++ b/spec/forms/ctc/confirm_legal_form_spec.rb
@@ -13,7 +13,8 @@ describe Ctc::ConfirmLegalForm do
       timezone_offset: "+240",
       client_system_time: "Mon Aug 02 2021 18:55:41 GMT-0400 (Eastern Daylight Time)",
       ip_address: "1.1.1.1",
-      recaptcha_score: "0.9"
+      recaptcha_score: "0.9",
+      timezone: "America/New_York"
     }
   end
 

--- a/spec/forms/ctc/income_form_spec.rb
+++ b/spec/forms/ctc/income_form_spec.rb
@@ -11,6 +11,7 @@ describe Ctc::IncomeForm do
         timezone_offset: "240",
         client_system_time: "Mon Aug 02 2021 18:55:41 GMT-0400 (Eastern Daylight Time)",
         ip_address: "1.1.1.1",
+        timezone: "America/New_York"
       }
     }
 

--- a/spec/models/efile_security_information_spec.rb
+++ b/spec/models/efile_security_information_spec.rb
@@ -1,3 +1,32 @@
+# == Schema Information
+#
+# Table name: efile_security_informations
+#
+#  id                  :bigint           not null, primary key
+#  browser_language    :string
+#  client_system_time  :string
+#  ip_address          :inet
+#  platform            :string
+#  recaptcha_score     :decimal(, )
+#  timezone            :string
+#  timezone_offset     :string
+#  user_agent          :string
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  client_id           :bigint
+#  device_id           :string
+#  efile_submission_id :bigint
+#
+# Indexes
+#
+#  index_client_efile_security_informations_efile_submissions_id  (efile_submission_id)
+#  index_efile_security_informations_on_client_id                 (client_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (client_id => clients.id)
+#  fk_rails_...  (efile_submission_id => efile_submissions.id)
+#
 require "rails_helper"
 
 describe EfileSecurityInformation do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -146,7 +146,8 @@ RSpec.configure do |config|
           browser_language: "en-US",
           platform: "iPad",
           timezone_offset: "+240",
-          client_system_time: "2021-07-28T21:21:32.306Z"
+          client_system_time: "2021-07-28T21:21:32.306Z",
+          timezone: "America/New_York"
         }
       )
     end


### PR DESCRIPTION
Adds timezone to efile security informations so that we can capture timezone in a format we'll be able to interpret as a part of `TimeZone.us_timezones` or whatever the method rails provides for timezone support.