### PR TITLE
Persist referrer onto ctc returns the same way we do on GYR returns

### DIFF
--- a/app/controllers/ctc/questions/income_controller.rb
+++ b/app/controllers/ctc/questions/income_controller.rb
@@ -41,7 +41,11 @@ module Ctc
       end
 
       def current_intake
-        @intake ||= Intake::CtcIntake.new(visitor_id: cookies[:visitor_id], source: session[:source])
+        @intake ||= Intake::CtcIntake.new(
+            visitor_id: cookies[:visitor_id],
+            source: session[:source],
+            referrer: session[:referrer]
+            )
       end
 
       def method_name

--- a/db/create_analytics_views.sql
+++ b/db/create_analytics_views.sql
@@ -171,7 +171,7 @@ CREATE VIEW analytics.intakes AS
            paid_charitable_contributions, paid_dependent_care, paid_local_tax, paid_medical_expenses,
            paid_mortgage_interest, paid_retirement_contributions, paid_school_supplies, paid_student_loan_interest,
            phone_number_can_receive_texts, preferred_interview_language, primary_consented_to_service, primary_consented_to_service_at, primary_tin_type,
-           received_alimony, received_irs_letter, refund_payment_method, reported_asset_sale_loss,
+           received_alimony, received_irs_letter, referrer, refund_payment_method, reported_asset_sale_loss,
            reported_self_employment_loss, satisfaction_face,
            savings_purchase_bond, savings_split_refund, separated, separated_year, signature_method,
            sms_notification_opt_in, sold_a_home, sold_assets, source, spouse_consented_to_service,

--- a/spec/controllers/ctc/questions/income_controller_spec.rb
+++ b/spec/controllers/ctc/questions/income_controller_spec.rb
@@ -23,6 +23,7 @@ describe Ctc::Questions::IncomeController do
       request.remote_ip = ip_address
       cookies[:visitor_id] = "visitor-id"
       session[:source] = "some-source"
+      session[:referrer] = "https://www.goggles.com/get-tax-refund"
 
       allow(MixpanelService).to receive(:send_event)
     end
@@ -34,6 +35,15 @@ describe Ctc::Questions::IncomeController do
         event_name: "question_answered",
         data: { had_reportable_income: "no" }
       ))
+    end
+
+    it "stores referrer, visitor_id, and referrer onto the intake" do
+      post :update, params: params
+      
+      intake = Intake.last
+      expect(intake.visitor_id).to eq "visitor-id"
+      expect(intake.source).to eq "some-source"
+      expect(intake.referrer).to eq "https://www.goggles.com/get-tax-refund"
     end
 
     it "updates client with intake security information" do

--- a/spec/controllers/ctc/questions/income_controller_spec.rb
+++ b/spec/controllers/ctc/questions/income_controller_spec.rb
@@ -39,7 +39,7 @@ describe Ctc::Questions::IncomeController do
 
     it "stores referrer, visitor_id, and referrer onto the intake" do
       post :update, params: params
-      
+
       intake = Intake.last
       expect(intake.visitor_id).to eq "visitor-id"
       expect(intake.source).to eq "some-source"


### PR DESCRIPTION
In an audit of how we persist the data we gather from a client's session, discovered that we are never persisting the referrer information onto the intake.