### PR TITLE
Tests: remove `before(:all)` in Rails helper that was adding default rows

### DIFF
--- a/spec/controllers/ctc/questions/confirm_information_controller_spec.rb
+++ b/spec/controllers/ctc/questions/confirm_information_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Ctc::Questions::ConfirmInformationController do
+describe Ctc::Questions::ConfirmInformationController, requires_default_vita_partners: true do
   let(:intake) { create(:client_with_ctc_intake_and_return).intake }
 
   describe "#edit" do

--- a/spec/controllers/ctc/questions/income_controller_spec.rb
+++ b/spec/controllers/ctc/questions/income_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Ctc::Questions::IncomeController do
+describe Ctc::Questions::IncomeController, requires_default_vita_partners: true do
   context '#update' do
     let(:ip_address) { "127.0.0.1" }
     let(:had_reportable_income) { "no" }

--- a/spec/controllers/hub/efile_submissions_controller_spec.rb
+++ b/spec/controllers/hub/efile_submissions_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Hub::EfileSubmissionsController do
+describe Hub::EfileSubmissionsController, requires_default_vita_partners: true do
   describe '#index' do
     it_behaves_like :an_action_for_admins_only, action: :index, method: :get
 

--- a/spec/controllers/hub/metrics_controller_spec.rb
+++ b/spec/controllers/hub/metrics_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Hub::MetricsController do
+describe Hub::MetricsController, requires_default_vita_partners: true do
   describe '#index' do
     let(:sla_breach_report_double) { instance_double(Report::SLABreachReport) }
     let(:vita_partner_1) { create :organization, name: "Vita Partner 1" }

--- a/spec/controllers/hub/unlinked_clients_controller_spec.rb
+++ b/spec/controllers/hub/unlinked_clients_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Hub::UnlinkedClientsController do
+RSpec.describe Hub::UnlinkedClientsController, requires_default_vita_partners: true do
   describe "#index" do
     it_behaves_like :a_get_action_for_admins_only, action: :index
 

--- a/spec/controllers/mailgun_webhooks_controller_spec.rb
+++ b/spec/controllers/mailgun_webhooks_controller_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe MailgunWebhooksController do
       end
     end
 
-    context "with HTTP basic auth credentials" do
+    context "with HTTP basic auth credentials", requires_default_vita_partners: true do
       before do
         request.env["HTTP_AUTHORIZATION"] = valid_auth_credentials
         allow(DatadogApi).to receive(:increment)

--- a/spec/factories/clients.rb
+++ b/spec/factories/clients.rb
@@ -101,7 +101,10 @@ FactoryBot.define do
     end
 
     factory :ctc_client do
-      vita_partner { VitaPartner.ctc_site }
+      vita_partner do
+        org = Organization.find_or_initialize_by(name: "GetCTC.org")
+        Site.find_or_initialize_by(name: "GetCTC.org (Site)", parent_organization: org)
+      end
     end
   end
 end

--- a/spec/features/ctc/client_session_duration_spec.rb
+++ b/spec/features/ctc/client_session_duration_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Session duration" do
+RSpec.feature "Session duration", requires_default_vita_partners: true do
   def authenticate_client(client)
     expect(page).to have_text "To view your progress, we’ll send you a secure code"
     fill_in "Email address", with: client.intake.email_address

--- a/spec/features/ctc/complete_intake_spec.rb
+++ b/spec/features/ctc/complete_intake_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "CTC Intake", :flow_explorer_screenshot_i18n_friendly, active_job: true do
+RSpec.feature "CTC Intake", :flow_explorer_screenshot_i18n_friendly, active_job: true, requires_default_vita_partners: true do
   before do
     allow_any_instance_of(Routes::CtcDomain).to receive(:matches?).and_return(true)
   end

--- a/spec/features/ctc/ctc_beta_spec.rb
+++ b/spec/features/ctc/ctc_beta_spec.rb
@@ -31,7 +31,7 @@ def begin_intake
   click_on I18n.t('general.negative')
 end
 
-RSpec.feature "CTC Beta intake", :flow_explorer_screenshot_i18n_friendly, active_job: true do
+RSpec.feature "CTC Beta intake", :flow_explorer_screenshot_i18n_friendly, active_job: true, requires_default_vita_partners: true do
   before do
     allow_any_instance_of(Routes::CtcDomain).to receive(:matches?).and_return(true)
     allow(Rails.env).to receive(:production?).and_return(true)

--- a/spec/features/ctc/ctc_intake_js_integration_spec.rb
+++ b/spec/features/ctc/ctc_intake_js_integration_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "CTC Intake Javascript Integrations", :js, active_job: true do
+RSpec.feature "CTC Intake Javascript Integrations", :js, active_job: true, requires_default_vita_partners: true do
   before do
     allow_any_instance_of(Routes::CtcDomain).to receive(:matches?).and_return(true)
   end

--- a/spec/features/ctc/edit_ctc_client_spec.rb
+++ b/spec/features/ctc/edit_ctc_client_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "a user editing a clients intake fields" do
+RSpec.describe "a user editing a clients intake fields", requires_default_vita_partners: true do
   context "as an admin user" do
     let(:organization) { create(:organization, name: "Assigned Org") }
     let!(:new_site) { create(:site, name: "Other Site") }

