### PR TITLE
GYR intake: don't show the environment warning page on prod when linking with a source

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -309,7 +309,11 @@ class ApplicationController < ActionController::Base
   end
 
   def redirect_to_intake_after_triage
-    redirect_to Questions::EnvironmentWarningController.to_path_helper
+    if Rails.env.production?
+      redirect_to Questions::OverviewController.to_path_helper
+    else
+      redirect_to Questions::EnvironmentWarningController.to_path_helper
+    end
   end
 
   def redirect_or_add_flash


### PR DESCRIPTION
Co-authored-by: Jenny Heath <jheath@codeforamerica.org>