### PR TITLE
Consent all clients (getCTC wasn't consented) and use that value to show clients

### DIFF
--- a/app/controllers/concerns/client_sortable.rb
+++ b/app/controllers/concerns/client_sortable.rb
@@ -18,9 +18,9 @@ module ClientSortable
 
   # TEMPORARILY reverting to use status in filtering so that we don't experience downtime when renaming column.
   def filtered_clients
-    clients = @clients.after_consent # inner joins on intake to get consented clients, also excludes clients without intakes
+    clients = @clients.with_consented_intake # inner joins on intake to get consented clients, also excludes clients without intakes
     if current_user&.greeter?
-      clients = clients.greetable.or(Client.after_consent.joins(:tax_returns).where(tax_returns: { assigned_user: current_user }).distinct)
+      clients = clients.greetable.or(Client.with_consented_intake.joins(:tax_returns).where(tax_returns: { assigned_user: current_user }).distinct)
     end
     clients = clients.joins(:intake) # exclude clients without an intake
     clients = clients.where(intake: Intake.where(type: "Intake::CtcIntake")) if @filters[:ctc_client].present?

--- a/app/controllers/concerns/client_sortable.rb
+++ b/app/controllers/concerns/client_sortable.rb
@@ -22,7 +22,6 @@ module ClientSortable
     if current_user&.greeter?
       clients = clients.greetable.or(Client.with_consented_intake.joins(:tax_returns).where(tax_returns: { assigned_user: current_user }).distinct)
     end
-    clients = clients.joins(:intake) # exclude clients without an intake
     clients = clients.where(intake: Intake.where(type: "Intake::CtcIntake")) if @filters[:ctc_client].present?
     clients = clients.where(tax_returns: { status: TaxReturnStateMachine::STATES_BY_STAGE[@filters[:stage]] }) if @filters[:stage].present?
     clients = clients.where.not(flagged_at: nil) if @filters[:flagged].present?

--- a/app/controllers/concerns/client_sortable.rb
+++ b/app/controllers/concerns/client_sortable.rb
@@ -18,14 +18,11 @@ module ClientSortable
 
   # TEMPORARILY reverting to use status in filtering so that we don't experience downtime when renaming column.
   def filtered_clients
-    clients = if current_user&.greeter?
-                # Greeters should only have "search" access to clients in intake stage AND clients assigned to them.
-                @clients.greetable || Client.joins(:tax_returns).where(tax_returns: { assigned_user: current_user }).distinct
-              else
-                @clients.after_consent
-              end
-    # Force an inner join to `intakes` to exclude clients from previous years
-    clients = clients.joins(:intake)
+    clients = @clients.after_consent # inner joins on intake to get consented clients, also excludes clients without intakes
+    if current_user&.greeter?
+      clients = clients.greetable.or(Client.after_consent.joins(:tax_returns).where(tax_returns: { assigned_user: current_user }).distinct)
+    end
+    clients = clients.joins(:intake) # exclude clients without an intake
     clients = clients.where(intake: Intake.where(type: "Intake::CtcIntake")) if @filters[:ctc_client].present?
     clients = clients.where(tax_returns: { status: TaxReturnStateMachine::STATES_BY_STAGE[@filters[:stage]] }) if @filters[:stage].present?
     clients = clients.where.not(flagged_at: nil) if @filters[:flagged].present?

--- a/app/controllers/ctc/questions/legal_consent_controller.rb
+++ b/app/controllers/ctc/questions/legal_consent_controller.rb
@@ -16,6 +16,13 @@ module Ctc
 
       def after_update_success
         send_mixpanel_event(event_name: "ctc_provided_personal_info")
+        if current_intake.primary_consented_to_service_at.blank?
+          current_intake.update(
+            primary_consented_to_service_ip: request.remote_ip,
+            primary_consented_to_service_at: DateTime.current,
+            primary_consented_to_service: "yes"
+          )
+        end
       end
 
       def illustration_path; end

--- a/app/controllers/hub/clients_controller.rb
+++ b/app/controllers/hub/clients_controller.rb
@@ -16,7 +16,7 @@ module Hub
       @page_title = I18n.t("hub.clients.index.title")
 
       # Compute the count of tax returns, up to a maximum amount. Postgres is slow at computing counts if they are very large.
-      tax_return_count = TaxReturn.where(client: filtered_clients.with_eager_loaded_associations.without_pagination.reorder(nil)).limit(MAX_COUNT + 1).size
+      tax_return_count = TaxReturn.where(client: filtered_clients.without_pagination.reorder(nil)).limit(MAX_COUNT + 1).size
       # @tax_return_count HAS to be defined before @clients, otherwise it will cause SQL errors
       @tax_return_count = tax_return_count > MAX_COUNT ? "" : tax_return_count.to_s
       @clients = filtered_and_sorted_clients.with_eager_loaded_associations.page(params[:page]).load

--- a/app/forms/hub/create_ctc_client_form.rb
+++ b/app/forms/hub/create_ctc_client_form.rb
@@ -167,6 +167,9 @@ module Hub
     def default_attributes
       {
           type: "Intake::CtcIntake",
+          primary_consented_to_service: "yes",
+          primary_consented_to_service_at: DateTime.now,
+          completed_at: DateTime.now
       }
     end
 

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -88,7 +88,7 @@ class Client < ApplicationRecord
   end
 
   delegate *delegated_intake_attributes, to: :intake
-  scope :after_consent, -> { distinct.joins(:tax_returns).merge(TaxReturn.where.not(status: "intake_before_consent")) }
+  scope :after_consent, -> { joins(:intake).where("intakes.primary_consented_to_service_at IS NOT NULL") }
   scope :greetable, -> do
     greeter_statuses = TaxReturnStateMachine.available_states_for(role_type: GreeterRole::TYPE).values.flatten
     distinct.joins(:tax_returns).where(tax_returns: { status: greeter_statuses })

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -88,7 +88,7 @@ class Client < ApplicationRecord
   end
 
   delegate *delegated_intake_attributes, to: :intake
-  scope :after_consent, -> { joins(:intake).where("intakes.primary_consented_to_service_at IS NOT NULL") }
+  scope :with_consented_intake, -> { joins(:intake).where("intakes.primary_consented_to_service_at IS NOT NULL") }
   scope :greetable, -> do
     greeter_statuses = TaxReturnStateMachine.available_states_for(role_type: GreeterRole::TYPE).values.flatten
     distinct.joins(:tax_returns).where(tax_returns: { status: greeter_statuses })
@@ -237,7 +237,7 @@ class Client < ApplicationRecord
     else
       matching_intakes = matching_intakes.where.not(type: "Intake::CtcIntake")
     end
-    Client.where.not(id: id).after_consent.where(intake: matching_intakes).pluck(:id)
+    Client.where.not(id: id).with_consented_intake.where(intake: matching_intakes).pluck(:id)
   end
 
   def clients_with_dupe_ssn(service_class)

--- a/spec/controllers/concerns/client_sortable_spec.rb
+++ b/spec/controllers/concerns/client_sortable_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe ClientSortable, type: :controller do
     allow(Client).to receive(:joins).and_return Client
     allow(clients_query_double).to receive(:joins).and_return clients_query_double
     allow(clients_query_double).to receive(:greetable).and_return clients_query_double
+    allow(clients_query_double).to receive(:or).and_return clients_query_double
     allow(clients_query_double).to receive(:sla_breach_date).and_return clients_query_double
     allow(clients_query_double).to receive(:delegated_order).and_return clients_query_double
     allow(clients_query_double).to receive(:where).and_return clients_query_double
@@ -55,21 +56,9 @@ RSpec.describe ClientSortable, type: :controller do
           expect(subject.filtered_and_sorted_clients).to eq clients_query_double
 
           expect(clients_query_double).to have_received(:greetable)
+          expect(clients_query_double).to have_received(:or)
         end
       end
-
-      context "there are not greetable clients" do
-        before do
-          allow(clients_query_double).to receive(:greetable).and_return nil
-        end
-
-        it "limits to intake statuses only" do
-          subject.filtered_and_sorted_clients
-
-          expect(Client).to have_received(:joins).with(:tax_returns)
-        end
-      end
-
     end
 
     context "default sort order" do

--- a/spec/controllers/concerns/client_sortable_spec.rb
+++ b/spec/controllers/concerns/client_sortable_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ClientSortable, type: :controller do
 
     allow(subject).to receive(:params).and_return params
     subject.instance_variable_set(:@clients, clients_query_double)
-    allow(clients_query_double).to receive(:after_consent).and_return clients_query_double
+    allow(clients_query_double).to receive(:with_consented_intake).and_return clients_query_double
     allow(Client).to receive(:joins).and_return Client
     allow(clients_query_double).to receive(:joins).and_return clients_query_double
     allow(clients_query_double).to receive(:greetable).and_return clients_query_double

--- a/spec/controllers/ctc/questions/legal_consent_controller_spec.rb
+++ b/spec/controllers/ctc/questions/legal_consent_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe Ctc::Questions::LegalConsentController do
-  let(:intake) { create :ctc_intake, visitor_id: "visitor-id" }
+  let(:intake) { create :ctc_intake, :unconsented, visitor_id: "visitor-id" }
 
   before do
     allow(MixpanelService).to receive(:send_event)
@@ -55,6 +55,13 @@ describe Ctc::Questions::LegalConsentController do
           distinct_id: "visitor-id",
           event_name: "ctc_provided_personal_info"
         )
