### PR TITLE
Flag clients if they do an incoming interaction (email, text, portal messages, or docs)

### DIFF
--- a/app/models/intake/gyr_intake.rb
+++ b/app/models/intake/gyr_intake.rb
@@ -374,7 +374,7 @@ class Intake::GyrIntake < Intake
   scope :accessible_intakes, -> { where.not(primary_consented_to_service_at: nil) }
   after_save do
     if saved_change_to_completed_at?(from: nil)
-      InteractionTrackingService.record_incoming_interaction(client) # client completed intake
+      InteractionTrackingService.record_incoming_interaction(client, set_flag: false) # client completed intake
     elsif completed_at.present?
       InteractionTrackingService.record_internal_interaction(client) # user updated completed intake
     end

--- a/app/services/interaction_tracking_service.rb
+++ b/app/services/interaction_tracking_service.rb
@@ -5,9 +5,10 @@ class InteractionTrackingService
   end
 
   # When a client contacts us, update last incoming interaction and last interaction
-  def self.record_incoming_interaction(client)
+  def self.record_incoming_interaction(client, set_flag: true)
     touches = [:last_incoming_interaction_at]
     touches.push(:first_unanswered_incoming_interaction_at) unless client.first_unanswered_incoming_interaction_at.present?
+    touches.push(:flagged_at) if set_flag && !client.flagged?
     client&.touch(*touches)
   end
 

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -217,6 +217,42 @@ describe Client do
         expect(client.flagged?).to eq false
       end
     end
+
+    context "when client has a new document" do
+      let!(:client) { create :client }
+      before { create :document, client: client, uploaded_by: client }
+
+      it "is flagged" do
+        expect(client.flagged?).to eq true
+      end
+    end
+
+    context "when clients intake was completed" do
+      let!(:client) { create :client, intake: create(:intake) }
+
+      it "is not flagged" do
+        client.intake.update(completed_at: Time.now)
+        expect(client.flagged?).to eq false
+      end
+    end
+
+    context "when client has a new incoming text message" do
+      let!(:client) { create :client }
+      before { create :incoming_text_message, client: client }
+
+      it "is flagged" do
+        expect(client.flagged?).to eq true
+      end
+    end
+
+    context "when client has a new incoming email" do
+      let!(:client) { create :client }
+      before { create :incoming_email, client: client }
+
+      it "is flagged" do
+        expect(client.flagged?).to eq true
+      end
+    end
   end
 
   describe "#flag!" do


### PR DESCRIPTION
This is a partial revert of 5ad7bfd64da6f3dcb1e465ecfb9ba6310fd3bdf2
but only ever sets the flag on, it doesn't turn the flag off for
outgoing interactions

It also doesn't set the flag when intake is completed

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>