### PR TITLE
Fix missing relationship query by symbolizing attribute

### DIFF
--- a/app/models/fraud/indicator.rb
+++ b/app/models/fraud/indicator.rb
@@ -82,7 +82,7 @@ module Fraud
       # skip this rule if we can't check against the reference object
       return [0, []] if references[reference].blank?
 
-      relationship = indicator_attributes[0]
+      relationship = indicator_attributes[0].to_sym
 
       scoped_records(references).where.missing(relationship).exists? ? [points, []] : [0, []]
     end

--- a/spec/models/fraud/indicator_spec.rb
+++ b/spec/models/fraud/indicator_spec.rb
@@ -274,7 +274,7 @@ describe Fraud::Indicator do
     it "builds the appropriate query" do
       fraud_indicator.execute(tax_return: tax_return)
       expect(EfileSubmission).to have_received(:where).with({ "tax_return" => tax_return })
-      expect(query_double.where).to have_received(:missing).with("efile_submission_transitions")
+      expect(query_double.where).to have_received(:missing).with(:efile_submission_transitions)
     end
 
     context "when elements with missing transitions exist" do


### PR DESCRIPTION
Fixes the "[ArgumentError](https://sentry.io/organizations/codeforamerica/issues/3210942123/?referrer=slack)
only Hash, Symbol and Array are allowed" issue