### PR TITLE
[#179868602] Simplify logic for marking as not unique transmitted

### DIFF
--- a/app/jobs/gyr_efiler/send_submission_job.rb
+++ b/app/jobs/gyr_efiler/send_submission_job.rb
@@ -25,20 +25,8 @@ module GyrEfiler
       # For most errors, transition to failed and raise the error for Sentry.
       #
       # However, if the IRS says our submission ID is not globally unique, we assume the IRS already received it.
-      if e.message.split("\n").any? do |line|
-        prefix = "Transaction Result: Fault String: ErrorExceptionDetail - Fault Code: soapenv:Server - Detail: "
-        next false unless line.start_with?(prefix)
-
-        parsed_error = Nokogiri::XML(line.slice(prefix.length..))
-        error_message_text = parsed_error.xpath('//ns2:ErrorMessageTxt', 'ns2' => 'http://www.irs.gov/a2a/mef/MeFHeader.xsd').text
-        error_message_code = parsed_error.xpath('//ns2:ErrorMessageCd', 'ns2' => 'http://www.irs.gov/a2a/mef/MeFHeader.xsd').text
-        error_classification_code = parsed_error.xpath('//ns2:ErrorClassificationCd', 'ns2' => 'http://www.irs.gov/a2a/mef/MeFHeader.xsd').text
-        next false unless parsed_error && error_message_text && error_message_code && error_classification_code
-
-        next error_classification_code == "REQUEST_ERROR" && error_message_code == "MEF00005" && error_message_text.match(
-          /\AMessage with Id: [^ ]+ containing submission ids: [^ ]+ specified in the SubmissionDataList is not globally unique - data violates rule: T0000-014\z/
-        )
-      end
+      not_unique_text = /Message with Id: [^ ]+ containing submission ids: [^ ]+ specified in the SubmissionDataList is not globally unique - data violates rule: T0000-014/
+      if e.message.match?(not_unique_text)
         submission.transition_to!(:transmitted, raw_response: e.inspect)
       else
         submission.transition_to!(:failed, error_code: "TRANSMISSION-SERVICE", raw_response: e.inspect)

--- a/spec/jobs/gyr_efiler/send_submission_job_spec.rb
+++ b/spec/jobs/gyr_efiler/send_submission_job_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe GyrEfiler::SendSubmissionJob, type: :job do
       end
 
       context "when the error indicates the IRS already received the data" do
-        let(:exception) { Efile::GyrEfilerService::Error.new("other\nlines\n#{file_fixture("gyr_efiler_duplicate_submission_log_line.txt").read}\nother\nlines") }
+        let(:exception) { Efile::GyrEfilerService::Error.new("#{file_fixture("gyr_efiler_duplicate_submission_log_line.txt").read}") }
 
         it "transitions to transmitted, storing the exception in raw_response" do
           expect do
@@ -89,6 +89,7 @@ RSpec.describe GyrEfiler::SendSubmissionJob, type: :job do
           expect(submission.efile_submission_transitions.last.metadata["raw_response"]).to eq(exception.inspect)
         end
       end
+
     end
 
     context "when the GyrEfiler lock is held" do


### PR DESCRIPTION
I simplified the logic for how we detect this error message by a lot, because I think the error message just wasnt matching the format that we expect. It seems like we can be fairly certain that this is the error if it's included in any of the text for now, so for now i think we can just keep it simple?