### PR TITLE
Rename cmd to web in Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,4 @@
-// Deployment procfile for Aptible
-cmd: bundle exec rails s -b 0.0.0.0 -p 3000
+// Deployment procfile for Aptible and Heroku
 web: bundle exec rails s -b 0.0.0.0 -p ${PORT:-3000}
 worker: bundle exec rails jobs:work
 cron: exec supercronic /app/crontab


### PR DESCRIPTION
All Aptible services called `cmd` are now scaled to zero, so I think this is peaceful.