### PR TITLE
Hub Clients list: try to speed up recent messages join by overspecifying client ids

### DIFF
--- a/app/services/recent_message_summary_service.rb
+++ b/app/services/recent_message_summary_service.rb
@@ -33,10 +33,10 @@ class RecentMessageSummaryService
 
   def self.summarize_incoming_emails(client_ids)
     summarize(client_ids) do
-      IncomingEmail.find_by_sql([<<~SQL, client_ids])
+      IncomingEmail.find_by_sql([<<~SQL, client_ids, client_ids])
         SELECT incoming_emails.id, incoming_emails.client_id, incoming_emails.created_at, incoming_emails.body_plain as message_body, intakes.preferred_name as prefetched_author from incoming_emails
         INNER JOIN intakes ON intakes.client_id = incoming_emails.client_id
-        WHERE incoming_emails.created_at IN (
+        WHERE incoming_emails.client_id in ( ? ) AND incoming_emails.created_at IN (
           select max(incoming_emails.created_at)
           from incoming_emails
           group by incoming_emails.client_id
@@ -48,11 +48,11 @@ class RecentMessageSummaryService
 
   def self.summarize_incoming_text_messages(client_ids)
     summarize(client_ids) do
-      IncomingTextMessage.find_by_sql([<<~SQL, client_ids])
+      IncomingTextMessage.find_by_sql([<<~SQL, client_ids, client_ids])
         SELECT incoming_text_messages.id, incoming_text_messages.client_id, incoming_text_messages.body as message_body, incoming_text_messages.created_at, intakes.preferred_name as prefetched_author
         FROM incoming_text_messages
         INNER JOIN intakes on intakes.client_id = incoming_text_messages.client_id
-        WHERE incoming_text_messages.created_at IN (
+        WHERE incoming_text_messages.client_id in ( ? ) AND incoming_text_messages.created_at IN (
           select max(incoming_text_messages.created_at)
           from incoming_text_messages
           group by incoming_text_messages.client_id
@@ -64,11 +64,11 @@ class RecentMessageSummaryService
 
   def self.summarize_outgoing_emails(client_ids)
     summarize(client_ids) do
-      OutgoingEmail.find_by_sql([<<~SQL, client_ids])
+      OutgoingEmail.find_by_sql([<<~SQL, client_ids, client_ids])
         SELECT outgoing_emails.id, outgoing_emails.client_id, outgoing_emails.body as message_body, outgoing_emails.created_at, user_id, users.name as prefetched_author
         FROM outgoing_emails
         INNER JOIN users on users.id = user_id
-        WHERE outgoing_emails.created_at IN (
+        WHERE outgoing_emails.client_id IN ( ? ) AND outgoing_emails.created_at IN (
           select max(outgoing_emails.created_at)
           from outgoing_emails
           group by client_id
@@ -80,11 +80,11 @@ class RecentMessageSummaryService
 
   def self.summarize_outgoing_text_messages(client_ids)
     summarize(client_ids) do
-      OutgoingTextMessage.find_by_sql([<<~SQL, client_ids])
+      OutgoingTextMessage.find_by_sql([<<~SQL, client_ids, client_ids])
         SELECT outgoing_text_messages.id, outgoing_text_messages.client_id, outgoing_text_messages.body as message_body, outgoing_text_messages.created_at, user_id, users.name as prefetched_author
         FROM outgoing_text_messages
         INNER JOIN users on users.id = user_id
-        WHERE outgoing_text_messages.created_at IN (
+        WHERE outgoing_text_messages.client_id IN ( ? ) AND outgoing_text_messages.created_at IN (
           select max(outgoing_text_messages.created_at)
           from outgoing_text_messages
           group by client_id
@@ -96,11 +96,11 @@ class RecentMessageSummaryService
 
   def self.summarize_incoming_portal_messages(client_ids)
     summarize(client_ids) do
-      IncomingTextMessage.find_by_sql([<<~SQL, client_ids])
+      IncomingTextMessage.find_by_sql([<<~SQL, client_ids, client_ids])
         SELECT incoming_portal_messages.id, incoming_portal_messages.client_id, incoming_portal_messages.body as message_body, incoming_portal_messages.created_at, intakes.preferred_name as prefetched_author
         FROM incoming_portal_messages
         INNER JOIN intakes on intakes.client_id = incoming_portal_messages.client_id
-        WHERE incoming_portal_messages.created_at IN (
+        WHERE incoming_portal_messages.client_id IN ( ? ) AND incoming_portal_messages.created_at IN (
           select max(incoming_portal_messages.created_at)
           from incoming_portal_messages
           group by incoming_portal_messages.client_id


### PR DESCRIPTION

We're trying to select the most recent incoming/outgoing sms/email for each client
we're going to show in the list. Previously, the client_ids of the people on the
current page were only used in one part of the query:

```
SELECT [stuff]
INNER_JOIN incoming_text_messages
WHERE incoming_text_messages.created_at IN (
  SELECT [stuff] HAVING client_id IN ( ? )
)
```

this successfully leveraged indexes when the list of client_ids was short,
but over a certain threshold postgres wanted to do a parallel seq scan of
the incoming_text_messages table.

it seems like if we *also* include the client ids in a WHERE outside the inner select,
postgres successfully uses just the indices and doesn't touch the incoming_text_messages table at all

```
SELECT [stuff]
INNER_JOIN incoming_text_messages
WHERE incoming_text_messages.client_id IN ( ? ) AND incoming_text_messages.created_at IN (
  SELECT [stuff] HAVING client_id IN ( ? )
)
```

for one query I tried, this went from a 4000ms query to a 5ms query