### PR TITLE
Add activerecord models for archived tables

### DIFF
--- a/app/models/archived/bank_account_2021.rb
+++ b/app/models/archived/bank_account_2021.rb
@@ -1,0 +1,31 @@
+module Archived
+  class BankAccount2021 < ApplicationRecord
+    self.table_name = 'archived_bank_accounts_2021'
+
+    belongs_to :intake, inverse_of: :bank_account
+
+    attr_encrypted :bank_name, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }
+    attr_encrypted :routing_number, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }
+    attr_encrypted :account_number, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }
+    # Enum values are acceptable BankAccountType values to be sent to the IRS (See efileTypes.xsd)
+    enum account_type: { checking: 1, savings: 2 }
+    before_save :hash_data
+
+    # map string enum value back to the corresponding integer
+    def account_type_code
+      self.class.account_types[account_type]
+    end
+
+    def duplicates
+      DeduplificationService.duplicates(self, :hashed_routing_number, :hashed_account_number)
+    end
+
+    def hash_data
+      [:routing_number, :account_number].each do |attr|
+        if send("#{attr}_changed?") && send(attr).present?
+          assign_attributes("hashed_#{attr}" => DeduplificationService.sensitive_attribute_hashed(self, attr))
+        end
+      end
+    end
+  end
+end

