### PR TITLE
Use full SSNs on GYR

### DIFF
--- a/app/forms/consent_form.rb
+++ b/app/forms/consent_form.rb
@@ -14,7 +14,6 @@ class ConsentForm < QuestionsForm
     :primary_tin_type
   )
   set_attributes_for :confirmation, :primary_ssn_confirmation
-  set_attributes_for :virtual, :ssn_no_employment
 
   validates_presence_of :primary_first_name
   validates_presence_of :primary_last_name

--- a/app/forms/consent_form.rb
+++ b/app/forms/consent_form.rb
@@ -29,12 +29,6 @@ class ConsentForm < QuestionsForm
     validates :primary_ssn_confirmation, presence: true
   end
 
-  before_validation do
-    if ssn_no_employment == "yes" && primary_tin_type == "ssn"
-      self.primary_tin_type = "ssn_no_employment"
-    end
-  end
-
   def save
     attributes = attributes_for(:intake)
       .except(:birth_date_year, :birth_date_month, :birth_date_day)

--- a/app/forms/ctc/base_primary_filer_form.rb
+++ b/app/forms/ctc/base_primary_filer_form.rb
@@ -15,10 +15,8 @@ module Ctc
     end
 
     def save
-      primary_last_four_ssn = primary_ssn.last(4) # merge last_four_ssn so that client can use data for logging in.
       @intake.update!(
         attributes_for(:intake).merge(
-          primary_last_four_ssn: primary_last_four_ssn,
           primary_birth_date: primary_birth_date
         )
       )

--- a/app/forms/ctc/base_spouse_form.rb
+++ b/app/forms/ctc/base_spouse_form.rb
@@ -17,10 +17,8 @@ module Ctc
     validates_presence_of :spouse_ssn, message: -> (_object, _data) { I18n.t('views.ctc.questions.spouse_info.ssn_required_message') }, if: -> { spouse_tin_type != "none" }
 
     def save
-      spouse_last_four_ssn = spouse_ssn.last(4) # merge last_four_ssn so that client can use data for logging in.
       @intake.update(attributes_for(:intake).merge(
         spouse_birth_date: spouse_birth_date,
-        spouse_last_four_ssn: spouse_last_four_ssn
       ))
     end
 

--- a/app/forms/hub/create_ctc_client_form.rb
+++ b/app/forms/hub/create_ctc_client_form.rb
@@ -167,8 +167,6 @@ module Hub
     def default_attributes
       {
           type: "Intake::CtcIntake",
-          primary_last_four_ssn: primary_ssn&.last(4),
-          spouse_last_four_ssn: spouse_ssn&.last(4),
       }
     end
 

--- a/app/forms/hub/update_ctc_client_form.rb
+++ b/app/forms/hub/update_ctc_client_form.rb
@@ -97,8 +97,6 @@ module Hub
     def default_attributes
       {
         type: "Intake::CtcIntake",
-        primary_last_four_ssn: primary_ssn&.last(4),
-        spouse_last_four_ssn: spouse_ssn&.last(4),
       }
     end
 

--- a/app/forms/spouse_consent_form.rb
+++ b/app/forms/spouse_consent_form.rb
@@ -15,7 +15,6 @@ class SpouseConsentForm < QuestionsForm
     :spouse_tin_type
   )
   set_attributes_for :confirmation, :spouse_ssn_confirmation
-  set_attributes_for :virtual, :ssn_no_employment
 
   validates_presence_of :spouse_first_name
   validates_presence_of :spouse_last_name
@@ -25,17 +24,6 @@ class SpouseConsentForm < QuestionsForm
   validates :spouse_ssn, individual_taxpayer_identification_number: true, if: -> { spouse_tin_type == "itin" }
   validates_presence_of :spouse_ssn
   validate :valid_birth_date
-
-  with_options if: -> { (spouse_ssn.present? && spouse_ssn != intake.spouse_ssn) || spouse_ssn_confirmation.present? } do
-    validates :spouse_ssn, confirmation: true
-    validates :spouse_ssn_confirmation, presence: true
-  end
-
-  before_validation do
-    if ssn_no_employment == "yes" && spouse_tin_type == "ssn"
-      self.spouse_tin_type = "ssn_no_employment"
-    end
-  end
 
   def save
     attributes = attributes_for(:intake)

--- a/app/forms/spouse_consent_form.rb
+++ b/app/forms/spouse_consent_form.rb
@@ -11,13 +11,31 @@ class SpouseConsentForm < QuestionsForm
     :birth_date_day,
     :spouse_first_name,
     :spouse_last_name,
-    :spouse_last_four_ssn
+    :spouse_ssn,
+    :spouse_tin_type
   )
+  set_attributes_for :confirmation, :spouse_ssn_confirmation
+  set_attributes_for :virtual, :ssn_no_employment
 
   validates_presence_of :spouse_first_name
   validates_presence_of :spouse_last_name
-  validates_length_of :spouse_last_four_ssn, maximum: 4, minimum: 4
+
+  validates :spouse_tin_type, presence: true
+  validates :spouse_ssn, social_security_number: true, if: -> { ["ssn", "ssn_no_employment"].include? spouse_tin_type }
+  validates :spouse_ssn, individual_taxpayer_identification_number: true, if: -> { spouse_tin_type == "itin" }
+  validates_presence_of :spouse_ssn
   validate :valid_birth_date
