### PR TITLE
CTC intake: add recaptcha to more pages

### DIFF
--- a/app/controllers/concerns/recaptcha_score_concern.rb
+++ b/app/controllers/concerns/recaptcha_score_concern.rb
@@ -1,7 +1,12 @@
 module RecaptchaScoreConcern
   def recaptcha_score_param(action)
     if verify_recaptcha(action: action)
-      return { recaptcha_score: recaptcha_reply['score'] } if recaptcha_reply.present?
+      if recaptcha_reply.present?
+        return {
+          recaptcha_score: recaptcha_reply['score'],
+          recaptcha_action: action
+        }
+      end
     elsif recaptcha_reply.present?
       Sentry.capture_message "Failed to verify recaptcha token due to the following errors: #{recaptcha_reply["error-codes"]}"
     else

--- a/app/controllers/ctc/portal/portal_controller.rb
+++ b/app/controllers/ctc/portal/portal_controller.rb
@@ -32,6 +32,12 @@ class Ctc::Portal::PortalController < Ctc::Portal::BaseAuthenticatedController
         return redirect_back(fallback_location: ctc_portal_edit_info_path)
       end
       @submission.transition_to(:resubmitted)
+      if recaptcha_score_param('resubmit').present?
+        current_client.recaptcha_scores.create(
+          score: recaptcha_score_param('resubmit')[:recaptcha_score],
+          action: recaptcha_score_param('resubmit')[:recaptcha_action]
+        )
+      end
       SystemNote::CtcPortalAction.generate!(
         model: @submission,
         action: 'resubmitted',
@@ -51,7 +57,7 @@ class Ctc::Portal::PortalController < Ctc::Portal::BaseAuthenticatedController
                                               :client_system_time,
                                               :recaptcha_score)
           .merge(ip_address: request.remote_ip)
-          .merge(recaptcha_score_param('resubmit'))
+          .merge(recaptcha_score: recaptcha_score_param('resubmit')[:recaptcha_score])
 
   end
 

--- a/app/controllers/ctc/questions/bank_account_controller.rb
+++ b/app/controllers/ctc/questions/bank_account_controller.rb
@@ -2,6 +2,7 @@ module Ctc
   module Questions
     class BankAccountController < QuestionsController
       include AuthenticatedCtcClientConcern
+      include RecaptchaScoreConcern
 
       layout "intake"
 
@@ -11,6 +12,10 @@ module Ctc
 
       def edit
         @form = form_class.from_bank_account(current_model)
+      end
+
+      def form_params
+        super.merge(recaptcha_score_param('bank_account'))
       end
 
       private

--- a/app/controllers/ctc/questions/dependents/info_controller.rb
+++ b/app/controllers/ctc/questions/dependents/info_controller.rb
@@ -3,6 +3,7 @@ module Ctc
     module Dependents
       class InfoController < BaseDependentController
         include AuthenticatedCtcClientConcern
+        include RecaptchaScoreConcern
 
         layout "intake"
 
@@ -25,6 +26,10 @@ module Ctc
         end
 
         private
+
+        def form_params
+          super.merge(recaptcha_score_param('dependents_info'))
+        end
 
         def illustration_path
           "ssn-itins.svg"

--- a/app/controllers/ctc/questions/legal_consent_controller.rb
+++ b/app/controllers/ctc/questions/legal_consent_controller.rb
@@ -4,8 +4,13 @@ module Ctc
       include AnonymousIntakeConcern
       include Ctc::CanBeginIntakeConcern
       include Ctc::ResetToStartIfIntakeNotPersistedConcern
+      include RecaptchaScoreConcern
 
       layout "intake"
+
+      def form_params
+        super.merge(recaptcha_score_param('legal_consent'))
+      end
 
       private
 

--- a/app/controllers/hub/security_controller.rb
+++ b/app/controllers/hub/security_controller.rb
@@ -7,6 +7,9 @@ module Hub
 
     def show
       @client = Client.find(params[:id])
+      @security_events = (
+        @client.efile_security_informations + @client.recaptcha_scores
+      ).sort_by(&:created_at)
     end
   end
 end

