### PR TITLE
Fix crash if the zip is invalid in page vita_providers/12345?zip=22222

### DIFF
--- a/app/controllers/vita_providers_controller.rb
+++ b/app/controllers/vita_providers_controller.rb
@@ -33,7 +33,7 @@ class VitaProvidersController < ApplicationController
     @provider = VitaProvider.find(params[:id])
     @zip = params[:zip]
     @page = params[:page]
-    if @zip.present?
+    if @zip.present? && ZipCodes.details(@zip)
       zip_details = ZipCodes.details(@zip)
       @zip_name = zip_details[:name]
       zip_centroid = Geometry.coords_to_point(
@@ -83,7 +83,7 @@ class VitaProvidersController < ApplicationController
       provider_id: @provider.id.to_s,
       provider_name: @provider.name,
     }
-    if @zip.present?
+    if @zip.present? && @distance.present?
       event_data = event_data.merge({
         provider_searched_zip: @zip,
         provider_searched_zip_name: @zip_name,

--- a/spec/controllers/vita_providers_controller_spec.rb
+++ b/spec/controllers/vita_providers_controller_spec.rb
@@ -176,6 +176,18 @@ RSpec.describe VitaProvidersController do
         end
       end
 
+      context "with an invalid zip in params" do
+        it "sends provider_page_view event with no zip to mixpanel" do
+          get :show, params: { id: provider.id, zip: "123456789" }
+
+          expected_data = {
+            provider_id: provider.id.to_s,
+            provider_name: "Public Library of the Test Suite",
+          }
+          expect(subject).to have_received(:send_mixpanel_event).with(event_name: "provider_page_view", data: expected_data)
+        end
+      end
+
       context "with zip in params" do
         it "gets the searched zip from params and calculates distance" do
           get :show, params: { id: provider.id.to_s, zip: "94609" }


### PR DESCRIPTION
You shouldn't be able to get to this URL with an invalid ZIP, but it's
always possible for someone to tamper with that param so we should
make it not crash.