### PR TITLE
Make reveals that come after narrower content match the width of that content

### DIFF
--- a/app/assets/stylesheets/components/_reveal.scss
+++ b/app/assets/stylesheets/components/_reveal.scss
@@ -9,9 +9,7 @@
 // this is used in places where we want the reveal to match the width of the form inputs above it
 .reveal-shrink-wrapper {
   .reveal {
-    @media screen and (min-width: $mobile-up) {
-      width: 475px;
-    }
+    max-width: $width-form-long;
   }
 }
 

--- a/app/assets/stylesheets/components/_reveal.scss
+++ b/app/assets/stylesheets/components/_reveal.scss
@@ -6,6 +6,15 @@
   padding: .2em .5em .3em .7em;
 }
 
+// this is used in places where we want the reveal to match the width of the form inputs above it
+.reveal-shrink-wrapper {
+  .reveal {
+    @media screen and (min-width: $mobile-up) {
+      width: 475px;
+    }
+  }
+}
+
 .reveal > p:first-of-type {
   margin-bottom: 0;
 }

--- a/app/assets/stylesheets/templates/_stimulus-received.scss
+++ b/app/assets/stylesheets/templates/_stimulus-received.scss
@@ -4,9 +4,5 @@
       font-size: 1.9rem;
     }
   }
-
-  .reveal__link {
-    font-weight: $font-weight-normal;
-  }
 }
 

--- a/app/views/ctc/questions/dependents/info/edit.html.erb
+++ b/app/views/ctc/questions/dependents/info/edit.html.erb
@@ -32,9 +32,11 @@
         <%= f.cfa_checkbox(:full_time_student, t('views.ctc.questions.dependents.info.full_time_student'), options: { checked_value: "yes", unchecked_value: "no" }) %>
         <%= f.cfa_checkbox(:permanently_totally_disabled, t('views.ctc.questions.dependents.info.permanently_totally_disabled'), options: { checked_value: "yes", unchecked_value: "no" }) %>
         <%= recaptcha_v3(action: 'dependents_info') %>
-        <%= render('components/molecules/reveal', title: t("views.ctc.questions.dependents.info.reveal_title")) do %>
-          <p><%= t("views.ctc.questions.dependents.info.reveal_info") %></p>
-        <% end %>
+        <div class="reveal-shrink-wrapper">
+          <%= render('components/molecules/reveal', title: t("views.ctc.questions.dependents.info.reveal_title")) do %>
+            <p><%= t("views.ctc.questions.dependents.info.reveal_info") %></p>
+          <% end %>
+        </div>
       </div>
     </div>
 

--- a/app/views/ctc/questions/filing_status/edit.html.erb
+++ b/app/views/ctc/questions/filing_status/edit.html.erb
@@ -15,9 +15,11 @@
             ]
           ) %>
 
-      <%= render('components/molecules/reveal', title: t("views.ctc.questions.filing_status.reveal_title")) do %>
-        <p><%= t("views.ctc.questions.filing_status.reveal_body") %></p>
-      <% end %>
+      <div class="reveal-shrink-wrapper">
+        <%= render('components/molecules/reveal', title: t("views.ctc.questions.filing_status.reveal_title")) do %>
+          <p><%= t("views.ctc.questions.filing_status.reveal_body") %></p>
+        <% end %>
+      </div>
     </div>
 
     <button class="button button--primary button--wide" type="submit">

