### PR TITLE
Fix flow_explorer_screenshots build and make sure it exits with a bad status when tests fail

### DIFF
--- a/lib/tasks/flow_explorer.rake
+++ b/lib/tasks/flow_explorer.rake
@@ -1,6 +1,8 @@
 namespace :flow_explorer do
   desc "Capture flow explorer screenshots by running specialized Capybara runs"
   task capture_screenshots: :environment do |_task|
+    all_passed = true
+
     # We run specs in spec/features/ctc because the GYR specs sometimes fail.
     # TODO(someday): Remove "spec/features/ctc" from command lines below so we generate screenshots from
     # any spec marked flow_explorer_screenshot: true or flow_explorer_screenshot_i18n_friendly: true.
@@ -10,8 +12,11 @@ namespace :flow_explorer do
       "FLOW_EXPLORER_LOCALE=es rspec --tag flow_explorer_screenshot_i18n_friendly spec/features/ctc",
     ].each do |cmd|
       puts "RUNNING: #{cmd}"
-      system(cmd)
+      result = system(cmd)
+      all_passed = false unless result
     end
+
+    exit all_passed
   end
 
   desc "Upload flow explorer screenshots to s3"

--- a/spec/features/ctc/complete_intake_spec.rb
+++ b/spec/features/ctc/complete_intake_spec.rb
@@ -119,16 +119,10 @@ RSpec.feature "CTC Intake", :flow_explorer_screenshot_i18n_friendly, active_job:
 
     # =========== DEPENDENTS ===========
     expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.had_dependents.title'))
-    if Capybara.current_driver == Capybara.javascript_driver
-      page.execute_script("document.querySelector('.reveal').remove()")
-    end
     click_on I18n.t('general.negative')
 
     expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_payments.title'))
     click_on I18n.t('general.back')
-    if Capybara.current_driver == Capybara.javascript_driver
-      page.execute_script("document.querySelector('.reveal').remove()")
-    end
     click_on I18n.t('general.affirmative')
 
     dependent_birth_year = 5.years.ago.year


### PR DESCRIPTION
The tests had some hacks that were trying to `document ... remove()`
a `.reveal` from the DOM because it was causing Capybara to misclick
sometimes. There doesn't seem to actually be a `.reveal` on these pages
(anymore?) so that code was crashing but it also means the code is not
needed anymore.