### PR TITLE
Fix complete_intake_spec to run successfully in a javascript context

### DIFF
--- a/spec/features/ctc/complete_intake_spec.rb
+++ b/spec/features/ctc/complete_intake_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.feature "CTC Intake", :flow_explorer_screenshot_i18n_friendly, active_job: true, requires_default_vita_partners: true do
   before do
     allow_any_instance_of(Routes::CtcDomain).to receive(:matches?).and_return(true)
+    allow_any_instance_of(FraudIndicatorService).to receive(:hold_indicators).and_return([])
   end
 
   scenario "new client entering ctc intake flow" do


### PR DESCRIPTION
previously it was getting stuck because apps went into fraud hold,
at least on CircleCI, presumably because the headless browser wasn't
convincing enough

now the test will skip the fraud indicators code ensuring that the
return is efiled without incident

this should fix the flow explorer screenshot generation which has
been broken for a while.