### PR TITLE
Flow explorer: fix flake in returning_filer_spec

### DIFF
--- a/spec/features/hub/edit_client_spec.rb
+++ b/spec/features/hub/edit_client_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe "a user editing a clients intake fields" do
 
       within "#primary-info" do
         fill_in "Preferred full name", with: "Colly Cauliflower"
-        fill_in "SSN/ITIN", with: "123456789"
+        fill_in "SSN/ITIN", with: "123-45-6789"
       end
 
       click_on "Save"

--- a/spec/features/web_intake/new_joint_filers_spec.rb
+++ b/spec/features/web_intake/new_joint_filers_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature "Web Intake Joint Filers", :flow_explorer_screenshot do
     screenshot_after do
       # Personal Info
       expect(page).to have_selector("h1", text: "First, let's get some basic information.")
-      fill_in "What is your preferred first name?", with: "Gary"
+      fill_in I18n.t('views.questions.personal_info.preferred_name'), with: "Gary"
       fill_in "Phone number", with: "415-888-0088"
       fill_in "Confirm phone number", with: "415-888-0088"
       fill_in I18n.t("attributes.primary_ssn"), with: "123-45-6789"

--- a/spec/features/web_intake/new_single_filer_spec.rb
+++ b/spec/features/web_intake/new_single_filer_spec.rb
@@ -35,11 +35,11 @@ RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot, active_job: 
     # Personal Info
     expect(intake.reload.current_step).to eq("/en/questions/personal-info")
     expect(page).to have_selector("h1", text: "First, let's get some basic information.")
-    fill_in "What is your preferred first name?", with: "Gary"
+    fill_in I18n.t('views.questions.personal_info.preferred_name'), with: "Gary"
     fill_in "Phone number", with: "8286345533"
     fill_in "Confirm phone number", with: "828-634-5533"
-    fill_in I18n.t("attributes.primary_ssn"), with: "123456789"
-    fill_in I18n.t("attributes.confirm_primary_ssn"), with: "123456789"
+    fill_in I18n.t("attributes.primary_ssn"), with: "123-45-6789"
+    fill_in I18n.t("attributes.confirm_primary_ssn"), with: "123-45-6789"
     fill_in "ZIP code", with: "20121"
     click_on "Continue"
 

--- a/spec/features/web_intake/returning_filer_spec.rb
+++ b/spec/features/web_intake/returning_filer_spec.rb
@@ -1,9 +1,11 @@
 require "rails_helper"
 
-RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot do
-  let(:primary_ssn) { "123456789" }
+RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot_i18n_friendly do
+  let(:primary_ssn) { "123-45-6789" }
   let!(:original_intake) { create :intake, email_address: "original@client.com", phone_number: "+14155537865", primary_consented_to_service: "yes", primary_ssn: primary_ssn, client: build(:client, tax_returns: [build(:tax_return, service_type: "online_intake")]) }
   let!(:ctc_intake_matching_ssn) { create :ctc_intake, primary_consented_to_service: "yes", primary_ssn: primary_ssn }
+  let(:returning_client_title) { I18n.t('views.questions.returning_client.title') }
+
   before do
     create(
       :intake,
@@ -18,23 +20,23 @@ RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot do
   scenario "returning client tries filing again is taken to returning client signpost page when a GYR intake with matching ssn exists" do
     visit backtaxes_questions_path
     check "2019"
-    click_on "Continue"
+    click_on I18n.t('general.continue')
 
     visit personal_info_questions_path
-    expect(page).to have_selector("h1", text: "First, let's get some basic information.")
-    fill_in "What is your preferred first name?", with: "Dupe"
-    fill_in "Phone number", with: "8286345533"
-    fill_in "Confirm phone number", with: "828-634-5533"
+    expect(page).to have_selector("h1", text: I18n.t('views.questions.personal_info.title'))
+    fill_in I18n.t('views.questions.personal_info.preferred_name'), with: "Dupe"
+    fill_in I18n.t('views.questions.personal_info.phone_number'), with: "8286345533"
+    fill_in I18n.t('views.questions.personal_info.phone_number_confirmation'), with: "828-634-5533"
     fill_in I18n.t("attributes.primary_ssn"), with: primary_ssn
     fill_in I18n.t("attributes.confirm_primary_ssn"), with: primary_ssn
-    fill_in "ZIP code", with: "20121"
-    click_on "Continue"
+    fill_in I18n.t('views.questions.personal_info.zip_code'), with: "20121"
+    click_on I18n.t('general.continue')
 
-    expect(page).to have_text "Looks like you’ve already started!"
+    expect(page).to have_text returning_client_title
     expect(current_path).to eq(returning_client_questions_path)
 
     within "main" do
-      click_on("Sign in")
+      click_on(I18n.t('general.sign_in'))
     end
     expect(current_path).to eq(new_portal_client_login_path)
   end
@@ -44,19 +46,19 @@ RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot do
   scenario "client with matching CTC intake & no matching GYR intake doesn't see GYR duplicate guard" do
     visit backtaxes_questions_path
     check "2019"
-    click_on "Continue"
+    click_on I18n.t('general.continue')
 
     visit personal_info_questions_path
-    expect(page).to have_selector("h1", text: "First, let's get some basic information.")
-    fill_in "What is your preferred first name?", with: "Dupe"
-    fill_in "Phone number", with: "8286345533"
-    fill_in "Confirm phone number", with: "828-634-5533"
-    fill_in I18n.t("attributes.primary_ssn"), with: "987654321"
-    fill_in I18n.t("attributes.confirm_primary_ssn"), with: "987654321"
-    fill_in "ZIP code", with: "20121"
-    click_on "Continue"
+    expect(page).to have_selector("h1", text: I18n.t('views.questions.personal_info.title'))
+    fill_in I18n.t('views.questions.personal_info.preferred_name'), with: "Dupe"
+    fill_in I18n.t('views.questions.personal_info.phone_number'), with: "828-634-5533"
+    fill_in I18n.t('views.questions.personal_info.phone_number_confirmation'), with: "828-634-5533"
+    fill_in I18n.t("attributes.primary_ssn"), with: "987-65-4321"
+    fill_in I18n.t("attributes.confirm_primary_ssn"), with: "987-65-4321"
+    fill_in I18n.t('views.questions.personal_info.zip_code'), with: "20121"
+    click_on I18n.t('general.continue')
 
-    expect(page).not_to have_text "Looks like you’ve already started!"
+    expect(page).not_to have_text returning_client_title
     expect(current_path).not_to eq(returning_client_questions_path)
   end
 end


### PR DESCRIPTION
another occasion where we need to put dashes in the SSNs if it runs in a real chrome

also adds an incredibly heavy-handed patch for `fill_in` that will raise
an error if we ever try to fill in an SSN that doesn't match the expected format