### PR TITLE
Update assignable users list and client vita partner logic

### DIFF
--- a/app/controllers/concerns/tax_return_assignable_users.rb
+++ b/app/controllers/concerns/tax_return_assignable_users.rb
@@ -5,10 +5,17 @@ module TaxReturnAssignableUsers
       if client.vita_partner.site?
         team_members = User.where(role: TeamMemberRole.where(site: client.vita_partner))
         site_coordinators = User.where(role: SiteCoordinatorRole.where(site: client.vita_partner))
-        assignable_users += team_members.or(site_coordinators).active.order(name: :asc)
-      else # client.vita_partner is an organization
+        org_leads = User.where(role: OrganizationLeadRole.where(organization: client.vita_partner.parent_organization))
+        assignable_users += team_members.or(site_coordinators).or(org_leads).active.order(name: :asc)
+      else
+        # when client.vita_partner is an organization
+        # we want to include all team and site members under the org
+        # due to user permissions, this will only be included if the user is an org lead/admin
+        child_sites = VitaPartner.sites.where(parent_organization: client.vita_partner)
+        org_team_members = User.where(role: TeamMemberRole.where(site: child_sites))
+        org_site_coordinators = User.where(role: SiteCoordinatorRole.where(site: child_sites))
         org_leads = User.where(role: OrganizationLeadRole.where(organization: client.vita_partner))
-        assignable_users += org_leads.active.order(name: :asc)
+        assignable_users += org_leads.or(org_team_members).or(org_site_coordinators).active.order(name: :asc)
       end
     end
     assignable_users.compact.uniq

--- a/app/controllers/concerns/tax_return_assignable_users.rb
+++ b/app/controllers/concerns/tax_return_assignable_users.rb
@@ -8,9 +8,8 @@ module TaxReturnAssignableUsers
         org_leads = User.where(role: OrganizationLeadRole.where(organization: client.vita_partner.parent_organization))
         assignable_users += team_members.or(site_coordinators).or(org_leads).active.order(name: :asc)
       else
-        # when client.vita_partner is an organization
-        # we want to include all team and site members under the org
-        # due to user permissions, this will only be included if the user is an org lead/admin
+        # client.vita_partner is an organization
+        # include all team and site members under the org
         child_sites = VitaPartner.sites.where(parent_organization: client.vita_partner)
         org_team_members = User.where(role: TeamMemberRole.where(site: child_sites))
         org_site_coordinators = User.where(role: SiteCoordinatorRole.where(site: child_sites))

--- a/app/controllers/hub/bulk_actions/change_assignee_and_status_controller.rb
+++ b/app/controllers/hub/bulk_actions/change_assignee_and_status_controller.rb
@@ -44,7 +44,7 @@ module Hub
 
       def update_assignee_and_status!
         @selection.tax_returns.find_each do |tax_return|
-          tax_return.assign!(assigned_user: @form.assigned_user, assigned_by: current_user) unless assignment_action == BulkTaxReturnUpdate::KEEP
+          UserAssignmentService.assign_tax_return!(tax_return: tax_return, assigned_user: @form.assigned_user) unless assignment_action == BulkTaxReturnUpdate::KEEP
           tax_return.transition_to!(@form.status) unless status_action == BulkTaxReturnUpdate::KEEP
         end
       end

--- a/app/controllers/hub/bulk_actions/change_assignee_and_status_controller.rb
+++ b/app/controllers/hub/bulk_actions/change_assignee_and_status_controller.rb
@@ -44,7 +44,7 @@ module Hub
 
       def update_assignee_and_status!
         @selection.tax_returns.find_each do |tax_return|
-          UserAssignmentService.assign_tax_return!(tax_return: tax_return, assigned_user: @form.assigned_user) unless assignment_action == BulkTaxReturnUpdate::KEEP
+          TaxReturnAssignmentService.new(tax_return: tax_return, assigned_user: @form.assigned_user, assigned_by: current_user).assign! unless assignment_action == BulkTaxReturnUpdate::KEEP
           tax_return.transition_to!(@form.status) unless status_action == BulkTaxReturnUpdate::KEEP
         end
       end

--- a/app/controllers/hub/bulk_actions/change_assignee_and_status_controller.rb
+++ b/app/controllers/hub/bulk_actions/change_assignee_and_status_controller.rb
@@ -44,7 +44,7 @@ module Hub
 
       def update_assignee_and_status!
         @selection.tax_returns.find_each do |tax_return|
-          tax_return.update!(assigned_user: @form.assigned_user) unless assignment_action == BulkTaxReturnUpdate::KEEP
+          tax_return.assign!(assigned_user: @form.assigned_user, assigned_by: current_user) unless assignment_action == BulkTaxReturnUpdate::KEEP
           tax_return.transition_to!(@form.status) unless status_action == BulkTaxReturnUpdate::KEEP
         end
       end

--- a/app/controllers/hub/bulk_actions/change_organization_controller.rb
+++ b/app/controllers/hub/bulk_actions/change_organization_controller.rb
@@ -12,7 +12,6 @@ module Hub
         @new_vita_partner = @vita_partners.find(@form.vita_partner_id)
 
         ActiveRecord::Base.transaction do
-          unassign_users_who_will_lose_access!
           update_clients_with_new_partner!
           create_notes!
           create_change_org_notifications!
@@ -37,15 +36,6 @@ module Hub
         if @new_vita_partner.present?
           bulk_update = BulkClientOrganizationUpdate.create!(tax_return_selection: @selection, vita_partner: @new_vita_partner)
           UserNotification.create!(notifiable: bulk_update, user: current_user)
-        end
-      end
-
-      # Must unassign _all_ tax returns from a client who would lose access (even if not explicitly selected in the tax_return_selection)
-      # because you can't change organization if any return is assigned to a user who would lose access.
-      def unassign_users_who_will_lose_access!
-        TaxReturn.where(client: @clients).where.not(assigned_user: nil).find_each do |tax_return|
-          assigned_user_retains_access = tax_return.assigned_user.accessible_vita_partners.include?(@new_vita_partner)
-          tax_return.update!(assigned_user: nil) unless assigned_user_retains_access
         end
       end
 

