### PR TITLE
Create irs_submission_id right before we submit to IRS

### DIFF
--- a/app/jobs/build_submission_bundle_job.rb
+++ b/app/jobs/build_submission_bundle_job.rb
@@ -8,7 +8,12 @@ class BuildSubmissionBundleJob < ApplicationJob
       return
     end
 
-    # TODO: Add IRS submission id generation here.
+    begin
+      submission.generate_irs_submission_id!
+    rescue StandardError => e
+      submission.transition_to!(:failed, error_code: 'IRS-ID-FAIL', raw_response: e.inspect)
+    end
+
     begin
       submission.generate_form_1040_pdf
     rescue StandardError => e

--- a/app/views/signups/new.html.erb
+++ b/app/views/signups/new.html.erb
@@ -2,7 +2,6 @@
 <% content_for :page_title do %>
   <%= @header %>
 <% end %>
-
 <% content_for :main do %>
   <section class="slab slab--white">
     <div class="grid">

--- a/spec/jobs/gyr_efiler/send_submission_job_spec.rb
+++ b/spec/jobs/gyr_efiler/send_submission_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe GyrEfiler::SendSubmissionJob, type: :job do
   end
 
   describe '#perform' do
-    let!(:submission) { create(:efile_submission, :queued, submission_bundle: { filename: "sensible-filename.zip", io: StringIO.new("i am a zip file") }) }
+    let!(:submission) { create(:efile_submission, :queued, irs_submission_id: "12345200202011234567", submission_bundle: { filename: "sensible-filename.zip", io: StringIO.new("i am a zip file") }) }
 
     let(:successful_result) do
       <<~RESULT
@@ -14,7 +14,7 @@ RSpec.describe GyrEfiler::SendSubmissionJob, type: :job do
         <SubmissionReceiptList xmlns="http://www.irs.gov/efile" xmlns:efile="http://www.irs.gov/efile">
            <Cnt>1</Cnt>
            <SubmissionReceiptGrp>
-              <SubmissionId>#{submission.irs_submission_id}</SubmissionId>
+              <SubmissionId>12345200202011234567</SubmissionId>
               <SubmissionReceivedTs>2021-07-15T12:32:59-04:00</SubmissionReceivedTs>
            </SubmissionReceiptGrp>
         </SubmissionReceiptList>

--- a/spec/lib/submission_builder/manifest_spec.rb
+++ b/spec/lib/submission_builder/manifest_spec.rb
@@ -3,10 +3,13 @@ require "rails_helper"
 describe SubmissionBuilder::Manifest do
   describe ".build" do
     let(:submission) { create :efile_submission, :ctc }
+    before do
+      submission.generate_irs_submission_id!
+    end
+
     context "when the XML is valid" do
       let(:file_double) { double }
       let(:schema_double) { double }
-      let(:submission) { create :efile_submission, :ctc }
 
       before do
         allow(File).to receive(:open).and_return(file_double)

--- a/spec/lib/submission_builder/shared/return_header1040_spec.rb
+++ b/spec/lib/submission_builder/shared/return_header1040_spec.rb
@@ -344,17 +344,17 @@ describe SubmissionBuilder::Shared::ReturnHeader1040 do
     end
 
     context "when re-submitting" do
-      let(:previous_submission) { create(:efile_submission, :transmitted, submission_bundle: { filename: "sensible-filename.zip", io: StringIO.new("i am a zip file") }, created_at: DateTime.new(2021, 8, 1, 12, 0)) }
+      let(:previous_submission) { create(:efile_submission, :transmitted, irs_submission_id: "12345202201011234567", submission_bundle: { filename: "sensible-filename.zip", io: StringIO.new("i am a zip file") }, created_at: DateTime.new(2021, 8, 1, 12, 0)) }
 
       before do
-        create(:efile_submission_transition, :preparing, efile_submission: submission, metadata: {previous_submission_id: previous_submission.id})
+        create(:efile_submission_transition, :preparing, efile_submission: submission, metadata: { previous_submission_id: previous_submission.id })
       end
 
       it "adds original submission metadata to the header" do
         expect(submission.previously_transmitted_submission).to eq(previous_submission)
         response = described_class.build(submission)
         xml = Nokogiri::XML::Document.parse(response.document.to_xml)
-        expect(xml.at("FederalOriginalSubmissionId").text).to eq previous_submission.irs_submission_id
+        expect(xml.at("FederalOriginalSubmissionId").text).to eq "12345202201011234567"
         expect(xml.at("FederalOriginalSubmissionIdDt").text).to eq "2021-08-01"
       end
     end

--- a/spec/lib/submission_bundle_spec.rb
+++ b/spec/lib/submission_bundle_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 
 describe SubmissionBundle do
-  let(:submission_2020) { create :efile_submission, :ctc, tax_year: 2020 }
-  let(:submission_2021) { create :efile_submission, :ctc, tax_year: 2021 }
+  let(:submission_2020) { create :efile_submission, :ctc, tax_year: 2020, irs_submission_id: "12345202201011234569" }
+  let(:submission_2021) { create :efile_submission, :ctc, tax_year: 2021, irs_submission_id: "12345202201011234568" }
+  let(:submission) { create :efile_submission, :ctc, tax_year: 2021, irs_submission_id: "12345202201011234567" }
 
   before do
     submission_2020.intake.update(


### PR DESCRIPTION
In the work for prepping for this season, we removed the logic that allows you to "resubmit" the same submission if it hasn't already been transmitted to the IRS. This is so that we can ensure there is a unique Fraud::Score object each time we generate a submission.

However, we don't want to end up in a place where we're generating a bunch of IRS submission Ids that we'll never use, so we can defer creating the submission ID til a bit later.


---
I feel like it's likely there should be some more tests written for this, so if reviewer wants to point out some other test coverage this may need that would be helpful!