### PR TITLE
Avoid inconsistent local test failures

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -6,5 +6,8 @@ if [ $(sysctl -n hw.logicalcpu) != "1" ] && ! psql "postgresql://localhost/vita-
   exit 1
 fi
 
+# Increase the # of max open files to avoid https://stackoverflow.com/questions/59890432/rack-error-runtimeerror-failed-to-get-urandom-in-a-rails-app-rails-5-0-6-ru
+ulimit -n 524288
+
 EAGER_LOAD=1 RAILS_CACHE_CLASSES=1 bundle exec turbo_tests || { echo "Not running JS tests due to rspec failure." ; exit 1; }
 yarn jest


### PR DESCRIPTION
On my workstation, I was inconsistently getting test failures like:

```
RuntimeError: failed to get urandom
```

https://stackoverflow.com/questions/59890432/rack-error-runtimeerror-failed-to-get-urandom-in-a-rails-app-rails-5-0-6-ru is a Q&A where someone else had the same problem. This pull request follows their strategy -- change the maximum permissible number of open files so that opening the `/dev/urandom` file does not fail.