### PR TITLE
Hub: render archived 2021 dependents in the 2021 style

### DIFF
--- a/app/models/archived/dependent_2021.rb
+++ b/app/models/archived/dependent_2021.rb
@@ -76,9 +76,9 @@ module Archived
     enum filed_joint_return: { unfilled: 0, yes: 1, no: 2 }, _prefix: :filed_joint_return
     enum lived_with_more_than_six_months: { unfilled: 0, yes: 1, no: 2 }, _prefix: :lived_with_more_than_six_months
     enum cant_be_claimed_by_other: { unfilled: 0, yes: 1, no: 2 }, _prefix: :cant_be_claimed_by_other
-    enum born_in_2020: { unfilled: 0, yes: 1, no: 2 }, _prefix: :residence_exception_born
-    enum passed_away_2020: { unfilled: 0, yes: 1, no: 2 }, _prefix: :residence_exception_passed_away
-    enum placed_for_adoption: { unfilled: 0, yes: 1, no: 2 }, _prefix: :residence_exception_adoption
+    enum born_in_2020: { unfilled: 0, yes: 1, no: 2 }, _prefix: :born_in_2020
+    enum passed_away_2020: { unfilled: 0, yes: 1, no: 2 }, _prefix: :passed_away_2020
+    enum placed_for_adoption: { unfilled: 0, yes: 1, no: 2 }, _prefix: :placed_for_adoption
     enum permanent_residence_with_client: { unfilled: 0, yes: 1, no: 2 }, _prefix: :permanent_residence_with_client
     enum claim_anyway: { unfilled: 0, yes: 1, no: 2 }, _prefix: :claim_anyway
     enum meets_misc_qualifying_relative_requirements: { unfilled: 0, yes: 1, no: 2 }, _prefix: :meets_misc_qualifying_relative_requirements
@@ -126,41 +126,58 @@ module Archived
       end
     end
 
+    # Transforms relationship to the format expected by the IRS submission
+    # (upcased with spaces instead of underscores)
     def irs_relationship_enum
-      relationship_info.irs_enum
+      relationship&.upcase.gsub("_", " ")
     end
 
-    def qualifying_child?(tax_year = 2020)
-      Efile::DependentEligibility::QualifyingChild.new(self, tax_year).qualifies?
+    def eligible_for_child_tax_credit_2020?
+      yr_2020_age < 17 && yr_2020_qualifying_child? && tin_type_ssn?
     end
 
-    def qualifying_relative?(tax_year = 2020)
-      Efile::DependentEligibility::QualifyingRelative.new(self, tax_year).qualifies?
+    def eligible_for_eip1?
+      yr_2020_age < 17 && yr_2020_qualifying_child? && [:ssn, :atin].include?(tin_type&.to_sym)
     end
 
-    def eligible_for_child_tax_credit?(tax_year = 2020)
-      child_qualifiers = Efile::DependentEligibility::QualifyingChild.new(self, tax_year)
-      child_qualifiers.qualifies? && child_qualifiers.under_qualifying_age_limit? && tin_type_ssn?
+    def eligible_for_eip2?
+      yr_2020_age < 17 && yr_2020_qualifying_child? && [:ssn, :atin].include?(tin_type&.to_sym)
     end
 
-    def eligible_for_eip1?(tax_year = 2020)
-      child_qualifiers = Efile::DependentEligibility::QualifyingChild.new(self, tax_year)
-      child_qualifiers.qualifies? && child_qualifiers.under_qualifying_age_limit? && [:ssn, :atin].include?(tin_type&.to_sym)
+    def eligible_for_eip3?
+      yr_2020_qualifying_child? || yr_2020_qualifying_relative?
     end
 
-    def eligible_for_eip2?(tax_year = 2020)
-      child_qualifiers = Efile::DependentEligibility::QualifyingChild.new(self, tax_year)
-      child_qualifiers.qualifies? && child_qualifiers.under_qualifying_age_limit? && [:ssn, :atin].include?(tin_type&.to_sym)
+    def qualifying_child_relationship?
+      QUALIFYING_CHILD_RELATIONSHIPS.include? relationship.downcase
     end
 
