### PR TITLE
Ensure that production's `gyr_url` and `ctc_url` start with www so the website behaves properly

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,8 +3,8 @@ require_relative "./shared_deployment_config"
 Rails.application.configure do
   config.active_storage.service = :s3_prod
 
-  config.ctc_url = "https://getctc.org"
-  config.gyr_url = "https://getyourrefund.org"
+  config.ctc_url = "https://www.getctc.org"
+  config.gyr_url = "https://www.getyourrefund.org"
   ctc_email_from_domain = "getctc.org"
   gyr_email_from_domain = "getyourrefund.org"
   config.email_from = {


### PR DESCRIPTION
The heroku PR apps PR changed Routes::CtcDomain#matches? to use `ctc_url`
(which was configured to just https://getctc.org) instead of
Rails.application.config.ctc_domains[:production] (which was www.getctc.org)

A person visiting the site will always get redirected to the www version,
so there's hopefully no harm in putting the www in `ctc_url` rather than
doing something fancier to ensure that both `www.getctc.org` and `getctc.org`
work everywhere. But I have been wrong before!