--- a/app/models/archived/dependent_2021.rb
+++ b/app/models/archived/dependent_2021.rb
@@ -1,0 +1,162 @@
+module Archived
+  class Dependent2021 < ApplicationRecord
+    self.table_name = 'archived_dependents_2021'
+
+    include SoftDeletable
+
+    belongs_to :intake, inverse_of: :dependents
+
+    attr_encrypted :ssn, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }
+    attr_encrypted :ip_pin, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }
+
+    auto_strip_attributes :ssn, :ip_pin, :first_name, :middle_initial, :last_name, virtual: true
+
+    enum was_student: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :was_student
+    enum on_visa: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :on_visa
+    enum north_american_resident: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :north_american_resident
+    enum disabled: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :disabled
+    enum was_married: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :was_married
+    enum tin_type: { ssn: 0, atin: 1, itin: 2, none: 3, ssn_no_employment: 4 }, _prefix: :tin_type
+    enum has_ip_pin: { unfilled: 0, yes: 1, no: 2 }, _prefix: :has_ip_pin
+    enum full_time_student: { unfilled: 0, yes: 1, no: 2 }, _prefix: :full_time_student
+    enum permanently_totally_disabled: { unfilled: 0, yes: 1, no: 2 }, _prefix: :permanently_totally_disabled
+    enum no_ssn_atin: { unfilled: 0, yes: 1, no: 2 }, _prefix: :no_ssn_atin
+    enum provided_over_half_own_support: { unfilled: 0, yes: 1, no: 2 }, _prefix: :provided_over_half_own_support
+    enum filed_joint_return: { unfilled: 0, yes: 1, no: 2 }, _prefix: :filed_joint_return
+    enum lived_with_more_than_six_months: { unfilled: 0, yes: 1, no: 2 }, _prefix: :lived_with_more_than_six_months
+    enum cant_be_claimed_by_other: { unfilled: 0, yes: 1, no: 2 }, _prefix: :cant_be_claimed_by_other
+    enum born_in_2020: { unfilled: 0, yes: 1, no: 2 }, _prefix: :born_in_2020
+    enum passed_away_2020: { unfilled: 0, yes: 1, no: 2 }, _prefix: :passed_away_2020
+    enum placed_for_adoption: { unfilled: 0, yes: 1, no: 2 }, _prefix: :placed_for_adoption
+    enum permanent_residence_with_client: { unfilled: 0, yes: 1, no: 2 }, _prefix: :permanent_residence_with_client
+    enum claim_anyway: { unfilled: 0, yes: 1, no: 2 }, _prefix: :claim_anyway
+    enum meets_misc_qualifying_relative_requirements: { unfilled: 0, yes: 1, no: 2 }, _prefix: :meets_misc_qualifying_relative_requirements
+
+    before_destroy :remove_error_associations
+
+    validates_presence_of :first_name
+    validates_presence_of :last_name
+
+    validates_presence_of :birth_date
+    # Create birth_date_* accessor methods for Honeycrisp's cfa_date_select
+    delegate :month, :day, :year, to: :birth_date, prefix: :birth_date, allow_nil: true
+
+    validates_presence_of :relationship, on: :ctc_valet_form
+
+    validates_presence_of :ssn, on: :ctc_valet_form
+    validates_confirmation_of :ssn, if: -> { ssn.present? && ssn_changed? }
+    validates :ssn, social_security_number: true, if: -> { ssn.present? && tin_type == "ssn" }
+    validates :ssn, individual_taxpayer_identification_number: true, if: -> { ssn.present? && tin_type == "itin" }
+
+    with_options on: :ip_pin_entry_form do
+      validates :ip_pin, presence: true, if: -> { has_ip_pin_yes? }
+    end
+
+    validates :ip_pin, ip_pin: true
+
+    before_validation do
+      self.ssn = self.ssn.remove(/\D/) if ssn_changed? && self.ssn
+    end
+
+    QUALIFYING_CHILD_RELATIONSHIPS = %w[daughter son stepchild stepbrother stepsister foster_child grandchild niece nephew half_brother half_sister brother sister]
+
+    QUALIFYING_RELATIVE_RELATIONSHIPS = %w[parent grandparent aunt uncle]
+
+    def full_name
+      parts = [first_name, middle_initial, last_name]
+      parts << suffix if suffix.present?
+      parts.compact.join(' ')
+    end
+
+    def error_summary
+      if errors.present?
+        concatenated_message_strings = errors.messages.map { |key, messages| messages.join(" ") }.join(" ")
+        "Errors: " + concatenated_message_strings
+      end
+    end
+
+    # Transforms relationship to the format expected by the IRS submission
+    # (upcased with spaces instead of underscores)
+    def irs_relationship_enum
+      relationship&.upcase.gsub("_", " ")
+    end
+
+    def eligible_for_child_tax_credit_2020?
+      yr_2020_age < 17 && yr_2020_qualifying_child? && tin_type_ssn?
+    end
+
+    def eligible_for_eip1?
+      yr_2020_age < 17 && yr_2020_qualifying_child? && [:ssn, :atin].include?(tin_type&.to_sym)
+    end
+
+    def eligible_for_eip2?
+      yr_2020_age < 17 && yr_2020_qualifying_child? && [:ssn, :atin].include?(tin_type&.to_sym)
+    end
+
+    def eligible_for_eip3?
+      yr_2020_qualifying_child? || yr_2020_qualifying_relative?
+    end
+
+    def qualifying_child_relationship?
+      QUALIFYING_CHILD_RELATIONSHIPS.include? relationship.downcase
+    end
+
+    def qualifying_relative_relationship?
+      QUALIFYING_RELATIVE_RELATIONSHIPS.include? relationship.downcase
+    end
+
+    def meets_qc_misc_conditions?
+      provided_over_half_own_support_no? && filed_joint_return_no?
+    end
+
+    def meets_qc_claimant_condition?
+      cant_be_claimed_by_other_yes? ||
+        (cant_be_claimed_by_other_no? && claim_anyway_yes?)
+    end
+
+    def meets_qc_residence_condition_generic?
+      # This method should only be called when creating the `Rules` instance.
+      #
+      # The age check is handled in the year-specific rules; the rest is handled here.
+      lived_with_more_than_six_months_yes? ||
+        (lived_with_more_than_six_months_no? &&
+          (born_in_2020_yes? || passed_away_2020_yes? || placed_for_adoption_yes? || permanent_residence_with_client_yes?))
+    end
+
+    def mixpanel_data
+      {
+        dependent_age_at_end_of_tax_year: yr_2020_age.to_s,
+        dependent_under_6: yr_2020_age < 6 ? "yes" : "no",
+        dependent_months_in_home: months_in_home.to_s,
+        dependent_was_student: was_student,
+        dependent_on_visa: on_visa,
+        dependent_north_american_resident: north_american_resident,
+        dependent_disabled: disabled,
+        dependent_was_married: was_married,
+      }
+    end
+
+    # Methods on Dependent::Rules can be accessed (and mocked-out) as yr_2020_* and yr_2021_*. In the future, we might
+    # add a default year with no prefix.
+    delegate :age, :born_in_final_6_months?, :disqualified_child_qualified_relative?, :meets_qc_age_condition?, :meets_qc_residence_condition?, :qualifying_child?, :qualifying_relative?, to: :rules_2020, prefix: :yr_2020
+    delegate :age, :born_in_final_6_months?, :disqualified_child_qualified_relative?, :meets_qc_age_condition?, :meets_qc_residence_condition?, :qualifying_child?, :qualifying_relative?, to: :rules_2021, prefix: :yr_2021
+
+    private
+
+    def rules_2020
+      rules(2020)
+    end
+
+    def rules_2021
+      rules(2021)
+    end
+
+    def rules(year)
+      Dependent::Rules.new(birth_date, year, full_time_student_yes?, permanently_totally_disabled_yes?, ssn.present?, qualifying_child_relationship?, qualifying_relative_relationship?, meets_misc_qualifying_relative_requirements_yes?, meets_qc_residence_condition_generic?, meets_qc_claimant_condition?, meets_qc_misc_conditions?)
+    end
+
+    def remove_error_associations
+      EfileSubmissionTransitionError.where(dependent_id: self.id).update_all(dependent_id: nil)
+    end
+  end
+end

