### PR TITLE
Update StimulusPayments in CTC RRC flow #181452311

### DIFF
--- a/app/controllers/ctc/questions/stimulus_payments_controller.rb
+++ b/app/controllers/ctc/questions/stimulus_payments_controller.rb
@@ -8,8 +8,7 @@ module Ctc
       def edit
         tax_return = current_intake.default_tax_return
         benefits = Efile::BenefitsEligibility.new(tax_return: tax_return, dependents: current_intake.dependents)
-        @first_stimulus_amount = benefits.eip1_amount
-        @second_stimulus_amount = benefits.eip2_amount
+        @third_stimulus_amount = benefits.eip3_amount
         super
       end
 

--- a/app/controllers/ctc/questions/stimulus_three_controller.rb
+++ b/app/controllers/ctc/questions/stimulus_three_controller.rb
@@ -5,6 +5,10 @@ module Ctc
 
       layout "intake"
 
+      def self.show?(intake)
+        intake.eip3_amount_received.nil?
+      end
+
       private
 
       def illustration_path

--- a/app/forms/ctc/stimulus_payments_form.rb
+++ b/app/forms/ctc/stimulus_payments_form.rb
@@ -7,20 +7,22 @@ module Ctc
 
     def save
       tax_return = intake.default_tax_return
-      if eip_received_choice == 'yes_received'
+      case eip_received_choice
+      when 'this_amount'
         benefits = Efile::BenefitsEligibility.new(tax_return: tax_return, dependents: intake.dependents)
         @intake.update(
-          eip1_entry_method: 'calculated_amount',
-          eip2_entry_method: 'calculated_amount',
-          eip1_amount_received: benefits.eip1_amount,
-          eip2_amount_received: benefits.eip2_amount
+          eip3_entry_method: 'calculated_amount',
+          eip3_amount_received: benefits.eip3_amount,
         )
-      else
+      when 'different_amount'
         @intake.update(
-          eip1_entry_method: 'unfilled',
-          eip2_entry_method: 'unfilled',
-          eip1_amount_received: nil,
-          eip2_amount_received: nil
+          eip3_entry_method: 'unfilled',
+          eip3_amount_received: nil,
+        )
+      when 'no_amount'
+        @intake.update(
+          eip3_entry_method: 'did_not_receive',
+          eip3_amount_received: 0,
         )
       end
     end

--- a/app/forms/ctc/stimulus_three_form.rb
+++ b/app/forms/ctc/stimulus_three_form.rb
@@ -6,7 +6,7 @@ module Ctc
     validates :eip3_amount_received, gyr_numericality: { only_integer: true }, if: :not_blank?
 
     def save
-      @intake.update(attributes_for(:intake))
+      @intake.update(attributes_for(:intake).merge(eip3_entry_method: 'manual_entry'))
     end
 
     def not_blank?

--- a/app/lib/ctc_question_navigation.rb
+++ b/app/lib/ctc_question_navigation.rb
@@ -55,8 +55,7 @@ class CtcQuestionNavigation
     Ctc::Questions::AdvanceCtcReceivedController,
 
     # => EIP
-    # Hiding this page for now, will return to flow in later story
-    # Ctc::Questions::StimulusPaymentsController,
+    Ctc::Questions::StimulusPaymentsController,
     Ctc::Questions::StimulusThreeController,
     Ctc::Questions::StimulusReceivedController,
     Ctc::Questions::StimulusOwedController,

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -50,6 +50,7 @@
 #  eip2_amount_received                                 :integer
 #  eip2_entry_method                                    :integer          default(0), not null
 #  eip3_amount_received                                 :integer
+#  eip3_entry_method                                    :integer          default(0), not null
 #  eip_only                                             :boolean
 #  email_address                                        :citext
 #  email_address_verified_at                            :datetime

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -50,6 +50,7 @@
 #  eip2_amount_received                                 :integer
 #  eip2_entry_method                                    :integer          default("unfilled"), not null
 #  eip3_amount_received                                 :integer
+#  eip3_entry_method                                    :integer          default(0), not null
 #  eip_only                                             :boolean
 #  email_address                                        :citext
 #  email_address_verified_at                            :datetime
