### PR TITLE
Use HubClientPresenter to wrap client in Hub::Clients::SecretsController

### DIFF
--- a/app/controllers/hub/clients/secrets_controller.rb
+++ b/app/controllers/hub/clients/secrets_controller.rb
@@ -7,6 +7,7 @@ module Hub
       respond_to :js
 
       def show
+        @client = Hub::ClientsController::HubClientPresenter.new(@client)
         @partial_params = {}
         if params[:secret_name] == 'primary_ssn'
           @partial_path = 'hub/clients/displayed_ssn_itin'
@@ -44,7 +45,7 @@ module Hub
       def create_access_log
         AccessLog.create!(
           user: current_user,
-          record: @client,
+          record: @client.__getobj__,
           event_type: params[:secret_name].end_with?('ssn') ? "read_ssn_itin" : "read_ip_pin",
           created_at: DateTime.now,
           ip_address: request.remote_ip,

--- a/spec/controllers/hub/clients/secrets_controller_spec.rb
+++ b/spec/controllers/hub/clients/secrets_controller_spec.rb
@@ -66,6 +66,20 @@ describe Hub::Clients::SecretsController, type: :controller do
           end
         end
       end
+
+      context "for an archived intake" do
+        render_views
+
+        let(:intake) { nil }
+        let(:client) { build(:client) }
+
+        let!(:archived_intake) { create :archived_2021_ctc_intake, client: client, primary_ssn: '555-11-2222', preferred_name: "Andy Archive" }
+
+        it "shows the secret from the archived intake" do
+          get :show, params: params, format: :js, xhr: true
+          expect(response.body).to include(archived_intake.primary_ssn)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>