### PR TITLE
Transition tax return statuses when previous status was not ready

### DIFF
--- a/app/controllers/mailgun_webhooks_controller.rb
+++ b/app/controllers/mailgun_webhooks_controller.rb
@@ -82,6 +82,8 @@ class MailgunWebhooksController < ActionController::Base
         )
       end
 
+      TransitionNotFilingService.run(client)
+
       if contact_record&.body&.blank? && contact_record&.attachment_count&.zero? && client.forward_message_to_intercom?
         Sentry.capture_message("IncomingEmail #{contact_record.id} does not have a body or any attachments.")
       elsif client.forward_message_to_intercom?

--- a/app/controllers/portal/messages_controller.rb
+++ b/app/controllers/portal/messages_controller.rb
@@ -10,6 +10,7 @@ module Portal
       if @message.save
         flash_message = "#{I18n.t("portal.messages.create.message_sent")} #{helpers.client_contact_preference(current_client, no_tags: true)}"
         flash[:notice] = flash_message
+        TransitionNotFilingService.run(current_client)
         IntercomService.create_intercom_message_from_portal_message(@message, inform_of_handoff: true) if current_client.forward_message_to_intercom?
         redirect_to portal_root_path
       else

--- a/app/models/tax_return.rb
+++ b/app/models/tax_return.rb
@@ -66,11 +66,11 @@ class TaxReturn < ApplicationRecord
     @state_machine ||= TaxReturnStateMachine.new(self, transition_class: TaxReturnTransition)
   end
 
-  delegate :can_transition_to?, :history, :last_transition, :last_transition_to,
+  delegate :can_transition_to?, :history, :last_transition, :current_state, :last_transition_to,
            :transition_to!, :transition_to, :in_state?, :advance_to, :previous_transition, :previous_state, :last_changed_by, to: :state_machine
 
   def current_state
-    state_machine.last_transition&.to_state || status
+    state_machine.current_state || status
   end
 
   before_save do

--- a/app/services/incoming_text_message_service.rb
+++ b/app/services/incoming_text_message_service.rb
@@ -51,6 +51,8 @@ class IncomingTextMessageService
         documents: documents
       )
 
+      TransitionNotFilingService.run(client)
+
       IntercomService.create_intercom_message_from_sms(contact_record, inform_of_handoff: true) if client.forward_message_to_intercom?
 
       ClientChannel.broadcast_contact_record(contact_record)

--- a/app/services/transition_not_filing_service.rb
+++ b/app/services/transition_not_filing_service.rb
@@ -1,0 +1,17 @@
+# transition not_filing intakes back to intake in progress if that was their previous status.
+class TransitionNotFilingService
+  def self.run(client)
+    transitionable_statuses = ["intake_in_progress"]
+    if client.tax_returns.present?
+      client.tax_returns.each do |tr|
+        next unless tr.current_state == "file_not_filing"
+
+        transitionable_statuses.each do |status|
+          if tr.previous_transition.present? && tr.previous_transition.to_state == status
+            tr.transition_to!(status)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/mailgun_webhooks_controller_spec.rb
+++ b/spec/controllers/mailgun_webhooks_controller_spec.rb
@@ -115,6 +115,7 @@ RSpec.describe MailgunWebhooksController do
       context "with a matching client" do
         before do
           allow(ClientChannel).to receive(:broadcast_contact_record)
+          allow(TransitionNotFilingService).to receive(:run)
         end
 
         let(:tax_returns) { [(create :tax_return, status: "prep_preparing", year: 2020)] }
@@ -127,6 +128,11 @@ RSpec.describe MailgunWebhooksController do
         it "sends a real-time update to anyone on this client's page", active_job: true do
           post :create_incoming_email, params: params
           expect(ClientChannel).to have_received(:broadcast_contact_record).with(IncomingEmail.last)
+        end
+
+        it "calls the TransitionNotFilingService" do
+          post :create_incoming_email, params: params
+          expect(TransitionNotFilingService).to have_received(:run).with(client)
         end
 
         context "without an attachment" do

--- a/spec/services/transition_not_filing_service_spec.rb
+++ b/spec/services/transition_not_filing_service_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+describe TransitionNotFilingService do
+  describe 'run' do
+    context "with a client who has some tax returns in not_filing status" do
+      let(:client) { create :client, intake: (create :intake) }
+
+      context "when previous status is intake_in_progress" do
+        let(:tax_return) { create :tax_return, :intake_in_progress, client: client }
+
+        before do
+          tax_return.transition_to(:file_not_filing)
+        end
+        it "changes status back to intake in progress" do
+          expect(client.tax_returns.map(&:current_state)).to eq ["file_not_filing"]
+          described_class.run(client)
+          expect(client.tax_returns.map(&:current_state)).to eq ["intake_in_progress"]
+        end
+      end
+
+      context "when previous status is anything else" do
+        let(:tax_return) { create :tax_return, :intake_needs_doc_help, client: client }
+        before do
+          tax_return.transition_to(:file_not_filing)
+        end
+        it "does not change status" do
+          expect(client.tax_returns.map(&:current_state)).to eq ["file_not_filing"]
+          described_class.run(client)
+          expect(client.tax_returns.map(&:current_state)).to eq ["file_not_filing"]
+        end
+      end
+
+      context "when there is no previous state transitions" do
+        let!(:tax_return) { create :tax_return, :file_not_filing, client: client }
+
+        it "does not change status" do
+          expect(client.tax_returns.map(&:current_state)).to eq ["file_not_filing"]
+          described_class.run(client)
+          expect(client.tax_returns.map(&:current_state)).to eq ["file_not_filing"]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Works for portal messaging, text messages, and emails
- When current status is not_filing and previous status was "intake_in_progress", transitions the tax return back to the in progress status so that customer success can review.


One note: Order kind of matters here, because the tax returns need to transition back to their appropriate states if necessary BEFORE the Intercom forwarding is done. It likely eventually makes sense to consolidate this "post processing" logic into one service... ideally, we'd also be able to consolidate how incoming messages are dealt with altogether since the FORMAT of the message doesn't really affect how we want to deal with the messages themselves for the most part.