### PR TITLE
Updates from design-eng pairing

### DIFF
--- a/app/controllers/questions/married_controller.rb
+++ b/app/controllers/questions/married_controller.rb
@@ -9,7 +9,7 @@ module Questions
     end
 
     def illustration_path
-      "marital-status.svg"
+      "ever-married.svg"
     end
   end
 end

--- a/app/forms/life_situations_form.rb
+++ b/app/forms/life_situations_form.rb
@@ -1,7 +1,16 @@
 class LifeSituationsForm < QuestionsForm
   set_attributes_for :intake, :was_full_time_student, :was_on_visa, :had_disability, :was_blind
+  set_attributes_for :confirmation, :no_life_situations_apply
+  validates :no_life_situations_apply, at_least_one_or_none_of_the_above_selected: true
 
   def save
     @intake.update(attributes_for(:intake))
+  end
+
+  def at_least_one_selected
+    was_full_time_student == "yes" ||
+      was_on_visa == "yes" ||
+      had_disability == "yes" ||
+      was_blind == "yes"
   end
 end

--- a/app/forms/spouse_life_situations_form.rb
+++ b/app/forms/spouse_life_situations_form.rb
@@ -1,7 +1,16 @@
 class SpouseLifeSituationsForm < QuestionsForm
   set_attributes_for :intake, :spouse_was_full_time_student, :spouse_was_on_visa, :spouse_had_disability, :spouse_was_blind
+  set_attributes_for :confirmation, :no_life_situations_apply
+  validates :no_life_situations_apply, at_least_one_or_none_of_the_above_selected: true
 
   def save
     @intake.update(attributes_for(:intake))
+  end
+
+  def at_least_one_selected
+    spouse_was_full_time_student == "yes" ||
+      spouse_was_on_visa == "yes" ||
+      spouse_had_disability == "yes" ||
+      spouse_was_blind == "yes"
   end
 end

--- a/app/views/questions/arp_payments/edit.html.erb
+++ b/app/views/questions/arp_payments/edit.html.erb
@@ -9,7 +9,7 @@
     <p><%= text %></p>
   <% end %>
 
-  <%= form_with model: @form, url: current_path, local: true, method: "put", builder: VitaMinFormBuilder, html: { class: "form-card" } do |f| %>
+  <%= form_with model: @form, url: current_path, local: true, method: "put", builder: VitaMinFormBuilder, html: { class: "form-card form-card--long" } do |f| %>
     <div class="spacing-above-0">
       <%= f.cfa_input_field :eip1_amount_received, t("views.questions.arp_payments.labels.stimulus_1"), type: "number", prefix: "$" %>
       <%= f.cfa_input_field :eip2_amount_received, t("views.questions.arp_payments.labels.stimulus_2"), type: "number", prefix: "$" %>

--- a/app/views/questions/spouse_issued_identity_pin/edit.html.erb
+++ b/app/views/questions/spouse_issued_identity_pin/edit.html.erb
@@ -1,1 +1,8 @@
 <% content_for :form_question, t("views.questions.spouse_issued_identity_pin.title") %>
+<% content_for :form_help_text, t("views.questions.issued_identity_pin.help_text",
+                                  :ip_pin_link => link_to(t('views.questions.issued_identity_pin.link_text'),
+                                                          'https://www.irs.gov/identity-theft-fraud-scams/retrieve-your-ip-pin',
+                                                          target: '_blank',
+                                                          rel: 'noopener',
+                                                          'data-track-click': 'irs-identity-pin-link',
+                                                          'data-track-attribute-position': 'help-text') ).html_safe %>

--- a/spec/features/web_intake/new_single_filer_spec.rb
+++ b/spec/features/web_intake/new_single_filer_spec.rb
@@ -128,6 +128,7 @@ RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot, active_job: 
     # Primary filer personal information
     expect(page).to have_selector("h1", text: "Select any situations that were true for you in #{TaxReturn.current_tax_year}")
     expect(track_progress).to eq(0)
+    check I18n.t("general.none_of_the_above")
     click_on "Continue"
 
     expect(page).to have_selector("h1", text: I18n.t("views.questions.arp_payments.title"))


### PR DESCRIPTION
**What we achieved:**
- Added help text to `SpouseIssuedIdentityPin`
- Updated the icon on the `MarriedController` (from confused and distant little peoples to close and cohabitated little peoples)
- Updated the size of the labels on the`ArpPayments` page (they were giant because the form was missing a class that makes them small)
- Update `LifeSituations` and `SpouseLifeSituations` to require the client to select something (anything!). Note that the design of the error display is not optimal, but we did what we could with the time we had. We will iterate on this at future sessions or in future stories.
<img width="585" alt="image" src="https://user-images.githubusercontent.com/6520735/159765637-1430a344-e15e-433c-bd2a-f6c3c6eda90d.png">
<img width="563" alt="image" src="https://user-images.githubusercontent.com/6520735/159765871-8ddf064b-b9d1-4408-a7b7-fc6e4733148d.png">
<img width="616" alt="image" src="https://user-images.githubusercontent.com/6520735/159766023-09486fba-d357-4b7a-9d48-a1c08204b09e.png">
<img width="564" alt="image" src="https://user-images.githubusercontent.com/6520735/159766236-2b498290-8a55-43d0-85c5-edca42fbcf5f.png">




