### PR TITLE
specs: Add a MockDogapi concern to consistently replace Dogapi::Client with a mock

### DIFF
--- a/spec/lib/datadog_api_spec.rb
+++ b/spec/lib/datadog_api_spec.rb
@@ -1,17 +1,12 @@
 require 'rails_helper'
 
 describe DatadogApi do
-  let(:mock_dogapi) { instance_double(Dogapi::Client, emit_point: nil) }
+  include MockDogapi
 
   before do
-    allow(Dogapi::Client).to receive(:new).and_return(mock_dogapi)
     DatadogApi.configure do |c|
       allow(c).to receive(:namespace).and_return("test.dogapi")
     end
-  end
-
-  after do
-    DatadogApi.instance_variable_set("@dogapi_client", nil)
   end
 
   context "when enabled" do
@@ -26,8 +21,8 @@ describe DatadogApi do
       DatadogApi.increment('counter')
 
       expect(Dogapi::Client).to have_received(:new).once
-      expect(mock_dogapi).to have_received(:emit_point).once.with('test.dogapi.volume', 11, {:tags => ["env:"+Rails.env], :type => "gauge"})
-      expect(mock_dogapi).to have_received(:emit_point).once.with('test.dogapi.counter', 1, {:tags => ["env:"+Rails.env], :type => "count"})
+      expect(@mock_dogapi).to have_received(:emit_point).once.with('test.dogapi.volume', 11, {:tags => ["env:"+Rails.env], :type => "gauge"})
+      expect(@mock_dogapi).to have_received(:emit_point).once.with('test.dogapi.counter', 1, {:tags => ["env:"+Rails.env], :type => "count"})
     end
   end
 
@@ -43,7 +38,7 @@ describe DatadogApi do
       DatadogApi.increment('counter')
 
       expect(Dogapi::Client).not_to have_received(:new)
-      expect(mock_dogapi).not_to have_received(:emit_point)
+      expect(@mock_dogapi).not_to have_received(:emit_point)
     end
   end
 end

--- a/spec/support/mock_dogapi.rb
+++ b/spec/support/mock_dogapi.rb
@@ -1,0 +1,14 @@
+module MockDogapi
+  extend ActiveSupport::Concern
+
+  included do
+    before do
+      @mock_dogapi = instance_double(Dogapi::Client, emit_point: nil)
+      allow(Dogapi::Client).to receive(:new).and_return(@mock_dogapi)
+    end
+
+    after do
+      DatadogApi.instance_variable_set("@dogapi_client", nil)
+    end
+  end
+end

--- a/spec/tasks/stats_spec.rb
+++ b/spec/tasks/stats_spec.rb
@@ -2,8 +2,7 @@ require 'rails_helper'
 
 describe 'stats:track_metrics' do
   include_context "rake"
-
-  let(:fake_dogapi) { instance_double(Dogapi::Client) }
+  include MockDogapi
 
   around do |example|
     ActiveJob::Base.queue_adapter = :delayed_job
@@ -16,9 +15,8 @@ describe 'stats:track_metrics' do
       allow(c).to receive(:enabled).and_return(true)
     end
 
-    allow(Dogapi::Client).to receive(:new).and_return(fake_dogapi)
     @emit_point_params = []
-    allow(fake_dogapi).to receive(:emit_point) do |*params|
+    allow(@mock_dogapi).to receive(:emit_point) do |*params|
       @emit_point_params << params
     end
 


### PR DESCRIPTION
previously, if a test did this, it was required to unset the memoized
@dogapi_client in the DatadogApi class, otherwise later tests could
complain that they were using stale mocks from another test.

now it will be more automatically cleaned up