### PR TITLE
Use match_array when we cannot guarantee ordering of an array in the tests

### DIFF
--- a/spec/controllers/questions/consent_controller_spec.rb
+++ b/spec/controllers/questions/consent_controller_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Questions::ConsentController do
 
           expect(intake.tax_returns.pluck(:status).uniq).to eq ["intake_in_progress"]
           expect(intake.tax_returns.count).to eq 2
-          expect(intake.tax_returns.pluck(:year)).to eq [2021, 2020]
+          expect(intake.tax_returns.pluck(:year)).to match_array([2021, 2020])
         end
 
         context "when a tax return for a selected year already exists" do
@@ -68,7 +68,7 @@ RSpec.describe Questions::ConsentController do
             post :update, params: params
 
             expect(intake.tax_returns.count).to eq 3
-            expect(intake.tax_returns.pluck(:year)).to eq [2018, 2021, 2020]
+            expect(intake.tax_returns.pluck(:year)).to match_array([2018, 2021, 2020])
             expect(intake.tax_returns.find_by(year: 2018)).to eq tax_return
           end
         end


### PR DESCRIPTION
In https://app.circleci.com/pipelines/github/codeforamerica/vita-min/10140/workflows/c0ceb8ad-1995-4279-b760-db0a070f658e/jobs/24913 , a test failed, and it uses `pluck`, and I guess we can't guarantee the order that tax return years will come back from a `pluck`, so I think `match_array` is a better fit than `eq`.