### PR TITLE
Always validate that dependents have a birth_date [#179379352]

### DIFF
--- a/app/models/dependent.rb
+++ b/app/models/dependent.rb
@@ -82,8 +82,7 @@ class Dependent < ApplicationRecord
   validates_presence_of :first_name
   validates_presence_of :last_name
 
-  # Allow birth date to be blank when we first create dependents in the CTC intake flow, but nowhere else
-  validates_presence_of :birth_date, unless: -> { intake&.is_ctc? }
+  validates_presence_of :birth_date
   validates_presence_of :birth_date, on: :ctc_valet_form
 
   validates_presence_of :relationship, on: :ctc_valet_form

--- a/app/models/dependent.rb
+++ b/app/models/dependent.rb
@@ -83,7 +83,6 @@ class Dependent < ApplicationRecord
   validates_presence_of :last_name
 
   validates_presence_of :birth_date
-  validates_presence_of :birth_date, on: :ctc_valet_form
 
   validates_presence_of :relationship, on: :ctc_valet_form
 


### PR DESCRIPTION
Upon save, you now see a useful validation error.

![image](https://user-images.githubusercontent.com/67708639/136080096-1929045d-dfa7-41b8-8c66-ff7e531234db.png)
