### PR TITLE
Don't run any validations on suspend/unsuspend of an organization

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -223,10 +223,10 @@ class User < ApplicationRecord
 
   def suspend!
     assigned_tax_returns.update(assigned_user: nil)
-    update!(suspended_at: DateTime.now)
+    update_columns(suspended_at: DateTime.now)
   end
 
   def activate!
-    update!(suspended_at: nil)
+    update_columns(suspended_at: nil)
   end
 end


### PR DESCRIPTION
Some users had a sketchy email, somehow, and it shouldn't block the whole operation from working