### PR TITLE
Document upload: limit thumbnail resizing to 5 seconds and show default image if it errored

### DIFF
--- a/app/controllers/active_storage/representations/redirect_controller.rb
+++ b/app/controllers/active_storage/representations/redirect_controller.rb
@@ -1,0 +1,20 @@
+class ActiveStorage::Representations::RedirectController < ActiveStorage::Representations::BaseController
+  def show
+    Timeout.timeout(5) do
+      @representation = @blob.representation(params[:variation_key]).processed
+      expires_in ActiveStorage.service_urls_expire_in
+      redirect_to @representation.url(disposition: params[:disposition])
+    end
+  rescue ActiveSupport::MessageVerifier::InvalidSignature
+    head :not_found
+  rescue
+    redirect_to ActionController::Base.helpers.asset_path('document.svg')
+  end
+
+  private
+
+  def set_representation
+    # the assignment of `@representation =` from BaseController is inlined into `show`
+    # so we can wrap the whole thing in the same timeout/rescue logic
+  end
+end

--- a/spec/controllers/active_storage/representations/redirect_controller_spec.rb
+++ b/spec/controllers/active_storage/representations/redirect_controller_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe ActiveStorage::Representations::RedirectController do
+  let(:document) { create(:document, upload_path: (Rails.root.join("spec", "fixtures", "files", "picture_id.jpg"))) }
+
+  it "returns a signed url to see the resized image" do
+    representation = document.upload.representation(resize: "140x140")
+    get :show, params: { signed_blob_id: document.upload.blob.signed_id, variation_key: representation.variation.key, filename: 'picture_id.jpg' }
+
+    expect(response).to redirect_to(/.*\/rails\/active_storage\/.*picture_id.jpg/)
+  end
+
+  context 'when the document cannot be resized' do
+    it "returns a default image path" do
+      variation_key = document.upload.representation(resize: "140x140").variation.key
+      signed_blob_id = document.upload.blob.signed_id
+
+      allow_any_instance_of(ActiveStorage::Blob).to receive(:variant).and_raise(StandardError)
+
+      get :show, params: { signed_blob_id: signed_blob_id, variation_key: variation_key, filename: 'picture_id.jpg' }
+
+      expect(response).to redirect_to(/document.*svg/)
+    end
+  end
+
+  context 'when the document takes too long to resize' do
+    before do
+      allow(Timeout).to receive(:timeout).and_raise(Timeout::Error)
+    end
+
+    it "returns a default image path" do
+      representation = document.upload.representation(resize: "140x140")
+      get :show, params: { signed_blob_id: document.upload.blob.signed_id, variation_key: representation.variation.key, filename: 'picture_id.jpg' }
+
+      expect(response).to redirect_to(/document.*svg/)
+    end
+  end
+end


### PR DESCRIPTION
We've been getting sentry errors for files that ImageMagick has trouble resizing.
Sometimes this is because they are very large pixel sizes (9000x12000) and ImageMagick
likes to make big uncompressed files on disk when converting them to a 140x140px thumbnail.

Even if we let ImageMagick make bigger files without crashing, it takes a really long time
to resize images of this size. So we will timeout any resize attempts at 5 seconds and
rescue from all errors to ensure we don't see this stuff in Sentry anymore.

Co-authored-by: Whitney Schaefer <wschaefer@codeforamerica.org>