### PR TITLE
GYR intake: move personal info questions immediately after welcome page

### DIFF
--- a/app/controllers/questions/personal_info_controller.rb
+++ b/app/controllers/questions/personal_info_controller.rb
@@ -3,6 +3,10 @@ module Questions
     include AnonymousIntakeConcern
     skip_before_action :require_intake
 
+    def self.show?(intake)
+      intake.blank? || intake.triage.blank?
+    end
+
     def current_intake
       Intake::GyrIntake.new
     end

--- a/app/controllers/questions/personal_info_controller.rb
+++ b/app/controllers/questions/personal_info_controller.rb
@@ -3,8 +3,8 @@ module Questions
     include AnonymousIntakeConcern
     skip_before_action :require_intake
 
-    def self.show?(intake)
-      intake.blank? || intake.triage.blank?
+    def self.show?(intake, session)
+      intake.blank? || intake.triage.blank? || SourceParameter.source_skips_triage(session[:source])
     end
 
     def current_intake

--- a/app/controllers/questions/triage_controller.rb
+++ b/app/controllers/questions/triage_controller.rb
@@ -32,7 +32,7 @@ module Questions
     end
 
     def redirect_if_matching_source_param
-      redirect_to_intake_after_triage if SourceParameter.find_vita_partner_by_code(session[:source]).present?
+      redirect_to_intake_after_triage if SourceParameter.source_skips_triage(session[:source])
     end
 
     def set_show_client_sign_in_link

--- a/app/controllers/questions/triage_income_level_controller.rb
+++ b/app/controllers/questions/triage_income_level_controller.rb
@@ -19,6 +19,7 @@ module Questions
         referrer: session[:referrer],
         locale: I18n.locale,
         visitor_id: cookies[:visitor_id],
+        intake_id: current_intake&.id,
       )
     end
 

--- a/app/controllers/questions/triage_personal_info_controller.rb
+++ b/app/controllers/questions/triage_personal_info_controller.rb
@@ -15,7 +15,7 @@ module Questions
     end
 
     def redirect_if_matching_source_param
-      redirect_to_intake_after_triage if SourceParameter.find_vita_partner_by_code(session[:source]).present?
+      redirect_to_intake_after_triage if SourceParameter.source_skips_triage(session[:source])
     end
   end
 end

--- a/app/controllers/questions/triage_personal_info_controller.rb
+++ b/app/controllers/questions/triage_personal_info_controller.rb
@@ -1,0 +1,21 @@
+module Questions
+  class TriagePersonalInfoController < PersonalInfoController
+    before_action :redirect_if_matching_source_param
+
+    def self.show?(intake)
+      true
+    end
+
+    def self.form_class
+      PersonalInfoForm
+    end
+
+    def self.form_key
+      "personal_info_form"
+    end
+
+    def redirect_if_matching_source_param
+      redirect_to_intake_after_triage if SourceParameter.find_vita_partner_by_code(session[:source]).present?
+    end
+  end
+end

--- a/app/forms/triage_income_level_form.rb
+++ b/app/forms/triage_income_level_form.rb
@@ -1,6 +1,6 @@
 class TriageIncomeLevelForm < TriageForm
   include FormAttributes
-  set_attributes_for :triage, :filing_status, :income_level, :source, :referrer, :locale, :visitor_id
+  set_attributes_for :triage, :filing_status, :income_level, :source, :referrer, :locale, :visitor_id, :intake_id
 
   validates :income_level, presence: true, inclusion: Triage.income_levels.keys
 end

--- a/app/lib/concerns/controller_navigation.rb
+++ b/app/lib/concerns/controller_navigation.rb
@@ -39,9 +39,16 @@ module ControllerNavigation
 
   def seek(list)
     list.detect do |controller_class|
-      controller_class.show?(
-        controller_class.model_for_show_check(current_controller)
-      )
+      if controller_class.method(:show?).arity > 1
+        controller_class.show?(
+          controller_class.model_for_show_check(current_controller),
+          @current_controller.session
+        )
+      else
+        controller_class.show?(
+          controller_class.model_for_show_check(current_controller)
+        )
+      end
     end
   end
 end

