### PR TITLE
Flow explorer: Fix routing_spec.rb for screenshot build

### DIFF
--- a/spec/lib/synthetic_note_spec.rb
+++ b/spec/lib/synthetic_note_spec.rb
@@ -49,7 +49,6 @@ describe SyntheticNote do
       end
     end
 
-
     context "with outbound calls" do
       let(:day1) { DateTime.new(2019, 10, 5, 8, 1).utc }
       let(:day2) { DateTime.new(2020, 10, 5, 5, 1).utc }


### PR DESCRIPTION
another instance of us needing to add dashes when typing SSNs because of JS

also make the routing_spec flow_explorer_screenshot_i18n_friendly