### PR TITLE
Add shadow ban capability, create new submissions on every resubmission, and break preparing and bundling into two states

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -91,7 +91,7 @@ module ApplicationHelper
       "icons/accepted.svg"
     when "cancelled"
       "icons/cancelled.svg"
-    when "new", "preparing", "transmitted"
+    when "new", "preparing", "transmitted", "bundling"
       "icons/sending.svg"
     end
   end

--- a/app/jobs/build_submission_bundle_job.rb
+++ b/app/jobs/build_submission_bundle_job.rb
@@ -1,7 +1,6 @@
 class BuildSubmissionBundleJob < ApplicationJob
   def perform(submission_id)
     submission = EfileSubmission.includes(:intake, :qualifying_dependents, :address, :tax_return, client: :efile_security_informations).find(submission_id)
-    persist_dependent_records(submission)
 
     address_creation = submission.generate_irs_address
     unless address_creation.valid?
@@ -9,6 +8,7 @@ class BuildSubmissionBundleJob < ApplicationJob
       return
     end
 
+    # TODO: Add IRS submission id generation here.
     begin
       submission.generate_form_1040_pdf
     rescue StandardError => e
@@ -17,7 +17,7 @@ class BuildSubmissionBundleJob < ApplicationJob
     end
 
     begin
-      # TODO: This needs to be updated for the 2021 tax season
+      # TODO: This needs to be updated for the 2021 tax season to include the 8812.
       response = SubmissionBundle.build(submission, documents: ["adv_ctc_irs1040"])
     rescue StandardError => e
       submission.transition_to!(:failed, error_code: 'BUNDLE-FAIL', raw_response: e.inspect)
@@ -28,16 +28,6 @@ class BuildSubmissionBundleJob < ApplicationJob
       submission.transition_to!(:queued)
     else
       submission.transition_to!(:failed, error_code: 'BUNDLE-FAIL', raw_response: response.errors)
-    end
-  end
-
-  def persist_dependent_records(submission)
-    # If any associated EfileSubmissionDependents existed from a previous run of the same submission (never made it to IRS),
-    # destroy them and recreate them so we're using the most recent dependent data to calculate eligibility
-    EfileSubmissionDependent.where(efile_submission: submission).delete_all
-
-    submission.intake.dependents.each do |dependent|
-      EfileSubmissionDependent.create_from_eligibility(submission, dependent)
     end
   end
 end

--- a/app/jobs/deny_restricted_verification_attempt_job.rb
+++ b/app/jobs/deny_restricted_verification_attempt_job.rb
@@ -1,0 +1,7 @@
+class DenyRestrictedVerificationAttemptJob < ApplicationJob
+  def perform(verification_attempt)
+    return unless verification_attempt.current_state == "restricted"
+
+    verification_attempt.transition_to(:denied)
+  end
+end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -27,6 +27,7 @@
 #  login_token                              :string
 #  message_tracker                          :jsonb
 #  previous_sessions_active_seconds         :integer
+#  restricted_at                            :datetime
 #  routing_method                           :integer
 #  sign_in_count                            :integer          default(0), not null
 #  still_needs_help                         :integer          default("unfilled"), not null

--- a/app/models/efile_submission_dependent.rb
+++ b/app/models/efile_submission_dependent.rb
@@ -23,7 +23,7 @@ class EfileSubmissionDependent < ApplicationRecord
 
   delegate :age, :first_name, :last_name, :ssn, :irs_relationship_enum, :birth_date, :tin_type_ssn?, :tin_type_atin?, to: :dependent
 
-  def self.create_from_eligibility(submission, dependent)
+  def self.create_qualifying_dependent(submission, dependent)
     raise "Cannot create EfileSubmissionDependent for dependent not associated with submission's intake" unless submission.intake.dependents.where(id: dependent.id).exists?
 
     eligibility = Efile::DependentEligibility::Eligibility.new(dependent, submission.tax_year)

--- a/app/models/fraud/indicator.rb
+++ b/app/models/fraud/indicator.rb
@@ -18,6 +18,7 @@
 #  updated_at           :datetime         not null
 #
 module Fraud