--- a/app/forms/ctc/bank_account_form.rb
+++ b/app/forms/ctc/bank_account_form.rb
@@ -8,6 +8,7 @@ module Ctc
                        :account_number,
                        :account_type
     set_attributes_for :confirmation, :my_bank_account, :routing_number_confirmation, :account_number_confirmation
+    set_attributes_for :recaptcha, :recaptcha_score, :recaptcha_action
 
     with_options if: -> { (account_number.present? && account_number != @bank_account&.account_number) || account_number_confirmation.present? } do
       validates :account_number, confirmation: true
@@ -39,6 +40,13 @@ module Ctc
       if @bank_account.valid?
         @bank_account.save
         @bank_account.intake.update(refund_payment_method: "direct_deposit")
+      end
+
+      if attributes_for(:recaptcha)[:recaptcha_score].present?
+        @bank_account.intake.client.recaptcha_scores.create(
+          score: attributes_for(:recaptcha)[:recaptcha_score],
+          action: attributes_for(:recaptcha)[:recaptcha_action]
+        )
       end
     end
 

--- a/app/forms/ctc/confirm_legal_form.rb
+++ b/app/forms/ctc/confirm_legal_form.rb
@@ -9,8 +9,9 @@ module Ctc
                        :timezone_offset,
                        :client_system_time,
                        :ip_address,
-                       :recaptcha_score,
+                       :recaptcha_score, # will eventually be removed, we want it to live on RecaptchaScore
                        :timezone
+    set_attributes_for :recaptcha, :recaptcha_score, :recaptcha_action
 
     validates :consented_to_legal, acceptance: { accept: 'yes', message: I18n.t("views.ctc.questions.confirm_legal.error") }
     validates_presence_of :device_id, :user_agent, :browser_language, :platform, :timezone_offset, :client_system_time, :ip_address, :timezone
@@ -29,6 +30,13 @@ module Ctc
         rescue Statesman::GuardFailedError
           Rails.logger.error "Failed to transition EfileSubmission##{efile_submission.id} to :preparing"
         end
+      end
+
+      if attributes_for(:recaptcha)[:recaptcha_score].present?
+        @intake.client.recaptcha_scores.create(
+          score: attributes_for(:recaptcha)[:recaptcha_score],
+          action: attributes_for(:recaptcha)[:recaptcha_action]
+        )
       end
     end
   end

--- a/app/forms/ctc/dependents/info_form.rb
+++ b/app/forms/ctc/dependents/info_form.rb
@@ -16,6 +16,7 @@ module Ctc
       set_attributes_for :birthday, :birth_date_month, :birth_date_day, :birth_date_year
       set_attributes_for :misc, :ssn_no_employment
       set_attributes_for :confirmation, :ssn_confirmation
+      set_attributes_for :recaptcha, :recaptcha_score, :recaptcha_action
 
       validates :first_name, presence: true, legal_name: true
       validates :last_name, presence: true, legal_name: true
@@ -53,6 +54,13 @@ module Ctc
         @dependent.save
 
         @dependent.update!(lived_with_more_than_six_months: "yes") if @dependent.born_in_last_6_months_of_2020?
+
+        if attributes_for(:recaptcha)[:recaptcha_score].present?
+          @dependent.intake.client.recaptcha_scores.create(
+            score: attributes_for(:recaptcha)[:recaptcha_score],
+            action: attributes_for(:recaptcha)[:recaptcha_action]
+          )
+        end
       end
 
       def self.existing_attributes(dependent, _attribute_keys)

--- a/app/forms/ctc/legal_consent_form.rb
+++ b/app/forms/ctc/legal_consent_form.rb
@@ -12,6 +12,7 @@ module Ctc
     set_attributes_for :birthday, :primary_birth_date_month, :primary_birth_date_day, :primary_birth_date_year
     set_attributes_for :confirmation, :primary_ssn_confirmation
     set_attributes_for :misc, :ssn_no_employment
+    set_attributes_for :recaptcha, :recaptcha_score, :recaptcha_action
 
     before_validation :normalize_phone_numbers
 
@@ -28,6 +29,16 @@ module Ctc
       if primary_tin_type == "ssn_no_employment"
         self.primary_tin_type = "ssn"
         self.ssn_no_employment = "yes"
