### PR TITLE
Create routes for ajax_mixpanel_events in CtcDomain

### DIFF
--- a/app/views/ctc/ctc_pages/california_benefits.html.erb
+++ b/app/views/ctc/ctc_pages/california_benefits.html.erb
@@ -22,7 +22,7 @@
               <p><%= t("views.ctc_pages.california_benefits.option_one.p2", current_tax_year: current_tax_year) %></p>
             </div>
             <div>
-              <%= link_to url_for(host: MultiTenantService.new(:gyr).host, controller: "/public_pages", action: 'diy'), class: "button button--full-width text--centered spacing-above-25 button--centered", "data-track-click": "click_cdss-active-choice-file-gyr" do %>
+              <%= link_to url_for(host: MultiTenantService.new(:gyr).host, controller: "/public_pages", action: 'diy'), class: "button button--full-width text--centered spacing-above-25 button--centered", "data-track-click": "cdss-active-choice-file-gyr" do %>
                 <%= t("views.ctc.questions.use_gyr.file_gyr") %>
               <% end %>
             </div>
@@ -36,7 +36,7 @@
             <h2 class="spacing-below-25 spacing-above-0"><%= t("views.ctc_pages.california_benefits.option_two.title_html") %></h2>
             <p><%= t("views.ctc_pages.california_benefits.option_two.p1", current_tax_year: current_tax_year) %></p>
             <p><%= t("views.ctc_pages.california_benefits.option_two.p2", current_tax_year: current_tax_year) %></p>
-            <%= link_to root_url, class: "button button--full-width text--centered spacing-above-25 button--centered", "data-track-click": "click_cdss-active-choice-file-getctc" do %>
+            <%= link_to root_url, class: "button button--full-width text--centered spacing-above-25 button--centered", "data-track-click": "cdss-active-choice-file-getctc" do %>
               <%= t("views.ctc_pages.california_benefits.option_two.file_ctc") %>
             <% end %>
           </div>

--- a/app/views/questions/triage_express/edit.html.erb
+++ b/app/views/questions/triage_express/edit.html.erb
@@ -16,7 +16,7 @@
     <%= link_to t("questions.triage_gyr_express.edit.sign_up_for_express"),
                 url_for(host: MultiTenantService.new(:ctc).host, controller: "/public_pages", action: "source_routing", source: "gyr"),
                 class: "button button--primary button--wide spacing-above-60 text--centered",
-                "data-track-click": "click_triage-express-only-choose-express-signup"
+                "data-track-click": "triage-express-only-choose-express-signup"
     %>
   </div>
 <% end %>

--- a/app/views/questions/triage_gyr/edit.html.erb
+++ b/app/views/questions/triage_gyr/edit.html.erb
@@ -8,11 +8,11 @@
   <p class="text--line-breaks"><%= t('.help_text') %></p>
 
   <div class="spacing-above-60">
-    <%= link_to t('.file_online'), next_path, class: "button button--primary button--wide text--centered", "data-track-click": "click_triage-gyr-file-online" %>
+    <%= link_to t('.file_online'), next_path, class: "button button--primary button--wide text--centered", "data-track-click": "triage-gyr-file-online" %>
   </div>
   <div>
-    <%= link_to t('.file_in_person'), vita_providers_path, class: "button button--wide text--centered", "data-track-click": "click_triage-gyr-file-in-person" %>
+    <%= link_to t('.file_in_person'), vita_providers_path, class: "button button--wide text--centered", "data-track-click": "triage-gyr-file-in-person" %>
   </div>
 
-  <p><%= link_to t('.file_on_my_own'), diy_email_path, class: "link--cta", "data-track-click": "click_triage-gyr-actually-diy" %></p>
+  <p><%= link_to t('.file_on_my_own'), diy_email_path, class: "link--cta", "data-track-click": "triage-gyr-actually-diy" %></p>
 <% end %>

