### PR TITLE
Hub: show warning instead of crashing for any Client records with no intake up to 2022-04-15

### DIFF
--- a/app/controllers/hub/clients_controller.rb
+++ b/app/controllers/hub/clients_controller.rb
@@ -185,7 +185,7 @@ module Hub
           @archived = true if @intake
         end
         # For a short while, we created Client records with no intake and/or moved which client the intake belonged to.
-        if !@intake && @client.created_at < Date.parse('2022-03-15') && @client.created_at > Date.parse('2022-03-09')
+        if !@intake && @client.created_at < Date.parse('2022-04-15')
           @missing_intake = true
           @intake = Intake::GyrIntake.new(client_id: @client.id)
           @intake.readonly!


### PR DESCRIPTION
There are various issues that may have caused these "orphaned" clients in the past,
and we want the `show` page to be accessable for them rather than crashing.

But we don't expect any to happen in the future, so if there are orphaned clients
created for new reasons in the future we will allow the page to crash on their
behalf.