+
+  with_options if: -> { (spouse_ssn.present? && spouse_ssn != intake.spouse_ssn) || spouse_ssn_confirmation.present? } do
+    validates :spouse_ssn, confirmation: true
+    validates :spouse_ssn_confirmation, presence: true
+  end
+
+  before_validation do
+    if ssn_no_employment == "yes" && spouse_tin_type == "ssn"
+      self.spouse_tin_type = "ssn_no_employment"
+    end
+  end
 
   def save
     attributes = attributes_for(:intake)

--- a/app/models/dependent.rb
+++ b/app/models/dependent.rb
@@ -113,10 +113,6 @@ class Dependent < ApplicationRecord
     parts.compact.join(' ')
   end
 
-  def last_four_ssn
-    ssn&.last(4)
-  end
-
   def error_summary
     if errors.present?
       concatenated_message_strings = errors.messages.map { |key, messages| messages.join(" ") }.join(" ")

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -284,6 +284,8 @@ class Intake < ApplicationRecord
       self.email_domain = email_address.split('@').last.downcase
       self.canonical_email_address = compute_canonical_email_address
     end
+    self.primary_last_four_ssn = primary_ssn&.last(4) if encrypted_primary_ssn_changed?
+    self.spouse_last_four_ssn = spouse_ssn&.last(4) if encrypted_spouse_ssn_changed?
   end
 
   attr_encrypted :primary_last_four_ssn, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }

--- a/app/views/ctc/questions/legal_consent/edit.html.erb
+++ b/app/views/ctc/questions/legal_consent/edit.html.erb
@@ -24,8 +24,8 @@
             help_text: t("hub.clients.show.date_of_birth_help"),
             classes: ["ctc-intake-date-text-input"]
             ) %>
