### PR TITLE
Fix SendOutgoingTextMessageJob to not crash for an Invalid Phone Number error

### DIFF
--- a/app/jobs/send_outgoing_text_message_job.rb
+++ b/app/jobs/send_outgoing_text_message_job.rb
@@ -12,11 +12,13 @@ class SendOutgoingTextMessageJob < ApplicationJob
       outgoing_text_message: outgoing_text_message
     )
 
-    outgoing_text_message.update(
-      twilio_status: message.status,
-      twilio_sid: message.sid,
-      sent_at: DateTime.now
-    )
+    if message
+      outgoing_text_message.update(
+        twilio_status: message.status,
+        twilio_sid: message.sid,
+        sent_at: DateTime.now
+      )
+    end
   end
 
   def priority

--- a/app/services/twilio_service.rb
+++ b/app/services/twilio_service.rb
@@ -72,6 +72,8 @@ class TwilioService
       unless e.code == 21211 # Invalid 'To' Phone Number https://www.twilio.com/docs/api/errors/21211
         raise
       end
+
+      nil
     end
   end
 end


### PR DESCRIPTION
since it is no longer raising an error, the calling code needs to be aware
that sometimes send_text_message will not return a message