### PR TITLE
Remove fallback creation of intake

### DIFF
--- a/app/forms/job_count_form.rb
+++ b/app/forms/job_count_form.rb
@@ -3,11 +3,6 @@ class JobCountForm < QuestionsForm
   validates_presence_of :job_count
 
   def save
-    # remove when earlier questions are added - this is only for the first form
-    unless @intake.present?
-      @intake = Intake::GyrIntake.new
-    end
-
     @intake.update(attributes_for(:intake))
   end
 end


### PR DESCRIPTION
Job count still has vestiges of a WIP intake creation from when it was the first page created. 