### PR TITLE
Remove stray punctuation in HTML title on the Hub

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -6,7 +6,7 @@
       <%= content_for :page_title do %>Free tax help from IRS-certified volunteers.<% end %>
     <% end %>
 
-    <title><%= content_for(:page_title) %> | The Hub %></title>
+    <title><%= content_for(:page_title) %> | The Hub</title>
 
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
     <meta content="utf-8" http-equiv="encoding">


### PR DESCRIPTION
Before -- notice the window title has an extra `%>` in it

![image](https://user-images.githubusercontent.com/67708639/139730798-21c4ce34-a312-49c0-8483-8508e6607343.png)

After -- it's cleaned-up

![image](https://user-images.githubusercontent.com/67708639/139730986-80b02a79-1dc9-43ae-ae37-e16c0be2a275.png)
