### PR TITLE
[#181102079] Ensure at-capacity clients aren't blocked by the duplicate guard

### DIFF
--- a/app/helpers/duplicate_intake_guard.rb
+++ b/app/helpers/duplicate_intake_guard.rb
@@ -1,6 +1,6 @@
 class DuplicateIntakeGuard < SimpleDelegator
   def has_duplicate?
-    ClientLoginService.new(:gyr).active_intake_accounts
+    ClientLoginService.new(:gyr).accessible_intakes
       .where(
          (arel_table[:email_address].eq(email_address)
            .and(arel_table[:email_address].not_eq(nil)))

--- a/app/helpers/duplicate_intake_guard.rb
+++ b/app/helpers/duplicate_intake_guard.rb
@@ -1,7 +1,6 @@
 class DuplicateIntakeGuard < SimpleDelegator
   def has_duplicate?
-    Intake::GyrIntake
-      .where(primary_consented_to_service: "yes")
+    ClientLoginService.new(:gyr).active_intake_accounts
       .where(
          (arel_table[:email_address].eq(email_address)
            .and(arel_table[:email_address].not_eq(nil)))

--- a/app/services/client_login_service.rb
+++ b/app/services/client_login_service.rb
@@ -12,10 +12,10 @@ class ClientLoginService
     # these might have multiple email addresses
     to_addresses = EmailAccessToken.lookup(raw_token).pluck(:email_address)
     emails = to_addresses.map { |to| to.split(",") }.flatten(1)
-    email_intake_matches = accessible_intakes.where(email_address: emails)
-    spouse_email_intake_matches = accessible_intakes.where(spouse_email_address: emails)
+    email_intake_matches = active_intake_accounts.where(email_address: emails)
+    spouse_email_intake_matches = active_intake_accounts.where(spouse_email_address: emails)
     phone_numbers = TextMessageAccessToken.lookup(raw_token).pluck(:sms_phone_number)
-    phone_intake_matches = accessible_intakes.where(sms_phone_number: phone_numbers)
+    phone_intake_matches = active_intake_accounts.where(sms_phone_number: phone_numbers)
     intake_matches = email_intake_matches.or(spouse_email_intake_matches).or(phone_intake_matches)
 
     # Client.by_raw_login_token supports login links generated from mid-Jan through early March 2021.
@@ -23,26 +23,26 @@ class ClientLoginService
   end
 
   def can_login_by_email_verification?(email_address, service_type: :gyr)
-    accessible_intakes.where(email_address: email_address).or(accessible_intakes.where(spouse_email_address: email_address)).exists?
+    active_intake_accounts.where(email_address: email_address).or(active_intake_accounts.where(spouse_email_address: email_address)).exists?
   end
 
   def can_login_by_sms_verification?(sms_phone_number, service_type: :gyr)
-    accessible_intakes.where(sms_phone_number: sms_phone_number, sms_notification_opt_in: "yes").exists?
+    active_intake_accounts.where(sms_phone_number: sms_phone_number, sms_notification_opt_in: "yes").exists?
+  end
+
+  def active_intake_accounts
+    service_type.to_sym == :gyr ? self.class.active_gyr_intake_accounts : self.class.active_ctc_intake_accounts
   end
 
   private
 
-  def accessible_intakes
-    service_type.to_sym == :gyr ? self.class.gyr_accessible_intakes : self.class.ctc_accessible_intakes
-  end
-
-  def self.gyr_accessible_intakes
+  def self.active_gyr_intake_accounts
     online_consented = Intake::GyrIntake.joins(:tax_returns).where({ tax_returns: { service_type: "online_intake" } }).where(primary_consented_to_service: "yes")
     drop_off = Intake::GyrIntake.joins(:tax_returns).where({ tax_returns: { service_type: "drop_off" } })
     online_consented.or(drop_off)
   end
 
-  def self.ctc_accessible_intakes
+  def self.active_ctc_intake_accounts
     sms_verified = Intake::CtcIntake.where.not(sms_phone_number_verified_at: nil)
     email_verified = Intake::CtcIntake.where.not(email_address_verified_at: nil)
     navigator_verified = Intake::CtcIntake.where.not(navigator_has_verified_client_identity: nil)
@@ -52,7 +52,7 @@ class ClientLoginService
 
   def self.has_ctc_duplicate?(intake)
     has_dupe = false
-    accessible_intakes = ctc_accessible_intakes.where.not(id: intake.id)
+    accessible_intakes = active_ctc_intake_accounts.where.not(id: intake.id)
     if intake.email_address.present?
       has_dupe = accessible_intakes.where(email_address: intake.email_address).exists?
     end

--- a/app/services/client_login_service.rb
+++ b/app/services/client_login_service.rb
@@ -12,10 +12,10 @@ class ClientLoginService
     # these might have multiple email addresses
     to_addresses = EmailAccessToken.lookup(raw_token).pluck(:email_address)
     emails = to_addresses.map { |to| to.split(",") }.flatten(1)
-    email_intake_matches = active_intake_accounts.where(email_address: emails)
-    spouse_email_intake_matches = active_intake_accounts.where(spouse_email_address: emails)
+    email_intake_matches = accessible_intakes.where(email_address: emails)
+    spouse_email_intake_matches = accessible_intakes.where(spouse_email_address: emails)
     phone_numbers = TextMessageAccessToken.lookup(raw_token).pluck(:sms_phone_number)
-    phone_intake_matches = active_intake_accounts.where(sms_phone_number: phone_numbers)
+    phone_intake_matches = accessible_intakes.where(sms_phone_number: phone_numbers)
     intake_matches = email_intake_matches.or(spouse_email_intake_matches).or(phone_intake_matches)
 
     # Client.by_raw_login_token supports login links generated from mid-Jan through early March 2021.
@@ -23,26 +23,26 @@ class ClientLoginService
   end
 
   def can_login_by_email_verification?(email_address, service_type: :gyr)
-    active_intake_accounts.where(email_address: email_address).or(active_intake_accounts.where(spouse_email_address: email_address)).exists?
+    accessible_intakes.where(email_address: email_address).or(accessible_intakes.where(spouse_email_address: email_address)).exists?
   end
 
   def can_login_by_sms_verification?(sms_phone_number, service_type: :gyr)
-    active_intake_accounts.where(sms_phone_number: sms_phone_number, sms_notification_opt_in: "yes").exists?
+    accessible_intakes.where(sms_phone_number: sms_phone_number, sms_notification_opt_in: "yes").exists?
   end
 
-  def active_intake_accounts
-    service_type.to_sym == :gyr ? self.class.active_gyr_intake_accounts : self.class.active_ctc_intake_accounts
+  def accessible_intakes
+    service_type.to_sym == :gyr ? self.class.accessible_gyr_intakes : self.class.accessible_ctc_intakes
   end
 
   private
 
-  def self.active_gyr_intake_accounts
+  def self.accessible_gyr_intakes
     online_consented = Intake::GyrIntake.joins(:tax_returns).where({ tax_returns: { service_type: "online_intake" } }).where(primary_consented_to_service: "yes")
     drop_off = Intake::GyrIntake.joins(:tax_returns).where({ tax_returns: { service_type: "drop_off" } })
     online_consented.or(drop_off)
   end
 
-  def self.active_ctc_intake_accounts
+  def self.accessible_ctc_intakes
     sms_verified = Intake::CtcIntake.where.not(sms_phone_number_verified_at: nil)
     email_verified = Intake::CtcIntake.where.not(email_address_verified_at: nil)
     navigator_verified = Intake::CtcIntake.where.not(navigator_has_verified_client_identity: nil)
@@ -52,7 +52,7 @@ class ClientLoginService
 
   def self.has_ctc_duplicate?(intake)
     has_dupe = false
-    accessible_intakes = active_ctc_intake_accounts.where.not(id: intake.id)
+    accessible_intakes = accessible_ctc_intakes.where.not(id: intake.id)
     if intake.email_address.present?
       has_dupe = accessible_intakes.where(email_address: intake.email_address).exists?
     end

--- a/spec/features/web_intake/returning_filer_spec.rb
+++ b/spec/features/web_intake/returning_filer_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot do
       :intake,
       email_address: "returning@client.com",
       primary_consented_to_service: "yes",
+      client: build(:client, tax_returns: [build(:tax_return, service_type: "online_intake")])
     )
   end
 

--- a/spec/helpers/duplicate_intake_guard_spec.rb
+++ b/spec/helpers/duplicate_intake_guard_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe DuplicateIntakeGuard do
 
   describe "has_duplicate?" do
     context "intake with matching email address exists" do
-      let!(:existing_intake) { create(:intake, email_address: "existing@client.com") }
+      let!(:existing_intake) { create(:intake, email_address: "existing@client.com", client: build(:client, tax_returns: [build(:tax_return, service_type: "online_intake")])) }
       let(:matching_intake) { create(:intake, email_address: "existing@client.com") }
 
       it "returns false if the intake is not completed" do
@@ -27,7 +27,7 @@ RSpec.describe DuplicateIntakeGuard do
     end
 
     context "intake with matching phone number exists" do
-      let!(:existing_intake) { create(:intake, phone_number: "+15005550006") }
+      let!(:existing_intake) { create(:intake, phone_number: "+15005550006", client: build(:client, tax_returns: [build(:tax_return, service_type: "online_intake")])) }
       let(:matching_intake) { create(:intake, phone_number: "+15005550006") }
 
       it "returns false if the intake is not completed" do


### PR DESCRIPTION
## Summary

In the DuplicateIntakeGuard, ask the `ClientLoginService` which clients can log in, and use that to filter which clients are considered duplicates.

For right now, our At Capacity page implies that people don't have accounts, and auto-logs them out, so this change makes the duplicate intake guard act consistently with regard to that.

## Review requested from

- @embarnard - can you let me know how/if this affects your work on [[GYR] Update the duplicate check to check for full SSNs](https://www.pivotaltracker.com/story/show/180352601)?
- @bytheway875 - this is a relatively big departure from what you and I agreed on yesterday, so I'd love to discuss it and if possible have you be the reviewer of record.