### PR TITLE
Limit ssn input fields to 11 characters

### DIFF
--- a/app/views/ctc/portal/primary_filer/edit.html.erb
+++ b/app/views/ctc/portal/primary_filer/edit.html.erb
@@ -27,8 +27,8 @@
                   classes: ["ctc-intake-date-text-input"]
               ) %>
           <%= f.cfa_select(:primary_tin_type, t('views.ctc.portal.primary_filer.form_of_identity'), tin_options_for_select(include_itin: true), help_text: t('views.ctc.portal.primary_filer.form_of_identity_note')) %>
-          <%= f.cfa_input_field(:primary_ssn, t("views.ctc.questions.legal_consent.ssn"), classes: ["form-width--long"]) %>
-          <%= f.cfa_input_field(:primary_ssn_confirmation, t("views.ctc.questions.legal_consent.ssn_confirmation"), classes: ["form-width--long"]) %>
+          <%= f.cfa_input_field(:primary_ssn, t("views.ctc.questions.legal_consent.ssn"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
+          <%= f.cfa_input_field(:primary_ssn_confirmation, t("views.ctc.questions.legal_consent.ssn_confirmation"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
           <%= f.cfa_input_field(:primary_ip_pin, t("views.ctc.questions.ip_pin_entry.label", name: current_intake.primary_full_name), type: "tel", classes: ["form-width--long"]) %>
         </div>
 

--- a/app/views/ctc/portal/spouse/edit.html.erb
+++ b/app/views/ctc/portal/spouse/edit.html.erb
@@ -26,8 +26,8 @@
               ) %>
           <%= f.cfa_select(:spouse_tin_type, t("views.ctc.questions.spouse_info.spouse_identity"), tin_options_for_select(include_itin: true, include_none: true), help_text: t("views.ctc.questions.spouse_info.spouse_identity_help_text")) %>
           <%= f.cfa_checkbox(:ssn_no_employment, t('views.ctc.questions.legal_consent.ssn_not_valid_for_employment'), options: { checked_value: "yes", unchecked_value: "no" }) %>
-          <%= f.cfa_input_field(:spouse_ssn, t("views.ctc.questions.spouse_info.spouse_ssn_itin"), classes: ["form-width--long"]) %>
-          <%= f.cfa_input_field(:spouse_ssn_confirmation, t("views.ctc.questions.spouse_info.spouse_ssn_itin_confirmation"), classes: ["form-width--long"]) %>
+          <%= f.cfa_input_field(:spouse_ssn, t("views.ctc.questions.spouse_info.spouse_ssn_itin"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
+          <%= f.cfa_input_field(:spouse_ssn_confirmation, t("views.ctc.questions.spouse_info.spouse_ssn_itin_confirmation"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
           <%= f.cfa_input_field(:spouse_ip_pin, t("views.ctc.questions.ip_pin_entry.label", name: current_intake.spouse_full_name), type: "tel", classes: ["form-width--long"]) %>
         </div>
 

--- a/app/views/ctc/questions/legal_consent/edit.html.erb
+++ b/app/views/ctc/questions/legal_consent/edit.html.erb
@@ -26,8 +26,8 @@
             ) %>
       <%= f.cfa_select(:primary_tin_type, t('views.ctc.questions.legal_consent.tin_type'), tin_options_for_select(include_itin: true)) %>
       <%= f.cfa_checkbox(:ssn_no_employment, t('views.ctc.questions.legal_consent.ssn_not_valid_for_employment'), options: { checked_value: "yes", unchecked_value: "no" }) %>
-      <%= f.cfa_input_field(:primary_ssn, t("views.ctc.questions.legal_consent.ssn"), classes: ["form-width--long"]) %>
-      <%= f.cfa_input_field(:primary_ssn_confirmation, t("views.ctc.questions.legal_consent.ssn_confirmation"), classes: ["form-width--long"]) %>
+      <%= f.cfa_input_field(:primary_ssn, t("views.ctc.questions.legal_consent.ssn"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
+      <%= f.cfa_input_field(:primary_ssn_confirmation, t("views.ctc.questions.legal_consent.ssn_confirmation"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
       <%= f.cfa_input_field(:phone_number, t("views.ctc.questions.legal_consent.sms_phone_number"), classes: ["form-width--long"]) %>
       <%= f.cfa_checkbox(:primary_active_armed_forces, t("views.ctc.questions.legal_consent.primary_active_armed_forces.title"), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= recaptcha_v3(action: 'legal_consent') %>

--- a/app/views/ctc/questions/spouse_info/edit.html.erb
+++ b/app/views/ctc/questions/spouse_info/edit.html.erb
@@ -20,8 +20,8 @@
           ) %>
       <%= f.cfa_select(:spouse_tin_type, t("views.ctc.questions.spouse_info.spouse_identity"), tin_options_for_select(include_itin: true), help_text: t("views.ctc.questions.spouse_info.spouse_identity_help_text")) %>
       <%= f.cfa_checkbox(:ssn_no_employment, t('views.ctc.questions.legal_consent.ssn_not_valid_for_employment'), options: { checked_value: "yes", unchecked_value: "no" }) %>
-      <%= f.cfa_input_field(:spouse_ssn, t("views.ctc.questions.spouse_info.spouse_ssn_itin"), classes: ["form-width--long"]) %>
-      <%= f.cfa_input_field(:spouse_ssn_confirmation, t("views.ctc.questions.spouse_info.spouse_ssn_itin_confirmation"), classes: ["form-width--long"]) %>
+      <%= f.cfa_input_field(:spouse_ssn, t("views.ctc.questions.spouse_info.spouse_ssn_itin"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
+      <%= f.cfa_input_field(:spouse_ssn_confirmation, t("views.ctc.questions.spouse_info.spouse_ssn_itin_confirmation"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
       <%= f.cfa_checkbox(:spouse_can_be_claimed_as_dependent, t("views.ctc.questions.spouse_info.spouse_can_be_claimed_as_dependent"), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox(:spouse_active_armed_forces, t("views.ctc.questions.spouse_info.spouse_active_armed_forces"), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= render('components/molecules/reveal', title: t("views.ctc.questions.spouse_info.spouse_active_armed_forces_reveal")) do %>


### PR DESCRIPTION
This allows for hyphens in the social security numbers entered, whereas limiting it to 9 would not. We strip those hyphens out before storing it.