--- a/app/lib/gyr_question_navigation.rb
+++ b/app/lib/gyr_question_navigation.rb
@@ -3,6 +3,7 @@ class GyrQuestionNavigation
 
   FLOW = [
       Questions::WelcomeController,
+      Questions::TriagePersonalInfoController, # creates Intake record and Client record
       Questions::TriageIncomeLevelController,
       Questions::TriageStartIdsController,
       Questions::TriageIdTypeController,
@@ -25,7 +26,7 @@ class GyrQuestionNavigation
       Questions::OverviewController,
 
       # Contact information and preferences
-      Questions::PersonalInfoController, # creates Intake record and Client record
+      Questions::PersonalInfoController, # creates Intake record and Client record, if triage was skipped
       Questions::SsnItinController,
       Questions::BacktaxesController,
       Questions::StartWithCurrentYearController,

--- a/app/models/source_parameter.rb
+++ b/app/models/source_parameter.rb
@@ -30,6 +30,10 @@ class SourceParameter < ApplicationRecord
     SourceParameter.includes(:vita_partner).find_by(code: code&.downcase)&.vita_partner
   end
 
+  def self.source_skips_triage(source)
+    source == 'full-service' || find_vita_partner_by_code(source).present?
+  end
+
   private
 
   def downcase_code

--- a/spec/features/web_intake/itin_applicant_filer_spec.rb
+++ b/spec/features/web_intake/itin_applicant_filer_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature "A client who wants help getting an ITIN" do
   context "when an itin applicant is unique" do
     scenario "the client does not get blocked by returning client page and is sent to optional consent" do
       answer_gyr_triage_questions({
+                                      need_itin: true,
                                       filing_status: "single",
                                       income_level: "1_to_12500",
                                       id_type: "need_itin_help",
@@ -24,14 +25,6 @@ RSpec.feature "A client who wants help getting an ITIN" do
       click_on I18n.t('general.continue_example')
 
       expect(page).to have_selector("h1", text: "Just a few simple steps to file!")
-      click_on "Continue"
-
-      expect(page).to have_selector("h1", text: "First, let's get some basic information.")
-      fill_in "What is your preferred first name?", with: "Gary"
-      fill_in "Phone number", with: "8286345533"
-      fill_in "Confirm phone number", with: "828-634-5533"
-      fill_in "ZIP code", with: "20121"
-      select I18n.t('general.affirmative'), from: I18n.t('views.questions.personal_info.need_itin_help')
       click_on "Continue"
 
       # don't show SSN/ITIN page
@@ -108,6 +101,7 @@ RSpec.feature "A client who wants help getting an ITIN" do
 
     scenario "the client fills out triage and beginning of intake, but after consent gets sent to returning client page" do
       answer_gyr_triage_questions({
+                                      need_itin: true,
                                       filing_status: "single",
                                       income_level: "1_to_12500",
                                       id_type: "need_itin_help",
@@ -126,14 +120,6 @@ RSpec.feature "A client who wants help getting an ITIN" do
       click_on I18n.t('general.continue_example')
 
       expect(page).to have_selector("h1", text: "Just a few simple steps to file!")
-      click_on "Continue"
-
-      expect(page).to have_selector("h1", text: "First, let's get some basic information.")
-      fill_in "What is your preferred first name?", with: "Gary"
-      fill_in "Phone number", with: "8286345533"
-      fill_in "Confirm phone number", with: "828-634-5533"
-      fill_in "ZIP code", with: "20121"
-      select I18n.t('general.affirmative'), from: I18n.t('views.questions.personal_info.need_itin_help')
       click_on "Continue"
 
       # don't show SSN/ITIN page

--- a/spec/features/web_intake/new_joint_filers_spec.rb
+++ b/spec/features/web_intake/new_joint_filers_spec.rb
@@ -9,6 +9,10 @@ RSpec.feature "Web Intake Joint Filers", :flow_explorer_screenshot do
   scenario "new client filing joint taxes with spouse and dependents", js: true, screenshot: true do
     answer_gyr_triage_questions(screenshot_method: self.method(:screenshot_after), choices: :defaults)
 
+    # creates intake and triage
+    intake = Intake.last
+    expect(intake.triage).to eq(Triage.last)
+
     screenshot_after do
       expect(page).to have_selector("h1", text: I18n.t('questions.triage_gyr.edit.title'))
       click_on I18n.t('questions.triage.gyr_tile.choose_gyr')
@@ -31,18 +35,6 @@ RSpec.feature "Web Intake Joint Filers", :flow_explorer_screenshot do
     end
     click_on "Continue"
 
-    screenshot_after do
-      # Personal Info
-      expect(page).to have_selector("h1", text: "First, let's get some basic information.")
-      fill_in I18n.t('views.questions.personal_info.preferred_name'), with: "Gary"
-      fill_in "Phone number", with: "415-888-0088"
-      fill_in "Confirm phone number", with: "415-888-0088"
-      fill_in "ZIP code", with: "20121"
-      select "No", from: "Do you need assistance applying for an ITIN?"
-    end
-    click_on "Continue"
-    # creates intake
-    intake = Intake.last
 
     screenshot_after do
       # SSN or ITIN

--- a/spec/features/web_intake/new_single_filer_spec.rb
+++ b/spec/features/web_intake/new_single_filer_spec.rb
@@ -9,6 +9,10 @@ RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot, active_job: 
   scenario "new client filing single without dependents" do
     answer_gyr_triage_questions(choices: :defaults)
 
+    # creates intake and triage
+    intake = Intake.last
+    expect(intake.triage).to eq(Triage.last)
+
     expect(page).to have_selector("h1", text: I18n.t('questions.triage_gyr.edit.title'))
     click_on I18n.t('questions.triage.gyr_tile.choose_gyr')
 
@@ -22,17 +26,6 @@ RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot, active_job: 
     # Overview
     expect(page).to have_selector("h1", text: "Just a few simple steps to file!")
     click_on "Continue"
-
-    # Personal Info
-    expect(page).to have_selector("h1", text: "First, let's get some basic information.")
-    fill_in I18n.t('views.questions.personal_info.preferred_name'), with: "Gary"
-    fill_in "Phone number", with: "8286345533"
-    fill_in "Confirm phone number", with: "828-634-5533"
-    fill_in "ZIP code", with: "20121"
-    select I18n.t('general.negative'), from: I18n.t('views.questions.personal_info.need_itin_help')
-    click_on "Continue"
-    # creates intake
-    intake = Intake.last
 
     select "Social Security Number (SSN)", from: "Identification Type"
     fill_in I18n.t("attributes.primary_ssn"), with: "123-45-6789"


### PR DESCRIPTION
If you come in with a source that skips triage, you still see
the personal info questions first

Co-authored-by: Jenny Heath <jheath@codeforamerica.org>