### PR TITLE
Recaptcha failures increment datadog metrics instead of going to Sentry

### DIFF
--- a/app/controllers/concerns/recaptcha_score_concern.rb
+++ b/app/controllers/concerns/recaptcha_score_concern.rb
@@ -2,15 +2,18 @@ module RecaptchaScoreConcern
   def recaptcha_score_param(action)
     if verify_recaptcha(action: action)
       if recaptcha_reply.present?
+        DatadogApi.increment("recaptcha.success")
+
         return {
           recaptcha_score: recaptcha_reply['score'],
           recaptcha_action: action
         }
       end
     elsif recaptcha_reply.present?
-      Sentry.capture_message "Failed to verify recaptcha token due to the following errors: #{recaptcha_reply["error-codes"]}"
+      error_codes = Array(recaptcha_reply["error-codes"]).join("_")
+      DatadogApi.increment("recaptcha.failure.with_error", tags: ["error_codes:#{error_codes}"])
     else
-      Sentry.capture_message "Something bad happened when attempting recaptcha!"
+      DatadogApi.increment("recaptcha.failure.unknown")
     end
     {}
   end

--- a/app/lib/datadog_api.rb
+++ b/app/lib/datadog_api.rb
@@ -46,10 +46,11 @@ module DatadogApi
     end
   end
 
-  def self.increment(label)
+  def self.increment(label, tags: [])
     return unless configuration.enabled
 
-    self.client.emit_point(self.apply_namespace(label), 1, {:tags => ["env:" + configuration.env], :type => METRIC_TYPES[:count]})
+    tags << "env:#{configuration.env}"
+    self.client.emit_point(self.apply_namespace(label), 1, {:tags => tags, :type => METRIC_TYPES[:count]})
   end
 
   def self.gauge(label, value, tags: [])

--- a/spec/controllers/concerns/recaptcha_score_concern_spec.rb
+++ b/spec/controllers/concerns/recaptcha_score_concern_spec.rb
@@ -7,6 +7,19 @@ RSpec.describe RecaptchaScoreConcern, type: :controller do
   end
 
   describe "#recaptcha_score_param" do
+    include MockDogapi
+
+    before do
+      DatadogApi.configure do |c|
+        allow(c).to receive(:enabled).and_return(true)
+      end
+
+      @emit_point_params = []
+      allow(@mock_dogapi).to receive(:emit_point) do |*params|
+        @emit_point_params << params
+      end
+    end
+
     context "when able to verify" do
       before do
         allow_any_instance_of(Recaptcha::Adapters::ControllerMethods).to receive(:recaptcha_reply).and_return({ 'score' => "0.7" })
@@ -14,19 +27,23 @@ RSpec.describe RecaptchaScoreConcern, type: :controller do
 
       it "returns a score" do
         expect(subject.recaptcha_score_param("test")).to eq({ recaptcha_score: "0.7", recaptcha_action: "test" })
+        expect(@emit_point_params).to eq([
+          ["vita-min.dogapi.recaptcha.success", 1, {:tags=>["env:test"], :type=>"count"}]
+        ])
       end
     end
 
     context "when unable to verify" do
       before do
-        allow(Sentry).to receive(:capture_message)
         allow_any_instance_of(Recaptcha::Adapters::ControllerMethods).to receive(:verify_recaptcha).and_return(false)
-        allow_any_instance_of(Recaptcha::Adapters::ControllerMethods).to receive(:recaptcha_reply).and_return({ 'error-codes' => "[a-terrible-test-failure]" })
+        allow_any_instance_of(Recaptcha::Adapters::ControllerMethods).to receive(:recaptcha_reply).and_return({ 'error-codes' => ['a-terrible-test-failure'] })
       end
 
       it "sends a Sentry message and returns an empty hash" do
         expect(subject.recaptcha_score_param("test")).to eq({})
-        expect(Sentry).to have_received(:capture_message).with("Failed to verify recaptcha token due to the following errors: [a-terrible-test-failure]")
+        expect(@emit_point_params).to eq([
+          ["vita-min.dogapi.recaptcha.failure.with_error", 1, {:tags=>["error_codes:a-terrible-test-failure", "env:test"], :type=>"count"}]
+        ])
       end
 
       context "when no reply is available" do
@@ -36,7 +53,9 @@ RSpec.describe RecaptchaScoreConcern, type: :controller do
 
         it "sends a more dire Sentry message and returns an empty hash" do
           expect(subject.recaptcha_score_param("test")).to eq({})
-          expect(Sentry).to have_received(:capture_message).with("Something bad happened when attempting recaptcha!")
+          expect(@emit_point_params).to eq([
+            ["vita-min.dogapi.recaptcha.failure.unknown", 1, {:tags=>["env:test"], :type=>"count"}]
+          ])
         end
       end
     end


### PR DESCRIPTION
If they go to Sentry, we just have to ignore them forever, which clutters
everything up

Also sends a point to Datadog when the recaptcha is successful, so we can
compare the rates of successful recaptcha to failed ones and see if
anything goes amiss.