@@ -284,6 +285,7 @@ class Intake::CtcIntake < Intake
   enum had_dependents: { unfilled: 0, yes: 1, no: 2 }, _prefix: :had_dependents
   enum eip1_entry_method: { unfilled: 0, calculated_amount: 1, did_not_receive: 2, manual_entry: 3 }, _prefix: :eip1_entry_method
   enum eip2_entry_method: { unfilled: 0, calculated_amount: 1, did_not_receive: 2, manual_entry: 3 }, _prefix: :eip2_entry_method
+  enum eip3_entry_method: { unfilled: 0, calculated_amount: 1, did_not_receive: 2, manual_entry: 3 }, _prefix: :eip3_entry_method
   enum eip1_and_2_amount_received_confidence: { unfilled: 0, sure: 1, unsure: 2 }, _prefix: :eip1_and_2_amount_received_confidence
   enum advance_ctc_entry_method: { unfilled: 0, calculated_amount: 1, did_not_receive: 2, manual_entry: 3 }, _prefix: :advance_ctc_entry_method
   enum filed_prior_tax_year: { unfilled: 0, filed_full: 1, filed_non_filer: 2, did_not_file: 3 }, _prefix: :filed_prior_tax_year

--- a/app/models/intake/gyr_intake.rb
+++ b/app/models/intake/gyr_intake.rb
@@ -50,6 +50,7 @@
 #  eip2_amount_received                                 :integer
 #  eip2_entry_method                                    :integer          default(0), not null
 #  eip3_amount_received                                 :integer
+#  eip3_entry_method                                    :integer          default(0), not null
 #  eip_only                                             :boolean
 #  email_address                                        :citext
 #  email_address_verified_at                            :datetime

--- a/app/views/ctc/questions/stimulus_payments/edit.html.erb
+++ b/app/views/ctc/questions/stimulus_payments/edit.html.erb
@@ -1,4 +1,4 @@
-<% @main_question = t("views.ctc.questions.stimulus_payments.title") %>
+<% @main_question = t("views.ctc.questions.stimulus_payments.title", third_stimulus_amount: calculated_or_provided_dollar_amount(@third_stimulus_amount)) %>
 
 <% content_for :page_title, @main_question %>
 
@@ -6,31 +6,37 @@
   <h1 class="h2"><%= @main_question %></h1>
 
   <div class="review-box spacing-below-35">
-    <div class="review-box__title spacing-below-15">
-      <h2><%= t("views.ctc.questions.stimulus_payments.first_stimulus") %></h2>
-    </div>
-    <div class="h2 spacing-below-15 spacing-above-0 first-stimulus"><%= calculated_or_provided_dollar_amount(@first_stimulus_amount) %></div>
-    <p><%= t("views.ctc.questions.stimulus_payments.first_stimulus_details") %></p>
-
     <div class="review-box__title">
-      <h2><%= t("views.ctc.questions.stimulus_payments.second_stimulus") %></h2>
+      <h2><%= t("views.ctc.questions.stimulus_payments.third_stimulus") %></h2>
     </div>
-    <div class="h2 spacing-below-15 spacing-above-0 second-stimulus"><%= calculated_or_provided_dollar_amount(@second_stimulus_amount) %></div>
-    <p><%= t("views.ctc.questions.stimulus_payments.second_stimulus_details") %></p>
+    <div class="h2 spacing-below-15 spacing-above-0"><%= calculated_or_provided_dollar_amount(@third_stimulus_amount) %></div>
+    <% t('views.ctc.questions.stimulus_payments.third_stimulus_details').each do |body| %>
+      <p><%= body %></p>
+    <% end %>
   </div>
 
-  <p class="text--bold"><%= t("views.ctc.questions.stimulus_payments.question") %></p>
+  <%= render('components/molecules/reveal', title: t("views.ctc.questions.stimulus_payments.reveal.title")) do %>
+    <% t('views.ctc.questions.stimulus_payments.reveal.content_html',
+         link_to_get_your_refund: link_to(t("views.ctc_pages.home.service_name"), url_for(host: MultiTenantService.new(:gyr).host, controller: "/public_pages", action: 'home'))).each do |body| %>
+      <p><%= body %></p>
+    <% end %>
+  <% end %>
+
+  <p class="text--bold spacing-above-35"><%= t("views.ctc.questions.stimulus_payments.question") %></p>
   <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
-    <%= f.hidden_field :eip1_entry_method, value: :calculated_amount %>
-    <%= f.hidden_field :eip2_entry_method, value: :calculated_amount %>
+    <%= f.hidden_field :eip3_entry_method, value: :calculated_amount %>
 
     <div class="button-group button-group--center button--wide">
