### PR TITLE
Use ssn to check for duplicates on ctc clients

### DIFF
--- a/app/controllers/concerns/anonymous_intake_concern.rb
+++ b/app/controllers/concerns/anonymous_intake_concern.rb
@@ -7,10 +7,6 @@ module AnonymousIntakeConcern
 
   private
 
-  def redirect_if_duplicate_ctc_client
-    redirect_to questions_returning_client_path if current_intake.has_duplicate?
-  end
-
   def set_show_client_sign_in_link
     @show_client_sign_in_link = true
   end

--- a/app/controllers/concerns/ctc/after_verification_concern.rb
+++ b/app/controllers/concerns/ctc/after_verification_concern.rb
@@ -7,7 +7,7 @@ module Ctc
     def after_verification_actions
       send_mixpanel_event(event_name: "ctc_contact_verified")
       sign_in current_intake.client
-      current_intake.tax_returns.last.advance_to("intake_in_progress")
+      current_intake.tax_returns.last.advance_to("intake_in_progress") # transitioning this makes the client display in the hub
 
       ClientMessagingService.send_system_message_to_all_opted_in_contact_methods(
         client: current_intake.client,

--- a/app/controllers/ctc/questions/email_verification_controller.rb
+++ b/app/controllers/ctc/questions/email_verification_controller.rb
@@ -4,7 +4,6 @@ module Ctc
       include AnonymousIntakeConcern
       include Ctc::AfterVerificationConcern
       include Ctc::CanBeginIntakeConcern
-      before_action :redirect_if_duplicate_ctc_client
       before_action :send_verification_code, only: [:edit]
 
       layout "intake"

--- a/app/controllers/ctc/questions/filed_prior_tax_year_controller.rb
+++ b/app/controllers/ctc/questions/filed_prior_tax_year_controller.rb
@@ -2,9 +2,9 @@ module Ctc
   module Questions
     class FiledPriorTaxYearController < QuestionsController
       include Ctc::ResetToStartIfIntakeNotPersistedConcern
-
+      include AnonymousIntakeConcern
       layout "intake"
-
+      
       private
 
       def illustration_path

--- a/app/controllers/ctc/questions/legal_consent_controller.rb
+++ b/app/controllers/ctc/questions/legal_consent_controller.rb
@@ -16,13 +16,19 @@ module Ctc
 
       def after_update_success
         send_mixpanel_event(event_name: "ctc_provided_personal_info")
-        if current_intake.primary_consented_to_service_at.blank?
-          current_intake.update(
-              primary_consented_to_service_ip: request.remote_ip,
-              primary_consented_to_service_at: DateTime.current,
-              primary_consented_to_service: "yes"
-          )
+        unless current_intake.has_duplicate?
+          if current_intake.primary_consented_to_service_at.blank?
+            current_intake.update(
+                primary_consented_to_service_ip: request.remote_ip,
+                primary_consented_to_service_at: DateTime.current,
+                primary_consented_to_service: "yes"
+            )
+          end
         end
+      end
+
+      def next_path
+        current_intake.has_duplicate? ? questions_returning_client_path : super
       end
 
       def illustration_path; end

--- a/app/controllers/ctc/questions/phone_verification_controller.rb
+++ b/app/controllers/ctc/questions/phone_verification_controller.rb
@@ -4,7 +4,6 @@ module Ctc
       include AnonymousIntakeConcern
       include Ctc::AfterVerificationConcern
       include Ctc::CanBeginIntakeConcern
-      before_action :redirect_if_duplicate_ctc_client
       before_action :send_verification_code, only: [:edit]
 
       layout "intake"

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -351,6 +351,29 @@ class Intake < ApplicationRecord
     }
   }
 
+  scope :accessible_intakes, -> { where.not(primary_consented_to_service_at: nil) }
+
+  def duplicates
+    return itin_duplicates if itin_applicant?
+    return self.class.none unless hashed_primary_ssn.present?
+
+    DeduplificationService.duplicates(self, :hashed_primary_ssn, from_scope: self.class.accessible_intakes)
+  end
+
+  def itin_duplicates
+    if email_address.present? && sms_phone_number.present?
+      DeduplificationService.duplicates(self, :email_address, :primary_birth_date, from_scope: Intake::GyrIntake.accessible_intakes).or(
+          DeduplificationService.duplicates(self, :sms_phone_number, :primary_birth_date, from_scope: Intake::GyrIntake.accessible_intakes)
+      )
+    elsif email_address.present?
+      DeduplificationService.duplicates(self, :email_address, :primary_birth_date, from_scope: Intake::GyrIntake.accessible_intakes)
+    elsif sms_phone_number.present?
+      DeduplificationService.duplicates(self, :sms_phone_number, :primary_birth_date, from_scope: Intake::GyrIntake.accessible_intakes)
+    else
+      self.class.none
+    end
+  end
+
   def is_ctc?
     false
   end

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -354,19 +354,6 @@ class Intake::CtcIntake < Intake
     }
   }
 
