### PR TITLE
Intake: require authentication for OptionalConsentController

### DIFF
--- a/app/controllers/questions/optional_consent_controller.rb
+++ b/app/controllers/questions/optional_consent_controller.rb
@@ -1,5 +1,7 @@
 module Questions
   class OptionalConsentController < QuestionsController
+    include AuthenticatedClientConcern
+
     layout "intake"
 
     def illustration_path; end

--- a/app/lib/gyr_question_navigation.rb
+++ b/app/lib/gyr_question_navigation.rb
@@ -47,8 +47,8 @@ class GyrQuestionNavigation
                                     # generate a "Preliminary" 13614-C signed by the primary
                                     # Routes client to a vita partner, if route-able
                                     # creates TaxReturn records for backtaxes years
-      Questions::OptionalConsentController,
       Questions::AtCapacityController,
+      Questions::OptionalConsentController,
       Questions::ChatWithUsController, # This and all later controllers require a client to be signed in.,
       # Primary filer personal information
       Questions::LifeSituationsController,

--- a/spec/controllers/questions/consent_controller_spec.rb
+++ b/spec/controllers/questions/consent_controller_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe Questions::ConsentController do
               )
               expect(organization_router).to have_received(:determine_partner)
               expect(intake.tax_returns.count).to eq 0
-              expect(response).to redirect_to optional_consent_questions_path
+              expect(response).to redirect_to Questions::AtCapacityController.to_path_helper
             end
           end
         end

--- a/spec/controllers/questions/optional_consent_controller_spec.rb
+++ b/spec/controllers/questions/optional_consent_controller_spec.rb
@@ -4,49 +4,58 @@ RSpec.describe Questions::OptionalConsentController do
   let(:intake) { create :intake, preferred_name: "Ruthie Rutabaga" }
   let!(:tax_return) { create :tax_return, client: intake.client }
 
-  before do
-    sign_in intake.client
+  describe "#edit" do
+    it_behaves_like :a_get_action_for_authenticated_clients_only, action: :edit
   end
 
   describe "#update" do
-    context "with valid params" do
-      let (:params) do
-        {
-          optional_consent_form: {
-            disclose_consented: true,
-            global_carryforward_consented: false,
-            relational_efin_consented: true,
-            use_consented: true,
-          }
-        }
-      end
-      let(:ip_address) { "127.0.0.1" }
-      let(:user_agent) { "IceFerret" }
-      let(:current_time) { DateTime.new(2021, 2, 23) }
+    it_behaves_like :a_post_action_for_authenticated_clients_only, action: :update
 
+    context "with an authenticated client" do
       before do
-        allow(DateTime).to receive(:now).and_return current_time
-        request.remote_ip = ip_address
-        request.user_agent = user_agent
+        sign_in intake.client
       end
 
-      it "saves the answer, along with a timestamp and ip address" do
-        post :update, params: params
+      context "with valid params" do
+        let (:params) do
+          {
+            optional_consent_form: {
+              disclose_consented: true,
+              global_carryforward_consented: false,
+              relational_efin_consented: true,
+              use_consented: true,
+            }
+          }
+        end
+        let(:ip_address) { "127.0.0.1" }
+        let(:user_agent) { "IceFerret" }
+        let(:current_time) { DateTime.new(2021, 2, 23) }
 
-        intake.reload
-        consent = intake.client.consent
-        expect(consent.disclose_consented_at).to eq current_time
-        expect(consent.global_carryforward_consented_at).to be_nil
-        expect(consent.relational_efin_consented_at).to eq current_time
-        expect(consent.use_consented_at).to eq current_time
-        expect(consent.user_agent).to eq "IceFerret"
-        expect(consent.ip).to eq "127.0.0.1"
+        before do
+          allow(DateTime).to receive(:now).and_return current_time
+          request.remote_ip = ip_address
+          request.user_agent = user_agent
+        end
+
+        it "saves the answer, along with a timestamp and ip address" do
+          post :update, params: params
+
+          intake.reload
+          consent = intake.client.consent
+          expect(consent.disclose_consented_at).to eq current_time
+          expect(consent.global_carryforward_consented_at).to be_nil
+          expect(consent.relational_efin_consented_at).to eq current_time
+          expect(consent.use_consented_at).to eq current_time
+          expect(consent.user_agent).to eq "IceFerret"
+          expect(consent.ip).to eq "127.0.0.1"
+        end
       end
     end
   end
 
   describe "#after_update_success" do
     before do