+      end
+
+      it "sets the consented to service properties as well" do
+        post :update, params: params
+        expect(intake.reload.primary_consented_to_service_at).not_to be_nil
+        expect(intake.primary_consented_to_service).to eq "yes"
+        expect(intake.primary_consented_to_service_ip).not_to be_nil
       end
     end
   end

--- a/spec/controllers/hub/clients_controller_spec.rb
+++ b/spec/controllers/hub/clients_controller_spec.rb
@@ -310,9 +310,8 @@ RSpec.describe Hub::ClientsController do
         let!(:tobias) { create :client, vita_partner: organization, intake: create(:intake, :filled_out, preferred_name: "Tobias", needs_help_2018: "yes", preferred_interview_language: "es", state_of_residence: "TX") }
         let!(:tobias_2019_return) { create :tax_return, :intake_in_progress, client: tobias, year: 2019, assigned_user: assigned_user }
         let!(:tobias_2018_return) { create :tax_return, :intake_in_progress, client: tobias, year: 2018, assigned_user: assigned_user }
-        let!(:lucille) { create :client, vita_partner: organization, intake: create(:intake, preferred_name: "Lucille") }
-        let!(:lucille_2018_return) { create(:tax_return, :intake_before_consent, client: lucille, year: 2018, assigned_user: assigned_user) }
-        let!(:bob_loblaw) { create :client, vita_partner: organization, intake: create(:ctc_intake, preferred_name: "Bob Loblaw") }
+        let!(:lucille) { create :client, vita_partner: organization, intake: create(:intake, :unconsented, preferred_name: "Lucille") }
+        let!(:bob_loblaw) { create :client, vita_partner: organization, intake: create(:ctc_intake, :unconsented, preferred_name: "Bob Loblaw") }
         let!(:bob_loblaw_online_intake_return) { create :tax_return, :intake_before_consent, service_type: :online_intake, client: bob_loblaw }
 
         it "does not show a client whose tax returns are all before_consent" do