+  # See Notion for rule descriptions: https://www.notion.so/cfa/Fraud-Rules-2022-b89c29aa9776457aa70f51bc796a58ea
   class Indicator < ApplicationRecord
     self.table_name = "fraud_indicators"
 

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -6,7 +6,7 @@
 #  additional_info                                      :string
 #  adopted_child                                        :integer          default(0), not null
 #  advance_ctc_amount_received                          :integer
-#  advance_ctc_entry_method                             :integer          default(0), not null
+#  advance_ctc_entry_method                             :integer          default("unfilled"), not null
 #  already_applied_for_stimulus                         :integer          default(0), not null
 #  already_filed                                        :integer          default("unfilled"), not null
 #  balance_pay_from_bank                                :integer          default(0), not null
@@ -50,7 +50,7 @@
 #  eip2_amount_received                                 :integer
 #  eip2_entry_method                                    :integer          default("unfilled"), not null
 #  eip3_amount_received                                 :integer
-#  eip3_entry_method                                    :integer          default(0), not null
+#  eip3_entry_method                                    :integer          default("unfilled"), not null
 #  eip_only                                             :boolean
 #  email_address                                        :citext
 #  email_address_verified_at                            :datetime

--- a/app/views/hub/notes/_system_note_verification_attempt_transition.erb
+++ b/app/views/hub/notes/_system_note_verification_attempt_transition.erb
@@ -1,8 +1,13 @@
 <p>
+
   <% if transition.to_state == "escalated" %>
     <%= transition.initiated_by.name_with_role %> <%= transition.to_state %> <%= link_to "verification attempt", hub_verification_attempt_path(id: transition.verification_attempt.id) %> for additional review.
   <% elsif transition.to_state == "requested_replacements" %>
     <%= transition.initiated_by.name_with_role %> <%= I18n.t("messages.new_photos_requested.admin_note") %> for <%= link_to "verification attempt", hub_verification_attempt_path(id: transition.verification_attempt.id) %>
+  <% elsif transition.to_state == "restricted" %>
+    Client <%= link_to "verification attempt", hub_verification_attempt_path(id: transition.verification_attempt.id) %> transitioned to restricted state due to fraud score.
+  <% elsif transition.to_state == "pending" %>
+    Client submitted <%= link_to "verification attempt", hub_verification_attempt_path(id: transition.verification_attempt.id) %>
   <% else %>
     <%= transition.initiated_by.name_with_role %> <%= transition.to_state %> <%= link_to "verification attempt", hub_verification_attempt_path(id: transition.verification_attempt.id) %>.
   <% end %>

--- a/app/views/hub/verification_attempts/show.html.erb
+++ b/app/views/hub/verification_attempts/show.html.erb
@@ -96,7 +96,11 @@
         <% end %>
       </ul>
       <% content_for :sticky_action_footer do %>
-        <% if @verification_attempt.current_state == "escalated" && !@form.can_handle_escalations? %>
+        <% if @verification_attempt.current_state == "restricted" %>
+          <div class="flash--notice slab slab--half-padded verification-attempts-show__actions">
+            No action can be taken on this verification attempt because of its high fraud score.
+          </div>
+        <% elsif @verification_attempt.current_state == "escalated" && !@form.can_handle_escalations? %>
           <div class="flash--warning slab slab--half-padded verification-attempts-show__actions">
             Your role does not have permissions to take action on this escalated verification attempt.
           </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1814,6 +1814,9 @@ en:
             accepted:
               label: Accepted
               message: Your return has been accepted by the IRS. You should receive a payment in 4 or more weeks.
+            bundling:
+              label: Electronically filing
+              message: We are preparing your return. We'll continue to update you on the status of your submission.
             cancelled:
               message: We will no longer attempt to submit this return to the IRS. This may be because you requested that we do not submit the return, or because a rejection from the IRS indicated that we can not resubmit on your behalf.
             failed:
@@ -1826,10 +1829,10 @@ en:
               label: More information needed
               message: We need more information from you before we can file your return.
             new:
-              label: Electronically filed
+              label: Electronically filing
               message: We are preparing your return. We'll continue to update you on the status of your submission.
             preparing:
-              label: Electronically filed
+              label: Electronically filing
               message: We are preparing your return. We'll continue to update you on the status of your submission.
             rejected:
               label: Rejected

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1771,6 +1771,9 @@ es:
             accepted:
               label: Aceptada
               message: El IRS aceptó su declaración de impuestos. Recibirá un pago en 4 o más semanas.
+            bundling:
+              label: Tramitados electrónicamente
+              message: Estamos preparando su declaración. Seguiremos informándole sobre el estado de su presentación.
             cancelled:
               message: Ya no intentaremos enviar esta declaración al IRS. Esto puede deberse a que solicitó que no enviemos la declaración o porque un rechazo del IRS indicó que no podemos volver a enviarla en su nombre.
             failed:

--- a/db/migrate/20220401145344_change_indicators_to_snapshot_on_fraud_score.rb
+++ b/db/migrate/20220401145344_change_indicators_to_snapshot_on_fraud_score.rb
@@ -1,0 +1,5 @@
+class ChangeIndicatorsToSnapshotOnFraudScore < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :fraud_scores, :indicators, :snapshot
+  end
+end

--- a/db/migrate/20220401183023_add_restricted_at_to_client.rb
+++ b/db/migrate/20220401183023_add_restricted_at_to_client.rb
@@ -1,0 +1,5 @@
+class AddRestrictedAtToClient < ActiveRecord::Migration[6.1]
+  def change
+    add_column :clients, :restricted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_29_172454) do
+ActiveRecord::Schema.define(version: 2022_04_01_183023) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -527,6 +527,7 @@ ActiveRecord::Schema.define(version: 2022_03_29_172454) do
     t.string "login_token"
     t.jsonb "message_tracker", default: {}
     t.integer "previous_sessions_active_seconds"
+    t.datetime "restricted_at"
     t.integer "routing_method"
     t.integer "sign_in_count", default: 0, null: false
     t.integer "still_needs_help", default: 0, null: false
@@ -829,8 +830,8 @@ ActiveRecord::Schema.define(version: 2022_03_29_172454) do
   create_table "fraud_scores", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.bigint "efile_submission_id"
-    t.jsonb "indicators"
     t.integer "score"
+    t.jsonb "snapshot"
     t.datetime "updated_at", precision: 6, null: false
     t.index ["efile_submission_id"], name: "index_fraud_scores_on_efile_submission_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,10 +2,3 @@ unless Rails.env.production?
   Seeder.new.run
 end
 
-Fraud::Indicators::Timezone.create(name: "America/Chicago", activated_at: DateTime.now)
-Fraud::Indicators::Timezone.create(name: "America/Indiana/Indianapolis", activated_at: DateTime.now)
-Fraud::Indicators::Timezone.create(name: "America/Indianapolis", activated_at: DateTime.now)
-Fraud::Indicators::Timezone.create(name: "Mexico/Tijuana", activated_at: nil)
-Fraud::Indicators::Timezone.create(name: "America/New_York", activated_at: DateTime.now)
-Fraud::Indicators::Timezone.create(name: "America/Los_Angeles", activated_at: DateTime.now)
-

--- a/spec/controllers/ctc/portal/portal_controller_spec.rb
+++ b/spec/controllers/ctc/portal/portal_controller_spec.rb
@@ -67,7 +67,8 @@ describe Ctc::Portal::PortalController do
       it "updates status, makes a note, and redirects to the portal home" do
         expect {
           put :resubmit, params: params
-        }.to change(client.efile_security_informations, :count).by 1
+        }.to change(client.efile_security_informations, :count).by(1)
+         .and change(client.efile_submissions, :count).by(1)
 
         client.reload
         expect(client.efile_security_informations.last.ip_address).to be_present
@@ -84,7 +85,7 @@ describe Ctc::Portal::PortalController do
           'action' => 'resubmitted'
         })
         expect(submission.last_transition_to(:resubmitted)).to be_present
-        expect(submission.current_state).to eq("preparing") # transitions to resubmitted and then to preparing
+        expect(submission.current_state).to eq("resubmitted") # transitions to resubmitted and then to bundling
         expect(response).to redirect_to Ctc::Portal::PortalController.to_path_helper(action: :home)
       end
 