+      end
+    end
+
+    def save
+      super
+      if attributes_for(:recaptcha)[:recaptcha_score].present?
+        @intake.client.recaptcha_scores.create(
+          score: attributes_for(:recaptcha)[:recaptcha_score],
+          action: attributes_for(:recaptcha)[:recaptcha_action]
+        )
       end
     end
 

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -64,6 +64,7 @@ class Client < ApplicationRecord
   has_many :users_assigned_to_tax_returns, through: :tax_returns, source: :assigned_user
   has_many :efile_submissions, through: :tax_returns
   has_many :efile_security_informations, dependent: :destroy
+  has_many :recaptcha_scores, dependent: :destroy
   accepts_nested_attributes_for :tax_returns
   accepts_nested_attributes_for :intake
   accepts_nested_attributes_for :efile_security_informations
@@ -285,6 +286,12 @@ class Client < ApplicationRecord
 
   def hub_status_updatable
     !online_ctc?
+  end
+
+  def recaptcha_scores_average
+    return efile_security_informations.last&.recaptcha_score unless recaptcha_scores.present?
+
+    (recaptcha_scores.map(&:score).sum / recaptcha_scores.size).round(2)
   end
 
   private

--- a/app/models/recaptcha_score.rb
+++ b/app/models/recaptcha_score.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: recaptcha_scores
+#
+#  id         :bigint           not null, primary key
+#  action     :string           not null
+#  score      :decimal(, )      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  client_id  :bigint           not null
+#
+# Indexes
+#
+#  index_recaptcha_scores_on_client_id  (client_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (client_id => clients.id)
+#
+class RecaptchaScore < ApplicationRecord
+  belongs_to :client
+end

--- a/app/services/fraud_indicator_service.rb
+++ b/app/services/fraud_indicator_service.rb
@@ -30,7 +30,8 @@ class FraudIndicatorService
   end
 
   def recaptcha_score
-    @efile_security_informations.any? { |esi| esi.recaptcha_score.present? && esi.recaptcha_score < 0.3 }
+    average = @client.recaptcha_scores_average
+    average.present? && average < 0.3
   end
 
   def international_timezone

--- a/app/views/ctc/questions/bank_account/edit.html.erb
+++ b/app/views/ctc/questions/bank_account/edit.html.erb
@@ -25,6 +25,7 @@
       <%= f.cfa_input_field(:routing_number_confirmation, t("views.ctc.questions.routing_number.routing_number_confirmation"), classes: ["form-width--long"]) %>
       <%= f.cfa_input_field(:account_number, t("views.ctc.questions.account_number.account_number"), classes: ["form-width--long"], type: bank_account_field_type(:account_number)) %>
       <%= f.cfa_input_field(:account_number_confirmation, t("views.ctc.questions.account_number.account_number_confirmation"), classes: ["form-width--long"]) %>
+      <%= recaptcha_v3(action: 'bank_account') %>
     </div>
 
     <button class="button button--primary button--wide" type="submit">

--- a/app/views/ctc/questions/dependents/info/edit.html.erb
+++ b/app/views/ctc/questions/dependents/info/edit.html.erb
@@ -31,6 +31,7 @@
         <label class="form-question"> <%= t('views.ctc.questions.dependents.info.situations') %> </label>
         <%= f.cfa_checkbox(:full_time_student, t('views.ctc.questions.dependents.info.full_time_student'), options: { checked_value: "yes", unchecked_value: "no" }) %>
         <%= f.cfa_checkbox(:permanently_totally_disabled, t('views.ctc.questions.dependents.info.permanently_totally_disabled'), options: { checked_value: "yes", unchecked_value: "no" }) %>
+        <%= recaptcha_v3(action: 'dependents_info') %>
         <%= render('components/molecules/reveal', title: t("views.ctc.questions.dependents.info.reveal_title")) do %>
           <p><%= t("views.ctc.questions.dependents.info.reveal_info") %></p>
         <% end %>