@@ -411,17 +410,12 @@ RSpec.describe Hub::ClientsController do
         end
 
         context "when there are clients with no current intakes (clients from previous tax years)" do
-          let!(:former_year_client) { create :client, vita_partner: organization, intake: build(:intake, :filled_out) }
+          let!(:former_year_client) { create :client, vita_partner: organization, intake: nil }
           let!(:former_year_tax_return) { create :tax_return, :intake_in_progress, client: former_year_client, year: 2021, assigned_user: assigned_user }
-
-          before do
-            # In reality this intake would be moved to the `archived_intakes_2021` table, but removing it from the DB is good enough for our purposes
-            former_year_client.intake.destroy
-          end
 
           it "does not show those clients in the list" do
             get :index
-
+            expect(assigns(:clients)).not_to include former_year_client
             expect(assigns(:clients)).to match_array([george_sr, michael, tobias])
           end
         end

--- a/spec/controllers/questions/consent_controller_spec.rb
+++ b/spec/controllers/questions/consent_controller_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Questions::ConsentController do
-  let(:intake) { create :intake, preferred_name: "Ruthie Rutabaga", email_address: "hi@example.com", sms_phone_number: "+18324651180", source: "SourceParam", zip_code: "80309", needs_help_2021: "yes", needs_help_2020: "yes" }
-  let(:client) { intake.client }
+  let(:intake) { create :intake, :unconsented, preferred_name: "Ruthie Rutabaga", email_address: "hi@example.com", sms_phone_number: "+18324651180", source: "SourceParam", zip_code: "80309", needs_help_2021: "yes", needs_help_2020: "yes" }
+  let(:client) { intake.client}
   let!(:routing_double) { double(routing_method: "zip_code", determine_partner: (create :organization) ) }
 
   before do

--- a/spec/factories/intakes.rb
+++ b/spec/factories/intakes.rb
@@ -297,10 +297,10 @@ module IntakeFactoryHelpers
 end
 
 FactoryBot.define do
