### PR TITLE
Add a limit to a count that was slow [#178761000]

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -8,4 +8,7 @@ class ApplicationRecord < ActiveRecord::Base
   # Migrate to enumerate_columns_in_select_statements when we switch to Rails 7
   # https://www.bigbinary.com/blog/rails-7-adds-setting-for-enumerating-columns-in-select-statements
   class_attribute :ignored_columns, default: [:__fake_column__]
+
+  # Allow counting up to a max number; see https://alexcastano.com/the-hidden-cost-of-the-invisible-queries-in-rails/#how-far-do-you-plan-to-count
+  scope :more_than, ->(n) { limit(n + 1).count > n }
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -10,5 +10,5 @@ class ApplicationRecord < ActiveRecord::Base
   class_attribute :ignored_columns, default: [:__fake_column__]
 
   # Allow counting up to a max number; see https://alexcastano.com/the-hidden-cost-of-the-invisible-queries-in-rails/#how-far-do-you-plan-to-count
-  scope :more_than, ->(n) { limit(n + 1).count > n }
+  scope :size_greater_than?, ->(n) { limit(n + 1).count > n }
 end

--- a/app/views/shared/_client_filters_and_add_client.html.erb
+++ b/app/views/shared/_client_filters_and_add_client.html.erb
@@ -63,7 +63,7 @@
 
     <div>
       <% # Only show vita partner filtering if user has more than one available vita partner to select from. %>
-      <% if @vita_partners.size > 1 %>
+      <% if @vita_partners.more_than(1) %>
         <div class="form-group">
           <label for="org-site-filter" class="form-question"><%= t("hub.clients.index.organization") %></label>
           <div>

--- a/app/views/shared/_client_filters_and_add_client.html.erb
+++ b/app/views/shared/_client_filters_and_add_client.html.erb
@@ -63,7 +63,7 @@
 
     <div>
       <% # Only show vita partner filtering if user has more than one available vita partner to select from. %>
-      <% if @vita_partners.more_than(1) %>
+      <% if @vita_partners.size_greater_than?(1) %>
         <div class="form-group">
           <label for="org-site-filter" class="form-question"><%= t("hub.clients.index.organization") %></label>
           <div>


### PR DESCRIPTION
In the case of one Datadog trace that took [12 seconds](https://app.datadoghq.com/apm/resource/getyourrefund-app/rack.request/cdcfc5ba36696a5b?query=env%3Aproduction%20service%3Agetyourrefund-app%20operation_name%3Arack.request%20resource_name%3A%22Hub%3A%3AClientsController%23index%22&env=production&event=AgAAAX8ABOEGTikpwQAAAAAAAAAYAAAAAEFYOEFCT2RoQUFDQzFUQWFhdXZaWFdZZwAAACQAAAAAMDE3ZjAwOTEtMTA5Ny00NjliLWJlZTEtY2UwZDkyYWVmNmMy&index=apm-search&spanID=210293794687323406&spanViewType=metadata&timeHint=1644972794118&topGraphs=latency%3Alatency%2CbreakdownAs%3Apercentage%2Cerrors%3Acount%2Chits%3Acount&traceID=2334651170558058865&start=1644964108991&end=1645136908991&paused=false), 0.25 seconds were spent counting `vita_partners`.

That's not a long time, but it's also easy to fix.