### PR TITLE
Fraud updates

### DIFF
--- a/app/lib/canonical_email.rb
+++ b/app/lib/canonical_email.rb
@@ -19,6 +19,8 @@ class CanonicalEmail
   end
 
   def self.get(email)
+    return unless email.present?
+    
     new(email).canonical_email
   end
 

--- a/app/models/fraud/indicator.rb
+++ b/app/models/fraud/indicator.rb
@@ -111,7 +111,7 @@ module Fraud
     end
 
     def calculate_points_from_count(count)
-      return 0 unless count >= threshold
+      return 0 if threshold.present? && count < threshold
       return points unless multiplier.present?
 
       applied_count = (count - 1)

--- a/app/models/fraud/indicator.rb
+++ b/app/models/fraud/indicator.rb
@@ -72,7 +72,6 @@ module Fraud
     def duplicates(references)
       # skip this rule if we can't check against the reference object
       return passing_response if references[reference].blank?
-
       duplicate_ids = DeduplificationService.duplicates(references[reference], *indicator_attributes, from_scope: query_model_name.constantize).pluck(:id)
       points = calculate_points_from_count(duplicate_ids.count)
       duplicate_ids.present? ? response(points, duplicate_ids.uniq) : passing_response
@@ -97,7 +96,8 @@ module Fraud
     private
 
     def scoped_records(references)
-      self_reference = query_model_name.underscore == reference
+      compare_model_name = query_model_name.split("::")[0]
+      self_reference = compare_model_name.underscore == reference
       scope = self_reference ? { id: references[reference].id } : { reference => references[reference] }
       query_model_name.constantize.where(scope)
     end

--- a/app/models/fraud/indicator.rb
+++ b/app/models/fraud/indicator.rb
@@ -96,7 +96,7 @@ module Fraud
     private
 
     def scoped_records(references)
-      compare_model_name = query_model_name.split("::")[0]
+      compare_model_name = query_model_name.include?("Intake::") ? "Intake" : query_model_name # match from child intake type
       self_reference = compare_model_name.underscore == reference
       scope = self_reference ? { id: references[reference].id } : { reference => references[reference] }
       query_model_name.constantize.where(scope)
@@ -111,6 +111,7 @@ module Fraud
     end
 
     def calculate_points_from_count(count)
+      return 0 unless count >= threshold
       return points unless multiplier.present?
 
       applied_count = (count - 1)

--- a/app/models/fraud/indicator.rb
+++ b/app/models/fraud/indicator.rb
@@ -72,7 +72,9 @@ module Fraud
     def duplicates(references)
       # skip this rule if we can't check against the reference object
       return passing_response if references[reference].blank?
-      duplicate_ids = DeduplificationService.duplicates(references[reference], *indicator_attributes, from_scope: query_model_name.constantize).pluck(:id)
+
+      from_scope = query_model.respond_to?(:accessible_intakes) ? query_model.accessible_intakes : query_model
+      duplicate_ids = DeduplificationService.duplicates(references[reference], *indicator_attributes, from_scope: from_scope).pluck(:id)
       points = calculate_points_from_count(duplicate_ids.count)
       duplicate_ids.present? ? response(points, duplicate_ids.uniq) : passing_response
     end
@@ -95,11 +97,15 @@ module Fraud
 
     private
 
+    def query_model
+      query_model_name.constantize
+    end
+
     def scoped_records(references)
       compare_model_name = query_model_name.include?("Intake::") ? "Intake" : query_model_name # match from child intake type
       self_reference = compare_model_name.underscore == reference
       scope = self_reference ? { id: references[reference].id } : { reference => references[reference] }
-      query_model_name.constantize.where(scope)
+      query_model.where(scope)
     end
 
     def safelist

--- a/app/views/shared/_fraud_score_snapshot.html.erb
+++ b/app/views/shared/_fraud_score_snapshot.html.erb
@@ -9,8 +9,9 @@
   <div class="field-display spacing-below-5">
     <span class="form-question"><%= key.humanize %>:</span>
     <span class="label-value"><%= value["points"] %> points</span>
-    <br>
-    <span style="font-size: smaller">
+    <% if value["data"].present? %>
+      <br>
+      <span style="font-size: smaller">
       <% if indicator.indicator_type == "duplicates" %>
         <i><%= indicator.reference&.humanize %>s:
           <% value["data"].each_with_index do |id, i| %>
@@ -21,6 +22,7 @@
         <i><%= value["data"].join(", ") %></i>
       <% end %>
     </span>
+    <% end %>
   </div>
 <% end %>
 <% end %>

--- a/spec/lib/canonical_email_spec.rb
+++ b/spec/lib/canonical_email_spec.rb
@@ -29,5 +29,11 @@ describe CanonicalEmail do
         expect(CanonicalEmail.get("something.something-something+1234@other.com")).to eq "something.something-something+1234@other.com"
       end
     end
+
+    context "when passed argument is nil" do
+      it "is nil" do
+        expect(CanonicalEmail.get(nil)).to eq nil
+      end
+    end
   end
 end

--- a/spec/models/fraud/indicator_spec.rb
+++ b/spec/models/fraud/indicator_spec.rb
@@ -66,6 +66,22 @@ describe Fraud::Indicator do
       end
     end
 
+    context "when the reference is intake and query_model_name is Intake::CtcIntake" do
+      let(:intake) { create :intake }
+      let(:query_double) { double }
+      before do
+        indicator.reference = "intake"
+        indicator.query_model_name = "Intake::CtcIntake"
+        allow(Intake::CtcIntake).to receive(:where).and_return query_double
+        allow(query_double).to receive(:average)
+      end
+
+      it "builds the scoped query as a self-reference" do
+        indicator.execute(intake: intake)
+        expect(Intake::CtcIntake).to have_received(:where).with(id: intake.id)
+      end
+    end
+
     context "when the indicator type has a defined method" do
       before do
         allow(indicator).to receive(:average_under)

--- a/spec/models/fraud/indicator_spec.rb
+++ b/spec/models/fraud/indicator_spec.rb
@@ -244,6 +244,16 @@ describe Fraud::Indicator do
         multiplied_score = (80 + (2 * 2 * 0.25 * 80)).to_i
         expect(fraud_indicator.execute(intake: intake, client: client)).to eq [multiplied_score, [1,2,3]]
       end
+
+      context "when there are duplicates, but the threshold is greater than the number of duplicates" do
+        before do
+          fraud_indicator.threshold = 5
+        end
+
+        it "provides the duplicates but the score is 0" do
+          expect(fraud_indicator.execute(intake: intake, client: client)).to eq [0, [1,2,3]]
+        end
+      end
     end
 
     context "when there are no duplicates" do


### PR DESCRIPTION
Some cleanup of fraud things to fix some issues I've encountered with it:

- canonical email should not fail when email is nil
- we need to be able to use Intake::CtcIntake to scope down comparing phone numbers to only other ctc intakes instead of comparing to Gyr intakes too. need to update some of the model comparison code to allow for that.
- duplications allow for a lower threshold before we start penalizing based on points, but that was not implemented.