### PR TITLE
Rename column from deny to risky per fraud rule

### DIFF
--- a/app/models/fraud/indicators/domain.rb
+++ b/app/models/fraud/indicators/domain.rb
@@ -4,16 +4,16 @@
 #
 #  id           :bigint           not null, primary key
 #  activated_at :datetime
-#  deny         :boolean
 #  name         :string
+#  risky        :boolean
 #  safe         :boolean
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #
 # Indexes
 #
-#  index_fraud_indicators_domains_on_deny  (deny)
-#  index_fraud_indicators_domains_on_safe  (safe)
+#  index_fraud_indicators_domains_on_risky  (risky)
+#  index_fraud_indicators_domains_on_safe   (safe)
 #
 module Fraud
   module Indicators
@@ -27,10 +27,10 @@ module Fraud
       end
 
       validates :name, format: { with: /(\.)/ }
-      validate :deny_or_safe
+      validate :risky_or_safe
 
-      def self.denylist
-        where(deny: true).pluck(:name)
+      def self.riskylist
+        where(risky: true).pluck(:name)
       end
 
       def self.safelist
@@ -39,15 +39,15 @@ module Fraud
 
       private
 
-      def deny_or_safe
-        if deny.present? && safe.present?
-          cant_be_both = "Only one of deny or safe are allowed"
-          errors.add(:deny, cant_be_both)
+      def risky_or_safe
+        if risky.present? && safe.present?
+          cant_be_both = "Only one of risky or safe are allowed"
+          errors.add(:risky, cant_be_both)
           errors.add(:safe, cant_be_both)
         end
-        unless deny.present? || safe.present?
-          must_be_one = "One of deny or safe are required"
-          errors.add(:deny, must_be_one)
+        unless risky.present? || safe.present?
+          must_be_one = "One of risky or safe are required"
+          errors.add(:risky, must_be_one)
           errors.add(:safe, must_be_one)
         end
       end

--- a/db/migrate/20220427204338_change_deny_to_risky_on_fraud_indicator_domain.rb
+++ b/db/migrate/20220427204338_change_deny_to_risky_on_fraud_indicator_domain.rb
@@ -1,0 +1,5 @@
+class ChangeDenyToRiskyOnFraudIndicatorDomain < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured { rename_column :fraud_indicators_domains, :deny, :risky }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_26_000825) do
+ActiveRecord::Schema.define(version: 2022_04_27_204338) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -823,11 +823,11 @@ ActiveRecord::Schema.define(version: 2022_04_26_000825) do
   create_table "fraud_indicators_domains", force: :cascade do |t|
     t.datetime "activated_at"
     t.datetime "created_at", precision: 6, null: false
-    t.boolean "deny"
     t.string "name"
+    t.boolean "risky"
     t.boolean "safe"
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["deny"], name: "index_fraud_indicators_domains_on_deny"
+    t.index ["risky"], name: "index_fraud_indicators_domains_on_risky"
     t.index ["safe"], name: "index_fraud_indicators_domains_on_safe"
   end
 

--- a/spec/models/fraud/indicators/domain_spec.rb
+++ b/spec/models/fraud/indicators/domain_spec.rb
@@ -4,16 +4,16 @@
 #
 #  id           :bigint           not null, primary key
 #  activated_at :datetime
-#  deny         :boolean
 #  name         :string
+#  risky        :boolean
 #  safe         :boolean
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #
 # Indexes
 #
-#  index_fraud_indicators_domains_on_deny  (deny)
-#  index_fraud_indicators_domains_on_safe  (safe)
+#  index_fraud_indicators_domains_on_risky  (risky)
+#  index_fraud_indicators_domains_on_safe   (safe)
 #
 require "rails_helper"
 
@@ -27,21 +27,21 @@ describe Fraud::Indicators::Domain do
       end
     end
 
-    context "when deny and safe are both set" do
+    context "when risky and safe are both set" do
       it "is not valid" do
-        instance = described_class.new(name: "gmail.com", safe: true, deny: true)
+        instance = described_class.new(name: "gmail.com", safe: true, risky: true)
         expect(instance).not_to be_valid
-        expect(instance.errors[:safe]).to include("Only one of deny or safe are allowed")
-        expect(instance.errors[:deny]).to include("Only one of deny or safe are allowed")
+        expect(instance.errors[:safe]).to include("Only one of risky or safe are allowed")
+        expect(instance.errors[:risky]).to include("Only one of risky or safe are allowed")
       end
     end
 
-    context "when neither deny or safe are set" do
+    context "when neither risky or safe are set" do
       it "is not valid" do
         instance = described_class.new(name: "gmail.com")
         expect(instance).not_to be_valid
-        expect(instance.errors[:safe]).to include "One of deny or safe are required"
-        expect(instance.errors[:deny]).to include "One of deny or safe are required"
+        expect(instance.errors[:safe]).to include "One of risky or safe are required"
+        expect(instance.errors[:risky]).to include "One of risky or safe are required"
       end
     end
   end


### PR DESCRIPTION
The existing implementation to create rules requires "riskylist" but I accidentally called it deny