--- a/app/controllers/hub/clients/organizations_controller.rb
+++ b/app/controllers/hub/clients/organizations_controller.rb
@@ -16,7 +16,7 @@ module Hub
           UpdateClientVitaPartnerService.new(client: @client,
                                              vita_partner_id: client_params[:vita_partner_id],
                                              change_initiated_by: current_user).update!
-        rescue
+        rescue ActiveRecord::Rollback
           render :edit
         else
           redirect_to hub_client_path(id: @client.id)

--- a/app/controllers/hub/clients/organizations_controller.rb
+++ b/app/controllers/hub/clients/organizations_controller.rb
@@ -12,10 +12,14 @@ module Hub
       def edit; end
 
       def update
-        if @client.update(client_params)
-          redirect_to hub_client_path(id: @client.id)
-        else
+        begin
+          UpdateClientVitaPartnerService.new(client: @client,
+                                             vita_partner_id: client_params[:vita_partner_id],
+                                             change_initiated_by: current_user).update!
+        rescue
           render :edit
+        else
+          redirect_to hub_client_path(id: @client.id)
         end
       end
 

--- a/app/controllers/hub/clients/organizations_controller.rb
+++ b/app/controllers/hub/clients/organizations_controller.rb
@@ -13,10 +13,12 @@ module Hub
 
       def update
         begin
-          UpdateClientVitaPartnerService.new(client: @client,
-                                             vita_partner_id: client_params[:vita_partner_id],
-                                             change_initiated_by: current_user).update!
-        rescue ActiveRecord::Rollback
+          ActiveRecord::Base.transaction do
+            UpdateClientVitaPartnerService.new(clients: [@client],
+                                               vita_partner_id: client_params[:vita_partner_id],
+                                               change_initiated_by: current_user).update!
+          end
+        rescue ActiveRecord::RecordInvalid
           render :edit
         else
           redirect_to hub_client_path(id: @client.id)

--- a/app/controllers/hub/tax_returns_controller.rb
+++ b/app/controllers/hub/tax_returns_controller.rb
@@ -27,6 +27,7 @@ module Hub
       if @tax_return.valid?
         @tax_return.save!
         @tax_return.transition_to(tax_return_params[:status])
+        TaxReturnAssignmentService.new(tax_return: @tax_return, assigned_user: @tax_return.assigned_user, assigned_by: current_user).assign!
         SystemNote::TaxReturnCreated.generate!(initiated_by: current_user, tax_return: @tax_return)
         flash[:notice] = I18n.t("hub.tax_returns.create.success", year: @tax_return.year, name: @client.preferred_name)
         redirect_to hub_client_path(id: @client.id)

--- a/app/controllers/hub/tax_returns_controller.rb
+++ b/app/controllers/hub/tax_returns_controller.rb
@@ -42,10 +42,11 @@ module Hub
     def show; end
 
     def update
