### PR TITLE
Use the `warning` gem to hide regexp warnings generated by device_detector

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,6 +96,7 @@ group :development, :test do
   gem 'parallel_tests'
   gem 'turbo_tests'
   gem 'timecop'
+  gem 'warning', require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -571,6 +571,7 @@ GEM
       equalizer (~> 0.0, >= 0.0.9)
     warden (1.2.9)
       rack (>= 2.0.9)
+    warning (1.2.1)
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -689,6 +690,7 @@ DEPENDENCIES
   twilio-ruby
   tzinfo-data
   valid_email2
+  warning
   web-console (>= 3.3.0)
   webdrivers
   webmock

--- a/config/initializers/warning.rb
+++ b/config/initializers/warning.rb
@@ -1,0 +1,7 @@
+if Rails.env.development? || Rails.env.test?
+  require 'warning'
+
+  # Remove if https://github.com/podigee/device_detector/pull/90 or something else removes the warnings
+  Warning.ignore(/device_detector.*warning: nested repeat operator/)
+  Warning.ignore(/device_detector.*warning: regular expression has/)
+end


### PR DESCRIPTION
until that gem is changed, someday

The warning ignoring part happens in a Rails initializer, so you'll still see the warnings if you run a test that loads device_detector but not Rails (do we have one of those?)