### PR TITLE
CTC intake: remove spouse can be claimed as dependent question

### DIFF
--- a/app/controllers/ctc/questions/spouse_info_controller.rb
+++ b/app/controllers/ctc/questions/spouse_info_controller.rb
@@ -12,7 +12,7 @@ module Ctc
       private
 
       def next_path
-        return questions_use_gyr_path if @form.intake.spouse_tin_type_none? || @form.intake.spouse_can_be_claimed_as_dependent_yes?
+        return questions_use_gyr_path if @form.intake.spouse_tin_type_none?
 
         super
       end

--- a/app/forms/ctc/spouse_info_form.rb
+++ b/app/forms/ctc/spouse_info_form.rb
@@ -7,7 +7,6 @@ module Ctc
                        :spouse_suffix,
                        :spouse_tin_type,
                        :spouse_ssn,
-                       :spouse_can_be_claimed_as_dependent,
                        :spouse_active_armed_forces
     set_attributes_for :birthday, :spouse_birth_date_month, :spouse_birth_date_day, :spouse_birth_date_year
     set_attributes_for :confirmation, :spouse_ssn_confirmation

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -191,7 +191,6 @@
 #  spouse_active_armed_forces                           :integer          default(0)
 #  spouse_auth_token                                    :string
 #  spouse_birth_date                                    :date
-#  spouse_can_be_claimed_as_dependent                   :integer          default(0)
 #  spouse_consented_to_service                          :integer          default(0), not null
 #  spouse_consented_to_service_at                       :datetime
 #  spouse_consented_to_service_ip                       :inet

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -191,7 +191,6 @@
 #  spouse_active_armed_forces                           :integer          default("unfilled")
 #  spouse_auth_token                                    :string
 #  spouse_birth_date                                    :date
-#  spouse_can_be_claimed_as_dependent                   :integer          default("unfilled")
 #  spouse_consented_to_service                          :integer          default(0), not null
 #  spouse_consented_to_service_at                       :datetime
 #  spouse_consented_to_service_ip                       :inet
@@ -291,7 +290,6 @@ class Intake::CtcIntake < Intake
   enum filed_prior_tax_year: { unfilled: 0, filed_full: 1, filed_non_filer: 2, did_not_file: 3 }, _prefix: :filed_prior_tax_year
   enum spouse_filed_prior_tax_year: { unfilled: 0, filed_full_joint: 1, filed_non_filer_joint: 2, filed_full_separate: 3, filed_non_filer_separate: 4, did_not_file: 5 }, _prefix: :spouse_filed_prior_tax_year
   enum had_reportable_income: { yes: 1, no: 2 }, _prefix: :had_reportable_income
-  enum spouse_can_be_claimed_as_dependent: { unfilled: 0, yes: 1, no: 2 }, _prefix: :spouse_can_be_claimed_as_dependent
   enum spouse_active_armed_forces: { unfilled: 0, yes: 1, no: 2 }, _prefix: :spouse_active_armed_forces
   enum cannot_claim_me_as_a_dependent: { unfilled: 0, yes: 1, no: 2 }, _prefix: :cannot_claim_me_as_a_dependent
   enum primary_active_armed_forces: { unfilled: 0, yes: 1, no: 2 }, _prefix: :primary_active_armed_forces

--- a/app/models/intake/gyr_intake.rb
+++ b/app/models/intake/gyr_intake.rb
@@ -191,7 +191,6 @@
 #  spouse_active_armed_forces                           :integer          default(0)
 #  spouse_auth_token                                    :string
 #  spouse_birth_date                                    :date
-#  spouse_can_be_claimed_as_dependent                   :integer          default(0)
 #  spouse_consented_to_service                          :integer          default("unfilled"), not null
 #  spouse_consented_to_service_at                       :datetime
 #  spouse_consented_to_service_ip                       :inet