-  def duplicates
-    if email_address.present? && sms_phone_number.present?
-      DeduplificationService.duplicates(self, :email_address, from_scope: self.class.accessible_intakes)
-          .or(DeduplificationService.duplicates(self, :sms_phone_number, from_scope: self.class.accessible_intakes))
-    elsif email_address.present?
-      DeduplificationService.duplicates(self, :email_address, from_scope: self.class.accessible_intakes)
-    elsif sms_phone_number.present?
-      DeduplificationService.duplicates(self, :sms_phone_number, from_scope: self.class.accessible_intakes)
-    else
-      self.class.none
-    end
-  end
-
   def itin_applicant?
     false
   end

--- a/spec/features/ctc/ctc_intake_offboard_duplicates_spec.rb
+++ b/spec/features/ctc/ctc_intake_offboard_duplicates_spec.rb
@@ -3,7 +3,13 @@ require "rails_helper"
 RSpec.feature "CTC Intake", :flow_explorer_screenshot_i18n_friendly, active_job: true do
   before do
     # create duplicated intake
-    create(:ctc_intake, email_address: "mango@example.com", email_notification_opt_in: "yes", email_address_verified_at: DateTime.now)
+    create(:ctc_intake,
+           primary_consented_to_service_at: DateTime.now,
+           primary_ssn: "111-22-8888",
+           email_address: "mango@example.com",
+           email_notification_opt_in: "yes",
+           email_address_verified_at: DateTime.now
+         )
     allow_any_instance_of(Routes::CtcDomain).to receive(:matches?).and_return(true)
   end
 
@@ -53,18 +59,6 @@ RSpec.feature "CTC Intake", :flow_explorer_screenshot_i18n_friendly, active_job:
     fill_in I18n.t('views.ctc.questions.legal_consent.ssn_confirmation'), with: "111-22-8888"
     fill_in I18n.t('views.ctc.questions.legal_consent.sms_phone_number'), with: "831-234-5678"
     check "agree_to_privacy_policy"
-    click_on I18n.t('general.continue')
-
-    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.filed_prior_tax_year.title', prior_tax_year: prior_tax_year))
-    choose I18n.t('views.ctc.questions.filed_prior_tax_year.did_not_file', prior_tax_year: prior_tax_year)
-    click_on I18n.t('general.continue')
-
-    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.contact_preference.title'))
-    click_on I18n.t('views.ctc.questions.contact_preference.email')
-
-    expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.email_address.title'))
-    fill_in I18n.t('views.questions.email_address.email_address'), with: "mango@example.com"
-    fill_in I18n.t('views.questions.email_address.email_address_confirmation'), with: "mango@example.com"
     click_on I18n.t('general.continue')
 
     expect(page).to have_selector("h1", text: I18n.t("views.questions.returning_client.title"))

--- a/spec/models/ctc_intake_spec.rb
+++ b/spec/models/ctc_intake_spec.rb
@@ -241,7 +241,7 @@ describe Intake::CtcIntake, requires_default_vita_partners: true do
         expect(described_class.accessible_intakes).to include intake
       end
     end
-    
+
     context "when navigator verification has occurred" do
       let!(:intake) { create :ctc_intake, navigator_has_verified_client_identity: true }
       it "is accessible" do
@@ -257,33 +257,17 @@ describe Intake::CtcIntake, requires_default_vita_partners: true do
       allow(dupe_double).to receive(:or)
     end
 
-    context "when only email is present" do
-      let(:intake) { create :ctc_intake, email_address: "mango@example.com", sms_phone_number: nil }
-      it "responds with duplicates from both email and sms" do
+    context "when hashed primary ssn is present" do
+      let(:intake) { create :ctc_intake, hashed_primary_ssn: "123456789" }
+      it "builds a query looking for duplicates" do
         intake.duplicates
-        expect(DeduplificationService).to have_received(:duplicates).exactly(1).times.with(intake, :email_address, from_scope: described_class.accessible_intakes)
+        expect(DeduplificationService).to have_received(:duplicates).exactly(1).times.with(intake, :hashed_primary_ssn, from_scope: described_class.accessible_intakes)
       end
     end
 
-    context "when only sms is present" do
-      let(:intake) { create :ctc_intake, email_address: nil, sms_phone_number: "+18324658840" }
-      it "responds with duplicates from sms" do
-        intake.duplicates
-        expect(DeduplificationService).to have_received(:duplicates).exactly(1).times.with(intake, :sms_phone_number, from_scope: described_class.accessible_intakes)
-      end
-    end
-
-    context "when both email and sms are present" do
-      let(:intake) { create :ctc_intake, email_address: "mango@example.com", sms_phone_number: "+18324658840" }
-      it "responds with duplicates from both email and sms" do
-        intake.duplicates
-        expect(DeduplificationService).to have_received(:duplicates).exactly(2).times
-      end
-    end
-
-    context "when neither phone number nor email are present" do
-      let(:intake) { create :ctc_intake, email_address: nil, sms_phone_number: nil }
-      it "responds with an empty ActiveRecord relation" do
+    context "when hashed primary ssn is not present" do
+      let(:intake) { create :ctc_intake, hashed_primary_ssn: nil }
+      it "responds with an empty collection" do
         expect(intake.duplicates).to eq described_class.none
       end
     end


### PR DESCRIPTION
Convert CTC clients to using SSN for duplicate check, but leave accessible intakes to those that have verified contact info.

This means that clients WILL be able to create multiple intakes with the same SSN, but they will not show up in the hub or block clients from creating another intake until they are also able to log in.