-    def eligible_for_eip3?(tax_year = 2020)
-      qualifying_child?(tax_year) || qualifying_relative?(tax_year)
+    def qualifying_relative_relationship?
+      QUALIFYING_RELATIVE_RELATIONSHIPS.include? relationship.downcase
+    end
+
+    def meets_qc_misc_conditions?
+      provided_over_half_own_support_no? && filed_joint_return_no?
+    end
+
+    def meets_qc_claimant_condition?
+      cant_be_claimed_by_other_yes? ||
+        (cant_be_claimed_by_other_no? && claim_anyway_yes?)
+    end
+
+    def meets_qc_residence_condition_generic?
+      # This method should only be called when creating the `Rules` instance.
+      #
+      # The age check is handled in the year-specific rules; the rest is handled here.
+      lived_with_more_than_six_months_yes? ||
+        (lived_with_more_than_six_months_no? &&
+          (born_in_2020_yes? || passed_away_2020_yes? || placed_for_adoption_yes? || permanent_residence_with_client_yes?))
     end
 
     def mixpanel_data
       {
-        dependent_age_at_end_of_tax_year: age_during(TaxReturn.current_tax_year).to_s,
-        dependent_under_6: age_during(TaxReturn.current_tax_year) < 6 ? "yes" : "no",
+        dependent_age_at_end_of_tax_year: yr_2020_age.to_s,
+        dependent_under_6: yr_2020_age < 6 ? "yes" : "no",
         dependent_months_in_home: months_in_home.to_s,
         dependent_was_student: was_student,
         dependent_on_visa: on_visa,
@@ -170,30 +187,85 @@ module Archived
       }
     end
 
-    delegate :qualifying_child_relationship?, :qualifying_relative_relationship?, to: :relationship_info
-
-    def relationship_info
-      return unless relationship.present?
-
-      Efile::Relationship.find(relationship)
-    end
-
-    def born_in_final_6_months_of_tax_year?(tax_year)
-      birth_date >= Date.new(tax_year, 6, 30) && birth_date <= Date.new(tax_year, 12, 31)
-    end
-
-    def born_after_tax_year?(tax_year)
-      birth_date.year > tax_year
-    end
-
-    def age_during(tax_year)
-      tax_year - birth_date.year
-    end
+    # Methods on Dependent::Rules can be accessed (and mocked-out) as yr_2020_* and yr_2021_*. In the future, we might
+    # add a default year with no prefix.
+    delegate :age, :born_in_final_6_months?, :disqualified_child_qualified_relative?, :meets_qc_age_condition?, :meets_qc_residence_condition?, :qualifying_child?, :qualifying_relative?, to: :rules_2020, prefix: :yr_2020
+    delegate :age, :born_in_final_6_months?, :disqualified_child_qualified_relative?, :meets_qc_age_condition?, :meets_qc_residence_condition?, :qualifying_child?, :qualifying_relative?, to: :rules_2021, prefix: :yr_2021
 
     private
 
+    def rules_2020
+      rules(2020)
+    end
+
+    def rules_2021
+      rules(2021)
+    end
+
+    def rules(year)
+      Rules.new(birth_date, year, full_time_student_yes?, permanently_totally_disabled_yes?, ssn.present?, qualifying_child_relationship?, qualifying_relative_relationship?, meets_misc_qualifying_relative_requirements_yes?, meets_qc_residence_condition_generic?, meets_qc_claimant_condition?, meets_qc_misc_conditions?)
+    end
+
     def remove_error_associations
       EfileSubmissionTransitionError.where(dependent_id: self.id).update_all(dependent_id: nil)
