### PR TITLE
Add some new destroy dependencies for client and update tests

### DIFF
--- a/app/models/efile_submission.rb
+++ b/app/models/efile_submission.rb
@@ -21,7 +21,7 @@ class EfileSubmission < ApplicationRecord
   has_one :intake, through: :tax_return
   has_one :client, through: :tax_return
   has_many :dependents, through: :intake
-  has_one :address, as: :record
+  has_one :address, as: :record, dependent: :destroy
   has_many :efile_submission_transitions, -> { order(id: :asc) }, class_name: "EfileSubmissionTransition", autosave: false, dependent: :destroy
   has_one_attached :submission_bundle
 

--- a/app/models/tax_return.rb
+++ b/app/models/tax_return.rb
@@ -50,7 +50,7 @@ class TaxReturn < ApplicationRecord
   has_many :assignments, class_name: "TaxReturnAssignment", dependent: :destroy
   has_many :tax_return_selection_tax_returns, dependent: :destroy
   has_many :tax_return_selections, through: :tax_return_selection_tax_returns
-  has_many :efile_submissions
+  has_many :efile_submissions, dependent: :destroy
   has_one :accepted_tax_return_analytics
   enum status: TaxReturnStatus::STATUSES, _prefix: :status
   enum certification_level: { advanced: 1, basic: 2, foreign_student: 3 }

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -529,11 +529,13 @@ describe Client do
       before do
         doc_request = create :documents_request, client: client
         create_list :document, 2, client: client, intake: intake, documents_request_id: doc_request.id
-        create_list :document, 2, client: client, intake: intake
         create_list :dependent, 2, intake: intake
         tax_return = create :tax_return, client: client, assigned_user: user, tax_return_selections: [tax_return_selection]
         tax_return_assignment = create :tax_return_assignment, tax_return: tax_return
         create :user_notification, user: user, notifiable: tax_return_assignment
+        submission = create :efile_submission, :investigating, tax_return: tax_return
+        create :address, record: submission
+        create_list :document, 2, client: client, intake: intake, tax_return: tax_return
         note = create :note, client: client, user: user
         create :user_notification, user: user, notifiable: note
         create :system_note, client: client
@@ -562,6 +564,8 @@ describe Client do
         expect(DocumentsRequest.count).to eq 0
         expect(TaxReturnAssignment.count).to eq 0
         expect(UserNotification.count).to eq 0
+        expect(Address.count).to eq(0)
+        expect(EfileSubmission.count).to eq(0)
       end
     end
   end


### PR DESCRIPTION
As we've changed the scope of what is attached to a client or a client's dependencies, we haven't always made sure that they get wiped when the client gets wiped. This attempts to fix that.