### PR TITLE
When Twilio raises an error, mark as failed in the Hub [#178990861]

### DIFF
--- a/app/jobs/send_outgoing_text_message_job.rb
+++ b/app/jobs/send_outgoing_text_message_job.rb
@@ -5,11 +5,16 @@ class SendOutgoingTextMessageJob < ApplicationJob
   def perform(outgoing_text_message_id)
     outgoing_text_message = OutgoingTextMessage.find(outgoing_text_message_id)
 
-    message = TwilioService.send_text_message(
-      to: outgoing_text_message.to_phone_number,
-      body: outgoing_text_message.body,
-      status_callback: outgoing_text_message_url(outgoing_text_message, locale: nil)
-    )
+    message = begin
+                TwilioService.send_text_message(
+                  to: outgoing_text_message.to_phone_number,
+                  body: outgoing_text_message.body,
+                  status_callback: outgoing_text_message_url(outgoing_text_message, locale: nil)
+                )
+              rescue Twilio::REST::RestError
+                outgoing_text_message.update(twilio_status: "twilio_error")
+                raise
+              end
 
     outgoing_text_message.update(
       twilio_status: message.status,

--- a/app/models/outgoing_text_message.rb
+++ b/app/models/outgoing_text_message.rb
@@ -27,7 +27,7 @@
 class OutgoingTextMessage < ApplicationRecord
   include ContactRecord
 
-  FAILED_TWILIO_STATUSES = ["undelivered", "failed", "delivery_unknown"].freeze
+  FAILED_TWILIO_STATUSES = ["undelivered", "failed", "delivery_unknown", "twilio_error"].freeze
   SUCCESSFUL_TWILIO_STATUSES = ["sent", "delivered"].freeze
   IN_PROGRESS_TWILIO_STATUSES = ["accepted", "queued", nil].freeze
   ALL_KNOWN_TWILIO_STATUSES = FAILED_TWILIO_STATUSES + SUCCESSFUL_TWILIO_STATUSES + IN_PROGRESS_TWILIO_STATUSES


### PR DESCRIPTION
Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>