### PR TITLE
Fix crash for archived dependents on the hub

### DIFF
--- a/app/views/hub/dependents/_dependent.html.erb
+++ b/app/views/hub/dependents/_dependent.html.erb
@@ -38,40 +38,48 @@
     </div>
   <% end %>
   <% if @client.intake.is_ctc? %>
-    <div>
-      <span>
-        <span class="form-question">
-          Dependent Type:
-        </span>
-        <%= dependent_eligibility = Efile::DependentEligibility::Eligibility.new(dependent, @client.intake.default_tax_year) %>
-
-        <span class="label-value">
-          <% if dependent_eligibility.qualifying_child? %>
-            Qualifying Child
-          <% elsif dependent_eligibility.qualifying_relative? %>
-            Qualifying Relative
-          <% else %>
-            Nonqualifying
-          <% end %>
-        </span>
-      </span>
-    </div>
-    <div class="spacing-above-5">
-      <% if dependent_eligibility.qualifying_ctc? %>
-        <span class="label">CTC</span>
-      <% end %>
-      <% if dependent_eligibility.qualifying_eip1? %>
-        <span class="label">EIP1</span>
-      <% end %>
-      <% if dependent_eligibility.qualifying_eip2? %>
-        <span class="label">EIP2</span>
-      <% end %>
-      <% if dependent_eligibility.qualifying_eip3? %>
-        <span class="label">EIP3</span>
-      <% end %>
+    <% if @client.archived? %>
       <% if dependent.soft_deleted_at.present? %>
-        <span class="label label--red">REMOVED</span>
+        <div class="spacing-above-5">
+          <span class="label label--red">REMOVED</span>
+        </div>
       <% end %>
-    </div>
+    <% else %>
+      <div>
+        <span>
+          <span class="form-question">
+            Dependent Type:
+          </span>
+          <%= dependent_eligibility = Efile::DependentEligibility::Eligibility.new(dependent, @client.intake.default_tax_year) %>
+
+          <span class="label-value">
+            <% if dependent_eligibility.qualifying_child? %>
+              Qualifying Child
+            <% elsif dependent_eligibility.qualifying_relative? %>
+              Qualifying Relative
+            <% else %>
+              Nonqualifying
+            <% end %>
+          </span>
+        </span>
+      </div>
+      <div class="spacing-above-5">
+        <% if dependent_eligibility.qualifying_ctc? %>
+          <span class="label">CTC</span>
+        <% end %>
+        <% if dependent_eligibility.qualifying_eip1? %>
+          <span class="label">EIP1</span>
+        <% end %>
+        <% if dependent_eligibility.qualifying_eip2? %>
+          <span class="label">EIP2</span>
+        <% end %>
+        <% if dependent_eligibility.qualifying_eip3? %>
+          <span class="label">EIP3</span>
+        <% end %>
+        <% if dependent.soft_deleted_at.present? %>
+          <span class="label label--red">REMOVED</span>
+        <% end %>
+      </div>
+    <% end %>
   <% end %>
 </li>

--- a/spec/features/hub/show_client_spec.rb
+++ b/spec/features/hub/show_client_spec.rb
@@ -66,13 +66,15 @@ RSpec.describe "a user viewing a client" do
     context "for a client with an archived 2021 CTC intake" do
       let(:intake) { nil }
       let!(:archived_intake) {  create(:archived_2021_ctc_intake, client: client) }
-      let!(:archived_dependent) {  create(:archived_2021_dependent, intake: archived_intake) }
+      let!(:archived_dependent_1) {  create(:archived_2021_dependent, intake: archived_intake, relationship: 'daughter') }
+      let!(:archived_dependent_2) {  create(:archived_2021_dependent, intake: archived_intake, relationship: 'other') }
       let!(:archived_bank_account) {  create(:archived_2021_bank_account, intake: archived_intake) }
 
       it "can view intake information" do
         visit hub_client_path(id: client.id)
         expect(page).to have_content(archived_intake.preferred_name)
-        expect(page).to have_content(archived_dependent.full_name)
+        expect(page).to have_content(archived_dependent_1.full_name)
+        expect(page).to have_content(archived_dependent_2.full_name)
         expect(page).to have_content(archived_bank_account.bank_name)
       end
     end


### PR DESCRIPTION
Archived dependents don't have all the methods needed to show
dependent eligibility info based on the new rules, and we should
probably stop updating them to have new/updated methods. So for
now we will stop trying to show 'Dependent Type' etc for archived
dependents at all.

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>