### PR TITLE
Make birth date non-nullable on dependents table [#179379352]

### DIFF
--- a/app/models/dependent.rb
+++ b/app/models/dependent.rb
@@ -3,7 +3,7 @@
 # Table name: dependents
 #
 #  id                                          :bigint           not null, primary key
-#  birth_date                                  :date
+#  birth_date                                  :date             not null
 #  born_in_2020                                :integer          default("unfilled"), not null
 #  cant_be_claimed_by_other                    :integer          default("unfilled"), not null
 #  claim_anyway                                :integer          default("unfilled"), not null

--- a/db/migrate/20211004220516_make_birth_date_non_null_on_dependents.rb
+++ b/db/migrate/20211004220516_make_birth_date_non_null_on_dependents.rb
@@ -1,0 +1,5 @@
+class MakeBirthDateNonNullOnDependents < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :dependents, :birth_date, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -279,7 +279,7 @@ ActiveRecord::Schema.define(version: 2021_10_04_222000) do
   end
 
   create_table "dependents", force: :cascade do |t|
-    t.date "birth_date"
+    t.date "birth_date", null: false
     t.integer "born_in_2020", default: 0, null: false
     t.integer "cant_be_claimed_by_other", default: 0, null: false
     t.integer "claim_anyway", default: 0, null: false

--- a/spec/factories/dependents.rb
+++ b/spec/factories/dependents.rb
@@ -3,7 +3,7 @@
 # Table name: dependents
 #
 #  id                                          :bigint           not null, primary key
-#  birth_date                                  :date
+#  birth_date                                  :date             not null
 #  born_in_2020                                :integer          default("unfilled"), not null
 #  cant_be_claimed_by_other                    :integer          default("unfilled"), not null
 #  claim_anyway                                :integer          default("unfilled"), not null

--- a/spec/models/dependent_spec.rb
+++ b/spec/models/dependent_spec.rb
@@ -3,7 +3,7 @@
 # Table name: dependents
 #
 #  id                                          :bigint           not null, primary key
-#  birth_date                                  :date
+#  birth_date                                  :date             not null
 #  born_in_2020                                :integer          default("unfilled"), not null
 #  cant_be_claimed_by_other                    :integer          default("unfilled"), not null
 #  claim_anyway                                :integer          default("unfilled"), not null


### PR DESCRIPTION
On production, there are 0 such dependents:

```
db=# select count(*) from dependents where birth_date is null;
 count
-------
     0
(1 row)
```

Same on demo:

```
irb(main):002:0> Dependent.where(birth_date: nil).count
=> 0
```

This would have prevented the strange situation that caused https://sentry.io/organizations/codeforamerica/issues/2690836784/?project=1880327&query=is%3Aunresolved&sort=freq&statsPeriod=14d