--- a/spec/controllers/ctc/questions/confirm_legal_controller_spec.rb
+++ b/spec/controllers/ctc/questions/confirm_legal_controller_spec.rb
@@ -43,7 +43,7 @@ describe Ctc::Questions::ConfirmLegalController do
 
     context "when submitting the form" do
       context "when checking 'I agree'" do
-        it "create a submission with the status of 'preparing' and send client a message and redirect to portal home" do
+        it "create a submission with the status of 'bundling' and send client a message and redirect to portal home" do
           expect {
             post :update, params: params
           }.to change(client.efile_security_informations, :count).by 1
@@ -51,7 +51,7 @@ describe Ctc::Questions::ConfirmLegalController do
 
           expect(response).to redirect_to ctc_portal_root_path
           efile_submission = client.reload.tax_returns.last.efile_submissions.last
-          expect(efile_submission.current_state).to eq "preparing"
+          expect(efile_submission.current_state).to eq "bundling"
           expect(client.efile_security_informations.last.ip_address).to eq ip_address
           expect(client.efile_security_informations.last.recaptcha_score).to eq 0.9
           recaptcha_score = client.recaptcha_scores.last
@@ -72,32 +72,16 @@ describe Ctc::Questions::ConfirmLegalController do
           before do
             allow_any_instance_of(RecaptchaScoreConcern).to receive(:recaptcha_score_param).and_return({})
           end
-          it "create a submission with the status of 'preparing' and send client a message and redirect to portal home" do
+          it "create a submission with the status of 'bundling' and send client a message and redirect to portal home" do
             expect {
               post :update, params: params
             }.to change(client.efile_security_informations, :count).by 1
 
             expect(response).to redirect_to ctc_portal_root_path
             efile_submission = client.reload.tax_returns.last.efile_submissions.last
-            expect(efile_submission.current_state).to eq "preparing"
+            expect(efile_submission.current_state).to eq "bundling"
             expect(client.efile_security_informations.last.ip_address).to eq ip_address
             expect(client.efile_security_informations.last.recaptcha_score).to eq nil
-          end
-        end
-
-        context "when HOLD_OFF_NEW_EFILE_SUBMISSIONS is set" do
-          around do |example|
-            ENV['HOLD_OFF_NEW_EFILE_SUBMISSIONS'] = '1'
-            example.run
-            ENV.delete('HOLD_OFF_NEW_EFILE_SUBMISSIONS')
-          end
-
-          it "create a submission that is still in status 'new'" do
-            post :update, params: params
-
-            expect(response).to redirect_to ctc_portal_root_path
-            efile_submission = client.reload.tax_returns.last.efile_submissions.last
-            expect(efile_submission.current_state).to eq "new"
           end
         end
       end

--- a/spec/controllers/hub/verification_attempts_controller_spec.rb
+++ b/spec/controllers/hub/verification_attempts_controller_spec.rb
@@ -10,7 +10,7 @@ describe Hub::VerificationAttemptsController, type: :controller do
       before do
         sign_in user
         3.times do
-          create :verification_attempt
+          create :verification_attempt, :pending
         end
         2.times do
           create :verification_attempt, :escalated
@@ -87,7 +87,7 @@ describe Hub::VerificationAttemptsController, type: :controller do
   end
 
   describe "#update" do
-    let!(:verification_attempt) { create :verification_attempt }
+    let!(:verification_attempt) { create :verification_attempt, :pending }
 
     context "when a user is logged in" do
       before do

--- a/spec/factories/clients.rb
+++ b/spec/factories/clients.rb
@@ -27,6 +27,7 @@
 #  login_token                              :string
 #  message_tracker                          :jsonb
 #  previous_sessions_active_seconds         :integer
+#  restricted_at                            :datetime
 #  routing_method                           :integer
 #  sign_in_count                            :integer          default(0), not null
 #  still_needs_help                         :integer          default("unfilled"), not null

--- a/spec/factories/efile_submissions.rb
+++ b/spec/factories/efile_submissions.rb
@@ -31,6 +31,11 @@ FactoryBot.define do
       end
     end
 