-      <%= f.button :submit, name: "#{f.object_name}[eip_received_choice]", value: "yes_received", class: "button button--wide text--centered" do %>
-        <%= t("views.ctc.questions.stimulus_payments.yes_received") %>
+      <%= f.button :submit, name: "#{f.object_name}[eip_received_choice]", value: "this_amount", class: "button button--wide text--centered" do %>
+        <%= t("views.ctc.questions.stimulus_payments.this_amount") %>
       <% end %>
 
-      <%= f.button :submit, name: "#{f.object_name}[eip_received_choice]", value: "no_did_not_receive", class: "button button--wide text--centered" do %>
-        <%= t("views.ctc.questions.stimulus_payments.no_did_not_receive") %>
+      <%= f.button :submit, name: "#{f.object_name}[eip_received_choice]", value: "different_amount", class: "button button--wide text--centered" do %>
+        <%= t("views.ctc.questions.stimulus_payments.different_amount") %>
+      <% end %>
+
+      <%= f.button :submit, name: "#{f.object_name}[eip_received_choice]", value: "no_amount", class: "button button--wide text--centered" do %>
+        <%= t("views.ctc.questions.stimulus_payments.no_amount") %>
       <% end %>
     </div>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2210,14 +2210,22 @@ en:
           eligible_for: 'You could be eligible for an additional:'
           title: It looks like you are still owed some stimulus payments. Would you like to claim it?
         stimulus_payments:
-          first_stimulus: First stimulus payment
-          first_stimulus_details: This payment should have arrived between April 2020 and October 2020.
-          no_did_not_receive: I received less than this amount
+          different_amount: I received a different amount
+          no_amount: I didn't received any payments
           question: Did you receive this amount?
-          second_stimulus: Second stimulus payment
-          second_stimulus_details: This payment should have arrived between December 2020 and January 2021.
-          title: We believe you are eligible for this much in the first two stimulus payments.
-          yes_received: I received this amount
+          reveal:
+            content_html:
+            - Stimulus payments were issued automatically to families who had recently filed tax returns, or who were enrolled in certain federal programs.
+            - The first stimulus payment was sent between April 2020 and October 2020. The second stimulus payment was sent in December 2020 or January 2021.
+            - To claim all or part of your first or second stimulus payments, you need to file a tax return for 2020. You can check your eligibility for filing back taxes for free using %{link_to_get_your_refund}.
+            title: How can I learn more about the first two stimulus payments?
+          third_stimulus: Estimate third stimulus payment
+          third_stimulus_details:
+          - We estimate that you should have received this amount based on your filing status and dependents.
+          - The third stimulus payment was sent in April 2021 and was $1,400 per adult tax filer plus $1,400 per dependent of any age.
+          - For example, a parent caring for two children would have received $4,200.
+          this_amount: I received this amount
+          title: Did you receive a total of %{third_stimulus_amount} for your third stimulus payment?
         stimulus_received:
           amount_received: Amount you’ve received
           eip_three: Third stimulus

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2167,14 +2167,22 @@ es:
           eligible_for: 'Podría ser elegible para un adicional:'
           title: Parece que todavía le deben algunos pagos de estímulo. ¿Te gustaría reclamarlo?
         stimulus_payments:
-          first_stimulus: Primer pago de estímulo
-          first_stimulus_details: Este pago debería haber llegado entre abril de 2020 y octubre de 2020.
-          no_did_not_receive: Recibí menos de esta cantidad
+          different_amount: Recibí una cantidad diferente
+          no_amount: No recibi ningun pago
           question: "¿Recibió esta cantidad?"
