### PR TITLE
When there are notes, remove unnecessary nil check; add test case [#178502843]

### DIFF
--- a/app/views/hub/notes/index.html.erb
+++ b/app/views/hub/notes/index.html.erb
@@ -10,7 +10,7 @@
   <div class="slab slab--padded">
     <div class="client-container">
       <ul class="day-list">
-        <% @all_notes_by_day&.each_with_index do |(datetime, notes), day_index| %>
+        <% @all_notes_by_day.each_with_index do |(datetime, notes), day_index| %>
           <li class="day-heading"><%= date_heading(datetime) %></li>
           <%= render partial: "note", collection: notes, locals: { last_day: day_index == @all_notes_by_day.size - 1 }  %>
         <% end %>

--- a/spec/presenters/notes_presenter_spec.rb
+++ b/spec/presenters/notes_presenter_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe NotesPresenter do
     let(:params) { { client_id: client.id } }
     let(:user) { create :admin_user }
 
-    before do
-      create :note # unrelated note
-      create :system_note # unrelated system note
-    end
-
     context "with notes from different days" do
+      before do
+        create :note # unrelated note
+        create :system_note # unrelated system note
+      end
+
       let(:document_note_double) { double(SyntheticNote) }
       let(:outbound_call_note_double) { double(SyntheticNote) }
       let(:day1){ DateTime.new(2019, 10, 5, 8, 1).utc }
@@ -37,5 +37,12 @@ RSpec.describe NotesPresenter do
       end
     end
 
+    context "with no notes at all" do
+      it "returns the empty hash" do
+        all_notes_by_day = NotesPresenter.grouped_notes(client)
+
+        expect(all_notes_by_day).to eq({})
+      end
+    end
   end
 end


### PR DESCRIPTION
This has no client/user-visible impact.

We were doing a null check on an instance variable; upon further research, we didn't need the null check.

Testing performed:

* Visited a client w/ no notes and no messages on localhost; validated that the notes and messages tab both load properly

I know the Pivotal Tracker story is about **adding** a null check, but it's also more generally about handling the case where there are no notes. The crash is from 5 months ago, and I think the test case proves we don't need it, so I wonder if we can try this approach. If it ends up being a bad idea, I'm willing to personally revert it.