+    trait :with_fraud_score do
+      after :create do |submission|
+        create :fraud_score, efile_submission: submission
+      end
+    end
 
     EfileSubmissionStateMachine.states.each do |state|
       trait state.to_sym do

--- a/spec/factories/fraud/indicators.rb
+++ b/spec/factories/fraud/indicators.rb
@@ -26,6 +26,7 @@ FactoryBot.define do
     points { 60 }
     query_model_name { Intake }
     reference { "intake" }
+    activated_at { DateTime.current }
     indicator_attributes { ["primary_first_name"] }
   end
 end

--- a/spec/factories/fraud/scores.rb
+++ b/spec/factories/fraud/scores.rb
@@ -1,0 +1,21 @@
+# == Schema Information
+#
+# Table name: fraud_scores
+#
+#  id                  :bigint           not null, primary key
+#  score               :integer
+#  snapshot            :jsonb
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  efile_submission_id :bigint
+#
+# Indexes
+#
+#  index_fraud_scores_on_efile_submission_id  (efile_submission_id)
+#
+FactoryBot.define do
+  factory :fraud_score, class: Fraud::Score do
+    score { 60 }
+    snapshot { { "timezone": { points: 60, data: ["Mexico/Tijuana"] } } }
+  end
+end

--- a/spec/features/hub/review_verification_attempts_spec.rb
+++ b/spec/features/hub/review_verification_attempts_spec.rb
@@ -2,10 +2,11 @@ require "rails_helper"
 
 RSpec.feature "Clients who have been flagged for fraud" do
   let(:user) { create :admin_user, name: "Judith Juice" }
-  let(:verification_attempt_1) { create :verification_attempt }
-  let(:verification_attempt_2) { create :verification_attempt }
-  let(:verification_attempt_3) { create :verification_attempt }
-  let(:verification_attempt_4) { create :verification_attempt, client_id: verification_attempt_2.client_id }
+  let(:verification_attempt_1) { create :verification_attempt, :pending }
+  let(:verification_attempt_2) { create :verification_attempt, :pending }
+  let(:verification_attempt_3) { create :verification_attempt, :pending }
+  let(:verification_attempt_4) { create :verification_attempt, :pending, client_id: verification_attempt_2.client_id }
+  let(:restricted_verification_attempt) { create :verification_attempt, :restricted }
 
   before do
     login_as user
@@ -73,6 +74,11 @@ RSpec.feature "Clients who have been flagged for fraud" do
     visit hub_client_notes_path(client_id: verification_attempt_1.client_id)
 
     expect(page).to have_content "#{user.name_with_role} approved verification attempt."
+  end
+
+  scenario "I can view, but not change status, on a restricted verification attempt" do
+    visit hub_verification_attempt_path(id: restricted_verification_attempt.id)
+    expect(page).to have_text "No action can be taken on this verification attempt because of its high fraud score."
   end
 
   scenario "I can escalate a verification attempt" do

--- a/spec/forms/hub/update_verification_attempt_form_spec.rb
+++ b/spec/forms/hub/update_verification_attempt_form_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Hub::UpdateVerificationAttemptForm do
   subject { described_class.new(verification_attempt, user, { note: "this is a note body.", state: "approved" })}
 
-  let!(:verification_attempt) { create :verification_attempt }
+  let!(:verification_attempt) { create :verification_attempt, :pending }
 
   describe "#initialize" do
 
@@ -18,7 +18,7 @@ describe Hub::UpdateVerificationAttemptForm do
   describe "validations" do
     subject { described_class.new(verification_attempt, user, params) }
 
