### PR TITLE
Consent drop off clients

### DIFF
--- a/app/forms/hub/create_client_form.rb
+++ b/app/forms/hub/create_client_form.rb
@@ -107,7 +107,9 @@ module Hub
     def default_intake_attributes
       {
         type: "Intake::GyrIntake",
-        visitor_id: SecureRandom.hex(26)
+        visitor_id: SecureRandom.hex(26),
+        primary_consented_to_service: "yes",
+        primary_consented_to_service_at: DateTime.now
       }
     end
 

--- a/app/jobs/delete_barely_started_gyr_intakes_job.rb
+++ b/app/jobs/delete_barely_started_gyr_intakes_job.rb
@@ -1,6 +1,6 @@
 class DeleteBarelyStartedGyrIntakesJob < ApplicationJob
   def perform
-    Intake::GyrIntake.where("created_at < ?", 2.days.ago).where(primary_consented_to_service: "unfilled")
+    Intake::GyrIntake.where("created_at < ?", 2.days.ago).where(primary_consented_to_service_at: nil)
                      .find_in_batches(batch_size: 1000) do |intakes|
       Client.find(intakes.pluck(:client_id)).map(&:destroy)
     end

--- a/app/models/intake/gyr_intake.rb
+++ b/app/models/intake/gyr_intake.rb
@@ -351,11 +351,7 @@ class Intake::GyrIntake < Intake
   enum widowed: { unfilled: 0, yes: 1, no: 2 }, _prefix: :widowed
   enum wants_to_itemize: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :wants_to_itemize
   enum received_advance_ctc_payment: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :received_advance_ctc_payment
-  scope :accessible_intakes, -> do
-    online_consented = joins(:tax_returns).where({ tax_returns: { service_type: "online_intake" } }).where(primary_consented_to_service: "yes")
-    drop_off = joins(:tax_returns).where({ tax_returns: { service_type: "drop_off" } })
-    online_consented.or(drop_off)
-  end
+  scope :accessible_intakes, -> { where.not(primary_consented_to_service_at: nil) }
   after_save do
     if saved_change_to_completed_at?(from: nil)
       InteractionTrackingService.record_incoming_interaction(client) # client completed intake

--- a/spec/features/hub/show_client_spec.rb
+++ b/spec/features/hub/show_client_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "a user viewing a client" do
     let(:first_org) { create :organization, coalition: coalition }
     let(:primary_ssn) { "1112223333" }
     let(:client) { create :client, vita_partner: first_org, intake: create(:intake, :with_contact_info, primary_ssn: primary_ssn) }
-    let!(:intake_with_ssn_match) { create :intake, primary_ssn: primary_ssn, client: create(:client_with_tax_return_state, tax_returns: [(create :tax_return, service_type: "drop_off")]) }
+    let!(:intake_with_ssn_match) { create :intake, primary_consented_to_service_at: DateTime.now, primary_ssn: primary_ssn, client: create(:client_with_tax_return_state, tax_returns: [(create :tax_return, service_type: "drop_off")]) }
     let!(:ctc_intake_with_ssn_match) { create :ctc_intake, primary_ssn: primary_ssn, sms_phone_number_verified_at: DateTime.now }
     let!(:second_org) { create :organization, coalition: coalition }
     before { login_as user }

--- a/spec/forms/hub/create_client_form_spec.rb
+++ b/spec/forms/hub/create_client_form_spec.rb
@@ -137,6 +137,8 @@ RSpec.describe Hub::CreateClientForm do
         expect(intake.vita_partner).to eq vita_partner
         expect(intake.primary_ssn).to eq "123456789"
         expect(intake.spouse_ssn).to eq "934769258"
+        expect(intake.primary_consented_to_service).to eq "yes"
+        expect(intake.primary_consented_to_service_at).not_to be_nil
       end
 
       it "creates tax returns for each tax_return where _create is true" do

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -540,10 +540,10 @@ describe Client do
     let(:ctc_client_inaccessible_ssn_match) { create :client, intake: create(:ctc_intake, primary_ssn: primary_ssn, sms_phone_number_verified_at: nil, email_address_verified_at: nil, navigator_has_verified_client_identity: nil) }
     let(:ctc_client_accessible_no_ssn_match) { create :client, intake: create(:ctc_intake, primary_ssn: "123456789", sms_phone_number_verified_at: DateTime.now) }
 
