### PR TITLE
Provide standard deduction for 2021

### DIFF
--- a/app/lib/standard_deduction.rb
+++ b/app/lib/standard_deduction.rb
@@ -5,7 +5,22 @@ class StandardDeduction
     @tax_year = tax_year
   end
 
-  def standard_deduction_2020(filing_status: nil)
+  def standard_deduction(filing_status)
+    return unless filing_status
+
+    send("standard_deduction_#{tax_year}", filing_status)
+  rescue NoMethodError
+    raise NotImplementedError, "Standard deduction rule not implemented for #{tax_year}"
+  end
+
+  def self.for(tax_year:, filing_status:)
+    obj = new(tax_year: tax_year)
+    obj.standard_deduction(filing_status)
+  end
+
+  private
+  
+  def standard_deduction_2020(filing_status)
     case filing_status.to_sym
     when :married_filing_jointly, :qualifying_widow
       24800
@@ -16,15 +31,14 @@ class StandardDeduction
     end
   end
 
-  def standard_deduction(filing_status)
-    return unless filing_status
-    send("standard_deduction_#{tax_year}", filing_status: filing_status)
-  rescue NoMethodError
-    raise NotImplementedError, "Standard deduction rule not implemented for #{tax_year}"
-  end
-
-  def self.for(tax_year:, filing_status:)
-    obj = new(tax_year: tax_year)
-    obj.standard_deduction(filing_status)
+  def standard_deduction_2021(filing_status)
+    case filing_status.to_sym
+    when :married_filing_jointly, :qualifying_widow
+      25100
+    when :head_of_household
+      18800
+    when :single, :married_filing_separately
+      12550
+    end
   end
 end

--- a/spec/factories/state_routing_targets.rb
+++ b/spec/factories/state_routing_targets.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: state_routing_targets
+#
+#  id                 :bigint           not null, primary key
+#  state_abbreviation :string           not null
+#  target_type        :string           not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  target_id          :bigint           not null
+#
+# Indexes
+#
+#  index_state_routing_targets_on_target  (target_type,target_id)
+#
 FactoryBot.define do
   factory :state_routing_target do
     target { build :organization }

--- a/spec/lib/standard_deduction_spec.rb
+++ b/spec/lib/standard_deduction_spec.rb
@@ -10,16 +10,16 @@ describe StandardDeduction do
       end
     end
 
+    context "when filing status is not provided" do
+      it "returns nil" do
+        expect(described_class.for(tax_year: 2021, filing_status: nil)).to eq nil
+      end
+    end
+
     context "tax_year: 2020" do
       context "filing_status: single" do
         it "is 12400" do
           expect(described_class.for(tax_year: 2020, filing_status: "single")).to eq 12400
-        end
-      end
-
-      context "filing_status: married_filing_separately" do
-        it "is 12400" do
-          expect(described_class.for(tax_year: 2020, filing_status: "married_filing_separately")).to eq 12400
         end
       end
 
@@ -44,6 +44,38 @@ describe StandardDeduction do
       context "filing_status: head_of_household" do
         it "is 18650" do
           expect(described_class.for(tax_year: 2020, filing_status: "head_of_household")).to eq 18650
+        end
+      end
+    end
+
+    context "tax_year: 2021" do
+      context "filing_status: single" do
+        it "is 12550" do
+          expect(described_class.for(tax_year: 2021, filing_status: "single")).to eq 12550
+        end
+      end
+
+      context "filing_status: married_filing_separately" do
+        it "is 12550" do
+          expect(described_class.for(tax_year: 2021, filing_status: "married_filing_separately")).to eq 12550
+        end
+      end
+
+      context "filing_status: married_filing_jointly" do
+        it "is 25100" do
+          expect(described_class.for(tax_year: 2021, filing_status: "married_filing_jointly")).to eq 25100
+        end
+      end
+
+      context "filing_status: qualifying_widow" do
+        it "is 25100" do
+          expect(described_class.for(tax_year: 2021, filing_status: "qualifying_widow")).to eq 25100
+        end
+      end
+
+      context "filing_status: head_of_household" do
+        it "is 18800" do
+          expect(described_class.for(tax_year: 2021, filing_status: "head_of_household")).to eq 18800
         end
       end
     end


### PR DESCRIPTION
Because of the updates to how we're programmatically looking for standard deduction values I can't update the config tax year without updating standard deduction first.