--- a/app/models/archived/intake/ctc_intake_2021.rb
+++ b/app/models/archived/intake/ctc_intake_2021.rb
@@ -1,0 +1,122 @@
+class Archived::Intake::CtcIntake2021 < Archived::Intake2021
+  attribute :eip1_amount_received, :money
+  attribute :eip2_amount_received, :money
+  attribute :primary_prior_year_agi_amount, :money
+  attribute :spouse_prior_year_agi_amount, :money
+
+  attr_encrypted :primary_ssn, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }
+  attr_encrypted :spouse_ssn, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }
+  attr_encrypted :primary_ip_pin, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }
+  attr_encrypted :spouse_ip_pin, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }
+  attr_encrypted :primary_signature_pin, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }
+  attr_encrypted :spouse_signature_pin, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }
+
+  enum had_dependents: { unfilled: 0, yes: 1, no: 2 }, _prefix: :had_dependents
+  enum eip1_entry_method: { unfilled: 0, calculated_amount: 1, did_not_receive: 2, manual_entry: 3 }, _prefix: :eip1_entry_method
+  enum eip2_entry_method: { unfilled: 0, calculated_amount: 1, did_not_receive: 2, manual_entry: 3 }, _prefix: :eip2_entry_method
+  enum eip1_and_2_amount_received_confidence: { unfilled: 0, sure: 1, unsure: 2 }, _prefix: :eip1_and_2_amount_received_confidence
+  enum filed_prior_tax_year: { unfilled: 0, filed_full: 1, filed_non_filer: 2, did_not_file: 3 }, _prefix: :filed_prior_tax_year
+  enum spouse_filed_prior_tax_year: { unfilled: 0, filed_full_joint: 1, filed_non_filer_joint: 2, filed_full_separate: 3, filed_non_filer_separate: 4, did_not_file: 5 }, _prefix: :spouse_filed_prior_tax_year
+  enum had_reportable_income: { yes: 1, no: 2 }, _prefix: :had_reportable_income
+  enum spouse_can_be_claimed_as_dependent: { unfilled: 0, yes: 1, no: 2 }, _prefix: :spouse_can_be_claimed_as_dependent
+  enum spouse_active_armed_forces: { unfilled: 0, yes: 1, no: 2 }, _prefix: :spouse_active_armed_forces
+  enum cannot_claim_me_as_a_dependent: { unfilled: 0, yes: 1, no: 2 }, _prefix: :cannot_claim_me_as_a_dependent
+  enum primary_active_armed_forces: { unfilled: 0, yes: 1, no: 2 }, _prefix: :primary_active_armed_forces
+  enum has_primary_ip_pin: { unfilled: 0, yes: 1, no: 2 }, _prefix: :has_primary_ip_pin
+  enum has_spouse_ip_pin: { unfilled: 0, yes: 1, no: 2 }, _prefix: :has_spouse_ip_pin
+  enum consented_to_legal: { unfilled: 0, yes: 1, no: 2 }, _prefix: :consented_to_legal
+
+  has_one :bank_account, inverse_of: :intake, dependent: :destroy, class_name: 'Archived::BankAccount2021', foreign_key: 'archived_intakes_2021_id'
+  accepts_nested_attributes_for :bank_account
+
+  before_validation do
+    attributes_to_change = self.changes_to_save.keys
+    name_attributes = ["primary_first_name", "primary_last_name", "spouse_first_name", "spouse_last_name"]
+
+    (attributes_to_change & name_attributes).each do |attribute|
+      if self.attributes[attribute].present?
+        new_value = self.attributes[attribute].split(/\s/).filter { |str| !str.empty? }.join(" ")
+        self.assign_attributes(attribute => new_value)
+      end
+    end
+  end
+
+  PHOTO_ID_TYPES = {
+    drivers_license: {
+      display_name: "Drivers License",
+      field_name: :with_drivers_license_photo_id
+    },
+    passport: {
+      display_name: "US Passport",
+      field_name: :with_passport_photo_id
+    },
+    other_state: {
+      display_name: "Other State ID",
+      field_name: :with_other_state_photo_id
+    },
+    vita_approved: {
+      display_name: "Identification approved by my VITA site",
+      field_name: :with_vita_approved_photo_id
+    }
+  }
+
+  TAXPAYER_ID_TYPES = {
+    social_security: {
+      display_name: "Social Security card",
+      field_name: :with_social_security_taxpayer_id
+    },
+    itin: {
+      display_name: "Individual Taxpayer ID Number (ITIN) letter",
+      field_name: :with_itin_taxpayer_id
+    },
+    vita_approved: {
+      display_name: "Identification approved by my VITA site",
+      field_name: :with_vita_approved_taxpayer_id
+    }
+  }
+
+  def document_types_definitely_needed
+    []
+  end
+
+  def is_ctc?
+    true
+  end
+
+  def default_tax_return
+    tax_returns.find_by(year: TaxReturn.current_tax_year)
+  end
+
+  # we dont currently ask for preferred name in the onboarding flow, so let's use primary first name to keep the app working for MVP
+  def preferred_name
+    read_attribute(:preferred_name) || primary_first_name
+  end
+
+  def photo_id_display_names
+    names = []
+    PHOTO_ID_TYPES.each do |_, type|
+      if self.send(type[:field_name])
+        names << type[:display_name]
+      end
+    end
+    names.join(', ')
+  end
+
+  def taxpayer_id_display_names
+    names = []
+    TAXPAYER_ID_TYPES.each do |_, type|
+      if self.send(type[:field_name])
+        names << type[:display_name]
+      end
+    end
+    names.join(', ')
+  end
+
+  def any_ip_pins?
+    primary_ip_pin.present? || spouse_ip_pin.present? || dependents.any? { |d| d.ip_pin.present? }
+  end
+
+  def filing_jointly?
+    client.tax_returns.last.filing_status_married_filing_jointly?
+  end
+end