--- a/app/views/ctc/questions/legal_consent/edit.html.erb
+++ b/app/views/ctc/questions/legal_consent/edit.html.erb
@@ -30,6 +30,7 @@
       <%= f.cfa_input_field(:primary_ssn_confirmation, t("views.ctc.questions.legal_consent.ssn_confirmation"), classes: ["form-width--long"]) %>
       <%= f.cfa_input_field(:phone_number, t("views.ctc.questions.legal_consent.sms_phone_number"), classes: ["form-width--long"]) %>
       <%= f.cfa_checkbox(:primary_active_armed_forces, t("views.ctc.questions.legal_consent.primary_active_armed_forces.title"), options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <%= recaptcha_v3(action: 'legal_consent') %>
 
       <%= render('components/molecules/reveal', title: t("views.ctc.questions.legal_consent.primary_active_armed_forces.reveal_label")) do %>
         <p> <%= t("views.ctc.questions.legal_consent.primary_active_armed_forces.reveal_content") %> </p>

--- a/app/views/hub/security/_efile_security_information.html.erb
+++ b/app/views/hub/security/_efile_security_information.html.erb
@@ -1,51 +1,49 @@
-<% @client.efile_security_informations.each do |esf| %>
+<tr class="index-table__row index-table__vertical_align">
+  <td class="index-table__cell"><%= timestamp(esf.created_at) %></td>
+  <td class="index-table__cell"><strong>Device data</strong></td>
+  <td class="index-table__cell">
+    <div class="field-display spacing-below-5">
+      <span class="form-question">Browser Language:</span>
+      <span class="label-value"><%= esf.browser_language %></span>
+    </div>
+    <div class="field-display spacing-below-5">
+      <span class="form-question">Client System Time:</span>
+      <span class="label-value"><%= esf.client_system_time %></span>
+    </div>
+    <div class="field-display spacing-below-5">
+      <span class="form-question">IP Address:</span>
+      <span class="label-value"><%= esf.ip_address %></span>
+    </div>
+    <div class="field-display spacing-below-5">
+      <span class="form-question">Platform:</span>
+      <span class="label-value"><%= esf.platform %></span>
+    </div>
+    <div class="field-display spacing-below-5">
+      <span class="form-question">Timezone Offset:</span>
+      <span class="label-value"><%= esf.timezone_offset %></span>
+    </div>
+    <div class="field-display spacing-below-5">
+      <span class="form-question">User Agent Header:</span>
+      <span class="label-value"><%= esf.user_agent %></span>
+    </div>
+    <div class="field-display spacing-below-5">
+      <span class="form-question">Device ID:</span>
+      <span class="label-value"><%= esf.device_id %></span>
+    </div>
+    <div class="field-display spacing-below-5">
+      <span class="form-question">Timezone</span>
+      <span class="label-value"><%= esf.timezone %></span>
+    </div>
+  </td>
+</tr>
+<% if esf.recaptcha_score.present? %>
   <tr class="index-table__row index-table__vertical_align">
     <td class="index-table__cell"><%= timestamp(esf.created_at) %></td>
-    <td class="index-table__cell"><strong>Device data</strong></td>
+    <td class="index-table__cell"><strong>Legacy recaptcha score</strong></td>
     <td class="index-table__cell">
       <div class="field-display spacing-below-5">
-        <span class="form-question">Browser Language:</span>
-        <span class="label-value"><%= esf.browser_language %></span>
-      </div>
-      <div class="field-display spacing-below-5">
-        <span class="form-question">Client System Time:</span>
-        <span class="label-value"><%= esf.client_system_time %></span>
-      </div>
-      <div class="field-display spacing-below-5">
-        <span class="form-question">IP Address:</span>
-        <span class="label-value"><%= esf.ip_address %></span>
-      </div>
-      <div class="field-display spacing-below-5">
-        <span class="form-question">Platform:</span>
-        <span class="label-value"><%= esf.platform %></span>
-      </div>
-      <div class="field-display spacing-below-5">
-        <span class="form-question">Timezone Offset:</span>
-        <span class="label-value"><%= esf.timezone_offset %></span>
-      </div>
-      <div class="field-display spacing-below-5">
-        <span class="form-question">User Agent Header:</span>
-        <span class="label-value"><%= esf.user_agent %></span>
-      </div>
-      <div class="field-display spacing-below-5">
-        <span class="form-question">Device ID:</span>
-        <span class="label-value"><%= esf.device_id %></span>
-      </div>
-      <div class="field-display spacing-below-5">
-        <span class="form-question">Timezone</span>
-        <span class="label-value"><%= esf.timezone %></span>
+        <span class="label-value"><%= esf.recaptcha_score %></span>
       </div>
     </td>
   </tr>
-  <% if esf.recaptcha_score.present? %>
-    <tr class="index-table__row index-table__vertical_align">
-      <td class="index-table__cell"><%= timestamp(esf.created_at) %></td>
-      <td class="index-table__cell"><strong>Recaptcha score</strong></td>
-      <td class="index-table__cell">
-        <div class="field-display spacing-below-5">
-          <span class="label-value"><%= esf.recaptcha_score %></span>
-        </div>
-      </td>
-    </tr>
-  <% end %>
 <% end %>

--- a/app/views/hub/security/_recaptcha_score.html.erb
+++ b/app/views/hub/security/_recaptcha_score.html.erb
@@ -1,0 +1,10 @@
+<tr class="index-table__row index-table__vertical_align">
+  <td class="index-table__cell"><%= timestamp(recaptcha_score.created_at) %></td>
+  <td class="index-table__cell"><strong>Recaptcha score</strong></td>
+  <td class="index-table__cell">
+    <div class="field-display spacing-below-5">
+      <span class="form-question"><%= "#{recaptcha_score.action}:" %></span>
+      <span class="label-value"><%= recaptcha_score.score %></span>
+    </div>
+  </td>
+</tr>

--- a/app/views/hub/security/show.html.erb
+++ b/app/views/hub/security/show.html.erb
@@ -3,6 +3,10 @@
   <%= render "hub/clients/navigation" %>
 
   <div class="slab slab--not-padded spacing-above-25" id="body">
+    <div class="spacing-below-25">
+      Current recaptcha score average: <%= @client.recaptcha_scores_average %>
+    </div>
+
     <table class="index-table">
       <thead class="index-table__head">
         <tr class="index-table__row">
@@ -13,7 +17,13 @@
       </thead>
 
       <tbody>
-        <%= render(partial: "efile_security_information") %>
+        <% @security_events.each do |event| %>
+          <% if event.is_a?(EfileSecurityInformation) %>
+            <%= render(partial: "efile_security_information", locals: { esf: event }) %>
+          <% elsif event.is_a?(RecaptchaScore) %>
+            <%= render(partial: "recaptcha_score", locals: { recaptcha_score: event }) %>
+          <% end %>
+        <% end %>
       </tbody>
     </table>
   </div>

--- a/db/migrate/20211005214611_create_recaptcha_scores.rb
+++ b/db/migrate/20211005214611_create_recaptcha_scores.rb
@@ -1,0 +1,11 @@
+class CreateRecaptchaScores < ActiveRecord::Migration[6.0]
+  def change
+    create_table :recaptcha_scores do |t|
+      t.decimal :score, null: false
+      t.string :action, null: false
+      t.references :client, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_04_222000) do
+ActiveRecord::Schema.define(version: 2021_10_05_214611) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -828,6 +828,15 @@ ActiveRecord::Schema.define(version: 2021_10_04_222000) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "recaptcha_scores", force: :cascade do |t|
+    t.string "action", null: false
+    t.bigint "client_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.decimal "score", null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["client_id"], name: "index_recaptcha_scores_on_client_id"
+  end
+
   create_table "reports", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.jsonb "data"
