### PR TITLE
[#181375840] Fix extra query in deduplication service

### DIFF
--- a/app/lib/deduplification_service.rb
+++ b/app/lib/deduplification_service.rb
@@ -6,17 +6,13 @@ class DeduplificationService
     OpenSSL::HMAC.hexdigest("SHA256", key, "#{attr}|#{value}")
   end
 
-  def self.duplicates(instance, *attrs, from_scope: nil)
+  def self.duplicates(instance, *attrs, from_scope:)
     match_on = Array(attrs).inject({}) do |hash, attr|
       hash[attr] = values(instance, attr)
       hash
     end
 
-    if from_scope.present?
-      from_scope.where.not(id: instance.id).where(match_on)
-    else
-      instance.class.where.not(id: instance.id).where(match_on)
-    end
+    from_scope.where.not(id: instance.id).where(match_on)
   end
 
   def self.values(instance, attr)

--- a/app/models/archived/bank_account_2021.rb
+++ b/app/models/archived/bank_account_2021.rb
@@ -45,7 +45,7 @@ module Archived
     end
 
     def duplicates
-      DeduplificationService.duplicates(self, :hashed_routing_number, :hashed_account_number)
+      DeduplificationService.duplicates(self, :hashed_routing_number, :hashed_account_number, from_scope: self.class)
     end
 
     def hash_data

--- a/app/models/bank_account.rb
+++ b/app/models/bank_account.rb
@@ -41,7 +41,7 @@ class BankAccount < ApplicationRecord
   end
 
   def duplicates
-    DeduplificationService.duplicates(self, :hashed_routing_number, :hashed_account_number)
+    DeduplificationService.duplicates(self, :hashed_routing_number, :hashed_account_number, from_scope: self.class)
   end
 
   def hash_data

--- a/app/services/fraud_indicator_service.rb
+++ b/app/services/fraud_indicator_service.rb
@@ -48,6 +48,6 @@ class FraudIndicatorService
   end
 
   def duplicate_phone_number
-    DeduplificationService.duplicates(@client.intake, :phone_number).where.not(completed_at: nil).where(type: "Intake::CtcIntake").count > 2
+    DeduplificationService.duplicates(@client.intake, :phone_number, from_scope: @client.intake.class).where.not(completed_at: nil).where(type: "Intake::CtcIntake").count > 2
   end
 end

--- a/spec/features/web_intake/itin_applicant_filer_spec.rb
+++ b/spec/features/web_intake/itin_applicant_filer_spec.rb
@@ -96,9 +96,15 @@ RSpec.feature "A client who wants help getting an ITIN" do
   end
 
   context "when the itin applicant has a duplicate" do
-    before do
-      # duplicated itin app
-      create(:intake, primary_birth_date: Date.new(1971, 3, 5), email_address: "gary.gardengnome@example.green", triage: (create :triage, id_type: "need_itin_help"))
+    let!(:duplicated_itin_app) do
+      create(
+        :intake,
+        primary_birth_date: Date.new(1971, 3, 5),
+        email_address: "gary.gardengnome@example.green",
+        primary_consented_to_service: "yes",
+        primary_consented_to_service_at: 15.minutes.ago,
+        triage: (create :triage, id_type: "need_itin_help")
+      )
     end
 
     scenario "the client fills out triage and beginning of intake, but after consent gets sent to returning client page" do

--- a/spec/features/web_intake/returning_filer_spec.rb
+++ b/spec/features/web_intake/returning_filer_spec.rb
@@ -2,8 +2,18 @@ require "rails_helper"
 
 RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot_i18n_friendly do
   let(:primary_ssn) { "123-45-6789" }
-  let!(:original_intake) { create :intake, email_address: "original@client.com", phone_number: "+14155537865", primary_consented_to_service: "yes", primary_ssn: primary_ssn, client: build(:client, tax_returns: [build(:tax_return, service_type: "online_intake")]) }
-  let!(:ctc_intake_matching_ssn) { create :ctc_intake, primary_consented_to_service: "yes", primary_ssn: primary_ssn }
+  let!(:original_intake) do
+    create(
+      :intake,
+      email_address: "original@client.com",
+      phone_number: "+14155537865",
+      primary_consented_to_service: "yes",
+      primary_consented_to_service_at: 15.minutes.ago,
+      primary_ssn: primary_ssn,
+      client: build(:client, tax_returns: [build(:tax_return, service_type: "online_intake")])
+    )
+  end
+  let!(:ctc_intake_matching_ssn) { create :ctc_intake, primary_consented_to_service: "yes", primary_consented_to_service_at: 15.minutes.ago, primary_ssn: primary_ssn }
   let(:returning_client_title) { I18n.t('views.questions.returning_client.title') }
 
   before do

--- a/spec/lib/deduplification_service_spec.rb
+++ b/spec/lib/deduplification_service_spec.rb
@@ -33,7 +33,7 @@ describe DeduplificationService do
 
     context "when passed with one attr" do
       it "uses the single argument to create the where clause" do
-        described_class.duplicates(instance, :hashed_routing_number)
+        described_class.duplicates(instance, :hashed_routing_number, from_scope: instance.class)
         expect(query_double).to have_received(:where).with({ hashed_routing_number: instance.hashed_routing_number })
       end
 
@@ -48,7 +48,7 @@ describe DeduplificationService do
         end
 
         it "looks for the old and new hash in the db for matches on either" do
-          described_class.duplicates(instance, :hashed_routing_number)
+          described_class.duplicates(instance, :hashed_routing_number, from_scope: instance.class)
           expect(query_double).to have_received(:where).with({ hashed_routing_number: ["new_hash", "old_hash"] })
         end
       end
@@ -63,7 +63,7 @@ describe DeduplificationService do
         end
 
         it "uses the raw attr value to build the query" do
-          described_class.duplicates(instance, :phone_number)
+          described_class.duplicates(instance, :phone_number, from_scope: instance.class)
           expect(query_double).to have_received(:where).with({ phone_number: "+18324658840" })
         end
       end
@@ -71,19 +71,7 @@ describe DeduplificationService do
 
     context "when passed with an array of attributes" do
       it "uses the attributes to create the where clause" do
-        described_class.duplicates(instance, :hashed_routing_number, :hashed_account_number)
-        expect(query_double).to have_received(:where).with({ hashed_routing_number: instance.hashed_routing_number, hashed_account_number: instance.hashed_account_number })
-      end
-    end
-
-    context "when from_scope argument is present" do
-      before do
-        allow(BankAccount).to receive_message_chain(:order, :where, :not).and_return query_double
-        allow(query_double).to receive(:where).and_return query_double
-      end
-
-      it "calls the query off of the scoped query passed in" do
-        described_class.duplicates(instance, :hashed_routing_number, :hashed_account_number, from_scope: BankAccount.order(:created_at))
+        described_class.duplicates(instance, :hashed_routing_number, :hashed_account_number, from_scope: instance.class)
         expect(query_double).to have_received(:where).with({ hashed_routing_number: instance.hashed_routing_number, hashed_account_number: instance.hashed_account_number })
       end
     end

--- a/spec/models/intake/gyr_intake_spec.rb
+++ b/spec/models/intake/gyr_intake_spec.rb
@@ -332,7 +332,7 @@ describe Intake::GyrIntake do
 
       context "when there is another accessible intake with the same ssn" do
         let!(:dupe) {
-          (create :tax_return, client: (create :client, intake: create(:intake, primary_consented_to_service: "yes", primary_ssn: "123456789")), service_type: "drop_off").intake
+          (create :tax_return, client: (create :client, intake: create(:intake, primary_consented_to_service: 'yes', primary_consented_to_service_at: 15.minutes.ago, primary_ssn: "123456789")), service_type: "drop_off").intake
         }
         let(:intake) { create :intake, primary_ssn: "123456789" }
         it "returns that as a duplicate" do


### PR DESCRIPTION
the `from_scope.present?` intended to mean 'was from_scope passed in?'
but accidentally instantiated every intake in the database, which
was getting slower and slower

Changed `DeduplicationService.duplicates` to always require a `from_scope`
because some tests were accidentally relying on `.present?` being false
so they would revert to using the unscoped query; keeping the argument
non-optional hopefully makes things simpler overall.

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>