### PR TITLE
Configure open and close times for getctc season

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -120,6 +120,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_ctc_beta_cookie
+    return unless Routes::CtcDomain.new.matches?(request)
     ctc_beta = params[:ctc_beta]
     if ctc_beta == "1"
       cookies.permanent[:ctc_beta] = true

--- a/app/controllers/concerns/ctc/can_begin_intake_concern.rb
+++ b/app/controllers/concerns/ctc/can_begin_intake_concern.rb
@@ -9,13 +9,10 @@ module Ctc
     private
 
     def check_ctc_intake_cookie
-      return unless Rails.env.production?
+      return if open_for_ctc_intake?
       return if current_client&.intake&.is_ctc?
-      return if ENV['CTC_INTAKE_PUBLIC_ACCESS']
 
-      unless cookies[:ctc_intake_ok]
-        raise ActionController::RoutingError.new('Not Found')
-      end
+      raise ActionController::RoutingError.new('Not Found')
     end
   end
 end

--- a/app/controllers/ctc/ctc_pages_controller.rb
+++ b/app/controllers/ctc/ctc_pages_controller.rb
@@ -1,10 +1,6 @@
 module Ctc
   class CtcPagesController < CtcController
     def home
-      if cookies[:ctc_beta] && ENV['DISABLE_CTC_BETA_PARAM'].blank?
-        redirect_to Ctc::Questions::OverviewController.to_path_helper
-      end
-
       case session[:source]
       when "cactc", "fed", "child"
         redirect_to action: :help

--- a/app/controllers/ctc/ctc_pages_controller.rb
+++ b/app/controllers/ctc/ctc_pages_controller.rb
@@ -1,8 +1,7 @@
 module Ctc
   class CtcPagesController < CtcController
     def home
-      if params[:ctc_beta] == "1" && ENV['DISABLE_CTC_BETA_PARAM'].blank?
-        cookies.permanent[:ctc_intake_ok] = "yes"
+      if cookies[:ctc_beta] && ENV['DISABLE_CTC_BETA_PARAM'].blank?
         redirect_to Ctc::Questions::OverviewController.to_path_helper
       end
 

--- a/app/controllers/session_toggles_controller.rb
+++ b/app/controllers/session_toggles_controller.rb
@@ -1,5 +1,7 @@
 class SessionTogglesController < ApplicationController
   layout "hub"
+  include AccessControllable
+  before_action :require_sign_in, if: -> { Rails.env.production? }
 
   def index
     @toggle = SessionToggle.new(session, 'app_time')

--- a/app/views/ctc/ctc_pages/home.html.erb
+++ b/app/views/ctc/ctc_pages/home.html.erb
@@ -1,5 +1,3 @@
-<% intake_public_access = ENV['CTC_INTAKE_PUBLIC_ACCESS'] == 'true' %>
-
 <% content_for :page_title do %>
   <%= t("views.ctc_pages.home.title") %>
 <% end %>
@@ -14,7 +12,7 @@
         <h1 class="landing-page-header">
           <%= t("views.ctc_pages.home.header") %>
         </h1>
-        <% unless intake_public_access %>
+        <% unless open_for_ctc_intake? %>
           <p>
             <%= t("views.ctc_pages.home.subheader.launching_soon_html") %>
           </p>

--- a/app/views/ctc/ctc_pages/home.html.erb
+++ b/app/views/ctc/ctc_pages/home.html.erb
@@ -27,7 +27,7 @@
           <% end %>
         </p>
         <div>
-          <% if intake_public_access && open_for_ctc_intake? %>
+          <% if open_for_ctc_intake? %>
             <%= link_to t('views.ctc_pages.home.file_your_return'), questions_overview_path, id: "firstCta", class: "button button--primary button--locale-specific", lang: locale %>
           <% else %>
             <%= link_to t('views.ctc_pages.home.sign_up_for_updates'), new_ctc_signup_path, id: "firstCta", class: "button button--primary" %>

--- a/app/views/ctc/ctc_pages/stimulus_home.html.erb
+++ b/app/views/ctc/ctc_pages/stimulus_home.html.erb
@@ -1,5 +1,3 @@
-<% intake_public_access = ENV['CTC_INTAKE_PUBLIC_ACCESS'] == 'true' %>
-
 <% content_for :page_title do %>
   <%= t("views.ctc_pages.stimulus_home.title") %>
 <% end %>