--- a/app/views/ctc/questions/legal_consent/edit.html.erb
+++ b/app/views/ctc/questions/legal_consent/edit.html.erb
@@ -32,9 +32,11 @@
       <%= f.cfa_checkbox(:primary_active_armed_forces, t("views.ctc.questions.legal_consent.primary_active_armed_forces.title", current_tax_year: current_tax_year), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= recaptcha_v3(action: 'legal_consent') %>
 
-      <%= render('components/molecules/reveal', title: t("views.ctc.questions.legal_consent.primary_active_armed_forces.reveal_label")) do %>
-        <p> <%= t("views.ctc.questions.legal_consent.primary_active_armed_forces.reveal_content") %> </p>
-      <% end %>
+      <div class="reveal-shrink-wrapper">
+        <%= render('components/molecules/reveal', title: t("views.ctc.questions.legal_consent.primary_active_armed_forces.reveal_label")) do %>
+          <p> <%= t("views.ctc.questions.legal_consent.primary_active_armed_forces.reveal_content") %> </p>
+        <% end %>
+      </div>
     </div>
 
     <p><%= t("views.ctc.questions.legal_consent.agree_to_share") %></p>

--- a/app/views/ctc/questions/spouse_info/edit.html.erb
+++ b/app/views/ctc/questions/spouse_info/edit.html.erb
@@ -24,9 +24,11 @@
       <%= f.cfa_input_field(:spouse_ssn_confirmation, t("views.ctc.questions.spouse_info.spouse_ssn_itin_confirmation"), classes: ["form-width--long"], options: { maxlength: 11 }) %>
       <%= f.cfa_checkbox(:spouse_can_be_claimed_as_dependent, t("views.ctc.questions.spouse_info.spouse_can_be_claimed_as_dependent"), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox(:spouse_active_armed_forces, t("views.ctc.questions.spouse_info.spouse_active_armed_forces", current_tax_year: current_tax_year), options: { checked_value: "yes", unchecked_value: "no" }) %>
-      <%= render('components/molecules/reveal', title: t("views.ctc.questions.spouse_info.spouse_active_armed_forces_reveal")) do %>
-        <p><%= t("views.ctc.questions.spouse_info.spouse_active_armed_forces_reveal_content") %></p>
-      <% end %>
+      <div class="reveal-shrink-wrapper">
+        <%= render('components/molecules/reveal', title: t("views.ctc.questions.spouse_info.spouse_active_armed_forces_reveal")) do %>
+          <p><%= t("views.ctc.questions.spouse_info.spouse_active_armed_forces_reveal_content") %></p>
+        <% end %>
+      </div>
     </div>
 
     <button class="button button--primary button--wide spacing-below-15" type="submit">

--- a/app/views/ctc/questions/stimulus_one_received/edit.html.erb
+++ b/app/views/ctc/questions/stimulus_one_received/edit.html.erb
@@ -7,12 +7,10 @@
   <h1 class="h2"><%= @main_question %></h1>
 
   <%= t("views.ctc.questions.stimulus_one_received.help_html") %>
-  <div class="reveal">
-    <span class="text--small"><a href="#" class="reveal__link"><%= t("views.ctc.questions.stimulus_one_received.reveal_label") %></a></span>
-    <div class="reveal__content">
-      <%= t("views.ctc.questions.stimulus_one_received.reveal_content") %>
-    </div>
-  </div>
+
+  <%= render('components/molecules/reveal', title: t("views.ctc.questions.stimulus_one_received.reveal_label")) do %>
+    <%= t("views.ctc.questions.stimulus_one_received.reveal_content") %>
+  <% end %>
 
   <%= form_with model: @form, url: questions_stimulus_one_received_path, local: true, method: "put", builder: VitaMinFormBuilder, class: "stimulus-received-form" do |f| %>
     <%= f.cfa_input_field(:eip1_amount_received, t("views.ctc.questions.stimulus_one_received.eip1_amount_received_label"), prefix: "$") %>

--- a/app/views/ctc/questions/stimulus_two_received/edit.html.erb
+++ b/app/views/ctc/questions/stimulus_two_received/edit.html.erb
@@ -7,12 +7,10 @@
   <h1 class="h2"><%= @main_question %></h1>
 
   <%= t("views.ctc.questions.stimulus_two_received.help_html") %>
-  <div class="reveal">
-    <span class="text--small"><a href="#" class="reveal__link"><%= t("views.ctc.questions.stimulus_two_received.reveal_label") %></a></span>
-    <div class="reveal__content">
-      <%= t("views.ctc.questions.stimulus_two_received.reveal_content") %>
-    </div>
-  </div>
+
+  <%= render('components/molecules/reveal', title: t("views.ctc.questions.stimulus_two_received.reveal_label")) do %>
+    <%= t("views.ctc.questions.stimulus_two_received.reveal_content") %>
+  <% end %>
 
   <%= form_with model: @form, url: questions_stimulus_two_received_path, local: true, method: "put", builder: VitaMinFormBuilder, class: "stimulus-received-form" do |f| %>
     <%= f.cfa_input_field(:eip2_amount_received, t("views.ctc.questions.stimulus_two_received.eip2_amount_received_label"), prefix: "$") %>

--- a/app/views/questions/optional_consent/edit.html.erb
+++ b/app/views/questions/optional_consent/edit.html.erb
@@ -14,9 +14,11 @@
     <%= f.simplified_cfa_checkbox(:relational_efin_consented, t("views.questions.optional_consent.relational_efin_html", relational_efin_url: relational_efin_path), options: { checked_value: true, unchecked_value: false, checked: true }) %>
     <%= f.simplified_cfa_checkbox(:global_carryforward_consented, t("views.questions.optional_consent.global_carryforward_html", global_carryforward_url: global_carryforward_path), options: { checked_value: true, unchecked_value: false, checked: true }) %>
 
-    <%= render("components/molecules/reveal", title: t("views.questions.optional_consent.legal_details_title")) do %>
-      <%= t("views.questions.optional_consent.legal_details_html") %>
-    <% end %>
+    <div class="reveal-shrink-wrapper">
+      <%= render("components/molecules/reveal", title: t("views.questions.optional_consent.legal_details_title")) do %>
+        <%= t("views.questions.optional_consent.legal_details_html") %>
+      <% end %>
+    </div>
 
     <button class="button button--primary button--wide spacing-above-60" type="submit">
       <%= t("views.questions.optional_consent.cta") %>


### PR DESCRIPTION
disclaimer: the way i did this is maybe questionable but it didn't seem like there was a way to write a CSS rule that figured out which things to apply itself to. if that sentence doesn't make sense please call me!

summary: Anu and i looked at every reveal and adjusted their widths based on what looked right to her (hence the custom wrapper with the punny name)

screenshots!
whereas before, the reveal on this page would have been wider than the inputs above it, it is now the same width:
![image](https://user-images.githubusercontent.com/43800769/145880765-41823df8-6b1c-46e1-b059-3085a6fc046a.png)
