### PR TITLE
Twilio: ignore bad phone number errors (error 21211)

### DIFF
--- a/app/jobs/send_outgoing_text_message_job.rb
+++ b/app/jobs/send_outgoing_text_message_job.rb
@@ -5,16 +5,12 @@ class SendOutgoingTextMessageJob < ApplicationJob
   def perform(outgoing_text_message_id)
     outgoing_text_message = OutgoingTextMessage.find(outgoing_text_message_id)
 
-    message = begin
-                TwilioService.send_text_message(
-                  to: outgoing_text_message.to_phone_number,
-                  body: outgoing_text_message.body,
-                  status_callback: outgoing_text_message_url(outgoing_text_message, locale: nil)
-                )
-              rescue Twilio::REST::RestError
-                outgoing_text_message.update(twilio_status: "twilio_error")
-                raise
-              end
+    message = TwilioService.send_text_message(
+      to: outgoing_text_message.to_phone_number,
+      body: outgoing_text_message.body,
+      status_callback: outgoing_text_message_url(outgoing_text_message, locale: nil),
+      outgoing_text_message: outgoing_text_message
+    )
 
     outgoing_text_message.update(
       twilio_status: message.status,

--- a/spec/jobs/send_outgoing_text_message_job_spec.rb
+++ b/spec/jobs/send_outgoing_text_message_job_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe SendOutgoingTextMessageJob, type: :job do
           to: outgoing_text_message.to_phone_number,
           body: "body",
           status_callback: "http://test.host/outgoing_text_messages/#{outgoing_text_message.id}",
+          outgoing_text_message: outgoing_text_message
         )
 
         outgoing_text_message.reload
@@ -30,8 +31,10 @@ RSpec.describe SendOutgoingTextMessageJob, type: :job do
     end
 
     context "when Twilio raises an exception" do
+      include MockTwilio
+
       before do
-        allow(TwilioService).to receive(:send_text_message) { |*_args, **_kwargs| raise(Twilio::REST::RestError.new(400, OpenStruct.new(body: {}))) }
+        allow_any_instance_of(FakeTwilioMessageContext).to receive(:create).and_raise(Twilio::REST::RestError.new(400, OpenStruct.new(body: {})))
       end
 
       it "sets the status to twilio_error" do


### PR DESCRIPTION
Numbers such as 555-555-5555 are not valid but we don't know that
until we try to send an SMS to them. currently this causes an error
that goes to Sentry and we want to silence some of that noise.

For clients going through the initial SMS verification flow,
if the message doesn't come through they will hopefully click "go back"
and retry with a better phone number.

Co-authored-by: Shannon Byrne <sbyrne@codeforamerica.org>