-  trait :primary_consented do
-    primary_consented_to_service_at { 2.weeks.ago }
-    primary_consented_to_service { "yes" }
-    primary_consented_to_service_ip { "1.1.1.1" } # IRS approved IP address
+  trait :unconsented do
+    primary_consented_to_service_at { nil }
+    primary_consented_to_service { "no" }
+    primary_consented_to_service_ip { nil }
   end
 
   trait :with_banking_details do
@@ -540,6 +540,9 @@ FactoryBot.define do
     eip3_amount_received { 1000 }
     primary_tin_type { "ssn" }
     current_step { "/en/questions/overview" }
+    primary_consented_to_service_at { 2.weeks.ago }
+    primary_consented_to_service { "yes" }
+    primary_consented_to_service_ip { "1.1.1.1" } # IRS approved IP address
   end
 
   factory :intake, class: Intake::GyrIntake do
@@ -548,5 +551,8 @@ FactoryBot.define do
     sequence(:visitor_id) { |n| "visitor_id_#{n}" }
     needs_to_flush_searchable_data_set_at { 1.minute.ago }
     current_step { "/en/questions/overview" }
+    primary_consented_to_service_at { 2.weeks.ago }
+    primary_consented_to_service { "yes" }
+    primary_consented_to_service_ip { "1.1.1.1" } # IRS approved IP address
   end
 end

--- a/spec/factories/tax_returns.rb
+++ b/spec/factories/tax_returns.rb
@@ -69,7 +69,7 @@ FactoryBot.define do
 
     trait :ctc do
       year { 2021 }
-      client { create(:ctc_intake, :with_contact_info, :with_address, :with_dependents, :with_ssns, :with_bank_account, :primary_consented, dependent_count: 3).client }
+      client { create(:ctc_intake, :with_contact_info, :with_address, :with_dependents, :with_ssns, :with_bank_account, dependent_count: 3).client }
       is_ctc { true }
       internal_efile { true }
     end

--- a/spec/features/ctc/edit_ctc_client_spec.rb
+++ b/spec/features/ctc/edit_ctc_client_spec.rb
@@ -184,6 +184,7 @@ RSpec.describe "a user editing a clients intake fields", requires_default_vita_p
 
       it "can see clients created through CTC intake with their current status" do
         new_client = Client.last
+        expect(Client.last.intake.primary_consented_to_service_at).to be_present
 
         login_as user
 

--- a/spec/features/hub/clients_searching_sorting_and_filtering_spec.rb
+++ b/spec/features/hub/clients_searching_sorting_and_filtering_spec.rb
@@ -19,12 +19,31 @@ RSpec.describe "searching, sorting, and filtering clients" do
       let(:site) { create :site, name: "Some child site", parent_organization_id: vita_partner_other.id }
       let!(:vita_partner_other) { create :organization, name: "Some Other Org", allows_greeters: true }
       let!(:vita_partner_ctc) { create :organization, name: "CTC Org", processes_ctc: true }
