### PR TITLE
delayed_jobs table stores job_class and job_object_id

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,3 +1,21 @@
 class ApplicationJob < ActiveJob::Base
   include ConsolidatedTraceHelper
+
+  def job_object_id
+    # This assumes most of our jobs use positional arguments
+    # where the id or thing the job is working on is the first
+    # argument. Subclasses are free to override `job_object_id`
+    # to look elsewhere in the arguments.
+    # If we eventually end up using keyword arguments more often this could
+    # be extended to look at the first keyword argument as well.
+    if arguments.first.is_a?(Integer)
+      arguments.first
+    elsif arguments.first.respond_to?(:id)
+      arguments.first.id
+    end
+  end
+
+  def serialize
+    super.merge("job_object_id" => job_object_id)
+  end
 end

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,2 +1,21 @@
 Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.max_attempts = 1
+
+module Delayed
+  module Plugins
+    class AddExtraJobAttributes < Plugin
+      callbacks do |lifecycle|
+        lifecycle.before(:enqueue) do |delayed_job|
+          serialized_job = delayed_job.payload_object.job_data
+          delayed_job.assign_attributes(
+            job_class: serialized_job['job_class'],
+            job_object_id: serialized_job['job_object_id'],
+            active_job_id: serialized_job['job_id']
+          )
+        end
+      end
+    end
+  end
+end
+
+Delayed::Worker.plugins << Delayed::Plugins::AddExtraJobAttributes

--- a/db/migrate/20211103232748_add_extra_fields_to_delayed_job.rb
+++ b/db/migrate/20211103232748_add_extra_fields_to_delayed_job.rb
@@ -1,0 +1,7 @@
+class AddExtraFieldsToDelayedJob < ActiveRecord::Migration[6.0]
+  def change
+    add_column :delayed_jobs, :job_class, :string
+    add_column :delayed_jobs, :job_object_id, :bigint
+    add_column :delayed_jobs, :active_job_id, :string
+  end
+end

--- a/db/migrate/20211103233054_index_delayed_jobs_on_active_job_id.rb
+++ b/db/migrate/20211103233054_index_delayed_jobs_on_active_job_id.rb
@@ -1,0 +1,7 @@
+class IndexDelayedJobsOnActiveJobId < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :delayed_jobs, :active_job_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20211103233101_index_delayed_jobs_on_job_class_and_job_object_id.rb
+++ b/db/migrate/20211103233101_index_delayed_jobs_on_job_class_and_job_object_id.rb
@@ -1,0 +1,7 @@
+class IndexDelayedJobsOnJobClassAndJobObjectId < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :delayed_jobs, [:job_class, :job_object_id], algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_01_234237) do
+ActiveRecord::Schema.define(version: 2021_11_03_233101) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -269,10 +269,13 @@ ActiveRecord::Schema.define(version: 2021_11_01_234237) do
   end
 
   create_table "delayed_jobs", force: :cascade do |t|
+    t.string "active_job_id"
     t.integer "attempts", default: 0, null: false
     t.datetime "created_at"
     t.datetime "failed_at"
     t.text "handler", null: false
+    t.string "job_class"
+    t.bigint "job_object_id"
     t.text "last_error"
     t.datetime "locked_at"
     t.string "locked_by"
@@ -280,6 +283,8 @@ ActiveRecord::Schema.define(version: 2021_11_01_234237) do
     t.string "queue"
     t.datetime "run_at"
     t.datetime "updated_at"
+    t.index ["active_job_id"], name: "index_delayed_jobs_on_active_job_id"
+    t.index ["job_class", "job_object_id"], name: "index_delayed_jobs_on_job_class_and_job_object_id"
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 

--- a/spec/jobs/after_transition_tasks_for_rejected_return_job_spec.rb
+++ b/spec/jobs/after_transition_tasks_for_rejected_return_job_spec.rb
@@ -62,4 +62,18 @@ describe AfterTransitionTasksForRejectedReturnJob do
       end
     end
   end
+
+  describe '#job_object_id' do
+    let(:submission) { create(:efile_submission, :transmitted) }
+    let(:efile_error) { create(:efile_error, code: "IRS-ERROR", expose: true, auto_wait: false, auto_cancel: false) }
+
+    before do
+      submission.transition_to!(:rejected, error_code: efile_error.code)
+    end
+
+    it 'returns the id of the EfileSubmission record' do
+      job = described_class.perform_later(submission, submission.last_transition)
+      expect(job.job_object_id).to eq(submission.id)
+    end
+  end
 end

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe ApplicationJob do
+  before do
+    SampleJobClass = Class.new(ApplicationJob) do
+      def perform(object_id)
+        return true
+      end
+    end
+  end
+
+  around do |example|
+    ActiveJob::Base.queue_adapter = :delayed_job
+    example.run
+    ActiveJob::Base.queue_adapter = :test
+  end
+
+  it 'persists job class and arguments to the delayed_jobs table' do
+    SampleJobClass.perform_later(123)
+    delayed_job = Delayed::Job.last
+    expect(delayed_job.job_class).to eq(SampleJobClass.to_s)
+    expect(delayed_job.job_object_id).to eq(123)
+  end
+end

--- a/spec/jobs/send_outgoing_email_job_spec.rb
+++ b/spec/jobs/send_outgoing_email_job_spec.rb
@@ -19,4 +19,13 @@ RSpec.describe SendOutgoingEmailJob, type: :job do
       expect(outgoing_email.sent_at).to eq fake_time
     end
   end
+
+  describe '#job_object_id' do
+    let(:outgoing_email) { create :outgoing_email }
+
+    it 'returns the id of the OutgoingEmail record' do
+      job = described_class.perform_later(outgoing_email.id)
+      expect(job.job_object_id).to eq(outgoing_email.id)
+    end
+  end
 end

--- a/spec/support/active_job.rb
+++ b/spec/support/active_job.rb
@@ -4,7 +4,7 @@ RSpec.configure do |config|
   config.include ActiveJob::TestHelper, type: :feature
 
   config.before(:each) do |example|
-    if [:job, :feature].include? example.metadata[:type] || example.metadata[:active_job]
+    if (ActiveJob::Base.queue_adapter.respond_to?(:perform_enqueued_jobs)) && ([:job, :feature].include?(example.metadata[:type]) || example.metadata[:active_job])
       clear_enqueued_jobs
       clear_performed_jobs
     end


### PR DESCRIPTION
This is accomplished by adding a hook to Delayed::Worker.plugins
which copies properties from the serialized job handler onto the
Delayed::Job record.

The job_class part in particular makes it easier to determine how
many of a given job are trying to run. Otherwise you have to pull
all the jobs into memory and check `job.payload_object.handler['job_class']`

The job_object_id part is occasionally useful if you wanted to see
how many SuchAndSuchJobs are queued up for a particular intake or
submission or whatever other ActiveRecord model the might be most
aligned with.

The active_job_id part is just because we did it that way in GCF
and may occasionally be useful when digging through logs? Who could say.