--- a/app/views/session_toggles/index.html.erb
+++ b/app/views/session_toggles/index.html.erb
@@ -3,41 +3,52 @@
 <% content_for :back_to, "admin_tools" %>
 
 <% content_for :card do %>
-  <div class="slab">
+  <div class="slab slab--half-padded">
     <div class="grid">
       <h1><%= @main_heading %></h1>
+      <% unless Rails.env.production? %>
+        <div class="form-card__content">
+          <%= form_for(@toggle, url: { action: :create }, method: :post, local: true, builder: VitaMinFormBuilder, html: { class: "form-card form-card--long" }) do |f| %>
+            <%= f.hidden_field :name %>
+            <%=
+              f.cfa_input_field(
+                  :value,
+                  "App time (Pacific)",
+                  type: 'datetime-local',
+                  options: {
+                      value: f.object.value&.in_time_zone("America/Los_Angeles")&.strftime('%Y-%m-%dT%H:%M')
+                  },
+                  classes: ['form-width--long'],
+                  )
+            %>
+
+            <button class="button button--cta spacing-above-0" type="submit">
+              <%= t("general.save") %>
+            </button>
+            <button class="button button--cta spacing-above-0" type="submit" name="clear">
+              <%= "Clear" %>
+            </button>
+          <% end %>
+        </div>
+
+        <hr class="spacing-above-5 spacing-below-15"/>
+      <% end %>
 
       <p>Relevant times in this environment:</p>
-
+      <h4>Get Your Refund</h4>
       <ul class="list--bulleted">
         <li>Start of unique-links only intake: <%= timestamp(Rails.configuration.start_of_unique_links_only_intake) %></li>
         <li>Start of open intake: <%= timestamp(Rails.configuration.start_of_open_intake) %></li>
         <li>End of intake: <%= timestamp(Rails.configuration.end_of_intake) %></li>
       </ul>
 
-      <div class="form-card__content">
-        <%= form_for(@toggle, url: { action: :create }, method: :post, local: true, builder: VitaMinFormBuilder, html: { class: "form-card form-card--long" }) do |f| %>
-          <%= f.hidden_field :name %>
-          <%=
-            f.cfa_input_field(
-              :value,
-              "App time (Pacific)",
-              type: 'datetime-local',
-              options: {
-                value: f.object.value&.in_time_zone("America/Los_Angeles")&.strftime('%Y-%m-%dT%H:%M')
-              },
-              classes: ['form-width--long'],
-            )
-          %>
-
-          <button class="button button--cta spacing-above-0" type="submit">
-            <%= t("general.save") %>
-          </button>
-          <button class="button button--cta spacing-above-0" type="submit" name="clear">
-            <%= "Clear" %>
-          </button>
-        <% end %>
-      </div>
+      <h4>Get CTC</h4>
+      <ul class="list--bulleted">
+        <li>Soft launch: <%= timestamp(Rails.configuration.ctc_soft_launch) %></li>
+        <li>Full launch: <%= timestamp(Rails.configuration.ctc_full_launch) %></li>
+        <li>End of intake: <%= timestamp(Rails.configuration.ctc_end_of_intake) %></li>
+        <li>End of login: <%= timestamp(Rails.configuration.ctc_end_of_login) %></li>
+      </ul>
     </div>
   </div>
 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,6 +45,11 @@ module VitaMin
     config.start_of_open_intake = Time.find_zone('America/Los_Angeles').parse('2022-01-31 09:59:59')
     config.end_of_intake = Time.find_zone('America/Los_Angeles').parse('2022-08-31 23:59:59')
 
+    config.ctc_soft_launch = Time.find_zone("America/New_York").parse("2022-05-04 09:00:00")
+    config.ctc_full_launch = Time.find_zone("America/New_York").parse("2022-05-11 09:00:00")
+    config.ctc_end_of_intake = Time.find_zone("America/New_York").parse("2022-10-15 17:00:00")
+    config.ctc_end_of_login = Time.find_zone("America/New_York").parse("2022-10-19 17:00:00")
+
     config.include_optimizely = false
   end
 end

--- a/config/environments/demo.rb
+++ b/config/environments/demo.rb
@@ -21,5 +21,8 @@ Rails.application.configure do
   config.start_of_unique_links_only_intake = Time.find_zone('America/Los_Angeles').parse('2022-01-01 00:00:00')
   config.start_of_open_intake = Time.find_zone('America/Los_Angeles').parse('2022-01-03 00:00:00')
 
