### PR TITLE
Preload :child_sites to optimize taggable_vita_partners [#178761000]

### DIFF
--- a/app/helpers/tagging_helper.rb
+++ b/app/helpers/tagging_helper.rb
@@ -1,10 +1,11 @@
 module TaggingHelper
   def taggable_vita_partners(vita_partners)
     taggable_vita_partners = []
-    vita_partners.organizations.each do |vita_partner|
-      taggable_vita_partners << { id: vita_partner.id, name: vita_partner.name, value: vita_partner.id }
-      vita_partner.child_sites.each do |site|
-        taggable_vita_partners << { id: site.id, name: site.name, parentName: vita_partner.name, value: site.id }
+    # We query via the Organization model to trigger auto-loading of child_sites per Organization model's default scope.
+    Organization.where(id: vita_partners.organizations).each do |organization|
+      taggable_vita_partners << { id: organization.id, name: organization.name, value: organization.id }
+      organization.child_sites.each do |site|
+        taggable_vita_partners << { id: site.id, name: site.name, parentName: organization.name, value: site.id }
       end
     end
     taggable_vita_partners.to_json.to_s.html_safe


### PR DESCRIPTION
Before this change, taggable_vita_partners seems to do a lot of SQL queries (N+1), and http://localhost:3000/en/hub/clients shows me a lot of queries if I have a lot of `organizations` in the database. After, it only does two, due to the preload.