### PR TITLE
Hub editing: don't allow updating a CTC client's EIP received values to 'nil'

### DIFF
--- a/app/forms/hub/update_ctc_client_form.rb
+++ b/app/forms/hub/update_ctc_client_form.rb
@@ -70,6 +70,9 @@ module Hub
     validates :primary_ip_pin, ip_pin: true
     validates :spouse_ip_pin, ip_pin: true
 
+    validates :eip1_amount_received, gyr_numericality: { only_integer: true }, if: -> { @client.intake.eip1_amount_received.present? }
+    validates :eip2_amount_received, gyr_numericality: { only_integer: true }, if: -> { @client.intake.eip2_amount_received.present? }
+
     validate :at_least_one_photo_id_type_selected, if: -> { @client.tax_returns.any? { |tax_return| tax_return.service_type == "drop_off" } }
     validate :at_least_one_taxpayer_id_type_selected, if: -> { @client.tax_returns.any? { |tax_return| tax_return.service_type == "drop_off" } }
     validate :valid_primary_birth_date

--- a/spec/forms/hub/update_ctc_client_form_spec.rb
+++ b/spec/forms/hub/update_ctc_client_form_spec.rb
@@ -187,6 +187,26 @@ RSpec.describe Hub::UpdateCtcClientForm do
         end
 
       end
+
+      context "updating the eip amounts received" do
+        context "if the eip1/2 values were already set" do
+          before do
+            intake.update(eip1_amount_received: 123, eip2_amount_received: 456)
+
+            form_attributes[:eip1_amount_received] = ""
+            form_attributes[:eip2_amount_received] = ""
+          end
+
+          it "does not allow settings amounts to nil" do
+            expect do
+              form = described_class.new(client, form_attributes)
+              form.save
+              intake.reload
+            end.not_to change(intake, :eip1_amount_received)
+            expect(intake.eip2_amount_received).to eq(456)
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
We are not able to file if these values are nil. They should be something
non-nil if they came from a client's intake (either 0, or our calculated value,
or the user's inputted value) so it's bad to throw away that information.

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>