### PR TITLE
Duplicate canonical 181962675

### DIFF
--- a/app/lib/canonical_email.rb
+++ b/app/lib/canonical_email.rb
@@ -1,0 +1,34 @@
+class CanonicalEmail
+  attr_accessor :handle, :domain
+  def initialize(email_address)
+    @handle, @domain = email_address.downcase.split("@")
+  end
+
+  def canonical_email
+    canonical_handle =  case domain
+                        when "gmail.com"
+                          plus_canonical.gsub(".", "")
+                        when "yahoo.com"
+                          hyphen_canonical
+                        when "hotmail.com", "outlook.com", "icloud.com", "me.com", "mac.com"
+                          plus_canonical
+                        else
+                          @handle
+                        end
+    [canonical_handle, domain].join("@")
+  end
+
+  def self.get(email)
+    new(email).canonical_email
+  end
+
+  private
+
+  def plus_canonical
+    @handle.split("+")[0]
+  end
+
+  def hyphen_canonical
+    @handle.split("-")[0]
+  end
+end

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -300,7 +300,7 @@ class Intake < ApplicationRecord
     self.needs_to_flush_searchable_data_set_at = Time.current
     if email_address.present?
       self.email_domain = email_address.split('@').last.downcase
-      self.canonical_email_address = compute_canonical_email_address
+      self.canonical_email_address = CanonicalEmail.get(email_address)
     end
     if primary_ssn_changed?
       self.primary_last_four_ssn = primary_ssn&.last(4)
@@ -526,14 +526,5 @@ class Intake < ApplicationRecord
 
   def itin_applicant?
     need_itin_help_yes?
-  end
-
-  def compute_canonical_email_address
-    if email_domain == 'gmail.com'
-      username, domain = email_address.split('@')
-      [username.gsub('.', ''), domain].join('@').downcase
-    else
-      email_address.downcase
-    end
   end
 end

--- a/spec/lib/canonical_email_spec.rb
+++ b/spec/lib/canonical_email_spec.rb
@@ -2,15 +2,15 @@ require "rails_helper"
 
 describe CanonicalEmail do
   describe ".get" do
-    context "google.com domain" do
+    context "gmail.com domain" do
       it "removes everything after the + and removes ." do
-        expect(CanonicalEmail.get("something.something-something+1234@google.com")).to eq "somethingsomething-something@google.com"
+        expect(CanonicalEmail.get("something.something-something+1234@gmail.com")).to eq "somethingsomething-something@gmail.com"
       end
     end
 
     context "yahoo.com domain" do
       it "removes everything following a hyphen" do
-        expect(CanonicalEmail.get("something.something-something-1234@yahoo.com")).to eq "something.somethingsomething@yahoo.com"
+        expect(CanonicalEmail.get("something.something-something+1234@yahoo.com")).to eq "something.something@yahoo.com"
       end
     end
     
@@ -21,6 +21,12 @@ describe CanonicalEmail do
         expect(CanonicalEmail.get("something.something-something+1234@icloud.com")).to eq "something.something-something@icloud.com"
         expect(CanonicalEmail.get("something.something-something+1234@me.com")).to eq "something.something-something@me.com"
         expect(CanonicalEmail.get("something.something-something+1234@mac.com")).to eq "something.something-something@mac.com"
+      end
+    end
+
+    context "any other domain" do
+      it "doesnt do anything to it" do
+        expect(CanonicalEmail.get("something.something-something+1234@other.com")).to eq "something.something-something+1234@other.com"
       end
     end
   end

--- a/spec/lib/canonical_email_spec.rb
+++ b/spec/lib/canonical_email_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe CanonicalEmail do
+  describe ".get" do
+    context "google.com domain" do
+      it "removes everything after the + and removes ." do
+        expect(CanonicalEmail.get("something.something-something+1234@google.com")).to eq "somethingsomething-something@google.com"
+      end
+    end
+
+    context "yahoo.com domain" do
+      it "removes everything following a hyphen" do
+        expect(CanonicalEmail.get("something.something-something-1234@yahoo.com")).to eq "something.somethingsomething@yahoo.com"
+      end
+    end
+    
+    context "hotmail.com, outlook.com, icloud.com, me.com, mac.com" do
+      it "removes everything after the +" do
+        expect(CanonicalEmail.get("something.something-something+1234@hotmail.com")).to eq "something.something-something@hotmail.com"
+        expect(CanonicalEmail.get("something.something-something+1234@outlook.com")).to eq "something.something-something@outlook.com"
+        expect(CanonicalEmail.get("something.something-something+1234@icloud.com")).to eq "something.something-something@icloud.com"
+        expect(CanonicalEmail.get("something.something-something+1234@me.com")).to eq "something.something-something@me.com"
+        expect(CanonicalEmail.get("something.something-something+1234@mac.com")).to eq "something.something-something@mac.com"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Duplicated canonical email rules:

• Gmail — Ignore + and everything after the +; ignore periods
• Yahoo — Ignore hyphen and everything following the hyphen
• Hotmail.com, outlook.com, icloud.com, me.com, mac.com — Ignore + and everything after the +
