### PR TITLE
Cover db:seed with a test

### DIFF
--- a/spec/tasks/seeds_spec.rb
+++ b/spec/tasks/seeds_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+describe 'db:seed' do
+  it 'runs without error' do
+    Rails.application.load_tasks
+    Rake::Task['db:seed'].invoke
+  end
+end


### PR DESCRIPTION
In https://github.com/codeforamerica/vita-min/pull/2097 we fixed a problem where `db:seed` was failing.

With this pull request, we run `db:seed` to the test suite so we notice these problems earlier.

You can validate that this pull request works by adding:

```
should_crash = 1 / 0
```

to `db/seeds.rb`  and see that this test fails.