### PR TITLE
Implement a custom GyrDiskService for ActiveStorage to workaround CircleCI issues

### DIFF
--- a/app/lib/active_storage/service/gyr_disk_service.rb
+++ b/app/lib/active_storage/service/gyr_disk_service.rb
@@ -1,0 +1,20 @@
+require "active_storage/service/disk_service"
+
+class ActiveStorage::Service::GyrDiskService < ActiveStorage::Service::DiskService
+  def upload(key, io, checksum: nil, **)
+    instrument :upload, key: key, checksum: checksum do
+      # This line from the real DiskService fails on certain docker + kernel combos, so we will do it a different way so our CircleCI builds work:
+      # IO.copy_stream(io, make_path_for(key))
+
+      # We should be able to remove this if CircleCI starts using a different linux kernel version (currently 5.4.0-1060-aws)
+
+      if io.respond_to?(:path)
+        File.write(make_path_for(key), File.read(io.path))
+      else
+        IO.copy_stream(io, make_path_for(key))
+      end
+
+      ensure_integrity_of(key, checksum) if checksum
+    end
+  end
+end

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -5,7 +5,7 @@ deploy_default: &deploy_default
   region: us-east-1
 
 test:
-  service: Disk
+  service: GyrDisk
   # Use /tmp which is autocleared periodically on macOS
   root: "/tmp/vita-min-test-storage"
 


### PR DESCRIPTION
As seen in this issue, certain versions of Docker and certain versions of the Linux
kernel manifest a problem where creating tempfiles wiht `IO.copy_stream` doesn't work:
https://github.com/docker/for-linux/issues/1015

CircleCI seems to have upgraded their linux kernels and now we're seeing this problem.
A temporary workaround is to change the ActiveStorage code to not use IO.copy_stream
by making a custom service (since the Disk service is only for test anyway so we can
do whatever we want)