### PR TITLE
CTC intake: fix change bank account button on confirm information page to stay within intake

### DIFF
--- a/app/views/ctc/questions/confirm_information/edit.html.erb
+++ b/app/views/ctc/questions/confirm_information/edit.html.erb
@@ -41,7 +41,7 @@
       </div>
     <% end %>
 
-    <%= render 'ctc/questions/confirm_information/bank_info', edit_controller: Ctc::Portal::RefundPaymentController, intake: current_intake %>
+    <%= render 'ctc/questions/confirm_information/bank_info', edit_controller: Ctc::Questions::RefundPaymentController, intake: current_intake %>
   </div>
 
   <p><strong><%= t("views.ctc.questions.confirm_information.set_pin") %></strong></p>


### PR DESCRIPTION
previously, it was taking clients to the portal, which is bad because
they would most likely end up back on /edit_info which would redirect
them to /home because they did not have a submission

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>