### PR TITLE
Fix crash if Phony tries to validate an integer

### DIFF
--- a/app/services/phone_parser.rb
+++ b/app/services/phone_parser.rb
@@ -1,12 +1,12 @@
 class PhoneParser
   def self.normalize(raw_phone_number)
     valid, phony_normalized = self.phony_normalize_or_error(raw_phone_number)
-    valid ? self.e164(phony_normalized) : raw_phone_number
+    valid ? self.e164(phony_normalized) : raw_phone_number&.to_s
   end
 
   def self.formatted_phone_number(raw_phone_number)
     valid, phony_normalized = self.phony_normalize_or_error(raw_phone_number)
-    valid ? Phony.format(phony_normalized, format: :national) : raw_phone_number
+    valid ? Phony.format(phony_normalized, format: :national) : raw_phone_number&.to_s
   end
 
   def self.phone_number_link(raw_phone_number)
@@ -19,6 +19,8 @@ class PhoneParser
   def self.phony_normalize_or_error(raw_phone_number)
     return [false, nil] if raw_phone_number.nil?
     return [false, ""] if raw_phone_number == ""
+
+    raw_phone_number = raw_phone_number.to_s
 
     phony_normalized = Phony.normalize(raw_phone_number, cc: '1')
     if Phony.plausible?(phony_normalized)

--- a/spec/services/phone_parser_spec.rb
+++ b/spec/services/phone_parser_spec.rb
@@ -41,6 +41,12 @@ describe PhoneParser do
         expect(described_class.normalize("415")).to eq("415")
       end
     end
+
+    context "with an integer phone number" do
+      it "returns the normalized number" do
+        expect(described_class.normalize(4158161286)).to eq("+14158161286")
+      end
+    end
   end
 
   describe ".formatted_phone_number" do


### PR DESCRIPTION
We are sending it an integer for 'twilio_phone_number' which
lives in the credentials file. we could also make that a string,
but accepting ints is something the old phone validation code
did, so now it will do it again.

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>