### PR TITLE
Only display spouse indicators if MFJ

### DIFF
--- a/app/lib/submission_builder/shared/return_header1040.rb
+++ b/app/lib/submission_builder/shared/return_header1040.rb
@@ -34,9 +34,7 @@ module SubmissionBuilder
           }
           xml.SelfSelectPINGrp {
             xml.PrimaryBirthDt date_type(intake.primary_birth_date)
-            if tax_return.filing_jointly?
-              xml.SpouseBirthDt date_type(intake.spouse_birth_date) if tax_return.filing_jointly?
-            end
+            xml.SpouseBirthDt date_type(intake.spouse_birth_date) if tax_return.filing_jointly?
             if intake.primary_prior_year_signature_pin.present?
               xml.PrimaryPriorYearPIN intake.primary_prior_year_signature_pin
             else

--- a/app/lib/submission_builder/ty2021/documents/irs1040.rb
+++ b/app/lib/submission_builder/ty2021/documents/irs1040.rb
@@ -21,8 +21,8 @@ module SubmissionBuilder
             xml.VirtualCurAcquiredDurTYInd intake.has_crypto_income
             xml.Primary65OrOlderInd "X" if tax_return.primary_age_65_or_older?
             xml.PrimaryBlindInd "X" if intake.was_blind_yes?
-            xml.Spouse65OrOlderInd "X" if tax_return.spouse_age_65_or_older?
-            xml.SpouseBlindInd "X" if intake.spouse_was_blind_yes?
+            xml.Spouse65OrOlderInd "X" if tax_return.spouse_age_65_or_older? && tax_return.filing_jointly?
+            xml.SpouseBlindInd "X" if intake.spouse_was_blind_yes? && tax_return.filing_jointly?
             xml.TotalBoxesCheckedCnt boxes_checked unless boxes_checked.zero?
             xml.TotalExemptPrimaryAndSpouseCnt filer_exemption_count
             qualifying_dependents.each do |dependent|
@@ -79,8 +79,8 @@ module SubmissionBuilder
         def boxes_checked(intake, tax_return)
           [intake.was_blind_yes?,
            tax_return.primary_age_65_or_older?,
-           tax_return.spouse_age_65_or_older?,
-           intake.spouse_was_blind_yes?
+           tax_return.spouse_age_65_or_older? && tax_return.filing_jointly?,
+           intake.spouse_was_blind_yes? && tax_return.filing_jointly?
           ].count(true)
         end
       end

--- a/spec/lib/submission_builder/ty2021/documents/irs1040_spec.rb
+++ b/spec/lib/submission_builder/ty2021/documents/irs1040_spec.rb
@@ -144,5 +144,19 @@ describe SubmissionBuilder::Ty2021::Documents::Irs1040 do
         expect(described_class.build(submission)).to be_valid
       end
     end
+
+    context "when not filing jointly but spouse information exists" do
+      before do
+        submission.tax_return.update(filing_status: "head_of_household")
+        submission.intake.update(spouse_was_blind: "yes", was_blind: "yes", primary_birth_date: Date.today - 85.years, spouse_birth_date: Date.today - 80.years)
+      end
+
+      it "does not check the spouse boxes on the return" do
+        xml = Nokogiri::XML::Document.parse(described_class.build(submission).document.to_xml)
+        expect(xml.at("Spouse65OrOlderInd")).to be_nil
+        expect(xml.at("SpouseBlindInd")).to be_nil
+        expect(xml.at("TotalBoxesCheckedCnt").text).to eq "2"
+      end
+    end
   end
 end


### PR DESCRIPTION
The other spouse indicators on the header and in the 1040 seem to already have the if filing_status guard