### PR TITLE
Index text_message_access_tokens on sms_phone_number

### DIFF
--- a/app/models/text_message_access_token.rb
+++ b/app/models/text_message_access_token.rb
@@ -12,8 +12,9 @@
 #
 # Indexes
 #
-#  index_text_message_access_tokens_on_client_id  (client_id)
-#  index_text_message_access_tokens_on_token      (token)
+#  index_text_message_access_tokens_on_client_id         (client_id)
+#  index_text_message_access_tokens_on_sms_phone_number  (sms_phone_number)
+#  index_text_message_access_tokens_on_token             (token)
 #
 class TextMessageAccessToken < ApplicationRecord
   validates_presence_of :token

--- a/db/migrate/20211113003152_index_sms_phone_number_on_text_message_access_tokens.rb
+++ b/db/migrate/20211113003152_index_sms_phone_number_on_text_message_access_tokens.rb
@@ -1,0 +1,7 @@
+class IndexSmsPhoneNumberOnTextMessageAccessTokens < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :text_message_access_tokens, :sms_phone_number, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_13_002344) do
+ActiveRecord::Schema.define(version: 2021_11_13_003152) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -980,6 +980,7 @@ ActiveRecord::Schema.define(version: 2021_11_13_002344) do
     t.string "token_type", default: "link"
     t.datetime "updated_at", precision: 6, null: false
     t.index ["client_id"], name: "index_text_message_access_tokens_on_client_id"
+    t.index ["sms_phone_number"], name: "index_text_message_access_tokens_on_sms_phone_number"
     t.index ["token"], name: "index_text_message_access_tokens_on_token"
   end
 

--- a/spec/factories/text_message_access_tokens.rb
+++ b/spec/factories/text_message_access_tokens.rb
@@ -12,8 +12,9 @@
 #
 # Indexes
 #
-#  index_text_message_access_tokens_on_client_id  (client_id)
-#  index_text_message_access_tokens_on_token      (token)
+#  index_text_message_access_tokens_on_client_id         (client_id)
+#  index_text_message_access_tokens_on_sms_phone_number  (sms_phone_number)
+#  index_text_message_access_tokens_on_token             (token)
 #
 FactoryBot.define do
   factory :text_message_access_token do

--- a/spec/models/text_message_access_token_spec.rb
+++ b/spec/models/text_message_access_token_spec.rb
@@ -12,8 +12,9 @@
 #
 # Indexes
 #
-#  index_text_message_access_tokens_on_client_id  (client_id)
-#  index_text_message_access_tokens_on_token      (token)
+#  index_text_message_access_tokens_on_client_id         (client_id)
+#  index_text_message_access_tokens_on_sms_phone_number  (sms_phone_number)
+#  index_text_message_access_tokens_on_token             (token)
 #
 require "rails_helper"
 


### PR DESCRIPTION
Same rationale as 543643137b90e3b1381a35f5e345181916bb67f0 which did this
for email. We look up the tokens by phone number to see that there aren't
too many. Now we can look it up faster.