--- a/app/models/archived/intake/gyr_intake_2021.rb
+++ b/app/models/archived/intake/gyr_intake_2021.rb
@@ -1,0 +1,133 @@
+class Archived::Intake::GyrIntake2021 < Archived::Intake2021
+  enum adopted_child: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :adopted_child
+  enum already_applied_for_stimulus: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :already_applied_for_stimulus
+  enum bought_energy_efficient_items: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :bought_energy_efficient_items
+  enum bought_health_insurance: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :bought_health_insurance
+  enum balance_pay_from_bank: { unfilled: 0, yes: 1, no: 2 }, _prefix: :balance_pay_from_bank
+  enum claimed_by_another: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :claimed_by_another
+  enum demographic_questions_opt_in: { unfilled: 0, yes: 1, no: 2 }, _prefix: :demographic_questions_opt_in
+  enum demographic_english_conversation: { unfilled: 0, very_well: 1, well: 2 , not_well: 3, not_at_all: 4, prefer_not_to_answer: 5}, _prefix: :demographic_english_conversation
+  enum demographic_english_reading: { unfilled: 0, very_well: 1, well: 2 , not_well: 3, not_at_all: 4, prefer_not_to_answer: 5}, _prefix: :demographic_english_reading
+  enum demographic_disability: { unfilled: 0, yes: 1, no: 2, prefer_not_to_answer: 3 }, _prefix: :demographic_disability
+  enum demographic_veteran: { unfilled: 0, yes: 1, no: 2, prefer_not_to_answer: 3 }, _prefix: :demographic_veteran
+  enum demographic_primary_ethnicity: { unfilled: 0, hispanic_latino: 1, not_hispanic_latino: 2, prefer_not_to_answer: 3 }, _prefix: :demographic_primary_ethnicity
+  enum demographic_spouse_ethnicity: { unfilled: 0, hispanic_latino: 1, not_hispanic_latino: 2, prefer_not_to_answer: 3 }, _prefix: :demographic_spouse_ethnicity
+  enum divorced: { unfilled: 0, yes: 1, no: 2 }, _prefix: :divorced
+  enum ever_married: { unfilled: 0, yes: 1, no: 2 }, _prefix: :ever_married
+  enum ever_owned_home: { unfilled: 0, yes: 1, no: 2 }, _prefix: :ever_owned_home
+  enum feeling_about_taxes: { unfilled: 0, positive: 1, neutral: 2, negative: 3 }, _prefix: :feeling_about_taxes
+  enum filing_for_stimulus: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :filing_for_stimulus
+  enum filing_joint: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :filing_joint
+  enum had_asset_sale_income: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :had_asset_sale_income
+  enum had_debt_forgiven: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :had_debt_forgiven
+  enum had_dependents: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :had_dependents
+  enum had_disability: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :had_disability
+  enum had_disability_income: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :had_disability_income
+  enum had_disaster_loss: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :had_disaster_loss
+  enum had_farm_income: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :had_farm_income
+  enum had_gambling_income: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :had_gambling_income
+  enum had_hsa: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :had_hsa
+  enum had_interest_income: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :had_interest_income
+  enum had_local_tax_refund: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :had_local_tax_refund
+  enum had_other_income: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :had_other_income
+  enum had_rental_income: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :had_rental_income
+  enum had_retirement_income: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :had_retirement_income
+  enum had_self_employment_income: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :had_self_employment_income
+  enum had_social_security_income: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :had_social_security_income
+  enum had_social_security_or_retirement: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :had_social_security_or_retirement
+  enum had_student_in_family: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :had_student_in_family
+  enum had_tax_credit_disallowed: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :had_tax_credit_disallowed
+  enum had_tips: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :had_tips
+  enum had_unemployment_income: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :had_unemployment_income
+  enum had_wages: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :had_wages
+  enum income_over_limit: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :income_over_limit
+  enum issued_identity_pin: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :issued_identity_pin
+  enum lived_with_spouse: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :lived_with_spouse
+  enum made_estimated_tax_payments: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :made_estimated_tax_payments
+  enum married: { unfilled: 0, yes: 1, no: 2 }, _prefix: :married
+  enum multiple_states: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :multiple_states
+  enum needs_help_2016: { unfilled: 0, yes: 1, no: 2 }, _prefix: :needs_help_2016
+  enum needs_help_2017: { unfilled: 0, yes: 1, no: 2 }, _prefix: :needs_help_2017
+  enum needs_help_2018: { unfilled: 0, yes: 1, no: 2 }, _prefix: :needs_help_2018
+  enum needs_help_2019: { unfilled: 0, yes: 1, no: 2 }, _prefix: :needs_help_2019
+  enum needs_help_2020: { unfilled: 0, yes: 1, no: 2 }, _prefix: :needs_help_2020
+  enum needs_help_2021: { unfilled: 0, yes: 1, no: 2 }, _prefix: :needs_help_2021
+  enum no_eligibility_checks_apply: { unfilled: 0, yes: 1, no: 2 }, _prefix: :no_eligibility_checks_apply
+  enum no_ssn: { unfilled: 0, yes: 1, no: 2 }, _prefix: :no_ssn
+  enum paid_alimony: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :paid_alimony
+  enum paid_charitable_contributions: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :paid_charitable_contributions
+  enum paid_dependent_care: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :paid_dependent_care
+  enum paid_local_tax: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :paid_local_tax
+  enum paid_medical_expenses: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :paid_medical_expenses
+  enum paid_mortgage_interest: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :paid_mortgage_interest
+  enum paid_retirement_contributions: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :paid_retirement_contributions
+  enum paid_school_supplies: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :paid_school_supplies
+  enum paid_student_loan_interest: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :paid_student_loan_interest
+  enum phone_number_can_receive_texts: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :phone_number_can_receive_texts
+  enum received_alimony: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :received_alimony
+  enum received_homebuyer_credit: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :received_homebuyer_credit
+  enum received_irs_letter: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :received_irs_letter
+  enum received_stimulus_payment: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :received_stimulus_payment
+  enum reported_asset_sale_loss: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :reported_asset_sale_loss
+  enum reported_self_employment_loss: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :reported_self_employment_loss
+  enum satisfaction_face: { unfilled: 0, positive: 1, neutral: 2, negative: 3 }, _prefix: :satisfaction_face
+  enum savings_split_refund: { unfilled: 0, yes: 1, no: 2 }, _prefix: :savings_split_refund
+  enum savings_purchase_bond: { unfilled: 0, yes: 1, no: 2 }, _prefix: :savings_purchase_bond
+  enum separated: { unfilled: 0, yes: 1, no: 2 }, _prefix: :separated
+  enum sold_a_home: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :sold_a_home
+  enum sold_assets: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :sold_assets
+  enum spouse_consented_to_service: { unfilled: 0, yes: 1, no: 2 }, _prefix: :spouse_consented_to_service
+  enum spouse_was_full_time_student: { unfilled: 0, yes: 1, no: 2}, _prefix: :spouse_was_full_time_student
+  enum spouse_was_on_visa: { unfilled: 0, yes: 1, no: 2 }, _prefix: :spouse_was_on_visa
+  enum spouse_had_disability: { unfilled: 0, yes: 1, no: 2 }, _prefix: :spouse_had_disability
+  enum spouse_was_blind: { unfilled: 0, yes: 1, no: 2 }, _prefix: :spouse_was_blind
+  enum spouse_issued_identity_pin: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :spouse_issued_identity_pin
+  enum was_blind: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :was_blind
+  enum was_full_time_student: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :was_full_time_student
+  enum was_on_visa: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :was_on_visa
+  enum widowed: { unfilled: 0, yes: 1, no: 2 }, _prefix: :widowed
+  enum wants_to_itemize: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :wants_to_itemize
+
+  after_save do
+    if saved_change_to_completed_at?(from: nil)
+      InteractionTrackingService.record_incoming_interaction(client) # client completed intake
+    elsif completed_at.present?
+      InteractionTrackingService.record_internal_interaction(client) # user updated completed intake
+    end
+  end
+
+  def relevant_document_types
+    DocumentTypes::ALL_TYPES.select do |doc_type_class|
+      doc_type_class.relevant_to?(self)
+    end
+  end
+
+  def relevant_intake_document_types
+    DocumentNavigation::FLOW.map do |doc_type_controller|
+      doc_type = doc_type_controller.document_type
+      doc_type if doc_type && doc_type.relevant_to?(self)
+    end.compact
+  end
+
+  def document_types_definitely_needed
+    relevant_document_types.select(&:needed_if_relevant?).reject do |document_type|
+      documents.where(document_type: document_type.key).present?
+    end
+  end
+
+  # create a faux bank account to turn bank account data into a BankAccount object
+  def bank_account
+    return nil unless encrypted_bank_account_number || encrypted_bank_name || encrypted_bank_routing_number
+
+    type = Archived::BankAccount2021.account_types.keys.include?(bank_account_type) ? bank_account_type : nil
+    @bank_account ||= Archived::BankAccount2021.new(account_type: type, bank_name: bank_name, account_number: bank_account_number, routing_number: bank_routing_number)
+  end
+
+  def document_types_possibly_needed
+    relevant_document_types.reject(&:needed_if_relevant?).reject do |document_type|
+      document_type == DocumentTypes::Other
+    end.reject do |document_type|
+      documents.where(document_type: document_type.key).present?
+    end
+  end
+end

