### PR TITLE
Update invitations page selection + user edit tweaks

### DIFF
--- a/app/assets/stylesheets/_honeycrisp-compact.scss
+++ b/app/assets/stylesheets/_honeycrisp-compact.scss
@@ -176,6 +176,13 @@
         display: none;
       }
     }
+    .select, select {
+      width: 100%;
+    }
+    input:disabled, select:disabled {
+      background-color: darken($color-grey-light, 5%);
+      cursor: not-allowed;
+    }
   }
 
   .checkbox-group {

--- a/app/helpers/role_helper.rb
+++ b/app/helpers/role_helper.rb
@@ -1,6 +1,10 @@
 module RoleHelper
   def user_role(user)
-    case user.role_type
+    readable_role_from_role_type(user.role_type)
+  end
+
+  def readable_role_from_role_type(role_type)
+    case role_type
     when AdminRole::TYPE
       I18n.t("general.admin")
     when OrganizationLeadRole::TYPE
@@ -15,7 +19,7 @@ module RoleHelper
       I18n.t("general.greeter")
     when TeamMemberRole::TYPE
       I18n.t("general.team_member")
-    end
+    end.titleize
   end
 
   def user_group(user)

--- a/app/helpers/time_helper.rb
+++ b/app/helpers/time_helper.rb
@@ -32,10 +32,11 @@ module TimeHelper
     entry.presence && entry[0]
   end
 
-  def formatted_datetime(datetime)
+  def formatted_datetime(datetime, year: false)
     return unless datetime
 
-    datetime.strftime("%b %d %-l:%M %p")
+    format = year ? "%b %d %Y %-l:%M %p" : "%b %d %-l:%M %p"
+    datetime.strftime(format)
   end
 
   def formatted_business_days_ago(time)
@@ -45,11 +46,5 @@ module TimeHelper
     converted_now = Date.parse(DateTime.now.utc.to_s)
 
     converted_time.business_days_until(converted_now)
-  end
-
-  def formatted_datetime(datetime)
-    return unless datetime
-
-    tag.span(datetime.strftime("%b %d %-l:%M %p"))
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -122,6 +122,18 @@ class User < ApplicationRecord
     end
   end
 
+  def self.roles
+    [
+      AdminRole::TYPE,
+      ClientSuccessRole::TYPE,
+      GreeterRole::TYPE,
+      CoalitionLeadRole::TYPE,
+      OrganizationLeadRole::TYPE,
+      SiteCoordinatorRole::TYPE,
+      TeamMemberRole::TYPE
+    ]
+  end
+
   def accessible_users
     case role_type
     when AdminRole::TYPE

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -126,8 +126,8 @@ class User < ApplicationRecord
     [
       AdminRole::TYPE,
       ClientSuccessRole::TYPE,
-      GreeterRole::TYPE,
       CoalitionLeadRole::TYPE,
+      GreeterRole::TYPE,
       OrganizationLeadRole::TYPE,
       SiteCoordinatorRole::TYPE,
       TeamMemberRole::TYPE

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -20,7 +20,7 @@
       <% if params[:role] == OrganizationLeadRole::TYPE %>
         <div class="form-group">
           <%= label_tag(:organization_id, t(".organization_label"), class: "form-question") %>
-          <div class="select form-width--long"">
+          <div class="select form-width--long">
             <%= select_tag :organization_id, options_for_select(@vita_partners.organizations.map { |org| [org.name, org.id] }), class: "select__element" %>
           </div>
         </div>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -37,8 +37,9 @@
 
       <% if params[:role] == SiteCoordinatorRole::TYPE %>
         <div class="form-group">
+          <%= label_tag(:site_id, t(".site_label"), class: "form-question") %>
+
           <div class="select form-width--long">
-            <%= label_tag(:site_id, t(".site_label"), class: "form-question") %>
             <%= select_tag(:site_id, options_for_select(@vita_partners.sites.map { |site| [site.name, site.id] }), class: "select__element") %>
           </div>
         </div>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -1,7 +1,7 @@
 <% @main_heading = t(".title") %>
 <% content_for :page_title, @main_heading %>
 <% content_for :card do %>
-  <div class="slab">
+  <div class="slab slab--not-padded">
     <%= form_for(resource, as: resource_name, url: invitation_path(resource_name), local: true, builder: VitaMinFormBuilder, html: { method: :post }) do |f| %>
       <h1><%= @main_heading %></h1>
 
@@ -10,32 +10,56 @@
           <li><%= error_message %></li>
         <% end %>
       </ul>
+      <div class="form-group">
+        <%= label_tag(:role, "Which role?", class: "form-question") %>
+        <div class="select form-width--long">
+          <%= select_tag(:role, options_for_select([readable_role_from_role_type(params[:role]), params[:role]]), class: "select__element", disabled: true, style: "background-color: #F8F8F8") %>
+        </div>
+      </div>
+
+      <% if params[:role] == OrganizationLeadRole::TYPE %>
+        <div class="form-group">
+          <%= label_tag(:organization_id, t(".organization_label"), class: "form-question") %>
+          <div class="select form-width--long"">
+            <%= select_tag :organization_id, options_for_select(@vita_partners.organizations.map { |org| [org.name, org.id] }), class: "select__element" %>
+          </div>
+        </div>
+      <% end %>
+
+      <% if params[:role] == CoalitionLeadRole::TYPE %>
+        <div class="form-group">
+          <%= label_tag(:coalition_id, t(".coalition_label"), class: "form-question") %>
+          <div class="select form-width--long">
+            <%= select_tag(:coalition_id, options_for_select(@coalitions.all.map { |coalition| [coalition.name, coalition.id] }), class: "select__element") %>
+          </div>
+        </div>
+      <% end %>
+
+      <% if params[:role] == SiteCoordinatorRole::TYPE %>
+        <div class="form-group">
+          <div class="select form-width--long">
+            <%= label_tag(:site_id, t(".site_label"), class: "form-question") %>
+            <%= select_tag(:site_id, options_for_select(@vita_partners.sites.map { |site| [site.name, site.id] }), class: "select__element") %>
+          </div>
+        </div>
+      <% end %>
+
+      <% if params[:role] == TeamMemberRole::TYPE %>
+        <div class="form-group">
+          <%= label_tag(:site_id, t(".site_label"), class: "form-question") %>
+          <div class="select form-width--long">
+            <%= select_tag(:site_id, options_for_select(@vita_partners.sites.map { |site| [site.name, site.id] }), class: "select__element") %>
+          </div>
+        </div>
+      <% end %>
 
       <%= f.cfa_input_field(:name, t(".name_label"), classes: ['form-width--long']) %>
       <%= f.cfa_input_field(:email, t(".email_label"), type: 'email', classes: ['form-width--long']) %>
-      <%= f.hidden_field :role, value: params.dig(:user, :role) %>
+      <%= f.hidden_field(:role, value: params[:role]) %>
 
-      <% if params.dig(:user, :role) == OrganizationLeadRole::TYPE %>
-        <%= label_tag(:organization_id, t(".organization_label")) %>
-        <%= select_tag :organization_id, options_for_select(@vita_partners.organizations.map { |org| [org.name, org.id] }) %>
-      <% end %>
-
-      <% if params.dig(:user, :role) == CoalitionLeadRole::TYPE %>
-        <%= label_tag(:coalition_id, t(".coalition_label")) %>
-        <%= select_tag(:coalition_id, options_for_select(@coalitions.all.map { |coalition| [coalition.name, coalition.id] })) %>
-      <% end %>
-
-      <% if params.dig(:user, :role) == SiteCoordinatorRole::TYPE %>
-        <%= label_tag(:site_id, t(".site_label")) %>
-        <%= select_tag(:site_id, options_for_select(@vita_partners.sites.map { |site| [site.name, site.id] })) %>
-      <% end %>
-
-      <% if params.dig(:user, :role) == TeamMemberRole::TYPE %>
-        <%= label_tag(:site_id, t(".site_label")) %>
-        <%= select_tag(:site_id, options_for_select(@vita_partners.sites.map { |site| [site.name, site.id] })) %>
-      <% end %>
-
-      <%= f.submit t(".submit"), class: "button button--primary" %>
+      <div>
+        <%= f.submit t(".submit"), class: "button button--primary" %>
+      </div>
     <% end %>
   </div>
 <% end %>

--- a/app/views/hub/users/edit.html.erb
+++ b/app/views/hub/users/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, @user.name %>
 <% content_for :card do %>
   <div class ="slab slab--padded">
-    <div class="client-container">
+    <div>
       <h1><%= @user.name %></h1>
 
       <% if current_user.admin? %>
@@ -16,15 +16,20 @@
         <% end %>
       <% end %>
 
-      <%= form_with model: [:hub, @user], method: :put, local: true, builder: VitaMinFormBuilder, html: { class: 'form-card form-card--long' } do |f| %>
-        <p>
-          <strong><%= t("general.email") %>:</strong> <%= @user.email %>
-          <%= link_to t("general.resend_invitation"), user_profile_resend_invitation_path(user_id: @user.id), class: "button button-small", method: :put %>
-        </p>
+      <%= form_with model: [:hub, @user], method: :put, local: true, builder: VitaMinFormBuilder, html: { class: 'form-card' } do |f| %>
+        <div>
+          <div class="form-group">
+            <%= label_tag(:email, t("general.email"), class: "form-question") %>
+            <%= text_field_tag :email, @user.email, disabled: true, class: "text-input form-width--long" %>
+            <%= link_to t("general.resend_invitation"), user_profile_resend_invitation_path(user_id: @user.id), class: "button button--small spacing-above-5", style:"margin-bottom: 0", method: :put %>
+          </div>
+        </div>
 
-        <%= f.cfa_input_field(:name, t("general.name")) %>
-        <%= f.cfa_input_field(:phone_number, t("general.phone_number"), type: "phone") %>
-        <%= f.cfa_select(:timezone, t("general.timezone"), timezone_select_options) %>
+        <%= f.cfa_input_field(:name, t("general.name"), classes: ['form-width--long']) %>
+        <%= f.cfa_input_field(:phone_number, t("general.phone_number"), classes: ['form-width--long']) %>
+        <div class="form-width--long">
+          <%= f.cfa_select(:timezone, t("general.timezone"), timezone_select_options) %>
+        </div>
 
         <button class="button button--cta" type="submit">
           <%=t("general.save") %>
@@ -36,17 +41,20 @@
 
         <p id="current-role"><%= [user_role(@user), user_group(@user)].compact.join(", ") %></p>
 
-        <%= render('components/molecules/reveal', title: t(".reassign")) do %>
-          <ul class="list--bulleted">
-            <li><%= link_to t("general.admin"), edit_role_hub_user_path({user: {role: AdminRole::TYPE}}) %></li>
-            <li><%= link_to t("general.client_success"), edit_role_hub_user_path({user: {role: ClientSuccessRole::TYPE}}) %></li>
-            <li><%= link_to t("general.greeter"), edit_role_hub_user_path({user: {role: GreeterRole::TYPE}}) %></li>
-            <li><%= link_to t("general.coalition_lead"), edit_role_hub_user_path({user: {role: CoalitionLeadRole::TYPE}}) %></li>
-            <li><%= link_to t("general.organization_lead"), edit_role_hub_user_path({user: {role: OrganizationLeadRole::TYPE}}) %></li>
-            <li><%= link_to t("general.site_coordinator"), edit_role_hub_user_path({user: {role: SiteCoordinatorRole::TYPE}}) %></li>
-            <li><%= link_to t("general.team_member"), edit_role_hub_user_path({user: {role: TeamMemberRole::TYPE}}) %></li>
-          </ul>
-        <% end %>
+        <div style="width: 375px">
+          <%= render('components/molecules/reveal', title: t(".reassign")) do %>
+            <ul class="list--bulleted">
+              <li><%= link_to t("general.admin"), edit_role_hub_user_path({user: {role: AdminRole::TYPE}}) %></li>
+              <li><%= link_to t("general.client_success"), edit_role_hub_user_path({user: {role: ClientSuccessRole::TYPE}}) %></li>
+              <li><%= link_to t("general.greeter"), edit_role_hub_user_path({user: {role: GreeterRole::TYPE}}) %></li>
+              <li><%= link_to t("general.coalition_lead"), edit_role_hub_user_path({user: {role: CoalitionLeadRole::TYPE}}) %></li>
+              <li><%= link_to t("general.organization_lead"), edit_role_hub_user_path({user: {role: OrganizationLeadRole::TYPE}}) %></li>
+              <li><%= link_to t("general.site_coordinator"), edit_role_hub_user_path({user: {role: SiteCoordinatorRole::TYPE}}) %></li>
+              <li><%= link_to t("general.team_member"), edit_role_hub_user_path({user: {role: TeamMemberRole::TYPE}}) %></li>
+            </ul>
+          <% end %>
+        </div>
+
       <% end %>
     </div>
   </div>

--- a/app/views/hub/users/edit.html.erb
+++ b/app/views/hub/users/edit.html.erb
@@ -21,7 +21,9 @@
           <div class="form-group">
             <%= label_tag(:email, t("general.email"), class: "form-question") %>
             <%= text_field_tag :email, @user.email, disabled: true, class: "text-input form-width--long" %>
-            <%= link_to t("general.resend_invitation"), user_profile_resend_invitation_path(user_id: @user.id), class: "button button--small spacing-above-5", style:"margin-bottom: 0", method: :put %>
+            <% unless @user.invitation_accepted? %>
+              <%= link_to t("general.resend_invitation"), user_profile_resend_invitation_path(user_id: @user.id), class: "button button--small spacing-above-5", style:"margin-bottom: 0", method: :put %>
+            <% end %>
           </div>
         </div>
 
@@ -44,13 +46,9 @@
         <div style="width: 375px">
           <%= render('components/molecules/reveal', title: t(".reassign")) do %>
             <ul class="list--bulleted">
-              <li><%= link_to t("general.admin"), edit_role_hub_user_path({user: {role: AdminRole::TYPE}}) %></li>
-              <li><%= link_to t("general.client_success"), edit_role_hub_user_path({user: {role: ClientSuccessRole::TYPE}}) %></li>
-              <li><%= link_to t("general.greeter"), edit_role_hub_user_path({user: {role: GreeterRole::TYPE}}) %></li>
-              <li><%= link_to t("general.coalition_lead"), edit_role_hub_user_path({user: {role: CoalitionLeadRole::TYPE}}) %></li>
-              <li><%= link_to t("general.organization_lead"), edit_role_hub_user_path({user: {role: OrganizationLeadRole::TYPE}}) %></li>
-              <li><%= link_to t("general.site_coordinator"), edit_role_hub_user_path({user: {role: SiteCoordinatorRole::TYPE}}) %></li>
-              <li><%= link_to t("general.team_member"), edit_role_hub_user_path({user: {role: TeamMemberRole::TYPE}}) %></li>
+              <% User.roles.each do |role_type| %>
+                <li><%= link_to readable_role_from_role_type(role_type), edit_role_hub_user_path(role: role_type) if can?(:manage, role_type.constantize) %></li>
+              <% end %>
             </ul>
           <% end %>
         </div>

--- a/app/views/hub/users/edit_role.html.erb
+++ b/app/views/hub/users/edit_role.html.erb
@@ -1,74 +1,76 @@
 <% content_for :page_title, @user.name %>
 <% content_for :card do %>
-  <h1><%= @user.name %></h1>
+  <div class="slab slab--padded">
+    <h1><%= @user.name %></h1>
 
-  <h2>Current role</h2>
+    <h2>Current role</h2>
 
-  <p><%= [user_role(@user), user_group(@user)].compact.join(", ") %></p>
+    <p><%= [user_role(@user), user_group(@user)].compact.join(", ") %></p>
 
-  <h2>New role</h2>
+    <h2>New role</h2>
 
-  <%= form_for(@user, method: :patch, url: update_role_hub_user_path, local: true, builder: VitaMinFormBuilder) do |f| %>
+    <%= form_for(@user, method: :patch, url: update_role_hub_user_path, local: true, builder: VitaMinFormBuilder) do |f| %>
 
-    <%= f.hidden_field :role, value: params[:role] %>
-    <% if params[:role] == AdminRole::TYPE %>
-      <p><%= t("general.admin") %></p>
-    <% end %>
+      <%= f.hidden_field :role, value: params[:role] %>
+      <% if params[:role] == AdminRole::TYPE %>
+        <p><%= t("general.admin") %></p>
+      <% end %>
 
-    <% if params[:role] == ClientSuccessRole::TYPE %>
-      <p><%= t("general.client_success") %></p>
-    <% end %>
+      <% if params[:role] == ClientSuccessRole::TYPE %>
+        <p><%= t("general.client_success") %></p>
+      <% end %>
 
-    <% if params[:role] == GreeterRole::TYPE %>
-      <p><%= t("general.greeter") %></p>
-    <% end %>
+      <% if params[:role] == GreeterRole::TYPE %>
+        <p><%= t("general.greeter") %></p>
+      <% end %>
 
-    <% if params[:role] == CoalitionLeadRole::TYPE %>
-      <p><%= readable_role_from_role_type(CoalitionLeadRole::TYPE) %></p>
-      <div class="form-group">
-        <%= label_tag(:coalition_id, t("devise.invitations.new.coalition_label"), class: "form-question") %>
-        <div class="select form-width--long">
-          <%= select_tag(:coalition_id, options_for_select(@coalitions.all.map { |coalition| [coalition.name, coalition.id] }), class: "select__element") %>
+      <% if params[:role] == CoalitionLeadRole::TYPE %>
+        <p><%= readable_role_from_role_type(CoalitionLeadRole::TYPE) %></p>
+        <div class="form-group">
+          <%= label_tag(:coalition_id, t("devise.invitations.new.coalition_label"), class: "form-question") %>
+          <div class="select form-width--long">
+            <%= select_tag(:coalition_id, options_for_select(@coalitions.all.map { |coalition| [coalition.name, coalition.id] }), class: "select__element") %>
+          </div>
         </div>
-      </div>
-    <% end %>
+      <% end %>
 
-    <% if params[:role] == OrganizationLeadRole::TYPE %>
-      <p><%= readable_role_from_role_type(OrganizationLeadRole::TYPE) %></p>
-      <div class="form-group">
-        <%= label_tag(:organization_id, t("devise.invitations.new.organization_label"), class: "form-question") %>
-        <div class="select form-width--long">
-          <%= select_tag :organization_id, options_for_select(@vita_partners.organizations.map { |org| [org.name, org.id] }), class: "select__element" %>
+      <% if params[:role] == OrganizationLeadRole::TYPE %>
+        <p><%= readable_role_from_role_type(OrganizationLeadRole::TYPE) %></p>
+        <div class="form-group">
+          <%= label_tag(:organization_id, t("devise.invitations.new.organization_label"), class: "form-question") %>
+          <div class="select form-width--long">
+            <%= select_tag :organization_id, options_for_select(@vita_partners.organizations.map { |org| [org.name, org.id] }), class: "select__element" %>
+          </div>
         </div>
-      </div>
-    <% end %>
+      <% end %>
 
-    <% if params[:role] == SiteCoordinatorRole::TYPE %>
-      <p><%= readable_role_from_role_type(SiteCoordinatorRole::TYPE) %></p>
+      <% if params[:role] == SiteCoordinatorRole::TYPE %>
+        <p><%= readable_role_from_role_type(SiteCoordinatorRole::TYPE) %></p>
 
-      <div class="form-group">
-        <div class="select form-width--long">
+        <div class="form-group">
+          <div class="select form-width--long">
+            <%= label_tag(:site_id, t("devise.invitations.new.site_label"), class: "form-question") %>
+            <%= select_tag(:site_id, options_for_select(@vita_partners.sites.map { |site| [site.name, site.id] }), class: "select__element") %>
+          </div>
+        </div>
+      <% end %>
+
+      <% if params[:role] == TeamMemberRole::TYPE %>
+        <p><%= readable_role_from_role_type(TeamMemberRole::TYPE) %></p>
+
+        <div class="form-group">
           <%= label_tag(:site_id, t("devise.invitations.new.site_label"), class: "form-question") %>
-          <%= select_tag(:site_id, options_for_select(@vita_partners.sites.map { |site| [site.name, site.id] }), class: "select__element") %>
+          <div class="select form-width--long">
+            <%= select_tag(:site_id, options_for_select(@vita_partners.sites.map { |site| [site.name, site.id] }), class: "select__element") %>
+          </div>
         </div>
+      <% end %>
+
+      <div>
+        <%= f.submit t("general.submit"), class: "button button--primary" %>
+
+        <%= link_to t("general.cancel"), edit_hub_user_path, class: "button" %>
       </div>
     <% end %>
-
-    <% if params[:role] == TeamMemberRole::TYPE %>
-      <p><%= readable_role_from_role_type(TeamMemberRole::TYPE) %></p>
-
-      <div class="form-group">
-        <%= label_tag(:site_id, t("devise.invitations.new.site_label"), class: "form-question") %>
-        <div class="select form-width--long">
-          <%= select_tag(:site_id, options_for_select(@vita_partners.sites.map { |site| [site.name, site.id] }), class: "select__element") %>
-        </div>
-      </div>
-    <% end %>
-
-    <div>
-      <%= f.submit t("general.submit"), class: "button button--primary" %>
-
-      <%= link_to t("general.cancel"), edit_hub_user_path, class: "button" %>
-    </div>
-  <% end %>
+  </div>
 <% end %>

--- a/app/views/hub/users/edit_role.html.erb
+++ b/app/views/hub/users/edit_role.html.erb
@@ -10,41 +10,59 @@
 
   <%= form_for(@user, method: :patch, url: update_role_hub_user_path, local: true, builder: VitaMinFormBuilder) do |f| %>
 
-    <%= f.hidden_field :role, value: params.dig(:user, :role) %>
-    <% if params.dig(:user, :role) == AdminRole::TYPE %>
+    <%= f.hidden_field :role, value: params[:role] %>
+    <% if params[:role] == AdminRole::TYPE %>
       <p><%= t("general.admin") %></p>
     <% end %>
 
-    <% if params.dig(:user, :role) == ClientSuccessRole::TYPE %>
+    <% if params[:role] == ClientSuccessRole::TYPE %>
       <p><%= t("general.client_success") %></p>
     <% end %>
 
-    <% if params.dig(:user, :role) == GreeterRole::TYPE %>
+    <% if params[:role] == GreeterRole::TYPE %>
       <p><%= t("general.greeter") %></p>
     <% end %>
 
-    <% if params.dig(:user, :role) == CoalitionLeadRole::TYPE %>
-      <p><%= t("general.coalition_lead") %></p>
-      <%= label_tag(:coalition_id, t("devise.invitations.new.coalition_label")) %>
-      <%= select_tag(:coalition_id, options_for_select(@coalitions.all.map { |coalition| [coalition.name, coalition.id] })) %>
+    <% if params[:role] == CoalitionLeadRole::TYPE %>
+      <p><%= readable_role_from_role_type(CoalitionLeadRole::TYPE) %></p>
+      <div class="form-group">
+        <%= label_tag(:coalition_id, t("devise.invitations.new.coalition_label"), class: "form-question") %>
+        <div class="select form-width--long">
+          <%= select_tag(:coalition_id, options_for_select(@coalitions.all.map { |coalition| [coalition.name, coalition.id] }), class: "select__element") %>
+        </div>
+      </div>
     <% end %>
 
-    <% if params.dig(:user, :role) == OrganizationLeadRole::TYPE %>
-      <p><%= t("general.organization_lead") %></p>
-      <%= label_tag(:organization_id, t("devise.invitations.new.organization_label")) %>
-      <%= select_tag(:organization_id, options_for_select(@vita_partners.organizations.map { |org| [org.name, org.id] })) %>
+    <% if params[:role] == OrganizationLeadRole::TYPE %>
+      <p><%= readable_role_from_role_type(OrganizationLeadRole::TYPE) %></p>
+      <div class="form-group">
+        <%= label_tag(:organization_id, t("devise.invitations.new.organization_label"), class: "form-question") %>
+        <div class="select form-width--long">
+          <%= select_tag :organization_id, options_for_select(@vita_partners.organizations.map { |org| [org.name, org.id] }), class: "select__element" %>
+        </div>
+      </div>
     <% end %>
 
-    <% if params.dig(:user, :role) == SiteCoordinatorRole::TYPE %>
-      <p><%= t("general.site_coordinator") %></p>
-      <%= label_tag(:site_id, t("devise.invitations.new.site_label")) %>
-      <%= select_tag(:site_id, options_for_select(@vita_partners.sites.map { |site| [site.name, site.id] })) %>
+    <% if params[:role] == SiteCoordinatorRole::TYPE %>
+      <p><%= readable_role_from_role_type(SiteCoordinatorRole::TYPE) %></p>
+
+      <div class="form-group">
+        <div class="select form-width--long">
+          <%= label_tag(:site_id, t("devise.invitations.new.site_label"), class: "form-question") %>
+          <%= select_tag(:site_id, options_for_select(@vita_partners.sites.map { |site| [site.name, site.id] }), class: "select__element") %>
+        </div>
+      </div>
     <% end %>
 
-    <% if params.dig(:user, :role) == TeamMemberRole::TYPE %>
-      <p><%= t("general.team_member") %></p>
-      <%= label_tag(:site_id, t("devise.invitations.new.site_label")) %>
-      <%= select_tag(:site_id, options_for_select(@vita_partners.sites.map { |site| [site.name, site.id] })) %>
+    <% if params[:role] == TeamMemberRole::TYPE %>
+      <p><%= readable_role_from_role_type(TeamMemberRole::TYPE) %></p>
+
+      <div class="form-group">
+        <%= label_tag(:site_id, t("devise.invitations.new.site_label"), class: "form-question") %>
+        <div class="select form-width--long">
+          <%= select_tag(:site_id, options_for_select(@vita_partners.sites.map { |site| [site.name, site.id] }), class: "select__element") %>
+        </div>
+      </div>
     <% end %>
 
     <div>

--- a/app/views/hub/users/edit_role.html.erb
+++ b/app/views/hub/users/edit_role.html.erb
@@ -48,8 +48,8 @@
         <p><%= readable_role_from_role_type(SiteCoordinatorRole::TYPE) %></p>
 
         <div class="form-group">
+          <%= label_tag(:site_id, t("devise.invitations.new.site_label"), class: "form-question") %>
           <div class="select form-width--long">
-            <%= label_tag(:site_id, t("devise.invitations.new.site_label"), class: "form-question") %>
             <%= select_tag(:site_id, options_for_select(@vita_partners.sites.map { |site| [site.name, site.id] }), class: "select__element") %>
           </div>
         </div>

--- a/app/views/invitations/index.html.erb
+++ b/app/views/invitations/index.html.erb
@@ -10,21 +10,19 @@
     </div>
       <%= f.submit "Continue", class: "button button--primary" %>
     <% end %>
-
     <hr/>
     <h3><%= @unaccepted_invitations.length %> outstanding invitations</h3>
     <% if @unaccepted_invitations.present? %>
       <ul class="invitations">
         <% @unaccepted_invitations.each do |invited_user| %>
           <li id="invitation-<%= invited_user.id %>" class="invitation">
-            <%= invited_user.name %> (<%= user_role(invited_user) %>) &lt;<%= invited_user.email %>&gt; <%= user_group(invited_user) %> (<%= t(".invitation.sent_at", datetime: formatted_datetime(invited_user.invitation_sent_at) %>)
+            <%= invited_user.name %> (<%= user_role(invited_user) %>) &lt;<%= invited_user.email %>&gt; <%= user_group(invited_user) %> (<%= t(".invitation.sent_at", datetime: formatted_datetime(invited_user.invitation_sent_at)) %>)
             <%= form_with(model: invited_user, url: user_invitation_path, method: :post, local: true) do |f| %>
-              <%= link_to t("general.resend_invitation"), user_resend_invitation_path(user_id: invited_user.id), class: "button button--small", method: :put %>
+              <%= link_to t("general.resend_invitation"), user_resend_invitation_path(user_id: invited_user.id), class: "button button--small spacing-above-5", method: :put %>
             <% end %>
           </li>
         <% end %>
       </ul>
     <% end %>
   </div>
-
 <% end %>

--- a/app/views/invitations/index.html.erb
+++ b/app/views/invitations/index.html.erb
@@ -1,65 +1,26 @@
 <% content_for :card do %>
   <div class="slab">
     <h1><%= t(".title") %></h1>
-
-    <div class="actions">
-      <div>
-        <% if can? :manage, OrganizationLeadRole %>
-          <%= link_to new_user_invitation_path(user: {role: OrganizationLeadRole::TYPE}), class: "button" do %>
-            <%= t(".actions.new_org_lead_invite") %>
-          <% end %>
-        <% end %>
-      </div>
-
-      <div>
-        <% if can? :manage, AdminRole %>
-          <%= link_to new_user_invitation_path(user: {role: AdminRole::TYPE}), class: "button" do %>
-            <%= t(".actions.new_admin_invite") %>
-          <% end %>
-        <% end %>
-      </div>
-
-      <div>
-        <% if can? :manage, CoalitionLeadRole %>
-          <%= link_to new_user_invitation_path(user: {role: CoalitionLeadRole::TYPE}), class: "button" do %>
-            <%= t(".actions.new_coalition_lead_invite") %>
-          <% end %>
-        <% end %>
-      </div>
-
-      <div>
-        <% if can? :manage, SiteCoordinatorRole %>
-          <%= link_to new_user_invitation_path(user: {role: SiteCoordinatorRole::TYPE}), class: "button" do %>
-            <%= t(".actions.new_site_coordinator_invite") %>
-          <% end %>
-        <% end %>
-      </div>
-
-      <div>
-        <% if can? :manage, ClientSuccessRole %>
-          <%= link_to new_user_invitation_path(user: {role: ClientSuccessRole::TYPE}), class: "button" do %>
-            <%= t(".actions.new_client_success_invite") %>
-          <% end %>
-        <% end %>
-      </div>
-
-      <div>
-        <% if can? :manage, GreeterRole %>
-          <%= link_to new_user_invitation_path(user: {role: GreeterRole::TYPE}), class: "button" do %>
-            <%= t(".actions.new_greeter_invite") %>
-          <% end %>
-        <% end %>
-      </div>
-
-      <div>
-        <% if can? :manage, TeamMemberRole %>
-          <%= link_to new_user_invitation_path(user: {role: TeamMemberRole::TYPE}), class: "button" do %>
-            <%= t(".actions.new_team_member_invite") %>
-          <% end %>
-        <% end %>
+    <%= form_for :invitation, url: "/hub/invitation/new", method: "get" do |f| %>
+    <div class="form-group">
+      <%= label_tag(:role, "What type of user do you want to invite?", class: "form-question") %>
+      <div class="select">
+        <%= select_tag :role, options_for_select([
+            ([t("general.admin"), AdminRole::TYPE] if can?(:manage, AdminRole)),
+            ([t("general.coalition_lead"), CoalitionLeadRole::TYPE] if can?(:manage, CoalitionLeadRole)),
+            ([t("general.organization_lead"), OrganizationLeadRole::TYPE] if can?(:manage, OrganizationLeadRole)),
+            ([t("general.site_coordinator"), SiteCoordinatorRole::TYPE] if can?(:manage, SiteCoordinatorRole)),
+            ([t("general.client_success"), ClientSuccessRole::TYPE] if can?(:manage, ClientSuccessRole)),
+            ([t("general.greeter"), GreeterRole::TYPE] if can?(:manage, GreeterRole)),
+            ([t("general.team_member"), TeamMemberRole::TYPE] if can?(:manage, TeamMemberRole))
+        ].compact), class: "select__element" %>
       </div>
     </div>
+      <%= f.submit "Continue", class: "button" %>
+    <% end %>
 
+    <hr/>
+    <h3><%= @unaccepted_invitations.length %> outstanding invitations</h3>
     <% if @unaccepted_invitations.present? %>
       <ul class="invitations list--bulleted">
         <% @unaccepted_invitations.each do |invited_user| %>

--- a/app/views/invitations/index.html.erb
+++ b/app/views/invitations/index.html.erb
@@ -16,7 +16,7 @@
       <ul class="invitations">
         <% @unaccepted_invitations.each do |invited_user| %>
           <li id="invitation-<%= invited_user.id %>" class="invitation">
-            <%= invited_user.name %> (<%= user_role(invited_user) %>) &lt;<%= invited_user.email %>&gt; <%= user_group(invited_user) %> (<%= t(".invitation.sent_at", datetime: formatted_datetime(invited_user.invitation_sent_at)) %>)
+            <%= invited_user.name %> (<%= user_role(invited_user) %>) &lt;<%= invited_user.email %>&gt; <%= user_group(invited_user) %> (<%= t(".invitation.sent_at", datetime: formatted_datetime(invited_user.invitation_sent_at, year: true)) %>)
             <%= form_with(model: invited_user, url: user_invitation_path, method: :post, local: true) do |f| %>
               <%= link_to t("general.resend_invitation"), user_resend_invitation_path(user_id: invited_user.id), class: "button button--small spacing-above-5", method: :put %>
             <% end %>

--- a/app/views/invitations/index.html.erb
+++ b/app/views/invitations/index.html.erb
@@ -8,7 +8,7 @@
         <%= select_tag :role, options_for_select(User.roles.map {|role_type| [readable_role_from_role_type(role_type), role_type] if can?(:manage, role_type.constantize)}.compact), class: "select__element" %>
       </div>
     </div>
-      <%= f.submit "Continue", class: "button" %>
+      <%= f.submit "Continue", class: "button button--primary" %>
     <% end %>
 
     <hr/>
@@ -17,9 +17,9 @@
       <ul class="invitations list--bulleted">
         <% @unaccepted_invitations.each do |invited_user| %>
           <li id="invitation-<%= invited_user.id %>" class="invitation">
-            <%= invited_user.name %> (<%= user_role(invited_user) %>) &lt;<%= invited_user.email %>&gt; <%= user_group(invited_user) unless invited_user.role.is_a?(GreeterRole) %> (<%= t(".invitation.sent_at", datetime: invited_user.invitation_sent_at) %>)
+            <%= invited_user.name %> (<%= user_role(invited_user) %>) &lt;<%= invited_user.email %>&gt; <%= user_group(invited_user) %> (<%= t(".invitation.sent_at", datetime: invited_user.invitation_sent_at) %>)
             <%= form_with(model: invited_user, url: user_invitation_path, method: :post, local: true) do |f| %>
-              <%= link_to t("general.resend_invitation"), user_resend_invitation_path(user_id: invited_user.id), class: "button button-small", method: :put %>
+              <%= link_to t("general.resend_invitation"), user_resend_invitation_path(user_id: invited_user.id), class: "button button--small", method: :put %>
             <% end %>
           </li>
         <% end %>

--- a/app/views/invitations/index.html.erb
+++ b/app/views/invitations/index.html.erb
@@ -14,10 +14,10 @@
     <hr/>
     <h3><%= @unaccepted_invitations.length %> outstanding invitations</h3>
     <% if @unaccepted_invitations.present? %>
-      <ul class="invitations list--bulleted">
+      <ul class="invitations">
         <% @unaccepted_invitations.each do |invited_user| %>
           <li id="invitation-<%= invited_user.id %>" class="invitation">
-            <%= invited_user.name %> (<%= user_role(invited_user) %>) &lt;<%= invited_user.email %>&gt; <%= user_group(invited_user) %> (<%= t(".invitation.sent_at", datetime: invited_user.invitation_sent_at) %>)
+            <%= invited_user.name %> (<%= user_role(invited_user) %>) &lt;<%= invited_user.email %>&gt; <%= user_group(invited_user) %> (<%= t(".invitation.sent_at", datetime: formatted_datetime(invited_user.invitation_sent_at) %>)
             <%= form_with(model: invited_user, url: user_invitation_path, method: :post, local: true) do |f| %>
               <%= link_to t("general.resend_invitation"), user_resend_invitation_path(user_id: invited_user.id), class: "button button--small", method: :put %>
             <% end %>

--- a/app/views/invitations/index.html.erb
+++ b/app/views/invitations/index.html.erb
@@ -5,15 +5,7 @@
     <div class="form-group">
       <%= label_tag(:role, "What type of user do you want to invite?", class: "form-question") %>
       <div class="select">
-        <%= select_tag :role, options_for_select([
-            ([t("general.admin"), AdminRole::TYPE] if can?(:manage, AdminRole)),
-            ([t("general.coalition_lead"), CoalitionLeadRole::TYPE] if can?(:manage, CoalitionLeadRole)),
-            ([t("general.organization_lead"), OrganizationLeadRole::TYPE] if can?(:manage, OrganizationLeadRole)),
-            ([t("general.site_coordinator"), SiteCoordinatorRole::TYPE] if can?(:manage, SiteCoordinatorRole)),
-            ([t("general.client_success"), ClientSuccessRole::TYPE] if can?(:manage, ClientSuccessRole)),
-            ([t("general.greeter"), GreeterRole::TYPE] if can?(:manage, GreeterRole)),
-            ([t("general.team_member"), TeamMemberRole::TYPE] if can?(:manage, TeamMemberRole))
-        ].compact), class: "select__element" %>
+        <%= select_tag :role, options_for_select(User.roles.map {|role_type| [readable_role_from_role_type(role_type), role_type] if can?(:manage, role_type.constantize)}.compact), class: "select__element" %>
       </div>
     </div>
       <%= f.submit "Continue", class: "button" %>

--- a/app/views/invitations/index.html.erb
+++ b/app/views/invitations/index.html.erb
@@ -4,7 +4,7 @@
     <%= form_for :invitation, url: "/hub/invitation/new", method: "get" do |f| %>
     <div class="form-group">
       <%= label_tag(:role, "What type of user do you want to invite?", class: "form-question") %>
-      <div class="select">
+      <div class="select form-width--long">
         <%= select_tag :role, options_for_select(User.roles.map {|role_type| [readable_role_from_role_type(role_type), role_type] if can?(:manage, role_type.constantize)}.compact), class: "select__element" %>
       </div>
     </div>

--- a/config/environments/demo.rb
+++ b/config/environments/demo.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   }
   config.action_mailer.default_url_options = { host: 'demo.getyourrefund.org' }
   config.action_mailer.asset_host = config.gyr_url
-  config.offseason = true
+  config.offseason = false
   config.hide_ctc = false
 
   Rails.application.default_url_options = config.action_mailer.default_url_options

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1099,14 +1099,6 @@ en:
       success: Added %{code} to %{name}.
   invitations:
     index:
-      actions:
-        new_admin_invite: Invite a new admin
-        new_client_success_invite: Invite a new client success
-        new_coalition_lead_invite: Invite a new coalition lead
-        new_greeter_invite: Invite a new greeter
-        new_org_lead_invite: Invite a new organization lead
-        new_site_coordinator_invite: Invite a new site coordinator
-        new_team_member_invite: Invite a new team member
       invitation:
         sent_at: Sent at %{datetime}
       title: Invitations

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1083,14 +1083,6 @@ es:
       success: Se agregó %{code} a %{name}.
   invitations:
     index:
-      actions:
-        new_admin_invite: Invite a un nuevo admin
-        new_client_success_invite: Invitar a un nuevo cliente al éxito
-        new_coalition_lead_invite: Invite a un nuevo líder de la coalición
-        new_greeter_invite: Invitar a un nuevo saludador
-        new_org_lead_invite: Invite a un nuevo líder de la organización
-        new_site_coordinator_invite: Invitar a una nueva coordinadora del sitio
-        new_team_member_invite: Invitar a un nuevo miembro del equipo
       invitation:
         sent_at: Enviado a las %{datetime}
       title: Invitaciones

--- a/spec/controllers/hub/users_controller_spec.rb
+++ b/spec/controllers/hub/users_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Hub::UsersController do
 
         expect(response).to be_ok
         expect(response.body).to have_content "Adam Avocado"
-        expect(response.body).to have_content "Organization lead"
+        expect(response.body).to have_content "Organization Lead"
         expect(response.body).to have_content "Orange organization"
       end
 

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -30,12 +30,12 @@ RSpec.describe InvitationsController do
           allow(subject.current_ability).to receive(:can?).with(:manage, GreeterRole).and_return(true)
         end
 
-        it "filters invite buttons based on ability" do
+        it "filters invite options" do
           get :index
 
           expect(response).to be_ok
-          expect(response.body).not_to include("Invite a new admin")
-          expect(response.body).to include("Invite a new greeter")
+          expect(response.body).not_to include('value="AdminRole"')
+          expect(response.body).to include('value="GreeterRole"')
         end
       end
     end

--- a/spec/features/hub/edit_user_spec.rb
+++ b/spec/features/hub/edit_user_spec.rb
@@ -73,12 +73,12 @@ RSpec.describe "a user editing a user" do
           user_to_edit = create(:coalition_lead_user)
 
           visit edit_hub_user_path(id: user_to_edit)
-          click_on "Client success"
+          click_on "Client Success"
 
           click_on "Submit"
 
           within "#current-role" do
-            expect(page).to have_text "Client success"
+            expect(page).to have_text "Client Success"
           end
         end
 
@@ -102,7 +102,7 @@ RSpec.describe "a user editing a user" do
           create :coalition, name: "Coal Coalition"
 
           visit edit_hub_user_path(id: user_to_edit)
-          click_on "Coalition lead"
+          click_on "Coalition Lead"
 
           expect(page).to have_text("Coal Coalition")
 
@@ -111,7 +111,7 @@ RSpec.describe "a user editing a user" do
           click_on "Submit"
 
           within "#current-role" do
-            expect(page).to have_text "Coalition lead, Koala Koalition"
+            expect(page).to have_text "Coalition Lead, Koala Koalition"
           end
         end
 
@@ -120,7 +120,7 @@ RSpec.describe "a user editing a user" do
           create :organization, name: "Odious Organization"
 
           visit edit_hub_user_path(id: user_to_edit)
-          click_on "Organization lead"
+          click_on "Organization Lead"
 
           expect(page).to have_text("Odious Organization")
 
@@ -129,7 +129,7 @@ RSpec.describe "a user editing a user" do
           click_on "Submit"
 
           within "#current-role" do
-            expect(page).to have_text "Organization lead, Orange Organization"
+            expect(page).to have_text "Organization Lead, Orange Organization"
           end
         end
 
@@ -139,7 +139,7 @@ RSpec.describe "a user editing a user" do
           create :site, name: "Sour Site"
 
           visit edit_hub_user_path(id: user_to_edit)
-          click_on "Site coordinator"
+          click_on "Site Coordinator"
 
           expect(page).to have_text("Sour Site")
 
@@ -148,7 +148,7 @@ RSpec.describe "a user editing a user" do
           click_on "Submit"
 
           within "#current-role" do
-            expect(page).to have_text "Site coordinator, Suite Site"
+            expect(page).to have_text "Site Coordinator, Suite Site"
           end
         end
 
@@ -158,7 +158,7 @@ RSpec.describe "a user editing a user" do
           create :site, name: "Sour Site"
 
           visit edit_hub_user_path(id: user_to_edit)
-          click_on "Team member"
+          click_on "Team Member"
 
           expect(page).to have_text("Sour Site")
 
@@ -167,7 +167,7 @@ RSpec.describe "a user editing a user" do
           click_on "Submit"
 
           within "#current-role" do
-            expect(page).to have_text "Team member, Suite Site"
+            expect(page).to have_text "Team Member, Suite Site"
           end
         end
       end

--- a/spec/features/hub/invitations/admin_spec.rb
+++ b/spec/features/hub/invitations/admin_spec.rb
@@ -13,7 +13,8 @@ RSpec.feature "Inviting admin users" do
 
       # Invitations page
       expect(page).to have_selector "h1", text: "Invitations"
-      click_on "Invite a new admin"
+      select "Admin", from: "What type of user do you want to invite?"
+      click_on "Continue"
 
       # new invitation page
       expect(page).to have_text "Send a new invitation"

--- a/spec/features/hub/invitations/client_success_spec.rb
+++ b/spec/features/hub/invitations/client_success_spec.rb
@@ -13,7 +13,8 @@ RSpec.feature "Inviting client success" do
 
       # Invitations page
       expect(page).to have_selector "h1", text: "Invitations"
-      click_on "Invite a new client success"
+      select "Client Success", from: "What type of user do you want to invite?"
+      click_on "Continue"
 
       # new invitation page
       expect(page).to have_text "Send a new invitation"
@@ -27,7 +28,7 @@ RSpec.feature "Inviting client success" do
       within(".invitations") do
         expect(page).to have_text "Chard Swiss"
         expect(page).to have_text "chard@clientsuccess.org"
-        expect(page).to have_text "Client success"
+        expect(page).to have_text "Client Success"
       end
       invited_user = User.where(invited_by: user).last
       expect(invited_user).to be_present
@@ -65,7 +66,7 @@ RSpec.feature "Inviting client success" do
 
       expect(page).to have_text "You're all set and ready to go! You've joined an amazing team!"
       expect(page).to have_text "Chard Swiss"
-      expect(page).to have_text "Client success"
+      expect(page).to have_text "Client Success"
     end
   end
 end

--- a/spec/features/hub/invitations/coalition_lead_spec.rb
+++ b/spec/features/hub/invitations/coalition_lead_spec.rb
@@ -14,7 +14,8 @@ RSpec.feature "Inviting coalition leads" do
 
       # Invitations page
       expect(page).to have_selector "h1", text: "Invitations"
-      click_on "Invite a new coalition lead"
+      select "Coalition Lead", from: "What type of user do you want to invite?"
+      click_on "Continue"
 
       # new invitation page
       expect(page).to have_text "Send a new invitation"
@@ -30,7 +31,7 @@ RSpec.feature "Inviting coalition leads" do
       within(".invitations") do
         expect(page).to have_text "Colleen Cauliflower"
         expect(page).to have_text "colleague@cauliflower.org"
-        expect(page).to have_text "Coalition lead"
+        expect(page).to have_text "Coalition Lead"
       end
       invited_user = User.where(invited_by: user).last
       expect(invited_user).to be_present
@@ -69,7 +70,7 @@ RSpec.feature "Inviting coalition leads" do
 
       expect(page).to have_text "You're all set and ready to go! You've joined an amazing team!"
       expect(page).to have_text "Colleen Cauliflower"
-      expect(page).to have_text "Coalition lead"
+      expect(page).to have_text "Coalition Lead"
       expect(page).to have_text "Kohlrabi Koalition"
     end
   end

--- a/spec/features/hub/invitations/greeter_spec.rb
+++ b/spec/features/hub/invitations/greeter_spec.rb
@@ -14,7 +14,8 @@ RSpec.feature "Inviting greeters" do
 
       # Invitations page
       expect(page).to have_selector "h1", text: "Invitations"
-      click_on "Invite a new greeter"
+      select "Greeter", from: "What type of user do you want to invite?"
+      click_on "Continue"
 
       # new invitation page
       expect(page).to have_text "Send a new invitation"

--- a/spec/features/hub/invitations/org_lead_spec.rb
+++ b/spec/features/hub/invitations/org_lead_spec.rb
@@ -14,7 +14,8 @@ RSpec.feature "Inviting organization leads" do
 
       # Invitations page
       expect(page).to have_selector "h1", text: "Invitations"
-      click_on "Invite a new organization lead"
+      select "Organization Lead", from: "What type of user do you want to invite?"
+      click_on "Continue"
 
       # new invitation page
       expect(page).to have_text "Send a new invitation"
@@ -69,7 +70,7 @@ RSpec.feature "Inviting organization leads" do
 
       expect(page).to have_text "You're all set and ready to go! You've joined an amazing team!"
       expect(page).to have_text "Colleen Cauliflower"
-      expect(page).to have_text "Organization lead"
+      expect(page).to have_text "Organization Lead"
       expect(page).to have_text "Brassica Asset Builders"
     end
   end

--- a/spec/features/hub/invitations/site_coordinator_spec.rb
+++ b/spec/features/hub/invitations/site_coordinator_spec.rb
@@ -14,7 +14,8 @@ RSpec.feature "Inviting site coordinator" do
 
       # Invitations page
       expect(page).to have_selector "h1", text: "Invitations"
-      click_on "Invite a new site coordinator"
+      select "Site Coordinator", from: "What type of user do you want to invite?"
+      click_on "Continue"
 
       # new invitation page
       expect(page).to have_text "Send a new invitation"
@@ -30,7 +31,7 @@ RSpec.feature "Inviting site coordinator" do
       within(".invitations") do
         expect(page).to have_text "Colleen Cauliflower"
         expect(page).to have_text "colleague@cauliflower.org"
-        expect(page).to have_text "Site coordinator"
+        expect(page).to have_text "Site Coordinator"
       end
 
       # resend invitation
@@ -69,7 +70,7 @@ RSpec.feature "Inviting site coordinator" do
 
       expect(page).to have_text "You're all set and ready to go! You've joined an amazing team!"
       expect(page).to have_text "Colleen Cauliflower"
-      expect(page).to have_text "Site coordinator"
+      expect(page).to have_text "Site Coordinator"
       expect(page).to have_text "Spring Onion Site"
     end
   end

--- a/spec/features/hub/invitations/team_member_spec.rb
+++ b/spec/features/hub/invitations/team_member_spec.rb
@@ -16,7 +16,8 @@ RSpec.feature "Inviting team members" do
 
       # Invitations page
       expect(page).to have_selector "h1", text: "Invitations"
-      click_on "Invite a new team member"
+      select "Team Member", from: "What type of user do you want to invite?"
+      click_on "Continue"
 
       # new invitation page
       expect(page).to have_text "Send a new invitation"
@@ -33,7 +34,7 @@ RSpec.feature "Inviting team members" do
       within(".invitations") do
         expect(page).to have_text "Tammy Tomato"
         expect(page).to have_text "colleague@tomato.org"
-        expect(page).to have_text "Team member"
+        expect(page).to have_text "Team Member"
         expect(page).to have_text "Squash Site"
       end
       invited_user = User.where(invited_by: user).last
@@ -49,7 +50,7 @@ RSpec.feature "Inviting team members" do
       within(".invitations") do
         expect(page).to have_text "Tammy Tomato"
         expect(page).to have_text "colleague@tomato.org"
-        expect(page).to have_text "Team member"
+        expect(page).to have_text "Team Member"
         expect(page).to have_text "Squash Site"
       end
       invited_user = User.where(invited_by: user).last
@@ -79,7 +80,7 @@ RSpec.feature "Inviting team members" do
 
       expect(page).to have_text "You're all set and ready to go! You've joined an amazing team!"
       expect(page).to have_text "Tammy Tomato"
-      expect(page).to have_text "Team member"
+      expect(page).to have_text "Team Member"
       expect(page).to have_text "Squash Site"
     end
   end

--- a/spec/helpers/role_helper_spec.rb
+++ b/spec/helpers/role_helper_spec.rb
@@ -12,7 +12,7 @@ describe RoleHelper do
     context "a client success user" do
       let(:user) { create :client_success_user }
       it "returns the user role" do
-        expect(helper.user_role(user)).to eq "Client success"
+        expect(helper.user_role(user)).to eq "Client Success"
       end
     end
 
@@ -20,7 +20,7 @@ describe RoleHelper do
       let(:user) { create :user, role: create(:organization_lead_role) }
 
       it "shows they are an org lead" do
-        expect(helper.user_role(user)).to eq "Organization lead"
+        expect(helper.user_role(user)).to eq "Organization Lead"
       end
     end
 
@@ -28,7 +28,7 @@ describe RoleHelper do
       let(:user) { create :user, role: create(:team_member_role) }
 
       it "shows their role" do
-        expect(helper.user_role(user)).to eq "Team member"
+        expect(helper.user_role(user)).to eq "Team Member"
       end
     end
 
@@ -36,7 +36,7 @@ describe RoleHelper do
       let(:user) { create :user, role: create(:coalition_lead_role) }
 
       it "shows they are a coalition lead" do
-        expect(helper.user_role(user)).to eq "Coalition lead"
+        expect(helper.user_role(user)).to eq "Coalition Lead"
       end
     end
 
@@ -44,7 +44,7 @@ describe RoleHelper do
       let(:user) { create :user, role: create(:site_coordinator_role) }
 
       it "shows they are a site coordinator" do
-        expect(helper.user_role(user)).to eq "Site coordinator"
+        expect(helper.user_role(user)).to eq "Site Coordinator"
       end
     end
 


### PR DESCRIPTION
Based on pairing with design:
- Updates role names to be in a consistent order in each implementation of roles as a list (User.roles)
- Title cases roles for display purposes
- Uses dropdown for invitation index select instead of buttons for each role
- Removes resend invitation button if the invitation has already been accepted
- Defaults select in hub to be 100% width of parent container (like text-input), which can then be limited by the form width classes.