### PR TITLE
Fix crash generating F14446 consent form during intake

### DIFF
--- a/app/controllers/questions/spouse_consent_controller.rb
+++ b/app/controllers/questions/spouse_consent_controller.rb
@@ -17,7 +17,7 @@ module Questions
     end
 
     def after_update_success
-      GenerateRequiredConsentPdfJob.perform_later(current_intake, "Consent Form 14446.pdf")
+      GenerateRequiredConsentPdfJob.perform_later(current_intake)
       GenerateF13614cPdfJob.perform_later(current_intake.id, "Preliminary 13614-C.pdf")
     end
   end

--- a/spec/controllers/questions/spouse_consent_controller_spec.rb
+++ b/spec/controllers/questions/spouse_consent_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Questions::SpouseConsentController do
       it "queues a job to regenerate the 14446 and the 13614-C" do
         post :update, params: params
 
-        expect(GenerateRequiredConsentPdfJob).to have_received(:perform_later).with(intake, "Consent Form 14446.pdf")
+        expect(GenerateRequiredConsentPdfJob).to have_received(:perform_later).with(intake)
         expect(GenerateF13614cPdfJob).to have_received(:perform_later).with(intake.id, "Preliminary 13614-C.pdf")
       end
     end


### PR DESCRIPTION
Currently the ConsentPdf defines its own #output_filename
so we don't need to pass one in to the GenerateRequiredConsentPdfJob,
which does not accept multiple arguments at this time.

Co-authored-by: Em Barnard-Shao <ebarnard@codeforamerica.org>