+      sign_in intake.client
       intake.client.update(consent: build(:consent))
     end
 

--- a/spec/features/web_intake/itin_applicant_filer_spec.rb
+++ b/spec/features/web_intake/itin_applicant_filer_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.feature "A client who wants help getting an ITIN" do
   include MockTwilio
 
+  let!(:default_vita_partner) { create :organization, name: "Default Organization", national_overflow_location: true }
+
   context "when an itin applicant is unique" do
     scenario "the client does not get blocked by returning client page and is sent to optional consent" do
       answer_gyr_triage_questions({

--- a/spec/features/web_intake/routing_spec.rb
+++ b/spec/features/web_intake/routing_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 feature "Intake Routing Spec", :flow_explorer_screenshot_i18n_friendly, :active_job do
   include MockTwilio
 
-  def fill_out_notification_preferences
+  def fill_out_notification_preferences(fill_out_optional_consent: true)
     # Notification Preference
     check I18n.t('views.questions.notification_preference.options.email_notification_opt_in')
     check I18n.t('views.questions.notification_preference.options.sms_notification_opt_in')
@@ -46,20 +46,22 @@ feature "Intake Routing Spec", :flow_explorer_screenshot_i18n_friendly, :active_
     select "1971", from: "consent_form_birth_date_year"
     click_on I18n.t("views.questions.consent.cta")
 
-    # Optional consent form
-    expect(page).to have_selector("h1", text: I18n.t('views.questions.optional_consent.title'))
-    toggles = {
-      strip_html_tags(I18n.t('views.questions.optional_consent.consent_to_use_html')).split(':').first => consent_to_use_path,
-      strip_html_tags(I18n.t('views.questions.optional_consent.consent_to_disclose_html')).split(':').first => consent_to_disclose_path,
-      strip_html_tags(I18n.t('views.questions.optional_consent.relational_efin_html')).split(':').first => relational_efin_path,
-      strip_html_tags(I18n.t('views.questions.optional_consent.global_carryforward_html')).split(':').first => global_carryforward_path,
-    }
-    toggles.each do |toggle_text, link_path|
-      expect(page).to have_checked_field(toggle_text)
-      expect(page).to have_link(toggle_text, href: link_path)
+    if fill_out_optional_consent
+      # Optional consent form
+      expect(page).to have_selector("h1", text: I18n.t('views.questions.optional_consent.title'))
+      toggles = {
+        strip_html_tags(I18n.t('views.questions.optional_consent.consent_to_use_html')).split(':').first => consent_to_use_path,
+        strip_html_tags(I18n.t('views.questions.optional_consent.consent_to_disclose_html')).split(':').first => consent_to_disclose_path,
+        strip_html_tags(I18n.t('views.questions.optional_consent.relational_efin_html')).split(':').first => relational_efin_path,
+        strip_html_tags(I18n.t('views.questions.optional_consent.global_carryforward_html')).split(':').first => global_carryforward_path,
+      }
+      toggles.each do |toggle_text, link_path|
+        expect(page).to have_checked_field(toggle_text)
+        expect(page).to have_link(toggle_text, href: link_path)
+      end
+      uncheck toggles.keys.last
+      click_on I18n.t('general.continue')
     end
-    uncheck toggles.keys.last
-    click_on I18n.t('general.continue')
   end
 
   let!(:expected_source_param_vita_partner) { create :organization, name: "Cobra Academy" }
@@ -243,7 +245,7 @@ feature "Intake Routing Spec", :flow_explorer_screenshot_i18n_friendly, :active_
       fill_in I18n.t('views.questions.interview_scheduling.title'), with: "During school hours"
       click_on I18n.t('general.continue')
 
-      fill_out_notification_preferences
+      fill_out_notification_preferences(fill_out_optional_consent: false)
 
       expect(page.html).to have_text I18n.t('views.questions.at_capacity.title')
     end


### PR DESCRIPTION
this will prevent us from getting sentry errors when people try to visit
this controller while unauthenticated

Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>