### PR TITLE
Fix active client count for organization capacities

### DIFF
--- a/db/migrate/20220202214204_update_organization_capacities_to_version_4.rb
+++ b/db/migrate/20220202214204_update_organization_capacities_to_version_4.rb
@@ -1,0 +1,5 @@
+class UpdateOrganizationCapacitiesToVersion4 < ActiveRecord::Migration[6.1]
+  def change
+    update_view :organization_capacities, version: 4, revert_to_version: 3
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_27_212445) do
+ActiveRecord::Schema.define(version: 2022_02_02_214204) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -1522,7 +1522,8 @@ ActiveRecord::Schema.define(version: 2022_01_27_212445) do
              FROM vita_partners vita_partners_1
           ), client_ids AS (
            SELECT DISTINCT tax_returns.client_id
-             FROM tax_returns
+             FROM (tax_returns
+               JOIN intakes ON ((intakes.client_id = tax_returns.client_id)))
             WHERE ((tax_returns.status >= 102) AND (tax_returns.status <= 404) AND (tax_returns.status <> 403) AND (tax_returns.status <> 106) AND (tax_returns.status <> 130))
           ), partner_and_client_counts AS (
            SELECT organization_id_by_vita_partner_id.organization_id,

--- a/db/views/organization_capacities_v04.sql
+++ b/db/views/organization_capacities_v04.sql
@@ -1,0 +1,22 @@
+WITH
+    organization_id_by_vita_partner_id AS (
+        select id, (CASE WHEN parent_organization_id IS NULL THEN id ELSE parent_organization_id END) AS organization_id
+        from vita_partners
+    ),
+    client_ids AS
+    (
+        select distinct tax_returns.client_id
+        from tax_returns
+        INNER JOIN intakes ON (intakes.client_id) = tax_returns.client_id
+
+        where tax_returns.status >= 102 AND tax_returns.status <= 404 AND tax_returns.status != 403 AND tax_returns.status != 106 AND tax_returns.status != 130
+    ),
+    partner_and_client_counts AS (
+        SELECT organization_id, count(clients.id) as active_client_count
+        FROM organization_id_by_vita_partner_id
+        LEFT OUTER JOIN clients ON organization_id_by_vita_partner_id.id = clients.vita_partner_id
+        WHERE clients.id IN (select client_id from client_ids) GROUP BY organization_id
+    )
+SELECT id as vita_partner_id, name, capacity_limit, CASE WHEN partner_and_client_counts.active_client_count IS NULL THEN 0 ELSE partner_and_client_counts.active_client_count END
+    FROM vita_partners
+    LEFT OUTER JOIN partner_and_client_counts ON vita_partners.id=partner_and_client_counts.organization_id WHERE parent_organization_id IS NULL;

--- a/spec/models/organization_capacity_spec.rb
+++ b/spec/models/organization_capacity_spec.rb
@@ -17,7 +17,7 @@ describe OrganizationCapacity do
       context "for #{status} status" do
         let(:organization) { create :organization }
         before do
-          create :client_with_status, status: status[0], vita_partner: organization
+          create :client_with_status, status: status[0], vita_partner: organization, intake: create(:intake)
         end
 
         if TaxReturnStatus::STATUS_KEYS_INCLUDED_IN_CAPACITY.include?(status[0])

--- a/spec/models/organization_capacity_spec.rb
+++ b/spec/models/organization_capacity_spec.rb
@@ -31,6 +31,30 @@ describe OrganizationCapacity do
         end
       end
     end
+
+    context "when intake associated with client is archived" do
+      let(:organization) { create :organization }
+      before do
+        client = create :client_with_status, status: :prep_ready_for_prep, vita_partner: organization
+        create :archived_2021_gyr_intake, client: client
+      end
+
+      it "does not include the client in the client count" do
+        expect(described_class.find(organization.id).active_client_count).to eq 0
+      end
+    end
+
+    context "when intake associated with client is not archived" do
+      let(:organization) { create :organization }
+      let(:intake) { create :intake }
+      before do
+        create :client_with_status, status: :prep_ready_for_prep, vita_partner: organization, intake: intake
+      end
+
+      it "does include the client in the client count" do
+        expect(described_class.find(organization.id).active_client_count).to eq 1
+      end
+    end
   end
 
   describe '.with_capacity' do

--- a/spec/models/organization_capacity_spec.rb
+++ b/spec/models/organization_capacity_spec.rb
@@ -68,7 +68,7 @@ describe OrganizationCapacity do
     context "with an organization whose active clients equal capacity" do
       let(:organization) { create :organization, capacity_limit: 1 }
       before do
-        create :client_with_status, status: TaxReturnStatus::STATUS_KEYS_INCLUDED_IN_CAPACITY[0], vita_partner: organization
+        create :client_with_status, status: TaxReturnStatus::STATUS_KEYS_INCLUDED_IN_CAPACITY[0], vita_partner: organization, intake: create(:intake)
       end
 
       it "does not have capacity" do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -83,7 +83,7 @@ describe Organization do
     context "at capacity" do
       before do
         organization.capacity_limit.times do
-          client = create :client, vita_partner: organization
+          client = create :client, vita_partner: organization, intake: create(:intake)
           create :tax_return, status: "intake_ready", client: client
         end
       end
@@ -97,7 +97,7 @@ describe Organization do
       context "clients assigned to organization exceed capacity limit" do
         before do
           (organization.capacity_limit + 1).times do
-            client = create :client, vita_partner: organization
+            client = create :client, vita_partner: organization, intake: create(:intake)
             create :tax_return, status: in_range_statuses.sample, client: client
           end
         end
@@ -113,7 +113,7 @@ describe Organization do
 
         before do
           (organization.capacity_limit + 1).times do
-            client = create :client, vita_partner: [site_1, site_2, organization].sample
+            client = create :client, vita_partner: [site_1, site_2, organization].sample, intake: create(:intake)
             create :tax_return, status: in_range_statuses.sample, client: client
           end
         end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -69,7 +69,7 @@ describe Site do
     context "when parent org is at capacity" do
       before do
         10.times do
-          client = create :client, vita_partner: site
+          client = create :client, vita_partner: site, intake: create(:intake)
           create :tax_return, status: "intake_ready", client: client
         end
       end

--- a/spec/presenters/hub/organizations_presenter_spec.rb
+++ b/spec/presenters/hub/organizations_presenter_spec.rb
@@ -14,7 +14,7 @@ describe Hub::OrganizationsPresenter do
     create :state_routing_target, target: organization, state_abbreviation: "CA"
     create :state_routing_target, target: coalition, state_abbreviation: "CA"
     create :state_routing_target, target: organization, state_abbreviation: "TX"
-    create :client, :with_return, vita_partner: organization, status: "review_ready_for_qr"
+    create :client, :with_return, vita_partner: organization, status: "review_ready_for_qr", intake: create(:intake)
   end
 
   context "with an admin user with admin abilities" do

--- a/spec/services/partner_routing_service_spec.rb
+++ b/spec/services/partner_routing_service_spec.rb
@@ -191,7 +191,7 @@ describe PartnerRoutingService do
               srt = create(:state_routing_target, target: vita_partner, state_abbreviation: "NC")
               create(:state_routing_fraction, state_routing_target: srt, routing_fraction: 0.4, vita_partner: vita_partner)
               (vita_partner.capacity_limit + 1).times do
-                create :client_with_status, vita_partner: vita_partner, status: "intake_ready"
+                create :client_with_status, vita_partner: vita_partner, status: "intake_ready", intake: create(:intake)
               end
             }
 


### PR DESCRIPTION
Addresses [this story](https://www.pivotaltracker.com/story/show/181129414).

Also Asheesh paired on this whole thing with me and was a big help, I'm just bad at using git-duet. We learned a lot about joins.

### User impacting issue
Organization capacity active client counts are much higher than expected. There is a discrepancy between what is shown as the current client count and the number of clients pulled up via filtering on the all clients page.

### Why is this happening
Organization capacity, as calculated in `organization_capacities_v03.sql`, does not reference intakes at all. It loads any clients who have a tax return in a set of "non-terminal" statuses.

This means that if last years clients did not have all of their tax returns updated to a "terminal" status (that does not count against capacity) then they are still showing up in the current capacity count.

Contrast this with the clients page, which does an inner join on intake in order to exclude all clients with archived intakes. And so the numbers on the clients page are much lower than those shown for the active client capacity count.

### Solution
Similar to the inner join on intake in `client_sortable.rb`, we do an inner join on intake for client capacity so that we take only clients with this years intake into account.

### Implications
Clients without intakes will not be included in the active client count for an organization. 