-          second_stimulus: Segundo pago de estímulo
-          second_stimulus_details: Este pago debería haber llegado entre diciembre de 2020 y enero de 2021.
-          title: Creemos que tiene derecho a esta cantidad para los dos primeros pagos del estímulo.
-          yes_received: Recibí esta cantidad
+          reveal:
+            content_html:
+            - Los pagos de estímulo se emitieron automáticamente a las familias que habían presentado declaraciones de impuestos recientemente o que estaban inscritas en ciertos programas federales.
+            - El primer pago de estímulo se envió entre abril de 2020 y octubre de 2020. El segundo pago de estímulo se envió en diciembre de 2020 o enero de 2021.
+            - Para reclamar todo o parte de su primer o segundo pago de estímulo, debe presentar una declaración de impuestos para 2020. Puede verificar su elegibilidad para presentar impuestos atrasados de forma gratuita utilizando %{link_to_get_your_refund}.
+            title: "¿Cómo puedo obtener más información sobre los dos primeros pagos de estímulo?"
+          third_stimulus: Estimar tercer pago de estímulo
+          third_stimulus_details:
+          - Estimamos que debería haber recibido esta cantidad en función de su estado civil y dependientes.
+          - El tercer pago de estímulo se envió en abril de 2021 y fue de $1,400 por contribuyente adulto más $1,400 por dependiente de cualquier edad.
+          - Por ejemplo, un padre que cuida a dos niños habría recibido $4,200.
+          this_amount: Recibí esta cantidad
+          title: "¿Recibió un total de %{third_stimulus_amount} por su tercer pago de estímulo?"
         stimulus_received:
           amount_received: Cantidad que ha recibido
           eip_three: Tercer estímulo

--- a/db/migrate/20220329172454_add_eip3_entry_method_to_intake.rb
+++ b/db/migrate/20220329172454_add_eip3_entry_method_to_intake.rb
@@ -1,0 +1,5 @@
+class AddEip3EntryMethodToIntake < ActiveRecord::Migration[6.1]
+  def change
+    add_column :intakes, :eip3_entry_method, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_24_174507) do
+ActiveRecord::Schema.define(version: 2022_03_29_172454) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -919,6 +919,7 @@ ActiveRecord::Schema.define(version: 2022_03_24_174507) do
     t.integer "eip2_amount_received"
     t.integer "eip2_entry_method", default: 0, null: false
     t.integer "eip3_amount_received"
+    t.integer "eip3_entry_method", default: 0, null: false
     t.boolean "eip_only"
     t.citext "email_address"
     t.datetime "email_address_verified_at"

--- a/spec/controllers/ctc/questions/stimulus_payments_controller_spec.rb
+++ b/spec/controllers/ctc/questions/stimulus_payments_controller_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
-# TODO: fix this when StimulusPayments is reachable again
-xdescribe Ctc::Questions::StimulusPaymentsController do
+describe Ctc::Questions::StimulusPaymentsController do
   let(:intake) { create :ctc_intake, client: client }
   let(:client) { create :client, tax_returns: [build(:tax_return, year: 2021)] }
 
@@ -10,17 +9,16 @@ xdescribe Ctc::Questions::StimulusPaymentsController do
   end
 
   describe "#update" do
-    it "persists eip1_entry_method and eip2_entry_method and redirects to the next path" do
+    it "persists eip3_entry_method and redirects to the next path" do
       post :update, params: {
         ctc_stimulus_payments_form: {
-          eip_received_choice: "yes_received",
+          eip_received_choice: "this_amount",
         }
       }
 
       intake.reload
-      expect(intake).to be_eip1_entry_method_calculated_amount
-      expect(intake).to be_eip2_entry_method_calculated_amount
-      # TODO: correct redirect to next path for new RRC flow
+      expect(intake).to be_eip3_entry_method_calculated_amount
+      expect(response).to redirect_to questions_stimulus_received_path
     end
   end
 end

--- a/spec/factories/intakes.rb
+++ b/spec/factories/intakes.rb
@@ -50,6 +50,7 @@
 #  eip2_amount_received                                 :integer
 #  eip2_entry_method                                    :integer          default(0), not null
 #  eip3_amount_received                                 :integer
+#  eip3_entry_method                                    :integer          default(0), not null
 #  eip_only                                             :boolean
 #  email_address                                        :citext
 #  email_address_verified_at                            :datetime

--- a/spec/features/ctc/complete_intake_spec.rb
+++ b/spec/features/ctc/complete_intake_spec.rb
@@ -213,6 +213,9 @@ RSpec.feature "CTC Intake", :flow_explorer_screenshot_i18n_friendly, active_job:
     click_on I18n.t('general.continue')
 
     # =========== RECOVERY REBATE CREDIT ===========
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_payments.title', third_stimulus_amount: "$4,200"))
+    click_on I18n.t('views.ctc.questions.stimulus_payments.different_amount')
+
     expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_three.title'))
     fill_in I18n.t('views.ctc.questions.stimulus_three.how_much'), with: "1800"
     click_on I18n.t('general.continue')

--- a/spec/features/ctc/rrc_intake_questions_spec.rb
+++ b/spec/features/ctc/rrc_intake_questions_spec.rb
@@ -1,66 +1,56 @@
 require "rails_helper"
 