-    let(:gyr_client_accessible_ssn_match_online) { create :client_with_tax_return_state, intake: create(:intake, primary_ssn: primary_ssn, primary_consented_to_service: "yes"), tax_returns: [(create :tax_return, service_type: "online_intake")] }
-    let(:gyr_client_accessible_ssn_match_drop_off) { create :client_with_tax_return_state, intake: create(:intake, primary_ssn: primary_ssn, primary_consented_to_service: "unfilled"), tax_returns: [(create :tax_return, service_type: "drop_off")] }
-    let(:gyr_client_inaccessible_ssn_match) { create :client_with_tax_return_state, intake: create(:intake, primary_ssn: primary_ssn, primary_consented_to_service: "unfilled"), tax_returns: [(create :tax_return, service_type: "online_intake")] }
-    let(:gyr_client_accessible_no_ssn_match) { create :client_with_tax_return_state, intake: create(:intake, primary_ssn: "123456789"), tax_returns: [(create :tax_return, service_type: "drop_off")] }
+    let(:gyr_client_accessible_ssn_match_online) { create :client_with_tax_return_state, intake: create(:intake, primary_ssn: primary_ssn, primary_consented_to_service_at: DateTime.now), tax_returns: [(create :tax_return, service_type: "online_intake")] }
+    let(:gyr_client_accessible_ssn_match_drop_off) { create :client_with_tax_return_state, intake: create(:intake, primary_ssn: primary_ssn, primary_consented_to_service_at: DateTime.now), tax_returns: [(create :tax_return, service_type: "drop_off")] }
+    let(:gyr_client_inaccessible_ssn_match) { create :client_with_tax_return_state, intake: create(:intake, primary_ssn: primary_ssn, primary_consented_to_service_at: nil), tax_returns: [(create :tax_return, service_type: "online_intake")] }
+    let(:gyr_client_accessible_no_ssn_match) { create :client_with_tax_return_state, intake: create(:intake, primary_ssn: "123456789", primary_consented_to_service_at: DateTime.now), tax_returns: [(create :tax_return, service_type: "drop_off")] }
 
     context "GYR client" do
       let!(:client) { create :client, intake: create(:intake, primary_ssn: primary_ssn) }

--- a/spec/models/intake/gyr_intake_spec.rb
+++ b/spec/models/intake/gyr_intake_spec.rb
@@ -265,28 +265,17 @@ require "rails_helper"
 
 describe Intake::GyrIntake do
   describe ".accessible_intakes" do
-    context "consented intake without tax returns" do
-      let!(:intake) { create :intake, primary_consented_to_service: "yes" }
-      it "does not appear in the accessible intakes" do
+    context "a consented intake" do
+      let!(:intake) { create :intake, primary_consented_to_service_at: DateTime.now }
+      it "appears as an accessible intake" do
+        expect(described_class.accessible_intakes).to include intake
+      end
+    end
+
+    context "not consented intakes" do
+      let!(:intake) { create :intake, primary_consented_to_service_at: nil }
+      it "are not present in the accessible intakes" do
         expect(described_class.accessible_intakes).not_to include intake
-      end
-    end
-
-    context "consented online intake with tax returns" do
-      let!(:intake) {
-        (create :tax_return, client: (create :client, intake: create(:intake, primary_consented_to_service: "yes")), service_type: "online_intake").intake
-      }
-      it "appears in the accessible intakes" do
-        expect(described_class.accessible_intakes).to include intake
-      end
-    end
-
-    context "drop off intakes" do
-      let!(:intake) {
-        (create :tax_return, client: (create :client, intake: create(:intake, primary_consented_to_service: "yes")), service_type: "drop_off").intake
-      }
-      it "appears in the accessible intakes" do
-        expect(described_class.accessible_intakes).to include intake
       end
     end
   end

--- a/spec/services/client_login_service_spec.rb
+++ b/spec/services/client_login_service_spec.rb
@@ -97,14 +97,6 @@ describe ClientLoginService do
           it "returns a blank set" do
             expect(subject.clients_for_token("raw_token")).to match_array []
           end
-
-          context "with a client that is a drop off" do
-            let(:service_type) { "drop_off" }
-
-            it "returns the client" do
-              expect(subject.clients_for_token("raw_token")).to match_array [client]
-            end
-          end
         end
 
         context "with a ctc service type and ctc intake with verified contact info" do
@@ -128,13 +120,13 @@ describe ClientLoginService do
     let(:phone_number) { "+18324651680" }
     let!(:client) { create :client, intake: intake, tax_returns: [create(:tax_return, service_type: service_type, status: "prep_ready_for_prep")] }
     let(:sms_notification_opt_in) { "yes" }
-    let(:primary_consented_to_service) { "yes" }
+    let(:primary_consented_to_service_at) { DateTime.current }
     let(:service_type) { "online_intake" }
 
     context "service_type is :gyr" do
       subject { described_class.new(:gyr) }
 
-      let(:intake) { (create :intake, sms_phone_number: phone_number, primary_consented_to_service: primary_consented_to_service, sms_notification_opt_in: sms_notification_opt_in)}
+      let(:intake) { (create :intake, sms_phone_number: phone_number, primary_consented_to_service_at: primary_consented_to_service_at, sms_notification_opt_in: sms_notification_opt_in)}
 
       context "when client phone number maps to online, consented return with sms opt in" do
         it "is true" do
