### PR TITLE
Fix the layout for service component in spanish by truncating content

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4168,8 +4168,8 @@ es:
         required_information: Información obligatoria
         services:
           diy:
-            colloquial: Declarar por mi cuenta, "DIY" en inglés
-            cta: Elegir declarar por mi cuenta o "File Myself" en inglés
+            colloquial: ''
+            cta: Elegir declarar por mi cuenta
             service_description: Declare rápidamente por su cuenta para 2021.
             service_name: Declarar por mi cuenta o "File Myself" en inglés
           express:


### PR DESCRIPTION
The layout for the service component is broken in spanish because the content is too long. Product has approved truncating some of the content so that they layout is not broken.