### PR TITLE
Fix bash syntax for default port

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,6 +1,6 @@
 // Deployment procfile for Aptible
 cmd: bundle exec rails s -b 0.0.0.0 -p 3000
-web: bundle exec rails s -b 0.0.0.0 -p ${PORT:3000}
+web: bundle exec rails s -b 0.0.0.0 -p ${PORT:-3000}
 worker: bundle exec rails jobs:work
 cron: exec supercronic /app/crontab
 release: bin/rails heroku:release


### PR DESCRIPTION
Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>