### PR TITLE
CTC+Mixpanel: add various data-track-click events for CTC -> GYR offboarding

### DIFF
--- a/app/views/ctc/ctc_pages/home.html.erb
+++ b/app/views/ctc/ctc_pages/home.html.erb
@@ -37,7 +37,7 @@
           </div>
         <% else %>
           <div class="spacing-below-60">
-            <%= link_to t("views.ctc_pages.home.get_your_refund_link"), url_for(host: MultiTenantService.new(:gyr).host, controller: "/public_pages", action: 'home' ) %>
+            <%= link_to t("views.ctc_pages.home.get_your_refund_link"), url_for(host: MultiTenantService.new(:gyr).host, controller: "/public_pages", action: 'home', params: { source: 'gctc_ref' }), "data-track-click": "gctc_to_gyr" %>
           </div>
         <% end %>
       </div>
@@ -164,7 +164,7 @@
       </div>
       <div class="grid__item width-one-whole">
         <% t('views.ctc_pages.home.obtain.body_html',
-              link_to_get_your_refund: link_to(t("views.ctc_pages.home.service_name"), url_for(host: MultiTenantService.new(:gyr).host, controller: "/public_pages", action: 'home')),
+              link_to_get_your_refund: link_to(t("views.ctc_pages.home.service_name"), url_for(host: MultiTenantService.new(:gyr).host, controller: "/public_pages", action: 'home', params: { source: 'gctc_ref' }), "data-track-click": "gctc_to_gyr"),
               link_to_sign_up: link_to(t("views.ctc_pages.home.link_to_sign_up"), new_ctc_signup_path)).each do |body| %>
           <p><%= body %></p>
         <% end %>
@@ -176,7 +176,7 @@
           <div class="accordion__content" id="a4">
             <% standard_deduction = StandardDeduction.new(tax_year: current_tax_year) %>
             <% t('views.ctc_pages.home.obtain.not_filed.body_html',
-                link_to_get_your_refund: link_to(t("views.ctc_pages.home.service_name"), url_for(host: MultiTenantService.new(:gyr).host, controller: "/public_pages", action: 'home')),
+                link_to_get_your_refund: link_to(t("views.ctc_pages.home.service_name"), url_for(host: MultiTenantService.new(:gyr).host, controller: "/public_pages", action: 'home', params: { source: 'gctc_ref' }), "data-track-click": "gctc_to_gyr"),
                 link_to_sign_up: link_to(t("views.ctc_pages.home.link_to_sign_up"), new_ctc_signup_path),
                 single_deduction: number_to_currency(standard_deduction.standard_deduction(:single)),
                 joint_deduction: number_to_currency(standard_deduction.standard_deduction(:married_filing_jointly))

--- a/app/views/ctc/questions/file_full_return/edit.html.erb
+++ b/app/views/ctc/questions/file_full_return/edit.html.erb
@@ -19,7 +19,7 @@
     <%= t("views.ctc.questions.file_full_return.simplified_btn") %>
   <% end %>
 
-  <%= link_to url_for(host: MultiTenantService.new(:gyr).host, controller: "/public_pages", action: 'diy'), class: "button button--full-width text--centered" do %>
+  <%= link_to url_for(host: MultiTenantService.new(:gyr).host, controller: "/public_pages", action: 'diy', params: { source: 'gctc_ref' }), class: "button button--full-width text--centered", "data-track-click": "gctc_to_gyr_filefullreturn" do %>
     <%= t("views.ctc.questions.file_full_return.full_btn") %>
   <% end %>
 <% end %>

--- a/app/views/ctc/questions/restrictions/edit.html.erb
+++ b/app/views/ctc/questions/restrictions/edit.html.erb
@@ -17,7 +17,7 @@
     <%= t("general.continue") %>
   <% end %>
 
-  <%= link_to Ctc::Questions::UseGyrController.to_path_helper, class: "button button--full-width text--centered " do %>
+  <%= link_to Ctc::Questions::UseGyrController.to_path_helper, class: "button button--full-width text--centered ", "data-track-click": "gctc_to_gyr_restrictions" do %>
     <%= t("views.ctc.questions.restrictions.cannot_use_ctc") %>
   <% end %>
 <% end %>

--- a/app/views/ctc/questions/use_gyr/edit.html.erb
+++ b/app/views/ctc/questions/use_gyr/edit.html.erb
@@ -19,7 +19,7 @@
   <p><strong><%= t("views.ctc.questions.use_gyr.still_benefit") %></strong></p>
   <p><strong><%= t("views.ctc.questions.use_gyr.collect_money") %></strong></p>
 
-  <%= link_to url_for(host: MultiTenantService.new(:gyr).host, controller: "/public_pages", action: 'home'), class: "button button--wide button--primary text--centered spacing-above-60" do %>
+  <%= link_to url_for(host: MultiTenantService.new(:gyr).host, controller: "/public_pages", action: 'home', params: { source: 'gctc_ref' }), class: "button button--wide button--primary text--centered spacing-above-60", "data-track-click": "gctc_to_gyr_usegyr" do %>
     <%=t("views.ctc.questions.use_gyr.file_gyr") %>
   <% end %>
   <%= link_to root_path(anchor: 'ctc_faq'), class: "button button--wide text--centered" do %>


### PR DESCRIPTION
also, when we link to GYR from CTC, use the source '?source=gctc_ref'

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>