-      let!(:alan_intake_in_progress) { create :client, vita_partner_id: vita_partner.id, intake: (create :intake, preferred_name: "Alan Avocado", created_at: 1.day.ago, state_of_residence: "CA"), last_outgoing_communication_at: Time.new(2021, 4, 23), first_unanswered_incoming_interaction_at: Time.new(2021, 4, 23), tax_returns: [(create :tax_return, :intake_in_progress, year: 2019, assigned_user: user)] }
-      let!(:zach_prep_ready_for_call) { create :client, vita_partner: vita_partner_other, intake: (create :intake, preferred_name: "Zach Zucchini", created_at: 3.days.ago, state_of_residence: "WI"), last_outgoing_communication_at: Time.new(2021, 4, 28), first_unanswered_incoming_interaction_at: nil, tax_returns: [(create :tax_return, :prep_ready_for_prep, year: 2018)] }
-      let!(:patty_prep_ready_for_call) { create :client, vita_partner: vita_partner_other, intake: (create :intake, preferred_name: "Patty Banana", created_at: 1.day.ago, state_of_residence: "AL", with_incarcerated_navigator: true), last_outgoing_communication_at: Time.new(2021, 5, 1), first_unanswered_incoming_interaction_at: Time.new(2021, 5, 1), tax_returns: [(create :tax_return, :prep_ready_for_prep, year: 2019, assigned_user: user)] }
-      let!(:marty_ctc) { create :client, vita_partner: vita_partner_ctc, intake: (create :ctc_intake, preferred_name: "Marty Mango", created_at: 5.days.ago, state_of_residence: "ME"), last_outgoing_communication_at: Time.new(2021, 5, 2), first_unanswered_incoming_interaction_at: Time.new(2021, 5, 5), tax_returns: [(create :tax_return, :prep_ready_for_prep, year: 2021)] }
-      let!(:betty_intake_in_progress) { create :client, vita_partner: site, intake: (create :intake, preferred_name: "Betty Banana", created_at: 2.days.ago, state_of_residence: "TX", with_general_navigator: true), last_outgoing_communication_at: Time.new(2021, 5, 3), first_unanswered_incoming_interaction_at: Time.new(2021, 4, 28), tax_returns: [(create :tax_return, :intake_in_progress, year: 2018, assigned_user: mona_user)] }
-
+      let!(:alan_intake_in_progress) do
+        intake = create :intake, client: (build :client, vita_partner_id: vita_partner.id, last_outgoing_communication_at: Time.new(2021, 4, 23), first_unanswered_incoming_interaction_at: Time.new(2021, 4, 23)), preferred_name: "Alan Avocado", created_at: 1.day.ago, state_of_residence: "CA"
+        create :tax_return, :intake_in_progress, year: 2019, assigned_user: user, client: intake.client
+        intake.client
+      end
+      let!(:zach_prep_ready_for_call) do
+        intake = create :intake, client: (build :client, vita_partner: vita_partner_other, last_outgoing_communication_at: Time.new(2021, 4, 28), first_unanswered_incoming_interaction_at: nil), preferred_name: "Zach Zucchini", created_at: 3.days.ago, state_of_residence: "WI"
+        create :tax_return, :prep_ready_for_prep, year: 2018, client: intake.client
+        intake.client
+      end
+      let!(:patty_prep_ready_for_call) do
+        intake = create :intake, client: (build :client, vita_partner: vita_partner_other,  last_outgoing_communication_at: Time.new(2021, 5, 1), first_unanswered_incoming_interaction_at: Time.new(2021, 5, 1)), preferred_name: "Patty Banana", created_at: 1.day.ago, state_of_residence: "AL", with_incarcerated_navigator: true
+        create :tax_return, :prep_ready_for_prep, year: 2019, assigned_user: user, client: intake.client
+        intake.client
+      end
+      let!(:marty_ctc) do
+        intake = create :ctc_intake, client: (build :client, vita_partner: vita_partner_ctc, last_outgoing_communication_at: Time.new(2021, 5, 2), first_unanswered_incoming_interaction_at: Time.new(2021, 5, 5)), preferred_name: "Marty Mango", created_at: 5.days.ago, state_of_residence: "ME"
+        create :tax_return, :prep_ready_for_prep, year: 2021, client: intake.client
+        intake.client
+      end
+      let!(:betty_intake_in_progress) do
+        intake = create :intake, client: (build :client, vita_partner: site, last_outgoing_communication_at: Time.new(2021, 5, 3), first_unanswered_incoming_interaction_at: Time.new(2021, 4, 28)), preferred_name: "Betty Banana", created_at: 2.days.ago, state_of_residence: "TX", with_general_navigator: true
+        create :tax_return, :intake_in_progress, year: 2018, assigned_user: mona_user, client: intake.client
+        intake.client
+      end
       before do
         allow(DateTime).to receive(:now).and_return DateTime.new(2021, 5, 4)
         Intake.refresh_search_index
@@ -365,6 +384,32 @@ RSpec.describe "searching, sorting, and filtering clients" do
         expect(page.all('.client-row').length).to eq 2
         page.find('a', text: "Breached SLA").find('.clear-filter').click
         expect(page.all('.client-row').length).to eq 12
