### PR TITLE
Add error notice and add bank information if client selected direct deposit but has no bank information

### DIFF
--- a/app/assets/stylesheets/_honeycrisp-compact.scss
+++ b/app/assets/stylesheets/_honeycrisp-compact.scss
@@ -203,6 +203,10 @@
     margin-left: $s15;
   }
 
+  .button--no-margin {
+    margin: 0;
+  }
+
   .button--cta {
     background-color: black;
     border: 1px solid black;

--- a/app/controllers/ctc/portal/portal_controller.rb
+++ b/app/controllers/ctc/portal/portal_controller.rb
@@ -22,7 +22,9 @@ class Ctc::Portal::PortalController < Ctc::Portal::BaseAuthenticatedController
   end
 
   def edit_info
-    @intake_updated_since_last_submission = SystemNote.where('created_at > ?', @submission.created_at).where(type: [SystemNote::CtcPortalAction, SystemNote::CtcPortalUpdate].map(&:to_s)).any?
+    intake_updated_since_last_submission = SystemNote.where('created_at > ?', @submission.created_at).where(type: [SystemNote::CtcPortalAction, SystemNote::CtcPortalUpdate].map(&:to_s)).any?
+    direct_deposit_missing_bank_account = current_client.intake.refund_payment_method_direct_deposit? && !current_client.intake.bank_account.present?
+    @submit_enabled = intake_updated_since_last_submission && !direct_deposit_missing_bank_account
   end
 
   def resubmit

--- a/app/models/dependent.rb
+++ b/app/models/dependent.rb
@@ -179,7 +179,7 @@ class Dependent < ApplicationRecord
     age_at_end_of_year(2020) < 17 && qualifying_child_2020? && [:ssn, :atin].include?(tin_type&.to_sym)
   end
 
-  def eligible_for_eip3? #is this right?
+  def eligible_for_eip3?
     qualifying_child_2020? || qualifying_relative_2020?
   end
 

--- a/app/views/ctc/portal/portal/edit_info.html.erb
+++ b/app/views/ctc/portal/portal/edit_info.html.erb
@@ -14,6 +14,11 @@
         <h1 class="h2"><%= @main_question %></h1>
 
         <div class="review-box spacing-below-35">
+          <% if @intake.refund_payment_method_direct_deposit? && !@intake.bank_account.present? %>
+            <div class="notice--error">
+              <p><%= t("views.ctc.portal.edit_info.no_ba_error_html") %></p>
+            </div>
+          <% end %>
           <h2 class="review-box__title"><%= t("views.ctc.questions.confirm_information.your_information") %></h2>
           <div class="review-box__space-between primary-info">
             <div>
@@ -43,22 +48,7 @@
             %>
           <% end %>
 
-          <div class="review-box__title">
-            <h2><%= t("views.ctc.questions.confirm_bank_account.bank_information") %></h2>
-          </div>
-          <% unless @intake.bank_account.present? %>
-            <p><%= t("views.ctc.portal.edit_info.no_bank_account") %></p>
-          <% end %>
-
-          <% if @intake.refund_payment_method_direct_deposit? %>
-            <%= render 'ctc/questions/confirm_information/bank_account_info', bank_account: @intake.bank_account, edit_controller: Ctc::Portal::RefundPaymentController %>
-          <% elsif @intake.refund_payment_method_check? %>
-            <p><%= t("views.ctc.portal.edit_info.will_send_check_to_address") %></p>
-          <% end %>
-
-          <% if @intake.refund_payment_method_check? || !@intake.bank_account.present? %>
-            <%= link_to "Add bank information", ctc_portal_refund_payment_path, class: "button button--small spacing-below-0" %>
-          <% end %>
+          <%= render 'ctc/questions/confirm_information/bank_info', edit_controller: Ctc::Portal::RefundPaymentController, intake: @intake %>
         </div>
 
         <% if @submission.can_transition_to?(:resubmitted) %>
@@ -66,7 +56,12 @@
             <%= t("views.ctc.portal.edit_info.help_text") %>
           </p>
           <%= recaptcha_v3(action: 'resubmit') %>
-          <%= button_tag(class: "button button--primary button--full-width", type: "submit", data: { disable_with: t("general.please_wait") }, disabled: !@intake_updated_since_last_submission) do %>
+          <%= button_tag(
+                class: "button button--primary button--full-width",
+                type: "submit",
+                data: { disable_with: t("general.please_wait") },
+                disabled: !@submit_enabled
+              ) do %>
             <%= t("views.ctc.portal.edit_info.resubmit") %>
           <% end %>
         <% else %>

--- a/app/views/ctc/questions/confirm_information/_bank_info.html.erb
+++ b/app/views/ctc/questions/confirm_information/_bank_info.html.erb
@@ -1,0 +1,19 @@
+<div class="review-box__title">
+  <% if intake.refund_payment_method_direct_deposit? %>
+    <h2><%= t("views.ctc.questions.confirm_bank_account.bank_information") %></h2>
+  <% end %>
+</div>
+
+<% if intake.bank_account.present? && intake.refund_payment_method_direct_deposit? %>
+  <%= render 'ctc/questions/confirm_information/bank_account_info', bank_account: intake.bank_account, edit_controller: edit_controller %>
+<% else %>
+  <% if intake.refund_payment_method_direct_deposit? && intake.bank_account.blank? %>
+    <p><%= t("views.ctc.portal.edit_info.no_bank_account") %></p>
+  <% end %>
+
+  <% if intake.refund_payment_method_check? %>
+    <p><%= t("views.ctc.portal.edit_info.will_send_check_to_address") %></p>
+  <% end %>
+
+  <%= link_to t("views.ctc.portal.edit_info.add_bank_information"), edit_controller.to_path_helper(clear: true), class: "button button--small spacing-below-0" %>
+<% end %>

--- a/app/views/ctc/questions/confirm_information/edit.html.erb
+++ b/app/views/ctc/questions/confirm_information/edit.html.erb
@@ -5,6 +5,11 @@
   <p><%= t("views.ctc.questions.confirm_information.help_text")  %></p>
 
   <div class="review-box spacing-below-35">
+    <% if current_intake.refund_payment_method_direct_deposit? && !current_intake.bank_account.present? %>
+      <div class="notice--error">
+        <p><%= t("views.ctc.portal.edit_info.no_ba_error_html") %></p>
+      </div>
+    <% end %>
 
     <%= render 'primary_filer_info', intake: current_intake, edit_controller: Ctc::Update::PrimaryFilerController %>
 
@@ -36,13 +41,7 @@
       </div>
     <% end %>
 
-    <% if current_intake.refund_payment_method_direct_deposit? %>
-      <div class="review-box__title">
-        <h2><%= t("views.ctc.questions.confirm_bank_account.bank_information") %></h2>
-      </div>
-
-      <%= render "bank_account_info", bank_account: current_intake.bank_account %>
-    <% end %>
+    <%= render 'ctc/questions/confirm_information/bank_info', edit_controller: Ctc::Portal::RefundPaymentController, intake: current_intake %>
   </div>
 
   <p><strong><%= t("views.ctc.questions.confirm_information.set_pin") %></strong></p>

--- a/app/views/hub/efile_submissions/show.html.erb
+++ b/app/views/hub/efile_submissions/show.html.erb
@@ -9,11 +9,12 @@
         <h1><%= tax_return.year %> Tax Return (<%= latest_efile_submission.current_state %>)</h1>
         <% if latest_efile_submission.can_transition_to?(:resubmitted) %>
           <div style="margin-left: 10px;">
-            <%= link_to("Resubmit",
+            <%= button_to("Resubmit",
                         resubmit_hub_efile_submission_path(id: latest_efile_submission.id),
                         method: :patch,
+                        disabled: latest_efile_submission.intake.refund_payment_method_direct_deposit? && !latest_efile_submission.intake.bank_account.present?,
                         data: { confirm: "Have you updated the necessary information for #{@client.legal_name}?" },
-                        class: "button button--small button--teal")
+                        class: "button button--small button--teal button--no-margin")
             %>
           </div>
         <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1618,8 +1618,10 @@ en:
             subtitle: You will not receive Child Tax Credit, because you have no eligible dependents.
             title: You have removed all of your CTC eligible dependents.
         edit_info:
+          add_bank_information: Add bank information
           help_text: Please ensure that all of your information is correct prior to submitting your tax return. Once you resubmit, your tax return will be transmitted to the IRS and you will not be able to make any additional changes.
           help_text_cant_submit: Please wait to submit any additional changes to your submission. We are waiting on a response to your previous submission from the IRS.
+          no_ba_error_html: "<strong>Error:</strong> You selected Direct Deposit, but you did not add your bank information. Please update your bank information by selecting Add bank information below."
           no_bank_account: No bank information entered.
           resubmit: Resubmit my tax return
           title: Correct your submitted information

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1589,8 +1589,10 @@ es:
             subtitle: No recibirá Crédito Tributario por Hijos porque no tiene dependientes elegibles.
             title: Ha eliminado a todos sus dependientes elegibles de CTC.
         edit_info:
+          add_bank_information: Agregar información bancaria
           help_text: Asegúrese de que toda su información sea correcta antes de enviar su declaración de impuestos. Una vez que vuelva a enviarla, su declaración de impuestos se transmitirá al IRS y no podrá realizar ningún cambio adicional.
           help_text_cant_submit: Espere a enviar cambios adicionales a su envío. Estamos esperando una respuesta a su presentación anterior del IRS.
+          no_ba_error_html: "<strong>Error:</strong> Seleccionó Depósito directo, pero no agregó su información bancaria. Actualice su información bancaria seleccionando Agregar información bancaria a continuación."
           no_bank_account: No se ingresó información bancaria.
           resubmit: Volver a enviar mi declaración de impuestos
           title: Corrija su información enviada


### PR DESCRIPTION
Co-authored-by: Catie Talbot <ctalbot@codeforamerica.org>
Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>
Co-authored-by: Maria Quadri <mquadri@codeforamerica.org>