### PR TITLE
Fix timedout devise gap

### DIFF
--- a/app/views/shared/_flash_alerts.html.erb
+++ b/app/views/shared/_flash_alerts.html.erb
@@ -1,5 +1,6 @@
 <% if flash.any? %>
   <% flash.each do |type, message| %>
+    <!-- Remove timedout, which devise also pushes into flash: https://github.com/heartcombo/devise/issues/1777 -->
     <% next if type == "timedout" %>
     <div class="slab slab--flash flash--<%= type %>">
       <div class="grid">

--- a/app/views/shared/_flash_alerts.html.erb
+++ b/app/views/shared/_flash_alerts.html.erb
@@ -1,5 +1,6 @@
 <% if flash.any? %>
   <% flash.each do |type, message| %>
+    <% next if type == "timedout" %>
     <div class="slab slab--flash flash--<%= type %>">
       <div class="grid">
         <div class="grid__item" role="alert">


### PR DESCRIPTION
devise uses flash to store temporary state. this is why sometimes we see "true" on the page or, now that the background color of the hero has changed, a white gap at the top of the page.

Devise does not want to stop using flash to store this state even though people have told them to use session becuase this is weird since about 2012. To fix, we can just skip from outputting the value of the timedout flash onto the page.
![Screen Shot 2022-03-14 at 11 55 41 AM](https://user-images.githubusercontent.com/4494389/158243970-cb402063-ea6d-4391-a613-d79d5fadce60.png)
![Screen Shot 2022-03-14 at 11 55 46 AM](https://user-images.githubusercontent.com/4494389/158243972-d90fe042-0dc3-4a06-81c0-a412dd93f506.png)