--- a/app/views/questions/triage_gyr_express/edit.html.erb
+++ b/app/views/questions/triage_gyr_express/edit.html.erb
@@ -48,13 +48,13 @@
   </div>
 
   <div class="spacing-above-60">
-    <%= link_to t('.file_with_gyr'), next_path, class: "button button--wide text--centered", "data-track-click": "click_triage-gyr-express-choose-gyr" %>
+    <%= link_to t('.file_with_gyr'), next_path, class: "button button--wide text--centered", "data-track-click": "triage-gyr-express-choose-gyr" %>
   </div>
   <div>
     <%= link_to t('.sign_up_for_express'),
                 url_for(host: MultiTenantService.new(:ctc).host, controller: "/public_pages", action: 'source_routing', source: "gyr"),
                 class: "button button--wide text--centered",
-                "data-track-click": "click_triage-gyr-express-choose-express-signup"
+                "data-track-click": "triage-gyr-express-choose-express-signup"
     %>
   </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -406,6 +406,9 @@ Rails.application.routes.draw do
         get "/:source" => "ctc_pages#source_routing", constraints: { source: /[0-9a-zA-Z_-]{1,100}/ }
       end
     end
+
+    resources :ajax_mixpanel_events, only: [:create]
+
     get '/.well-known/pki-validation/:id', to: 'public_pages#pki_validation'
   end
 

--- a/spec/features/web_intake/triage_spec.rb
+++ b/spec/features/web_intake/triage_spec.rb
@@ -184,8 +184,8 @@ RSpec.feature "triage flow" do
 
       expect(page).to have_selector("h1", text: I18n.t("questions.triage_gyr_express.edit.title"))
 
-      expect(page).to have_selector("a.button[data-track-click=\"click_triage-gyr-express-choose-gyr\"]", text: I18n.t("questions.triage_gyr_express.edit.file_with_gyr"))
-      expect(page).to have_selector("a.button[data-track-click=\"click_triage-gyr-express-choose-express-signup\"]", text: I18n.t("questions.triage_gyr_express.edit.sign_up_for_express"))
+      expect(page).to have_selector("a.button[data-track-click=\"triage-gyr-express-choose-gyr\"]", text: I18n.t("questions.triage_gyr_express.edit.file_with_gyr"))
+      expect(page).to have_selector("a.button[data-track-click=\"triage-gyr-express-choose-express-signup\"]", text: I18n.t("questions.triage_gyr_express.edit.sign_up_for_express"))
     end
 
     scenario "client ends up on Express page after filling out triage" do
@@ -199,7 +199,7 @@ RSpec.feature "triage flow" do
 
       expect(page).to have_selector("h1", text: I18n.t("questions.triage_express.edit.title"))
 
-      expect(page).to have_selector("a.button[data-track-click=\"click_triage-express-only-choose-express-signup\"]", text: I18n.t("questions.triage_gyr_express.edit.sign_up_for_express"))
+      expect(page).to have_selector("a.button[data-track-click=\"triage-express-only-choose-express-signup\"]", text: I18n.t("questions.triage_gyr_express.edit.sign_up_for_express"))
     end
 
     scenario "client ends up on GYR page after filling out triage" do
@@ -211,9 +211,9 @@ RSpec.feature "triage flow" do
 
       expect(page).to have_selector("h1", text: I18n.t("questions.triage_gyr.edit.title"))
 
-      expect(page).to have_selector("a.button[data-track-click=\"click_triage-gyr-file-online\"]", text: I18n.t("questions.triage_gyr.edit.file_online"))
-      expect(page).to have_selector("a.button[data-track-click=\"click_triage-gyr-file-in-person\"]", text: I18n.t("questions.triage_gyr.edit.file_in_person"))
-      expect(page).to have_selector("a[data-track-click=\"click_triage-gyr-actually-diy\"]", text: I18n.t("questions.triage_gyr.edit.file_on_my_own"))
+      expect(page).to have_selector("a.button[data-track-click=\"triage-gyr-file-online\"]", text: I18n.t("questions.triage_gyr.edit.file_online"))
+      expect(page).to have_selector("a.button[data-track-click=\"triage-gyr-file-in-person\"]", text: I18n.t("questions.triage_gyr.edit.file_in_person"))
+      expect(page).to have_selector("a[data-track-click=\"triage-gyr-actually-diy\"]", text: I18n.t("questions.triage_gyr.edit.file_on_my_own"))
     end
   end
 end