+      end
+    end
+
+    context "as a greeter" do
+      let(:user) { create :greeter_user }
+      context "with greetable clients" do
+        let!(:vita_partner) { create :organization, name: "Some Other Org", allows_greeters: true }
+        let!(:non_greetable_vita_partner) { create :organization, name: "Cant Greet Here", allows_greeters: false }
+        let!(:greetable_client) { create :client_with_tax_return_state, tax_return_state: :intake_greeter_info_requested, intake: (create :intake, preferred_name: "Leslie Wilson"), vita_partner: vita_partner }
+        let!(:assigned_client) { create :client, intake: (create :intake, preferred_name: "Owen Wilson"), tax_returns: [create(:tax_return, assigned_user: user)]}
+        let!(:inaccessible_client) { create :client, intake: (create :intake, preferred_name: "Volleyball Wilson"), tax_returns: [create(:tax_return, assigned_user: nil)]}
+        let!(:non_greetable_client) { create :client_with_tax_return_state, tax_return_state: :intake_greeter_info_requested, intake: (create :intake, preferred_name: "Kaitlyn Wilson", vita_partner: non_greetable_vita_partner)}
+
+        scenario "I can view clients" do
+          visit hub_clients_path
+
+          expect(Client.greetable).to include greetable_client
+
+          expect(page).to have_text "All Clients"
+          within ".client-table" do
+            expect(page.all('.client-row')[0]).to have_text(greetable_client.preferred_name)
+            expect(page.all('.client-row')[1]).to have_text(assigned_client.preferred_name)
+            expect(page).not_to have_text(inaccessible_client.preferred_name)
+            expect(page).not_to have_text(non_greetable_client.preferred_name)
+          end
+        end
       end
     end
   end

--- a/spec/features/portal/client_login_spec.rb
+++ b/spec/features/portal/client_login_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Logging in" do
   context "With a client who consented", active_job: true do
     let(:tax_return) { create(:tax_return, :ready_to_sign) }
     let(:client) { create :client, tax_returns: [tax_return] }
-    let!(:intake) { create :intake, :primary_consented, preferred_name: "Carrie", primary_first_name: "Carrie", primary_last_name: "Carrot", primary_last_four_ssn: "9876", email_address: "example@example.com", sms_phone_number: "+15005550006", sms_notification_opt_in: "yes", client: client }
+    let!(:intake) { create :intake, preferred_name: "Carrie", primary_first_name: "Carrie", primary_last_name: "Carrot", primary_last_four_ssn: "9876", email_address: "example@example.com", sms_phone_number: "+15005550006", sms_notification_opt_in: "yes", client: client }
 
     context "As a client logging in from the login page" do
       context "signing in with verification code" do

--- a/spec/features/portal/still_needs_help_spec.rb
+++ b/spec/features/portal/still_needs_help_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Still Needs Help" do
   context "When a client has triggered the Still Needs Help flow", active_job: true do
     let(:tax_return) { create(:tax_return, :intake_in_progress) }
     let(:client) { create :client, tax_returns: [tax_return], triggered_still_needs_help_at: Time.now }
-    let!(:intake) { create :intake, :primary_consented, preferred_name: "Carrie", primary_first_name: "Carrie", primary_last_name: "Carrot", primary_last_four_ssn: "9876", email_address: "example@example.com", sms_phone_number: "+15005550006", client: client }
+    let!(:intake) { create :intake, preferred_name: "Carrie", primary_first_name: "Carrie", primary_last_name: "Carrot", primary_last_four_ssn: "9876", email_address: "example@example.com", sms_phone_number: "+15005550006", client: client }
 
     context "As a client visiting the portal" do
       before do

--- a/spec/lib/consent_pdf_spec.rb
+++ b/spec/lib/consent_pdf_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ConsentPdf do
 
   describe "#output_file" do
     context "with an empty intake record" do
-      let(:intake) { create :intake }
+      let(:intake) { create :intake, :unconsented }
 
       it "returns a pdf with default fields and values" do
         consent_pdf = ConsentPdf.new(intake)

--- a/spec/lib/f15080_vita_consent_to_disclose_pdf_spec.rb
+++ b/spec/lib/f15080_vita_consent_to_disclose_pdf_spec.rb
@@ -5,7 +5,7 @@ describe F15080VitaConsentToDisclosePdf do
 
   describe "#output_file" do
     context "with an empty intake record" do
-      let(:intake) { create :intake }
+      let(:intake) { create :intake, :unconsented }
       it "returns a pdf with default fields and values" do
         consent_pdf = F15080VitaConsentToDisclosePdf.new(intake)
         output_file = consent_pdf.output_file

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -90,16 +90,15 @@ describe Client do
     end
   end
 
-  describe ".after_consent scope" do
+  describe ".with_consented_intake scope" do
     let!(:client_not_consented) { create :client, intake: (create :intake, primary_consented_to_service_at: nil)}
     let!(:client_consented) { create :client, intake: (create :intake, primary_consented_to_service_at: DateTime.now) }
     let!(:client_no_intake) { create :client, intake: nil }
     it "includes consented clients and excludes non consented clients" do