@@ -143,7 +135,7 @@ describe ClientLoginService do
       end
 
       context "when a clients phone number is linked to a return that has not consented" do
-        let(:primary_consented_to_service) { "no" }
+        let(:primary_consented_to_service_at) { nil }
 
         it "is false" do
           expect(subject.can_login_by_sms_verification?(phone_number)).to be false
@@ -168,7 +160,7 @@ describe ClientLoginService do
     context "service_type is :ctc" do
       subject { described_class.new(:ctc) }
 
-      let(:intake) { (create :ctc_intake, phone_number: other_phone_number, sms_phone_number: sms_phone_number, primary_consented_to_service: primary_consented_to_service, sms_notification_opt_in: sms_notification_opt_in, sms_phone_number_verified_at: verified_at_time, navigator_has_verified_client_identity: navigator_verified)}
+      let(:intake) { (create :ctc_intake, phone_number: other_phone_number, sms_phone_number: sms_phone_number, primary_consented_to_service_at: primary_consented_to_service_at, sms_notification_opt_in: sms_notification_opt_in, sms_phone_number_verified_at: verified_at_time, navigator_has_verified_client_identity: navigator_verified)}
       let(:sms_phone_number) { phone_number }
       let(:other_phone_number) { nil }
       let(:verified_at_time) { Time.current }
@@ -209,10 +201,10 @@ describe ClientLoginService do
   describe ".handle_email_request" do
     context "when service_type is :gyr" do
       subject { described_class.new(:gyr) }
-      context "when there is a consented online intake with matching email" do
+      context "when there is a consented intake with matching email" do
         let(:email_address) { "mango@example.com" }
         before do
-          create :client, intake: (create :intake, email_address: email_address, primary_consented_to_service: "yes"), tax_returns: [create(:tax_return, service_type: "online_intake", status: "prep_ready_for_prep")]
+          create :client, intake: (create :intake, email_address: email_address, primary_consented_to_service_at: DateTime.now), tax_returns: [create(:tax_return, service_type: "online_intake", status: "prep_ready_for_prep")]
         end
 
         it "is true" do
@@ -220,10 +212,10 @@ describe ClientLoginService do
         end
       end
 
-      context "when there is a consented online intake with a matching spouse email" do
+      context "when there is a consented intake with a matching spouse email" do
         let(:email_address) { "mangospouse@example.com" }
         before do
-          create :client, intake: (create :intake, spouse_email_address: email_address, primary_consented_to_service: "yes"), tax_returns: [create(:tax_return, service_type: "online_intake", status: "prep_ready_for_prep")]
+          create :client, intake: (create :intake, spouse_email_address: email_address, primary_consented_to_service_at: DateTime.now), tax_returns: [create(:tax_return, service_type: "online_intake", status: "prep_ready_for_prep")]
         end
 
         it "is true" do
@@ -231,32 +223,10 @@ describe ClientLoginService do
         end
       end
 
-      context "when there is a drop off intake with a matching email" do
-        let(:email_address) { "persimmion@example.com" }
-        before do
-          create :client, intake: (create :intake, email_address: email_address), tax_returns: [create(:tax_return, service_type: "drop_off", status: "prep_ready_for_prep")]
-        end
-
-        it "is true" do
-          expect(subject.can_login_by_email_verification?(email_address)).to be true
-        end
-      end
-
-      context "when there is a drop off intake with a matching spouse email" do
-        let(:email_address) { "persimmion@example.com" }
-        before do
-          create :client, intake: (create :intake, spouse_email_address: email_address), tax_returns: [create(:tax_return, service_type: "drop_off", status: "prep_ready_for_prep")]
-        end
-
-        it "is true" do
-          expect(subject.can_login_by_email_verification?(email_address)).to be true
-        end
-      end
-
-      context "when there is a matching online intake that has not consented to service" do
+      context "when there is a matching intake that has not consented to service" do
         let(:email_address) { "noconsent@example.com" }
         before do
-          create :client, intake: (create :intake, spouse_email_address: email_address), tax_returns: [create(:tax_return, service_type: "online_intake", status: "prep_ready_for_prep")]
+          create :client, intake: (create :intake, spouse_email_address: email_address, primary_consented_to_service_at: nil), tax_returns: [create(:tax_return, service_type: "online_intake", status: "prep_ready_for_prep")]
         end
 
         it "is false" do


### PR DESCRIPTION
Mark as primary_consented_to_service_at

Also, use primary_consented_to_service_at instead of the enum.

Need to backfill on prod for existing drop offs when we release.