### PR TITLE
Never raise IpSpoofAttackError to sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -10,5 +10,6 @@ Sentry.init do |config|
 
   config.excluded_exceptions = Sentry::Configuration::IGNORE_DEFAULT + Sentry::Rails::IGNORE_DEFAULT + %w(
     ActionController::UnknownFormat
+    ActionDispatch::RemoteIp::IpSpoofAttackError
   )
 end


### PR DESCRIPTION
it's not something we will ever take action on so we don't need it to go there