-      TaxReturnAssignmentService.assign!(tax_return: @tax_return,
-                                     assigned_user: @assigned_user,
-                                     assigned_by: current_user,
-                                     create_notifications: true)
+      assignment_service = TaxReturnAssignmentService.new(tax_return: @tax_return,
+                                                          assigned_user: @assigned_user,
+                                                          assigned_by: current_user)
+      assignment_service.assign!
+      assignment_service.send_notifications
       flash.now[:notice] = I18n.t("hub.tax_returns.update.flash_success",
                                   client_name: @tax_return.client.preferred_name,
                                   tax_year: @tax_return.year,

--- a/app/controllers/hub/tax_returns_controller.rb
+++ b/app/controllers/hub/tax_returns_controller.rb
@@ -42,7 +42,10 @@ module Hub
     def show; end
 
     def update
-      @tax_return.assign!(assigned_user: @assigned_user, assigned_by: current_user)
+      TaxReturnAssignmentService.assign!(tax_return: @tax_return,
+                                     assigned_user: @assigned_user,
+                                     assigned_by: current_user,
+                                     create_notifications: true)
       flash.now[:notice] = I18n.t("hub.tax_returns.update.flash_success",
                                   client_name: @tax_return.client.preferred_name,
                                   tax_year: @tax_return.year,

--- a/app/models/tax_return.rb
+++ b/app/models/tax_return.rb
@@ -276,31 +276,6 @@ class TaxReturn < ApplicationRecord
     true
   end
 
-  def assign!(assigned_user: nil, assigned_by: nil)
-    update!(assigned_user: assigned_user)
-    SystemNote::AssignmentChange.generate!(initiated_by: assigned_by, tax_return: self)
-
-    if assigned_user.present? && (assigned_user != assigned_by)
-      UserNotification.create!(
-        user: assigned_user,
-        notifiable: TaxReturnAssignment.create!(
-          assigner: assigned_by,
-          tax_return: self
-        )
-      )
-      UserMailer.assignment_email(
-        assigned_user: assigned_user,
-        assigning_user: assigned_by,
-        assigned_at: updated_at,
-        tax_return: self
-      ).deliver_later
-    end
-
-    if assigned_user.present? && assigned_user.role.try(:vita_partner_id).present? && assigned_user.role.vita_partner_id != client.vita_partner_id
-      client.update!(vita_partner_id: assigned_user.role.vita_partner_id)
-    end
-  end
-
   private
 
   def send_mixpanel_status_change_event

--- a/app/models/tax_return.rb
+++ b/app/models/tax_return.rb
@@ -295,6 +295,10 @@ class TaxReturn < ApplicationRecord
         tax_return: self
       ).deliver_later
     end
+
+    if assigned_user.present? && assigned_user.role.try(:vita_partner_id).present? && assigned_user.role.vita_partner_id != client.vita_partner_id
+      client.update!(vita_partner_id: assigned_user.role.vita_partner_id)
+    end
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -143,9 +143,10 @@ class User < ApplicationRecord
       team_members = User.where(role: TeamMemberRole.where(site: sites))
       organization_leads.or(site_coordinators).or(team_members)
     when SiteCoordinatorRole::TYPE, TeamMemberRole::TYPE
+      organization_leads = User.where(role: OrganizationLeadRole.where(organization: role.site.parent_organization))
       site_coordinators = User.where(role: SiteCoordinatorRole.where(site: role.site))
       team_members = User.where(role: TeamMemberRole.where(site: role.site))
-      site_coordinators.or(team_members)
+      organization_leads.or(site_coordinators).or(team_members)
     else
       User.none
     end

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -1,0 +1,7 @@
+class BaseService
+  def self.ensure_transaction
+    raise StandardError, "Service requiring transaction was called without a transaction open" unless ActiveRecord::Base.connection.open_transactions.positive?
+
+    yield
+  end
+end

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -1,6 +1,8 @@
 class BaseService
   def self.ensure_transaction
-    raise StandardError, "Service requiring transaction was called without a transaction open" unless ActiveRecord::Base.connection.open_transactions.positive?
+    # require 2 open transactions in test, otherwise 1. this is due to the default rspec transaction.
+    required_open_transactions = Rails.env.test? ? ActiveRecord::Base.connection.open_transactions > 1 : ActiveRecord::Base.connection.open_transactions.positive?
+    raise StandardError, "Service requiring transaction was called without a transaction open" unless required_open_transactions
 
     yield
   end

--- a/app/services/tax_return_assignment_service.rb
+++ b/app/services/tax_return_assignment_service.rb
@@ -7,13 +7,15 @@ class TaxReturnAssignmentService
   end
 
   def assign!
-    @tax_return.update!(assigned_user: @assigned_user)
-    if @assigned_user.present? &&
-       [TeamMemberRole::TYPE, SiteCoordinatorRole::TYPE, OrganizationLeadRole::TYPE].include?(@assigned_user.role_type) &&
-       @assigned_user.role.vita_partner_id != @client.vita_partner_id
-      UpdateClientVitaPartnerService.new(client: @client,
-                                         vita_partner_id: @assigned_user.role.vita_partner_id,
-                                         change_initiated_by: @assigned_user).update!
+    ActiveRecord::Base.transaction do
+      @tax_return.update!(assigned_user: @assigned_user)
+      if @assigned_user.present? &&
+         [TeamMemberRole::TYPE, SiteCoordinatorRole::TYPE, OrganizationLeadRole::TYPE].include?(@assigned_user.role_type) &&
+         @assigned_user.role.vita_partner_id != @client.vita_partner_id
+        UpdateClientVitaPartnerService.new(clients: [@client],
+                                           vita_partner_id: @assigned_user.role.vita_partner_id,
+                                           change_initiated_by: @assigned_user).update!
+      end
     end
   end
 

--- a/app/services/tax_return_assignment_service.rb
+++ b/app/services/tax_return_assignment_service.rb
@@ -1,0 +1,43 @@
+class TaxReturnAssignmentService
+  def initialize(tax_return: nil, assigned_user: nil, assigned_by: nil, create_notifications: false)
+    @tax_return = tax_return
+    @client = tax_return.client
+    @assigned_user = assigned_user
+    @assigned_by = assigned_by
+    @create_notifications = create_notifications
+  end
+
+  def assign!
+    @tax_return.update!(assigned_user: @assigned_user)
+    create_notifications if @create_notifications
+    if @assigned_user.present? &&
+      @assigned_user.role.try(:vita_partner_id).present? &&
+      @assigned_user.role.vita_partner_id != @client.vita_partner_id
+      UpdateClientVitaPartnerService.new(client: @client,
+                                         vita_partner_id: @assigned_user.role.vita_partner_id,
+                                         change_initiated_by: @assigned_user).update!
+    end
+  end
+
+  private
+
+  def create_notifications
+    SystemNote::AssignmentChange.generate!(initiated_by: @assigned_by, tax_return: @tax_return)
+
+    if @assigned_user.present? && (@assigned_user != @assigned_by)
+      UserNotification.create!(
+        user: @assigned_user,
+        notifiable: TaxReturnAssignment.create!(
+          assigner: @assigned_by,
+          tax_return: @tax_return
+        )
+      )
+      UserMailer.assignment_email(
+        assigned_user: @assigned_user,
+        assigning_user: @assigned_by,
+        assigned_at: @tax_return.updated_at,
+        tax_return: @tax_return
+      ).deliver_later
+    end
+  end
+end

--- a/app/services/tax_return_assignment_service.rb
+++ b/app/services/tax_return_assignment_service.rb
@@ -1,27 +1,23 @@
 class TaxReturnAssignmentService
-  def initialize(tax_return: nil, assigned_user: nil, assigned_by: nil, create_notifications: false)
+  def initialize(tax_return: nil, assigned_user: nil, assigned_by: nil)
     @tax_return = tax_return
     @client = tax_return.client
     @assigned_user = assigned_user
     @assigned_by = assigned_by
-    @create_notifications = create_notifications
   end
 
   def assign!
     @tax_return.update!(assigned_user: @assigned_user)
-    create_notifications if @create_notifications
     if @assigned_user.present? &&
-      @assigned_user.role.try(:vita_partner_id).present? &&
-      @assigned_user.role.vita_partner_id != @client.vita_partner_id
+       [TeamMemberRole::TYPE, SiteCoordinatorRole::TYPE, OrganizationLeadRole::TYPE].include?(@assigned_user.role_type) &&
+       @assigned_user.role.vita_partner_id != @client.vita_partner_id
       UpdateClientVitaPartnerService.new(client: @client,
                                          vita_partner_id: @assigned_user.role.vita_partner_id,
                                          change_initiated_by: @assigned_user).update!
     end
   end
 
-  private
-
-  def create_notifications
+  def send_notifications
     SystemNote::AssignmentChange.generate!(initiated_by: @assigned_by, tax_return: @tax_return)
 
     if @assigned_user.present? && (@assigned_user != @assigned_by)

--- a/app/services/tax_return_assignment_service.rb
+++ b/app/services/tax_return_assignment_service.rb
@@ -1,5 +1,5 @@
 class TaxReturnAssignmentService
-  def initialize(tax_return: nil, assigned_user: nil, assigned_by: nil)
+  def initialize(tax_return:, assigned_user:, assigned_by: nil)
     @tax_return = tax_return
     @client = tax_return.client
     @assigned_user = assigned_user

--- a/app/services/update_client_vita_partner_service.rb
+++ b/app/services/update_client_vita_partner_service.rb
@@ -1,0 +1,19 @@
+class UpdateClientVitaPartnerService
+  def initialize(client:, vita_partner_id:, change_initiated_by: nil)
+    @client = client
+    @new_vita_partner = VitaPartner.find_by_id(vita_partner_id)
+    @change_initiated_by = change_initiated_by
+  end
+
+  def update!
+    ActiveRecord::Base.transaction do
+      @client.update!(vita_partner: @new_vita_partner, change_initiated_by: @change_initiated_by)
+      # unassign users who have lost access
+      @client.tax_returns.where.not(assigned_user: nil).each do |tax_return|
+        assigned_user_retains_access = tax_return.assigned_user.accessible_vita_partners.include?(@new_vita_partner)
+        tax_return.update!(assigned_user: nil) unless assigned_user_retains_access
+      end
+      SystemNote::OrganizationChange.generate!(client: @client, initiated_by: @change_initiated_by)
+    end
+  end
+end

--- a/app/services/update_client_vita_partner_service.rb
+++ b/app/services/update_client_vita_partner_service.rb
@@ -1,22 +1,24 @@
-class UpdateClientVitaPartnerService
-  def initialize(client:, vita_partner_id:, change_initiated_by: nil)
-    @client = client
+class UpdateClientVitaPartnerService < BaseService
+  def initialize(clients:, vita_partner_id:, change_initiated_by: nil)
+    @clients = clients
     @new_vita_partner = VitaPartner.find_by_id(vita_partner_id)
     @change_initiated_by = change_initiated_by
   end
 
   def update!
-    ActiveRecord::Base.transaction do
-      raise ActiveRecord::Rollback unless @client.update(vita_partner: @new_vita_partner, change_initiated_by: @change_initiated_by)
+    BaseService.ensure_transaction do
+      @clients.each do |client|
+        client.update!(vita_partner: @new_vita_partner, change_initiated_by: @change_initiated_by)
+        SystemNote::OrganizationChange.generate!(client: client, initiated_by: @change_initiated_by)
+      end
 
       # unassign users who have lost access
-      @client.tax_returns.where.not(assigned_user: nil).each do |tax_return|
+      TaxReturn.where(client: @clients).where.not(assigned_user: nil).each do |tax_return|
         assigned_user_retains_access = tax_return.assigned_user.accessible_vita_partners.include?(@new_vita_partner)
         unless assigned_user_retains_access
-          raise ActiveRecord::Rollback unless tax_return.update(assigned_user: nil)
+          tax_return.update!(assigned_user: nil)
         end
       end
-      SystemNote::OrganizationChange.generate!(client: @client, initiated_by: @change_initiated_by)
     end
   end
 end

--- a/app/views/hub/clients/organizations/edit.html.erb
+++ b/app/views/hub/clients/organizations/edit.html.erb
@@ -5,6 +5,8 @@
     <h2>
       Edit Organization for <%= @client.preferred_name %>
     </h2>
+    <p class="text--help text--bold"><%= t(".warning_text_1") %></p>
+    <p class="text--help text--bold spacing-below-25"><%= t(".warning_text_2") %></p>
     <%= form_with model: @client, url: organization_hub_client_path(id: @client.id), local: true, method: :patch, builder: VitaMinFormBuilder do |f|%>
 
       <%= f.cfa_select(:vita_partner_id, t("general.organization"), grouped_vita_partner_options) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,9 +7,6 @@ en:
           attributes:
             ssn:
               blank: To claim family member as a dependent for benefits, an SSN or ATIN is required.
-  clients:
-    errors:
-      tax_return_assigned_user_access: "%{affected_users} would lose access if you assign this client to %{new_partner}. Please change tax return assignments before reassigning this client."
   controllers:
     application_controller:
       maintenance: GetYourRefund.org will be down for scheduled maintenance for about 1 hour starting at %{time}.
@@ -676,6 +673,10 @@ en:
         send_for_prep: Send for prep
         tax_years: Tax years
         title: Add a new client
+      organizations:
+        edit:
+          warning_text_1: 'Note: All returns on this client will be assigned to the new organization.'
+          warning_text_2: Changing the organization may cause assigned hub users to lose access and be unassigned.
       show:
         basic_info: Basic Info
         date_of_birth: Date of birth
@@ -710,10 +711,6 @@ en:
           success: 'Success: Action taken! %{action_list}.'
           text_message: sent text message
       urgent: Urgent
-      organizations:
-        edit:
-          warning_text_1: 'Note: All returns on this client will be assigned to the new organization.'
-          warning_text_2: Changing the organization may cause assigned hub users to lose access and be unassigned.
     ctc_clients:
       edit:
         title: Edit CTC Client Profile

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -710,6 +710,10 @@ en:
           success: 'Success: Action taken! %{action_list}.'
           text_message: sent text message
       urgent: Urgent
+      organizations:
+        edit:
+          warning_text_1: 'Note: All returns on this client will be assigned to the new organization.'
+          warning_text_2: Changing the organization may cause assigned hub users to lose access and be unassigned.
     ctc_clients:
       edit:
         title: Edit CTC Client Profile

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -7,9 +7,6 @@ es:
           attributes:
             ssn:
               blank: Para reclamar a un miembro de la familia como dependiente para los beneficios, se requiere un SSN o ATIN.
-  clients:
-    errors:
-      tax_return_assigned_user_access: "%{affected_users} perdería el acceso si asigna este cliente a %{new_partner}. Cambie las asignaciones de la declaración de impuestos antes de reasignar a este cliente."
   controllers:
     application_controller:
       maintenance: GetYourRefund.org estará inactivo para mantenimiento programado durante aproximadamente 1 hora a partir de %{time}.
@@ -676,6 +673,10 @@ es:
         send_for_prep: Enviar para preparar
         tax_years: Años de impuestos
         title: Agregar un nuevo cliente
+      organizations:
+        edit:
+          warning_text_1: 'Nota: Todas las devoluciones de este cliente se asignarán a la nueva organización.'
+          warning_text_2: Cambiar la organización puede hacer que los usuarios del concentrador asignados pierdan el acceso y se anulen la asignación.
       show:
         basic_info: Información básica
         date_of_birth: Fecha de nacimiento
@@ -710,10 +711,6 @@ es:
           success: 'Éxito: Acción completo! %{action_list}.'
           text_message: envió mensjaje de texto
       urgent: Urgente
-      organizations:
-        edit:
-          warning_text_1: 'Nota: Todas las devoluciones de este cliente se asignarán a la nueva organización.'
-          warning_text_2: Cambiar la organización puede hacer que los usuarios del concentrador asignados pierdan el acceso y se anulen la asignación.
     ctc_clients:
       edit:
         title: Edit CTC Client Profile

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -710,6 +710,10 @@ es:
           success: 'Éxito: Acción completo! %{action_list}.'
           text_message: envió mensjaje de texto
       urgent: Urgente
+      organizations:
+        edit:
+          warning_text_1: 'Nota: Todas las devoluciones de este cliente se asignarán a la nueva organización.'
+          warning_text_2: Cambiar la organización puede hacer que los usuarios del concentrador asignados pierdan el acceso y se anulen la asignación.
     ctc_clients:
       edit:
         title: Edit CTC Client Profile

--- a/spec/controllers/concerns/tax_return_assignable_users_spec.rb
+++ b/spec/controllers/concerns/tax_return_assignable_users_spec.rb
@@ -8,27 +8,29 @@ RSpec.describe TaxReturnAssignableUsers, type: :controller do
 
   describe "#assignable_users" do
     let(:client) { create :client, vita_partner: site }
-    let(:site) { create :site }
-    let(:organization) { create :organization}
+    let(:site) { create :site, parent_organization: organization }
+    let(:second_site) { create :site, parent_organization: organization }
+    let(:organization) { create :organization }
     let!(:tax_return) { create :tax_return, client: client, assigned_user: assigned_user }
 
     let!(:assigned_user) { create :user, role: create(:team_member_role, site: site) }
     let!(:team_member) { create :user, role: create(:team_member_role, site: site) }
+    let!(:another_team_member) { create :user, role: create(:team_member_role, site: second_site) }
     let!(:site_coordinator) { create :user, role: create(:site_coordinator_role, site: site) }
     let!(:org_lead) { create :user, role: create(:organization_lead_role, organization: organization) }
+    let!(:another_org_lead) { create :user, role: create(:organization_lead_role, organization: organization) }
     let!(:inaccessible_user) { create :user }
 
     context "when the tax return is assigned to a site" do
-      it "includes team members and site coordinators" do
-        expect(subject.assignable_users(client, [assigned_user])).to match_array [assigned_user, team_member, site_coordinator]
+      it "includes the assigned user, site's team members, site coordinators, and the org leads" do
+        expect(subject.assignable_users(client, [assigned_user])).to match_array [assigned_user, team_member, site_coordinator, org_lead, another_org_lead]
       end
     end
 
     context "when the tax return is assigned to an org" do
       let!(:client) { create :client, vita_partner: organization }
-
-      it "includes assigned user and org leads" do
-        expect(subject.assignable_users(client, [assigned_user])).to match_array [assigned_user, org_lead]
+      it "includes the assigned user, all sites' team members and coordinators under the org, and the other org leads" do
+        expect(subject.assignable_users(client, [assigned_user])).to match_array [assigned_user, another_team_member, team_member, site_coordinator, org_lead, another_org_lead]
       end
     end
   end

--- a/spec/controllers/hub/clients/organizations_controller_spec.rb
+++ b/spec/controllers/hub/clients/organizations_controller_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Hub::Clients::OrganizationsController, type: :controller do
 
       context "when something goes wrong in the service call" do
         before do
-          allow(instance).to receive(:update!).and_raise(ActiveRecord::Rollback)
+          allow(instance).to receive(:update!).and_raise(ActiveRecord::RecordInvalid)
         end
 
         it "rescues the ActiveRecord::Rollback and returns a 300" do

--- a/spec/controllers/hub/clients/organizations_controller_spec.rb
+++ b/spec/controllers/hub/clients/organizations_controller_spec.rb
@@ -49,13 +49,23 @@ RSpec.describe Hub::Clients::OrganizationsController, type: :controller do
       end
 
       context "when assigning to an vita partner that you don't have access to" do
-        let(:other_org) { create :organization}
+        let(:other_org) { create :organization }
         let(:params) { { id: client.id, client: { vita_partner_id: other_org.id } } }
 
         it "returns a 403" do
           patch :update, params: params
-
           expect(response).to be_forbidden
+        end
+      end
+
+      context "when something goes wrong in the service call" do
+        before do
+          allow(instance).to receive(:update!).and_raise(ActiveRecord::Rollback)
+        end
+
+        it "rescues the ActiveRecord::Rollback and returns a 300" do
+          patch :update, params: params
+          expect(response).to render_template :edit
         end
       end
     end

--- a/spec/controllers/hub/clients/organizations_controller_spec.rb
+++ b/spec/controllers/hub/clients/organizations_controller_spec.rb
@@ -26,42 +26,29 @@ RSpec.describe Hub::Clients::OrganizationsController, type: :controller do
 
   describe "#update" do
     let(:params) { { id: client.id, client: { vita_partner_id: site.id } } }
+    let(:instance) { instance_double(UpdateClientVitaPartnerService) }
+    let(:double_class) { class_double(UpdateClientVitaPartnerService).as_stubbed_const }
+
+    before do
+      allow(double_class).to receive(:new).and_return(instance)
+      allow(instance).to receive(:update!)
+    end
 
     it_behaves_like :a_post_action_for_authenticated_users_only, action: :update
 
     context "as an authenticated organization lead user" do
-      before { sign_in user }
+      before do
+        sign_in user
+      end
 
-      it "can assign to a site in my organiztion" do
-        expect {
-          patch :update, params: params
-          client.reload
-        }.to change(client, :vita_partner).from(client.vita_partner).to(site)
-         .and change(SystemNote::OrganizationChange, :count).by(1)
+      it "calls the UpdateClientVitaPartnerService service and redirects" do
+        patch :update, params: params
 
-        expect(SystemNote.last.user).to eq user
-
+        expect(instance).to have_received(:update!).once
         expect(response).to redirect_to hub_client_path(id: client.id)
       end
 
-      context "when reassigning would remove access for one or more tax return assignees" do
-        let(:tax_return_assignee) { create :team_member_user, site: site }
-        let(:client) { create :client, vita_partner: site }
-        let!(:tax_return) { create :tax_return, client: client, assigned_user: tax_return_assignee }
-        let(:params) { { id: client.id, client: { vita_partner_id: other_site.id } } }
-
-        render_views
-        it "adds a validation error and does not reassign the client" do
-          patch :update, params: params
-
-          expect(response).to be_ok
-          expect(client.reload.vita_partner).to eq site
-          expect(response).to render_template :edit
-          expect(assigns(:client).errors).to include :vita_partner_id
-        end
-      end
-
-      context "when assigning to an vite partner that you don't have access to" do
+      context "when assigning to an vita partner that you don't have access to" do
         let(:other_org) { create :organization}
         let(:params) { { id: client.id, client: { vita_partner_id: other_org.id } } }
 

--- a/spec/controllers/hub/tax_returns_controller_spec.rb
+++ b/spec/controllers/hub/tax_returns_controller_spec.rb
@@ -150,11 +150,11 @@ RSpec.describe Hub::TaxReturnsController, type: :controller do
       context "client is assigned to an org" do
         let(:client_assigned_group) { organization }
 
-        it "returns a list of org leads at the client's assigned organization + the assigned user + myself" do
+        it "returns a list of org leads, site coords, and team members at the client's assigned organization, the assigned user, and myself" do
           get :edit, params: params, format: :js, xhr: true
 
           expect(response).to be_ok
-          expect(assigns(:assignable_users)).to match_array [user, currently_assigned_coalition_lead, organization_lead]
+          expect(assigns(:assignable_users)).to match_array [user, currently_assigned_coalition_lead, organization_lead, site_coordinator, team_member]
         end
       end
 
@@ -286,7 +286,7 @@ RSpec.describe Hub::TaxReturnsController, type: :controller do
       end
 
       context "when trying to assign to an unassignable user" do
-        let(:assigned_user) { site_coordinator }
+        let(:assigned_user) { create(:team_member_user) }
 
         it "is is forbidden" do
           put :update, params: params, format: :js, xhr: true

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -736,54 +736,6 @@ describe Client do
     end
   end
 
-  describe "after_commit for creating vita partner note" do
-    let(:user) { create :user }
-    let(:client) { create :client }
-    let(:new_vita_partner) { create :vita_partner }
-    before do
-      allow(SystemNote::OrganizationChange).to receive(:generate!)
-    end
-
-    context "when updating the vita partner" do
-      it "should create a system note recording the change" do
-        client.update(vita_partner: new_vita_partner, change_initiated_by: user)
-        expect(SystemNote::OrganizationChange).to have_received(:generate!).with({ client: client, initiated_by: user })
-      end
-    end
-
-    context "when updating other attributes" do
-      it "should not create a system note recording the change" do
-        client.update(routing_method: "source_param")
-        expect(SystemNote::OrganizationChange).not_to have_received(:generate!)
-      end
-    end
-  end
-
-  describe "before_update for un-assigning tax return users" do
-    let(:current_site) { create :site }
-    let(:other_site) { create :site, parent_organization: current_site.parent_organization }
-    let(:client) { create :client, vita_partner: current_site, tax_returns: [tax_return] }
-    let(:tax_return) { create :tax_return, year: 2019, assigned_user: assigned_user }
-
-    context "when the assigned user does not have access to the new vita partner" do
-      let(:assigned_user) { create :team_member_user, site: current_site }
-
-      it "removes the assignee from the return" do
-        client.update(vita_partner: other_site)
-        expect(tax_return.reload.assigned_user).to eq(nil)
-      end
-    end
-
-    context "when the assigned user does have access to the new vita partner" do
-      let(:assigned_user) { create :organization_lead_user, organization: current_site.parent_organization }
-
-      it "leaves the assignee on the return" do
-        client.update(vita_partner: other_site)
-        expect(tax_return.reload.assigned_user).to eq(assigned_user)
-      end
-    end
-  end
-
   describe ".locale_counts" do
     context "with all languages present" do
       before do

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -759,7 +759,7 @@ describe Client do
     end
   end
 
-  describe "after_update for un-assigning tax return users" do
+  describe "before_update for un-assigning tax return users" do
     let(:current_site) { create :site }
     let(:other_site) { create :site, parent_organization: current_site.parent_organization }
     let(:client) { create :client, vita_partner: current_site, tax_returns: [tax_return] }

--- a/spec/models/tax_return_spec.rb
+++ b/spec/models/tax_return_spec.rb
@@ -1246,56 +1246,6 @@ describe TaxReturn do
     end
   end
 
-  describe "#assign!" do
-    let(:assigned_user) { create :user }
-    let(:assigned_by) { create :user }
-    let(:tax_return) { create :tax_return, assigned_user: (create :user) }
-
-    before do
-      allow(UserMailer).to receive_message_chain(:assignment_email, :deliver_later)
-    end
-
-    context "when assigned_user_id is nil" do
-      it "updates the assigned user to be nil, creates a note, does not send email" do
-        expect {
-          tax_return.assign!(assigned_user: nil, assigned_by: assigned_by)
-        }.to change(tax_return.reload, :assigned_user_id).to(nil)
-         .and change(SystemNote, :count).by(1)
-
-        expect(UserMailer).not_to have_received(:assignment_email)
-      end
-    end
-
-    context "when assigned_user_id is present" do
-      it "updates the user, creates a system note, and sends an email" do
-        expect {
-          tax_return.assign!(assigned_user: assigned_user, assigned_by: assigned_by)
-        }.to change(tax_return.reload, :assigned_user_id).to(assigned_user.id)
-         .and change(SystemNote, :count).by(1)
-
-        expect(UserMailer).to have_received(:assignment_email).with(
-            assigned_user: assigned_user,
-            assigning_user: assigned_by,
-            tax_return: tax_return,
-            assigned_at: tax_return.updated_at
-        ).once
-      end
-
-      context "when assigned user has a different vita partner than the clients" do
-        let(:tax_return) { create :tax_return, assigned_user: (create :user), client: create(:client, vita_partner: old_site) }
-        let(:assigned_user) { create :user, role: create(:team_member_role, site: new_site) }
-        let(:new_site) { create :site }
-        let(:old_site) { create :site }
-
-        it "updates the vita partner to the assigned users vita partner" do
-          expect {
-            tax_return.assign!(assigned_user: assigned_user, assigned_by: assigned_by)
-          }.to change(tax_return.reload.client, :vita_partner).from(old_site).to(new_site)
-        end
-      end
-    end
-  end
-
   describe "filing_status_code" do
     let(:tax_return) { create :tax_return, filing_status: "single" }
     it "returns the integer corresponding to the enum string value" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -286,8 +286,9 @@ RSpec.describe User, type: :model do
     let(:admin) { create :admin_user }
 
     context "team member user" do
-      it "return only the current user" do
+      it "should return all the site coordinators and team members at the site, and the org leads" do
         expected_results = [
+          organization_lead, sibling_organization_lead,
           site_coordinator, sibling_site_coordinator,
           team_member, sibling_team_member
         ]
@@ -296,8 +297,9 @@ RSpec.describe User, type: :model do
     end
 
     context "site coordinator user" do
-      it "should return all the site coordinators and team members at the site" do
+      it "should return all the site coordinators and team members at the site, and the org leads" do
         expected_results = [
+          organization_lead, sibling_organization_lead,
           site_coordinator, sibling_site_coordinator,
           team_member, sibling_team_member
         ]

--- a/spec/services/base_service_spec.rb
+++ b/spec/services/base_service_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 describe BaseService do
   describe '.ensure_transaction' do
     context "with a caller inside of a transaction" do

--- a/spec/services/base_service_spec.rb
+++ b/spec/services/base_service_spec.rb
@@ -1,0 +1,18 @@
+describe BaseService do
+  describe '.ensure_transaction' do
+    context "with a caller inside of a transaction" do
+      it "doesn't raise an error and yields" do
+        ActiveRecord::Base.transaction do
+          expect { BaseService.ensure_transaction{ |_| } }.not_to raise_error
+          expect { |block| BaseService.ensure_transaction(&block) }.to yield_with_no_args
+        end
+      end
+    end
+
+    context "with a caller outside of a transaction" do
+      it "raises an error" do
+        expect { BaseService.ensure_transaction{ |_| } }.to raise_error(StandardError, "Service requiring transaction was called without a transaction open")
+      end
+    end
+  end
+end

--- a/spec/services/tax_return_assignment_service_spec.rb
+++ b/spec/services/tax_return_assignment_service_spec.rb
@@ -1,13 +1,13 @@
 require "rails_helper"
 
 describe TaxReturnAssignmentService do
+  subject do
+    TaxReturnAssignmentService.new(tax_return: tax_return,
+                                   assigned_user: assigned_user,
+                                   assigned_by: assigned_by)
+  end
+
   describe ".assign" do
-    subject do
-      TaxReturnAssignmentService.new(tax_return: tax_return,
-                                         assigned_user: assigned_user,
-                                         assigned_by: assigned_by,
-                                         create_notifications: create_notifications).assign!
-    end
     let(:tax_return) { create :tax_return, assigned_user: (create :user) }
     let(:assigned_user) { create :user }
     let(:assigned_by) { create :user }
@@ -20,7 +20,7 @@ describe TaxReturnAssignmentService do
     context "when assigned_user_id is nil" do
       let(:assigned_user) { nil }
       it "updates the assigned user to be nil, creates a note, does not send email" do
-        expect { subject }.to change(tax_return.reload, :assigned_user_id).to(nil)
+        expect { subject.assign! }.to change(tax_return.reload, :assigned_user_id).to(nil)
                                                                           .and change(SystemNote, :count).by(1)
         expect(UserMailer).not_to have_received(:assignment_email)
       end
@@ -28,7 +28,7 @@ describe TaxReturnAssignmentService do
 
     context "when assigned_user_id is present" do
       it "updates the user, creates a system note, and sends an email" do
-        expect { subject }.to change(tax_return.reload, :assigned_user_id).to(assigned_user.id)
+        expect { subject.assign! }.to change(tax_return.reload, :assigned_user_id).to(assigned_user.id)
                                                                           .and change(SystemNote, :count).by(1)
         expect(UserMailer).to have_received(:assignment_email).with(
           assigned_user: assigned_user,

--- a/spec/services/tax_return_assignment_service_spec.rb
+++ b/spec/services/tax_return_assignment_service_spec.rb
@@ -40,7 +40,7 @@ describe TaxReturnAssignmentService do
         end
 
         it "calls the UpdateClientVitaPartnerService" do
-          subject.assign!
+          expect{ subject.assign! }.not_to raise_error
           expect(instance).to have_received(:update!).once
         end
       end

--- a/spec/services/tax_return_assignment_service_spec.rb
+++ b/spec/services/tax_return_assignment_service_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+describe TaxReturnAssignmentService do
+  describe ".assign" do
+    subject do
+      TaxReturnAssignmentService.new(tax_return: tax_return,
+                                         assigned_user: assigned_user,
+                                         assigned_by: assigned_by,
+                                         create_notifications: create_notifications).assign!
+    end
+    let(:tax_return) { create :tax_return, assigned_user: (create :user) }
+    let(:assigned_user) { create :user }
+    let(:assigned_by) { create :user }
+    let(:create_notifications) { true }
+
+    before do
+      allow(UserMailer).to receive_message_chain(:assignment_email, :deliver_later)
+    end
+
+    context "when assigned_user_id is nil" do
+      let(:assigned_user) { nil }
+      it "updates the assigned user to be nil, creates a note, does not send email" do
+        expect { subject }.to change(tax_return.reload, :assigned_user_id).to(nil)
+                                                                          .and change(SystemNote, :count).by(1)
+        expect(UserMailer).not_to have_received(:assignment_email)
+      end
+    end
+
+    context "when assigned_user_id is present" do
+      it "updates the user, creates a system note, and sends an email" do
+        expect { subject }.to change(tax_return.reload, :assigned_user_id).to(assigned_user.id)
+                                                                          .and change(SystemNote, :count).by(1)
+        expect(UserMailer).to have_received(:assignment_email).with(
+          assigned_user: assigned_user,
+          assigning_user: assigned_by,
+          tax_return: tax_return,
+          assigned_at: tax_return.updated_at
+        ).once
+      end
+
+      context "when assigned user has a different vita partner than the clients" do
+        let(:tax_return) { create :tax_return, assigned_user: (create :user), client: create(:client, vita_partner: old_site) }
+        let(:assigned_user) { create :user, role: create(:team_member_role, site: new_site) }
+        let(:new_site) { create :site }
+        let(:old_site) { create :site }
+
+        let(:instance) { instance_double(UpdateClientVitaPartnerService) }
+        let(:double_class) { class_double(UpdateClientVitaPartnerService).as_stubbed_const }
+
+        before do
+          allow(double_class).to receive(:new).and_return(instance)
+          allow(instance).to receive(:update!)
+        end
+
+        it "calls the UpdateClientVitaPartnerService" do
+          subject
+          expect(instance).to have_received(:update!).once
+        end
+      end
+    end
+  end
+end

--- a/spec/services/update_client_vita_partner_service_spec.rb
+++ b/spec/services/update_client_vita_partner_service_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe UpdateClientVitaPartnerService do
   describe ".update" do
-    subject { UpdateClientVitaPartnerService.new(client: client, vita_partner_id: other_site.id, change_initiated_by: assigned_user).update! }
+    subject { UpdateClientVitaPartnerService.new(client: client, vita_partner_id: other_site.id, change_initiated_by: assigned_user) }
 
     let(:current_site) { create :site }
     let(:other_site) { create :site, parent_organization: current_site.parent_organization }
@@ -11,19 +11,31 @@ describe UpdateClientVitaPartnerService do
     let(:assigned_user) { create :team_member_user, site: current_site }
 
     context "when an assigned user does not have access to the new vita partner" do
-
       it "changes the vita partner" do
-        expect { subject }.to change(client, :vita_partner).from(current_site).to(other_site)
+        expect { subject.update! }.to change(client, :vita_partner).from(current_site).to(other_site)
       end
 
       it "leaves a note" do
-        expect { subject }.to change(SystemNote::OrganizationChange, :count).by(1)
+        expect { subject.update! }.to change(SystemNote::OrganizationChange, :count).by(1)
         expect(SystemNote.last.user).to eq assigned_user
       end
 
       it "removes the assignee from the tax return" do
-        subject
+        subject.update!
         expect(tax_return.reload.assigned_user).to eq(nil)
+      end
+
+      context "and something goes terribly wrong in un-assignment" do
+        before do
+          allow_any_instance_of(TaxReturn).to receive(:update).and_return false
+        end
+
+        it "rolls back the transaction, saving nothing" do
+          subject.update!
+          expect(client.reload.vita_partner).to eq(current_site)
+          expect(tax_return.reload.assigned_user).to eq(assigned_user)
+          expect(SystemNote::OrganizationChange.count).to eq(0)
+        end
       end
     end
 
@@ -31,11 +43,11 @@ describe UpdateClientVitaPartnerService do
       let(:assigned_user) { create :organization_lead_user, organization: current_site.parent_organization }
 
       it "changes the vita partner" do
-        expect { subject }.to change(client, :vita_partner).from(current_site).to(other_site)
+        expect { subject.update! }.to change(client, :vita_partner).from(current_site).to(other_site)
       end
 
       it "leaves the assignee on the return" do
-        subject
+        subject.update!
         expect(tax_return.reload.assigned_user).to eq(assigned_user)
       end
     end

--- a/spec/services/update_client_vita_partner_service_spec.rb
+++ b/spec/services/update_client_vita_partner_service_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+describe UpdateClientVitaPartnerService do
+  describe ".update" do
+    subject { UpdateClientVitaPartnerService.new(client: client, vita_partner_id: other_site.id, change_initiated_by: assigned_user).update! }
+
+    let(:current_site) { create :site }
+    let(:other_site) { create :site, parent_organization: current_site.parent_organization }
+    let(:client) { create :client, vita_partner: current_site, tax_returns: [tax_return] }
+    let(:tax_return) { create :tax_return, year: 2019, assigned_user: assigned_user }
+    let(:assigned_user) { create :team_member_user, site: current_site }
+
+    context "when an assigned user does not have access to the new vita partner" do
+
+      it "changes the vita partner" do
+        expect { subject }.to change(client, :vita_partner).from(current_site).to(other_site)
+      end
+
+      it "leaves a note" do
+        expect { subject }.to change(SystemNote::OrganizationChange, :count).by(1)
+        expect(SystemNote.last.user).to eq assigned_user
+      end
+
+      it "removes the assignee from the tax return" do
+        subject
+        expect(tax_return.reload.assigned_user).to eq(nil)
+      end
+    end
+
+    context "when the assigned user does have access to the new vita partner" do
+      let(:assigned_user) { create :organization_lead_user, organization: current_site.parent_organization }
+
+      it "changes the vita partner" do
+        expect { subject }.to change(client, :vita_partner).from(current_site).to(other_site)
+      end
+
+      it "leaves the assignee on the return" do
+        subject
+        expect(tax_return.reload.assigned_user).to eq(assigned_user)
+      end
+    end
+  end
+end

--- a/spec/services/update_client_vita_partner_service_spec.rb
+++ b/spec/services/update_client_vita_partner_service_spec.rb
@@ -2,6 +2,10 @@ require "rails_helper"
 
 describe UpdateClientVitaPartnerService do
   describe ".update" do
+    before do
+      allow(BaseService).to receive(:ensure_transaction).and_yield
+    end
+
     subject { UpdateClientVitaPartnerService.new(clients: [client], vita_partner_id: other_site.id, change_initiated_by: assigned_user) }
 
     let(:current_site) { create :site }


### PR DESCRIPTION
The main problem we want to solve is org leads need a faster way to assign the client's tax returns to a site team member. 

**The current process** 
Change the client's vita partner to the site, now the assignable users show the site members, change assigned users on the tax returns to site members.

Site members need a way to pass clients back to org leads. Currently, there is no way to do this. The site member needs to un-assign the client and then change the clients org.

**The new process**
A client's vita partner is the org lead's org. The org lead sees all site members under this org in the list of assignable users. The org lead changes one of the tax returns to be assigned to a site member, the client's vita partner is updated to that site. Now the list of assignable users on the tax returns ONLY list site members for that site, and org leads for the parent org.

A site member wants to reassign it to the parent org/org lead. They select the org lead from the assignable user drop down, the client's vita partner is updated to the org. 

Anytime a client's vita partner changes, everyone else is unassigned from the tax returns if they lose access. This prevents weird divergent site member assignments from occurring. Yay.

