### PR TITLE
[#181384680] Remove stray letter on GetCTC homepage

### DIFF
--- a/app/views/ctc/ctc_pages/home.html.erb
+++ b/app/views/ctc/ctc_pages/home.html.erb
@@ -8,7 +8,6 @@
 
 <%= render 'shared/facebook_pixel' %>
 <main role="main" class="ctc-home">
-  <%#= render 'ctc_offseason_warning' %>d
   <div class="slab slab--hero">
     <div class="grid-flex contained column-row space-between">
       <div class="grid-flex column-column spacing-below-35">

--- a/app/views/ctc/ctc_pages/stimulus_home.html.erb
+++ b/app/views/ctc/ctc_pages/stimulus_home.html.erb
@@ -7,7 +7,6 @@
 
 <%= render 'shared/facebook_pixel' %>
 <main role="main" class="ctc-home">
-  <%= render 'ctc_offseason_warning' %>
   <div class="slab slab--hero">
     <div class="grid-flex contained column-row space-between">
       <div class="grid-flex column-column spacing-below-35">


### PR DESCRIPTION
While at it, remove the offseason banner from the CTC stimulus landing page.