### PR TITLE
Vita Providers index: Avoid crash when page is too high [#181019039]

### DIFF
--- a/app/controllers/vita_providers_controller.rb
+++ b/app/controllers/vita_providers_controller.rb
@@ -60,7 +60,7 @@ class VitaProvidersController < ApplicationController
       zip: @zip,
       zip_name: @zip_name,
       result_count: @providers.total_entries.to_s,
-      distance_to_closest_result: (@providers.first&.cached_query_distance / METERS_IN_MILE).round,
+      distance_to_closest_result: (@providers.first.nil? ? nil : (@providers.first.cached_query_distance / METERS_IN_MILE).round),
       page: @page,
     }
     send_mixpanel_event(event_name: "provider_search", data: event_data)

--- a/app/lib/seeder.rb
+++ b/app/lib/seeder.rb
@@ -10,6 +10,7 @@ class Seeder
   include ActiveSupport::Testing::TimeHelpers
 
   def run
+    VitaProvider.find_or_initialize_by(name: "Public Library of the Seed Data").update(irs_id: "12345", coordinates: Geometry.coords_to_point(lat: 37.781707, lon: -122.408363), details: "972 Mission St\nSan Francisco, CA 94103\nAsk for help at the front desk\nFull Service\n415-555-1212")
     national_org = VitaPartner.find_or_create_by!(name: "GYR National Organization", type: Organization::TYPE)
     national_org.update(allows_greeters: true, national_overflow_location: true)
 

--- a/spec/controllers/vita_providers_controller_spec.rb
+++ b/spec/controllers/vita_providers_controller_spec.rb
@@ -150,6 +150,33 @@ RSpec.describe VitaProvidersController do
           expect(assigns(:providers)).to eq([])
         end
       end
+
+      context "with page number past the end of results" do
+        let!(:closest_providers) { create_list :vita_provider, 5, :with_coordinates, lat_lon: [37.834519, -122.263273] }
+        let!(:next_closest_providers) { create_list :vita_provider, 5, :with_coordinates, lat_lon: [37.826387, -122.269738] }
+        let(:params) do
+          { zip: "94609", page: "3" }
+        end
+
+        it "shows no search results" do
+          get :index, params: params
+          expect(response).to be_ok
+
+          expect(assigns(:providers)).to eq([])
+        end
+
+        it "sends mixpanel data with distance to closest result of nil" do
+          get :index, params: params
+          expected_data = {
+            zip: "94609",
+            zip_name: "Oakland, California",
+            result_count: "10",
+            distance_to_closest_result: nil,
+            page: "3",
+          }
+          expect(subject).to have_received(:send_mixpanel_event).with(event_name: "provider_search", data: expected_data)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
When you have the seed data (e.g. on Heroku) and you search for 94110:

![image](https://user-images.githubusercontent.com/67708639/163833337-0373fd4f-9a9d-4e7f-a6da-f6a07e54c17f.png)

When you URL-hack to go to page 2 despite there being only one page:

![image](https://user-images.githubusercontent.com/67708639/163833412-7c702822-b9c7-435a-9629-51b3c8152f22.png)
