### PR TITLE
Speed up client login by removing an .or() that was causing bad performance

### DIFF
--- a/app/controllers/portal/client_logins_controller.rb
+++ b/app/controllers/portal/client_logins_controller.rb
@@ -39,7 +39,7 @@ module Portal
       if @verification_code_form.valid?
         hashed_verification_code = VerificationCodeService.hash_verification_code_with_contact_info(params[:contact_info], params[:verification_code])
 
-        if client_login_service.clients_for_token(hashed_verification_code).exists?
+        if client_login_service.clients_for_token(hashed_verification_code).present?
           DatadogApi.increment("client_logins.verification_codes.right_code")
           redirect_to edit_portal_client_login_path(id: hashed_verification_code)
           return

--- a/app/services/client_login_service.rb
+++ b/app/services/client_login_service.rb
@@ -19,7 +19,7 @@ class ClientLoginService
     intake_matches = email_intake_matches.or(spouse_email_intake_matches).or(phone_intake_matches)
 
     # Client.by_raw_login_token supports login links generated from mid-Jan through early March 2021.
-    Client.where(intake: intake_matches).or(Client.by_raw_login_token(raw_token))
+    (Client.where(intake: intake_matches) + Client.by_raw_login_token(raw_token)).uniq
   end
 
   def can_login_by_email_verification?(email_address, service_type: :gyr)


### PR DESCRIPTION
Before, the query ended up being something like
```
SELECT * FROM clients WHERE id IN (...) OR login_token = ?
```

There's an index on clients.login_token, and the id is of course indexed.
So postgres ideally should've just done two index scans and combined them.
But instead it does a seq scan of the clients table, which is getting slower
and slower.

If we run two queries instead and combine the results in memory, it's a lot
faster (3ms vs 250+ ms)