### PR TITLE
Do not send Mixpanel event for /healthcheck

### DIFF
--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -1,5 +1,6 @@
 class PublicPagesController < ApplicationController
   skip_before_action :check_maintenance_mode
+  skip_after_action :track_page_view, only: [:healthcheck]
 
   def include_analytics?
     true

--- a/spec/controllers/public_pages_controller_spec.rb
+++ b/spec/controllers/public_pages_controller_spec.rb
@@ -93,6 +93,12 @@ RSpec.describe PublicPagesController do
       expect(response).to be_ok
       expect(response.body).to include I18n.t("views.public_pages.home.header")
     end
+
+    it "is not instrumented by Mixpanel" do
+      allow(MixpanelService).to receive(:send_event)
+      get :healthcheck
+      expect(MixpanelService).not_to have_received(:send_event)
+    end
   end
 
   describe "#source_routing" do


### PR DESCRIPTION
Result of brief investigation as to why Mixpanel's `GetYourRefund.Dev` account is emitting a significant number of events: 30%+ of the activity of `GetYourRefund.Prod`.  

This may not be the only source of extra events, but seems like a good place to start,