### PR TITLE
Fix IP pin page, none of the above option

### DIFF
--- a/app/forms/ctc/ip_pin_form.rb
+++ b/app/forms/ctc/ip_pin_form.rb
@@ -40,7 +40,6 @@ module Ctc
     end
 
     def at_least_one_selected
-      no_ip_pins == "yes" ||
         has_primary_ip_pin == "yes" ||
         has_spouse_ip_pin == "yes" ||
         (dependents_attributes&.values || []).any? { |attributes| attributes["has_ip_pin"] == "yes" }

--- a/spec/forms/ctc/ip_pin_form_spec.rb
+++ b/spec/forms/ctc/ip_pin_form_spec.rb
@@ -119,9 +119,11 @@ describe Ctc::IpPinForm do
         let(:intake) { create :ctc_intake, has_primary_ip_pin: "yes", primary_ip_pin: "123456", has_spouse_ip_pin: "yes", spouse_ip_pin: "123457" }
         let(:dependent) { create :dependent, intake: intake, has_ip_pin: "yes", ip_pin: "123458" }
 
-        it "removes their IP PINs" do
-          described_class.new(intake, params).save
+        it "is valid and removes their IP PINs" do
+          form = described_class.new(intake, params)
+          expect(form).to be_valid
 
+          form.save
           intake.reload
           dependent.reload
 


### PR DESCRIPTION
When using the `at_least_one_or_none_of_the_above` validator, you cannot include the `none_of_the_above` attribute in the form implemented `at_least_one_selected`. I added a test to this form to prevent this in the future (for this form). 

It is unfortunately, something you need to be aware of when using this validator, otherwise bad behavior occurs (selecting none of the above will cause the error message to show, incorrectly).