### PR TITLE
Incoming emails: remove the database constraint that body_plain cannot be null

### DIFF
--- a/app/models/incoming_email.rb
+++ b/app/models/incoming_email.rb
@@ -5,7 +5,7 @@
 #  id                 :bigint           not null, primary key
 #  attachment_count   :integer
 #  body_html          :string
-#  body_plain         :string           not null
+#  body_plain         :string
 #  from               :citext           not null
 #  received           :string
 #  received_at        :datetime         not null

--- a/db/migrate/20220225230327_remove_non_null_constraint_from_incoming_email_body_plain.rb
+++ b/db/migrate/20220225230327_remove_non_null_constraint_from_incoming_email_body_plain.rb
@@ -1,0 +1,5 @@
+class RemoveNonNullConstraintFromIncomingEmailBodyPlain < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :incoming_emails, :body_plain, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_25_002148) do
+ActiveRecord::Schema.define(version: 2022_02_25_230327) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -803,7 +803,7 @@ ActiveRecord::Schema.define(version: 2022_02_25_002148) do
   create_table "incoming_emails", force: :cascade do |t|
     t.integer "attachment_count"
     t.string "body_html"
-    t.string "body_plain", null: false
+    t.string "body_plain"
     t.bigint "client_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.citext "from", null: false

--- a/spec/controllers/mailgun_webhooks_controller_spec.rb
+++ b/spec/controllers/mailgun_webhooks_controller_spec.rb
@@ -245,6 +245,21 @@ RSpec.describe MailgunWebhooksController do
             expect(IntercomService).not_to have_received(:create_intercom_message_from_email).with(IncomingEmail.last, inform_of_handoff: true)
           end
         end
+
+        context "without a body but with a subject" do
+          it "stores the email" do
+            expect do
+              post :create_incoming_email, params: params.except!("body-plain", "body-html", "stripped-text", "stripped-html")
+            end.to change(IncomingEmail, :count).by(1)
+
+            email = IncomingEmail.last
+            expect(email.client).to eq client
+            expect(email.body_plain).to be_nil
+            expect(email.body_html).to be_nil
+            expect(email.stripped_text).to be_nil
+            expect(email.stripped_html).to be_nil
+          end
+        end
       end
 
       context "with multiple matching clients" do

--- a/spec/factories/incoming_emails.rb
+++ b/spec/factories/incoming_emails.rb
@@ -5,7 +5,7 @@
 #  id                 :bigint           not null, primary key
 #  attachment_count   :integer
 #  body_html          :string
-#  body_plain         :string           not null
+#  body_plain         :string
 #  from               :citext           not null
 #  received           :string
 #  received_at        :datetime         not null

--- a/spec/models/incoming_email_spec.rb
+++ b/spec/models/incoming_email_spec.rb
@@ -5,7 +5,7 @@
 #  id                 :bigint           not null, primary key
 #  attachment_count   :integer
 #  body_html          :string
-#  body_plain         :string           not null
+#  body_plain         :string
 #  from               :citext           not null
 #  received           :string
 #  received_at        :datetime         not null


### PR DESCRIPTION
Mailgun will actually send us webhooks where 'body-plain' is omitted entirely
if the message just has a subject but no body (or maybe just attachments)

Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>