@@ -1091,6 +1100,7 @@ ActiveRecord::Schema.define(version: 2021_10_04_222000) do
   add_foreign_key "outgoing_emails", "users"
   add_foreign_key "outgoing_text_messages", "clients"
   add_foreign_key "outgoing_text_messages", "users"
+  add_foreign_key "recaptcha_scores", "clients"
   add_foreign_key "site_coordinator_roles", "vita_partners"
   add_foreign_key "source_parameters", "vita_partners"
   add_foreign_key "system_notes", "clients"

--- a/spec/controllers/concerns/recaptcha_score_concern_spec.rb
+++ b/spec/controllers/concerns/recaptcha_score_concern_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe RecaptchaScoreConcern, type: :controller do
       end
 
       it "returns a score" do
-        expect(subject.recaptcha_score_param("test")).to eq({ recaptcha_score: "0.7" })
+        expect(subject.recaptcha_score_param("test")).to eq({ recaptcha_score: "0.7", recaptcha_action: "test" })
       end
     end
 

--- a/spec/controllers/ctc/portal/portal_controller_spec.rb
+++ b/spec/controllers/ctc/portal/portal_controller_spec.rb
@@ -59,7 +59,8 @@ describe Ctc::Portal::PortalController do
       end
       before do
         sign_in client, scope: :client