-    let!(:verification_attempt) { create :verification_attempt }
+    let!(:verification_attempt) { create :verification_attempt, :pending }
     let!(:user) { create :admin_user }
     let(:params) do
       {
@@ -119,7 +119,7 @@ describe Hub::UpdateVerificationAttemptForm do
 
   describe "#save" do
     context "when required params are provided" do
-      let!(:verification_attempt) { create :verification_attempt }
+      let!(:verification_attempt) { create :verification_attempt, :pending }
       let!(:user) { create :admin_user }
 
       it "increases the verification transitions count by 1" do

--- a/spec/jobs/build_submission_bundle_job_spec.rb
+++ b/spec/jobs/build_submission_bundle_job_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe BuildSubmissionBundleJob do
   describe '.perform' do
-    let(:submission) { create :efile_submission, :preparing, :ctc }
+    let(:submission) { create :efile_submission, :bundling, :ctc }
     let(:address_valid?) { true }
     let(:address_errors) { "" }
 
@@ -38,37 +38,6 @@ describe BuildSubmissionBundleJob do
         expect(submission.efile_submission_transitions.last.efile_errors.first.code).to eq "PDF-1040-FAIL"
 
         expect(submission.efile_submission_transitions.last.metadata['error_code']).to eq "PDF-1040-FAIL"
-      end
-    end
-
-    context "EfileSubmissionDependent creation" do
-      before do
-        allow(SubmissionBundle).to receive(:build).and_return SubmissionBundleResponse.new
-        allow_any_instance_of(EfileSubmission).to receive(:submission_bundle).and_return "yes"
-        submission.intake.dependents.delete_all
-        create :qualifying_child, intake: submission.intake # creates object
-        create :qualifying_relative, intake: submission.intake # creates object
-        create :dependent, intake: submission.intake # does not qualify, does not create object
-      end
-
-      it "creates EfileSubmissionDependent objects for each qualifying dependent" do
-        expect(submission.intake.dependents.length).to eq 3
-        expect {
-          described_class.perform_now(submission.id)
-        }.to change(EfileSubmissionDependent, :count).by 2
-      end
-
-      context "when objects already exist for some dependents" do
-        before do
-          EfileSubmissionDependent.create(dependent: submission.intake.dependents.first, efile_submission: submission)
-        end
-
-        it "does not create duplicated objects" do
-          expect(submission.intake.dependents.length).to eq 3
-          expect(EfileSubmissionDependent.where(efile_submission: submission).count).to eq 1
-          described_class.perform_now(submission.id)
-          expect(EfileSubmissionDependent.count).to eq 2 # there is still only one entry for each qualifying dependent
-        end
       end
     end
 

--- a/spec/lib/submission_builder/ty2020/adv_ctc_irs1040_spec.rb
+++ b/spec/lib/submission_builder/ty2020/adv_ctc_irs1040_spec.rb
@@ -13,9 +13,9 @@ describe SubmissionBuilder::TY2020::AdvCtcIrs1040 do
       dependent3 = submission.intake.dependents.third
       dependent3_attrs = attributes_for(:qualifying_relative, first_name: "Kelly", birth_date: Date.new(1960, 1, 1), relationship: "parent", ssn: "123001236")
       dependent3.update(dependent3_attrs)
-      EfileSubmissionDependent.create_from_eligibility(submission, dependent)
-      EfileSubmissionDependent.create_from_eligibility(submission, dependent2)
-      EfileSubmissionDependent.create_from_eligibility(submission, dependent3)
+      EfileSubmissionDependent.create_qualifying_dependent(submission, dependent)
+      EfileSubmissionDependent.create_qualifying_dependent(submission, dependent2)
+      EfileSubmissionDependent.create_qualifying_dependent(submission, dependent3)
       submission.reload
     end
 

--- a/spec/lib/submission_builder/ty2021/lapsed_filer_irs_1040_spec.rb
+++ b/spec/lib/submission_builder/ty2021/lapsed_filer_irs_1040_spec.rb
@@ -20,9 +20,9 @@ describe SubmissionBuilder::TY2021::LapsedFilerIrs1040 do
       dependent3 = submission.intake.dependents.third
       dependent3_attrs = attributes_for(:qualifying_relative, first_name: "Kelly", birth_date: Date.new(1960, 1, 1), relationship: "parent", ssn: "123001236")
       dependent3.update(dependent3_attrs)
-      EfileSubmissionDependent.create_from_eligibility(submission, dependent)
-      EfileSubmissionDependent.create_from_eligibility(submission, dependent2)
-      EfileSubmissionDependent.create_from_eligibility(submission, dependent3)
+      EfileSubmissionDependent.create_qualifying_dependent(submission, dependent)
+      EfileSubmissionDependent.create_qualifying_dependent(submission, dependent2)
+      EfileSubmissionDependent.create_qualifying_dependent(submission, dependent3)
       submission.reload
     end
 

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -27,6 +27,7 @@
 #  login_token                              :string
 #  message_tracker                          :jsonb
 #  previous_sessions_active_seconds         :integer
+#  restricted_at                            :datetime
 #  routing_method                           :integer
 #  sign_in_count                            :integer          default(0), not null
 #  still_needs_help                         :integer          default("unfilled"), not null

--- a/spec/models/efile_submission_dependent_spec.rb
+++ b/spec/models/efile_submission_dependent_spec.rb
@@ -23,7 +23,7 @@ describe EfileSubmissionDependent do
   let(:submission) { create :efile_submission }
   let(:dependent) { create :dependent }
 
-  describe '.create_from_eligibility' do
+  describe '.create_qualifying_dependent' do
     let(:results) do
       {
           qualifying_child: true,
@@ -39,7 +39,7 @@ describe EfileSubmissionDependent do
     context "when the submission and dependent are not already associated through the intake" do
       it "raises an error" do
         expect {
-          EfileSubmissionDependent.create_from_eligibility(submission, dependent)
+          EfileSubmissionDependent.create_qualifying_dependent(submission, dependent)
         }.to raise_error RuntimeError
       end
     end
@@ -59,7 +59,7 @@ describe EfileSubmissionDependent do
       end
 
       it "calculates eligibility" do
-        EfileSubmissionDependent.create_from_eligibility(submission, dependent)
+        EfileSubmissionDependent.create_qualifying_dependent(submission, dependent)
         expect(eligibility_double).to have_received(:qualifying_ctc?).exactly(2).times
         expect(eligibility_double).to have_received(:qualifying_child?).exactly(2).times
         expect(eligibility_double).to have_received(:qualifying_relative?).exactly(2).times
@@ -68,7 +68,7 @@ describe EfileSubmissionDependent do
       context "when the tested dependent is eligible for something" do
         it "creates an EfileSubmissionDependent object" do
           expect {
-            EfileSubmissionDependent.create_from_eligibility(submission, dependent)
+            EfileSubmissionDependent.create_qualifying_dependent(submission, dependent)
           }.to change(EfileSubmissionDependent, :count).by(1)
           object = EfileSubmissionDependent.last
 
@@ -88,7 +88,7 @@ describe EfileSubmissionDependent do
         end
         it "does not create an EfileSubmissionDependent object" do
           expect {
-            EfileSubmissionDependent.create_from_eligibility(submission, dependent)
+            EfileSubmissionDependent.create_qualifying_dependent(submission, dependent)
           }.not_to change(EfileSubmissionDependent, :count)
         end
       end

--- a/spec/models/fraud/score_spec.rb
+++ b/spec/models/fraud/score_spec.rb
@@ -3,8 +3,8 @@
 # Table name: fraud_scores
 #
 #  id                  :bigint           not null, primary key
-#  indicators          :jsonb
 #  score               :integer
+#  snapshot            :jsonb
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  efile_submission_id :bigint
@@ -45,7 +45,7 @@ describe Fraud::Score do
                                                                   })
           object = Fraud::Score.last
           expect(object.score).to eq 120
-          expect(object.indicators).to eq ({ "first_indicator" => { "points" => 60, "data" => [1,2,3] }, "second_indicator" => { "points" => 60, "data" => [1,2,3] } })
+          expect(object.snapshot).to eq ({ "first_indicator" => { "points" => 60, "data" => [1,2,3] }, "second_indicator" => { "points" => 60, "data" => [1,2,3] } })
         end
       end
     end


### PR DESCRIPTION
This replaces the new fraud scoring and no longer leverages the fraud service in EfileSubmissionStateMachine

However, the verification attempts still show the list of broken rules based on the old fraud service AND the fraud_hold status on the client's efile submission list is not yet hooked up to show the fraud indicators based on the fraud score object, so nothing will show there. I still need to rip out the Fraud Indicator Service and swap implementations over to using Fraud::Score.

I wish that I had pulled the verification attempt changes into a separate PR so that this one wasn't so large, but it is currently included as part of this PR.