### PR TITLE
Index email_access_tokens on email_address

### DIFF
--- a/app/models/email_access_token.rb
+++ b/app/models/email_access_token.rb
@@ -12,8 +12,9 @@
 #
 # Indexes
 #
-#  index_email_access_tokens_on_client_id  (client_id)
-#  index_email_access_tokens_on_token      (token)
+#  index_email_access_tokens_on_client_id      (client_id)
+#  index_email_access_tokens_on_email_address  (email_address)
+#  index_email_access_tokens_on_token          (token)
 #
 class EmailAccessToken < ApplicationRecord
   validates_presence_of :token

--- a/db/migrate/20211112213611_index_email_address_on_email_access_tokens.rb
+++ b/db/migrate/20211112213611_index_email_address_on_email_access_tokens.rb
@@ -1,0 +1,7 @@
+class IndexEmailAddressOnEmailAccessTokens < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :email_access_tokens, :email_address, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_12_081410) do
+ActiveRecord::Schema.define(version: 2021_11_12_213611) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -445,6 +445,7 @@ ActiveRecord::Schema.define(version: 2021_11_12_081410) do
     t.string "token_type", default: "link"
     t.datetime "updated_at", precision: 6, null: false
     t.index ["client_id"], name: "index_email_access_tokens_on_client_id"
+    t.index ["email_address"], name: "index_email_access_tokens_on_email_address"
     t.index ["token"], name: "index_email_access_tokens_on_token"
   end
 

--- a/spec/factories/email_access_tokens.rb
+++ b/spec/factories/email_access_tokens.rb
@@ -12,8 +12,9 @@
 #
 # Indexes
 #
-#  index_email_access_tokens_on_client_id  (client_id)
-#  index_email_access_tokens_on_token      (token)
+#  index_email_access_tokens_on_client_id      (client_id)
+#  index_email_access_tokens_on_email_address  (email_address)
+#  index_email_access_tokens_on_token          (token)
 #
 FactoryBot.define do
   factory :email_access_token do

--- a/spec/models/email_access_token_spec.rb
+++ b/spec/models/email_access_token_spec.rb
@@ -12,8 +12,9 @@
 #
 # Indexes
 #
-#  index_email_access_tokens_on_client_id  (client_id)
-#  index_email_access_tokens_on_token      (token)
+#  index_email_access_tokens_on_client_id      (client_id)
+#  index_email_access_tokens_on_email_address  (email_address)
+#  index_email_access_tokens_on_token          (token)
 #
 require "rails_helper"
 


### PR DESCRIPTION
We lookup how many tokens exist for the same email address
when we create new tokens, so that there can be at most 4
outstanding for the same email. But we didn't have an index
on email_address so it's been doing a seq scan.

Not the slowest thing our app does but it's better to speed it up!