### PR TITLE
Fix crash for archived intakes with dependents

### DIFF
--- a/app/models/archived/dependent_2021.rb
+++ b/app/models/archived/dependent_2021.rb
@@ -55,7 +55,7 @@ module Archived
 
     include SoftDeletable
 
-    belongs_to :intake, inverse_of: :dependents
+    belongs_to :intake, inverse_of: :dependents, foreign_key: 'archived_intakes_2021_id', class_name: 'Archived::Intake2021'
 
     attr_encrypted :ssn, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }
     attr_encrypted :ip_pin, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }

--- a/app/views/hub/clients/show.html.erb
+++ b/app/views/hub/clients/show.html.erb
@@ -98,7 +98,7 @@
               <span class="form-question"><%= t("general.dependents") %>:</span>
               <span class="label-value"><%= @client.intake&.dependents.with_deleted.length %></span>
               <ul id="dependents-list" class="no-bullets">
-                <%= render @client.intake.dependents.with_deleted %>
+                <%= render partial: 'hub/dependents/dependent', collection: @client.intake.dependents.with_deleted %>
               </ul>
             </div>
           </div>

--- a/spec/factories/archived/dependent_2021.rb
+++ b/spec/factories/archived/dependent_2021.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :archived_2021_dependent, class: Archived::Dependent2021 do
+    first_name { "Kara" }
+    last_name { "Kiwi" }
+    birth_date { Date.new(2011, 3, 5) }
+    relationship { "daughter" }
+  end
+end

--- a/spec/features/hub/show_client_spec.rb
+++ b/spec/features/hub/show_client_spec.rb
@@ -53,10 +53,12 @@ RSpec.describe "a user viewing a client" do
     context "for a client with an archived 2021 intake" do
       let(:intake) { nil }
       let!(:archived_intake) {  create(:archived_2021_gyr_intake, client: client) }
+      let!(:archived_dependent) {  create(:archived_2021_dependent, intake: archived_intake) }
 
       it "can view intake information" do
         visit hub_client_path(id: client.id)
         expect(page).to have_content(archived_intake.preferred_name)
+        expect(page).to have_content(archived_dependent.full_name)
       end
     end
   end


### PR DESCRIPTION
the relationship between `Archived::Dependent2021` and their associated
intake wasn't really set up right