### PR TITLE
Add a data mask to SSN and ITIN input fields

### DIFF
--- a/app/forms/consent_form.rb
+++ b/app/forms/consent_form.rb
@@ -23,7 +23,7 @@ class ConsentForm < QuestionsForm
   validates :primary_ssn, individual_taxpayer_identification_number: true, if: -> { primary_tin_type == "itin" }
   validates_presence_of :primary_ssn
 
-  with_options if: -> { (primary_ssn.present? && primary_ssn != intake.primary_ssn) || primary_ssn_confirmation.present? } do
+  with_options if: -> { (primary_ssn.present? && primary_ssn.remove("-") != intake.primary_ssn) || primary_ssn_confirmation.present? } do
     validates :primary_ssn, confirmation: true
     validates :primary_ssn_confirmation, presence: true
   end

--- a/app/forms/ctc/base_primary_filer_form.rb
+++ b/app/forms/ctc/base_primary_filer_form.rb
@@ -9,7 +9,10 @@ module Ctc
     validates :primary_ssn, social_security_number: true, if: -> { ["ssn", "ssn_no_employment"].include? primary_tin_type }
     validates :primary_ssn, individual_taxpayer_identification_number: true, if: -> { primary_tin_type == "itin" }
 
-    before_validation { primary_ssn&.remove!("-") }
+    before_validation do
+      primary_ssn&.remove!("-")
+      primary_ssn_confirmation&.remove!("-")
+    end
     with_options if: -> { (primary_ssn.present? && primary_ssn != intake.primary_ssn) || primary_ssn_confirmation.present? } do
       validates :primary_ssn, confirmation: true
       validates :primary_ssn_confirmation, presence: true

--- a/app/forms/ctc/base_primary_filer_form.rb
+++ b/app/forms/ctc/base_primary_filer_form.rb
@@ -9,6 +9,7 @@ module Ctc
     validates :primary_ssn, social_security_number: true, if: -> { ["ssn", "ssn_no_employment"].include? primary_tin_type }
     validates :primary_ssn, individual_taxpayer_identification_number: true, if: -> { primary_tin_type == "itin" }
 
+    before_validation { primary_ssn.remove!("-") }
     with_options if: -> { (primary_ssn.present? && primary_ssn != intake.primary_ssn) || primary_ssn_confirmation.present? } do
       validates :primary_ssn, confirmation: true
       validates :primary_ssn_confirmation, presence: true

--- a/app/forms/ctc/base_primary_filer_form.rb
+++ b/app/forms/ctc/base_primary_filer_form.rb
@@ -9,11 +9,7 @@ module Ctc
     validates :primary_ssn, social_security_number: true, if: -> { ["ssn", "ssn_no_employment"].include? primary_tin_type }
     validates :primary_ssn, individual_taxpayer_identification_number: true, if: -> { primary_tin_type == "itin" }
 
-    before_validation do
-      primary_ssn&.remove!("-")
-      primary_ssn_confirmation&.remove!("-")
-    end
-    with_options if: -> { (primary_ssn.present? && primary_ssn != intake.primary_ssn) || primary_ssn_confirmation.present? } do
+    with_options if: -> { (primary_ssn.present? && primary_ssn.remove("-") != intake.primary_ssn) || primary_ssn_confirmation.present? } do
       validates :primary_ssn, confirmation: true
       validates :primary_ssn_confirmation, presence: true
     end

--- a/app/forms/ctc/base_primary_filer_form.rb
+++ b/app/forms/ctc/base_primary_filer_form.rb
@@ -9,7 +9,7 @@ module Ctc
     validates :primary_ssn, social_security_number: true, if: -> { ["ssn", "ssn_no_employment"].include? primary_tin_type }
     validates :primary_ssn, individual_taxpayer_identification_number: true, if: -> { primary_tin_type == "itin" }
 
-    before_validation { primary_ssn.remove!("-") }
+    before_validation { primary_ssn&.remove!("-") }
     with_options if: -> { (primary_ssn.present? && primary_ssn != intake.primary_ssn) || primary_ssn_confirmation.present? } do
       validates :primary_ssn, confirmation: true
       validates :primary_ssn_confirmation, presence: true

--- a/app/forms/ctc/base_spouse_form.rb
+++ b/app/forms/ctc/base_spouse_form.rb
@@ -9,7 +9,10 @@ module Ctc
     validates :spouse_ssn, social_security_number: true, if: -> { ["ssn", "ssn_no_employment"].include?(spouse_tin_type) && spouse_ssn.present? }
     validates :spouse_ssn, individual_taxpayer_identification_number: true, if: -> { spouse_tin_type == "itin" }
 
