### PR TITLE
Fix deprecation error with Capybara::Selenium::Driver

### DIFF
--- a/spec/support/selenium_chrome_headless.rb
+++ b/spec/support/selenium_chrome_headless.rb
@@ -3,8 +3,6 @@
 # someday if we move from /features/ to /system/
 # like in https://github.com/codeforamerica/gcf-backend/blob/main/spec/support/system_tests.rb#L34
 Capybara.register_driver :selenium_chrome_headless do |app|
-  version = Capybara::Selenium::Driver.load_selenium
-  options_key = Capybara::Selenium::Driver::CAPS_VERSION.satisfied_by?(version) ? :capabilities : :options
   browser_options = ::Selenium::WebDriver::Chrome::Options.new.tap do |opts|
     opts.add_argument('--headless')
     opts.add_argument('--disable-gpu') if Gem.win_platform?
@@ -17,5 +15,5 @@ Capybara.register_driver :selenium_chrome_headless do |app|
     opts.add_argument('--force-device-scale-factor=1')
   end
 
-  Capybara::Selenium::Driver.new(app, **Hash[:browser => :chrome, options_key => browser_options])
+  Capybara::Selenium::Driver.new(app, **Hash[:browser => :chrome, :capabilities => browser_options])
 end


### PR DESCRIPTION
We used to conditionally initialize Capybara::Selenium::Driver with either :options
or :capabilities depending on the version, but the version matching was comparing
strictly against `~> 4.0`. Now that there's 4.1 we would have to update that
conditional, but it doesn't matter because we should just always send `capabilities`