### PR TITLE
Remove source param logic that caused reporting problems overcounting organic google

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -107,9 +107,11 @@ class ApplicationController < ActionController::Base
     session[:source]
   end
 
+  # Allow session[:source] to re-set on every interaction so we can track all
+  # unique source entry points in Mixpanel.
   def set_source
     source_from_params = params[:source] || params[:utm_source] || params[:s]
-    if !session[:source] && source_from_params.present?
+    if source_from_params.present?
       # Use at most 100 chars in session so we don't overflow it.
       session[:source] = source_from_params.slice(0, 100)
     elsif request.headers.fetch(:referer, "").include?("google.com")

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -846,6 +846,42 @@ RSpec.describe ApplicationController do
     end
   end
 
+  describe "#set_source" do
+    let(:source) { nil }
+
+    context "when session[:source] is not already set" do
+      context "when there is a source param" do
+        it "sets it to the source param" do
+          get :index, params: { source: "my_custom_param" }
+          expect(session[:source]).to eq "my_custom_param"
+        end
+      end
+
+      context "when there is no source param and referrer is google" do
+        before do
+          request.headers[:referer] = "google.com/something"
+        end
+
+        it "sets the source to organic_google" do
+          get :index, params: { source: nil, utm_source: nil, s: nil }
+          expect(session[:source]).to eq "organic_google"
+        end
+      end
+
+      context "when there is no source param and the referrer is anything else" do
+        it "sets the source to nil" do
+          request.headers[:referer] = "bing.com/something"
+        end
+
+        it "sets the source to organic_google" do
+          get :index, params: { source: nil, utm_source: nil, s: nil }
+          expect(session[:source]).to eq nil
+        end
+        end
+      end
+    end
+  end
+
   describe "#set_collapse_main_menu" do
     context "there is no cookie" do
       it "sets collapse main menu to true" do

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -869,14 +869,13 @@ RSpec.describe ApplicationController do
       end
 
       context "when there is no source param and the referrer is anything else" do
-        it "sets the source to nil" do
+        before do
           request.headers[:referer] = "bing.com/something"
         end
 
-        it "sets the source to organic_google" do
+        it "sets the source to nil" do
           get :index, params: { source: nil, utm_source: nil, s: nil }
           expect(session[:source]).to eq nil
-        end
         end
       end
     end


### PR DESCRIPTION
We pushed some code in October that attempted to escape hatch if session[:source] was already set, but it was actually incorrectly allowing session[:source] organic_google to be written in the case that the session value was already set and the client was entering from google.