### PR TITLE
Feature tests now try to print console output when the tests fail

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -173,4 +173,19 @@ RSpec.configure do |config|
   config.before(type: :feature, js: true) do |example|
     @metadata_screenshot = example.metadata[:screenshot]
   end
+
+  config.after(type: :feature, js: true) do |example|
+    if example.exception
+      begin
+        browser_console_logs = page.driver.browser.logs.get(:browser)
+        if browser_console_logs.length > 0
+          STDERR.puts "\n\nvv During this test failure, there was some output in the browser's console vv"
+          STDERR.puts browser_console_logs.map(&:message).join("\n")
+          STDERR.puts "^^ ^^"
+        end
+      rescue
+        # Don't let any errors from printing the errors cause more errors
+      end
+    end
+  end
 end

--- a/spec/support/selenium_chrome_headless.rb
+++ b/spec/support/selenium_chrome_headless.rb
@@ -15,6 +15,7 @@ Capybara.register_driver :selenium_chrome_headless do |app|
     opts.add_argument('--force-device-scale-factor=1')
 
     opts.add_argument('--window-size=1280x1280')
+    opts.add_option('goog:loggingPrefs', {browser: 'ALL'})
   end
 
   Capybara::Selenium::Driver.new(app, **Hash[:browser => :chrome, :capabilities => browser_options])


### PR DESCRIPTION
we have some flakes that might be caused by the javascript crashing,
but we won't know until we look for output indicative of that

Co-authored-by: Jenny Heath <jheath@codeforamerica.org>