+  config.ctc_soft_launch = Time.find_zone("America/New_York").parse("2022-03-01 09:00:00")
+  config.ctc_full_launch = Time.find_zone("America/New_York").parse("2022-04-01 09:00:00")
+
   config.include_optimizely = true
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -100,4 +100,7 @@ Rails.application.configure do
   config.ctc_url = "http://ctc.localhost:3000"
   config.gyr_url = "http://localhost:3000"
   config.efile_environment = ""
+
+  config.ctc_soft_launch = Time.find_zone("America/New_York").parse("2022-03-01 09:00:00")
+  config.ctc_full_launch = Time.find_zone("America/New_York").parse("2022-04-01 09:00:00")
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,9 +44,7 @@ Rails.application.routes.draw do
   end
 
   get '/healthcheck' => 'public_pages#healthcheck'
-  unless Rails.env.production?
-    resources :session_toggles, only: [:index, :create]
-  end
+  resources :session_toggles, only: [:index, :create]
 
   constraints(Routes::GyrDomain.new) do
     mount Cfa::Styleguide::Engine => "/cfa"

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1218,6 +1218,41 @@ RSpec.describe ApplicationController do
     end
   end
 
+  describe "#set_ctc_beta_param" do
+    context "when the ctc_beta param is present and equal to 1" do
+      context "when not from Ctc domain" do
+        before do
+          allow_any_instance_of(Routes::CtcDomain).to receive(:matches?).and_return false
+        end
+
+        it "does not set a cookie" do
+          get :index, params: { ctc_beta: 1 }
+          expect(cookies[:ctc_beta]).not_to be_present
+        end
+      end
+
+      context "when on ctc domain" do
+        before do
+          allow_any_instance_of(Routes::CtcDomain).to receive(:matches?).and_return true
+        end
+        
+        context "when the param value is 1" do
+          it "sets the cookie value" do
+            get :index, params: { ctc_beta: 1 }
+            expect(cookies[:ctc_beta]).to eq "true"
+          end
+        end
+
+        context "when the param value is not 1" do
+          it "does not set the cookie" do
+            get :index, params: { ctc_beta: 2 }
+            expect(cookies[:ctc_beta]).not_to be_present
+          end
+        end
+      end
+    end
+  end
+
   describe "#set_source" do
     context "when there is already a source in the session" do
       before do

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -952,69 +952,6 @@ RSpec.describe ApplicationController do
         end
       end
     end
-
-    # context "during the time when only unique links allow intake" do
-    #   before do
-    #     allow(Rails.application.config).to receive(:start_of_unique_links_only_intake).and_return(past)
-    #     allow(Rails.application.config).to receive(:start_of_open_intake).and_return(future)
-    #     allow(Rails.application.config).to receive(:end_of_intake).and_return(future)
-    #   end
-    #
-    #   [
-    #       [nil, false],
-    #       ["yes", true],
-    #   ].each do |cookie_value, expected|
-    #     context "when the used_unique_link cookie is #{cookie_value.inspect}" do
-    #       before { request.cookies[:used_unique_link] = cookie_value }
-    #
-    #       it "returns #{expected}" do
-    #         expect(subject.open_for_intake?).to eq expected
-    #       end
-    #     end
-    #   end
-    # end
-
-    # context "during the time when intake is open" do
-    #   before do
-    #     allow(Rails.application.config).to receive(:start_of_unique_links_only_intake).and_return(past)
-    #     allow(Rails.application.config).to receive(:start_of_open_intake).and_return(past)
-    #     allow(Rails.application.config).to receive(:end_of_intake).and_return(future)
-    #   end
-    #
-    #   [
-    #       [nil, true],
-    #       ["yes", true],
-    #   ].each do |cookie_value, expected|
-    #     context "when the used_unique_link cookie is #{cookie_value.inspect}" do
-    #       before { request.cookies[:used_unique_link] = cookie_value }
-    #
-    #       it "returns #{expected}" do
-    #         expect(subject.open_for_intake?).to eq expected
-    #       end
-    #     end
-    #   end
-    # end
-
-    # context "during the time when intake is closed" do
-    #   before do
-    #     allow(Rails.configuration).to receive(:start_of_unique_links_only_intake).and_return(past)
-    #     allow(Rails.configuration).to receive(:start_of_open_intake).and_return(past)
-    #     allow(Rails.configuration).to receive(:end_of_intake).and_return(past)
-    #   end
-    #
-    #   [
-    #       [nil, false],
-    #       ["yes", false],
-    #   ].each do |cookie_value, expected|
-    #     context "when the used_unique_link cookie is #{cookie_value.inspect}" do
-    #       before { request.cookies[:used_unique_link] = cookie_value }
-    #
-    #       it "returns #{expected}" do
-    #         expect(subject.open_for_intake?).to eq expected
-    #       end
-    #     end
-    #   end
-    # end
   end
 
   describe "#open_for_ctc_login?" do