-    before_validation { spouse_ssn&.remove!("-") }
+    before_validation do
+      spouse_ssn&.remove!("-")
+      spouse_ssn_confirmation&.remove!("-")
+    end
     with_options if: -> { (spouse_ssn.present? && spouse_ssn != intake.spouse_ssn) || spouse_ssn_confirmation.present? } do
       validates :spouse_ssn, confirmation: true
       validates :spouse_ssn_confirmation, presence: true

--- a/app/forms/ctc/base_spouse_form.rb
+++ b/app/forms/ctc/base_spouse_form.rb
@@ -9,11 +9,7 @@ module Ctc
     validates :spouse_ssn, social_security_number: true, if: -> { ["ssn", "ssn_no_employment"].include?(spouse_tin_type) && spouse_ssn.present? }
     validates :spouse_ssn, individual_taxpayer_identification_number: true, if: -> { spouse_tin_type == "itin" }
 
-    before_validation do
-      spouse_ssn&.remove!("-")
-      spouse_ssn_confirmation&.remove!("-")
-    end
-    with_options if: -> { (spouse_ssn.present? && spouse_ssn != intake.spouse_ssn) || spouse_ssn_confirmation.present? } do
+    with_options if: -> { (spouse_ssn.present? && spouse_ssn.remove("-") != intake.spouse_ssn) || spouse_ssn_confirmation.present? } do
       validates :spouse_ssn, confirmation: true
       validates :spouse_ssn_confirmation, presence: true
     end

--- a/app/forms/ctc/base_spouse_form.rb
+++ b/app/forms/ctc/base_spouse_form.rb
@@ -9,6 +9,7 @@ module Ctc
     validates :spouse_ssn, social_security_number: true, if: -> { ["ssn", "ssn_no_employment"].include?(spouse_tin_type) && spouse_ssn.present? }
     validates :spouse_ssn, individual_taxpayer_identification_number: true, if: -> { spouse_tin_type == "itin" }
 
+    before_validation { spouse_ssn.remove!("-") }
     with_options if: -> { (spouse_ssn.present? && spouse_ssn != intake.spouse_ssn) || spouse_ssn_confirmation.present? } do
       validates :spouse_ssn, confirmation: true
       validates :spouse_ssn_confirmation, presence: true

--- a/app/forms/ctc/base_spouse_form.rb
+++ b/app/forms/ctc/base_spouse_form.rb
@@ -9,7 +9,7 @@ module Ctc
     validates :spouse_ssn, social_security_number: true, if: -> { ["ssn", "ssn_no_employment"].include?(spouse_tin_type) && spouse_ssn.present? }
     validates :spouse_ssn, individual_taxpayer_identification_number: true, if: -> { spouse_tin_type == "itin" }
 
-    before_validation { spouse_ssn.remove!("-") }
+    before_validation { spouse_ssn&.remove!("-") }
     with_options if: -> { (spouse_ssn.present? && spouse_ssn != intake.spouse_ssn) || spouse_ssn_confirmation.present? } do
       validates :spouse_ssn, confirmation: true
       validates :spouse_ssn_confirmation, presence: true

--- a/app/forms/spouse_consent_form.rb
+++ b/app/forms/spouse_consent_form.rb
@@ -23,6 +23,12 @@ class SpouseConsentForm < QuestionsForm
   validates :spouse_ssn, social_security_number: true, if: -> { ["ssn", "ssn_no_employment"].include? spouse_tin_type }
   validates :spouse_ssn, individual_taxpayer_identification_number: true, if: -> { spouse_tin_type == "itin" }
   validates_presence_of :spouse_ssn
+
+  with_options if: -> { (spouse_ssn.present? && spouse_ssn.remove("-") != intake.spouse_ssn) || spouse_ssn_confirmation.present? } do
+    validates :spouse_ssn, confirmation: true
+    validates :spouse_ssn_confirmation, presence: true
+  end
+
   validate :valid_birth_date
 
   def save

--- a/app/javascript/packs/application.js.erb
+++ b/app/javascript/packs/application.js.erb
@@ -31,3 +31,6 @@ import "../lib/honeycrisp";
   AjaxMixpanelEvents.init();
 <% end %>
 Listeners.init();
+
+import jMaskGlobals from "jquery-mask-plugin";
+jMaskGlobals.watchDataMask = true;

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -275,6 +275,11 @@ class Intake < ApplicationRecord
   validates :phone_number, :sms_phone_number, allow_blank: true, e164_phone: true
   validates_presence_of :visitor_id
 
+  before_validation do
+    self.primary_ssn = self.primary_ssn.remove(/\D/) if primary_ssn_changed? && self.primary_ssn
+    self.spouse_ssn = self.spouse_ssn.remove(/\D/) if spouse_ssn_changed? && self.spouse_ssn
+  end
+
   before_save do
     self.needs_to_flush_searchable_data_set_at = Time.current
     if email_address.present?

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -286,11 +286,6 @@ class Intake::CtcIntake < Intake
   accepts_nested_attributes_for :bank_account
 
   before_validation do
