### PR TITLE
Heroku review apps no longer automatically redirect

### DIFF
--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -1,6 +1,5 @@
 class PublicPagesController < ApplicationController
   skip_before_action :check_maintenance_mode
-  before_action :redirect_to_main_url_on_heroku, only: [:home]
 
   def include_analytics?
     true
@@ -64,17 +63,6 @@ class PublicPagesController < ApplicationController
     respond_to do |format|
       format.text { render 'public_pages/pki_validation'  }
       format.any { head 404 }
-    end
-  end
-
-  private
-
-  def redirect_to_main_url_on_heroku
-    return unless Rails.env.heroku?
-
-    # On Heroku Review Apps, it's convenient to use our *.getyourrefund-testing.org URL where possible.
-    if request.host != MultiTenantService.new(:gyr).host
-      redirect_to(url_for(action: :home, host: MultiTenantService.new(:gyr).host))
     end
   end
 end

--- a/app/views/shared/_environment_warning.html.erb
+++ b/app/views/shared/_environment_warning.html.erb
@@ -17,4 +17,15 @@
       </div>
     </div>
   <% end %>
+  <% if Rails.env.heroku? %>
+    <div class="slab slab--flash flash--warning">
+      <div class="grid">
+        <div class="grid__item">
+          You're on a Heroku review app, you can also visit this via the url
+            <%= link_to url_for(action: :home, host: MultiTenantService.new(:gyr).host), url_for(action: :home, host: MultiTenantService.new(:gyr).host) %> (GYR) or
+            <%= link_to url_for(action: :home, host: MultiTenantService.new(:ctc).host), url_for(action: :home, host: MultiTenantService.new(:ctc).host) %> (CTC)
+        </div>
+      </div>
+    </div>
+  <% end %>
 <% end %>


### PR DESCRIPTION
they will instead show a banner that has the GYR and CTC URLs

this should help in situations where we are not sure if the
review app is failing to load because of DNS or because there
is an actual problem (e.g. seeds failed, configuration error...)

Co-authored-by: Jenny Heath <jheath@codeforamerica.org>