+    end
+  end
+
+  class Rules
+    def initialize(birth_date, tax_year, full_time_student_yes, permanently_totally_disabled_yes, ssn_present, qualifying_child_relationship, qualifying_relative_relationship, meets_misc_qualifying_relative_requirements_yes, meets_qc_residence_condition_generic, meets_qc_claimant_condition, meets_qc_misc_conditions)
+      @birth_date = birth_date
+      @tax_year = tax_year
+      @full_time_student_yes = full_time_student_yes
+      @permanently_totally_disabled_yes = permanently_totally_disabled_yes
+      @ssn_present = ssn_present
+      @qualifying_child_relationship = qualifying_child_relationship
+      @qualifying_relative_relationship = qualifying_relative_relationship
+      @meets_misc_qualifying_relative_requirements_yes = meets_misc_qualifying_relative_requirements_yes
+      @meets_qc_residence_condition_generic = meets_qc_residence_condition_generic
+      @meets_qc_claimant_condition = meets_qc_claimant_condition
+      @meets_qc_misc_conditions = meets_qc_misc_conditions
+
+      # For tax year e.g. 1999, someone is 1 year old if born on any day in 1998.
+      @age = @tax_year - @birth_date.year
+    end
+
+    def born_in_final_6_months?
+      @birth_date >= Date.new(@tax_year, 6, 30) && @birth_date <= Date.new(@tax_year, 12, 31)
+    end
+
+    def age; @age; end
+
+    def meets_qc_age_condition?
+      @age >= 0 && (
+      @permanently_totally_disabled_yes ||
+        (@age < 19) ||
+        (@full_time_student_yes && @age < 24)
+      )
+    end
+
+    def disqualified_child_qualified_relative?
+      @age >= 0 && (
+      @qualifying_child_relationship && !meets_qc_age_condition?
+      )
+    end
+
+    def qualifying_relative?
+      @meets_misc_qualifying_relative_requirements_yes &&
+        @ssn_present &&
+        (disqualified_child_qualified_relative? || @qualifying_relative_relationship)
+    end
+
+    def meets_qc_residence_condition?
+      @meets_qc_residence_condition_generic || born_in_final_6_months?
+    end
+
+    def qualifying_child?
+      @qualifying_child_relationship &&
+        @ssn_present &&
+        @meets_qc_claimant_condition &&
+        @meets_qc_misc_conditions &&
+        meets_qc_age_condition? &&
+        meets_qc_residence_condition?
     end
   end
 end

--- a/app/views/hub/dependents/_archived_2021_ctc_dependent_detail.html.erb
+++ b/app/views/hub/dependents/_archived_2021_ctc_dependent_detail.html.erb
@@ -1,0 +1,33 @@
+<div>
+      <span>
+        <span class="form-question">
+          Dependent Type:
+        </span>
+        <span class="label-value">
+          <% if dependent.yr_2020_qualifying_child? %>
+            Qualifying Child
+          <% elsif dependent.yr_2020_qualifying_relative? %>
+            Qualifying Relative
+          <% else %>
+            Nonqualifying
+          <% end %>
+        </span>
+      </span>
+</div>
+<div class="spacing-above-5">
+  <% if dependent.eligible_for_child_tax_credit_2020? %>
+    <span class="label">CTC</span>
+  <% end %>
+  <% if dependent.eligible_for_eip1? %>
+    <span class="label">EIP1</span>
+  <% end %>
+  <% if dependent.eligible_for_eip2? %>
+    <span class="label">EIP2</span>
+  <% end %>
+  <% if dependent.eligible_for_eip3? %>
+    <span class="label">EIP3</span>
+  <% end %>
+  <% if dependent.soft_deleted_at.present? %>
+    <span class="label label--red">REMOVED</span>
+  <% end %>
+</div>

--- a/app/views/hub/dependents/_dependent.html.erb
+++ b/app/views/hub/dependents/_dependent.html.erb
@@ -38,40 +38,10 @@
     </div>
   <% end %>
   <% if @client.intake.is_ctc? %>
