### PR TITLE
Use unscoped fraud indicators so that we can see historical fraud information

### DIFF
--- a/app/controllers/hub/efile_submissions_controller.rb
+++ b/app/controllers/hub/efile_submissions_controller.rb
@@ -21,7 +21,7 @@ module Hub
       @client = Hub::ClientsController::HubClientPresenter.new(client)
       authorize! :read, client
       @tax_returns = client.tax_returns.joins(:efile_submissions).eager_load(efile_submissions: :fraud_score).uniq # get all tax returns with submissions
-      @fraud_indicators = Fraud::Indicator.all
+      @fraud_indicators = Fraud::Indicator.unscoped
       redirect_to hub_client_path(id: @client.id) and return unless @tax_returns.present?
     end
 

--- a/app/controllers/hub/security_controller.rb
+++ b/app/controllers/hub/security_controller.rb
@@ -9,7 +9,7 @@ module Hub
       @client = Hub::ClientsController::HubClientPresenter.new(Client.find(params[:id]))
       @duplicate_bank_client_ids = duplicate_bank_client_ids
       @most_recent_verification_attempt = @client.verification_attempts.last
-      @fraud_indicators = Fraud::Indicator.all
+      @fraud_indicators = Fraud::Indicator.unscoped
       @security_events = (
         @client.efile_security_informations + @client.recaptcha_scores + @client.fraud_scores
       ).sort_by(&:created_at)

--- a/app/forms/hub/update_verification_attempt_form.rb
+++ b/app/forms/hub/update_verification_attempt_form.rb
@@ -30,7 +30,7 @@ module Hub
     end
 
     def fraud_indicators
-      @fraud_indicators ||= Fraud::Indicator.all
+      @fraud_indicators ||= Fraud::Indicator.unscoped
     end
 
     def can_write_note?


### PR DESCRIPTION
When we turned off the phone number rule in demo, old fraud scores that used a phone number no longer were able to process the data correctly because it relies on looking at the parent rule to understand the data in context. By using the unscoped query, we can look for old applied rules.

Another option would be to skip outputting detailed data about fraud rules that have since been disabled.