-RSpec.xdescribe "CTC Intake", :flow_explorer_screenshot_i18n_friendly, active_job: true do
-  # TODO: after we have the RRC calculation based on dependents, set up some cases for routing to owed vs received
+RSpec.describe "CTC Intake", :flow_explorer_screenshot_i18n_friendly, active_job: true do
   let(:client) { create :client, intake: create(:ctc_intake, primary_active_armed_forces: "yes"), tax_returns: [create(:tax_return, year: 2021)] }
+  let(:calculated_third_stimulus) { 2800 }
+  let(:third_stimulus_string) { "$2,800"}
 
   before do
     login_as client, scope: :client
     allow_any_instance_of(Routes::CtcDomain).to receive(:matches?).and_return(true)
+    allow_any_instance_of(Efile::BenefitsEligibility).to receive(:eip3_amount).and_return(calculated_third_stimulus)
   end
 
   scenario "when the client says they received the amounts calculated on /stimulus-payments, we direct them to /stimulus-received and display the calculated amounts" do
     visit "/questions/stimulus-payments"
-    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_payments.title'))
-    click_on I18n.t('views.ctc.questions.stimulus_payments.yes_received')
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_payments.title', third_stimulus_amount: third_stimulus_string))
+    click_on I18n.t('views.ctc.questions.stimulus_payments.this_amount')
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_received.title'))
+    click_on I18n.t('general.continue')
   end
 
-  context "when the client says they did not receive the amounts calculated on /stimulus-payments" do
-    scenario "when the client's provided amounts (sum) are less than the calculated amounts (sum), we direct them to /stimulus-owed" do
+  context "when the client says they received a different amount than the one shown on on /stimulus-payments" do
+    scenario "when the client's provided amounts are less than the calculated amount, we direct them to /stimulus-owed" do
       visit "/questions/stimulus-payments"
-      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_payments.title'))
-      click_on I18n.t('views.ctc.questions.stimulus_payments.no_did_not_receive')
+      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_payments.title', third_stimulus_amount: third_stimulus_string))
+      click_on I18n.t('views.ctc.questions.stimulus_payments.different_amount')
       expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_three.title'))
+      fill_in I18n.t('views.ctc.questions.stimulus_three.how_much'), with: "1800"
       click_on I18n.t('general.continue')
-    end
-
-    xscenario "when the client's provided amounts (sum) is greater than the calculated amounts (sum), we will do something as yet unknown" do; end
-
-    scenario "when the client says they did not receive stimulus 1 or 2, it saves zero as that amount" do
-      visit "en/questions/stimulus-payments"
-      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_payments.title'))
-      click_on I18n.t('views.ctc.questions.stimulus_payments.no_did_not_receive')
-      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_three.title'))
+      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_owed.title'))
       click_on I18n.t('general.continue')
-    end
-  end
-
-  context "when a client clicks that they received less than the stimulus amount after previously saying that was the amount they received, it should reset the amounts" do
-    scenario do
-      visit "en/questions/stimulus-payments"
-      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_payments.title'))
-      click_on I18n.t('views.ctc.questions.stimulus_payments.yes_received')
-      # TODO: update this test for the new RRC flow
-    end
-  end
-
-  context "client ends up on /stimulus-owed" do
-    before do
-      client.intake.update(eip1_amount_received: 0, eip2_amount_received: 0)
-    end
-
-    scenario "when the client says they do want to claim the remaining stimulus money" do
-      visit "/questions/stimulus-owed"
-      click_on I18n.t("views.ctc.questions.stimulus_owed.claim")
-      expect(client.intake.reload.claim_owed_stimulus_money).to eq "yes"
       expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.refund_payment.title'))
     end
 
-    scenario "when the client says they don't want to claim the remaining stimulus money" do
-      visit "/questions/stimulus-owed"
-      click_on I18n.t("views.ctc.questions.stimulus_owed.dont_claim")
-      expect(client.intake.reload.claim_owed_stimulus_money).to eq "no"
+    scenario "when the client's provided amount is greater than the calculated amount, we direct them to /stimulus-received" do
+      visit "/questions/stimulus-payments"
+      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_payments.title', third_stimulus_amount: third_stimulus_string))
+      click_on I18n.t('views.ctc.questions.stimulus_payments.different_amount')
+      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_three.title'))
+      fill_in I18n.t('views.ctc.questions.stimulus_three.how_much'), with: "3800"
+      click_on I18n.t('general.continue')
+      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_received.title'))
+      click_on I18n.t('general.continue')
       expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.refund_payment.title'))
     end
