### PR TITLE
Index EfileSubmission on irs_submission_id

### DIFF
--- a/app/models/efile_submission.rb
+++ b/app/models/efile_submission.rb
@@ -11,8 +11,9 @@
 #
 # Indexes
 #
-#  index_efile_submissions_on_created_at     (created_at)
-#  index_efile_submissions_on_tax_return_id  (tax_return_id)
+#  index_efile_submissions_on_created_at         (created_at)
+#  index_efile_submissions_on_irs_submission_id  (irs_submission_id)
+#  index_efile_submissions_on_tax_return_id      (tax_return_id)
 #
 class EfileSubmission < ApplicationRecord
   belongs_to :tax_return

--- a/db/migrate/20211112231601_add_index_on_efile_submissions_irs_submission_id.rb
+++ b/db/migrate/20211112231601_add_index_on_efile_submissions_irs_submission_id.rb
@@ -1,0 +1,7 @@
+class AddIndexOnEfileSubmissionsIrsSubmissionId < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :efile_submissions, :irs_submission_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_12_213611) do
+ActiveRecord::Schema.define(version: 2021_11_12_231601) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -434,6 +434,7 @@ ActiveRecord::Schema.define(version: 2021_11_12_213611) do
     t.bigint "tax_return_id"
     t.datetime "updated_at", precision: 6, null: false
     t.index ["created_at"], name: "index_efile_submissions_on_created_at"
+    t.index ["irs_submission_id"], name: "index_efile_submissions_on_irs_submission_id"
     t.index ["tax_return_id"], name: "index_efile_submissions_on_tax_return_id"
   end
 

--- a/spec/factories/efile_submissions.rb
+++ b/spec/factories/efile_submissions.rb
@@ -11,8 +11,9 @@
 #
 # Indexes
 #
-#  index_efile_submissions_on_created_at     (created_at)
-#  index_efile_submissions_on_tax_return_id  (tax_return_id)
+#  index_efile_submissions_on_created_at         (created_at)
+#  index_efile_submissions_on_irs_submission_id  (irs_submission_id)
+#  index_efile_submissions_on_tax_return_id      (tax_return_id)
 #
 FactoryBot.define do
   factory :efile_submission do

--- a/spec/models/efile_submission_spec.rb
+++ b/spec/models/efile_submission_spec.rb
@@ -11,8 +11,9 @@
 #
 # Indexes
 #
-#  index_efile_submissions_on_created_at     (created_at)
-#  index_efile_submissions_on_tax_return_id  (tax_return_id)
+#  index_efile_submissions_on_created_at         (created_at)
+#  index_efile_submissions_on_irs_submission_id  (irs_submission_id)
+#  index_efile_submissions_on_tax_return_id      (tax_return_id)
 #
 require "rails_helper"
 


### PR DESCRIPTION
This is mostly used when we generate a random submission ID
and check the DB to see whether we have already used that one.

Since there was no index it was doing a full table scan, which
is slower than it needs to be.