### PR TITLE
Upgrade gnutls and root certificates [#179809550]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update --allow-releaseinfo-change
 
 # System prerequisites
 RUN apt-get update \
- && apt-get -y install build-essential libpq-dev pdftk-java ghostscript poppler-utils curl \
+ && apt-get -y install ca-certificates libgnutls30 build-essential libpq-dev pdftk-java ghostscript poppler-utils curl \
  && curl -sL https://deb.nodesource.com/setup_12.x | bash - \
  && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \


### PR DESCRIPTION
Based on https://github.com/nodesource/distributions/issues/1266 and https://letsencrypt.org/certificates/ and the current CA chain of nodesource.com, this would fix it. I've also tested that staging couldn't deploy before this change, and can after this change.

It makes sense to me why ca-certificates had to be updated. I'm surprised gnutls also had to be, but oh well.

![image](https://user-images.githubusercontent.com/67708639/135918134-105af7d8-0360-445a-9bfb-369328dae2a4.png)