@@ -1030,7 +967,7 @@ RSpec.describe ApplicationController do
       allow_any_instance_of(described_class).to receive(:open_for_ctc_login?).and_call_original
     end
 
-    context "when intake is closed" do
+    context "when login is closed" do
       before do
         allow(Rails.application.config).to receive(:ctc_end_of_login).and_return(past)
 
@@ -1075,69 +1012,6 @@ RSpec.describe ApplicationController do
         end
       end
     end
-
-    # context "during the time when only unique links allow intake" do
-    #   before do
-    #     allow(Rails.application.config).to receive(:start_of_unique_links_only_intake).and_return(past)
-    #     allow(Rails.application.config).to receive(:start_of_open_intake).and_return(future)
-    #     allow(Rails.application.config).to receive(:end_of_intake).and_return(future)
-    #   end
-    #
-    #   [
-    #       [nil, false],
-    #       ["yes", true],
-    #   ].each do |cookie_value, expected|
-    #     context "when the used_unique_link cookie is #{cookie_value.inspect}" do
-    #       before { request.cookies[:used_unique_link] = cookie_value }
-    #
-    #       it "returns #{expected}" do
-    #         expect(subject.open_for_intake?).to eq expected
-    #       end
-    #     end
-    #   end
-    # end
-
-    # context "during the time when intake is open" do
-    #   before do
-    #     allow(Rails.application.config).to receive(:start_of_unique_links_only_intake).and_return(past)
-    #     allow(Rails.application.config).to receive(:start_of_open_intake).and_return(past)
-    #     allow(Rails.application.config).to receive(:end_of_intake).and_return(future)
-    #   end
-    #
-    #   [
-    #       [nil, true],
-    #       ["yes", true],
-    #   ].each do |cookie_value, expected|
-    #     context "when the used_unique_link cookie is #{cookie_value.inspect}" do
-    #       before { request.cookies[:used_unique_link] = cookie_value }
-    #
-    #       it "returns #{expected}" do
-    #         expect(subject.open_for_intake?).to eq expected
-    #       end
-    #     end
-    #   end
-    # end
-
-    # context "during the time when intake is closed" do
-    #   before do
-    #     allow(Rails.configuration).to receive(:start_of_unique_links_only_intake).and_return(past)
-    #     allow(Rails.configuration).to receive(:start_of_open_intake).and_return(past)
-    #     allow(Rails.configuration).to receive(:end_of_intake).and_return(past)
-    #   end
-    #
-    #   [
-    #       [nil, false],
-    #       ["yes", false],
-    #   ].each do |cookie_value, expected|
-    #     context "when the used_unique_link cookie is #{cookie_value.inspect}" do
-    #       before { request.cookies[:used_unique_link] = cookie_value }
-    #
-    #       it "returns #{expected}" do
-    #         expect(subject.open_for_intake?).to eq expected
-    #       end
-    #     end
-    #   end
-    # end
   end
 
   describe '#show_offseason_banner?' do

--- a/spec/controllers/concerns/ctc/can_begin_intake_concern_spec.rb
+++ b/spec/controllers/concerns/ctc/can_begin_intake_concern_spec.rb
@@ -10,7 +10,6 @@ describe Ctc::CanBeginIntakeConcern, type: :controller do
       end
     end
 
-
     context "when open for intake" do
       before do
         allow_any_instance_of(ApplicationController).to receive(:open_for_ctc_intake?).and_return true

--- a/spec/controllers/ctc/ctc_pages_controller_spec.rb
+++ b/spec/controllers/ctc/ctc_pages_controller_spec.rb
@@ -2,19 +2,6 @@ require "rails_helper"
 
 describe Ctc::CtcPagesController do
   describe "#home" do
