### PR TITLE
Intake persists and indexes canoncial_email_address and email_domain

### DIFF
--- a/app/lib/interesting_change_arbiter.rb
+++ b/app/lib/interesting_change_arbiter.rb
@@ -1,8 +1,14 @@
 class InterestingChangeArbiter
+  IGNORED_KEYS = %w[
+    canonical_email_address
+    email_domain
+    needs_to_flush_searchable_data_set_at
+    updated_at
+  ]
+
   def self.determine_changes(original_model, model)
     interesting_changes = model.saved_changes.reject do |k, v|
-      k == "updated_at" ||
-        k == "needs_to_flush_searchable_data_set_at" ||
+      IGNORED_KEYS.include?(k) ||
         k.match?("hashed_") ||
         encrypted_columns(model).include?(k)
     end

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -12,6 +12,7 @@
 #  bought_energy_efficient_items                        :integer
 #  bought_health_insurance                              :integer          default(0), not null
 #  cannot_claim_me_as_a_dependent                       :integer          default("unfilled"), not null
+#  canonical_email_address                              :string
 #  city                                                 :string
 #  claim_owed_stimulus_money                            :integer          default("unfilled"), not null
 #  claimed_by_another                                   :integer          default(0), not null
@@ -49,6 +50,7 @@
 #  eip_only                                             :boolean
 #  email_address                                        :citext
 #  email_address_verified_at                            :datetime
+#  email_domain                                         :string
 #  email_notification_opt_in                            :integer          default("unfilled"), not null
 #  encrypted_bank_account_number                        :string
 #  encrypted_bank_account_number_iv                     :string
@@ -236,9 +238,11 @@
 # Indexes
 #
 #  index_intakes_on_bank_account_id                        (bank_account_id)
+#  index_intakes_on_canonical_email_address                (canonical_email_address)
 #  index_intakes_on_client_id                              (client_id)
 #  index_intakes_on_completed_at                           (completed_at) WHERE (completed_at IS NOT NULL)
 #  index_intakes_on_email_address                          (email_address)
+#  index_intakes_on_email_domain                           (email_domain)
 #  index_intakes_on_needs_to_flush_searchable_data_set_at  (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_intakes_on_phone_number                           (phone_number)
 #  index_intakes_on_searchable_data                        (searchable_data) USING gin

--- a/app/models/intake/gyr_intake.rb
+++ b/app/models/intake/gyr_intake.rb
@@ -12,6 +12,7 @@
 #  bought_energy_efficient_items                        :integer
 #  bought_health_insurance                              :integer          default("unfilled"), not null
 #  cannot_claim_me_as_a_dependent                       :integer          default(0), not null
+#  canonical_email_address                              :string
 #  city                                                 :string
 #  claim_owed_stimulus_money                            :integer          default("unfilled"), not null
 #  claimed_by_another                                   :integer          default("unfilled"), not null
@@ -49,6 +50,7 @@
 #  eip_only                                             :boolean
 #  email_address                                        :citext
 #  email_address_verified_at                            :datetime
+#  email_domain                                         :string
 #  email_notification_opt_in                            :integer          default("unfilled"), not null
 #  encrypted_bank_account_number                        :string
 #  encrypted_bank_account_number_iv                     :string
@@ -236,9 +238,11 @@
 # Indexes
 #
 #  index_intakes_on_bank_account_id                        (bank_account_id)
+#  index_intakes_on_canonical_email_address                (canonical_email_address)
 #  index_intakes_on_client_id                              (client_id)
 #  index_intakes_on_completed_at                           (completed_at) WHERE (completed_at IS NOT NULL)
 #  index_intakes_on_email_address                          (email_address)
+#  index_intakes_on_email_domain                           (email_domain)
 #  index_intakes_on_needs_to_flush_searchable_data_set_at  (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_intakes_on_phone_number                           (phone_number)
 #  index_intakes_on_searchable_data                        (searchable_data) USING gin

--- a/db/migrate/20211112081156_add_canonical_email_address_to_intake.rb
+++ b/db/migrate/20211112081156_add_canonical_email_address_to_intake.rb
@@ -1,0 +1,5 @@
+class AddCanonicalEmailAddressToIntake < ActiveRecord::Migration[6.0]
+  def change
+    add_column :intakes, :canonical_email_address, :string
+  end
+end

--- a/db/migrate/20211112081217_add_email_domain_to_intake.rb
+++ b/db/migrate/20211112081217_add_email_domain_to_intake.rb
@@ -1,0 +1,5 @@
+class AddEmailDomainToIntake < ActiveRecord::Migration[6.0]
+  def change
+    add_column :intakes, :email_domain, :string
+  end
+end

