### PR TITLE
Hub: fix crashes with archived clients with outbound calls on messages and notes pages

### DIFF
--- a/app/controllers/hub/messages_controller.rb
+++ b/app/controllers/hub/messages_controller.rb
@@ -19,7 +19,7 @@ module Hub
 
     class HubClientPresenter < Hub::ClientsController::HubClientPresenter
       def messages_by_day
-        @_messages ||= MessagePresenter.grouped_messages(@client)
+        @_messages ||= MessagePresenter.grouped_messages(self)
       end
     end
   end

--- a/app/controllers/hub/notes_controller.rb
+++ b/app/controllers/hub/notes_controller.rb
@@ -35,11 +35,11 @@ module Hub
 
     class HubClientPresenter < Hub::ClientsController::HubClientPresenter
       def all_notes_by_day
-        NotesPresenter.grouped_notes(@client)
+        NotesPresenter.grouped_notes(self)
       end
 
       def taggable_users
-        @_taggable_users ||= User.taggable_for(@client).to_json(only: [:name, :id], methods: :name_with_role_and_entity).to_s.html_safe
+        @_taggable_users ||= User.taggable_for(self).to_json(only: [:name, :id], methods: :name_with_role_and_entity).to_s.html_safe
       end
     end
   end

--- a/spec/controllers/hub/notes_controller_spec.rb
+++ b/spec/controllers/hub/notes_controller_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Hub::NotesController, type: :controller do
 
       it "returns notes grouped by day" do
         expect(presenter.all_notes_by_day).to eq([])
-        expect(NotesPresenter).to have_received(:grouped_notes).with(client)
+        expect(NotesPresenter).to have_received(:grouped_notes).with(presenter)
       end
     end
 

--- a/spec/features/hub/send_messages_spec.rb
+++ b/spec/features/hub/send_messages_spec.rb
@@ -71,6 +71,7 @@ RSpec.feature "Read and send messages to a client", js: true do
 
     context "the client's intake has been archived" do
       let!(:incoming_text_message) { create :incoming_text_message, client: client, body: "it is me, a client", created_at: DateTime.now }
+      let!(:outbound_call) { create :outbound_call, client: client, user: user }
 
       let(:intake) { nil }
       let!(:archived_intake) do
@@ -92,6 +93,7 @@ RSpec.feature "Read and send messages to a client", js: true do
 
         expect(page).to have_content(archived_intake.preferred_name)
         expect(page).to have_content(incoming_text_message.body)
+        expect(page).to have_content("Called by")
       end
     end
 


### PR DESCRIPTION
Co-authored-by: Catie Talbot <ctalbot@codeforamerica.org>