### PR TITLE
Fix dynamic take action changes

### DIFF
--- a/app/controllers/hub/clients_controller.rb
+++ b/app/controllers/hub/clients_controller.rb
@@ -98,7 +98,7 @@ module Hub
         @client,
         current_user,
         tax_return_id: params.dig(:tax_return, :id)&.to_i,
-        current_state: params.dig(:tax_return, :current_state),
+        status: params.dig(:tax_return, :current_state) || params.dig(:tax_return, :status),
         locale: params.dig(:tax_return, :locale)
       )
     end

--- a/app/forms/hub/take_action_form.rb
+++ b/app/forms/hub/take_action_form.rb
@@ -9,9 +9,9 @@ module Hub
                   :internal_note_body,
                   :action_list,
                   :current_user,
-                  :client,
-                  :current_state
-    validates_presence_of :current_state
+                  :client
+    attr_accessor :state_transition, :status
+    validates_presence_of :status
     validate :belongs_to_client
     validate :state_has_changed
     validate :message_body_excludes_replace_me
@@ -58,7 +58,7 @@ module Hub
     end
 
     def self.permitted_params
-      [:tax_return_id, :current_state, :locale, :message_body, :contact_method, :internal_note_body]
+      [:tax_return_id, :status, :locale, :message_body, :contact_method, :internal_note_body]
     end
 
     def tax_return
@@ -72,9 +72,9 @@ module Hub
     end
 
     def set_default_message_body
-      @message_body = "" and return unless current_state.present? && contact_method_options.present?
+      @message_body = "" and return unless status.present? && contact_method_options.present?
 
-      template = TaxReturnStatus.message_template_for(current_state, locale)
+      template = TaxReturnStatus.message_template_for(status, locale)
       @message_body = ReplacementParametersService.new(body: template, client: client, tax_return: tax_return, preparer: current_user, locale: locale).process
     end
 
@@ -89,7 +89,7 @@ module Hub
     end
 
     def state_has_changed
-      errors.add(:current_state, I18n.t("forms.errors.status_must_change")) if current_state == tax_return&.current_state
+      errors.add(:status, I18n.t("forms.errors.status_must_change")) if status == tax_return&.status
     end
 
     def belongs_to_client

--- a/app/services/tax_return_service.rb
+++ b/app/services/tax_return_service.rb
@@ -1,14 +1,14 @@
 class TaxReturnService
   def self.handle_state_change(form)
     action_list = []
-    form.tax_return.transition_to!(form.current_state, initiated_by_user_id: form.current_user.id)
+    form.tax_return.transition_to!(form.status, initiated_by_user_id: form.current_user.id)
     action_list << I18n.t("hub.clients.update_take_action.flash_message.status")
     SystemNote::StatusChange.generate!(initiated_by: form.current_user, tax_return: form.tax_return)
     if form.message_body.present?
       args = { client: form.client, user: form.current_user, body: form.message_body, tax_return: form.tax_return, locale: form.locale }
       case form.contact_method
       when "email"
-        if form.current_state == "review_signature_requested"
+        if form.status == "review_signature_requested"
           ClientMessagingService.send_email_to_all_signers(**args)
         else
           ClientMessagingService.send_email(**args)