-      <%= f.cfa_select(:primary_tin_type, t('views.ctc.questions.legal_consent.tin_type'), tin_options_for_select(include_itin: true)) %>
-      <%= f.cfa_checkbox(:ssn_no_employment, t('views.ctc.questions.legal_consent.ssn_not_valid_for_employment'), options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <%= f.cfa_select(:primary_tin_type, t('general.tin_type'), tin_options_for_select(include_itin: true)) %>
+      <%= f.cfa_checkbox(:ssn_no_employment, t('general.ssn_not_valid_for_employment'), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_input_field(:primary_ssn, t("views.ctc.questions.legal_consent.ssn"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
       <%= f.cfa_input_field(:primary_ssn_confirmation, t("views.ctc.questions.legal_consent.ssn_confirmation"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
       <%= f.cfa_input_field(:phone_number, t("views.ctc.questions.legal_consent.sms_phone_number"), classes: ["form-width--long"]) %>
@@ -44,7 +44,6 @@
     </button>
   <% end %>
 <% end %>
-
 
 <% content_for :script do %>
   <script>

--- a/app/views/questions/consent/edit.html.erb
+++ b/app/views/questions/consent/edit.html.erb
@@ -10,7 +10,6 @@
       <%= f.cfa_input_field(:primary_first_name, t("views.questions.consent.primary_first_name")) %>
       <%= f.cfa_input_field(:primary_last_name, t("views.questions.consent.primary_last_name")) %>
     <%= f.cfa_select(:primary_tin_type, t('general.tin_type'), tin_options_for_select(include_itin: true)) %>
-    <%= f.cfa_checkbox(:ssn_no_employment, t('general.ssn_not_valid_for_employment'), options: { checked_value: "yes", unchecked_value: "no" }) %>
     <%= f.cfa_input_field(:primary_ssn, t("attributes.primary_ssn"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
     <%= f.cfa_input_field(:primary_ssn_confirmation, t("attributes.confirm_primary_ssn"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
       <div class="date-select">
@@ -29,13 +28,4 @@
       </button>
     <% end %>
 
-<% end %>
-
-<% content_for :script do %>
-  <script>
-      document.addEventListener("DOMContentLoaded", function() {
-          window.TINTypeSelector = document.getElementById("consent_form_primary_tin_type");
-          window.SSNEmploymentCheckboxSelector = document.getElementById("consent_form_ssn_no_employment").parentElement;
-      });
-  </script>
 <% end %>

--- a/app/views/questions/consent/edit.html.erb
+++ b/app/views/questions/consent/edit.html.erb
@@ -9,14 +9,10 @@
 
       <%= f.cfa_input_field(:primary_first_name, t("views.questions.consent.primary_first_name")) %>
       <%= f.cfa_input_field(:primary_last_name, t("views.questions.consent.primary_last_name")) %>
-      <%= f.cfa_input_field(
-              :primary_last_four_ssn,
-              t("views.questions.consent.primary_last_four_ssn"),
-              prefix: "XXX-XX-",
-              type: :tel,
-              classes: ["form-width--name field--last-four-ssn"],
-              options: { maxlength: 4 }
-          ) %>
+    <%= f.cfa_select(:primary_tin_type, t('general.tin_type'), tin_options_for_select(include_itin: true)) %>
+    <%= f.cfa_checkbox(:ssn_no_employment, t('general.ssn_not_valid_for_employment'), options: { checked_value: "yes", unchecked_value: "no" }) %>
+    <%= f.cfa_input_field(:primary_ssn, t("attributes.primary_ssn"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
+    <%= f.cfa_input_field(:primary_ssn_confirmation, t("attributes.confirm_primary_ssn"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
       <div class="date-select">
         <%= f.cfa_date_select(
                 :birth_date,
@@ -33,4 +29,13 @@
       </button>
     <% end %>
 
+<% end %>
+
+<% content_for :script do %>
+  <script>
+      document.addEventListener("DOMContentLoaded", function() {
+          window.TINTypeSelector = document.getElementById("consent_form_primary_tin_type");
+          window.SSNEmploymentCheckboxSelector = document.getElementById("consent_form_ssn_no_employment").parentElement;
+      });
+  </script>
 <% end %>

--- a/app/views/questions/spouse_consent/edit.html.erb
+++ b/app/views/questions/spouse_consent/edit.html.erb
@@ -26,7 +26,6 @@
                       }
                   ) %>
             </div>
-            <%= f.cfa_checkbox(:ssn_no_employment, t('views.ctc.questions.legal_consent.ssn_not_valid_for_employment'), options: { checked_value: "yes", unchecked_value: "no" }) %>
             <%= f.cfa_input_field(:spouse_ssn, t("attributes.spouse_ssn"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
             <%= f.cfa_input_field(:spouse_ssn_confirmation, t("attributes.confirm_spouse_ssn"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
             <button class="button button--primary button--wide" type="submit">

--- a/app/views/questions/spouse_consent/edit.html.erb
+++ b/app/views/questions/spouse_consent/edit.html.erb
@@ -37,12 +37,3 @@
     </div>
   </section>
 <% end %>
-
-<% content_for :script do %>
-  <script>
-      document.addEventListener("DOMContentLoaded", function() {
-          window.TINTypeSelector = document.getElementById("spouse_consent_form_spouse_tin_type");
-          window.SSNEmploymentCheckboxSelector = document.getElementById("spouse_consent_form_ssn_no_employment").parentElement;
-      });
-  </script>
-<% end %>

--- a/app/views/questions/spouse_consent/edit.html.erb
+++ b/app/views/questions/spouse_consent/edit.html.erb
@@ -15,14 +15,7 @@
 
             <%= f.cfa_input_field(:spouse_first_name, t("views.questions.spouse_consent.spouse_first_name")) %>
             <%= f.cfa_input_field(:spouse_last_name, t("views.questions.spouse_consent.spouse_last_name")) %>
-            <%= f.cfa_input_field(
-                    :spouse_last_four_ssn,
-                    t("views.questions.spouse_consent.spouse_last_four_ssn"),
-                    prefix: "XXX-XX-",
-                    type: :tel,
-                    classes: ["form-width--name field--last-four-ssn"],
-                    options: { maxlength: 4 }
-                ) %>
+            <%= f.cfa_select(:spouse_tin_type, t("views.ctc.questions.spouse_info.spouse_identity"), tin_options_for_select(include_itin: true, include_none: true), help_text: t("views.ctc.questions.spouse_info.spouse_identity_help_text")) %>
             <div class="date-select">
               <%= f.cfa_date_select(
                       :birth_date,
@@ -33,6 +26,9 @@
                       }
                   ) %>
             </div>
+            <%= f.cfa_checkbox(:ssn_no_employment, t('views.ctc.questions.legal_consent.ssn_not_valid_for_employment'), options: { checked_value: "yes", unchecked_value: "no" }) %>
+            <%= f.cfa_input_field(:spouse_ssn, t("attributes.spouse_ssn"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
+            <%= f.cfa_input_field(:spouse_ssn_confirmation, t("attributes.confirm_spouse_ssn"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
             <button class="button button--primary button--wide" type="submit">
               <%= t("views.questions.spouse_consent.cta") %>
             </button>
@@ -41,4 +37,13 @@
       </div>
     </div>
   </section>
+<% end %>
+
+<% content_for :script do %>
+  <script>
+      document.addEventListener("DOMContentLoaded", function() {
+          window.TINTypeSelector = document.getElementById("spouse_consent_form_spouse_tin_type");
+          window.SSNEmploymentCheckboxSelector = document.getElementById("spouse_consent_form_ssn_no_employment").parentElement;
+      });
+  </script>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,11 @@ en:
           attributes:
             ssn:
               blank: To claim family member as a dependent for benefits, an SSN or ATIN is required.
+  attributes:
+    confirm_primary_ssn: Confirm SSN or ITIN
+    confirm_spouse_ssn: Confirm spouse's SSN or ITIN
+    primary_ssn: SSN or ITIN
+    spouse_ssn: Spouse's SSN or ITIN
   controllers:
     application_controller:
       maintenance: GetYourRefund.org will be down for scheduled maintenance for about 1 hour starting at %{time}.
@@ -159,11 +164,12 @@ en:
         blank: Please enter your preferred name.
       primary_first_name:
         blank: Please enter your first name.
-      primary_last_four_ssn:
-        too_long: Please enter the last four digits of your SSN or ITIN.
-        too_short: Please enter the last four digits of your SSN or ITIN.
       primary_last_name:
         blank: Please enter your last name.
+      primary_ssn:
+        blank: An SSN or ITIN is required.
+      primary_tin_type:
+        blank: Identification type is required.
       signature_method:
         inclusion: Please select a pickup method.
       sms_phone_number:
@@ -174,11 +180,12 @@ en:
         confirmation: Please double check that the email addresses match.
       spouse_first_name:
         blank: Please enter your spouse's first name.
-      spouse_last_four_ssn:
-        too_long: Please enter the last four digits of your spouse's SSN or ITIN.
-        too_short: Please enter the last four digits of your spouse's SSN or ITIN.
       spouse_last_name:
         blank: Please enter your spouse's last name.
+      spouse_ssn:
+        blank: Spouse SSN or ITIN is required.
+      spouse_tin_type:
+        blank: Identification type is required.
       state:
         inclusion: Please select a state.
       state_of_residence:
@@ -437,6 +444,7 @@ en:
     spouse_last_four_ssn: Spouse's last 4 of SSN/ITIN
     ssn: SSN
     ssn_itin: SSN/ITIN
+    ssn_not_valid_for_employment: This SSN is not valid for employment
     start_filing: Start filing
     state: State
     state_routing: "%{state} Routing"
@@ -462,6 +470,7 @@ en:
       none: None of the above
       ssn: Social Security Number (SSN)
       ssn_no_employment: SSN (Not valid for employment)
+    tin_type: Identification Type
     today: Today
     type: Type
     ui: UI
@@ -1950,7 +1959,6 @@ en:
           ssn_confirmation: Confirm SSN or ITIN
           ssn_not_valid_for_employment: This SSN is not valid for employment
           suffix: Suffix
-          tin_type: Identification Type
           title: In order to file, we’ll need some basic information.
         life_situations2019:
           item1: The number of people in your household changed from your 2019 tax return
@@ -3062,7 +3070,6 @@ en:
         birth_date: Date of birth
         cta: I agree
         primary_first_name: Legal first name
-        primary_last_four_ssn: Last 4 of SSN/ITIN
         primary_last_name: Legal last name
         title: Great! Here's the legal stuff...
       debt_forgiven:
@@ -3377,7 +3384,6 @@ en:
         birth_date: Date of birth
         cta: I agree
         spouse_first_name: Spouse's legal first name
-        spouse_last_four_ssn: Last 4 of SSN/ITIN
         spouse_last_name: Spouse's legal last name
         title: We need your spouse to review our legal stuff...
       spouse_email_address:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -7,6 +7,11 @@ es:
           attributes:
             ssn:
               blank: Para reclamar a un miembro de la familia como dependiente para los beneficios, se requiere un SSN o ATIN.
+  attributes:
+    confirm_primary_ssn: Confirmar SSN o ITIN
+    confirm_spouse_ssn: Confirme el SSN o ITIN del cónyuge
+    primary_ssn: Número de seguro social o ITIN
+    spouse_ssn: Número de seguro social o ITIN del cónyuge
   controllers:
     application_controller:
       maintenance: GetYourRefund.org estará inactivo para mantenimiento programado durante aproximadamente 1 hora a partir de %{time}.
@@ -159,11 +164,12 @@ es:
         blank: Por favor, introduzca su nombre preferido.
       primary_first_name:
         blank: Por favor, introduzca su primer nombre.
-      primary_last_four_ssn:
-        too_long: Por favor, ingrese los últimos cuatro dígitos del SSN o ITIN de su pareja.
-        too_short: Por favor, ingrese los últimos cuatro dígitos de su SSN o ITIN.
       primary_last_name:
         blank: Por favor, ingrese su apellido.
+      primary_ssn:
+        blank: Se requiere un SSN o ITIN.
+      primary_tin_type:
+        blank: Se requiere el tipo de identificación.
       signature_method:
         inclusion: Por favor, seleccione un método de recogida.
       sms_phone_number:
@@ -174,11 +180,12 @@ es:
         confirmation: Por favor, revise que las direcciones de correo electrónico sean iguales.
       spouse_first_name:
         blank: Por favor ingrese el nombre de su cónyuge.
-      spouse_last_four_ssn:
-        too_long: Por favor, ingrese los últimos cuatro dígitos del SSN o ITIN de su pareja.
-        too_short: Por favor, ingrese los últimos cuatro dígitos del SSN o ITIN de su pareja.
       spouse_last_name:
         blank: Por favor, ingrese el apellido de su pareja.
+      spouse_ssn:
+        blank: Se requiere el número de seguro social o ITIN del cónyuge.
+      spouse_tin_type:
+        blank: Se requiere el tipo de identificación.
       state:
         inclusion: Por favor, seleccione un estado.
       state_of_residence:
@@ -437,6 +444,7 @@ es:
     spouse_last_four_ssn: Últimos 4 de SSN / ITIN (cónyuge)
     ssn: SSN
     ssn_itin: SSN/ITIN
+    ssn_not_valid_for_employment: Este SSN no es válido para empleo
     start_filing: Empiece a declarar
     state: Estado
     state_routing: Enrutamiento de %{state}
@@ -462,6 +470,7 @@ es:
       none: Ninguna de las anteriores
       ssn: Número de Seguro Social (SSN)
       ssn_no_employment: Número de Seguro Social/SSN (No es válido para el empleo)
+    tin_type: Tipo de identificación
     today: Hoy
     type: Tipo
     ui: UI
@@ -1899,7 +1908,6 @@ es:
           ssn_confirmation: Confirme el SSN o ITIN
           ssn_not_valid_for_employment: Este SSN no es válido para empleo
           suffix: Forma de tratamiento, por ejemplo, Sr., Sra., Srta.
-          tin_type: Tipo de identificación
           title: Para presentar una declaración, necesitaremos algunos datos básicos.
         life_situations2019:
           item1: El número de personas en su hogar cambió con respecto a su declaración de impuestos de 2019
@@ -3031,7 +3039,6 @@ es:
         birth_date: Fecha de nacimiento
         cta: estoy de acuerdo
         primary_first_name: Primer nombre legal
-        primary_last_four_ssn: Últimos 4 de SSN / ITIN
         primary_last_name: Apellido legal
         title: "¡Excelente! Aquí están las cosas legales ..."
       debt_forgiven:
@@ -3346,7 +3353,6 @@ es:
         birth_date: Fecha de nacimiento
         cta: Estoy de acuerdo
         spouse_first_name: Nombre legal de su cónyuge
-        spouse_last_four_ssn: Últimos 4 del SSN / ITIN
         spouse_last_name: Apellido legal de su cónyuge
         title: Necesitamos que su cónyuge revise algunos asuntos legales nuestros ...
       spouse_email_address:

--- a/spec/controllers/questions/consent_controller_spec.rb
+++ b/spec/controllers/questions/consent_controller_spec.rb
@@ -19,7 +19,9 @@ RSpec.describe Questions::ConsentController do
             birth_date_day: "10",
             primary_first_name: "Greta",
             primary_last_name: "Gnome",
-            primary_last_four_ssn: "5678"
+            primary_ssn: "123455678",
+            primary_ssn_confirmation: "123455678",
+            primary_tin_type: "ssn_no_employment"
           }
         }
       end
@@ -51,7 +53,7 @@ RSpec.describe Questions::ConsentController do
           data: hash_excluding(
             :primary_first_name,
             :primary_last_name,
-            :primary_last_four_ssn
+            :primary_ssn
           )
         ))
       end
@@ -74,7 +76,7 @@ RSpec.describe Questions::ConsentController do
             birth_date_day: "10",
             primary_first_name: "Grindelwald",
             primary_last_name: nil,
-            primary_last_four_ssn: nil
+            primary_ssn: nil
           }
         }
       end
@@ -84,7 +86,8 @@ RSpec.describe Questions::ConsentController do
 
         expect(response).to render_template :edit
         error_messages = assigns(:form).errors.messages
-        expect(error_messages[:primary_last_four_ssn].first).to eq "Please enter the last four digits of your SSN or ITIN."
+        expect(error_messages[:primary_ssn].first).to eq "An SSN or ITIN is required."
+        expect(error_messages[:primary_tin_type].first).to eq "Identification type is required."
         expect(error_messages[:primary_last_name].first).to eq "Please enter your last name."
       end
     end

--- a/spec/controllers/questions/spouse_consent_controller_spec.rb
+++ b/spec/controllers/questions/spouse_consent_controller_spec.rb
@@ -34,7 +34,9 @@ RSpec.describe Questions::SpouseConsentController do
             birth_date_day: "10",
             spouse_first_name: "Greta",
             spouse_last_name: "Gnome",
-            spouse_last_four_ssn: "5678"
+            spouse_ssn: "123456789",
+            spouse_ssn_confirmation: "123456789",
+            spouse_tin_type: "ssn"
           }
         }
       end
@@ -70,7 +72,8 @@ RSpec.describe Questions::SpouseConsentController do
             birth_date_day: "10",
             spouse_first_name: "George",
             spouse_last_name: nil,
-            spouse_last_four_ssn: nil
+            spouse_ssn: nil,
+            spouse_tin_type: nil,
           }
         }
       end
@@ -80,7 +83,8 @@ RSpec.describe Questions::SpouseConsentController do
 
         expect(response).to render_template :edit
         error_messages = assigns(:form).errors.messages
-        expect(error_messages[:spouse_last_four_ssn].first).to eq "Please enter the last four digits of your spouse's SSN or ITIN."
+        expect(error_messages[:spouse_ssn].first).to eq "Spouse SSN or ITIN is required."
+        expect(error_messages[:spouse_tin_type].first).to eq "Identification type is required."
         expect(error_messages[:spouse_last_name].first).to eq "Please enter your spouse's last name."
       end
     end

--- a/spec/factories/intakes.rb
+++ b/spec/factories/intakes.rb
@@ -327,8 +327,6 @@ FactoryBot.define do
   trait :with_ssns do
     primary_ssn { generate_fake_ssn.call }
     spouse_ssn { generate_fake_ssn.call }
-    primary_last_four_ssn { primary_ssn.to_s.last(4) }
-    spouse_last_four_ssn { primary_ssn.to_s.last(4) }
   end
 
   trait :with_documents do

--- a/spec/features/ctc/edit_ctc_client_spec.rb
+++ b/spec/features/ctc/edit_ctc_client_spec.rb
@@ -166,7 +166,6 @@ RSpec.describe "a user editing a clients intake fields" do
       expect(changes_table_contents('.changes-table')).to match({
         "eip1_and_2_amount_received_confidence" => ["sure", "nil"],
         "preferred_name" => ["Colleen Cauliflower", "Colly Cauliflower"],
-        "spouse_last_four_ssn" => ["[REDACTED]", "[REDACTED]"],
         "spouse_tin_type" => ["nil", "ssn"],
       })
     end

--- a/spec/features/ctc/portal_spec.rb
+++ b/spec/features/ctc/portal_spec.rb
@@ -357,7 +357,6 @@ RSpec.feature "CTC Intake", :js, :active_job do
           "spouse_first_name" => ["Eva", "Pomelostore"],
           "has_spouse_ip_pin" => ["unfilled", "no"],
           "spouse_tin_type" => ["nil", "ssn"],
-          "spouse_last_four_ssn" => ["[REDACTED]", "[REDACTED]"],
         })
 
         expect(changes_table_contents(".changes-note-#{notes[3].id}")).to match({

--- a/spec/features/web_intake/new_211_filer_spec.rb
+++ b/spec/features/web_intake/new_211_filer_spec.rb
@@ -33,7 +33,8 @@ RSpec.feature "Web Intake 211 Assisted Filer", :flow_explorer_screenshot do
     expect(page).to have_selector("h1", text: "Great! Here's the legal stuff...")
     fill_in "Legal first name", with: "Gary"
     fill_in "Legal last name", with: "Gnome"
-    fill_in "Last 4 of SSN/ITIN", with: "1234"
+    fill_in I18n.t("attributes.primary_ssn"), with: "123456789"
+    fill_in I18n.t("attributes.confirm_primary_ssn"), with: "123456789"
     select "March", from: "Month"
     select "5", from: "Day"
     select "1971", from: "Year"

--- a/spec/features/web_intake/new_joint_filers_spec.rb
+++ b/spec/features/web_intake/new_joint_filers_spec.rb
@@ -152,7 +152,8 @@ RSpec.feature "Web Intake Joint Filers", :flow_explorer_screenshot do
       expect(page).to have_selector("h1", text: "Great! Here's the legal stuff...")
       fill_in "Legal first name", with: "Gary"
       fill_in "Legal last name", with: "Gnome"
-      fill_in "Last 4 of SSN/ITIN", with: "1234"
+      fill_in I18n.t("attributes.primary_ssn"), with: "123456789"
+      fill_in I18n.t("attributes.confirm_primary_ssn"), with: "123456789"
       select "March", from: "Month"
       select "5", from: "Day"
       select "1971", from: "Year"
@@ -249,7 +250,8 @@ RSpec.feature "Web Intake Joint Filers", :flow_explorer_screenshot do
       expect(page).to have_selector("h1", text: "We need your spouse to review our legal stuff...")
       fill_in "Spouse's legal first name", with: "Greta"
       fill_in "Spouse's legal last name", with: "Gnome"
-      fill_in "Last 4 of SSN/ITIN", with: "1234"
+      fill_in I18n.t("attributes.spouse_ssn"), with: "123456789"
+      fill_in I18n.t("attributes.confirm_spouse_ssn"), with: "123456789"
       select "March", from: "Month"
       select "5", from: "Day"
       select "1971", from: "Year"

--- a/spec/features/web_intake/new_single_filer_spec.rb
+++ b/spec/features/web_intake/new_single_filer_spec.rb
@@ -99,7 +99,8 @@ RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot, active_job: 
     expect(page).to have_selector("h1", text: "Great! Here's the legal stuff...")
     fill_in "Legal first name", with: "Gary"
     fill_in "Legal last name", with: "Gnome"
-    fill_in "Last 4 of SSN/ITIN", with: "1234"
+    fill_in I18n.t("attributes.primary_ssn"), with: "123456789"
+    fill_in I18n.t("attributes.confirm_primary_ssn"), with: "123456789"
     select "March", from: "Month"
     select "5", from: "Day"
     select "1971", from: "Year"

--- a/spec/forms/consent_form_spec.rb
+++ b/spec/forms/consent_form_spec.rb
@@ -79,17 +79,6 @@ RSpec.describe ConsentForm do
       end
     end
 
-    context "when tin_type is ssn and ssn_no_employment is yes" do
-      let(:params) { valid_params.merge(primary_tin_type: "ssn", ssn_no_employment: "yes") }
-
-      it "sets tin type to ssn no employment" do
-        form = ConsentForm.new(intake, params)
-        form.valid?
-        form.save
-        expect(form.intake.reload.primary_tin_type).to eq "ssn_no_employment"
-      end
-    end
-
     context "when the date is not valid" do
       let(:params) { valid_params.merge(birth_date_month: "2", birth_date_day: "31") }
 

--- a/spec/forms/consent_form_spec.rb
+++ b/spec/forms/consent_form_spec.rb
@@ -15,7 +15,9 @@ RSpec.describe ConsentForm do
         birth_date_day: "10",
         primary_first_name: "Greta",
         primary_last_name: "Gnome",
-        primary_last_four_ssn: "5678"
+        primary_ssn: "123456789",
+        primary_ssn_confirmation: "123456789",
+        primary_tin_type: "ssn"
       }
     )
   end
@@ -40,7 +42,9 @@ RSpec.describe ConsentForm do
               birth_date_day: "10",
               primary_first_name: "Greta",
               primary_last_name: nil,
-              primary_last_four_ssn: nil
+              primary_ssn: nil,
+              primary_ssn_confirmation: nil,
+              primary_tin_type: nil
             }
           )
         )
@@ -48,18 +52,41 @@ RSpec.describe ConsentForm do
         expect(form).not_to be_valid
         expect(form.errors[:birth_date]).to be_present
         expect(form.errors[:primary_last_name]).to be_present
-        expect(form.errors[:primary_last_four_ssn]).to be_present
+        expect(form.errors[:primary_ssn]).to be_present
+        expect(form.errors[:primary_tin_type]).to be_present
       end
     end
 
-    context "with a last_four_ssn of a different length" do
-      let(:params) { valid_params.merge(primary_last_four_ssn: "765") }
+    context "with a last_four_ssn that is too short" do
+      let(:params) { valid_params.merge(primary_ssn: "765") }
 
       it "adds a validation error" do
         form = ConsentForm.new(intake, params)
 
         expect(form).not_to be_valid
-        expect(form.errors[:primary_last_four_ssn]).to be_present
+        expect(form.errors[:primary_ssn]).to be_present
+      end
+    end
+
+    context "with a last_four_ssn that is too long" do
+      let(:params) { valid_params.merge(primary_ssn: "12345678987654323") }
+
+      it "adds a validation error" do
+        form = ConsentForm.new(intake, params)
+
+        expect(form).not_to be_valid
+        expect(form.errors[:primary_ssn]).to be_present
+      end
+    end
+
+    context "when tin_type is ssn and ssn_no_employment is yes" do
+      let(:params) { valid_params.merge(primary_tin_type: "ssn", ssn_no_employment: "yes") }
+
+      it "sets tin type to ssn no employment" do
+        form = ConsentForm.new(intake, params)
+        form.valid?
+        form.save
+        expect(form.intake.reload.primary_tin_type).to eq "ssn_no_employment"
       end
     end
 

--- a/spec/forms/spouse_consent_form_spec.rb
+++ b/spec/forms/spouse_consent_form_spec.rb
@@ -78,18 +78,6 @@ RSpec.describe SpouseConsentForm do
       end
     end
 
-    context "when ssn_no_employment is yes and tin_type is ssn" do
-      let(:params) { valid_params.merge(spouse_tin_type: "ssn", ssn_no_employment: "yes") }
-
-      it "persists tin_type as ssn_no_employment" do
-        form = SpouseConsentForm.new(intake, params)
-        form.valid?
-        form.save
-
-        expect(form.intake.reload.spouse_tin_type).to eq "ssn_no_employment"
-      end
-    end
-
     context "when the date is not valid" do
       let(:params) { valid_params.merge(birth_date_month: "2", birth_date_day: "31") }
 

--- a/spec/forms/spouse_consent_form_spec.rb
+++ b/spec/forms/spouse_consent_form_spec.rb
@@ -15,7 +15,9 @@ RSpec.describe SpouseConsentForm do
         birth_date_day: "10",
         spouse_first_name: "Greta",
         spouse_last_name: "Gnome",
-        spouse_last_four_ssn: "5678"
+        spouse_tin_type: "ssn",
+        spouse_ssn: "123456789",
+        spouse_ssn_confirmation: "123456789"
       }
     )
   end
@@ -40,7 +42,8 @@ RSpec.describe SpouseConsentForm do
               birth_date_day: "10",
               spouse_first_name: "Greta",
               spouse_last_name: nil,
-              spouse_last_four_ssn: nil
+              spouse_ssn: nil,
+              spouse_tin_type: nil
             }
           )
         )