-      consented_clients = Client.after_consent
+      consented_clients = Client.with_consented_intake
       expect(consented_clients).to include client_consented
       expect(consented_clients).not_to include client_not_consented
       expect(consented_clients).not_to include client_no_intake
-
     end
   end
 

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -90,6 +90,19 @@ describe Client do
     end
   end
 
+  describe ".after_consent scope" do
+    let!(:client_not_consented) { create :client, intake: (create :intake, primary_consented_to_service_at: nil)}
+    let!(:client_consented) { create :client, intake: (create :intake, primary_consented_to_service_at: DateTime.now) }
+    let!(:client_no_intake) { create :client, intake: nil }
+    it "includes consented clients and excludes non consented clients" do
+      consented_clients = Client.after_consent
+      expect(consented_clients).to include client_consented
+      expect(consented_clients).not_to include client_not_consented
+      expect(consented_clients).not_to include client_no_intake
+
+    end
+  end
+
 
   describe ".needs_in_progress_survey scope" do
     let(:fake_time) { Time.utc(2021, 2, 6, 0, 0, 0) }
@@ -517,12 +530,12 @@ describe Client do
     let!(:client) { create :client, intake: create(:intake, email_address: "fizzy_pop@example.com", phone_number: "+15855551212", sms_phone_number: "+18285551212") }
 
     context "when there are other GYR clients with the same contact info" do
-      let!(:client_dupe_email) { create :client_with_tax_return_state, intake: create(:intake, email_address: "fizzy_pop@example.com"), tax_return_state: "intake_ready" }
-      let!(:ctc_client_dupe_email) { create :client_with_tax_return_state, intake: create(:ctc_intake, email_address: "fizzy_pop@example.com"), tax_return_state: "intake_ready" }
-      let!(:client_phone) { create :client_with_tax_return_state, intake: create(:intake, phone_number: "+15855551212"), tax_return_state: "intake_ready" }
-      let!(:client_sms) { create :client_with_tax_return_state, intake: create(:intake, sms_phone_number: "+18285551212"), tax_return_state: "intake_ready" }
-      let!(:client_phone_match_sms) { create :client_with_tax_return_state, intake: create(:intake, phone_number: "+18285551212"), tax_return_state: "intake_ready" }
-      let!(:client_sms_match_phone) { create :client_with_tax_return_state, intake: create(:intake, sms_phone_number: "+15855551212"), tax_return_state: "intake_ready" }
+      let!(:client_dupe_email) { create :client, intake: create(:intake, email_address: "fizzy_pop@example.com") }
+      let!(:ctc_client_dupe_email) { create :client, intake: create(:ctc_intake, email_address: "fizzy_pop@example.com") }
+      let!(:client_phone) { create :client, intake: create(:intake, phone_number: "+15855551212") }
+      let!(:client_sms) { create :client, intake: create(:intake, sms_phone_number: "+18285551212") }
+      let!(:client_phone_match_sms) { create :client, intake: create(:intake, phone_number: "+18285551212")}
+      let!(:client_sms_match_phone) { create :client, intake: create(:intake, sms_phone_number: "+15855551212") }
 
       context "when searching for matching GYR clients" do
         it "returns the GYR clients ids" do
@@ -530,7 +543,7 @@ describe Client do
         end
 
         context "with a client who hasn't reached consent" do
-          let!(:client_before_consent) { create :client_with_tax_return_state, intake: create(:intake, email_address: "fizzy_pop@example.com"), tax_return_state: "intake_before_consent" }
+          let!(:client_before_consent) { create :client, intake: create(:intake, :unconsented, email_address: "fizzy_pop@example.com") }
 
           it "does not return the client who hasn't consented" do
             expect(client.clients_with_dupe_contact_info(false)).not_to include(client_before_consent.id)
@@ -553,7 +566,7 @@ describe Client do
         end
 
         context "with a client who hasn't reached consent" do
-          let!(:client_before_consent) { create :client_with_tax_return_state, intake: create(:ctc_intake, email_address: "fizzy_pop@example.com"), tax_return_state: "intake_before_consent" }
+          let!(:client_before_consent) { create :client, intake: create(:ctc_intake, :unconsented, email_address: "fizzy_pop@example.com") }
 
           it "does not return the client who hasn't consented" do
             expect(client.clients_with_dupe_contact_info(true)).not_to include(client_before_consent.id)

--- a/spec/services/client_login_service_spec.rb
+++ b/spec/services/client_login_service_spec.rb
@@ -25,7 +25,7 @@ describe ClientLoginService do
       context "with a client matching a TextMessageAccessToken" do
         before do
           create(:text_message_access_token, token: "hashed_token", sms_phone_number: "+16505551212")
