### PR TITLE
Fix crash on hub metrics page

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -30,6 +30,9 @@
 class Site < VitaPartner
   TYPE = "Site"
 
+  # Site records should not have an .organization_capacity but we want VitaPartner.includes(:organization_capacity) not to crash
+  has_one :organization_capacity, foreign_key: "vita_partner_id"
+
   belongs_to :parent_organization, class_name: "Organization"
   has_many :serviced_zip_codes, class_name: "VitaPartnerZipCode", foreign_key: "vita_partner_id"
   has_many :serviced_states, class_name: "VitaPartnerState", foreign_key: "vita_partner_id"

--- a/spec/controllers/hub/metrics_controller_spec.rb
+++ b/spec/controllers/hub/metrics_controller_spec.rb
@@ -29,6 +29,8 @@ describe Hub::MetricsController do
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :index
 
     context 'when authenticated as an admin' do
+      render_views
+
       before do
         sign_in current_user
       end
@@ -36,6 +38,7 @@ describe Hub::MetricsController do
       it 'renders the metrics index template' do
         get :index
         expect(response).to render_template :index
+        expect(response.body).to include(VitaPartner.client_support_org.name)
       end
 
       context "when a recent report already exists" do


### PR DESCRIPTION
Since we split VitaPartner into Site and Organization, Site did not
actually have a 'organization_capacity' association that could be
eager loaded.

For now, just pretend it does. We may come back and revisit later.

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>