--- a/spec/features/web_intake/triage_spec.rb
+++ b/spec/features/web_intake/triage_spec.rb
@@ -175,7 +175,11 @@ RSpec.feature "triage flow" do
   end
 
   context "Mixpanel events" do
-    scenario "client ends up on GYR/Express choice page after filling out triage" do
+    before do
+      allow(MixpanelService).to receive(:send_event)
+    end
+
+    scenario "client ends up on GYR/Express choice page after filling out triage", js: true do
       answer_gyr_triage_questions(
         income_level: "zero",
         filing_status: "single",
@@ -186,6 +190,10 @@ RSpec.feature "triage flow" do
 
       expect(page).to have_selector("a.button[data-track-click=\"triage-gyr-express-choose-gyr\"]", text: I18n.t("questions.triage_gyr_express.edit.file_with_gyr"))
       expect(page).to have_selector("a.button[data-track-click=\"triage-gyr-express-choose-express-signup\"]", text: I18n.t("questions.triage_gyr_express.edit.sign_up_for_express"))
+
+      click_on I18n.t("questions.triage_gyr_express.edit.file_with_gyr")
+      expect(page).to have_selector("h1", text: I18n.t("views.questions.backtaxes.title"))
+      expect(MixpanelService).to have_received(:send_event).with(event_name: "click_triage-gyr-express-choose-gyr")
     end
 
     scenario "client ends up on Express page after filling out triage" do

--- a/spec/features/web_intake/triage_spec.rb
+++ b/spec/features/web_intake/triage_spec.rb
@@ -175,10 +175,6 @@ RSpec.feature "triage flow" do
   end
 
   context "Mixpanel events" do
-    before do
-      allow(MixpanelService).to receive(:send_event)
-    end
-
     scenario "client ends up on GYR/Express choice page after filling out triage", js: true do
       answer_gyr_triage_questions(
         income_level: "zero",
@@ -190,10 +186,6 @@ RSpec.feature "triage flow" do
 
       expect(page).to have_selector("a.button[data-track-click=\"triage-gyr-express-choose-gyr\"]", text: I18n.t("questions.triage_gyr_express.edit.file_with_gyr"))
       expect(page).to have_selector("a.button[data-track-click=\"triage-gyr-express-choose-express-signup\"]", text: I18n.t("questions.triage_gyr_express.edit.sign_up_for_express"))
-
-      click_on I18n.t("questions.triage_gyr_express.edit.file_with_gyr")
-      expect(page).to have_selector("h1", text: I18n.t("views.questions.backtaxes.title"))
-      expect(MixpanelService).to have_received(:send_event).with(event_name: "click_triage-gyr-express-choose-gyr")
     end
 
     scenario "client ends up on Express page after filling out triage" do

--- a/spec/features/web_intake/triage_spec.rb
+++ b/spec/features/web_intake/triage_spec.rb
@@ -175,7 +175,7 @@ RSpec.feature "triage flow" do
   end
 
   context "Mixpanel events" do
-    scenario "client ends up on GYR/Express choice page after filling out triage", js: true do
+    scenario "client ends up on GYR/Express choice page after filling out triage" do
       answer_gyr_triage_questions(
         income_level: "zero",
         filing_status: "single",


### PR DESCRIPTION
2 things:

1) i forgot that the click handler appends "click_" to the events so i removed the redundant "click_" from the property name
2) more importantly, these events were not getting to mixpanel from the ctc domain because we didn't create the routes. i think. i'm still trying to get the events to show up in the dev environment on mixpanel.

this makes me think we should have better tests for the mixpanel events that are fired using the JS handler