### PR TITLE
Hub: fix crash on invitations page when invitation invalid (name is blank, etc)

### DIFF
--- a/app/helpers/role_helper.rb
+++ b/app/helpers/role_helper.rb
@@ -19,7 +19,7 @@ module RoleHelper
       I18n.t("general.greeter")
     when TeamMemberRole::TYPE
       I18n.t("general.team_member")
-    end.titleize
+    end&.titleize
   end
 
   def user_group(user)

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -2,7 +2,7 @@
 <% content_for :page_title, @main_heading %>
 <% content_for :card do %>
   <div class="slab slab--not-padded">
-    <%= form_for(resource, as: resource_name, url: invitation_path(resource_name), local: true, builder: VitaMinFormBuilder, html: { method: :post }) do |f| %>
+    <%= form_for(resource, as: resource_name, url: invitation_path(resource_name, role: params[:role]), local: true, builder: VitaMinFormBuilder, html: { method: :post }) do |f| %>
       <h1><%= @main_heading %></h1>
 
       <ul>
@@ -13,7 +13,7 @@
       <div class="form-group">
         <%= label_tag(:role, "Which role?", class: "form-question") %>
         <div class="select form-width--long">
-          <%= select_tag(:role, options_for_select([readable_role_from_role_type(params[:role]), params[:role]]), class: "select__element", disabled: true, style: "background-color: #F8F8F8") %>
+          <%= select_tag(:role, options_for_select([readable_role_from_role_type(params[:role]), params[:role]], params[:role]), class: "select__element", disabled: true, style: "background-color: #F8F8F8") %>
         </div>
       </div>
 

--- a/spec/features/hub/invitations/admin_spec.rb
+++ b/spec/features/hub/invitations/admin_spec.rb
@@ -69,5 +69,22 @@ RSpec.feature "Inviting admin users" do
       expect(page).to have_text "Aileen Artichoke"
       expect(page).to have_text "Admin"
     end
+
+    it "shows errors if the required data was not provided" do
+      visit hub_tools_path
+      click_on "Invitations"
+
+      # Invitations page
+      expect(page).to have_selector "h1", text: "Invitations"
+      select "Admin", from: "What type of user do you want to invite?"
+      click_on "Continue"
+
+      # new invitation page
+      expect(page).to have_text "Send a new invitation"
+      click_on "Send invitation email"
+
+      expect(page).to have_text(I18n.t('errors.messages.blank'))
+      expect(page).to have_select('Which role?', selected: 'AdminRole', disabled: true)
+    end
   end
 end


### PR DESCRIPTION
Co-authored-by: Shannon Byrne <sbyrne@codeforamerica.org>