### PR TITLE
Hub: fix sizing on errored bank account fields for CTC Client form

### DIFF
--- a/app/assets/stylesheets/components/_hub-form.scss
+++ b/app/assets/stylesheets/components/_hub-form.scss
@@ -14,6 +14,11 @@
     &.card-small {
       max-width: 575px;
     }
+
+    .question-with-follow-up__follow-up {
+      margin: 0;
+      padding: 0;
+    }
   }
 
   &__input-with-checkbox {


### PR DESCRIPTION
our .question-with-follow-up__follow-up class adds extra padding
that is not needed in any of these hub forms, so we conditionally
override the margin/padding now