### PR TITLE
Perform Datadog metrics calls in Concurrent::Future background thread

### DIFF
--- a/app/lib/datadog_api.rb
+++ b/app/lib/datadog_api.rb
@@ -62,7 +62,9 @@ module DatadogApi
   def self.emit_point(label:, tags:, value:, type:)
     tags << "env:#{configuration.env}"
     Concurrent::Future.execute do
-      self.client.emit_point(self.apply_namespace(label), value, { tags: tags, type: type })
+      client.emit_point(self.apply_namespace(label), value, { tags: tags, type: type })
+    rescue Net::OpenTimeout
+      nil
     end
   end
   private_class_method :emit_point

--- a/app/lib/datadog_api.rb
+++ b/app/lib/datadog_api.rb
@@ -1,9 +1,8 @@
 module DatadogApi
-
   METRIC_TYPES = {
-      count: "count".freeze,
-      gauge: "gauge".freeze,
-      rate: "rate".freeze,
+    count: "count".freeze,
+    gauge: "gauge".freeze,
+    rate: "rate".freeze,
   }.freeze
 
   class Configuration
@@ -49,14 +48,22 @@ module DatadogApi
   def self.increment(label, tags: [])
     return unless configuration.enabled
 
-    tags << "env:#{configuration.env}"
-    self.client.emit_point(self.apply_namespace(label), 1, {:tags => tags, :type => METRIC_TYPES[:count]})
+    future = emit_point(label: label, tags: tags, value: 1, type: METRIC_TYPES[:count])
+    @synchronous ? future.value! : future
   end
 
   def self.gauge(label, value, tags: [])
     return unless configuration.enabled
 
-    tags << "env:#{configuration.env}"
-    self.client.emit_point(self.apply_namespace(label), value, {:tags => tags, :type => METRIC_TYPES[:gauge]})
+    future = emit_point(label: label, tags: tags, value: value, type: METRIC_TYPES[:gauge])
+    @synchronous ? future.value! : future
   end
+
+  def self.emit_point(label:, tags:, value:, type:)
+    tags << "env:#{configuration.env}"
+    Concurrent::Future.execute do
+      self.client.emit_point(self.apply_namespace(label), value, { tags: tags, type: type })
+    end
+  end
+  private_class_method :emit_point
 end

--- a/config/initializers/concurrent_future.rb
+++ b/config/initializers/concurrent_future.rb
@@ -1,0 +1,5 @@
+at_exit do
+  executor = Concurrent.global_io_executor
+  executor.shutdown
+  executor.kill unless executor.wait_for_termination(30.seconds)
+end

--- a/spec/lib/datadog_api_spec.rb
+++ b/spec/lib/datadog_api_spec.rb
@@ -4,6 +4,7 @@ describe DatadogApi do
   include MockDogapi
 
   before do
+    DatadogApi.instance_variable_set("@synchronous", false)
     DatadogApi.configure do |c|
       allow(c).to receive(:namespace).and_return("test.dogapi")
     end
@@ -16,9 +17,14 @@ describe DatadogApi do
       end
     end
 
-    it 'initializes and calls Dogapi::Client' do
-      DatadogApi.gauge('volume', 11)
-      DatadogApi.increment('counter')
+    it 'initializes and calls Dogapi::Client inside of a Promise' do
+      gauge = DatadogApi.gauge('volume', 11)
+      expect(gauge).to be_a Concurrent::Future
+      gauge.value! # wait for async operation to complete
+
+      increment =  DatadogApi.increment('counter')
+      expect(increment).to be_a Concurrent::Future
+      increment.value! # wait for async operation to complete
 
       expect(Dogapi::Client).to have_received(:new).once
       expect(@mock_dogapi).to have_received(:emit_point).once.with('test.dogapi.volume', 11, {:tags => ["env:"+Rails.env], :type => "gauge"})
@@ -34,8 +40,11 @@ describe DatadogApi do
     end
 
     it 'does not initialize and call Dogapi::Client' do
-      DatadogApi.gauge('volume', 11)
-      DatadogApi.increment('counter')
+      gauge = DatadogApi.gauge('volume', 11)
+      expect(gauge).to be nil
+
+      increment = DatadogApi.increment('counter')
+      expect(increment).to be nil
 
       expect(Dogapi::Client).not_to have_received(:new)
       expect(@mock_dogapi).not_to have_received(:emit_point)

--- a/spec/support/mock_dogapi.rb
+++ b/spec/support/mock_dogapi.rb
@@ -5,10 +5,12 @@ module MockDogapi
     before do
       @mock_dogapi = instance_double(Dogapi::Client, emit_point: nil)
       allow(Dogapi::Client).to receive(:new).and_return(@mock_dogapi)
+      DatadogApi.instance_variable_set("@synchronous", true)
     end
 
     after do
       DatadogApi.instance_variable_set("@dogapi_client", nil)
+      DatadogApi.instance_variable_set("@synchronous", false)
     end
   end
 end


### PR DESCRIPTION
Wraps `DatadogApi.guage` and `DatadogApi.increment` calls in a `Concurrent::Future` that can be force-resolved with `value!` inside of tests.

There is no error handling because I'm not sure what would be appropriate (suggestions please!).

If this pattern is acceptable, I'll subsequently look at Mixpanel calls or anything else that could appropriately be fire-and-forget.

I noticed a pattern of unit testing against the underlying adapter; I replaced those by testing against the wrapper.