### PR TITLE
Consecutive spaces bundle failure 179785272

### DIFF
--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -288,16 +288,13 @@ class Intake::CtcIntake < Intake
   end
 
   before_save do
-    # TODO: only normalize spacing when these attributes are being assigned/changed
-    [:primary_first_name, :primary_last_name, :spouse_first_name, :spouse_last_name].each do |attribute|
+    attributes_to_change = self.changes_to_save.keys
+    name_attributes = ["primary_first_name", "primary_last_name", "spouse_first_name", "spouse_last_name"]
+
+    (attributes_to_change & name_attributes).each do |attribute|
       new_value = self.send(attribute).split(/\s/).filter { |s| !s.empty? }.join(" ")
       self.assign_attributes(attribute => new_value)
     end
-
-    # self.primary_first_name = self.primary_first_name.split(/\s/).filter { |s| !s.empty? }.join(" ")
-    # self.primary_last_name = self.primary_last_name.split(/\s/).filter { |s| !s.empty? }.join(" ")
-    # self.spouse_first_name = self.spouse_first_name.split(/\s/).filter { |s| !s.empty? }.join(" ")
-    # self.spouse_last_name = self.spouse_last_name.split(/\s/).filter { |s| !s.empty? }.join(" ")
   end
 
   PHOTO_ID_TYPES = {

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -287,6 +287,19 @@ class Intake::CtcIntake < Intake
     self.spouse_ssn = self.spouse_ssn.remove(/\D/) if spouse_ssn_changed? && self.spouse_ssn
   end
 
+  before_save do
+    # TODO: only normalize spacing when these attributes are being assigned/changed
+    [:primary_first_name, :primary_last_name, :spouse_first_name, :spouse_last_name].each do |attribute|
+      new_value = self.send(attribute).split(/\s/).filter { |s| !s.empty? }.join(" ")
+      self.assign_attributes(attribute => new_value)
+    end
+
+    # self.primary_first_name = self.primary_first_name.split(/\s/).filter { |s| !s.empty? }.join(" ")
+    # self.primary_last_name = self.primary_last_name.split(/\s/).filter { |s| !s.empty? }.join(" ")
+    # self.spouse_first_name = self.spouse_first_name.split(/\s/).filter { |s| !s.empty? }.join(" ")
+    # self.spouse_last_name = self.spouse_last_name.split(/\s/).filter { |s| !s.empty? }.join(" ")
+  end
+
   PHOTO_ID_TYPES = {
     drivers_license: {
       display_name: "Drivers License",

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -292,8 +292,10 @@ class Intake::CtcIntake < Intake
     name_attributes = ["primary_first_name", "primary_last_name", "spouse_first_name", "spouse_last_name"]
 
     (attributes_to_change & name_attributes).each do |attribute|
-      new_value = self.send(attribute).split(/\s/).filter { |s| !s.empty? }.join(" ")
-      self.assign_attributes(attribute => new_value)
+      if self.send(attribute).present?
+        new_value = self.send(attribute).split(/\s/).filter { |str| !str.empty? }.join(" ")
+        self.assign_attributes(attribute => new_value)
+      end
     end
   end
 

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -287,13 +287,13 @@ class Intake::CtcIntake < Intake
     self.spouse_ssn = self.spouse_ssn.remove(/\D/) if spouse_ssn_changed? && self.spouse_ssn
   end
 
-  before_save do
+  before_validation do
     attributes_to_change = self.changes_to_save.keys
     name_attributes = ["primary_first_name", "primary_last_name", "spouse_first_name", "spouse_last_name"]
 
     (attributes_to_change & name_attributes).each do |attribute|
-      if self.send(attribute).present?
-        new_value = self.send(attribute).split(/\s/).filter { |str| !str.empty? }.join(" ")
+      if self.attributes[attribute].present?
+        new_value = self.attributes[attribute].split(/\s/).filter { |str| !str.empty? }.join(" ")
         self.assign_attributes(attribute => new_value)
       end
     end

--- a/spec/models/ctc_intake_spec.rb
+++ b/spec/models/ctc_intake_spec.rb
@@ -237,4 +237,25 @@ describe Intake::CtcIntake do
       end
     end
   end
+
+  context "before_save" do
+    context "normalize spaces in names" do
+      let(:intake) {
+        build :ctc_intake,
+          primary_first_name: "Anna  Marie",
+          primary_last_name: "Apple   Mango",
+          spouse_first_name: "Roberta    Margaret",
+          spouse_last_name: "Raspberry   Melon"
+      }
+
+      it "makes sure names with spaces only have one space between each name" do
+        intake.save
+
+        expect(intake.primary_first_name).to eq "Anna Marie"
+        expect(intake.primary_last_name).to eq "Apple Mango"
+        expect(intake.spouse_first_name).to eq "Roberta Margaret"
+        expect(intake.spouse_last_name).to eq "Raspberry Melon"
+      end
+    end
+  end
 end

--- a/spec/models/ctc_intake_spec.rb
+++ b/spec/models/ctc_intake_spec.rb
@@ -238,7 +238,7 @@ describe Intake::CtcIntake do
     end
   end
 
-  context "before_save" do
+  context "before_validation" do
     context "normalize spaces in names" do
       let(:intake) {
         build :ctc_intake,
@@ -249,7 +249,7 @@ describe Intake::CtcIntake do
       }
 
       it "makes sure names with spaces only have one space between each name" do
-        intake.save
+        intake.valid?
 
         expect(intake.primary_first_name).to eq "Anna Marie"
         expect(intake.primary_last_name).to eq "Apple Mango"


### PR DESCRIPTION
We considered the following options for this:
- removing extra spaces in each form where primary/spouse legal names are updated
- removing extra spaces in a `before_save` hook on the model level (<- we went with this one)
- presenting the user with a validation error when they include extra spaces
- removing extra spaces just before sending the submission bundle

With both the `before_save` and the modifying at bundle-time, it seems like there's a risk of this being "hidden" from the developer / hub user. Would love to hear thoughts on minimizing the risk of creating an invisible step when troubleshooting either a bug or a particular user's case (this seems like it should be the main consideration here).

Re: the actual lines of code: we could do something less fancy than the current loop (for example, one line per attribute) that would make it more readable. Also welcome thoughts on this!