### PR TITLE
Fix crash in Fraud::Indicator#missing_relationship

### DIFF
--- a/app/models/fraud/indicator.rb
+++ b/app/models/fraud/indicator.rb
@@ -84,7 +84,7 @@ module Fraud
 
       relationship = indicator_attributes[0]
 
-      scoped_records(references).where.missing(relationship).exists? ? [points, []] : [0, []]
+      scoped_records(references).where.missing(relationship.to_sym).exists? ? [points, []] : [0, []]
     end
 
     def equals(references)


### PR DESCRIPTION
the value being passed in was always a string, so it would always crash ([Sentry](https://sentry.io/organizations/codeforamerica/issues/3210942123/?referrer=slack))

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>