### PR TITLE
Show a flash message and refresh current page if authenticity token is invalid

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -392,4 +392,12 @@ class ApplicationController < ActionController::Base
       format.js { head :forbidden }
     end
   end
+
+  rescue_from 'ActionController::InvalidAuthenticityToken' do
+    DatadogApi.increment("rails.invalid_authenticity_token")
+    flash[:alert] = I18n.t('general.authenticity_token_invalid')
+
+    redirect_path = request.referer.presence || request.fullpath
+    redirect_to redirect_path
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -231,6 +231,7 @@ en:
     at_time: at %{time}
     atin: ATIN
     attachment: Attachment
+    authenticity_token_invalid: There was a problem handling your request. Please try again.
     back: Go back
     bank_account:
       account_number: Account number

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -231,6 +231,7 @@ es:
     at_time: a las %{time}
     atin: ATIN
     attachment: Adjunto
+    authenticity_token_invalid: Hubo un problema con la realización de su encargo. Inténtalo de nuevo.
     back: Regresa
     bank_account:
       account_number: Número de cuenta

--- a/spec/controllers/concerns/recaptcha_score_concern_spec.rb
+++ b/spec/controllers/concerns/recaptcha_score_concern_spec.rb
@@ -10,14 +10,7 @@ RSpec.describe RecaptchaScoreConcern, type: :controller do
     include MockDogapi
 
     before do
-      DatadogApi.configure do |c|
-        allow(c).to receive(:enabled).and_return(true)
-      end
-
-      @emit_point_params = []
-      allow(@mock_dogapi).to receive(:emit_point) do |*params|
-        @emit_point_params << params
-      end
+      enable_datadog_and_stub_emit_point
     end
 
     context "when able to verify" do

--- a/spec/invalid_csrf_token_spec.rb
+++ b/spec/invalid_csrf_token_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+feature "Invalid CSRF token redirect" do
+  include MockDogapi
+
+  before do
+    # Rails turns off CSRF checks in test by default, turn them back on for just this test
+    allow_any_instance_of(ApplicationController).to receive(:protect_against_forgery?).and_return(true)
+
+    enable_datadog_and_stub_emit_point
+  end
+
+  it "re-renders the form the user was on, with an error message" do
+    visit "/faq"
+
+    click_on I18n.t('views.public_pages.faq.question_groups.stimulus.how_many_stimulus_payments_were_there.question')
+    clear_cookies
+
+    expect do
+      click_on I18n.t('views.questions.successfully_submitted.satisfaction_face.positive')
+    end.not_to change { FaqSurvey.count }
+
+    expect(page).to have_content(I18n.t('general.authenticity_token_invalid'))
+
+    expect(@emit_point_params).to eq([
+      ["vita-min.dogapi.rails.invalid_authenticity_token", 1, {:tags=>["env:test"], :type=>"count"}]
+    ])
+  end
+end

--- a/spec/support/helpers/feature_helpers.rb
+++ b/spec/support/helpers/feature_helpers.rb
@@ -100,6 +100,19 @@ module FeatureHelpers
     contents
   end
 
+  def clear_cookies
+    browser = Capybara.current_session.driver.browser
+    if browser.respond_to?(:clear_cookies)
+      # Rack::MockSession
+      browser.clear_cookies
+    elsif browser.respond_to?(:manage) && browser.manage.respond_to?(:delete_all_cookies)
+      # Selenium::WebDriver
+      browser.manage.delete_all_cookies
+    else
+      raise "Don't know how to clear cookies. Weird driver?"
+    end
+  end
+
   def strip_inner_newlines(text)
     text.gsub(/\n/, '')
   end

--- a/spec/support/mock_dogapi.rb
+++ b/spec/support/mock_dogapi.rb
@@ -13,4 +13,15 @@ module MockDogapi
       DatadogApi.instance_variable_set("@synchronous", false)
     end
   end
+
+  def enable_datadog_and_stub_emit_point
+    DatadogApi.configure do |c|
+      allow(c).to receive(:enabled).and_return(true)
+    end
+
+    @emit_point_params = []
+    allow(@mock_dogapi).to receive(:emit_point) do |*params|
+      @emit_point_params << params
+    end
+  end
 end

--- a/spec/tasks/stats_spec.rb
+++ b/spec/tasks/stats_spec.rb
@@ -11,14 +11,7 @@ describe 'stats:track_metrics' do
   end
 
   before do
-    DatadogApi.configure do |c|
-      allow(c).to receive(:enabled).and_return(true)
-    end
-
-    @emit_point_params = []
-    allow(@mock_dogapi).to receive(:emit_point) do |*params|
-      @emit_point_params << params
-    end
+    enable_datadog_and_stub_emit_point
 
     # Creating an OutgoingEmail immediately queues a job, this is here to make 2 delayed jobs
     create_list(:outgoing_email, 2)


### PR DESCRIPTION
Mostly this is just so we don't get a barrage of HTTP 500 errors when
we get security scanned. Though it might also be nice for people on
mobile devices whose cookies get cleared.