### PR TITLE
VitaPartner refactor: just the migrations

### DIFF
--- a/app/models/vita_partner.rb
+++ b/app/models/vita_partner.rb
@@ -11,6 +11,7 @@
 #  national_overflow_location :boolean          default(FALSE)
 #  processes_ctc              :boolean          default(FALSE)
 #  timezone                   :string           default("America/New_York")
+#  type                       :string
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
 #  coalition_id               :bigint

--- a/db/migrate/20211109194518_add_type_to_vita_partner.rb
+++ b/db/migrate/20211109194518_add_type_to_vita_partner.rb
@@ -1,0 +1,5 @@
+class AddTypeToVitaPartner < ActiveRecord::Migration[6.0]
+  def change
+    add_column :vita_partners, :type, :string
+  end
+end

--- a/db/migrate/20211109200705_backfill_type_on_vita_partner.rb
+++ b/db/migrate/20211109200705_backfill_type_on_vita_partner.rb
@@ -1,12 +1,13 @@
 class BackfillTypeOnVitaPartner < ActiveRecord::Migration[6.0]
-  disable_ddl_transaction!
 
   def up
-    orgs = VitaPartner.where(parent_organization_id: nil)
-    orgs.update_all(type: "Organization")
+    ActiveRecord::Base.connection.execute(
+      "UPDATE vita_partners SET type='Organization' WHERE parent_organization_id IS NULL"
+    )
 
-    sites = VitaPartner.where.not(parent_organization_id: nil)
-    sites.update_all(type: "Site")
+    ActiveRecord::Base.connection.execute(
+      "UPDATE vita_partners SET type='Site' WHERE parent_organization_id IS NOT NULL"
+    )
   end
 
   def down

--- a/db/migrate/20211109200705_backfill_type_on_vita_partner.rb
+++ b/db/migrate/20211109200705_backfill_type_on_vita_partner.rb
@@ -1,0 +1,15 @@
+class BackfillTypeOnVitaPartner < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def up
+    orgs = VitaPartner.where(parent_organization_id: nil)
+    orgs.update_all(type: "Organization")
+
+    sites = VitaPartner.where.not(parent_organization_id: nil)
+    sites.update_all(type: "Site")
+  end
+
+  def down
+    VitaPartner.all.update_all(type: nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_03_233101) do
+ActiveRecord::Schema.define(version: 2021_11_09_200705) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -1065,6 +1065,7 @@ ActiveRecord::Schema.define(version: 2021_11_03_233101) do
     t.bigint "parent_organization_id"
     t.boolean "processes_ctc", default: false
     t.string "timezone", default: "America/New_York"
+    t.string "type"
     t.datetime "updated_at", precision: 6, null: false
     t.index ["coalition_id"], name: "index_vita_partners_on_coalition_id"
     t.index ["parent_organization_id", "name", "coalition_id"], name: "index_vita_partners_on_parent_name_and_coalition", unique: true

--- a/spec/factories/vita_partners.rb
+++ b/spec/factories/vita_partners.rb
@@ -11,6 +11,7 @@
 #  national_overflow_location :boolean          default(FALSE)
 #  processes_ctc              :boolean          default(FALSE)
 #  timezone                   :string           default("America/New_York")
+#  type                       :string
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
 #  coalition_id               :bigint

--- a/spec/models/vita_partner_spec.rb
+++ b/spec/models/vita_partner_spec.rb
@@ -11,6 +11,7 @@
 #  national_overflow_location :boolean          default(FALSE)
 #  processes_ctc              :boolean          default(FALSE)
 #  timezone                   :string           default("America/New_York")
+#  type                       :string
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
 #  coalition_id               :bigint


### PR DESCRIPTION
The whole thing lives over here #1803

I pulled out the migrations, we should release these first (before and separate from the class changes) to prevent downtime.