### PR TITLE
Add support for Puerto Rico phone numbers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'image_processing'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.5.1', require: false
 gem 'phonelib'
+gem 'phony'
 gem 'pg'
 gem 'pg_search'
 gem 'activerecord-postgis-adapter'

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,6 @@ gem 'image_processing'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.5.1', require: false
-gem 'phonelib'
 gem 'phony'
 gem 'pg'
 gem 'pg_search'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -329,6 +329,7 @@ GEM
       activerecord (>= 5.2)
       activesupport (>= 5.2)
     phonelib (0.6.45)
+    phony (2.19.5)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -615,6 +616,7 @@ DEPENDENCIES
   pg
   pg_search
   phonelib
+  phony
   pry-byebug
   puma (>= 5.3.2)
   rack (>= 2.0.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,7 +328,6 @@ GEM
     pg_search (2.3.5)
       activerecord (>= 5.2)
       activesupport (>= 5.2)
-    phonelib (0.6.45)
     phony (2.19.5)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -615,7 +614,6 @@ DEPENDENCIES
   percy-capybara
   pg
   pg_search
-  phonelib
   phony
   pry-byebug
   puma (>= 5.3.2)

--- a/app/forms/portal/verification_code_form.rb
+++ b/app/forms/portal/verification_code_form.rb
@@ -7,7 +7,7 @@ module Portal
     def formatted_contact_info
       return contact_info if contact_info.include?("@")
 
-      local_phone_number(contact_info)
+      PhoneParser.formatted_phone_number(contact_info)
     end
   end
 end

--- a/app/helpers/phone_number_helper.rb
+++ b/app/helpers/phone_number_helper.rb
@@ -2,6 +2,5 @@ module PhoneNumberHelper
   def local_phone_number(phone_number)
     phony_normalized = Phony.normalize(phone_number, cc: '1')
     Phony.format(phony_normalized, format: :national)
-    # Phony.parse(phone_number, "US").local_number
   end
 end

--- a/app/helpers/phone_number_helper.rb
+++ b/app/helpers/phone_number_helper.rb
@@ -1,5 +1,7 @@
 module PhoneNumberHelper
   def local_phone_number(phone_number)
-    Phonelib.parse(phone_number, "US").local_number
+    phony_normalized = Phony.normalize(phone_number, cc: '1')
+    Phony.format(phony_normalized, format: :national)
+    # Phony.parse(phone_number, "US").local_number
   end
 end

--- a/app/helpers/phone_number_helper.rb
+++ b/app/helpers/phone_number_helper.rb
@@ -1,6 +1,3 @@
 module PhoneNumberHelper
-  def local_phone_number(phone_number)
-    phony_normalized = Phony.normalize(phone_number, cc: '1')
-    Phony.format(phony_normalized, format: :national)
-  end
+  delegate :formatted_phone_number, to: PhoneParser
 end

--- a/app/lib/phone_parser.rb
+++ b/app/lib/phone_parser.rb
@@ -1,5 +1,0 @@
-class PhoneParser
-  def self.normalize(raw_phone_number)
-    Phonelib.parse(raw_phone_number, "US").to_s
-  end
-end

--- a/app/lib/submission_builder/formatting_methods.rb
+++ b/app/lib/submission_builder/formatting_methods.rb
@@ -93,7 +93,8 @@ module SubmissionBuilder
     # phone number without country code or formatting
     # results in 10 digit number for transmitting to the IRS
     def phone_type(string)
-      Phonelib.parse(string, "US").national(false)
+      phony_normalized = Phony.normalize(string, cc: '1')
+      Phony.format(phony_normalized, format: :national, parentheses: false, spaces: '', local_spaces: '').to_s
     end
 
     # Timezones like '-60' need to be padded to '-060' to validate schema

--- a/app/models/incoming_text_message.rb
+++ b/app/models/incoming_text_message.rb
@@ -39,7 +39,7 @@ class IncomingTextMessage < ApplicationRecord
   end
 
   def from
-    Phonelib.parse(from_phone_number, "US").local_number
+    PhoneParser.local_phone_number(from_phone_number)
   end
 
   private

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -328,11 +328,11 @@ class Intake < ApplicationRecord
 
   # Returns the phone number formatted for user display, e.g.: "(510) 555-1234"
   def formatted_phone_number
-    Phonelib.parse(phone_number).local_number
+    PhoneParser.formatted_phone_number(phone_number)
   end
 
   def formatted_sms_phone_number
-    Phonelib.parse(sms_phone_number).local_number
+    PhoneParser.formatted_phone_number(sms_phone_number)
   end
 
   # Returns the sms phone number in the E164 standardized format, e.g.: "+15105551234"

--- a/app/models/outbound_call.rb
+++ b/app/models/outbound_call.rb
@@ -40,6 +40,6 @@ class OutboundCall < ApplicationRecord
   end
 
   def to
-    Phonelib.parse(to_phone_number, "US").local_number
+    PhoneParser.formatted_phone_number(to_phone_number)
   end
 end

--- a/app/models/outgoing_text_message.rb
+++ b/app/models/outgoing_text_message.rb
@@ -58,7 +58,7 @@ class OutgoingTextMessage < ApplicationRecord
   end
 
   def to
-    Phonelib.parse(to_phone_number, "US").local_number
+    PhoneParser.formatted_phone_number(to_phone_number)
   end
 
   private

--- a/app/models/vita_provider.rb
+++ b/app/models/vita_provider.rb
@@ -87,11 +87,11 @@ class VitaProvider < ApplicationRecord
   end
 
   def formatted_phone_number
-    phone_data.local_number
+    PhoneParser.formatted_phone_number(phone_number)
   end
 
   def sanitized_phone_number
-    phone_data.sanitized
+    PhoneParser.with_country_code(phone_number)
   end
 
   def google_maps_url
@@ -132,10 +132,6 @@ class VitaProvider < ApplicationRecord
   end
 
   private
-
-  def phone_data
-    Phonelib.parse(phone_number, "US")
-  end
 
   def get_phone_number(lines)
     lines.length > 0 && lines[-1].match?(/(\d{3}-\d{3}-\d{4})/) ? lines.pop : nil

--- a/app/services/phone_parser.rb
+++ b/app/services/phone_parser.rb
@@ -10,4 +10,28 @@ class PhoneParser
       raw_phone_number
     end
   end
+
+  def self.formatted_phone_number(raw_phone_number)
+    return nil if raw_phone_number.nil?
+    return "" if raw_phone_number == ""
+
+    phony_normalized = Phony.normalize(raw_phone_number, cc: '1')
+    if Phony.plausible?(phony_normalized)
+      Phony.format(phony_normalized, format: :national)
+    else
+      raw_phone_number
+    end
+  end
+
+  def self.with_country_code(raw_phone_number)
+    return nil if raw_phone_number.nil?
+    return "" if raw_phone_number == ""
+
+    phony_normalized = Phony.normalize(raw_phone_number, cc: '1')
+    if Phony.plausible?(phony_normalized)
+      phony_normalized
+    else
+      raw_phone_number
+    end
+  end
 end

--- a/app/services/phone_parser.rb
+++ b/app/services/phone_parser.rb
@@ -34,4 +34,9 @@ class PhoneParser
       raw_phone_number
     end
   end
+
+  def self.valid?(raw_phone_number)
+    phony_normalized = Phony.normalize(raw_phone_number, cc: '1')
+    Phony.plausible?(phony_normalized)
+  end
 end

--- a/app/services/phone_parser.rb
+++ b/app/services/phone_parser.rb
@@ -1,0 +1,6 @@
+class PhoneParser
+  def self.normalize(raw_phone_number)
+    phony_normalized = Phony.normalize(raw_phone_number, cc: '1')
+    Phony.format(phony_normalized, format: :international, parentheses: false, spaces: '', local_spaces: '').to_s
+  end
+end

--- a/app/services/phone_parser.rb
+++ b/app/services/phone_parser.rb
@@ -1,6 +1,13 @@
 class PhoneParser
   def self.normalize(raw_phone_number)
+    return nil if raw_phone_number.nil?
+    return "" if raw_phone_number == ""
+
     phony_normalized = Phony.normalize(raw_phone_number, cc: '1')
-    Phony.format(phony_normalized, format: :international, parentheses: false, spaces: '', local_spaces: '').to_s
+    if Phony.plausible?(phony_normalized)
+      Phony.format(phony_normalized, format: :international, parentheses: false, spaces: '', local_spaces: '').to_s
+    else
+      raw_phone_number
+    end
   end
 end

--- a/app/validators/e164_phone_validator.rb
+++ b/app/validators/e164_phone_validator.rb
@@ -1,6 +1,8 @@
 class E164PhoneValidator < ActiveModel::EachValidator
+  # The E.164 validator assumes the data has normalized into a +1NNNNNNNNNN format, aka E.164.
+  # This may occur in a form, or in a before_validation hook, etc.
   def validate_each(record, attr_name, value)
-    return if value =~ /\A\+1\d{10}\z/ && Phonelib.valid?(value)
+    return if value =~ /\A\+1\d{10}\z/ && Phony.plausible?(value)
 
     record.errors[attr_name] << I18n.t("errors.attributes.phone_number.invalid")
   end

--- a/app/views/ctc/questions/phone_verification/edit.html.erb
+++ b/app/views/ctc/questions/phone_verification/edit.html.erb
@@ -6,7 +6,7 @@
   <%= form_with model: @form, url: current_path, local: true, method: "put", builder: VitaMinFormBuilder, html: { class: "form-card form-card--long" } do |f| %>
     <h1 class="h2"><%= @main_question %></h1>
     <p>
-      <%= t("views.ctc.questions.verification.body") %> <strong><%= Phonelib.parse(current_intake.sms_phone_number).local_number %></strong>
+      <%= t("views.ctc.questions.verification.body") %> <strong><%= PhoneParser.formatted_phone_number(current_intake.sms_phone_number) %></strong>
     </p>
 
     <div class="form-card__content">

--- a/app/views/hub/outbound_calls/new.html.erb
+++ b/app/views/hub/outbound_calls/new.html.erb
@@ -6,7 +6,7 @@
       <h1 class="form-card__title">
         <%= @title %>
       </h1>
-      <p><%= t(".notice_html", receiving_number: local_phone_number(@form.twilio_phone_number))  %></p>
+      <p><%= t(".notice_html", receiving_number: formatted_phone_number(@form.twilio_phone_number))  %></p>
       <ul class="with-bullets">
         <% t(".notice_list").each do |item| %>
           <li><%= item %></li>

--- a/app/views/hub/outbound_calls/show.html.erb
+++ b/app/views/hub/outbound_calls/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :card do %>
   <div class="slab slab--padded">
-    <p><%= t(".body_html", to_phone_number: local_phone_number(@outbound_call.to_phone_number), from_phone_number: local_phone_number(@outbound_call.from_phone_number)) %></p>
+    <p><%= t(".body_html", to_phone_number: formatted_phone_number(@outbound_call.to_phone_number), from_phone_number: formatted_phone_number(@outbound_call.from_phone_number)) %></p>
     <p><%= link_to t(".back"), hub_client_path(id: @client.id) %></p>
     <div class="spacing-below-25">
       <div class="spacing-below-10 text--bold"><%= t("general.client_info") %></div>

--- a/spec/forms/hub/create_client_form_spec.rb
+++ b/spec/forms/hub/create_client_form_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Hub::CreateClientForm do
         widowed_year: "",
         email_address: "someone@example.com",
         phone_number: "5005550006",
-        sms_phone_number: "500-555-(0006)",
+        sms_phone_number: "500-555-0006",
         street_address: "972 Mission St.",
         city: "San Francisco",
         state: "CA",

--- a/spec/forms/hub/create_ctc_client_form_spec.rb
+++ b/spec/forms/hub/create_ctc_client_form_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Hub::CreateCtcClientForm do
         preferred_interview_language: preferred_interview_language,
         email_address: "someone@example.com",
         phone_number: "5005550006",
-        sms_phone_number: "500-555-(0006)",
+        sms_phone_number: "500-555-0006",
         primary_birth_date_year: "1963",
         primary_birth_date_month: "9",
         primary_birth_date_day: "10",
@@ -427,7 +427,7 @@ RSpec.describe Hub::CreateCtcClientForm do
           expect(obj.errors[:taxpayer_id_type]).to include "Please select at least one taxpayer ID type"
         end
       end
-      
+
       context "refund payment method" do
         before do
           params[:refund_payment_method] = nil

--- a/spec/forms/phone_number_form_spec.rb
+++ b/spec/forms/phone_number_form_spec.rb
@@ -36,6 +36,22 @@ RSpec.describe PhoneNumberForm do
           expect(form.attributes_for(:intake)[:phone_number]).to eq "+14155537865"
         end
       end
+
+      context "when phone number is a valid Puerto Rico number without country code" do
+        it "is valid and prepends a country code" do
+          form = PhoneNumberForm.new(
+            intake,
+            {
+              phone_number: "787.764.0000",
+              phone_number_confirmation: "787.764.0000",
+              phone_number_can_receive_texts: "no",
+            }
+          )
+
+          expect(form).to be_valid
+          expect(form.attributes_for(:intake)[:phone_number]).to eq "+17877640000"
+        end
+      end
     end
 
     context "when phone number is not valid" do

--- a/spec/helpers/phone_number_helper_spec.rb
+++ b/spec/helpers/phone_number_helper_spec.rb
@@ -1,10 +1,14 @@
 require "rails_helper"
 
 RSpec.describe PhoneNumberHelper do
-  describe "#local_phone_number" do
+  describe "#formatted_phone_number" do
+    before do
+      allow(PhoneParser).to receive(:formatted_phone_number).and_return("(415) 816-1286")
+    end
+
     it "returns a locally formatted phone number" do
-      expect(helper.local_phone_number("4158161286")).to eq "(415) 816-1286"
-      expect(helper.local_phone_number("14158161286")).to eq "(415) 816-1286"
+      expect(helper.formatted_phone_number("4158161286")).to eq "(415) 816-1286"
+      expect(PhoneParser).to have_received(:formatted_phone_number).with("4158161286")
     end
   end
 end

--- a/spec/lib/intake_pdf_spec.rb
+++ b/spec/lib/intake_pdf_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe IntakePdf do
       it "returns a pdf with default fields and values" do
         output_file = intake_pdf.output_file
         result = non_preparer_fields(output_file.path)
-        expect(result).to match(hash_including({
+        expect(result).to include(
           "first_name" => "",
           "middle_initial" => "",
           "last_name" => "",
@@ -152,7 +152,7 @@ RSpec.describe IntakePdf do
           "made_estimated_tax_payments" => "unfilled",
           "received_stimulus_payment" => "unfilled",
           "additional_comments" => ""
-        }))
+        )
       end
     end
 
@@ -326,7 +326,7 @@ RSpec.describe IntakePdf do
       it "returns a filled out pdf" do
         output_file = intake_pdf.output_file
         result = non_preparer_fields(output_file.path)
-        expect(result).to match(hash_including({
+        expect(result).to include(
            "first_name" => "Hoofie",
            "middle_initial" => "",
            "last_name" => "Heifer",
@@ -466,7 +466,7 @@ RSpec.describe IntakePdf do
            "made_estimated_tax_payments" => "unsure",
            "received_stimulus_payment" => "yes",
            "additional_comments" => "if there is another gnome living in my garden but only i have an income, does that make me head of household? Also here are some additional notes.",
-        }))
+        )
       end
     end
   end

--- a/spec/lib/submission_builder/formatting_methods_spec.rb
+++ b/spec/lib/submission_builder/formatting_methods_spec.rb
@@ -124,4 +124,18 @@ describe SubmissionBuilder::FormattingMethods do
       end
     end
   end
+
+  describe "#phone_type" do
+    context "with a California phone number" do
+      it "returns a 10-digit version without country code or formatting" do
+        expect(dummy_class.phone_type("+14158161286")).to eq("4158161286")
+      end
+    end
+
+    context "with a Puerto Rico phone number" do
+      it "returns a 10-digit version without country code or formatting" do
+        expect(dummy_class.phone_type("+17877640000")).to eq("7877640000")
+      end
+    end
+  end
 end

--- a/spec/models/outgoing_text_message_spec.rb
+++ b/spec/models/outgoing_text_message_spec.rb
@@ -145,9 +145,14 @@ RSpec.describe OutgoingTextMessage, type: :model do
   describe "#to" do
     let(:outgoing_text_message) { build :outgoing_text_message, to_phone_number: input_number }
     let(:input_number) { "+15005550006" }
+    let(:output) { "(500) 555-0006" }
+    before do
+      allow(PhoneParser).to receive(:formatted_phone_number).with(input_number).and_return(output)
+    end
 
     it "formats the provided phone number" do
-      expect(outgoing_text_message.to).to eq "(500) 555-0006"
+      expect(outgoing_text_message.to).to eq output
+      expect(PhoneParser).to have_received(:formatted_phone_number).with(input_number)
     end
   end
 

--- a/spec/services/phone_parser_spec.rb
+++ b/spec/services/phone_parser_spec.rb
@@ -42,4 +42,18 @@ describe PhoneParser do
       end
     end
   end
+
+  describe ".formatted_phone_number" do
+    it "returns a locally formatted phone number" do
+      expect(described_class.formatted_phone_number("4158161286")).to eq "(415) 816-1286"
+      expect(described_class.formatted_phone_number("14158161286")).to eq "(415) 816-1286"
+    end
+  end
+
+  describe ".with_country_code" do
+    it "returns a concise phone number with country code" do
+      expect(described_class.with_country_code("4158161286")).to eq "14158161286"
+      expect(described_class.with_country_code("14158161286")).to eq "14158161286"
+    end
+  end
 end

--- a/spec/services/phone_parser_spec.rb
+++ b/spec/services/phone_parser_spec.rb
@@ -56,46 +56,4 @@ describe PhoneParser do
       expect(described_class.with_country_code("14158161286")).to eq "14158161286"
     end
   end
-
-  describe ".valid?" do
-    context "with a valid e164 Twilio US format phone number" do
-      let(:value) { "+15005550006" }
-
-      it "does not add an error" do
-        expect(described_class.valid?(value)).to eq(true)
-      end
-    end
-
-    context "with an e164 number lacking a plus sign" do
-      let(:value) { "15005550006" }
-
-      it "adds an error" do
-        expect(described_class.valid?(value)).to eq(false)
-      end
-    end
-
-    context "with a valid non-e164 format phone number" do
-      let(:value) { "(500) 555-0006" }
-
-      it "adds an error" do
-        expect(described_class.valid?(value)).to eq(false)
-      end
-    end
-
-    context "with a clearly invalid phone number" do
-      let(:value) { "653423" }
-
-      it "adds an error" do
-        expect(record.errors[:phone_number]).to eq(["Please enter a valid phone number."])
-      end
-    end
-
-    context "with a blank value" do
-      let(:value) { " " }
-
-      it "adds an error" do
-        expect(record.errors[:phone_number]).to eq(["Please enter a valid phone number."])
-      end
-    end
-  end
 end

--- a/spec/services/phone_parser_spec.rb
+++ b/spec/services/phone_parser_spec.rb
@@ -23,5 +23,23 @@ describe PhoneParser do
         end
       end
     end
+
+    context "with nil" do
+      it "returns nil" do
+        expect(described_class.normalize(nil)).to eq(nil)
+      end
+    end
+
+    context "with empty string" do
+      it "returns empty string" do
+        expect(described_class.normalize("")).to eq("")
+      end
+    end
+
+    context "with an invalid, too-short number" do
+      it "returns it as-is" do
+        expect(described_class.normalize("415")).to eq("415")
+      end
+    end
   end
 end

--- a/spec/services/phone_parser_spec.rb
+++ b/spec/services/phone_parser_spec.rb
@@ -56,4 +56,46 @@ describe PhoneParser do
       expect(described_class.with_country_code("14158161286")).to eq "14158161286"
     end
   end
+
+  describe ".valid?" do
+    context "with a valid e164 Twilio US format phone number" do
+      let(:value) { "+15005550006" }
+
+      it "does not add an error" do
+        expect(described_class.valid?(value)).to eq(true)
+      end
+    end
+
+    context "with an e164 number lacking a plus sign" do
+      let(:value) { "15005550006" }
+
+      it "adds an error" do
+        expect(described_class.valid?(value)).to eq(false)
+      end
+    end
+
+    context "with a valid non-e164 format phone number" do
+      let(:value) { "(500) 555-0006" }
+
+      it "adds an error" do
+        expect(described_class.valid?(value)).to eq(false)
+      end
+    end
+
+    context "with a clearly invalid phone number" do
+      let(:value) { "653423" }
+
+      it "adds an error" do
+        expect(record.errors[:phone_number]).to eq(["Please enter a valid phone number."])
+      end
+    end
+
+    context "with a blank value" do
+      let(:value) { " " }
+
+      it "adds an error" do
+        expect(record.errors[:phone_number]).to eq(["Please enter a valid phone number."])
+      end
+    end
+  end
 end

--- a/spec/services/phone_parser_spec.rb
+++ b/spec/services/phone_parser_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe PhoneParser do
+  describe ".normalize" do
+    context "with a US number from California" do
+      context "with a +1" do
+        it "returns the normalized number" do
+          expect(described_class.normalize("+1 (415) 816-1286")).to eq("+14158161286")
+        end
+      end
+
+      context "without a +1" do
+        it "returns the normalized number" do
+          expect(described_class.normalize("(415) 816-1286")).to eq("+14158161286")
+        end
+      end
+    end
+
+    context "with a US number from Puerto Rico" do
+      context "without a +1" do
+        it "returns the normalized number" do
+          expect(described_class.normalize("787-764-0000")).to eq("+17877640000")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Switch to`Phony` library not `Phonelib` b/c apparently `Phonelib` is bad at Puerto Rico
- Should we probably delay this change until it's a lower-risk time like Nov 21?
- Can we run the new test that's Puerto Rico specific _without_ the `Phony` changes and see if they pass, to 100% validate that the `Phony` transition is needed?