--- a/db/migrate/20211112081402_index_canonical_email_address_on_intake.rb
+++ b/db/migrate/20211112081402_index_canonical_email_address_on_intake.rb
@@ -1,0 +1,7 @@
+class IndexCanonicalEmailAddressOnIntake < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :intakes, :canonical_email_address, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20211112081410_index_email_domain_on_intake.rb
+++ b/db/migrate/20211112081410_index_email_domain_on_intake.rb
@@ -1,0 +1,7 @@
+class IndexEmailDomainOnIntake < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :intakes, :email_domain, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_03_233101) do
+ActiveRecord::Schema.define(version: 2021_11_12_081410) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -535,6 +535,7 @@ ActiveRecord::Schema.define(version: 2021_11_03_233101) do
     t.integer "bought_energy_efficient_items"
     t.integer "bought_health_insurance", default: 0, null: false
     t.integer "cannot_claim_me_as_a_dependent", default: 0, null: false
+    t.string "canonical_email_address"
     t.string "city"
     t.integer "claim_owed_stimulus_money", default: 0, null: false
     t.integer "claimed_by_another", default: 0, null: false
@@ -574,6 +575,7 @@ ActiveRecord::Schema.define(version: 2021_11_03_233101) do
     t.boolean "eip_only"
     t.citext "email_address"
     t.datetime "email_address_verified_at"
+    t.string "email_domain"
     t.integer "email_notification_opt_in", default: 0, null: false
     t.string "encrypted_bank_account_number"
     t.string "encrypted_bank_account_number_iv"
@@ -755,9 +757,11 @@ ActiveRecord::Schema.define(version: 2021_11_03_233101) do
     t.boolean "with_vita_approved_taxpayer_id", default: false
     t.string "zip_code"
     t.index ["bank_account_id"], name: "index_intakes_on_bank_account_id"
+    t.index ["canonical_email_address"], name: "index_intakes_on_canonical_email_address"
     t.index ["client_id"], name: "index_intakes_on_client_id"
     t.index ["completed_at"], name: "index_intakes_on_completed_at", where: "(completed_at IS NOT NULL)"
     t.index ["email_address"], name: "index_intakes_on_email_address"
+    t.index ["email_domain"], name: "index_intakes_on_email_domain"
     t.index ["needs_to_flush_searchable_data_set_at"], name: "index_intakes_on_needs_to_flush_searchable_data_set_at", where: "(needs_to_flush_searchable_data_set_at IS NOT NULL)"
     t.index ["phone_number"], name: "index_intakes_on_phone_number"
     t.index ["searchable_data"], name: "index_intakes_on_searchable_data", using: :gin

--- a/spec/factories/intakes.rb
+++ b/spec/factories/intakes.rb
@@ -12,6 +12,7 @@
 #  bought_energy_efficient_items                        :integer
 #  bought_health_insurance                              :integer          default(0), not null
 #  cannot_claim_me_as_a_dependent                       :integer          default(0), not null
+#  canonical_email_address                              :string
 #  city                                                 :string
 #  claim_owed_stimulus_money                            :integer          default("unfilled"), not null
 #  claimed_by_another                                   :integer          default(0), not null
@@ -49,6 +50,7 @@
 #  eip_only                                             :boolean
 #  email_address                                        :citext
 #  email_address_verified_at                            :datetime
+#  email_domain                                         :string
 #  email_notification_opt_in                            :integer          default("unfilled"), not null
 #  encrypted_bank_account_number                        :string
 #  encrypted_bank_account_number_iv                     :string
@@ -236,9 +238,11 @@
 # Indexes
 #
 #  index_intakes_on_bank_account_id                        (bank_account_id)
+#  index_intakes_on_canonical_email_address                (canonical_email_address)
 #  index_intakes_on_client_id                              (client_id)
 #  index_intakes_on_completed_at                           (completed_at) WHERE (completed_at IS NOT NULL)
 #  index_intakes_on_email_address                          (email_address)
+#  index_intakes_on_email_domain                           (email_domain)
 #  index_intakes_on_needs_to_flush_searchable_data_set_at  (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_intakes_on_phone_number                           (phone_number)
 #  index_intakes_on_searchable_data                        (searchable_data) USING gin