-    <div>
-      <span>
-        <span class="form-question">
-          Dependent Type:
-        </span>
-        <%= dependent_eligibility = Efile::DependentEligibility::Eligibility.new(dependent, @client.intake.default_tax_year) %>
-
-        <span class="label-value">
-          <% if dependent_eligibility.qualifying_child? %>
-            Qualifying Child
-          <% elsif dependent_eligibility.qualifying_relative? %>
-            Qualifying Relative
-          <% else %>
-            Nonqualifying
-          <% end %>
-        </span>
-      </span>
-    </div>
-    <div class="spacing-above-5">
-      <% if dependent_eligibility.qualifying_ctc? %>
-        <span class="label">CTC</span>
-      <% end %>
-      <% if dependent_eligibility.qualifying_eip1? %>
-        <span class="label">EIP1</span>
-      <% end %>
-      <% if dependent_eligibility.qualifying_eip2? %>
-        <span class="label">EIP2</span>
-      <% end %>
-      <% if dependent_eligibility.qualifying_eip3? %>
-        <span class="label">EIP3</span>
-      <% end %>
-      <% if dependent.soft_deleted_at.present? %>
-        <span class="label label--red">REMOVED</span>
-      <% end %>
-    </div>
+    <% if @client.archived? %>
+      <%= render 'hub/dependents/archived_2021_ctc_dependent_detail', dependent: dependent %>
+    <% else %>
+      <%= render 'hub/dependents/dependent_detail', dependent: dependent %>
+    <% end %>
   <% end %>
 </li>

--- a/app/views/hub/dependents/_dependent_detail.html.erb
+++ b/app/views/hub/dependents/_dependent_detail.html.erb
@@ -1,0 +1,35 @@
+<div>
+      <span>
+        <span class="form-question">
+          Dependent Type:
+        </span>
+        <%= dependent_eligibility = Efile::DependentEligibility::Eligibility.new(dependent, @client.intake.default_tax_year) %>
+
+        <span class="label-value">
+          <% if dependent_eligibility.qualifying_child? %>
+            Qualifying Child
+          <% elsif dependent_eligibility.qualifying_relative? %>
+            Qualifying Relative
+          <% else %>
+            Nonqualifying
+          <% end %>
+        </span>
+      </span>
+</div>
+<div class="spacing-above-5">
+  <% if dependent_eligibility.qualifying_ctc? %>
+    <span class="label">CTC</span>
+  <% end %>
+  <% if dependent_eligibility.qualifying_eip1? %>
+    <span class="label">EIP1</span>
+  <% end %>
+  <% if dependent_eligibility.qualifying_eip2? %>
+    <span class="label">EIP2</span>
+  <% end %>
+  <% if dependent_eligibility.qualifying_eip3? %>
+    <span class="label">EIP3</span>
+  <% end %>
+  <% if dependent.soft_deleted_at.present? %>
+    <span class="label label--red">REMOVED</span>
+  <% end %>
+</div>

--- a/spec/features/hub/show_client_spec.rb
+++ b/spec/features/hub/show_client_spec.rb
@@ -66,13 +66,15 @@ RSpec.describe "a user viewing a client" do
     context "for a client with an archived 2021 CTC intake" do
       let(:intake) { nil }
       let!(:archived_intake) {  create(:archived_2021_ctc_intake, client: client) }
-      let!(:archived_dependent) {  create(:archived_2021_dependent, intake: archived_intake) }
+      let!(:archived_dependent_1) {  create(:archived_2021_dependent, intake: archived_intake, relationship: 'daughter') }
+      let!(:archived_dependent_2) {  create(:archived_2021_dependent, intake: archived_intake, relationship: 'other') }
       let!(:archived_bank_account) {  create(:archived_2021_bank_account, intake: archived_intake) }
 
       it "can view intake information" do
         visit hub_client_path(id: client.id)
         expect(page).to have_content(archived_intake.preferred_name)
-        expect(page).to have_content(archived_dependent.full_name)
+        expect(page).to have_content(archived_dependent_1.full_name)
+        expect(page).to have_content(archived_dependent_2.full_name)
         expect(page).to have_content(archived_bank_account.bank_name)
       end
     end


### PR DESCRIPTION
Alternative to #2310

This extracts a template corresponding to (roughly) how dependents
were rendered on this page in the previous tax season, that doesn't
have all the new dependents eligibility class stuff

Also reverts the Archived::Dependent2021 model to be closer
to the state when it was archived. we should mostly not
be making any changes to this model!

this strategy should give us the flexibility to continue changing
the 'current year' dependent model and its behavior without having
to mess with all the historical models