### PR TITLE
Write backfill for copying triage answers to intake

### DIFF
--- a/lib/tasks/backfill_triage_data.rake
+++ b/lib/tasks/backfill_triage_data.rake
@@ -1,0 +1,39 @@
+namespace :backfill_triage_data do
+  desc "Backfill data onto Triage that lived on Intake"
+  task intake_triage_fields: :environment do
+    Triage.includes(:intake).where('intake_id IS NOT NULL').find_each(batch_size: 100) do |triage|
+      filing_frequency = [
+        triage.filed_2018,
+        triage.filed_2019,
+        triage.filed_2020,
+        triage.filed_2021,
+      ]
+      if filing_frequency.all?("yes")
+        triage_filing_frequency = "every_year"
+      elsif filing_frequency.any?("yes")
+        triage_filing_frequency = "some_years"
+      elsif filing_frequency.all?("no")
+        triage_filing_frequency = "not_filed"
+      else
+        triage_filing_frequency = "unfilled"
+      end
+
+      if triage.income_type_rent_yes? || triage.income_type_farm_yes?
+        triage_vita_income_ineligible = "yes"
+      elsif triage.income_type_rent_no? && triage.income_type_farm_no?
+        triage_vita_income_ineligible = "no"
+      else
+        triage_vita_income_ineligible = "unfilled"
+      end
+
+      attributes = {
+        need_itin_help: triage.id_type_need_itin_help? ? "yes" : "no",
+        triage_filing_status: triage.filing_status,
+        triage_income_level: triage.income_level,
+        triage_filing_frequency: triage_filing_frequency,
+        triage_vita_income_ineligible: triage_vita_income_ineligible,
+      }
+      triage.intake.update(attributes)
+    end
+  end
+end

--- a/spec/tasks/backfill_triage_data_spec.rb
+++ b/spec/tasks/backfill_triage_data_spec.rb
@@ -1,0 +1,161 @@
+require 'rails_helper'
+
+describe "backfill_triage_data:intake_triage_fields" do
+  include_context "rake"
+
+  context "triage with no intake" do
+    let!(:triage_without_intake) { create :triage }
+
+    it "does not modify it" do
+      expect {
+        task.invoke
+      }.not_to change { triage_without_intake }
+    end
+  end
+
+  context "triage needs itin help" do
+    let!(:triage) { create :triage, intake: create(:intake), id_type: "need_itin_help" }
+
+    it "copies answer to Intake#need_itin_help" do
+      task.invoke
+
+      triage.reload
+      expect(triage.intake.need_itin_help).to eq "yes"
+    end
+  end
+
+  context "income level" do
+    let!(:triage) { create :triage, intake: create(:intake), income_level: "12500_to_25000" }
+
+    it "copies answer to Intake#triage_income_level" do
+      task.invoke
+
+      triage.reload
+      expect(triage.intake.triage_income_level).to eq "12500_to_25000"
+    end
+  end
+
+  context "filing frequency" do
+    context "every_year" do
+      let!(:triage) {
+        create(
+          :triage, intake: create(:intake),
+          filed_2018: "yes",
+          filed_2019: "yes",
+          filed_2020: "yes",
+          filed_2021: "yes"
+        )
+      }
+
+      it "copies answer to Intake#triage_filing_frequency" do
+        task.invoke
+
+        triage.reload
+        expect(triage.intake.triage_filing_frequency).to eq "every_year"
+      end
+    end
+
+    context "some_years" do
+      let!(:triage) {
+        create(
+          :triage, intake: create(:intake),
+          filed_2018: "yes",
+          filed_2019: "yes",
+          filed_2020: "no",
+          filed_2021: "no"
+        )
+      }
+
+      it "copies answer to Intake#triage_filing_frequency" do
+        task.invoke
+
+        triage.reload
+        expect(triage.intake.triage_filing_frequency).to eq "some_years"
+      end
+    end
+
+    context "not_filed" do
+      let!(:triage) {
+        create(
+          :triage, intake: create(:intake),
+          filed_2018: "no",
+          filed_2019: "no",
+          filed_2020: "no",
+          filed_2021: "no"
+        )
+      }
+
+      it "copies answer to Intake#triage_filing_frequency" do
+        task.invoke
+
+        triage.reload
+        expect(triage.intake.triage_filing_frequency).to eq "not_filed"
+      end
+    end
+
+    context "unfilled" do
+      let!(:triage) {
+        create(
+          :triage, intake: create(:intake),
+          filed_2018: "unfilled",
+          filed_2019: "unfilled",
+          filed_2020: "unfilled",
+          filed_2021: "unfilled"
+        )
+      }
+
+      it "copies answer to Intake#triage_filing_frequency" do
+        task.invoke
+
+        triage.reload
+        expect(triage.intake.triage_filing_frequency).to eq "unfilled"
+      end
+    end
+  end
+
+  context "filing status" do
+    let!(:triage) { create :triage, intake: create(:intake), filing_status: "single" }
+
+    it "copies answer to Intake#triage_filing_status" do
+      task.invoke
+
+      triage.reload
+      expect(triage.intake.triage_filing_status).to eq "single"
+    end
+  end
+
+  context "income ineligible" do
+    context "at least one of income_type_rent or income_type_farm is yes" do
+      let!(:triage) { create :triage, intake: create(:intake), income_type_rent: "yes" }
+
+      it "sets Intake#triage_vita_income_ineligible to yes" do
+        task.invoke
+
+        triage.reload
+        expect(triage.intake.triage_vita_income_ineligible).to eq "yes"
+      end
+    end
+
+    context "both income_type_rent and income_type_farm are no" do
+      let!(:triage) { create :triage, intake: create(:intake), income_type_rent: "no", income_type_farm: "no" }
+
+      it "sets Intake#triage_vita_income_ineligible to unfilled" do
+        task.invoke
+
+        triage.reload
+        expect(triage.intake.triage_vita_income_ineligible).to eq "no"
+      end
+    end
+
+    context "either is unfilled" do
+      let!(:triage) { create :triage, intake: create(:intake), income_type_rent: "unfilled" }
+
+      it "sets Intake#triage_vita_income_ineligible to unfilled" do
+        task.invoke
+
+        triage.reload
+        expect(triage.intake.triage_vita_income_ineligible).to eq "unfilled"
+      end
+    end
+  end
+end


### PR DESCRIPTION
in the cases of `triage_filing_frequency` and `triage_vita_income_ineligible`, we are condensing multiple columns into one, which makes for some complicated-ish edge cases to consider. that said, i chose not to consider too heavily the cases that seem very unlikely to occur in the wild (for example, when two questions were asked on one form but one of them has an answer and the other is "unfilled"). in other words, i really leaned into the idea that "we don't know what we don't know", so you'll see the expected cases laid out in their own if clauses and everything else goes in the "unfilled" bucket. if that doesn't make sense it would probably be faster to talk on the phone.

this was probably way too much thought to have put into backfilling a few columns that are at this point just for historical data analysis, but i was feeling too sleepy not to write a test.