### PR TITLE
Flow explorer: add intake generator for GYR

### DIFF
--- a/app/views/flows/_flow.html.erb
+++ b/app/views/flows/_flow.html.erb
@@ -14,7 +14,7 @@
           <%=
             image_tag(
               screenshot_path(decorated_controller),
-              onerror: 'this.onerror = null; $(this).hide()'
+              onerror: "this.onerror = null; this.style.display = 'none'"
             )
           %>
         </div>

--- a/app/views/flows/show.html.erb
+++ b/app/views/flows/show.html.erb
@@ -11,39 +11,37 @@
   </div>
 </div>
 
-<% if params[:id] == 'ctc' %>
-  <div class="reveal">
-    <a href="#" class="reveal__link">
-      <h3 class="spacing-below-0">Magic Intake Generator 🧙</h3>
-    </a>
-    <div class="reveal__content">
-      <p>This attempts to generate an intake so you can test specific pages. It might not work perfectly.</p>
-      <%= form_for @flow_params.form, url: generate_flows_path(type: :ctc), style: 'display: inline-block;' do |f| %>
-        <div class="honeycrisp-compact" style="display: flex;">
-          <div class="form-group">
-            <label>First Name:</label>
-            <%= f.text_field :first_name, style: 'width: 100%; max-width: 180px;' %>
-          </div>
-          <div class="form-group">
-            <label>Last Name:</label>
-            <%= f.text_field :last_name, style: 'width: 100%; max-width: 180px;' %>
-          </div>
-          <div class="form-group">
-            <label>Email Address:</label>
-            <%= f.text_field :email_address, style: 'width: 100%; max-width: 180px;' %>
-          </div>
-          <div class="form-group">
-            <label>SMS Phone Number:</label>
-            <%= f.text_field :sms_phone_number, style: 'width: 100%; max-width: 180px;' %>
-          </div>
+<div class="reveal">
+  <a href="#" class="reveal__link">
+    <h3 class="spacing-below-0">Magic Intake Generator 🧙</h3>
+  </a>
+  <div class="reveal__content">
+    <p>This attempts to generate an intake so you can test specific pages. It might not work perfectly.</p>
+    <%= form_for @flow_params.form, url: generate_flows_path(type: params[:id]), style: 'display: inline-block;' do |f| %>
+      <div class="honeycrisp-compact" style="display: flex;">
+        <div class="form-group">
+          <label>First Name:</label>
+          <%= f.text_field :first_name, style: 'width: 100%; max-width: 180px;' %>
         </div>
-        <% @sample_types.each do |app_type| %>
-          <%= submit_tag "#{app_type.to_s.titleize} ✨", name: "submit_#{app_type}", class: 'button button--small', method: :put %>
-        <% end %>
+        <div class="form-group">
+          <label>Last Name:</label>
+          <%= f.text_field :last_name, style: 'width: 100%; max-width: 180px;' %>
+        </div>
+        <div class="form-group">
+          <label>Email Address:</label>
+          <%= f.text_field :email_address, style: 'width: 100%; max-width: 180px;' %>
+        </div>
+        <div class="form-group">
+          <label>SMS Phone Number:</label>
+          <%= f.text_field :sms_phone_number, style: 'width: 100%; max-width: 180px;' %>
+        </div>
+      </div>
+      <% @sample_types.each do |app_type| %>
+        <%= submit_tag "#{app_type.to_s.titleize} ✨", name: "submit_#{app_type}", class: 'button button--small', method: :put %>
       <% end %>
-    </div>
+    <% end %>
   </div>
-<% end %>
+</div>
 
 <%= render 'flow_events' %>
 <div id="flow-wrapper">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -268,7 +268,9 @@ Rails.application.routes.draw do
       ### END Hub Admin routes (Case Management)
 
       unless Rails.env.production?
-        resources :flows, only: [:index, :show]
+        resources :flows, only: [:index, :show] do
+          post :generate, on: :collection
+        end
         resources :icons, only: [:index]
       end
 

--- a/spec/controllers/flows_controller_spec.rb
+++ b/spec/controllers/flows_controller_spec.rb
@@ -2,18 +2,18 @@ require "rails_helper"
 
 RSpec.describe FlowsController do
   describe '#generate' do
-    let(:default_params) do
-      {
-        type: :ctc,
-        flows_controller_sample_ctc_intake_form: {
-          first_name: 'Testuser',
-          last_name: 'Testuser',
-          email_address: 'testuser@example.com',
-        },
-      }
-    end
-
     context 'for a ctc intake' do
+      let(:default_params) do
+        {
+          type: :ctc,
+          flows_controller_sample_intake_form: {
+            first_name: 'Testuser',
+            last_name: 'Testuser',
+            email_address: 'testuser@example.com',
+          },
+        }
+      end
+
       it 'can generate a single intake' do
         post :generate, params: default_params.merge({ submit_single: 'Single ✨' })
         expect(controller.current_intake.tax_returns.last).to be_filing_status_single
@@ -30,6 +30,35 @@ RSpec.describe FlowsController do
         expect(controller.current_intake.dependents.count).to eq(2)
         expect(controller.current_intake.dependents.select { |d| d.eligible_for_child_tax_credit_2020? }.length).to eq(1)
         expect(controller.current_intake.dependents.select { |d| !d.eligible_for_child_tax_credit_2020? && d.yr_2020_qualifying_relative? }.length).to eq(1)
+      end
+    end
+
+    context 'for a gyr intake' do
+      let(:default_params) do
+        {
+          type: :gyr,
+          flows_controller_sample_intake_form: {
+            first_name: 'Testuser',
+            last_name: 'Testuser',
+            email_address: 'testuser@example.com',
+          },
+        }
+      end
+
+      it 'can generate a single intake' do
+        post :generate, params: default_params.merge({ submit_single: 'Single ✨' })
+        expect(controller.current_intake).to be_filing_joint_no
+      end
+
+      it 'can generate a married filing jointly intake' do
+        post :generate, params: default_params.merge({ submit_married_filing_jointly: 'Married Filing Jointly ✨' })
+        expect(controller.current_intake).to be_filing_joint_yes
+      end
+
+      it 'can generate a married filing jointly with dependents intake' do
+        post :generate, params: default_params.merge({ submit_married_filing_jointly_with_dependents: 'Married Filing Jointly With Dependents ✨' })
+        expect(controller.current_intake).to be_filing_joint_yes
+        expect(controller.current_intake.dependents.count).to eq(2)
       end
     end
   end


### PR DESCRIPTION
major differences as I see it (I probably missed stuff!):
* GYR intakes have a filing_joint true/false which is used instead of the filing_status on the tax return
* GYR intakes don't capture spouse full SSN or any dependent SSNs
* GYR intakes need preferred_name to be set in the DB