### PR TITLE
GetCTC consent: add link to privacy policy, style checkbox simplified

### DIFF
--- a/app/views/ctc/questions/legal_consent/edit.html.erb
+++ b/app/views/ctc/questions/legal_consent/edit.html.erb
@@ -39,7 +39,13 @@
       </div>
     </div>
 
-    <%= f.cfa_checkbox(:agree_to_privacy_policy, t("views.ctc.questions.legal_consent.agree_to_share_html"), options: { id: "agree_to_privacy_policy" }) %>
+    <div class="spacing-below-60">
+      <%= f.simplified_cfa_checkbox(
+            :agree_to_privacy_policy,
+            t("views.ctc.questions.legal_consent.agree_to_share_html", privacy_policy_link: ctc_privacy_path),
+            options: { id: "agree_to_privacy_policy" }
+          ) %>
+    </div>
 
     <button class="button button--primary button--wide" type="submit">
       <%=t("general.continue") %>


### PR DESCRIPTION
somehow the link to the privacy policy got lost on the last commit, also yvonne wanted the checkbox to be borderless

<img width="1312" alt="image" src="https://user-images.githubusercontent.com/43800769/164075202-33552a66-79f8-4170-aa5c-d3f9fb61b4f7.png">
