### PR TITLE
Reparent `documents_requests` on client instead of intake

### DIFF
--- a/app/controllers/portal/upload_documents_controller.rb
+++ b/app/controllers/portal/upload_documents_controller.rb
@@ -62,7 +62,7 @@ module Portal
     end
 
     def find_or_create_document_request
-      @document_request = DocumentsRequest.find_or_create_by(completed_at: nil, intake: current_client.intake)
+      @document_request = DocumentsRequest.find_or_create_by(completed_at: nil, client: current_client)
     end
 
     def current_path

--- a/app/forms/requested_document_upload_form.rb
+++ b/app/forms/requested_document_upload_form.rb
@@ -12,9 +12,9 @@ class RequestedDocumentUploadForm < QuestionsForm
     document_type = attributes_for(:documents_request)[:document_type] || DocumentTypes::RequestedLater
     if document_file_upload.present?
       @documents_request.documents.create(
-        uploaded_by: @documents_request.intake.client,
+        uploaded_by: @documents_request.client,
         document_type: document_type.key,
-        client_id: @documents_request.intake.client_id,
+        client: @documents_request.client,
         upload: document_file_upload,
       )
     end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -50,6 +50,7 @@ class Client < ApplicationRecord
 
   belongs_to :vita_partner, optional: true
   has_many :documents, dependent: :destroy
+  has_many :documents_requests, dependent: :destroy
   has_one :intake, inverse_of: :client, dependent: :destroy
   has_one :consent, dependent: :destroy
   has_many :outgoing_text_messages, dependent: :destroy

--- a/app/models/documents_request.rb
+++ b/app/models/documents_request.rb
@@ -6,19 +6,19 @@
 #  completed_at :datetime
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  intake_id    :bigint
+#  client_id    :bigint
 #
 # Indexes
 #
-#  index_documents_requests_on_intake_id  (intake_id)
+#  index_documents_requests_on_client_id  (client_id)
 #
 # Foreign Keys
 #
-#  fk_rails_...  (intake_id => intakes.id)
+#  fk_rails_...  (client_id => clients.id)
 #
 class DocumentsRequest < ApplicationRecord
-  belongs_to :intake
+  belongs_to :client
   has_many :documents
 
-  validates :intake, presence: true
+  validates :client, presence: true
 end

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -267,7 +267,6 @@ class Intake < ApplicationRecord
   pg_search_scope :search, against: searchable_fields, using: { tsearch: { prefix: true, tsvector_column: 'searchable_data' } }
 
   has_many :documents, dependent: :destroy
-  has_many :documents_requests, dependent: :destroy
   has_many :dependents, -> { order(created_at: :asc) }, inverse_of: :intake, dependent: :destroy
   belongs_to :client, inverse_of: :intake, optional: true
   has_many :tax_returns, through: :client

--- a/db/migrate/20211207222217_reparent_documents_request_on_client.rb
+++ b/db/migrate/20211207222217_reparent_documents_request_on_client.rb
@@ -1,0 +1,11 @@
+class ReparentDocumentsRequestOnClient < ActiveRecord::Migration[6.1]
+  def up
+    add_reference :documents_requests, :client, foreign_key: true, index: true
+    execute("UPDATE documents_requests SET client_id = intakes.client_id FROM intakes WHERE documents_requests.intake_id = intakes.id")
+    remove_reference :documents_requests, :intake
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_06_220636) do
+ActiveRecord::Schema.define(version: 2021_12_07_222217) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -371,11 +371,11 @@ ActiveRecord::Schema.define(version: 2021_12_06_220636) do
   end
 
   create_table "documents_requests", force: :cascade do |t|
+    t.bigint "client_id"
     t.datetime "completed_at"
     t.datetime "created_at", precision: 6, null: false
-    t.bigint "intake_id"
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["intake_id"], name: "index_documents_requests_on_intake_id"
+    t.index ["client_id"], name: "index_documents_requests_on_client_id"
   end
 
   create_table "efile_errors", force: :cascade do |t|
@@ -1134,7 +1134,7 @@ ActiveRecord::Schema.define(version: 2021_12_06_220636) do
   add_foreign_key "documents", "clients"
   add_foreign_key "documents", "documents_requests"
   add_foreign_key "documents", "tax_returns"
-  add_foreign_key "documents_requests", "intakes"
+  add_foreign_key "documents_requests", "clients"
   add_foreign_key "efile_security_informations", "clients"
   add_foreign_key "efile_security_informations", "efile_submissions"
   add_foreign_key "efile_submission_transitions", "efile_submissions"

--- a/spec/controllers/portal/upload_documents_controller_spec.rb
+++ b/spec/controllers/portal/upload_documents_controller_spec.rb
@@ -6,7 +6,7 @@ describe Portal::UploadDocumentsController do
     it_behaves_like :a_get_action_redirects_for_show_still_needs_help_clients, action: :edit
 
     context "when authenticated" do
-      let(:client) { create :client, intake: (create :intake), current_sign_in_at: Time.now }
+      let(:client) { create :client, intake: (build :intake), current_sign_in_at: Time.now }
 
       before do
         sign_in client
@@ -18,7 +18,7 @@ describe Portal::UploadDocumentsController do
       end
 
       context "when a documents request exists for the session" do
-        let!(:doc_request) { create(:documents_request, intake: client.intake) }
+        let!(:doc_request) { create(:documents_request, client: client) }
         let(:requested_docs_double) { double RequestedDocumentUploadForm }
         before do
           5.times do

--- a/spec/factories/documents_requests.rb
+++ b/spec/factories/documents_requests.rb
@@ -6,18 +6,18 @@
 #  completed_at :datetime
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  intake_id    :bigint
+#  client_id    :bigint
 #
 # Indexes
 #
-#  index_documents_requests_on_intake_id  (intake_id)
+#  index_documents_requests_on_client_id  (client_id)
 #
 # Foreign Keys
 #
-#  fk_rails_...  (intake_id => intakes.id)
+#  fk_rails_...  (client_id => clients.id)
 #
 FactoryBot.define do
   factory :documents_request do
-    intake
+    client
   end
 end

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -527,7 +527,7 @@ describe Client do
       let(:attachment) { fixture_file_upload("test-pattern.png") }
       let(:tax_return_selection) { create(:tax_return_selection) }
       before do
-        doc_request = create :documents_request, intake: intake
+        doc_request = create :documents_request, client: client
         create_list :document, 2, client: client, intake: intake, documents_request_id: doc_request.id
         create_list :document, 2, client: client, intake: intake
         create_list :dependent, 2, intake: intake


### PR DESCRIPTION
that table was the only thing with an intake_id foreign key and it makes the
strategy for archiving intakes a little weird