-        allow_any_instance_of(RecaptchaScoreConcern).to receive(:recaptcha_score_param).and_return({ recaptcha_score: "0.9" })
+        allow(controller).to receive(:verify_recaptcha).and_return(true)
+        allow(controller).to receive(:recaptcha_reply).and_return({ 'score' => "0.9" })
         client.tax_returns.first.update(efile_submissions: [submission])
       end
 
@@ -68,10 +69,13 @@ describe Ctc::Portal::PortalController do
           put :resubmit, params: params
         }.to change(client.efile_security_informations, :count).by 1
 
-        expect(client.reload.efile_security_informations.last.ip_address).to be_present
-        expect(client.reload.efile_security_informations.last.timezone).to eq "America/Chicago"
+        client.reload
+        expect(client.efile_security_informations.last.ip_address).to be_present
+        expect(client.efile_security_informations.last.timezone).to eq "America/Chicago"
 
-        expect(client.reload.efile_security_informations.last.recaptcha_score).to eq 0.9
+        expect(client.efile_security_informations.last.recaptcha_score).to eq 0.9
+
+        expect(client.recaptcha_scores.last.score).to eq 0.9
 
         system_note = SystemNote::CtcPortalAction.last
         expect(system_note.client).to eq(client)

--- a/spec/controllers/ctc/questions/bank_account_controller_spec.rb
+++ b/spec/controllers/ctc/questions/bank_account_controller_spec.rb
@@ -5,6 +5,8 @@ describe Ctc::Questions::BankAccountController do
 
   before do
     sign_in intake.client
+    allow(controller).to receive(:verify_recaptcha).and_return(true)
+    allow(controller).to receive(:recaptcha_reply).and_return({ 'score' => "0.9" })
   end
 
   describe "#update" do
@@ -37,9 +39,12 @@ describe Ctc::Questions::BankAccountController do
         }
       end
 
-      it "redirects to the next question" do
+      it "redirects to the next question and captures recaptcha score" do
         post :update, params: params
         expect(response).to redirect_to Ctc::Questions::ConfirmBankAccountController.to_path_helper
+        recaptcha_score = intake.client.recaptcha_scores.last
+        expect(recaptcha_score.score).to eq 0.9
+        expect(recaptcha_score.action).to eq 'bank_account'
       end
     end
   end

--- a/spec/controllers/ctc/questions/confirm_legal_controller_spec.rb
+++ b/spec/controllers/ctc/questions/confirm_legal_controller_spec.rb
@@ -6,7 +6,8 @@ describe Ctc::Questions::ConfirmLegalController do
 
   before do
     sign_in intake.client
-    allow_any_instance_of(RecaptchaScoreConcern).to receive(:recaptcha_score_param).and_return({ recaptcha_score: "0.9" })
+    allow(controller).to receive(:verify_recaptcha).and_return(true)
+    allow(controller).to receive(:recaptcha_reply).and_return({ 'score' => "0.9" })
   end
 
   describe "#edit" do
@@ -53,6 +54,9 @@ describe Ctc::Questions::ConfirmLegalController do
           expect(efile_submission.current_state).to eq "preparing"
           expect(client.efile_security_informations.last.ip_address).to eq ip_address
           expect(client.efile_security_informations.last.recaptcha_score).to eq 0.9
+          recaptcha_score = client.recaptcha_scores.last
+          expect(recaptcha_score.score).to eq 0.9
+          expect(recaptcha_score.action).to eq 'confirm_legal'
         end
 
         it "sends a Mixpanel event" do

--- a/spec/controllers/ctc/questions/dependents/info_controller_spec.rb
+++ b/spec/controllers/ctc/questions/dependents/info_controller_spec.rb
@@ -6,6 +6,8 @@ describe Ctc::Questions::Dependents::InfoController do
 
   before do
     sign_in intake.client