@@ -48,18 +51,42 @@ RSpec.describe SpouseConsentForm do
         expect(form).not_to be_valid
         expect(form.errors[:birth_date]).to be_present
         expect(form.errors[:spouse_last_name]).to be_present
-        expect(form.errors[:spouse_last_four_ssn]).to be_present
+        expect(form.errors[:spouse_ssn]).to be_present
+        expect(form.errors[:spouse_tin_type]).to be_present
       end
     end
 
-    context "with a last_four_ssn of a different length" do
-      let(:params) { valid_params.merge(spouse_last_four_ssn: "765") }
+    context "with a spouse_ssn that is too short" do
+      let(:params) { valid_params.merge(spouse_ssn: "765") }
 
       it "adds a validation error" do
         form = SpouseConsentForm.new(intake, params)
 
         expect(form).not_to be_valid
-        expect(form.errors[:spouse_last_four_ssn]).to be_present
+        expect(form.errors[:spouse_ssn]).to be_present
+      end
+    end
+
+    context "with a spouse_ssn that is too long" do
+      let(:params) { valid_params.merge(spouse_ssn: "765123123123123123123123") }
+
+      it "adds a validation error" do
+        form = SpouseConsentForm.new(intake, params)
+
+        expect(form).not_to be_valid
+        expect(form.errors[:spouse_ssn]).to be_present
+      end
+    end
+
+    context "when ssn_no_employment is yes and tin_type is ssn" do
+      let(:params) { valid_params.merge(spouse_tin_type: "ssn", ssn_no_employment: "yes") }
+
+      it "persists tin_type as ssn_no_employment" do
+        form = SpouseConsentForm.new(intake, params)
+        form.valid?
+        form.save
+
+        expect(form.intake.reload.spouse_tin_type).to eq "ssn_no_employment"
       end
     end
 