-          create(:intake, :primary_consented, client: client, sms_phone_number: "+16505551212")
+          create(:intake, client: client, sms_phone_number: "+16505551212")
         end
 
         it "returns the client" do
@@ -36,7 +36,7 @@ describe ClientLoginService do
       context "with a client whose email matches an EmailAccessToken" do
         before do
           create(:email_access_token, token: "hashed_token", email_address: "someone@example.com")
-          create(:intake, :primary_consented, client: client, email_address: "someone@example.com")
+          create(:intake, client: client, email_address: "someone@example.com")
         end
 
         it "returns the client" do
@@ -47,7 +47,7 @@ describe ClientLoginService do
       context "with a client whose spouse email matches an EmailAccessToken" do
         before do
           create(:email_access_token, token: "hashed_token", email_address: "someone@example.com")
-          create(:intake, :primary_consented, client: client, spouse_email_address: "someone@example.com")
+          create(:intake, client: client, spouse_email_address: "someone@example.com")
         end
 
         it "returns the client" do
@@ -58,7 +58,7 @@ describe ClientLoginService do
       context "with a client whose email is contained in a comma-separated EmailAccessToken" do
         before do
           create(:email_access_token, token: "hashed_token", email_address: "someone@example.com,other@example.com")
-          create(:intake, :primary_consented, client: client, email_address: "someone@example.com")
+          create(:intake, client: client, email_address: "someone@example.com")
         end
 
         it "returns the client" do
@@ -71,7 +71,7 @@ describe ClientLoginService do
         before do
           create(:email_access_token, token: "hashed_token", email_address: "someone@example.com", created_at: Time.current - (2.1).days)
           create(:text_message_access_token, token: "hashed_token", sms_phone_number: "+16505551212", created_at: Time.current - (2.1).days)
-          create(:intake, :primary_consented, client: client, spouse_email_address: "someone@example.com", sms_phone_number: "+16505551212")
+          create(:intake, client: client, spouse_email_address: "someone@example.com", sms_phone_number: "+16505551212")
         end
 
         it "returns a blank set" do
@@ -85,13 +85,13 @@ describe ClientLoginService do
         end
       end
 
-      context "with a client with no consent to service" do
+      context "with a client who has not consented" do
         subject { described_class.new(:gyr) }
         context "with a gyr service_type" do
           before do
             create(:email_access_token, token: "hashed_token", email_address: "someone@example.com")
             create(:text_message_access_token, token: "hashed_token", sms_phone_number: "+16505551212")
-            create(:intake, client: client, spouse_email_address: "someone@example.com", sms_phone_number: "+16505551212")
+            create(:intake, :unconsented, client: client, spouse_email_address: "someone@example.com", sms_phone_number: "+16505551212")
           end
 
           it "returns a blank set" do
@@ -226,7 +226,7 @@ describe ClientLoginService do
       context "when there is a drop off intake with a matching email" do
         let(:email_address) { "persimmion@example.com" }
         before do
-          create :client, intake: (create :intake, :primary_consented, email_address: email_address), tax_returns: [create(:tax_return, :prep_ready_for_prep, service_type: "drop_off")]
+          create :client, intake: (create :intake, email_address: email_address), tax_returns: [create(:tax_return, :prep_ready_for_prep, service_type: "drop_off")]
         end
 
         it "is true" do
@@ -237,7 +237,7 @@ describe ClientLoginService do
       context "when there is a drop off intake with a matching spouse email" do
         let(:email_address) { "persimmion@example.com" }
         before do
-          create :client, intake: (create :intake, :primary_consented, spouse_email_address: email_address), tax_returns: [create(:tax_return, :prep_ready_for_prep, service_type: "drop_off")]
+          create :client, intake: (create :intake, spouse_email_address: email_address), tax_returns: [create(:tax_return, :prep_ready_for_prep, service_type: "drop_off")]
         end
 
         it "is true" do


### PR DESCRIPTION
This should resolve a bug wherein clients without tax returns (ie all clients that had routing method of :at_capacity) were not discoverable using search, and it also mirrors the logic we use for allowing clients to log in.

Also I found a bug where the greeters were not able to see clients who were assigned to them but had been transitioned out of greetable states. I have not seen this reported as a bug, but it's a clear regression in the code introduced in this PR: https://github.com/codeforamerica/vita-min/pull/1147 . The code as written with the || would never execute the left hand side.