### PR TITLE
Fix crash submitting a CTC without a bank account

### DIFF
--- a/app/controllers/flows_controller.rb
+++ b/app/controllers/flows_controller.rb
@@ -246,6 +246,7 @@ class FlowsController < ApplicationController
         city: 'Los Angeles',
         state: 'CA',
         zip_code: '90210',
+        refund_payment_method: 'check',
       }
       client = Client.create!(
         intake_attributes: intake_attributes,

--- a/app/models/fraud/indicator.rb
+++ b/app/models/fraud/indicator.rb
@@ -70,6 +70,9 @@ module Fraud
     end
 
     def duplicates(references)
+      # skip this rule if we can't check against the reference object
+      return false if references[reference].blank?
+
       duplicate_ids = DeduplificationService.duplicates(references[reference], *indicator_attributes, from_scope: query_model_name.constantize).pluck(:id)
       points = calculate_points_from_count(duplicate_ids.count)
       duplicate_ids.present? ? [points, duplicate_ids.uniq] : [0, []]


### PR DESCRIPTION
The fraud check expected there would always be one, but sometimes it is a check instead

Also the flows generates an intake with refund_payment_method of check now

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>