--- a/spec/models/dependent_spec.rb
+++ b/spec/models/dependent_spec.rb
@@ -114,24 +114,6 @@ describe Dependent do
     end
   end
 
-  describe "#last_four_ssn" do
-    context "with an SSN filled out" do
-      let(:dependent) { build :dependent, ssn: "123456789" }
-
-      it "returns the last four digits" do
-        expect(dependent.last_four_ssn).to eq "6789"
-      end
-    end
-
-    context "without an SSN filled out" do
-      let(:dependent) { build :dependent, ssn: nil }
-
-      it "returns nil" do
-        expect(dependent.last_four_ssn).to be_nil
-      end
-    end
-  end
-
   describe "#meets_qc_misc_conditions?" do
     context "with a dependent that paid for more than half their expenses" do
       let(:dependent) { build :dependent, provided_over_half_own_support: "yes" }

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -317,6 +317,74 @@ describe Intake do
     end
   end
 
+  describe "keeping last 4 ssn in sync with ssn" do
+    context "when creating the object" do
+      let(:intake) { create :intake, primary_ssn: "12345678", spouse_ssn: "2345677777" }
+
+      it "updates last_four values when setting" do
+        expect(intake.primary_last_four_ssn).to eq "5678"
+        expect(intake.spouse_last_four_ssn).to eq "7777"
+      end
+    end
+
+    context "primary_ssn" do
+      let!(:intake) { create :intake, primary_ssn: "12345678", spouse_ssn: "2345677777" }
+
+      context "when removing primary_ssn" do
+        it "sets primary_last_four_ssn to nil" do
+          expect{
+            intake.update(primary_ssn: nil)
+          }.to change(intake, :primary_last_four_ssn).to(nil)
+        end
+      end
+
+      context "when setting primary_ssn to an empty string" do
+        it "sets primary_last_four_ssn to an empty string" do
+          expect{
+            intake.update(primary_ssn: "")
+          }.to change(intake, :primary_last_four_ssn).to("")
+        end
+      end
+
+      context "when changing primary_ssn" do
+        it "sets primary_last_four_ssn to a new value" do
+          expect{
+            intake.update(primary_ssn: "123456666")
+          }.to change(intake, :primary_last_four_ssn).to("6666")
+        end
+      end
+    end
+
+    context "spouse_ssn" do
+      let!(:intake) { create :intake, primary_ssn: "12345678", spouse_ssn: "2345677777" }
+
+      context "when removing spouse_ssn" do
+        it "sets spouse_last_four_ssn to nil" do
+          expect{
+            intake.update(spouse_ssn: nil)
+          }.to change(intake, :spouse_last_four_ssn).to(nil)
+        end
+      end
+
+      context "when setting spouse_ssn to an empty string" do
+        it "sets spouse_last_four_ssn to an empty string" do
+          expect{
+            intake.update(spouse_ssn: "")
+          }.to change(intake, :spouse_last_four_ssn).to("")
+        end
+      end
+
+      context "when changing spouse_ssn" do
+        it "sets spouse_last_four_ssn to a new value" do
+          expect{
+            intake.update(spouse_ssn: "123456666")
+          }.to change(intake, :spouse_last_four_ssn).to("6666")
+        end
+      end
+    end
+
+  end
+
   describe "canonical_email_address" do
     it "is persisted when the intake is saved" do
       example_intake = Intake.create!(email_address: "a.REAL.email@example.com", visitor_id: "visitor_id")

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -319,7 +319,7 @@ describe Intake do
 
   describe "keeping last 4 ssn in sync with ssn" do
     context "when creating the object" do
-      let(:intake) { create :intake, primary_ssn: "12345678", spouse_ssn: "2345677777" }
+      let(:intake) { create :intake, primary_ssn: "12345678", spouse_ssn: "234567777" }
 
       it "updates last_four values when setting" do
         expect(intake.primary_last_four_ssn).to eq "5678"


### PR DESCRIPTION
Switch to TIN Type + Full SSN on spouse and primary legal consent pages in GYR.

Also, now we will update the last 4 any time the intake is persisted with the full ssn updated.