### PR TITLE
Hub: don't crash when visiting a client with no associated intake from a particular time period

### DIFF
--- a/app/controllers/hub/clients_controller.rb
+++ b/app/controllers/hub/clients_controller.rb
@@ -159,6 +159,8 @@ module Hub
       attr_reader :intake
       attr_reader :archived
       alias_method :archived?, :archived
+      attr_reader :missing_intake
+      alias_method :missing_intake?, :missing_intake
 
       def self.delegated_intake_attributes
         [
@@ -181,6 +183,12 @@ module Hub
         unless @intake
           @intake = Archived::Intake2021.find_by(client_id: @client.id)
           @archived = true if @intake
+        end
+        # For a short while, we created Client records with no intake and/or moved which client the intake belonged to.
+        if !@intake && @client.created_at < Date.parse('2022-03-15') && @client.created_at > Date.parse('2022-03-09')
+          @missing_intake = true
+          @intake = Intake::GyrIntake.new(client_id: @client.id)
+          @intake.readonly!
         end
       end
 

--- a/app/views/hub/clients/_client_header.html.erb
+++ b/app/views/hub/clients/_client_header.html.erb
@@ -7,6 +7,17 @@
   </div>
 <% end %>
 
+<% if @client.missing_intake? %>
+  <div class="slab slab--flash flash--warning">
+    <div class="grid-flex center-aligned">
+      <%= image_tag("icons/warning-triangle.svg", class: "item-15r") %>
+      <span>
+        This Client ID exists, but the client's information could not be found due to an error. Try searching for the client's contact information to see if their information is associated with another Client ID or reach out to Support with questions.
+      </span>
+    </div>
+  </div>
+<% end %>
+
 <section class="slab slab--padded">
   <div class="client-header">
     <div class="client-header__left">


### PR DESCRIPTION
We had a bug that was reassociating the client for intakes unfortunately,
but there still may be reasons you want to see data on these hub pages
(mainly looking at any messages/documents sent before the client got changed)

Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>