### PR TITLE
Fix eligibility head of household bug

### DIFF
--- a/app/lib/efile/benefits_eligibility.rb
+++ b/app/lib/efile/benefits_eligibility.rb
@@ -86,7 +86,11 @@ module Efile
     private
 
     def rrc_eligible_filer_count
-      return intake.primary_tin_type == "ssn" ? 1 : 0 if tax_return.filing_status_single?
+      raise "unsupported filing type" unless tax_return.filing_status.in? %w[married_filing_jointly head_of_household single]
+      
+      unless tax_return.filing_status_married_filing_jointly?
+        return intake.primary_tin_type == "ssn" ? 1 : 0
+      end
 
       # if one spouse is a member of the armed forces, both qualify for benefits
       return 2 if [intake.primary_active_armed_forces, intake.spouse_active_armed_forces].any?("yes")

--- a/app/lib/efile/benefits_eligibility.rb
+++ b/app/lib/efile/benefits_eligibility.rb
@@ -86,17 +86,18 @@ module Efile
     private
 
     def rrc_eligible_filer_count
-      raise "unsupported filing type" unless tax_return.filing_status.in? %w[married_filing_jointly head_of_household single]
-      
-      unless tax_return.filing_status_married_filing_jointly?
-        return intake.primary_tin_type == "ssn" ? 1 : 0
+      case tax_return.filing_status
+      when "single", "head_of_household"
+        intake.primary_tin_type == "ssn" ? 1 : 0
+      when "married_filing_jointly"
+        # if one spouse is a member of the armed forces, both qualify for benefits
+        return 2 if [intake.primary_active_armed_forces, intake.spouse_active_armed_forces].any?("yes")
+
+        # only filers with SSNs (valid for employment) are eligible for RRC
+        [intake.primary_tin_type, intake.spouse_tin_type].count { |tin_type| tin_type == "ssn" }
+      else
+        raise "unsupported filing type"
       end
-
-      # if one spouse is a member of the armed forces, both qualify for benefits
-      return 2 if [intake.primary_active_armed_forces, intake.spouse_active_armed_forces].any?("yes")
-
-      # only filers with SSNs (valid for employment) are eligible for RRC
-      [intake.primary_tin_type, intake.spouse_tin_type].count { |tin_type| tin_type == "ssn" }
     end
   end
 end

--- a/spec/lib/efile/benefits_eligibility_spec.rb
+++ b/spec/lib/efile/benefits_eligibility_spec.rb
@@ -305,6 +305,38 @@ describe Efile::BenefitsEligibility do
           expect(subject.rrc_eligible_filer_count).to eq 0
         end
       end
+
+      context "when the filing status is not included in the ones we support" do
+        before do
+          client.tax_returns.last.update(filing_status: "qualifying_widow")
+        end
+
+        it "raises an error" do
+          expect {
+            subject.rrc_eligible_filer_count
+          }.to raise_error StandardError
+        end
+      end
+
+      context "when the filing status is head of household" do
+        context "when tin type is ssn" do
+          before do
+            client.intake.update(primary_tin_type: "ssn")
+          end
+          it "returns 1 for filer count" do
+            expect(subject.rrc_eligible_filer_count).to eq 1
+          end
+        end
+
+        context "when tin type is not ssn" do
+          before do
+            client.intake.update(primary_tin_type: "itin")
+          end
+          it "returns 0 for filer count" do
+            expect(subject.rrc_eligible_filer_count).to eq 0
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
When toggling from married filing jointly to head of household, the eligibility calculations would still use married filing jointly logic to determine the calculation (tin type and some of the spouse questions would be answered). This will raise an error for the statuses we do not support (so that we dont run into this error again in the future if we add another filing status), and makes the logic more explicit.