### PR TITLE
Add request_store patch to avoid lograge causing fatal errors [#180840709]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -125,5 +125,8 @@ group :test do
   gem 'percy-capybara'
 end
 
+# Add a fix for lograge/request_store to avoid fatal errors: https://github.com/steveklabnik/request_store/pull/78
+gem 'request_store', github: 'ghiculescu/request_store', branch: 'stack-overflow-const-response'
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,14 @@ GIT
       jquery-rails
       sass
 
+GIT
+  remote: https://github.com/ghiculescu/request_store.git
+  revision: 3d8e7bff5ba1ec270b412d3c658b1c6372cf73a3
+  branch: stack-overflow-const-response
+  specs:
+    request_store (1.5.0)
+      rack (>= 1.4)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -422,8 +430,6 @@ GEM
       json
     redcarpet (3.5.1)
     regexp_parser (2.2.0)
-    request_store (1.5.0)
-      rack (>= 1.4)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -666,6 +672,7 @@ DEPENDENCIES
   rails_autolink
   recaptcha
   redcarpet
+  request_store!
   rspec-rails
   rspec_junit_formatter
   rubocop (~> 0.82.0)


### PR DESCRIPTION
Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>

## How to test

- Set `config.consider_all_requests_local = false` in `development.rb`
- Run `puma`
- Run `ab -c 100 -n 2000 'http://0.0.0.0:3000/en/hub/sign_in?invalid=%c0C2e'`

Before this patch, the app will eventually hang and become unresponsive; after it, nope.


<details>
    <summary>Log lines before the hang</summary>
    
```
2022-01-14 10:54:25 -0500 Rack app ("GET /en/hub/sign_ininvalid=%c0C2e" - (127.0.0.1)): #<FrozenError: can't modify frozen fatal>
Error during failsafe response: Invalid query parameters: Invalid encoding for parameter: �C2e
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/request/utils.rb:39:in `check_param_encoding'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/request/utils.rb:34:in `block in check_param_encoding'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/request/utils.rb:34:in `each_value'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/request/utils.rb:34:in `check_param_encoding'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/http/request.rb:388:in `block in GET'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-2.2.3/lib/rack/request.rb:69:in `fetch'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-2.2.3/lib/rack/request.rb:69:in `fetch_header'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/http/request.rb:382:in `GET'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/http/parameters.rb:55:in `parameters'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/http/filter_parameters.rb:43:in `filtered_parameters'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_controller/metal/instrumentation.rb:24:in `process_action'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_controller/metal/params_wrapper.rb:249:in `process_action'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activerecord-6.1.4.1/lib/active_record/railties/controller_runtime.rb:27:in `process_action'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/abstract_controller/base.rb:165:in `process'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionview-6.1.4.1/lib/action_view/rendering.rb:39:in `process'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_controller/metal.rb:190:in `dispatch'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_controller/metal.rb:254:in `dispatch'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/routing/route_set.rb:50:in `dispatch'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/routing/route_set.rb:33:in `serve'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/routing/mapper.rb:19:in `block in <class:Constraints>'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/routing/mapper.rb:49:in `serve'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/journey/router.rb:50:in `block in serve'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/journey/router.rb:32:in `each'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/journey/router.rb:32:in `serve'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/routing/route_set.rb:842:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/middleware/show_exceptions.rb:52:in `render_exception'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/middleware/show_exceptions.rb:36:in `rescue in call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/lograge-0.11.2/lib/lograge/rails_ext/rack/logger.rb:15:in `call_app'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/railties-6.1.4.1/lib/rails/rack/logger.rb:26:in `block in call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activesupport-6.1.4.1/lib/active_support/tagged_logging.rb:99:in `block in tagged'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activesupport-6.1.4.1/lib/active_support/tagged_logging.rb:37:in `tagged'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activesupport-6.1.4.1/lib/active_support/tagged_logging.rb:99:in `tagged'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/railties-6.1.4.1/lib/rails/rack/logger.rb:26:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sprockets-rails-3.4.1/lib/sprockets/rails/quiet_assets.rb:13:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/middleware/remote_ip.rb:81:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/request_store-1.5.0/lib/request_store/middleware.rb:19:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/middleware/request_id.rb:26:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-2.2.3/lib/rack/method_override.rb:24:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-2.2.3/lib/rack/runtime.rb:22:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activesupport-6.1.4.1/lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/middleware/executor.rb:14:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/middleware/static.rb:24:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-2.2.3/lib/rack/sendfile.rb:110:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/middleware/host_authorization.rb:98:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-mini-profiler-2.3.3/lib/mini_profiler/profiler.rb:393:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/ddtrace-0.41.0/lib/ddtrace/contrib/rack/middlewares.rb:87:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/webpacker-5.4.3/lib/webpacker/dev_server_proxy.rb:25:in `perform_request'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-proxy-0.7.0/lib/rack/proxy.rb:63:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/railties-6.1.4.1/lib/rails/engine.rb:539:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/puma-5.5.2/lib/puma/configuration.rb:249:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/puma-5.5.2/lib/puma/request.rb:77:in `block in handle_request'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/puma-5.5.2/lib/puma/thread_pool.rb:344:in `with_force_shutdown'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/puma-5.5.2/lib/puma/request.rb:76:in `handle_request'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/puma-5.5.2/lib/puma/server.rb:447:in `process_client'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/puma-5.5.2/lib/puma/thread_pool.rb:151:in `block in spawn_thread'
2022-01-14 10:54:25 -0500 Rack app ("GET /en/hub/sign_ininvalid=%c0C2e" - (127.0.0.1)): #<FrozenError: can't modify frozen fatal>
Error during failsafe response: Invalid query parameters: Invalid encoding for parameter: �C2e
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/request/utils.rb:39:in `check_param_encoding'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/request/utils.rb:34:in `block in check_param_encoding'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/request/utils.rb:34:in `each_value'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/request/utils.rb:34:in `check_param_encoding'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/http/request.rb:388:in `block in GET'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-2.2.3/lib/rack/request.rb:69:in `fetch'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-2.2.3/lib/rack/request.rb:69:in `fetch_header'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/http/request.rb:382:in `GET'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/http/parameters.rb:55:in `parameters'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/http/filter_parameters.rb:43:in `filtered_parameters'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_controller/metal/instrumentation.rb:24:in `process_action'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_controller/metal/params_wrapper.rb:249:in `process_action'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activerecord-6.1.4.1/lib/active_record/railties/controller_runtime.rb:27:in `process_action'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/abstract_controller/base.rb:165:in `process'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionview-6.1.4.1/lib/action_view/rendering.rb:39:in `process'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_controller/metal.rb:190:in `dispatch'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_controller/metal.rb:254:in `dispatch'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/routing/route_set.rb:50:in `dispatch'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/routing/route_set.rb:33:in `serve'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/routing/mapper.rb:19:in `block in <class:Constraints>'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/routing/mapper.rb:49:in `serve'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/journey/router.rb:50:in `block in serve'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/journey/router.rb:32:in `each'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/journey/router.rb:32:in `serve'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/routing/route_set.rb:842:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/middleware/show_exceptions.rb:52:in `render_exception'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/middleware/show_exceptions.rb:36:in `rescue in call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/lograge-0.11.2/lib/lograge/rails_ext/rack/logger.rb:15:in `call_app'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/railties-6.1.4.1/lib/rails/rack/logger.rb:26:in `block in call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activesupport-6.1.4.1/lib/active_support/tagged_logging.rb:99:in `block in tagged'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activesupport-6.1.4.1/lib/active_support/tagged_logging.rb:37:in `tagged'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activesupport-6.1.4.1/lib/active_support/tagged_logging.rb:99:in `tagged'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/railties-6.1.4.1/lib/rails/rack/logger.rb:26:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sprockets-rails-3.4.1/lib/sprockets/rails/quiet_assets.rb:13:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/middleware/remote_ip.rb:81:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/request_store-1.5.0/lib/request_store/middleware.rb:19:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/middleware/request_id.rb:26:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-2.2.3/lib/rack/method_override.rb:24:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-2.2.3/lib/rack/runtime.rb:22:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activesupport-6.1.4.1/lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/middleware/executor.rb:14:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/middleware/static.rb:24:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-2.2.3/lib/rack/sendfile.rb:110:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/middleware/host_authorization.rb:98:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-mini-profiler-2.3.3/lib/mini_profiler/profiler.rb:393:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/ddtrace-0.41.0/lib/ddtrace/contrib/rack/middlewares.rb:87:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/webpacker-5.4.3/lib/webpacker/dev_server_proxy.rb:25:in `perform_request'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-proxy-0.7.0/lib/rack/proxy.rb:63:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/railties-6.1.4.1/lib/rails/engine.rb:539:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/puma-5.5.2/lib/puma/configuration.rb:249:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/puma-5.5.2/lib/puma/request.rb:77:in `block in handle_request'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/puma-5.5.2/lib/puma/thread_pool.rb:344:in `with_force_shutdown'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/puma-5.5.2/lib/puma/request.rb:76:in `handle_request'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/puma-5.5.2/lib/puma/server.rb:447:in `process_client'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/puma-5.5.2/lib/puma/thread_pool.rb:151:in `block in spawn_thread'
2022-01-14 10:54:25 -0500 Rack app ("GET /en/hub/sign_ininvalid=%c0C2e" - (127.0.0.1)): #<FrozenError: can't modify frozen fatal>
Error during failsafe response: Invalid query parameters: Invalid encoding for parameter: �C2e
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/request/utils.rb:39:in `check_param_encoding'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/request/utils.rb:34:in `block in check_param_encoding'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/request/utils.rb:34:in `each_value'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/request/utils.rb:34:in `check_param_encoding'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/http/request.rb:388:in `block in GET'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-2.2.3/lib/rack/request.rb:69:in `fetch'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-2.2.3/lib/rack/request.rb:69:in `fetch_header'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/http/request.rb:382:in `GET'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/http/parameters.rb:55:in `parameters'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/http/filter_parameters.rb:43:in `filtered_parameters'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_controller/metal/instrumentation.rb:24:in `process_action'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_controller/metal/params_wrapper.rb:249:in `process_action'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activerecord-6.1.4.1/lib/active_record/railties/controller_runtime.rb:27:in `process_action'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/abstract_controller/base.rb:165:in `process'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionview-6.1.4.1/lib/action_view/rendering.rb:39:in `process'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_controller/metal.rb:190:in `dispatch'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_controller/metal.rb:254:in `dispatch'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/routing/route_set.rb:50:in `dispatch'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/routing/route_set.rb:33:in `serve'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/routing/mapper.rb:19:in `block in <class:Constraints>'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/routing/mapper.rb:49:in `serve'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/journey/router.rb:50:in `block in serve'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/journey/router.rb:32:in `each'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/journey/router.rb:32:in `serve'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/routing/route_set.rb:842:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/middleware/show_exceptions.rb:52:in `render_exception'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/middleware/show_exceptions.rb:36:in `rescue in call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/lograge-0.11.2/lib/lograge/rails_ext/rack/logger.rb:15:in `call_app'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/railties-6.1.4.1/lib/rails/rack/logger.rb:26:in `block in call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activesupport-6.1.4.1/lib/active_support/tagged_logging.rb:99:in `block in tagged'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activesupport-6.1.4.1/lib/active_support/tagged_logging.rb:37:in `tagged'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activesupport-6.1.4.1/lib/active_support/tagged_logging.rb:99:in `tagged'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/railties-6.1.4.1/lib/rails/rack/logger.rb:26:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sprockets-rails-3.4.1/lib/sprockets/rails/quiet_assets.rb:13:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/middleware/remote_ip.rb:81:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/request_store-1.5.0/lib/request_store/middleware.rb:19:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/middleware/request_id.rb:26:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-2.2.3/lib/rack/method_override.rb:24:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-2.2.3/lib/rack/runtime.rb:22:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activesupport-6.1.4.1/lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/middleware/executor.rb:14:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/middleware/static.rb:24:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-2.2.3/lib/rack/sendfile.rb:110:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_dispatch/middleware/host_authorization.rb:98:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-mini-profiler-2.3.3/lib/mini_profiler/profiler.rb:393:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/ddtrace-0.41.0/lib/ddtrace/contrib/rack/middlewares.rb:87:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/webpacker-5.4.3/lib/webpacker/dev_server_proxy.rb:25:in `perform_request'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-proxy-0.7.0/lib/rack/proxy.rb:63:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/railties-6.1.4.1/lib/rails/engine.rb:539:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/puma-5.5.2/lib/puma/configuration.rb:249:in `call'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/puma-5.5.2/lib/puma/request.rb:77:in `block in handle_request'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/puma-5.5.2/lib/puma/thread_pool.rb:344:in `with_force_shutdown'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/puma-5.5.2/lib/puma/request.rb:76:in `handle_request'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/puma-5.5.2/lib/puma/server.rb:447:in `process_client'
  /Users/asheesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/puma-5.5.2/lib/puma/thread_pool.rb:151:in `block in spawn_thread'
2022-01-14 10:54:25 -0500 Rack app ("GET /en/hub/sign_ininvalid=%c0C2e" - (127.0.0.1)): #<FrozenError: can't modify frozen fatal>

```
</details>

## Thanks

Ben Sheldon discovered that lograge (which is why we use request_store) is correlated to the app hang.

Jenny Heath emphasized when I chatted with her that we need the app to be resilient to HTTP 500 errors; we may cause those by accident, so it is advisable to prioritize reliability in the face of a 500 rather than merely fixing the 500s.