--- a/app/views/ctc/questions/spouse_info/edit.html.erb
+++ b/app/views/ctc/questions/spouse_info/edit.html.erb
@@ -22,7 +22,6 @@
       <%= f.cfa_checkbox(:ssn_no_employment, t('views.ctc.questions.legal_consent.ssn_not_valid_for_employment'), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_input_field(:spouse_ssn, t("views.ctc.questions.spouse_info.spouse_ssn_itin"), classes: ["form-width--long"], options: { maxlength: 11, 'data-mask': '000-00-0000' }) %>
       <%= f.cfa_input_field(:spouse_ssn_confirmation, t("views.ctc.questions.spouse_info.spouse_ssn_itin_confirmation"), classes: ["form-width--long"], options: { maxlength: 11, 'data-mask': '000-00-0000' }) %>
-      <%= f.cfa_checkbox(:spouse_can_be_claimed_as_dependent, t("views.ctc.questions.spouse_info.spouse_can_be_claimed_as_dependent"), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox(:spouse_active_armed_forces, t("views.ctc.questions.spouse_info.spouse_active_armed_forces", current_tax_year: current_tax_year), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <div class="reveal-shrink-wrapper">
         <%= render('components/molecules/reveal', title: t("views.ctc.questions.spouse_info.spouse_active_armed_forces_reveal")) do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2238,7 +2238,6 @@ en:
           spouse_active_armed_forces: My spouse was a member of the United States Armed Forces for any time in %{current_tax_year}
           spouse_active_armed_forces_reveal: Why are you asking this?
           spouse_active_armed_forces_reveal_content: Being a member of the Armed Forces will help us better calculate your Recovery Rebate Credit
-          spouse_can_be_claimed_as_dependent: My spouse can be claimed as a dependent by someone else
           spouse_dob: Spouse's date of birth
           spouse_first_name: Spouse's legal first name
           spouse_identity: Spouse's form of identity

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2195,7 +2195,6 @@ es:
           spouse_active_armed_forces: Mi cónyuge fue miembro de las Fuerzas Armadas de los Estados Unidos durante cierto tiempo en %{current_tax_year}
           spouse_active_armed_forces_reveal: "¿Por qué me preguntan esto?"
           spouse_active_armed_forces_reveal_content: El ser miembro de las Fuerzas Armadas nos ayudará a calcular mejor su Crédito de Recuperación de Reembolso
-          spouse_can_be_claimed_as_dependent: Mi cónyuge puede ser reclamado como dependiente por otra persona
           spouse_dob: Fecha de nacimiento de su cónyuge
           spouse_first_name: Nombre legal de su cónyuge
           spouse_identity: Tipo de identificación de su cónyuge

--- a/db/migrate/20220421222721_remove_spouse_can_be_claimed_as_dependent_from_intake.rb
+++ b/db/migrate/20220421222721_remove_spouse_can_be_claimed_as_dependent_from_intake.rb
@@ -1,0 +1,5 @@
+class RemoveSpouseCanBeClaimedAsDependentFromIntake < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :intakes, :spouse_can_be_claimed_as_dependent
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_01_183023) do
+ActiveRecord::Schema.define(version: 2022_04_21_222721) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -1093,7 +1093,6 @@ ActiveRecord::Schema.define(version: 2022_04_01_183023) do
     t.integer "spouse_active_armed_forces", default: 0
     t.string "spouse_auth_token"
     t.date "spouse_birth_date"
-    t.integer "spouse_can_be_claimed_as_dependent", default: 0
     t.integer "spouse_consented_to_service", default: 0, null: false
     t.datetime "spouse_consented_to_service_at"
     t.inet "spouse_consented_to_service_ip"

--- a/spec/factories/intakes.rb
+++ b/spec/factories/intakes.rb
@@ -191,7 +191,6 @@
 #  spouse_active_armed_forces                           :integer          default(0)
 #  spouse_auth_token                                    :string
 #  spouse_birth_date                                    :date
-#  spouse_can_be_claimed_as_dependent                   :integer          default(0)
 #  spouse_consented_to_service                          :integer          default(0), not null
 #  spouse_consented_to_service_at                       :datetime
 #  spouse_consented_to_service_ip                       :inet

--- a/spec/forms/ctc/spouse_info_form_spec.rb
+++ b/spec/forms/ctc/spouse_info_form_spec.rb
@@ -15,7 +15,6 @@ describe Ctc::SpouseInfoForm do
       spouse_ssn_confirmation: spouse_ssn,
       spouse_tin_type: tin_type,
       ssn_no_employment: ssn_no_employment,
-      spouse_can_be_claimed_as_dependent: "no",
       spouse_active_armed_forces: "no"
     }
   }
@@ -86,7 +85,6 @@ describe Ctc::SpouseInfoForm do
       expect(intake.spouse_ssn).to eq "999781224"
       expect(intake.spouse_last_four_ssn).to eq "1224"
       expect(intake.spouse_tin_type).to eq "itin"
-      expect(intake.spouse_can_be_claimed_as_dependent).to eq "no"
       expect(form.intake).to eq intake # resets intake to be the created and persisted intake
     end
 

--- a/spec/models/intake/gyr_intake_spec.rb
+++ b/spec/models/intake/gyr_intake_spec.rb
@@ -191,7 +191,6 @@
 #  spouse_active_armed_forces                           :integer          default(0)
 #  spouse_auth_token                                    :string
 #  spouse_birth_date                                    :date
-#  spouse_can_be_claimed_as_dependent                   :integer          default(0)
 #  spouse_consented_to_service                          :integer          default("unfilled"), not null
 #  spouse_consented_to_service_at                       :datetime
 #  spouse_consented_to_service_ip                       :inet

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -191,7 +191,6 @@
 #  spouse_active_armed_forces                           :integer          default(0)
 #  spouse_auth_token                                    :string
 #  spouse_birth_date                                    :date
-#  spouse_can_be_claimed_as_dependent                   :integer          default(0)
 #  spouse_consented_to_service                          :integer          default(0), not null
 #  spouse_consented_to_service_at                       :datetime
 #  spouse_consented_to_service_ip                       :inet


### PR DESCRIPTION
I checked production and `Intake.where.not(spouse_can_be_claimed_as_dependent: 0).count` is 0, which is why it seems safe to remove the column!