--- a/app/models/archived/intake_2021.rb
+++ b/app/models/archived/intake_2021.rb
@@ -1,0 +1,330 @@
+module Archived
+  class Intake2021 < ApplicationRecord
+    self.table_name = 'archived_intakes_2021'
+
+    def self.discriminate_class_for_record(record)
+      if record['type'] == 'Intake::CtcIntake'
+        Archived::Intake::CtcIntake2021
+      elsif record['type'] == 'Intake::GyrIntake'
+        Archived::Intake::GyrIntake2021
+      else
+        self
+      end
+    end
+
+    include PgSearch::Model
+
+    def self.searchable_fields
+      [:client_id, :primary_first_name, :primary_last_name, :preferred_name, :spouse_first_name, :spouse_last_name, :email_address, :phone_number, :sms_phone_number]
+    end
+
+    pg_search_scope :search, against: searchable_fields, using: { tsearch: { prefix: true, tsvector_column: 'searchable_data' } }
+
+    has_many :documents, dependent: :destroy
+    has_many :dependents, -> { order(created_at: :asc) }, inverse_of: :intake, dependent: :destroy, class_name: 'Archived::Dependent2021', foreign_key: 'archived_intakes_2021_id'
+    belongs_to :client, inverse_of: :intake, optional: true
+    has_many :tax_returns, through: :client
+    belongs_to :vita_partner, optional: true
+    accepts_nested_attributes_for :dependents, allow_destroy: true
+    scope :completed_yes_no_questions, -> { where.not(completed_yes_no_questions_at: nil) }
+    validates :email_address, 'valid_email_2/email': true
+    validates :phone_number, :sms_phone_number, allow_blank: true, e164_phone: true
+    validates_presence_of :visitor_id
+
+    before_validation do
+      self.primary_ssn = self.primary_ssn.remove(/\D/) if primary_ssn_changed? && self.primary_ssn
+      self.spouse_ssn = self.spouse_ssn.remove(/\D/) if spouse_ssn_changed? && self.spouse_ssn
+    end
+
+    before_save do
+      self.needs_to_flush_searchable_data_set_at = Time.current
+      if email_address.present?
+        self.email_domain = email_address.split('@').last.downcase
+        self.canonical_email_address = compute_canonical_email_address
+      end
+      self.primary_last_four_ssn = primary_ssn&.last(4) if encrypted_primary_ssn_changed?
+      self.spouse_last_four_ssn = spouse_ssn&.last(4) if encrypted_spouse_ssn_changed?
+    end
+
+    attr_encrypted :primary_last_four_ssn, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }
+    attr_encrypted :spouse_last_four_ssn, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }
+    attr_encrypted :primary_ssn, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }
+    attr_encrypted :spouse_ssn, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }
+    attr_encrypted :bank_name, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }
+    attr_encrypted :bank_routing_number, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }
+    attr_encrypted :bank_account_number, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }
+
+    enum already_filed: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :already_filed
+    enum email_notification_opt_in: { unfilled: 0, yes: 1, no: 2 }, _prefix: :email_notification_opt_in
+    enum sms_notification_opt_in: { unfilled: 0, yes: 1, no: 2 }, _prefix: :sms_notification_opt_in
+    enum signature_method: { online: 0, in_person: 1 }, _prefix: :signature_method
+    enum bank_account_type: { unfilled: 0, checking: 1, savings: 2, unspecified: 3 }, _prefix: :bank_account_type
+    enum primary_consented_to_service: { unfilled: 0, yes: 1, no: 2 }, _prefix: :primary_consented_to_service
+    enum refund_payment_method: { unfilled: 0, direct_deposit: 1, check: 2 }, _prefix: :refund_payment_method
+    enum claim_owed_stimulus_money: { unfilled: 0, yes: 1, no: 2 }, _prefix: :claim_owed_stimulus_money
+    enum primary_tin_type: { ssn: 0, itin: 1, none: 2, ssn_no_employment: 3 }, _prefix: :primary_tin_type
+    enum spouse_tin_type: { ssn: 0, itin: 1, none: 2, ssn_no_employment: 3 }, _prefix: :spouse_tin_type
+
+    NAVIGATOR_TYPES = {
+      general: {
+        param: "1",
+        display_name: "General",
+        field_name: :with_general_navigator
+      },
+      incarcerated: {
+        param: "2",
+        display_name: "Incarcerated/reentry",
+        field_name: :with_incarcerated_navigator
+      },
+      limited_english: {
+        param: "3",
+        display_name: "Limited English",
+        field_name: :with_limited_english_navigator
+      },
+      unhoused: {
+        param: "4",
+        display_name: "Unhoused",
+        field_name: :with_unhoused_navigator
+      }
+    }
+
+    def is_ctc?
+      false
+    end
+
+    # Returns the phone number formatted for user display, e.g.: "(510) 555-1234"
+    def formatted_phone_number
+      Phonelib.parse(phone_number).local_number
+    end
+
+    def formatted_sms_phone_number
+      Phonelib.parse(sms_phone_number).local_number
+    end
+
+    # Returns the sms phone number in the E164 standardized format, e.g.: "+15105551234"
+    def standardized_sms_phone_number
+      PhoneParser.normalize(sms_phone_number)
+    end
+
+    def primary_full_name
+      parts = [primary_first_name, primary_last_name]
+      parts << primary_suffix if primary_suffix.present?
+      parts.join(' ')
+    end
+
+    def spouse_full_name
+      parts = [spouse_first_name, spouse_last_name]
+      parts << spouse_suffix if spouse_suffix.present?
+      parts.join(' ')
+    end
+
+    def primary_user
+      users.where.not(is_spouse: true).first
+    end
+
+    def spouse
+      users.where(is_spouse: true).first
+    end
+
+    def consented?
+      primary_consented_to_service_at.present?
+    end
+
+    def pdf
+      IntakePdf.new(self).output_file
+    end
+
+    def consent_pdf
+      ConsentPdf.new(self).output_file
+    end
+
+    def referrer_domain
+      URI.parse(referrer).host if referrer.present?
+    end
+
+    def state_of_residence_name
+      States.name_for_key(state_of_residence)
+    end
+
+    def had_a_job?
+      job_count.present? && job_count > 0
+    end
+
+    def eligible_for_vita?
+      # if any are unfilled this will return false
+      had_farm_income_no? && had_rental_income_no? && income_over_limit_no?
+    end
+
+    def any_students?
+      was_full_time_student_yes? ||
+        spouse_was_full_time_student_yes? ||
+        had_student_in_family_yes? ||
+        dependents.where(was_student: "yes").any?
+    end
+
+    def spouse_name_or_placeholder
+      return I18n.t("models.intake.your_spouse") unless spouse_first_name.present?
+      spouse_full_name
+    end
+
+    def student_names
+      names = []
+      names << primary_full_name if was_full_time_student_yes?
+      names << spouse_name_or_placeholder if spouse_was_full_time_student_yes?
+      names += dependents.where(was_student: "yes").map(&:full_name)
+      names
+    end
+
+    def external_id
+      return unless id.present?
+
+      ["intake", id].join("-")
+    end
+
+    def get_or_create_spouse_auth_token
+      return spouse_auth_token if spouse_auth_token.present?
+
+      new_token = SecureRandom.urlsafe_base64(8)
+      update(spouse_auth_token: new_token)
+      new_token
+    end
+
+    def most_recent_filing_year
+      filing_years.first || TaxReturn.current_tax_year
+    end
+
+    def filing_years
+      tax_returns.pluck(:year).sort.reverse
+    end
+
+    def filer_count
+      filing_joint_yes? ? 2 : 1
+    end
+
+    def include_bank_details?
+      refund_payment_method_direct_deposit? || balance_pay_from_bank_yes?
+    end
+
+    def year_before_most_recent_filing_year
+      most_recent_filing_year && most_recent_filing_year - 1
+    end
+
+    def contact_info_filtered_by_preferences
+      contact_info = {}
+      contact_info[:sms_phone_number] = sms_phone_number if sms_notification_opt_in_yes?
+      contact_info[:email] = email_address if email_notification_opt_in_yes?
+      contact_info
+    end
+
+    def opted_into_notifications?
+      sms_notification_opt_in_yes? || email_notification_opt_in_yes?
+    end
+
+    def had_earned_income?
+      had_a_job? || had_wages_yes? || had_self_employment_income_yes?
+    end
+
+    def had_dependents_under?(yrs)
+      dependents.any? { |dependent| dependent.yr_2020_age < yrs }
+    end
+
+    def needs_help_with_backtaxes?
+      TaxReturn.backtax_years.any? { |year| send("needs_help_#{year}_yes?") }
+    end
+
+    def formatted_contact_preferences
+      text = "Prefers notifications by:\n"
+      text << "    • Text message\n" if sms_notification_opt_in_yes?
+      text << "    • Email\n" if email_notification_opt_in_yes?
+      text
+    end
+
+    def formatted_mailing_address
+      return "N/A" unless street_address
+      <<~ADDRESS
+      #{street_address} #{street_address2}
+      #{city}, #{state} #{zip_code}
+      ADDRESS
+    end
+
+    def update_or_create_13614c_document(filename)
+      ClientPdfDocument.create_or_update(
+        output_file: pdf,
+        document_type: DocumentTypes::Form13614C,
+        client: client,
+        filename: filename
+      )
+    end
+
+    def update_or_create_14446_document(filename)
+      ClientPdfDocument.create_or_update(
+        output_file: consent_pdf,
+        document_type: DocumentTypes::Form14446,
+        client: client,
+        filename: filename
+      )
+    end
+
+    def update_or_create_additional_consent_pdf
+      ClientPdfDocument.create_or_update(
+        output_file: AdditionalConsentPdf.new(client).output_file,
+        document_type: DocumentTypes::AdditionalConsentForm,
+        client: client,
+        filename: "additional-consent-2021.pdf"
+      )
+    end
+
+    def might_encounter_delayed_service?
+      vita_partner.at_capacity?
+    end
+
+    def set_navigator(param)
+      _, navigator_type = NAVIGATOR_TYPES.find { | _, type| type[:param] == param }
+      return unless navigator_type
+
+      self.update(navigator_type[:field_name] => true)
+    end
+
+    def drop_off?
+      tax_returns.pluck(:service_type).any? "drop_off"
+    end
+
+    def navigator_display_names
+      names = []
+      NAVIGATOR_TYPES.each do |_, type|
+        if self.send(type[:field_name])
+          names << type[:display_name]
+        end
+      end
+      names.join(', ')
+    end
+
+    def self.refresh_search_index(limit: 10_000)
+      now = Time.current
+      ids = where('needs_to_flush_searchable_data_set_at < ?', now)
+        .limit(limit)
+        .pluck(:id)
+
+      where(id: ids)
+        .where('needs_to_flush_searchable_data_set_at < ?', now)
+        .update_all(<<-SQL)
+        searchable_data = to_tsvector('simple', array_to_string(ARRAY[#{searchable_fields.map { |f| "#{f}::text"}.join(",\n") }], ' ', '')),
+        needs_to_flush_searchable_data_set_at = NULL
+      SQL
+    end
+
+    def new_dependent_token
+      verifier = ActiveSupport::MessageVerifier.new(Rails.application.secret_key_base)
+      verifier.generate(SecureRandom.base36(24))
+    end
+
+    def compute_canonical_email_address
+      if email_domain == 'gmail.com'
+        username, domain = email_address.split('@')
+        [username.gsub('.', ''), domain].join('@').downcase
+      else
+        email_address.downcase
+      end
+    end
+  end
+end


### PR DESCRIPTION
The main sticky point is that grabbing an intake with Archived::Intake.last
wants to instantiate an 'Intake::GyrIntake' because we're not changing all
those 'type' columns, so you have to override something like
discriminate_class_for_record (which is private) to let you do your own
flavor of archive-aware STI