### PR TITLE
Fix Kernel#open deprecation warning by using URI#open

### DIFF
--- a/app/services/scrape_vita_providers_service.rb
+++ b/app/services/scrape_vita_providers_service.rb
@@ -24,7 +24,7 @@ class ScrapeVitaProvidersService
   private
 
   def request_page(url)
-    html = open(url).read
+    html = URI.open(url).read
     @current_document = Nokogiri::HTML(html) do |config|
       config.noblanks
     end


### PR DESCRIPTION
Saw a deprecation warning when running tests locally, decided to update it.