### PR TITLE
efile resubmit failed rake task: Actually loop over submissions

### DIFF
--- a/lib/tasks/efile.rake
+++ b/lib/tasks/efile.rake
@@ -14,7 +14,7 @@ namespace :efile do
     puts("#{user.email} retrying up to #{limit} failed efile submissions")
 
     puts("Printing 1 dot per EfileSubmission:")
-    EfileSubmission.in_state(:failed).limit(limit) do |submission|
+    EfileSubmission.in_state(:failed).limit(limit).find_each do |submission|
       submission.transition_to!(:resubmitted, { initiated_by_id: user.id })
       print(".")
     end


### PR DESCRIPTION
## Impact

Without this change, we would compute the set of failed efile submissions, but we would not actually loop over them.

Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>