### PR TITLE
Try hobby-basic Heroku database tier in review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -48,5 +48,10 @@
   },
   "addons": [
     "heroku-postgresql"
-  ]
+  ],
+  "environments": {
+    "review": {
+      "addons": ["heroku-postgresql:hobby-basic"]
+    }
+  }
 }

--- a/app.json
+++ b/app.json
@@ -47,11 +47,6 @@
     }
   },
   "addons": [
-    "heroku-postgresql"
-  ],
-  "environments": {
-    "review": {
-      "addons": ["heroku-postgresql:hobby-basic"]
-    }
-  }
+    "heroku-postgresql:hobby-basic"
+  ]
 }


### PR DESCRIPTION
This may address an issue where hobby-dev doesn't allow enough rows.

Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>