### PR TITLE
Instead of raising, use 0 as the fallback value for advanced CTC amount received

### DIFF
--- a/app/lib/efile/benefits_eligibility.rb
+++ b/app/lib/efile/benefits_eligibility.rb
@@ -54,9 +54,7 @@ module Efile
     end
 
     def advance_ctc_amount_received
-      raise "advance_ctc_amount_received is not present on intake #{intake.id}" unless intake.advance_ctc_amount_received
-
-      intake.advance_ctc_amount_received
+      intake.advance_ctc_amount_received || 0
     end
 
     # A quick calculation for ODC (Other Dependents Credit) which does not get paid out to our filers,

--- a/app/lib/irs8812_ty2021_pdf.rb
+++ b/app/lib/irs8812_ty2021_pdf.rb
@@ -8,7 +8,7 @@ class Irs8812Ty2021Pdf
   def initialize(submission)
     @submission = submission
     @qualifying_dependents = submission.qualifying_dependents
-    @ctc_qualifying_dependents =  @qualifying_dependents.select {|d| d.qualifying_ctc? }
+    @ctc_qualifying_dependents =  @qualifying_dependents.select(&:qualifying_ctc?)
     @benefits = Efile::BenefitsEligibility.new(tax_return: submission.tax_return, dependents: @qualifying_dependents)
   end
 
@@ -20,8 +20,8 @@ class Irs8812Ty2021Pdf
       ExclusionsTotalAmt2d: 0, #2d
       AGIExclusionsTotalAmt3: 0, #3
       NumQCSsn4a: @ctc_qualifying_dependents.length, #4a
-      NumQCOverSix4b: @ctc_qualifying_dependents.select { |d| d.age_during_tax_year < 6 }.length, #4b
-      NumQCUnderSix4c: @ctc_qualifying_dependents.select { |d| d.age_during_tax_year >= 6 }.length, #4c
+      NumQCOverSix4b: @ctc_qualifying_dependents.count { |d| d.age_during_tax_year < 6 }, #4b
+      NumQCUnderSix4c: @ctc_qualifying_dependents.count { |d| d.age_during_tax_year >= 6 }, #4c
       TotalCtcAmt5: @benefits.ctc_amount, #5
       NumNonCtcDependents6: @benefits.odc_amount / 500, #6
       OtherDependentCreditAmt7: @benefits.odc_amount, #7
@@ -36,7 +36,7 @@ class Irs8812Ty2021Pdf
       Line14c: 0, #14c
       Line14d: 0, #14d
       TotalCtcAmt14e: 0, #14e
-      AdvCtcReceived14f: @ctc_qualifying_dependents.none? ? nil : @benefits.advance_ctc_amount_received, #14f
+      AdvCtcReceived14f: @benefits.advance_ctc_amount_received, #14f
       CtcOwed14g: @benefits.outstanding_ctc_amount, #14g
       Line14h: 0, #14h
       CtcOwed14i: @benefits.outstanding_ctc_amount, #14i

--- a/app/lib/irs8812_ty2021_pdf.rb
+++ b/app/lib/irs8812_ty2021_pdf.rb
@@ -36,7 +36,7 @@ class Irs8812Ty2021Pdf
       Line14c: 0, #14c
       Line14d: 0, #14d
       TotalCtcAmt14e: 0, #14e
-      AdvCtcReceived14f: @ctc_qualifying_dependents.none? && @benefits.advance_ctc_amount_received.zero? ? nil : @benefits.advance_ctc_amount_received, #14f
+      AdvCtcReceived14f: @ctc_qualifying_dependents.none? ? nil : @benefits.advance_ctc_amount_received, #14f
       CtcOwed14g: @benefits.outstanding_ctc_amount, #14g
       Line14h: 0, #14h
       CtcOwed14i: @benefits.outstanding_ctc_amount, #14i

--- a/app/lib/submission_builder/ty2021/documents/schedule8812.rb
+++ b/app/lib/submission_builder/ty2021/documents/schedule8812.rb
@@ -35,7 +35,7 @@ module SubmissionBuilder
               xml.RCTCTaxLiabiltyLimitAmt 0 #14c
               xml.ODCAfterTaxLiabilityLimitAmt 0 #14d
               xml.CTCODCAfterTaxLiabilityLmtAmt 0 #14e
-              xml.AggregateAdvncCTCAmt ctc_qualifying_dependents.none? && benefits_eligibility.advance_ctc_amount_received.zero? ? nil : benefits_eligibility.advance_ctc_amount_received #14f
+              xml.AggregateAdvncCTCAmt ctc_qualifying_dependents.none? ? nil : benefits_eligibility.advance_ctc_amount_received #14f
               xml.NetCTCODCAfterLimitAmt benefits_eligibility.outstanding_ctc_amount #14g
               xml.NonrefundableODCAmt 0 #14h
               xml.RefundableCTCAmt benefits_eligibility.outstanding_ctc_amount #14i

--- a/app/lib/submission_builder/ty2021/documents/schedule8812.rb
+++ b/app/lib/submission_builder/ty2021/documents/schedule8812.rb
@@ -10,7 +10,7 @@ module SubmissionBuilder
           tax_return = submission.tax_return
           dependents = submission.qualifying_dependents
           benefits_eligibility = Efile::BenefitsEligibility.new(tax_return: tax_return, dependents: submission.qualifying_dependents)
