### PR TITLE
Improvements to efile dashboard performance (WIP)

### DIFF
--- a/app/models/efile_submission.rb
+++ b/app/models/efile_submission.rb
@@ -11,9 +11,10 @@
 #
 # Indexes
 #
-#  index_efile_submissions_on_created_at         (created_at)
-#  index_efile_submissions_on_irs_submission_id  (irs_submission_id)
-#  index_efile_submissions_on_tax_return_id      (tax_return_id)
+#  index_efile_submissions_on_created_at            (created_at)
+#  index_efile_submissions_on_irs_submission_id     (irs_submission_id)
+#  index_efile_submissions_on_tax_return_id         (tax_return_id)
+#  index_efile_submissions_on_tax_return_id_and_id  (tax_return_id,id DESC)
 #
 class EfileSubmission < ApplicationRecord
   belongs_to :tax_return

--- a/db/migrate/20211019193108_index_efile_submission_on_id_and_tax_return_id.rb
+++ b/db/migrate/20211019193108_index_efile_submission_on_id_and_tax_return_id.rb
@@ -1,0 +1,7 @@
+class IndexEfileSubmissionOnIdAndTaxReturnId < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :efile_submissions, [:tax_return_id, :id], order: {id: :desc}, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -436,6 +436,7 @@ ActiveRecord::Schema.define(version: 2021_11_15_175837) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["created_at"], name: "index_efile_submissions_on_created_at"
     t.index ["irs_submission_id"], name: "index_efile_submissions_on_irs_submission_id"
+    t.index ["tax_return_id", "id"], name: "index_efile_submissions_on_tax_return_id_and_id", order: { id: :desc }
     t.index ["tax_return_id"], name: "index_efile_submissions_on_tax_return_id"
   end
 

--- a/spec/factories/efile_submissions.rb
+++ b/spec/factories/efile_submissions.rb
@@ -11,9 +11,10 @@
 #
 # Indexes
 #
-#  index_efile_submissions_on_created_at         (created_at)
-#  index_efile_submissions_on_irs_submission_id  (irs_submission_id)
-#  index_efile_submissions_on_tax_return_id      (tax_return_id)
+#  index_efile_submissions_on_created_at            (created_at)
+#  index_efile_submissions_on_irs_submission_id     (irs_submission_id)
+#  index_efile_submissions_on_tax_return_id         (tax_return_id)
+#  index_efile_submissions_on_tax_return_id_and_id  (tax_return_id,id DESC)
 #
 FactoryBot.define do
   factory :efile_submission do

--- a/spec/models/efile_submission_spec.rb
+++ b/spec/models/efile_submission_spec.rb
@@ -11,9 +11,10 @@
 #
 # Indexes
 #
-#  index_efile_submissions_on_created_at         (created_at)
-#  index_efile_submissions_on_irs_submission_id  (irs_submission_id)
-#  index_efile_submissions_on_tax_return_id      (tax_return_id)
+#  index_efile_submissions_on_created_at            (created_at)
+#  index_efile_submissions_on_irs_submission_id     (irs_submission_id)
+#  index_efile_submissions_on_tax_return_id         (tax_return_id)
+#  index_efile_submissions_on_tax_return_id_and_id  (tax_return_id,id DESC)
 #
 require "rails_helper"
 


### PR DESCRIPTION
Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>

```
vita-min_development=# explain select * from (select id, tax_return_id, rank() OVER (partition by tax_return_id order by id desc) from efile_submissions) as stuff where stuff.rank = 1;
                                                                  QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------
 Subquery Scan on stuff  (cost=0.15..80.60 rows=4 width=24)
   Filter: (stuff.rank = 1)
   ->  WindowAgg  (cost=0.15..70.47 rows=810 width=24)
         ->  Index Only Scan using index_efile_submissions_on_tax_return_id_and_id on efile_submissions  (cost=0.15..56.30 rows=810 width=16)
(4 rows)
```

```
psql 'postgresql://localhost/vita-min_development'
```