-    context "with the ?ctc_beta=1 query parameter" do
-      before do
-        allow_any_instance_of(Routes::CtcDomain).to receive(:matches?).and_return true
-      end
-
-      it "sets the ctc_beta cookie and renders the homepage" do
-        get :home, params: { ctc_beta: "1" }
-
-        expect(cookies[:ctc_beta]).to eq('true')
-        expect(response).to be_okay
-      end
-    end
-
     context "without the ?ctc_beta=1 query parameter" do
       it "renders the homepage without setting the cookie" do
         get :home

--- a/spec/controllers/ctc/ctc_pages_controller_spec.rb
+++ b/spec/controllers/ctc/ctc_pages_controller_spec.rb
@@ -3,31 +3,23 @@ require "rails_helper"
 describe Ctc::CtcPagesController do
   describe "#home" do
     context "with the ?ctc_beta=1 query parameter" do
-      it "sets the ctc_intake_ok cookie and redirects to intake" do
-        get :home, params: {ctc_beta: "1"}
-
-        expect(cookies[:ctc_intake_ok]).to eq('yes')
-        expect(response).to redirect_to Ctc::Questions::OverviewController.to_path_helper
+      before do
+        allow_any_instance_of(Routes::CtcDomain).to receive(:matches?).and_return true
       end
 
-      context "when DISABLE_CTC_BETA_PARAM is set" do
-        around do |example|
-          ENV['DISABLE_CTC_BETA_PARAM'] = '1'
-          example.run
-          ENV.delete('DISABLE_CTC_BETA_PARAM')
-        end
+      it "sets the ctc_beta cookie and renders the homepage" do
+        get :home, params: { ctc_beta: "1" }
 
-        it "renders the home page without any cookies or redirects" do
-          get :home
-          expect(cookies[:ctc_intake_ok]).to be_nil
-          expect(response).to be_ok
-        end
+        expect(cookies[:ctc_beta]).to eq('true')
+        expect(response).to be_okay
       end
     end
 
     context "without the ?ctc_beta=1 query parameter" do
-      it "renders the homepage" do
+      it "renders the homepage without setting the cookie" do
         get :home
+        expect(cookies[:ctc_beta]).to be_nil
+
         expect(response).to be_ok
       end
     end

--- a/spec/controllers/session_toggles_controller_spec.rb
+++ b/spec/controllers/session_toggles_controller_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+describe SessionTogglesController do
+  describe "#index" do
+    context "when rails environment is not production" do
+      it "does not require login" do
+        get :index
+        expect(response.status).to eq 200
+      end
+    end
+
+    context 'when rails environment is production' do
+      before do
+        allow(Rails.env).to receive(:production?).and_return true
+      end
+
+      it_behaves_like :a_get_action_for_authenticated_users_only, action: :index
+    end
+  end
+end

--- a/spec/features/ctc/home_spec.rb
+++ b/spec/features/ctc/home_spec.rb
@@ -35,13 +35,9 @@ RSpec.feature "Visit CTC home page" do
     end
   end
 
-  context "when public access is allowed" do
+  context "when open for intake" do
     before do
-      ENV['CTC_INTAKE_PUBLIC_ACCESS'] = 'true'
-    end
-
-    after do
-      ENV.delete('CTC_INTAKE_PUBLIC_ACCESS')
+      allow_any_instance_of(ApplicationController).to receive(:open_for_ctc_intake?).and_return true
     end
 
     it "shows the button to file a simplified return" do


### PR DESCRIPTION
![Screen Shot 2022-04-19 at 4 25 17 PM](https://user-images.githubusercontent.com/4494389/164117203-d50aff7c-09e2-442a-9127-f58006eeb169.png)


---

Last year, I think we were auto-redirecting into the flow during the beta because the homepage wasn't set up to have any links to get started. However, now that we're able to toggle between open and closed states, we can change the home page during the beta state instead of redirecting into the flow directly. This seems to me to be more straightforward, so I removed the redirect into the flow for the beta (another reason I removed it is that I actually didn't fully understand how the ctc app was consuming the open_for_ctc_intake? and open_for_ctc_login? methods. Previously these were used in conjunction with additional environment variables, but we don't have to rely on those variables any more for this approach to work.

IF we want to make it clear to clients that we're in beta while it's beta time, maybe we can add a banner when the beta cookie is present and we haven't passed the full launch date yet...