### PR TITLE
rake stats:track_metrics reports queue length by job_class

### DIFF
--- a/lib/tasks/stats.rake
+++ b/lib/tasks/stats.rake
@@ -1,7 +1,13 @@
 namespace :stats do
   desc "Send custom application metrics to Datadog"
   task track_metrics: :environment do
-    DatadogApi.gauge('delayed_job.queue_length', Delayed::Job.where(failed_at: nil).where('run_at <= ?', Time.now).count)
+    Delayed::Job.where(failed_at: nil).group(:job_class).count.each do |job_class, count|
+      DatadogApi.gauge('delayed_job.queued_jobs', count, tags: ["job_class:#{job_class}"])
+    end
+
+    jobs_needing_to_run_now = Delayed::Job.where(failed_at: nil).where('run_at <= ?', Time.now)
+    DatadogApi.gauge('delayed_job.queue_length', jobs_needing_to_run_now.count)
+
     EfileSubmission.state_counts.each do |state, count|
       DatadogApi.gauge('efile_submissions.state_counts', count, tags: ["current_state:#{state}"])
     end

--- a/spec/tasks/stats_spec.rb
+++ b/spec/tasks/stats_spec.rb
@@ -33,6 +33,7 @@ describe 'stats:track_metrics' do
 
     expect(@emit_point_params).to match(array_including(
       ["vita-min.dogapi.delayed_job.queue_length", 2, tags: ["env:test"], type: "gauge"],
+      ["vita-min.dogapi.delayed_job.queued_jobs", 2, tags: ["job_class:SendOutgoingEmailJob", "env:test"], type: "gauge"],
       ["vita-min.dogapi.efile_submissions.state_counts", 2, tags: ["current_state:accepted", "env:test"], type: "gauge"],
       ["vita-min.dogapi.efile_submissions.state_counts", 1, tags: ["current_state:failed", "env:test"], type: "gauge"]
     ))


### PR DESCRIPTION
now that we are storing job_class on Delayed::Job this is possible