### PR TITLE
Only look for duplicates on completed intakes for phone number reuse

### DIFF
--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -237,6 +237,7 @@
 #
 #  index_intakes_on_bank_account_id                        (bank_account_id)
 #  index_intakes_on_client_id                              (client_id)
+#  index_intakes_on_completed_at                           (completed_at) WHERE (completed_at IS NOT NULL)
 #  index_intakes_on_email_address                          (email_address)
 #  index_intakes_on_needs_to_flush_searchable_data_set_at  (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_intakes_on_phone_number                           (phone_number)

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -237,6 +237,7 @@
 #
 #  index_intakes_on_bank_account_id                        (bank_account_id)
 #  index_intakes_on_client_id                              (client_id)
+#  index_intakes_on_completed_at                           (completed_at) WHERE (completed_at IS NOT NULL)
 #  index_intakes_on_email_address                          (email_address)
 #  index_intakes_on_needs_to_flush_searchable_data_set_at  (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_intakes_on_phone_number                           (phone_number)

--- a/app/models/intake/gyr_intake.rb
+++ b/app/models/intake/gyr_intake.rb
@@ -237,6 +237,7 @@
 #
 #  index_intakes_on_bank_account_id                        (bank_account_id)
 #  index_intakes_on_client_id                              (client_id)
+#  index_intakes_on_completed_at                           (completed_at) WHERE (completed_at IS NOT NULL)
 #  index_intakes_on_email_address                          (email_address)
 #  index_intakes_on_needs_to_flush_searchable_data_set_at  (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_intakes_on_phone_number                           (phone_number)

--- a/app/services/fraud_indicator_service.rb
+++ b/app/services/fraud_indicator_service.rb
@@ -48,6 +48,6 @@ class FraudIndicatorService
   end
 
   def duplicate_phone_number
-    DeduplificationService.duplicates(@client.intake, :phone_number).where(type: "Intake::CtcIntake").count > 2
+    DeduplificationService.duplicates(@client.intake, :phone_number).where.not(completed_at: nil).where(type: "Intake::CtcIntake").count > 2
   end
 end

--- a/db/migrate/20211101145402_add_index_to_completed_at.rb
+++ b/db/migrate/20211101145402_add_index_to_completed_at.rb
@@ -1,0 +1,12 @@
+class AddIndexToCompletedAt < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index(
+        :intakes,
+        :completed_at,
+        where: "completed_at IS NOT NULL",
+        algorithm: :concurrently
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_22_214045) do
+ActiveRecord::Schema.define(version: 2021_11_01_145402) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -750,6 +750,7 @@ ActiveRecord::Schema.define(version: 2021_10_22_214045) do
     t.string "zip_code"
     t.index ["bank_account_id"], name: "index_intakes_on_bank_account_id"
     t.index ["client_id"], name: "index_intakes_on_client_id"
+    t.index ["completed_at"], name: "index_intakes_on_completed_at", where: "(completed_at IS NOT NULL)"
     t.index ["email_address"], name: "index_intakes_on_email_address"
     t.index ["needs_to_flush_searchable_data_set_at"], name: "index_intakes_on_needs_to_flush_searchable_data_set_at", where: "(needs_to_flush_searchable_data_set_at IS NOT NULL)"
     t.index ["phone_number"], name: "index_intakes_on_phone_number"

--- a/spec/factories/intakes.rb
+++ b/spec/factories/intakes.rb
@@ -237,6 +237,7 @@
 #
 #  index_intakes_on_bank_account_id                        (bank_account_id)
 #  index_intakes_on_client_id                              (client_id)
+#  index_intakes_on_completed_at                           (completed_at) WHERE (completed_at IS NOT NULL)
 #  index_intakes_on_email_address                          (email_address)
 #  index_intakes_on_needs_to_flush_searchable_data_set_at  (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_intakes_on_phone_number                           (phone_number)

--- a/spec/models/intake/gyr_intake_spec.rb
+++ b/spec/models/intake/gyr_intake_spec.rb
@@ -237,6 +237,7 @@
 #
 #  index_intakes_on_bank_account_id                        (bank_account_id)
 #  index_intakes_on_client_id                              (client_id)
+#  index_intakes_on_completed_at                           (completed_at) WHERE (completed_at IS NOT NULL)
 #  index_intakes_on_email_address                          (email_address)
 #  index_intakes_on_needs_to_flush_searchable_data_set_at  (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_intakes_on_phone_number                           (phone_number)

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -237,6 +237,7 @@
 #
 #  index_intakes_on_bank_account_id                        (bank_account_id)
 #  index_intakes_on_client_id                              (client_id)
+#  index_intakes_on_completed_at                           (completed_at) WHERE (completed_at IS NOT NULL)
 #  index_intakes_on_email_address                          (email_address)
 #  index_intakes_on_needs_to_flush_searchable_data_set_at  (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_intakes_on_phone_number                           (phone_number)

--- a/spec/services/fraud_indicator_service_spec.rb
+++ b/spec/services/fraud_indicator_service_spec.rb
@@ -161,7 +161,7 @@ describe FraudIndicatorService do
       context "when there are 3 or more CTC Intakes with duplicated phone numbers" do
         before do
           3.times do
-            create :ctc_intake, phone_number: "+18324658840"
+            create :ctc_intake, phone_number: "+18324658840", completed_at: DateTime.current
           end
         end
 


### PR DESCRIPTION
Previously, we were capturing phone number reuse regardless of what stage they'd gotten to in the flow, which was a bit too strict. We only really need to consider phone number duplicates an issue if the other intakes are completed.