-    self.primary_ssn = self.primary_ssn.remove(/\D/) if primary_ssn_changed? && self.primary_ssn
-    self.spouse_ssn = self.spouse_ssn.remove(/\D/) if spouse_ssn_changed? && self.spouse_ssn
-  end
-
-  before_validation do
     attributes_to_change = self.changes_to_save.keys
     name_attributes = ["primary_first_name", "primary_last_name", "spouse_first_name", "spouse_last_name"]
 

--- a/app/views/ctc/portal/primary_filer/edit.html.erb
+++ b/app/views/ctc/portal/primary_filer/edit.html.erb
@@ -27,8 +27,8 @@
                   classes: ["ctc-intake-date-text-input"]
               ) %>
           <%= f.cfa_select(:primary_tin_type, t('views.ctc.portal.primary_filer.form_of_identity'), tin_options_for_select(include_itin: true), help_text: t('views.ctc.portal.primary_filer.form_of_identity_note')) %>
-          <%= f.cfa_input_field(:primary_ssn, t("views.ctc.questions.legal_consent.ssn"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
-          <%= f.cfa_input_field(:primary_ssn_confirmation, t("views.ctc.questions.legal_consent.ssn_confirmation"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
+          <%= f.cfa_input_field(:primary_ssn, t("views.ctc.questions.legal_consent.ssn"), classes: ["form-width--long"], options: { maxlength: 11, 'data-mask': '000-00-0000'  }) %>
+          <%= f.cfa_input_field(:primary_ssn_confirmation, t("views.ctc.questions.legal_consent.ssn_confirmation"), classes: ["form-width--long"], options: { maxlength: 11, 'data-mask': '000-00-0000' }) %>
           <%= f.cfa_input_field(:primary_ip_pin, t("views.ctc.questions.ip_pin_entry.label", name: current_intake.primary_full_name), type: "tel", classes: ["form-width--long"]) %>
         </div>
 

--- a/app/views/ctc/portal/spouse/edit.html.erb
+++ b/app/views/ctc/portal/spouse/edit.html.erb
@@ -26,8 +26,8 @@
               ) %>
           <%= f.cfa_select(:spouse_tin_type, t("views.ctc.questions.spouse_info.spouse_identity"), tin_options_for_select(include_itin: true, include_none: true), help_text: t("views.ctc.questions.spouse_info.spouse_identity_help_text")) %>
           <%= f.cfa_checkbox(:ssn_no_employment, t('views.ctc.questions.legal_consent.ssn_not_valid_for_employment'), options: { checked_value: "yes", unchecked_value: "no" }) %>
-          <%= f.cfa_input_field(:spouse_ssn, t("views.ctc.questions.spouse_info.spouse_ssn_itin"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
-          <%= f.cfa_input_field(:spouse_ssn_confirmation, t("views.ctc.questions.spouse_info.spouse_ssn_itin_confirmation"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
+          <%= f.cfa_input_field(:spouse_ssn, t("views.ctc.questions.spouse_info.spouse_ssn_itin"), classes: ["form-width--long"], options: { maxlength: 11, 'data-mask': '000-00-0000' }) %>
+          <%= f.cfa_input_field(:spouse_ssn_confirmation, t("views.ctc.questions.spouse_info.spouse_ssn_itin_confirmation"), classes: ["form-width--long"], options: { maxlength: 11, 'data-mask': '000-00-0000' }) %>
           <%= f.cfa_input_field(:spouse_ip_pin, t("views.ctc.questions.ip_pin_entry.label", name: current_intake.spouse_full_name), type: "tel", classes: ["form-width--long"]) %>
         </div>
 

--- a/app/views/ctc/questions/legal_consent/edit.html.erb
+++ b/app/views/ctc/questions/legal_consent/edit.html.erb
@@ -26,8 +26,8 @@
             ) %>
       <%= f.cfa_select(:primary_tin_type, t('general.tin_type'), tin_options_for_select(include_itin: true)) %>
       <%= f.cfa_checkbox(:ssn_no_employment, t('general.ssn_not_valid_for_employment'), options: { checked_value: "yes", unchecked_value: "no" }) %>
-      <%= f.cfa_input_field(:primary_ssn, t("views.ctc.questions.legal_consent.ssn"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
-      <%= f.cfa_input_field(:primary_ssn_confirmation, t("views.ctc.questions.legal_consent.ssn_confirmation"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
+      <%= f.cfa_input_field(:primary_ssn, t("views.ctc.questions.legal_consent.ssn"), classes: ["form-width--long"], options: { maxlength: 11, 'data-mask': '000-00-0000' }) %>
+      <%= f.cfa_input_field(:primary_ssn_confirmation, t("views.ctc.questions.legal_consent.ssn_confirmation"), classes: ["form-width--long"], options: { maxlength: 11, 'data-mask': '000-00-0000' }) %>
       <%= f.cfa_input_field(:phone_number, t("views.ctc.questions.legal_consent.sms_phone_number"), classes: ["form-width--long"]) %>
       <%= f.cfa_checkbox(:primary_active_armed_forces, t("views.ctc.questions.legal_consent.primary_active_armed_forces.title", current_tax_year: current_tax_year), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= recaptcha_v3(action: 'legal_consent') %>

--- a/app/views/ctc/questions/spouse_info/edit.html.erb
+++ b/app/views/ctc/questions/spouse_info/edit.html.erb
@@ -20,8 +20,8 @@
           ) %>
       <%= f.cfa_select(:spouse_tin_type, t("views.ctc.questions.spouse_info.spouse_identity"), tin_options_for_select(include_itin: true), help_text: t("views.ctc.questions.spouse_info.spouse_identity_help_text")) %>
       <%= f.cfa_checkbox(:ssn_no_employment, t('views.ctc.questions.legal_consent.ssn_not_valid_for_employment'), options: { checked_value: "yes", unchecked_value: "no" }) %>
-      <%= f.cfa_input_field(:spouse_ssn, t("views.ctc.questions.spouse_info.spouse_ssn_itin"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
-      <%= f.cfa_input_field(:spouse_ssn_confirmation, t("views.ctc.questions.spouse_info.spouse_ssn_itin_confirmation"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
+      <%= f.cfa_input_field(:spouse_ssn, t("views.ctc.questions.spouse_info.spouse_ssn_itin"), classes: ["form-width--long"], options: { maxlength: 11, 'data-mask': '000-00-0000' }) %>
+      <%= f.cfa_input_field(:spouse_ssn_confirmation, t("views.ctc.questions.spouse_info.spouse_ssn_itin_confirmation"), classes: ["form-width--long"], options: { maxlength: 11, 'data-mask': '000-00-0000' }) %>
       <%= f.cfa_checkbox(:spouse_can_be_claimed_as_dependent, t("views.ctc.questions.spouse_info.spouse_can_be_claimed_as_dependent"), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox(:spouse_active_armed_forces, t("views.ctc.questions.spouse_info.spouse_active_armed_forces", current_tax_year: current_tax_year), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= render('components/molecules/reveal', title: t("views.ctc.questions.spouse_info.spouse_active_armed_forces_reveal")) do %>

--- a/app/views/hub/clients/_displayed_spouse_ssn_itin.html.erb
+++ b/app/views/hub/clients/_displayed_spouse_ssn_itin.html.erb
@@ -1,8 +1,4 @@
 <span class="label-value">
-  <% if @client.intake.is_ctc? %>
     <%= @client.intake.spouse_ssn %>
-  <% else %>
-    <%= @client.intake.spouse_last_four_ssn %>
-  <% end %>
 </span>
 <span class="sr-only"><%= t("hub.ssn_itins.displayed") %></span>

--- a/app/views/hub/clients/_displayed_ssn_itin.html.erb
+++ b/app/views/hub/clients/_displayed_ssn_itin.html.erb
@@ -1,8 +1,4 @@
 <span class="label-value">
-  <% if @client.intake.is_ctc? %>
-    <%= @client.intake.primary_ssn %>
-  <% else %>
-    <%= @client.intake.primary_last_four_ssn %>
-  <% end %>
+  <%= @client.intake.primary_ssn %>
 </span>
 <span class="sr-only"><%= t("hub.ssn_itins.displayed") %></span>

--- a/app/views/hub/clients/show.html.erb
+++ b/app/views/hub/clients/show.html.erb
@@ -53,13 +53,9 @@
             <!-- SSN/ITIN hidden -->
             <div class="field-display primary-ssn">
               <span class="form-question">
-                <% if @client.intake.is_ctc? %>
                   <%= t("general.ssn_itin") %>:
-                <% else %>
-                  <%= t("general.last_four_ssn") %>:
-                <% end %>
               </span>
-              <% if @client.intake.primary_last_four_ssn.present? %>
+              <% if @client.intake.primary_ssn.present? %>
                 <%= render 'togglable_single_field', masked_value: @client.intake.primary_ssn.present? ? mask(@client.intake.primary_ssn, 0) : nil, secret_name: :primary_ssn %>
               <% else %>
                 <span class="label-value"><%= t("general.NA") %></span>
@@ -151,7 +147,8 @@
                 <% tax_return = @client.tax_returns.find_by(year: TaxReturn.current_tax_year) %>
                 <div class="field-display">
                   <span class="form-question"> Outstanding RRC / Claimed RRC: </span>
-                  <span class="label-value"><%= "$#{tax_return&.outstanding_recovery_rebate_credit}" if tax_return&.outstanding_recovery_rebate_credit %></span> /
+                  <span class="label-value"><%= "$#{tax_return&.outstanding_recovery_rebate_credit}" if tax_return&.outstanding_recovery_rebate_credit %></span>
+                  /
                   <span class="label-value"><%= "$#{tax_return&.claimed_recovery_rebate_credit}" if tax_return&.claimed_recovery_rebate_credit %></span>
                 </div>
                 <div class="field-display">
@@ -212,13 +209,9 @@
               <% end %>
               <div class="field-display spouse-ssn">
                 <span class="form-question">
-                  <% if @client.intake.is_ctc? %>
-                    <%= t("general.ssn_itin") %>:
-                  <% else %>
-                    <%= t("general.last_four_ssn") %>:
-                  <% end %>
+                  <%= t("general.ssn_itin") %>:
                 </span>
-                <% if @client.intake.spouse_last_four_ssn.present? %>
+                <% if @client.intake.spouse_ssn.present? %>
                   <%= render 'togglable_single_field', masked_value: @client.intake.spouse_ssn.present? ? mask(@client.intake.spouse_ssn, 0) : nil, secret_name: :spouse_ssn %>
                 <% else %>
                   <span class="label-value"><%= t("general.NA") %></span>
@@ -283,7 +276,7 @@
               <% if @client.intake.drop_off? %>
                 <div class="field-display">
                   <span class="form-question">Photo ID Used:</span>
-                  <span class="label-value"><%= @client.intake.photo_id_display_names || "N/A"%></span>
+                  <span class="label-value"><%= @client.intake.photo_id_display_names || "N/A" %></span>
                 </div>
                 <div class="field-display">
                   <span class="form-question">Taxpayer ID Used:</span>

--- a/app/views/questions/consent/edit.html.erb
+++ b/app/views/questions/consent/edit.html.erb
@@ -10,8 +10,8 @@
       <%= f.cfa_input_field(:primary_first_name, t("views.questions.consent.primary_first_name")) %>
       <%= f.cfa_input_field(:primary_last_name, t("views.questions.consent.primary_last_name")) %>
     <%= f.cfa_select(:primary_tin_type, t('general.tin_type'), tin_options_for_select(include_itin: true)) %>
-    <%= f.cfa_input_field(:primary_ssn, t("attributes.primary_ssn"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
-    <%= f.cfa_input_field(:primary_ssn_confirmation, t("attributes.confirm_primary_ssn"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
+    <%= f.cfa_input_field(:primary_ssn, t("attributes.primary_ssn"), classes: ["form-width--long"], options: { maxlength: 11, 'data-mask': '000-00-0000' }) %>
+    <%= f.cfa_input_field(:primary_ssn_confirmation, t("attributes.confirm_primary_ssn"), classes: ["form-width--long"], options: { maxlength: 11, 'data-mask': '000-00-0000' }) %>
       <div class="date-select">
         <%= f.cfa_date_select(
                 :birth_date,

--- a/app/views/questions/spouse_consent/edit.html.erb
+++ b/app/views/questions/spouse_consent/edit.html.erb
@@ -26,8 +26,8 @@
                       }
                   ) %>
             </div>
-            <%= f.cfa_input_field(:spouse_ssn, t("attributes.spouse_ssn"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
-            <%= f.cfa_input_field(:spouse_ssn_confirmation, t("attributes.confirm_spouse_ssn"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
+            <%= f.cfa_input_field(:spouse_ssn, t("attributes.spouse_ssn"), classes: ["form-width--long"], options: { maxlength: 11, 'data-mask': '000-00-0000' }) %>
+            <%= f.cfa_input_field(:spouse_ssn_confirmation, t("attributes.confirm_spouse_ssn"), classes: ["form-width--long"], options: { maxlength: 11, 'data-mask': '000-00-0000' }) %>
             <button class="button button--primary button--wide" type="submit">
               <%= t("views.questions.spouse_consent.cta") %>
             </button>

--- a/app/views/shared/_client_primary_info_fields.html.erb
+++ b/app/views/shared/_client_primary_info_fields.html.erb
@@ -65,6 +65,9 @@
             classes: ["form-width--name"],
             options: { maxlength: 11, 'data-mask': '000-00-0000' }
           ) %>
+        ) %>
+    <% end %>
+    <% if is_ctc %>
       <%= f.cfa_input_field(:primary_ip_pin, t("general.ip_pin")) %>
     <% end %>
   </div>

--- a/app/views/shared/_client_primary_info_fields.html.erb
+++ b/app/views/shared/_client_primary_info_fields.html.erb
@@ -63,10 +63,8 @@
             "Re-enter SSN/ITIN",
             type: :tel,
             classes: ["form-width--name"],
-            options: { maxlength: 11 }
-      ) %>
-    <% end %>
-    <% if is_ctc %>
+            options: { maxlength: 11, 'data-mask': '000-00-0000' }
+          ) %>
       <%= f.cfa_input_field(:primary_ip_pin, t("general.ip_pin")) %>
     <% end %>
   </div>

--- a/app/views/shared/_client_primary_info_fields.html.erb
+++ b/app/views/shared/_client_primary_info_fields.html.erb
@@ -65,7 +65,6 @@
             classes: ["form-width--name"],
             options: { maxlength: 11, 'data-mask': '000-00-0000' }
           ) %>
-        ) %>
     <% end %>
     <% if is_ctc %>
       <%= f.cfa_input_field(:primary_ip_pin, t("general.ip_pin")) %>

--- a/app/views/shared/_client_primary_info_fields.html.erb
+++ b/app/views/shared/_client_primary_info_fields.html.erb
@@ -55,7 +55,7 @@
         t("general.ssn_itin"),
         type: :tel,
         classes: ["form-width--name"],
-        options: { maxlength: 11 }
+        options: { maxlength: 11, 'data-mask': '000-00-0000'  }
     ) %>
     <% unless f.object.client&.persisted? %>
       <%= f.cfa_input_field(

--- a/app/views/shared/_client_spouse_info_fields.html.erb
+++ b/app/views/shared/_client_spouse_info_fields.html.erb
@@ -29,7 +29,7 @@
             t("general.ssn_itin"),
             type: :tel,
             classes: ["form-width--name"],
-            options: { maxlength: 11 }
+            options: { maxlength: 11, 'data-mask': '000-00-0000' }
     ) %>
     <% unless f.object.client&.persisted? %>
       <%= f.cfa_input_field(

--- a/app/views/shared/_client_spouse_info_fields.html.erb
+++ b/app/views/shared/_client_spouse_info_fields.html.erb
@@ -38,7 +38,25 @@
               "Re-enter SSN/ITIN",
               type: :tel,
               classes: ["form-width--name"],
-              options: { maxlength: 11 }
+              options: { maxlength: 11, 'data-mask': '000-00-0000' }
+          ) %>
+      <% unless f.object.client&.persisted? %>
+        <%= f.cfa_input_field(
+                :spouse_ssn_confirmation,
+                "Re-enter SSN/ITIN",
+                type: :tel,
+                classes: ["form-width--name"],
+                options: { maxlength: 11, 'data-mask': '000-00-0000' }
+            ) %>
+      <% end %>
+    <% else %>
+      <%= f.cfa_input_field(
+              :spouse_last_four_ssn,
+              t("general.last_four_ssn"),
+              prefix: "XXX-XX-",
+              type: :tel,
+              classes: ["form-width--name field--last-four-ssn"],
+              options: { maxlength: 4 }
           ) %>
     <% end %>
     <% if is_ctc %>

--- a/app/views/shared/_client_spouse_info_fields.html.erb
+++ b/app/views/shared/_client_spouse_info_fields.html.erb
@@ -32,31 +32,12 @@
             options: { maxlength: 11 }
     ) %>
     <% unless f.object.client&.persisted? %>
-
       <%= f.cfa_input_field(
               :spouse_ssn_confirmation,
               "Re-enter SSN/ITIN",
               type: :tel,
               classes: ["form-width--name"],
               options: { maxlength: 11, 'data-mask': '000-00-0000' }
-          ) %>
-      <% unless f.object.client&.persisted? %>
-        <%= f.cfa_input_field(
-                :spouse_ssn_confirmation,
-                "Re-enter SSN/ITIN",
-                type: :tel,
-                classes: ["form-width--name"],
-                options: { maxlength: 11, 'data-mask': '000-00-0000' }
-            ) %>
-      <% end %>
-    <% else %>
-      <%= f.cfa_input_field(
-              :spouse_last_four_ssn,
-              t("general.last_four_ssn"),
-              prefix: "XXX-XX-",
-              type: :tel,
-              classes: ["form-width--name field--last-four-ssn"],
-              options: { maxlength: 4 }
           ) %>
     <% end %>
     <% if is_ctc %>

--- a/app/views/shared/_dependent.html.erb
+++ b/app/views/shared/_dependent.html.erb
@@ -27,14 +27,14 @@
         "SSN/ATIN",
         type: :tel,
         classes: ["form-width--name"],
-        options: { maxlength: 11 }
+        options: { maxlength: 11, 'data-mask': '000-00-0000' }
         ) %>
     <%= f.cfa_input_field(
         :ssn_confirmation,
         "Re-enter SSN/ATIN",
         type: :tel,
         classes: ["form-width--name"],
-        options: { maxlength: 11 }
+        options: { maxlength: 11, 'data-mask': '000-00-0000' }
         ) %>
 
     <%= f.cfa_input_field(:ip_pin, t("general.ip_pin")) %>

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "css-minimizer-webpack-plugin": "^1.3.0",
     "imports-loader": "1.2.0",
     "jquery": "^3.5.1",
+    "jquery-mask-plugin": "^1.14.16",
     "jquery-ui": "^1.13.0",
     "mini-css-extract-plugin": "^1.4.0",
     "rails-erb-loader": "^5.5.2",

--- a/spec/features/hub/edit_client_spec.rb
+++ b/spec/features/hub/edit_client_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "a user editing a clients intake fields" do
         fill_in "Phone number", with: "(500) 555-0006"
         check "Opt into sms notifications"
         fill_in "Cell phone number", with: "500-555-0006"
-        fill_in "SSN/ITIN", with: "123456789"
+        fill_in "SSN/ITIN", with: "123-45-6789"
       end
 
       within "#marital-status-fields" do
@@ -156,7 +156,7 @@ RSpec.describe "a user editing a clients intake fields" do
         fill_in "Legal last name", with: "Pepper"
         fill_in "Email", with: "spicypeter@pepper.com"
         select "Social Security Number (SSN)", from: "Identification Type"
-        fill_in "SSN/ITIN", with: "142862222"
+        fill_in "SSN/ITIN", with: "142-86-2222"
       end
 
       click_on "Save"
@@ -200,7 +200,7 @@ RSpec.describe "a user editing a clients intake fields" do
       within ".primary-ssn" do
         expect do
           click_on "View"
-          expect(page).to have_text "6789"
+          expect(page).to have_text "123456789"
         end.to change(AccessLog, :count).by(1)
         expect(AccessLog.last.event_type).to eq "read_ssn_itin"
       end
@@ -208,7 +208,7 @@ RSpec.describe "a user editing a clients intake fields" do
       within ".spouse-ssn" do
         expect do
           click_on "View"
-          expect(page).to have_text "2222"
+          expect(page).to have_text "142862222"
         end.to change(AccessLog, :count).by(1)
         expect(AccessLog.last.event_type).to eq "read_ssn_itin"
       end

--- a/spec/features/hub/edit_client_spec.rb
+++ b/spec/features/hub/edit_client_spec.rb
@@ -217,8 +217,8 @@ RSpec.describe "a user editing a clients intake fields" do
         click_on "Edit"
       end
 
-      expect(find_field("hub_update_client_form[spouse_ssn]").value).to eq "142862222"
-      expect(find_field("hub_update_client_form[primary_ssn]").value).to eq "123456789"
+      expect(find_field("hub_update_client_form[spouse_ssn]").value).to eq "142-86-2222"
+      expect(find_field("hub_update_client_form[primary_ssn]").value).to eq "123-45-6789"
     end
 
     scenario "I can delete a client", js: true do

--- a/spec/features/hub/toggle_client_ssn_info_spec.rb
+++ b/spec/features/hub/toggle_client_ssn_info_spec.rb
@@ -10,14 +10,14 @@ RSpec.feature "Toggle ssn display" do
     scenario "client without ssn/itin" do
       visit hub_client_path(id: client_no_ssn)
       within(".primary-ssn") do
-        expect(page).to have_text "Last 4 of SSN/ITIN"
+        expect(page).to have_text "SSN/ITIN"
         expect(page).not_to have_text "View"
 
         expect(page).to have_text "N/A"
       end
 
       within(".spouse-ssn") do
-        expect(page).to have_text "Last 4 of SSN/ITIN"
+        expect(page).to have_text "SSN/ITIN"
         expect(page).not_to have_text "View"
 
         expect(page).to have_text "N/A"

--- a/spec/features/hub/toggle_client_ssn_info_spec.rb
+++ b/spec/features/hub/toggle_client_ssn_info_spec.rb
@@ -28,47 +28,46 @@ RSpec.feature "Toggle ssn display" do
       visit hub_client_path(id: client)
 
       within(".primary-ssn") do
-        expect(page).to have_text "Last 4 of SSN/ITIN"
+        expect(page).to have_text "SSN/ITIN"
         expect(page).to have_text "View"
 
-        expect(page).not_to have_text client.intake.primary_last_four_ssn
+        expect(page).not_to have_text client.intake.primary_ssn
 
         expect do
           click_on "View"
 
-          expect(page).to have_text "Last 4 of SSN/ITIN"
+          expect(page).to have_text "SSN/ITIN"
           expect(page).to have_text "Hide"
 
-          expect(page).to have_text client.intake.primary_last_four_ssn
+          expect(page).to have_text client.intake.primary_ssn
 
         end.to change(AccessLog, :count).by(1)
 
         click_on "Hide"
 
-        expect(page).not_to have_text client.intake.primary_last_four_ssn
+        expect(page).not_to have_text client.intake.primary_ssn
       end
 
       within(".spouse-ssn") do
-        expect(page).to have_text "Last 4 of SSN/ITIN"
+        expect(page).to have_text "SSN/ITIN"
         expect(page).to have_text "View"
 
-        expect(page).not_to have_text client.intake.spouse_last_four_ssn
+        expect(page).not_to have_text client.intake.spouse_ssn
 
         expect do
           click_on "View"
 
-          expect(page).to have_text "Last 4 of SSN/ITIN"
+          expect(page).to have_text "SSN/ITIN"
           expect(page).to have_text "Hide"
 
-          expect(page).to have_text client.intake.spouse_last_four_ssn
+          expect(page).to have_text client.intake.spouse_ssn
 
         end.to change(AccessLog, :count).by(1)
 
         click_on "Hide"
 
-        expect(page).not_to have_text client.intake.spouse_last_four_ssn
+        expect(page).not_to have_text client.intake.spouse_ssn
       end
-
     end
   end
 end

--- a/spec/features/hub/toggle_client_ssn_info_spec.rb
+++ b/spec/features/hub/toggle_client_ssn_info_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.feature "Toggle ssn display" do
   context "As an authenticated user" do
     let(:user) { create :admin_user}
-    let(:client) { create(:client, intake: create(:intake, filing_joint: "yes", primary_last_four_ssn: "1234", spouse_last_four_ssn: "4444" )) }
+    let(:client) { create(:client, intake: create(:intake, filing_joint: "yes", primary_ssn: "123456789", spouse_ssn: "444411222" )) }
     let(:client_no_ssn) { create(:client, intake: create(:intake, filing_joint: "yes")) }
     before { login_as user }
 

--- a/spec/features/web_intake/new_joint_filers_spec.rb
+++ b/spec/features/web_intake/new_joint_filers_spec.rb
@@ -150,6 +150,7 @@ RSpec.feature "Web Intake Joint Filers", :flow_explorer_screenshot do
     end
     click_on "Continue"
 
+    expect(intake.client.tax_returns.pluck(:status)).to eq ["intake_before_consent"]
     screenshot_after do
       # Consent form
       expect(page).to have_selector("h1", text: "Great! Here's the legal stuff...")
@@ -161,9 +162,8 @@ RSpec.feature "Web Intake Joint Filers", :flow_explorer_screenshot do
       select "5", from: "Day"
       select "1971", from: "Year"
     end
-    expect do
-      click_on "I agree"
-    end.to change { intake.reload.client.tax_returns.pluck(:status) }.from(["intake_before_consent"]).to(["intake_in_progress"])
+    click_on "I agree"
+    expect(intake.reload.client.tax_returns.pluck(:status)).to eq ["intake_in_progress"]
 
     screenshot_after do
       # Optional consent form

--- a/spec/features/web_intake/new_joint_filers_spec.rb
+++ b/spec/features/web_intake/new_joint_filers_spec.rb
@@ -253,8 +253,8 @@ RSpec.feature "Web Intake Joint Filers", :flow_explorer_screenshot do
       expect(page).to have_selector("h1", text: "We need your spouse to review our legal stuff...")
       fill_in "Spouse's legal first name", with: "Greta"
       fill_in "Spouse's legal last name", with: "Gnome"
-      fill_in I18n.t("attributes.spouse_ssn"), with: "123456789"
-      fill_in I18n.t("attributes.confirm_spouse_ssn"), with: "123456789"
+      fill_in I18n.t("attributes.spouse_ssn"), with: "123-45-6789"
+      fill_in I18n.t("attributes.confirm_spouse_ssn"), with: "123-45-6789"
       select "March", from: "Month"
       select "5", from: "Day"
       select "1971", from: "Year"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5735,6 +5735,11 @@ jest@^26.5.2:
     import-local "^3.0.2"
     jest-cli "^26.5.2"
 
+jquery-mask-plugin@^1.14.16:
+  version "1.14.16"
+  resolved "https://registry.yarnpkg.com/jquery-mask-plugin/-/jquery-mask-plugin-1.14.16.tgz#9ebb55947d984da5aade45315b2fe6b113e28aae"
+  integrity sha512-reywdHlYEkPbzWjTpcc1fk9XQ3PLvO5dzEAVqy8zI7NTF22tB1HbeU3iboZTLdkBEPaWAqeI2HtEjsGQ4roZKw==
+
 jquery-ui@^1.13.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/jquery-ui/-/jquery-ui-1.13.0.tgz#ab5ac65f37ca093c51b3478c4097f55bbc008f36"


### PR DESCRIPTION
Adds a javascript plugin to allow data-masking on fields, which adds hyphens into the field as you type.

For [this story](https://www.pivotaltracker.com/story/show/179062568)