--- a/spec/features/ctc/portal_spec.rb
+++ b/spec/features/ctc/portal_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "CTC Intake", :js, :active_job do
+RSpec.feature "CTC Intake", :js, :active_job, requires_default_vita_partners: true do
   module CtcPortalHelper
     def log_in_to_ctc_portal
       visit "/en/portal/login"

--- a/spec/features/ctc/sign_out_spec.rb
+++ b/spec/features/ctc/sign_out_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "sign out during CTC Intake", active_job: true, efile_security_params: true do
+RSpec.feature "sign out during CTC Intake", active_job: true, efile_security_params: true, requires_default_vita_partners: true do
   before do
     allow_any_instance_of(Routes::CtcDomain).to receive(:matches?).and_return(true)
   end

--- a/spec/forms/ctc/income_form_spec.rb
+++ b/spec/forms/ctc/income_form_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Ctc::IncomeForm do
+describe Ctc::IncomeForm, requires_default_vita_partners: true do
   context "validations" do
     let(:params) {
       {

--- a/spec/helpers/navigation_helper_spec.rb
+++ b/spec/helpers/navigation_helper_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe NavigationHelper do
+RSpec.describe NavigationHelper, requires_default_vita_partners: true do
   describe "#fraud_icon" do
     let(:client) { create(:client_with_ctc_intake_and_return)}
 

--- a/spec/helpers/vita_partner_helper_spec.rb
+++ b/spec/helpers/vita_partner_helper_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe VitaPartnerHelper do
+describe VitaPartnerHelper, requires_default_vita_partners: true do
   describe "#grouped_vita_partner_options" do
     context "when user's role is Team Member" do
       let(:team_member) { create :team_member_user }

--- a/spec/models/report/sla_breach_report_spec.rb
+++ b/spec/models/report/sla_breach_report_spec.rb
@@ -15,7 +15,7 @@
 #
 require 'rails_helper'
 
-RSpec.describe Report::SLABreachReport, type: :model do
+RSpec.describe Report::SLABreachReport, type: :model, requires_default_vita_partners: true do
   describe ".generate!" do
 
     let(:fake_report) do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -47,7 +47,7 @@
 #
 require "rails_helper"
 
-RSpec.describe User, type: :model do
+RSpec.describe User, type: :model, requires_default_vita_partners: true do
   describe "#valid?" do
     it "required fields" do
       user = User.new

--- a/spec/models/vita_partner_spec.rb
+++ b/spec/models/vita_partner_spec.rb
@@ -29,7 +29,7 @@
 #
 require "rails_helper"
 
-describe VitaPartner do
+describe VitaPartner, requires_default_vita_partners: true do
   describe "#active?" do
     context "when there is a routing target for vita partner > 0.0" do
       let(:vita_partner) { create :organization }

--- a/spec/presenters/hub/organizations_presenter_spec.rb
+++ b/spec/presenters/hub/organizations_presenter_spec.rb
@@ -59,13 +59,7 @@ describe Hub::OrganizationsPresenter do
 
     describe "#unrouted_independent_organizations" do
       it "returns a collection of the independent organizations that have no state routing rules" do
-        ctc_org = Organization.find_by(name: "GetCTC.org")
-        national_org = VitaPartner.find_by(name: "GYR National Organization")
-        expect(subject.unrouted_independent_organizations).to match_array([
-          unrouted_organization,
-          national_org,
-          ctc_org
-        ])
+        expect(subject.unrouted_independent_organizations).to match_array([unrouted_organization])
       end
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -88,13 +88,6 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
-  config.before(:all) do
-    # Create client support org
-    Organization.find_or_create_by!(name: "GYR National Organization", allows_greeters: true)
-    ctc_org = Organization.find_or_create_by!(name: "GetCTC.org", allows_greeters: false)
-    Site.find_or_create_by!(name: "GetCTC.org (Site)", parent_organization: ctc_org)
-  end
-
   config.before(:each) do
     stub_request(:post, /.*api\.twilio\.com.*/).to_return(status: 200, body: "", headers: {})
     stub_request(:post, "https://api.mixpanel.com/track").to_return(status: 200, body: "", headers: {})

--- a/spec/services/incoming_text_message_service_spec.rb
+++ b/spec/services/incoming_text_message_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe IncomingTextMessageService do
+describe IncomingTextMessageService, requires_default_vita_partners: true do
   describe ".process" do
     let(:body) { "Hello, it me" }
     let(:incoming_message_params) do

--- a/spec/support/default_records.rb
+++ b/spec/support/default_records.rb
@@ -1,0 +1,9 @@
+RSpec.configure do |config|
+  config.before(:each) do |example|
+    if example.metadata[:requires_default_vita_partners]
+      Organization.find_or_create_by!(name: "GYR National Organization", allows_greeters: true)
+      ctc_org = Organization.find_or_create_by!(name: "GetCTC.org", allows_greeters: false)
+      Site.find_or_create_by!(name: "GetCTC.org (Site)", parent_organization: ctc_org)
+    end
+  end
+end


### PR DESCRIPTION
tests can instead pull in default vita partners via requires_default_vita_partners
metadata