### PR TITLE
Suppress Ruby warnings when running test suite

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -9,5 +9,5 @@ fi
 # Increase the # of max open files to avoid https://stackoverflow.com/questions/59890432/rack-error-runtimeerror-failed-to-get-urandom-in-a-rails-app-rails-5-0-6-ru
 ulimit -n 524288
 
-EAGER_LOAD=1 RAILS_CACHE_CLASSES=1 bundle exec turbo_tests || { echo "Not running JS tests due to rspec failure." ; exit 1; }
+RUBYOPT="-W0" EAGER_LOAD=1 RAILS_CACHE_CLASSES=1 bundle exec turbo_tests || { echo "Not running JS tests due to rspec failure." ; exit 1; }
 yarn jest


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/67708639/146235079-8322a961-65bd-4f03-b08f-d745cf5f9e26.png)

After:

![image](https://user-images.githubusercontent.com/67708639/146235616-708a773c-3c68-4b64-aa31-8d637a7d3e01.png)

It's at least _less_ noisy.