### PR TITLE
Stats metric for job_latency should cast interval to integer

### DIFF
--- a/lib/tasks/stats.rake
+++ b/lib/tasks/stats.rake
@@ -8,7 +8,7 @@ namespace :stats do
     jobs_needing_to_run_now = Delayed::Job.where(failed_at: nil).where('run_at <= ?', Time.now)
     DatadogApi.gauge('delayed_job.queue_length', jobs_needing_to_run_now.count)
     
-    select_sql = Delayed::Job.sanitize_sql(["job_class, MAX(? - run_at) AS latency", Time.now])
+    select_sql = Delayed::Job.sanitize_sql(["job_class, EXTRACT(epoch FROM MAX(? - run_at)) AS latency", Time.now])
     Delayed::Job.select(select_sql).where(failed_at: nil).where('run_at <= ?', Time.now).group(:job_class).as_json.each do |job_class_data|
       latency = job_class_data['latency']
       job_class = job_class_data['job_class']


### PR DESCRIPTION
I made the mistake of testing this on GetCalFresh, which is [Rails 6.1 which automatically supports Postgres Interval datatypes](https://www.bigbinary.com/blog/rails-6-1-adds-postgresql-interval-data-type). Without that support, the interval must be cast to an integer, which this PR does.