### PR TITLE
Remove unused ClientsController#request_bank_account_info action

### DIFF
--- a/app/controllers/hub/clients_controller.rb
+++ b/app/controllers/hub/clients_controller.rb
@@ -50,11 +50,6 @@ module Hub
       @client = HubClientPresenter.new(@client)
     end
 
-    def request_bank_account_info
-      @client = Client.find(params[:id])
-      respond_to :js
-    end
-
     def edit
       return render "public_pages/page_not_found", status: 404 if @client.intake.is_ctc?
 


### PR DESCRIPTION
looks like a prototype for showing/hiding secrets that didn't
actually get used (Hub::Clients::BankAccount#show/hide were used instead)