### PR TITLE
Fix failing test on Circle caused by javascript SSN mask code

### DIFF
--- a/spec/features/web_intake/new_joint_filers_spec.rb
+++ b/spec/features/web_intake/new_joint_filers_spec.rb
@@ -156,8 +156,8 @@ RSpec.feature "Web Intake Joint Filers", :flow_explorer_screenshot do
       expect(page).to have_selector("h1", text: "Great! Here's the legal stuff...")
       fill_in "Legal first name", with: "Gary"
       fill_in "Legal last name", with: "Gnome"
-      fill_in I18n.t("attributes.primary_ssn"), with: "123456789"
-      fill_in I18n.t("attributes.confirm_primary_ssn"), with: "123456789"
+      fill_in I18n.t("attributes.primary_ssn"), with: "123-45-6789"
+      fill_in I18n.t("attributes.confirm_primary_ssn"), with: "123-45-6789"
       select "March", from: "Month"
       select "5", from: "Day"
       select "1971", from: "Year"


### PR DESCRIPTION
It seems like when we omit the dashes and Capybara types the
SSN to headless chrome, sometimes it gets mangled enough that
it no longer passes validation. Adding dashes when typing it
seems to always work.

Co-authored-by: Catie Talbot <ctalbot@codeforamerica.org>