### PR TITLE
Add an index to archived intakes table to speed up #probable_previous_year_intake

### DIFF
--- a/app/models/archived/intake/ctc_intake_2021.rb
+++ b/app/models/archived/intake/ctc_intake_2021.rb
@@ -243,6 +243,7 @@
 #  index_arcint_2021_on_email_domain                           (email_domain)
 #  index_arcint_2021_on_needs_to_flush_searchable_data_set_at  (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_arcint_2021_on_phone_number                           (phone_number)
+#  index_arcint_2021_on_probable_previous_year_intake_fields   (primary_birth_date,primary_first_name,primary_last_name)
 #  index_arcint_2021_on_searchable_data                        (searchable_data) USING gin
 #  index_arcint_2021_on_sms_phone_number                       (sms_phone_number)
 #  index_arcint_2021_on_spouse_email_address                   (spouse_email_address)

--- a/app/models/archived/intake/gyr_intake_2021.rb
+++ b/app/models/archived/intake/gyr_intake_2021.rb
@@ -243,6 +243,7 @@
 #  index_arcint_2021_on_email_domain                           (email_domain)
 #  index_arcint_2021_on_needs_to_flush_searchable_data_set_at  (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_arcint_2021_on_phone_number                           (phone_number)
+#  index_arcint_2021_on_probable_previous_year_intake_fields   (primary_birth_date,primary_first_name,primary_last_name)
 #  index_arcint_2021_on_searchable_data                        (searchable_data) USING gin
 #  index_arcint_2021_on_sms_phone_number                       (sms_phone_number)
 #  index_arcint_2021_on_spouse_email_address                   (spouse_email_address)

--- a/app/models/archived/intake_2021.rb
+++ b/app/models/archived/intake_2021.rb
@@ -243,6 +243,7 @@
 #  index_arcint_2021_on_email_domain                           (email_domain)
 #  index_arcint_2021_on_needs_to_flush_searchable_data_set_at  (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_arcint_2021_on_phone_number                           (phone_number)
+#  index_arcint_2021_on_probable_previous_year_intake_fields   (primary_birth_date,primary_first_name,primary_last_name)
 #  index_arcint_2021_on_searchable_data                        (searchable_data) USING gin
 #  index_arcint_2021_on_sms_phone_number                       (sms_phone_number)
 #  index_arcint_2021_on_spouse_email_address                   (spouse_email_address)

--- a/db/migrate/20220225002148_index_probable_previous_year_intake_fields_on_archived_intakes.rb
+++ b/db/migrate/20220225002148_index_probable_previous_year_intake_fields_on_archived_intakes.rb
@@ -1,0 +1,7 @@
+class IndexProbablePreviousYearIntakeFieldsOnArchivedIntakes < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :archived_intakes_2021, [:primary_birth_date, :primary_first_name, :primary_last_name], name: "index_arcint_2021_on_probable_previous_year_intake_fields", algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_15_232201) do
+ActiveRecord::Schema.define(version: 2022_02_25_002148) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -417,6 +417,7 @@ ActiveRecord::Schema.define(version: 2022_02_15_232201) do
     t.index ["email_domain"], name: "index_arcint_2021_on_email_domain"
     t.index ["needs_to_flush_searchable_data_set_at"], name: "index_arcint_2021_on_needs_to_flush_searchable_data_set_at", where: "(needs_to_flush_searchable_data_set_at IS NOT NULL)"
     t.index ["phone_number"], name: "index_arcint_2021_on_phone_number"
+    t.index ["primary_birth_date", "primary_first_name", "primary_last_name"], name: "index_arcint_2021_on_probable_previous_year_intake_fields"
     t.index ["searchable_data"], name: "index_arcint_2021_on_searchable_data", using: :gin
     t.index ["sms_phone_number"], name: "index_arcint_2021_on_sms_phone_number"
     t.index ["spouse_email_address"], name: "index_arcint_2021_on_spouse_email_address"


### PR DESCRIPTION
currently the ConsentController is slower than it ought to be
because it's making a non-indexed query on the very large archived
intakes table