### PR TITLE
Hub: fix notifications ("My Updates") page to not crash if any notifications reference archived intakes

### DIFF
--- a/app/views/hub/user_notifications/_note.html.erb
+++ b/app/views/hub/user_notifications/_note.html.erb
@@ -5,7 +5,7 @@
     <%= render 'shared/unread_icon', flag: true unless notification.read? %>
     <%= t(".body_html",
           assigner: notification.notifiable.user.name,
-          client_link: link_to(t(".body_link", client_name: notification.notifiable.client.preferred_name), hub_client_notes_path(client_id: notification.notifiable.client, anchor: 'last-item')))
+          client_link: link_to(t(".body_link", client_name: Hub::ClientsController::HubClientPresenter.new(notification.notifiable.client).preferred_name), hub_client_notes_path(client_id: notification.notifiable.client, anchor: 'last-item')))
     %>
   </div>
 </div>

--- a/app/views/hub/user_notifications/_system_note_document_help.html.erb
+++ b/app/views/hub/user_notifications/_system_note_document_help.html.erb
@@ -6,7 +6,7 @@
     <%= t(".body_html",
           client_link:
             link_to(
-                notification.notifiable.client.preferred_name,
+                Hub::ClientsController::HubClientPresenter.new(notification.notifiable.client).preferred_name,
                 hub_client_notes_path(client_id: notification.notifiable.client.id)
             )
         ) %>

--- a/app/views/hub/user_notifications/_tax_return_assignment.html.erb
+++ b/app/views/hub/user_notifications/_tax_return_assignment.html.erb
@@ -6,7 +6,7 @@
     <%= t(".body_html",
           assigner: notification.notifiable.assigner.name,
           tax_return_year: notification.notifiable.tax_return.year.to_s,
-          client_link: link_to(t(".body_link", client_name: notification.notifiable.tax_return.client.preferred_name), hub_client_path(id: notification.notifiable.tax_return.client)))
+          client_link: link_to(t(".body_link", client_name: Hub::ClientsController::HubClientPresenter.new(notification.notifiable.tax_return.client).preferred_name), hub_client_path(id: notification.notifiable.tax_return.client)))
     %>
   </div>
 </div>

--- a/spec/features/hub/notifications_spec.rb
+++ b/spec/features/hub/notifications_spec.rb
@@ -5,7 +5,8 @@ RSpec.feature "View user notifications" do
     let!(:notification) { create :user_notification, read: false, created_at: DateTime.new(2021, 3, 15), user: user, notifiable: tax_return_assignment }
     let!(:note_notification) { create :user_notification, created_at: DateTime.new(2021, 3,14), user: user, notifiable: note }
 
-    let(:client) { create :client, intake: create(:intake, preferred_name: "Jenny Odell") }
+    let(:intake) { create(:intake, preferred_name: "Jenny Odell") }
+    let(:client) { create :client, intake: intake }
     let(:tax_return_assignment) { create :tax_return_assignment, tax_return: tax_return, assigner: user_who_assigned }
     let(:note) { create :note, user: (create :user, name: "Someone Cool"), client: client }
     let(:user) { create :user, role: create(:organization_lead_role, organization: create(:organization)) }
@@ -25,6 +26,23 @@ RSpec.feature "View user notifications" do
 
       expect(page).to have_text("You've Been Tagged in a Note")
       expect(page).to have_text("Someone Cool has tagged you in Jenny Odell's notes.")
+    end
+
+    context "when the notifications reference archived clients" do
+      let(:intake) { nil }
+      let!(:archived_intake) {  create(:archived_2021_gyr_intake, client: client, preferred_name: "Jenny Odell") }
+
+      it "still shows the data for the notification" do
+        visit hub_user_notifications_path
+
+        expect(page).to have_text("You've Been Assigned a Client")
+        expect(page).to have_text("Jia Tolentino has assigned")
+        expect(page).to have_link("Jenny Odell's")
+        expect(page).to have_text("2020 return to you.")
+
+        expect(page).to have_text("You've Been Tagged in a Note")
+        expect(page).to have_text("Someone Cool has tagged you in Jenny Odell's notes.")
+      end
     end
   end
 end


### PR DESCRIPTION
Co-authored-by: Em Barnard-Shao <ebarnard@codeforamerica.org>