### PR TITLE
Avoid PreparedStatementCacheExpired exceptions

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,11 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  # Add a fake ignored column to cause Rails to not do "SELECT *";
+  # this avoids PreparedStatementCacheExpired exceptions.
+  # Based on https://flexport.engineering/avoiding-activerecord-preparedstatementcacheexpired-errors-4499a4f961cf
+  #
+  # Migrate to enumerate_columns_in_select_statements when we switch to Rails 7
+  # https://www.bigbinary.com/blog/rails-7-adds-setting-for-enumerating-columns-in-select-statements
+  class_attribute :ignored_columns, default: [:__fake_column__]
 end


### PR DESCRIPTION
Explanation:

- https://flexport.engineering/avoiding-activerecord-preparedstatementcacheexpired-errors-4499a4f961cf

Testing performed

Before -- when you do `Intake.all.limit(1)` in `rails c` the printout includes:

```
  Intake Load (1.5ms)  SELECT "intakes".* FROM "intakes" LIMIT $1  [["LIMIT", 1]]
```

After:


```
irb(main):003:0> Intake.all.limit(1)
  Intake Load (1.2ms)  SELECT "intakes"."id", "intakes"."additional_info", "intakes"."adopted_child", "intakes"."already_applied_for_stimulus", "intakes"."already_filed", "intakes"."balance_pay_from_bank", "intakes"."bank_account_id", "intakes"."bank_account_type", "intakes"."bought_energy_efficient_items", "intakes"."bought_health_insurance", "intakes"."cannot_claim_me_as_a_dependent", "intakes"."city", "intakes"."claim_owed_stimulus_money", "intakes"."claimed_by_another", "intakes"."client_id", "intakes"."completed_at", "intakes"."completed_yes_no_questions_at", "intakes"."consented_to_legal", "intakes"."continued_at_capacity", "intakes"."created_at", "intakes"."current_step", "intakes"."demographic_disability", "intakes"."demographic_english_conversation", "intakes"."demographic_english_reading", "intakes"."demographic_primary_american_indian_alaska_native", "intakes"."demographic_primary_asian", "intakes"."demographic_primary_black_african_american", "intakes"."demographic_primary_ethnicity", "intakes"."demographic_primary_native_hawaiian_pacific_islander", "intakes"."demographic_primary_prefer_not_to_answer_race", "intakes"."demographic_primary_white", "intakes"."demographic_questions_opt_in", "intakes"."demographic_spouse_american_indian_alaska_native", "intakes"."demographic_spouse_asian", "intakes"."demographic_spouse_black_african_american", "intakes"."demographic_spouse_ethnicity", "intakes"."demographic_spouse_native_hawaiian_pacific_islander", "intakes"."demographic_spouse_prefer_not_to_answer_race", "intakes"."demographic_spouse_white", "intakes"."demographic_veteran", "intakes"."divorced", "intakes"."divorced_year", "intakes"."eip1_amount_received", "intakes"."eip1_and_2_amount_received_confidence", "intakes"."eip1_entry_method", "intakes"."eip2_amount_received", "intakes"."eip2_entry_method", "intakes"."eip_only", "intakes"."email_address", "intakes"."email_address_verified_at", "intakes"."email_notification_opt_in", "intakes"."encrypted_bank_account_number", "intakes"."encrypted_bank_account_number_iv", "intakes"."encrypted_bank_name", "intakes"."encrypted_bank_name_iv", "intakes"."encrypted_bank_routing_number", "intakes"."encrypted_bank_routing_number_iv", "intakes"."encrypted_primary_ip_pin", "intakes"."encrypted_primary_ip_pin_iv", "intakes"."encrypted_primary_last_four_ssn", "intakes"."encrypted_primary_last_four_ssn_iv", "intakes"."encrypted_primary_signature_pin", "intakes"."encrypted_primary_signature_pin_iv", "intakes"."encrypted_primary_ssn", "intakes"."encrypted_primary_ssn_iv", "intakes"."encrypted_spouse_ip_pin", "intakes"."encrypted_spouse_ip_pin_iv", "intakes"."encrypted_spouse_last_four_ssn", "intakes"."encrypted_spouse_last_four_ssn_iv", "intakes"."encrypted_spouse_signature_pin", "intakes"."encrypted_spouse_signature_pin_iv", "intakes"."encrypted_spouse_ssn", "intakes"."encrypted_spouse_ssn_iv", "intakes"."ever_married", "intakes"."ever_owned_home", "intakes"."feedback", "intakes"."feeling_about_taxes", "intakes"."filed_2019", "intakes"."filed_2020", "intakes"."filing_for_stimulus", "intakes"."filing_joint", "intakes"."final_info", "intakes"."had_asset_sale_income", "intakes"."had_debt_forgiven", "intakes"."had_dependents", "intakes"."had_disability", "intakes"."had_disability_income", "intakes"."had_disaster_loss", "intakes"."had_farm_income", "intakes"."had_gambling_income", "intakes"."had_hsa", "intakes"."had_interest_income", "intakes"."had_local_tax_refund", "intakes"."had_other_income", "intakes"."had_rental_income", "intakes"."had_retirement_income", "intakes"."had_self_employment_income", "intakes"."had_social_security_income", "intakes"."had_social_security_or_retirement", "intakes"."had_student_in_family", "intakes"."had_tax_credit_disallowed", "intakes"."had_tips", "intakes"."had_unemployment_income", "intakes"."had_wages", "intakes"."has_primary_ip_pin", "intakes"."has_spouse_ip_pin", "intakes"."income_over_limit", "intakes"."interview_timing_preference", "intakes"."issued_identity_pin", "intakes"."job_count", "intakes"."lived_with_spouse", "intakes"."locale", "intakes"."made_estimated_tax_payments", "intakes"."married", "intakes"."multiple_states", "intakes"."navigator_has_verified_client_identity", "intakes"."navigator_name", "intakes"."needs_help_2016", "intakes"."needs_help_2017", "intakes"."needs_help_2018", "intakes"."needs_help_2019", "intakes"."needs_help_2020", "intakes"."needs_to_flush_searchable_data_set_at", "intakes"."no_eligibility_checks_apply", "intakes"."no_ssn", "intakes"."other_income_types", "intakes"."paid_alimony", "intakes"."paid_charitable_contributions", "intakes"."paid_dependent_care", "intakes"."paid_local_tax", "intakes"."paid_medical_expenses", "intakes"."paid_mortgage_interest", "intakes"."paid_retirement_contributions", "intakes"."paid_school_supplies", "intakes"."paid_student_loan_interest", "intakes"."phone_number", "intakes"."phone_number_can_receive_texts", "intakes"."preferred_interview_language", "intakes"."preferred_name", "intakes"."primary_active_armed_forces", "intakes"."primary_birth_date", "intakes"."primary_consented_to_service", "intakes"."primary_consented_to_service_at", "intakes"."primary_consented_to_service_ip", "intakes"."primary_first_name", "intakes"."primary_last_name", "intakes"."primary_middle_initial", "intakes"."primary_prior_year_agi_amount", "intakes"."primary_prior_year_signature_pin", "intakes"."primary_signature_pin_at", "intakes"."primary_suffix", "intakes"."primary_tin_type", "intakes"."received_alimony", "intakes"."received_homebuyer_credit", "intakes"."received_irs_letter", "intakes"."received_stimulus_payment", "intakes"."referrer", "intakes"."refund_payment_method", "intakes"."reported_asset_sale_loss", "intakes"."reported_self_employment_loss", "intakes"."requested_docs_token", "intakes"."requested_docs_token_created_at", "intakes"."routed_at", "intakes"."routing_criteria", "intakes"."routing_value", "intakes"."satisfaction_face", "intakes"."savings_purchase_bond", "intakes"."savings_split_refund", "intakes"."searchable_data", "intakes"."separated", "intakes"."separated_year", "intakes"."signature_method", "intakes"."sms_notification_opt_in", "intakes"."sms_phone_number", "intakes"."sms_phone_number_verified_at", "intakes"."sold_a_home", "intakes"."sold_assets", "intakes"."source", "intakes"."spouse_active_armed_forces", "intakes"."spouse_auth_token", "intakes"."spouse_birth_date", "intakes"."spouse_can_be_claimed_as_dependent", "intakes"."spouse_consented_to_service", "intakes"."spouse_consented_to_service_at", "intakes"."spouse_consented_to_service_ip", "intakes"."spouse_email_address", "intakes"."spouse_filed_2019", "intakes"."spouse_first_name", "intakes"."spouse_had_disability", "intakes"."spouse_issued_identity_pin", "intakes"."spouse_last_name", "intakes"."spouse_middle_initial", "intakes"."spouse_prior_year_agi_amount", "intakes"."spouse_prior_year_signature_pin", "intakes"."spouse_signature_pin_at", "intakes"."spouse_suffix", "intakes"."spouse_tin_type", "intakes"."spouse_was_blind", "intakes"."spouse_was_full_time_student", "intakes"."spouse_was_on_visa", "intakes"."state", "intakes"."state_of_residence", "intakes"."street_address", "intakes"."street_address2", "intakes"."timezone", "intakes"."type", "intakes"."updated_at", "intakes"."use_primary_name_for_name_control", "intakes"."viewed_at_capacity", "intakes"."visitor_id", "intakes"."vita_partner_id", "intakes"."vita_partner_name", "intakes"."wants_to_itemize", "intakes"."was_blind", "intakes"."was_full_time_student", "intakes"."was_on_visa", "intakes"."widowed", "intakes"."widowed_year", "intakes"."with_drivers_license_photo_id", "intakes"."with_general_navigator", "intakes"."with_incarcerated_navigator", "intakes"."with_itin_taxpayer_id", "intakes"."with_limited_english_navigator", "intakes"."with_other_state_photo_id", "intakes"."with_passport_photo_id", "intakes"."with_social_security_taxpayer_id", "intakes"."with_unhoused_navigator", "intakes"."with_vita_approved_photo_id", "intakes"."with_vita_approved_taxpayer_id", "intakes"."zip_code" FROM "intakes" LIMIT $1  [["LIMIT", 1]]
=> #<ActiveRecord::Relation [#<Intake::GyrIntake id: 1, additional_info: nil, adopted_child: "unfilled", already_applied_for_stimulus: "unfilled", already_filed: "unfilled", balance_pay_from_bank: "unfilled", bank_account_id: nil, bank_account_type: "checking", bought_energy_efficient_items: nil, bought_health_insurance: "unfilled", cannot_claim_me_as_a_dependent: 0, city: nil, claim_owed_stimulus_money: "unfilled", claimed_by_another: "unfilled", client_id: 1, completed_at: nil, completed_yes_no_questions_at: nil, consented_to_legal: 0, continued_at_capacity: false, created_at: "2021-10-05 16:07:01", current_step: nil, demographic_disability: "unfilled", demographic_english_conversation: "unfilled", demographic_english_reading: "unfilled", demographic_primary_american_indian_alaska_native: nil, demographic_primary_asian: nil, demographic_primary_black_african_american: nil, demographic_primary_ethnicity: "unfilled", demographic_primary_native_hawaiian_pacific_islander: nil, demographic_primary_prefer_not_to_answer_race: nil, demographic_primary_white: nil, demographic_questions_opt_in: "unfilled", demographic_spouse_american_indian_alaska_native: nil, demographic_spouse_asian: nil, demographic_spouse_black_african_american: nil, demographic_spouse_ethnicity: "unfilled", demographic_spouse_native_hawaiian_pacific_islander: nil, demographic_spouse_prefer_not_to_answer_race: nil, demographic_spouse_white: nil, demographic_veteran: "unfilled", divorced: "unfilled", divorced_year: nil, eip1_amount_received: nil, eip1_and_2_amount_received_confidence: nil, eip1_entry_method: 0, eip2_amount_received: nil, eip2_entry_method: 0, eip_only: nil, email_address: "crunch@example.com", email_address_verified_at: nil, email_notification_opt_in: "yes", encrypted_bank_account_number: "Q2WWnCQOava+5NPxdynJhjuo3r7VQZqc\n", encrypted_bank_account_number_iv: "Y+aUcfS18nXaXsqc\n", encrypted_bank_name: "+/Tc6dqLatXYkEE8yHW4ENfbWwibiRM3DvhouOMnOAc=\n", encrypted_bank_name_iv: "MEP/Ke9Ve2975XGk\n", encrypted_bank_routing_number: "fwFLRjyLcWqxs1Jskwalck6gNG3xXfg4\n", encrypted_bank_routing_number_iv: "Gs2bkHJT8kZJ6kxu\n", encrypted_primary_ip_pin: nil, encrypted_primary_ip_pin_iv: nil, encrypted_primary_last_four_ssn: nil, encrypted_primary_last_four_ssn_iv: nil, encrypted_primary_signature_pin: nil, encrypted_primary_signature_pin_iv: nil, encrypted_primary_ssn: nil, encrypted_primary_ssn_iv: nil, encrypted_spouse_ip_pin: nil, encrypted_spouse_ip_pin_iv: nil, encrypted_spouse_last_four_ssn: nil, encrypted_spouse_last_four_ssn_iv: nil, encrypted_spouse_signature_pin: nil, encrypted_spouse_signature_pin_iv: nil, encrypted_spouse_ssn: nil, encrypted_spouse_ssn_iv: nil, ever_married: "unfilled", ever_owned_home: "unfilled", feedback: nil, feeling_about_taxes: "unfilled", filed_2019: 0, filed_2020: 0, filing_for_stimulus: "unfilled", filing_joint: "unfilled", final_info: nil, had_asset_sale_income: "unfilled", had_debt_forgiven: "unfilled", had_dependents: "unfilled", had_disability: "unfilled", had_disability_income: "unfilled", had_disaster_loss: "unfilled", had_farm_income: "unfilled", had_gambling_income: "unfilled", had_hsa: "unfilled", had_interest_income: "unfilled", had_local_tax_refund: "unfilled", had_other_income: "unfilled", had_rental_income: "unfilled", had_retirement_income: "unfilled", had_self_employment_income: "unfilled", had_social_security_income: "unfilled", had_social_security_or_retirement: "unfilled", had_student_in_family: "unfilled", had_tax_credit_disallowed: "unfilled", had_tips: "unfilled", had_unemployment_income: "unfilled", had_wages: "unfilled", has_primary_ip_pin: 0, has_spouse_ip_pin: 0, income_over_limit: "unfilled", interview_timing_preference: nil, issued_identity_pin: "unfilled", job_count: nil, lived_with_spouse: "unfilled", locale: nil, made_estimated_tax_payments: "unfilled", married: "unfilled", multiple_states: "unfilled", navigator_has_verified_client_identity: nil, navigator_name: nil, needs_help_2016: "unfilled", needs_help_2017: "unfilled", needs_help_2018: "unfilled", needs_help_2019: "unfilled", needs_help_2020: "unfilled", needs_to_flush_searchable_data_set_at: "2021-10-05 16:07:01", no_eligibility_checks_apply: "unfilled", no_ssn: "unfilled", other_income_types: nil, paid_alimony: "unfilled", paid_charitable_contributions: "unfilled", paid_dependent_care: "unfilled", paid_local_tax: "unfilled", paid_medical_expenses: "unfilled", paid_mortgage_interest: "unfilled", paid_retirement_contributions: "unfilled", paid_school_supplies: "unfilled", paid_student_loan_interest: "unfilled", phone_number: nil, phone_number_can_receive_texts: "unfilled", preferred_interview_language: nil, preferred_name: "Captain", primary_active_armed_forces: 0, primary_birth_date: nil, primary_consented_to_service: "unfilled", primary_consented_to_service_at: "2021-10-05 16:07:01", primary_consented_to_service_ip: nil, primary_first_name: "Captain", primary_last_name: "Hook", primary_middle_initial: nil, primary_prior_year_agi_amount: nil, primary_prior_year_signature_pin: nil, primary_signature_pin_at: nil, primary_suffix: nil, primary_tin_type: nil, received_alimony: "unfilled", received_homebuyer_credit: "unfilled", received_irs_letter: "unfilled", received_stimulus_payment: "unfilled", referrer: nil, refund_payment_method: "unfilled", reported_asset_sale_loss: "unfilled", reported_self_employment_loss: "unfilled", requested_docs_token: nil, requested_docs_token_created_at: nil, routed_at: nil, routing_criteria: nil, routing_value: nil, satisfaction_face: "unfilled", savings_purchase_bond: "unfilled", savings_split_refund: "unfilled", searchable_data: nil, separated: "unfilled", separated_year: nil, signature_method: "online", sms_notification_opt_in: "yes", sms_phone_number: "+14155551212", sms_phone_number_verified_at: nil, sold_a_home: "unfilled", sold_assets: "unfilled", source: nil, spouse_active_armed_forces: 0, spouse_auth_token: nil, spouse_birth_date: nil, spouse_can_be_claimed_as_dependent: 0, spouse_consented_to_service: "unfilled", spouse_consented_to_service_at: nil, spouse_consented_to_service_ip: nil, spouse_email_address: nil, spouse_filed_2019: 0, spouse_first_name: nil, spouse_had_disability: "unfilled", spouse_issued_identity_pin: "unfilled", spouse_last_name: nil, spouse_middle_initial: nil, spouse_prior_year_agi_amount: nil, spouse_prior_year_signature_pin: nil, spouse_signature_pin_at: nil, spouse_suffix: nil, spouse_tin_type: nil, spouse_was_blind: "unfilled", spouse_was_full_time_student: "unfilled", spouse_was_on_visa: "unfilled", state: nil, state_of_residence: nil, street_address: nil, street_address2: nil, timezone: nil, type: "Intake::GyrIntake", updated_at: "2021-10-05 16:07:01", use_primary_name_for_name_control: false, viewed_at_capacity: false, visitor_id: "test_visitor_id", vita_partner_id: nil, vita_partner_name: nil, wants_to_itemize: "unfilled", was_blind: "unfilled", was_full_time_student: "unfilled", was_on_visa: "unfilled", widowed: "unfilled", widowed_year: nil, with_drivers_license_photo_id: false, with_general_navigator: false, with_incarcerated_navigator: false, with_itin_taxpayer_id: false, with_limited_english_navigator: false, with_other_state_photo_id: false, with_passport_photo_id: false, with_social_security_taxpayer_id: false, with_unhoused_navigator: false, with_vita_approved_photo_id: false, with_vita_approved_taxpayer_id: false, zip_code: nil, primary_last_four_ssn: nil, spouse_last_four_ssn: nil, primary_ssn: nil, spouse_ssn: nil, bank_name: nil, bank_routing_number: nil, bank_account_number: nil>]>
irb(main):004:0>
```