### PR TITLE
Fix national routing capabilities

### DIFF
--- a/app/services/partner_routing_service.rb
+++ b/app/services/partner_routing_service.rb
@@ -22,7 +22,9 @@ class PartnerRoutingService
     from_state_routing = vita_partner_from_state if @zip_code.present?
     return from_state_routing if from_state_routing.present?
 
-    # route_to_national_overflow_partner
+    from_national_routing = route_to_national_overflow_partner
+    return from_national_routing if from_national_routing.present?
+
     @routing_method = :at_capacity
     return
   end

--- a/spec/features/web_intake/routing_spec.rb
+++ b/spec/features/web_intake/routing_spec.rb
@@ -183,9 +183,51 @@ feature "Intake Routing Spec", :flow_explorer_screenshot, :active_job do
 
     expect(page.html).to have_text "Our team at Hogwarts is here to help!"
   end
+  context "at capacity but overflow site exists" do
+    let!(:default_vita_partner) { create :organization, name: "Default Organization", national_overflow_location: true }
+
+    before do
+      expected_state_vita_partner.update(capacity_limit: 0)
+    end
+
+    scenario "routes to national partner" do
+      visit "/questions/file-with-help"
+
+      expect(page).to have_text "Our full service option is right for you!"
+      click_on "Continue"
+
+      expect(page).to have_text "What years would you like to file for?"
+      check "2020"
+      click_on "Continue"
+
+      expect(Intake.last.source).to eq nil
+      expect(page).to have_text "Thanks for visiting the GetYourRefund demo application!"
+      click_on "Continue to example"
+
+      expect(page).to have_text "Let's get started"
+      click_on "Continue"
+
+      expect(page).to have_text "Just a few simple steps to file!"
+      click_on "Continue"
+
+      expect(page).to have_text "let's get some basic information"
+      fill_in "What is your preferred first name?", with: "Luna Lovegood"
+      fill_in "ZIP code", with: "28806"
+      fill_in "Phone number", with: "415-888-0088"
+      fill_in "Confirm phone number", with: "415-888-0088"
+      click_on "Continue"
+
+      fill_in "Do you have any time preferences for your interview phone call?", with: "During school hours"
+      click_on "Continue"
+
+      fill_out_notification_preferences
+
+      expect(page.html).to have_text "Default Organization is here to help"
+    end
+  end
 
   context "vita partner is at capacity" do
-    let!(:default_vita_partner) { create :organization, name: "Default Organization", national_overflow_location: true }
+    let!(:default_vita_partner) { create :organization, name: "Default Organization", national_overflow_location: false }
 
     before do
       expected_state_vita_partner.update(capacity_limit: 0)

--- a/spec/services/partner_routing_service_spec.rb
+++ b/spec/services/partner_routing_service_spec.rb
@@ -10,7 +10,6 @@ describe PartnerRoutingService do
   before do
     create :source_parameter, code: code, vita_partner: vita_partner
     create :vita_partner_zip_code, zip_code: "94606", vita_partner: vita_partner
-    5.times { create :organization, national_overflow_location: true }
   end
 
   describe "#determine_partner" do
@@ -183,5 +182,18 @@ describe PartnerRoutingService do
         end
       end
     end
+    
+    context "when there are no matches on other data or routing rules" do
+      context "when national overflow partners exist" do
+        let!(:overflow_partner) { create :organization, national_overflow_location: true }
+
+        it "routes to a national overflow partner" do
+          subject { PartnerRoutingService.new(zip_code: "11111") }
+          expect(subject.determine_partner).to eq overflow_partner
+          expect(subject.routing_method).to eq :national_overflow
+        end
+      end
+    end
+
   end
 end


### PR DESCRIPTION
instead of turning off routing to national sites, the code for national routing was commented out at the end of last season.