+  end
+
+  scenario "when the client says they did not receive any amount, we direct them to /stimulus-owed" do
+    visit "en/questions/stimulus-payments"
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_payments.title', third_stimulus_amount: third_stimulus_string))
+    click_on I18n.t('views.ctc.questions.stimulus_payments.no_amount')
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.stimulus_owed.title'))
+    click_on I18n.t('general.continue')
+    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.refund_payment.title'))
   end
 end

--- a/spec/forms/ctc/stimulus_payments_form_spec.rb
+++ b/spec/forms/ctc/stimulus_payments_form_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe Ctc::StimulusPaymentsForm do
-  let(:intake) { create :ctc_intake, client: client, eip1_amount_received: 0 }
+  let(:intake) { create :ctc_intake, client: client, eip3_amount_received: 123 }
   let(:client) { create :client, tax_returns: [build(:tax_return, year: 2021)] }
 
   let(:params) {
@@ -12,36 +12,39 @@ describe Ctc::StimulusPaymentsForm do
 
   describe '#save' do
     before do
-      allow_any_instance_of(Efile::BenefitsEligibility).to receive(:eip1_amount).and_return(2400)
-      allow_any_instance_of(Efile::BenefitsEligibility).to receive(:eip2_amount).and_return(1200)
+      allow_any_instance_of(Efile::BenefitsEligibility).to receive(:eip3_amount).and_return(2400)
     end
 
     context "when the client received the full amount" do
-      let(:eip_received_choice) { 'yes_received' }
+      let(:eip_received_choice) { 'this_amount' }
 
       it "persists the calculated eip values to the DB" do
         described_class.new(intake, params).save
 
         intake.reload
-        expect(intake.eip1_amount_received).to eq(2400)
-        expect(intake.eip2_amount_received).to eq(1200)
+        expect(intake.eip3_amount_received).to eq(2400)
       end
     end
 
     context "when the client received no amount" do
-      let(:eip_received_choice) { 'no_did_not_receive' }
-
-      before do
-        intake.update(eip1_amount_received: 123)
-        intake.update(eip1_amount_received: 456)
-      end
+      let(:eip_received_choice) { 'no_amount' }
 
       it "persists the calculated eip values to the DB" do
         described_class.new(intake, params).save
 
         intake.reload
-        expect(intake.eip1_amount_received).to be_nil
-        expect(intake.eip2_amount_received).to be_nil
+        expect(intake.eip3_amount_received).to eq(0)
+      end
+    end
+
+    context "when the client received a different amount" do
+      let(:eip_received_choice) { 'different_amount' }
+
+      it "persists the calculated eip values to the DB" do
+        described_class.new(intake, params).save
+
+        intake.reload
+        expect(intake.eip3_amount_received).to be_nil
       end
     end
   end

--- a/spec/models/intake/gyr_intake_spec.rb
+++ b/spec/models/intake/gyr_intake_spec.rb
@@ -50,6 +50,7 @@
 #  eip2_amount_received                                 :integer
 #  eip2_entry_method                                    :integer          default(0), not null
 #  eip3_amount_received                                 :integer
+#  eip3_entry_method                                    :integer          default(0), not null
 #  eip_only                                             :boolean
 #  email_address                                        :citext
 #  email_address_verified_at                            :datetime

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -50,6 +50,7 @@
 #  eip2_amount_received                                 :integer
 #  eip2_entry_method                                    :integer          default(0), not null
 #  eip3_amount_received                                 :integer
+#  eip3_entry_method                                    :integer          default(0), not null
 #  eip_only                                             :boolean
 #  email_address                                        :citext
 #  email_address_verified_at                            :datetime


### PR DESCRIPTION
This PR:
- Updates `StimulusPayments` copy to match the design mocks, removing references to EIP1 and EIP2, adding EIP3
- Adds a third option to `StimulusPayments` and updates the form to save the correct data based on the option selected
- Adds `eip3_entry_method` to intake, this is updated based on the clients answer on `StimulusPayments`
- Adds feature specs for the complete flow

<img width="686" alt="image" src="https://user-images.githubusercontent.com/6520735/160688219-e921cab3-7fb4-4e55-a9a7-0b2ab54bfa25.png">