--- a/spec/models/intake/gyr_intake_spec.rb
+++ b/spec/models/intake/gyr_intake_spec.rb
@@ -12,6 +12,7 @@
 #  bought_energy_efficient_items                        :integer
 #  bought_health_insurance                              :integer          default("unfilled"), not null
 #  cannot_claim_me_as_a_dependent                       :integer          default(0), not null
+#  canonical_email_address                              :string
 #  city                                                 :string
 #  claim_owed_stimulus_money                            :integer          default("unfilled"), not null
 #  claimed_by_another                                   :integer          default("unfilled"), not null
@@ -49,6 +50,7 @@
 #  eip_only                                             :boolean
 #  email_address                                        :citext
 #  email_address_verified_at                            :datetime
+#  email_domain                                         :string
 #  email_notification_opt_in                            :integer          default("unfilled"), not null
 #  encrypted_bank_account_number                        :string
 #  encrypted_bank_account_number_iv                     :string
@@ -236,9 +238,11 @@
 # Indexes
 #
 #  index_intakes_on_bank_account_id                        (bank_account_id)
+#  index_intakes_on_canonical_email_address                (canonical_email_address)
 #  index_intakes_on_client_id                              (client_id)
 #  index_intakes_on_completed_at                           (completed_at) WHERE (completed_at IS NOT NULL)
 #  index_intakes_on_email_address                          (email_address)
+#  index_intakes_on_email_domain                           (email_domain)
 #  index_intakes_on_needs_to_flush_searchable_data_set_at  (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_intakes_on_phone_number                           (phone_number)
 #  index_intakes_on_searchable_data                        (searchable_data) USING gin

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -12,6 +12,7 @@
 #  bought_energy_efficient_items                        :integer
 #  bought_health_insurance                              :integer          default(0), not null
 #  cannot_claim_me_as_a_dependent                       :integer          default(0), not null
+#  canonical_email_address                              :string
 #  city                                                 :string
 #  claim_owed_stimulus_money                            :integer          default("unfilled"), not null
 #  claimed_by_another                                   :integer          default(0), not null
@@ -49,6 +50,7 @@
 #  eip_only                                             :boolean
 #  email_address                                        :citext
 #  email_address_verified_at                            :datetime
+#  email_domain                                         :string
 #  email_notification_opt_in                            :integer          default("unfilled"), not null
 #  encrypted_bank_account_number                        :string
 #  encrypted_bank_account_number_iv                     :string
@@ -236,9 +238,11 @@
 # Indexes
 #
 #  index_intakes_on_bank_account_id                        (bank_account_id)
+#  index_intakes_on_canonical_email_address                (canonical_email_address)
 #  index_intakes_on_client_id                              (client_id)
 #  index_intakes_on_completed_at                           (completed_at) WHERE (completed_at IS NOT NULL)
 #  index_intakes_on_email_address                          (email_address)
+#  index_intakes_on_email_domain                           (email_domain)
 #  index_intakes_on_needs_to_flush_searchable_data_set_at  (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_intakes_on_phone_number                           (phone_number)
 #  index_intakes_on_searchable_data                        (searchable_data) USING gin
@@ -313,10 +317,30 @@ describe Intake do
     end
   end
 
+  describe "canonical_email_address" do
+    it "is persisted when the intake is saved" do
+      example_intake = Intake.create!(email_address: "a.REAL.email@example.com", visitor_id: "visitor_id")
+      expect(example_intake.canonical_email_address).to eq('a.real.email@example.com')
+
+      gmail_intake = Intake.create!(email_address: "a.REAL.email@gmail.com", visitor_id: "visitor_id")
+      expect(gmail_intake.canonical_email_address).to eq('arealemail@gmail.com')
+    end
+  end
+
   describe "email_address" do
     it "searches case-insensitively" do
       intake = Intake.create!(email_address: "eXample@EXAMPLE.COM", visitor_id: "visitor_id")
       expect(Intake.where(email_address: "example@example.com")).to include(intake)
+    end
+  end
+
+  describe "email_domain" do
+    it "is persisted when the intake is saved" do
+      example_intake = Intake.create!(email_address: "a.REAL.email@example.com", visitor_id: "visitor_id")
+      expect(example_intake.email_domain).to eq('example.com')
+
+      gmail_intake = Intake.create!(email_address: "a.REAL.email@gmail.com", visitor_id: "visitor_id")
+      expect(gmail_intake.email_domain).to eq('gmail.com')
     end
   end
 


### PR DESCRIPTION
For gmail addresses, canonical_email_address removes any dots before
the domain. e.g., john.q.public@gmail.com -> johnqpublic@gmail.com

Will be backfilled some time after this lands