### PR TITLE
When Rails thinks params are unparseable, drop the request

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,5 +1,6 @@
 require_relative "boot"
 require_relative "../lib/middleware/cleanup_mime_type_headers"
+require_relative "../lib/middleware/respond_with_400_on_bad_request"
 
 require "rails"
 # Pick the frameworks you want:
@@ -36,6 +37,7 @@ module VitaMin
     # the framework and any gems in your application.
     #
     config.middleware.use Middleware::CleanupMimeTypeHeaders
+    config.middleware.use Middleware::RespondWith400OnBadRequest
     config.current_tax_year = 2021
 
     # These defaults can be overridden per-environment if needed

--- a/lib/middleware/respond_with_400_on_bad_request.rb
+++ b/lib/middleware/respond_with_400_on_bad_request.rb
@@ -1,0 +1,26 @@
+module Middleware
+  class RespondWith400OnBadRequest
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      # Inspired by https://github.com/pulibrary/orangelight/pull/1409/files , call the part
+      # of Rails that crashes with bad requests, and bubble it up to the website visitor
+      # before calling into the rest of the app.
+      begin
+        ActionDispatch::Request.new(env.dup).params
+      rescue ActionController::BadRequest
+        return bad_request_response
+      end
+      @app.call(env)
+    end
+
+    private
+
+    def bad_request_response
+      bad_request_message = "Bad request"
+      [400, {"Content-Type" => "text/plain", "Content-Length" => bad_request_message.size}, [bad_request_message]]
+    end
+  end
+end

--- a/spec/middleware/respond_with_400_on_bad_request_spec.rb
+++ b/spec/middleware/respond_with_400_on_bad_request_spec.rb
@@ -1,0 +1,38 @@
+describe Middleware::RespondWith400OnBadRequest do
+  let(:mock_app) { double }
+  subject { described_class.new(mock_app) }
+
+  let(:success_response) { [200, {}, 'ok'] }
+  let(:env) { { "rack.input" => StringIO.new("") } }
+  let(:bad_request_message) { "Bad request" }
+  let(:bad_request_response) { [
+    400, {'Content-Type' => 'text/plain', 'Content-Length' => bad_request_message.size}, [bad_request_message]
+  ] }
+
+  before do
+    allow(mock_app).to receive(:call).and_return(success_response)
+  end
+
+  describe "#call" do
+    context "when app receives normal request parameters" do
+      it "calls the app" do
+        expect(subject.call(env)).to eq(success_response)
+        expect(mock_app).to have_received(:call).with(env)
+      end
+    end
+
+    context "when ActionDispatch::Request#params raises BadRequest" do
+      let(:instance) { instance_double(ActionDispatch::Request) }
+
+      before do
+        allow(ActionDispatch::Request).to receive(:new).and_return(instance)
+        allow(instance).to receive(:params).and_raise(ActionController::BadRequest)
+      end
+
+      it "returns a 400" do
+        expect(subject.call(env)).to eq(bad_request_response)
+        expect(mock_app).not_to have_received(:call)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Testing done

Visit `http://localhost:3000/?%AA%AA` before this change, and get an exception.

After this change, get a concise "Bad request" message.

## Rationale

Detectify has noticed that we crash on these bad requests: https://detectify.com/app/fd44602a-951a-42cc-80e5-570087ed8ce0/vulnerability . Detectify is a security scanner we use across the engineering team at CfA (securitymetrics.com is one we use within just GYR). The security scanner says this has a 0.0 vulnerability score, which I agree with; this crash has no security implications that I can find.

I wanted to write up this proposed fix which can make Detectify a little less noisy, and also hopefully make prod errors a little less noisy.

Since we are using Rails' own params parsing, I expect we won't have issues where this causes us to drop requests that are actually valid.

I tried to use `rescue_from` in `application_controller.rb` but I can't seem to catch these exceptions there, presumably because Rails generates the exception before passing control to our application.

I tried to use `get /400` in `routes.rb` but I can't seem to catch these exceptions there. I'm honestly not sure why.