### PR TITLE
Index intakes on spouse_email_address

### DIFF
--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -242,6 +242,7 @@
 #  index_intakes_on_phone_number                           (phone_number)
 #  index_intakes_on_searchable_data                        (searchable_data) USING gin
 #  index_intakes_on_sms_phone_number                       (sms_phone_number)
+#  index_intakes_on_spouse_email_address                   (spouse_email_address)
 #  index_intakes_on_type                                   (type)
 #  index_intakes_on_vita_partner_id                        (vita_partner_id)
 #

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -242,6 +242,7 @@
 #  index_intakes_on_phone_number                           (phone_number)
 #  index_intakes_on_searchable_data                        (searchable_data) USING gin
 #  index_intakes_on_sms_phone_number                       (sms_phone_number)
+#  index_intakes_on_spouse_email_address                   (spouse_email_address)
 #  index_intakes_on_type                                   (type)
 #  index_intakes_on_vita_partner_id                        (vita_partner_id)
 #

--- a/app/models/intake/gyr_intake.rb
+++ b/app/models/intake/gyr_intake.rb
@@ -242,6 +242,7 @@
 #  index_intakes_on_phone_number                           (phone_number)
 #  index_intakes_on_searchable_data                        (searchable_data) USING gin
 #  index_intakes_on_sms_phone_number                       (sms_phone_number)
+#  index_intakes_on_spouse_email_address                   (spouse_email_address)
 #  index_intakes_on_type                                   (type)
 #  index_intakes_on_vita_partner_id                        (vita_partner_id)
 #

--- a/db/migrate/20211019194457_add_spouse_email_address_index_to_intakes.rb
+++ b/db/migrate/20211019194457_add_spouse_email_address_index_to_intakes.rb
@@ -1,0 +1,7 @@
+class AddSpouseEmailAddressIndexToIntakes < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :intakes, :spouse_email_address, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_05_214611) do
+ActiveRecord::Schema.define(version: 2021_10_19_194457) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -751,6 +751,7 @@ ActiveRecord::Schema.define(version: 2021_10_05_214611) do
     t.index ["phone_number"], name: "index_intakes_on_phone_number"
     t.index ["searchable_data"], name: "index_intakes_on_searchable_data", using: :gin
     t.index ["sms_phone_number"], name: "index_intakes_on_sms_phone_number"
+    t.index ["spouse_email_address"], name: "index_intakes_on_spouse_email_address"
     t.index ["type"], name: "index_intakes_on_type"
     t.index ["vita_partner_id"], name: "index_intakes_on_vita_partner_id"
   end

--- a/spec/factories/intakes.rb
+++ b/spec/factories/intakes.rb
@@ -242,6 +242,7 @@
 #  index_intakes_on_phone_number                           (phone_number)
 #  index_intakes_on_searchable_data                        (searchable_data) USING gin
 #  index_intakes_on_sms_phone_number                       (sms_phone_number)
+#  index_intakes_on_spouse_email_address                   (spouse_email_address)
 #  index_intakes_on_type                                   (type)
 #  index_intakes_on_vita_partner_id                        (vita_partner_id)
 #

--- a/spec/models/intake/gyr_intake_spec.rb
+++ b/spec/models/intake/gyr_intake_spec.rb
@@ -242,6 +242,7 @@
 #  index_intakes_on_phone_number                           (phone_number)
 #  index_intakes_on_searchable_data                        (searchable_data) USING gin
 #  index_intakes_on_sms_phone_number                       (sms_phone_number)
+#  index_intakes_on_spouse_email_address                   (spouse_email_address)
 #  index_intakes_on_type                                   (type)
 #  index_intakes_on_vita_partner_id                        (vita_partner_id)
 #

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -242,6 +242,7 @@
 #  index_intakes_on_phone_number                           (phone_number)
 #  index_intakes_on_searchable_data                        (searchable_data) USING gin
 #  index_intakes_on_sms_phone_number                       (sms_phone_number)
+#  index_intakes_on_spouse_email_address                   (spouse_email_address)
 #  index_intakes_on_type                                   (type)
 #  index_intakes_on_vita_partner_id                        (vita_partner_id)
 #


### PR DESCRIPTION
We lookup using both the primary and spouse email when people login,
so we want them to both be equally fast.