+    allow(controller).to receive(:verify_recaptcha).and_return(true)
+    allow(controller).to receive(:recaptcha_reply).and_return({ 'score' => "0.9" })
   end
 
   describe "#edit" do
@@ -50,6 +52,9 @@ describe Ctc::Questions::Dependents::InfoController do
         new_dependent = intake.dependents.last
         expect(new_dependent.creation_token).to eq(unsigned_token)
         expect(new_dependent.full_name).to eq 'Fae Taxseason Jr'
+        recaptcha_score = intake.client.recaptcha_scores.last
+        expect(recaptcha_score.score).to eq 0.9
+        expect(recaptcha_score.action).to eq 'dependents_info'
       end
     end
 
@@ -80,6 +85,9 @@ describe Ctc::Questions::Dependents::InfoController do
           post :update, params: params
 
           expect(dependent.reload.full_name).to eq 'Fae Taxseason'
+          recaptcha_score = intake.client.recaptcha_scores.last # do we want to capture the recaptcha score again for editing a dependent?
+          expect(recaptcha_score.score).to eq 0.9
+          expect(recaptcha_score.action).to eq 'dependents_info'
         end
       end
     end

--- a/spec/controllers/ctc/questions/legal_consent_controller_spec.rb
+++ b/spec/controllers/ctc/questions/legal_consent_controller_spec.rb
@@ -6,6 +6,8 @@ describe Ctc::Questions::LegalConsentController do
   before do
     allow(MixpanelService).to receive(:send_event)
     session[:intake_id] = intake.id
+    allow(controller).to receive(:verify_recaptcha).and_return(true)
+    allow(controller).to receive(:recaptcha_reply).and_return({ 'score' => "0.9" })
   end
 
   describe "#edit" do
@@ -42,6 +44,9 @@ describe Ctc::Questions::LegalConsentController do
 
         client = Client.last
         expect(client.intake.primary_first_name).to eq "Marty"
+        recaptcha_score = client.recaptcha_scores.last
+        expect(recaptcha_score.score).to eq 0.9
+        expect(recaptcha_score.action).to eq 'legal_consent'
       end
 
       it "sends a Mixpanel event" do

--- a/spec/factories/recaptcha_scores.rb
+++ b/spec/factories/recaptcha_scores.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: recaptcha_scores
+#
+#  id         :bigint           not null, primary key
+#  action     :string           not null
+#  score      :decimal(, )      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  client_id  :bigint           not null
+#
+# Indexes
+#
+#  index_recaptcha_scores_on_client_id  (client_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (client_id => clients.id)
+#
+FactoryBot.define do
+  factory :recaptcha_score do
+    score { "9.99" }
+    action { "MyString" }
+    client { nil }
+  end
+end

--- a/spec/forms/ctc/confirm_legal_form_spec.rb
+++ b/spec/forms/ctc/confirm_legal_form_spec.rb
@@ -13,6 +13,7 @@ describe Ctc::ConfirmLegalForm do
       timezone_offset: "+240",
       client_system_time: "Mon Aug 02 2021 18:55:41 GMT-0400 (Eastern Daylight Time)",
       ip_address: "1.1.1.1",
+      recaptcha_action: "confirm_legal",
       recaptcha_score: "0.9",
       timezone: "America/New_York"
     }

--- a/spec/models/recaptcha_score_spec.rb
+++ b/spec/models/recaptcha_score_spec.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: recaptcha_scores
+#
+#  id         :bigint           not null, primary key
+#  action     :string           not null
+#  score      :decimal(, )      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  client_id  :bigint           not null
+#
+# Indexes
+#
+#  index_recaptcha_scores_on_client_id  (client_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (client_id => clients.id)
+#
+require 'rails_helper'
+
+RSpec.describe RecaptchaScore, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Recaptcha score is captured on the following pages:
* legal consent
* bank account
* dependent info
* confirm legal pages

since it is on more pages than the ones where we collect EfileSecurityInformation,
the recaptcha scores now live in their own RecaptchaScore model

The 'Security' tab now shows all the RecaptchaScore entries, with an
average also displayed on the last one

A client is given a fraud hold if the average of their recaptcha scores is less than 0.3

Co-authored-by: Em Barnard-Shao <ebarnard@codeforamerica.org>