--- a/app/views/hub/clients/edit_take_action.html.erb
+++ b/app/views/hub/clients/edit_take_action.html.erb
@@ -12,7 +12,7 @@
       <%= f.cfa_select(:tax_return_id, "Filing year", @take_action_form.tax_returns.pluck(:year, :id), include_blank: true) %>
       <div id="status">
         <%= f.cfa_select(
-                :current_state,
+                :status,
                 "Updated status",
                 grouped_status_options_for_select,
                 include_blank: true,

--- a/spec/controllers/hub/clients_controller_spec.rb
+++ b/spec/controllers/hub/clients_controller_spec.rb
@@ -1058,7 +1058,7 @@ RSpec.describe Hub::ClientsController do
           get :edit_take_action, params: params
 
           expect(assigns(:take_action_form)).to be_present
-          expect(assigns(:take_action_form).current_state).to be_nil
+          expect(assigns(:take_action_form).status).to be_nil
           expect(assigns(:take_action_form).tax_return_id).to be_nil
         end
       end
@@ -1081,7 +1081,7 @@ RSpec.describe Hub::ClientsController do
           get :edit_take_action, params: params
 
           expect(assigns(:take_action_form).tax_return_id).to eq tax_return_2019.id
-          expect(assigns(:take_action_form).current_state).to eq "intake_info_requested"
+          expect(assigns(:take_action_form).status).to eq "intake_info_requested"
           expect(assigns(:take_action_form).locale).to eq "es"
           expect(assigns(:take_action_form).message_body).not_to be_blank
           expect(assigns(:take_action_form).contact_method).to eq "email"

--- a/spec/features/hub/take_action_spec.rb
+++ b/spec/features/hub/take_action_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Change tax return status on a client" do
+RSpec.feature "Change tax return status on a client", :js do
   context "As an authenticated user" do
     let(:organization) { create :organization }
     let(:user) { create :user, name: "Example Preparer", role: create(:organization_lead_role, organization: organization) }
@@ -19,16 +19,17 @@ RSpec.feature "Change tax return status on a client" do
       click_on "Take action"
 
       expect(current_path).to eq(edit_take_action_hub_client_path(id: tax_return.client))
-      expect(page).to have_select("hub_take_action_form_current_state")
+      expect(page).to have_select("hub_take_action_form_status")
       select "Preparing", from: "Updated status"
       select "2019", from: "Filing year"
 
       expect(page).to have_select("hub_take_action_form_locale", selected: "English")
+      expect(page).to have_text "Preparing"
+
       choose "Text Message"
       fill_in "Send message", with: "Heads up! I am still working on it."
       fill_in "Add an internal note", with: "Leaving a note to the client"
       click_on "Send"
-      expect(page).to have_text "Preparing"
 
       expect(current_path).to eq hub_client_path(id: client.id)
       click_on "Notes"
@@ -43,17 +44,21 @@ RSpec.feature "Change tax return status on a client" do
       expect(page).to have_select("tax_return[current_state]", selected: "Not ready")
 
       within "#tax-return-#{tax_return.id}" do
-        select "Accepted"
+        select "Greeter - info requested"
         click_on "Update"
       end
 
       expect(current_path).to eq(edit_take_action_hub_client_path(id: tax_return.client))
-      expect(page).to have_select("hub_take_action_form_tax_return_id", selected: "2019")
-      expect(page).to have_select("hub_take_action_form_current_state", selected: "Accepted")
-      expect(page).to have_select("hub_take_action_form_locale", selected: "English")
 
-      expect(page).to have_text("Send message")
+      expect(page).to have_text("In order to continue filing your taxes, sign in here")
+      select "Accepted", from: "Updated status"
       expect(page).to have_text("Your #{tax_return.year} tax return has been accepted!")
+
+      expect(page).to have_select("hub_take_action_form_tax_return_id", selected: "2019")
+      expect(page).to have_select("hub_take_action_form_status", selected: "Accepted")
+      expect(page).to have_select("hub_take_action_form_locale", selected: "English")
+      expect(page).to have_field("hub_take_action_form_message_body")
+      expect(page).to have_text("Send message")
       expect(page).to have_text("By clicking send, you will also update status, send a team note, and update followers.")
 
       click_on "Send"

--- a/spec/forms/hub/take_action_form_spec.rb
+++ b/spec/forms/hub/take_action_form_spec.rb
@@ -18,20 +18,20 @@ RSpec.describe Hub::TakeActionForm do
     end
 
     context "when new status is same as current status" do
-      let(:form_params) {{ current_state: tax_return.current_state, tax_return_id: tax_return.id }}
+      let(:form_params) {{ status: tax_return.current_state, tax_return_id: tax_return.id }}
 
       it "add an error to the object" do
         expect(form).not_to be_valid
-        expect(form.errors[:current_state]).to include "Can't initiate status change to current status."
+        expect(form.errors[:status]).to include "Can't initiate status change to current status."
       end
     end
 
     context "when the status is blank" do
-      let(:form_params) {{ tax_return_id: tax_return.id, current_state: " \n" }}
+      let(:form_params) {{ tax_return_id: tax_return.id, status: " \n" }}
 
       it "add an error to the object" do
         expect(form).not_to be_valid
-        expect(form.errors[:current_state]).to include "Can't be blank."
+        expect(form.errors[:status]).to include "Can't be blank."
       end
     end
 
@@ -72,7 +72,7 @@ RSpec.describe Hub::TakeActionForm do
     context "default message body" do
 
       context "when a message body is provided" do
-        let(:form) { Hub::TakeActionForm.new(client, current_user,{ message_body: "hi", current_state: "intake_needs_info" }) }
+        let(:form) { Hub::TakeActionForm.new(client, current_user,{ message_body: "hi", status: "intake_needs_info" }) }
         it "does not overwrite the message body" do
           expect(form.message_body).to eq "hi"
         end
@@ -87,7 +87,7 @@ RSpec.describe Hub::TakeActionForm do
       end
 
       context "when a status that has a message template is provided and locale is english" do
-        let(:form) { Hub::TakeActionForm.new(client, current_user, { current_state: "intake_info_requested", locale: "en" }) }
+        let(:form) { Hub::TakeActionForm.new(client, current_user, { status: "intake_info_requested", locale: "en" }) }
         before do
           allow(intake).to receive(:email_notification_opt_in_yes?).and_return true
           allow(intake).to receive(:sms_notification_opt_in_yes?).and_return true
@@ -100,7 +100,7 @@ RSpec.describe Hub::TakeActionForm do
         end
 
         context "when the user has no contact methods" do
-          let(:form) { Hub::TakeActionForm.new(client, current_user, { current_state: "intake_info_requested", locale: "en" }) }
+          let(:form) { Hub::TakeActionForm.new(client, current_user, { status: "intake_info_requested", locale: "en" }) }
           before do
             allow(intake).to receive(:email_notification_opt_in_yes?).and_return false
             allow(intake).to receive(:sms_notification_opt_in_yes?).and_return false
@@ -112,7 +112,7 @@ RSpec.describe Hub::TakeActionForm do
       end
 
       context "when a status that has a message template is provided and locale is spanish" do
-        let(:form) { Hub::TakeActionForm.new(client, current_user, { current_state: "intake_info_requested", locale: "es" }) }
+        let(:form) { Hub::TakeActionForm.new(client, current_user, { status: "intake_info_requested", locale: "es" }) }
         let(:filled_out_template) {
           <<~MESSAGE
             ¡Hola Luna Lemon!
@@ -144,7 +144,7 @@ RSpec.describe Hub::TakeActionForm do
       end
 
       context "when a status without a message template is provided" do
-        let(:form) { Hub::TakeActionForm.new(client, current_user, { current_state: "non_matching_status"})}
+        let(:form) { Hub::TakeActionForm.new(client, current_user, { status: "non_matching_status" })}
         it "sets message body as an empty string" do
           expect(form.message_body).to eq ""
         end

--- a/spec/services/tax_return_service_spec.rb
+++ b/spec/services/tax_return_service_spec.rb
@@ -16,7 +16,7 @@ describe TaxReturnService do
     let(:user) { create :user }
     let(:tax_return) { create :tax_return, :intake_in_progress, client: client, year: 2019 }
     let(:form_params) {
-      { tax_return_id: tax_return.id, current_state: "intake_info_requested" }
+      { tax_return_id: tax_return.id, status: "intake_info_requested" }
     }
     let(:form) { Hub::TakeActionForm.new(client, user, form_params) }
 
@@ -52,7 +52,7 @@ describe TaxReturnService do
     end
 
     context "with an invalid status" do
-      let(:form_params) { { tax_return_id: tax_return.id, current_state: "bad-status" } }
+      let(:form_params) { { tax_return_id: tax_return.id, status: "bad-status" } }
 
       it "raises an error" do
         expect do
@@ -63,7 +63,7 @@ describe TaxReturnService do
 
     context "when the form has an outgoing message body" do
       let(:form_params) {
-        { tax_return_id: tax_return.id, message_body: "message body", contact_method: contact_method, current_state: "intake_info_requested" }
+        { tax_return_id: tax_return.id, message_body: "message body", contact_method: contact_method, status: "intake_info_requested" }
       }
       context "there is a email contact method" do
         let(:contact_method) { "email" }
@@ -88,7 +88,7 @@ describe TaxReturnService do
 
         context "when the status is signature requested" do
           let(:form_params) {
-            { tax_return_id: tax_return.id, message_body: "message body", contact_method: contact_method, current_state: "review_signature_requested" }
+            { tax_return_id: tax_return.id, message_body: "message body", contact_method: contact_method, status: "review_signature_requested" }
           }
 
           it "sends an email addressed to all statusfilers" do
@@ -125,7 +125,7 @@ describe TaxReturnService do
 
     context "when the form has a blank message body" do
       let(:form_params) {
-        { tax_return_id: tax_return.id, message_body: " \n", current_state: "intake_info_requested" }
+        { tax_return_id: tax_return.id, message_body: " \n", status: "intake_info_requested" }
       }
 
       it "does not send an email or a text message" do
@@ -138,7 +138,7 @@ describe TaxReturnService do
 
     context "when the form has an internal note body" do
       let(:form_params) {
-        { tax_return_id: tax_return.id, internal_note_body: "note body", current_state: "intake_info_requested" }
+        { tax_return_id: tax_return.id, internal_note_body: "note body", status: "intake_info_requested" }
       }
 
       it "creates an internal note from the user" do
@@ -161,7 +161,7 @@ describe TaxReturnService do
 
     context "when the form has a blank internal note body" do
       let(:form_params) {
-        { tax_return_id: tax_return.id, internal_note_body: " \n", current_state: "intake_info_requested" }
+        { tax_return_id: tax_return.id, internal_note_body: " \n", status: "intake_info_requested" }
       }
 
       it "does not create an internal note" do


### PR DESCRIPTION
Regression from updating column name to current_state -- the dynamic changes on the take action page weren't being applied. Decided to change what it's called on the take action page instead since the take action javascript is shared with the bulk auto update.