### PR TITLE
Don't run rubocop when dumping schema

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'devise-i18n'
 gem 'delayed_job_active_record'
 gem 'attr_encrypted'
 gem 'lograge'
-gem 'fix-db-schema-conflicts'
+gem 'fix-db-schema-conflicts', require: false
 gem 'valid_email2'
 gem 'auto_strip_attributes'
 gem 'ddtrace', '~> 0.41.0'

--- a/config/initializers/fix_db_schema_conflicts.rb
+++ b/config/initializers/fix_db_schema_conflicts.rb
@@ -1,0 +1,6 @@
+# We load `fix-db-schema-conflicts` with `require:false` in `Gemfile`, then require it here.
+#
+# This allows us to keep its column sorting functionality but skip its built-in Railtie that
+# appends behavior to db:schema:dump to run rubocop.
+
+require 'fix_db_schema_conflicts/schema_dumper'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -13,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2022_02_08_220255) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -1456,7 +1455,7 @@ ActiveRecord::Schema.define(version: 2022_02_08_220255) do
   create_table "vita_providers", force: :cascade do |t|
     t.string "appointment_info"
     t.boolean "archived", default: false, null: false
-    t.geography "coordinates", limit: { srid: 4326, type: "st_point", geographic: true }
+    t.geography "coordinates", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}
     t.datetime "created_at"
     t.string "dates"
     t.string "details"


### PR DESCRIPTION
We were seeing these odd differences in the schema that only show some of the time,
turns out you get different results if you migrate from the CLI vs clicking
the button to migrate on the website.

We don't need to run rubocop on the schema since it's a generated file and should
just be left how it is.

Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>