-          ctc_qualifying_dependents = dependents.select { |d| d.qualifying_ctc? }
+          ctc_qualifying_dependents = dependents.select(&:qualifying_ctc?)
           build_xml_doc("IRS1040Schedule8812", documentId: "IRS1040Schedule8812", documentName: "IRS1040Schedule8812") do |xml|
             xml.AdjustedGrossIncomeAmt 0 # 1
             xml.ExcldSect933PuertoRicoIncmAmt 0 # 2a
@@ -18,8 +18,8 @@ module SubmissionBuilder
             xml.AdditionalIncomeAdjAmt 0 #2d
             xml.ModifiedAGIAmt 0 #3
             xml.QlfyChildUnderAgeSSNCnt ctc_qualifying_dependents.length #4a
-            xml.QlfyChildIncldUnderAgeSSNCnt ctc_qualifying_dependents.select { |d| d.age_during_tax_year < 6 }.length #4b
-            xml.QlfyChildOverAgeSSNCnt ctc_qualifying_dependents.select { |d| d.age_during_tax_year >= 6 }.length #4c
+            xml.QlfyChildIncldUnderAgeSSNCnt ctc_qualifying_dependents.count { |d| d.age_during_tax_year < 6 } #4b
+            xml.QlfyChildOverAgeSSNCnt ctc_qualifying_dependents.count { |d| d.age_during_tax_year >= 6 } #4c
             xml.MaxCTCAfterLimitAmt benefits_eligibility.ctc_amount #5
             xml.OtherDependentCnt benefits_eligibility.odc_amount / 500 #6
             xml.OtherDependentCreditAmt benefits_eligibility.odc_amount #7
@@ -35,7 +35,7 @@ module SubmissionBuilder
               xml.RCTCTaxLiabiltyLimitAmt 0 #14c
               xml.ODCAfterTaxLiabilityLimitAmt 0 #14d
               xml.CTCODCAfterTaxLiabilityLmtAmt 0 #14e
-              xml.AggregateAdvncCTCAmt ctc_qualifying_dependents.none? ? nil : benefits_eligibility.advance_ctc_amount_received #14f
+              xml.AggregateAdvncCTCAmt benefits_eligibility.advance_ctc_amount_received #14f
               xml.NetCTCODCAfterLimitAmt benefits_eligibility.outstanding_ctc_amount #14g
               xml.NonrefundableODCAmt 0 #14h
               xml.RefundableCTCAmt benefits_eligibility.outstanding_ctc_amount #14i

--- a/spec/lib/efile/benefits_eligibility_spec.rb
+++ b/spec/lib/efile/benefits_eligibility_spec.rb
@@ -114,6 +114,26 @@ describe Efile::BenefitsEligibility do
     end
   end
 
+  describe "#advance_ctc_amount_received" do
+    context "intake has advance_ctc_amount_received" do
+      before do
+        intake.update(advance_ctc_amount_received: 600)
+      end
+      it "returns the amount on intake" do
+        expect(subject.advance_ctc_amount_received).to eq 600
+      end
+    end
+
+    context "intake has a nil advance_ctc_amount_received" do
+      before do
+        intake.update(advance_ctc_amount_received: nil)
+      end
+      it "returns 0" do
+        expect(subject.advance_ctc_amount_received).to eq 0
+      end
+    end
+  end
+
   describe "#outstanding_recovery_rebate_credit" do
     let(:client) { create :client_with_ctc_intake_and_return, intake: create(:intake, eip1_amount_received: eip1_amount_received, eip2_amount_received: eip2_amount_received, eip3_amount_received: eip3_amount_received) }
     let(:eip1_amount_received) { 0 }

--- a/spec/lib/irs8812_ty2021_pdf_spec.rb
+++ b/spec/lib/irs8812_ty2021_pdf_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Irs8812Ty2021Pdf do
                                   "Line14c" => "0", #14c
                                   "Line14d" => "0", #14d
                                   "TotalCtcAmt14e" => "0", #14e
-                                  "AdvCtcReceived14f" => "0", #14f
+                                  "AdvCtcReceived14f" => "", #14f
                                   "CtcOwed14g" => "0", #14g
                                   "Line14h" => "0", #14h
                                   "CtcOwed14i" => "0", #14i

--- a/spec/lib/irs8812_ty2021_pdf_spec.rb
+++ b/spec/lib/irs8812_ty2021_pdf_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Irs8812Ty2021Pdf do
                                   "Line14c" => "0", #14c
                                   "Line14d" => "0", #14d
                                   "TotalCtcAmt14e" => "0", #14e
-                                  "AdvCtcReceived14f" => "", #14f
+                                  "AdvCtcReceived14f" => "0", #14f
                                   "CtcOwed14g" => "0", #14g
                                   "Line14h" => "0", #14h
                                   "CtcOwed14i" => "0", #14i


### PR DESCRIPTION
Raising was causing [this sentry](https://sentry.io/organizations/codeforamerica/issues/3216566515/?project=1880321&referrer=slack) when creating the 8812 PDF and no qualifying CTC dependents were present on the intake (clients don't fill out `advance_ctc_amount_received` if there are no qualifying dependents).

Investigating the use of this value, it seems that it cannot return nil because it is used to compute outstanding amount, but using 0 as a fallback should be ok.

After checking with product, it turns out listing 0 or blank are the same, and so listing 0 if they haven't actually filled out the value is totally valid. Going to go with that for simplicities sake.