### PR TITLE
When security scan requests text/plain, allow it to get a 404 [#182030940]

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -400,4 +400,10 @@ class ApplicationController < ActionController::Base
     redirect_path = request.referer.presence || request.fullpath
     redirect_to redirect_path
   end
+
+  rescue_from 'ActionController::UnknownFormat' do
+    respond_to do |format|
+      format.any { head 404 }
+    end
+  end
 end

--- a/spec/controllers/hub/clients/bank_accounts_controller_spec.rb
+++ b/spec/controllers/hub/clients/bank_accounts_controller_spec.rb
@@ -30,7 +30,8 @@ describe Hub::Clients::BankAccountsController, type: :controller do
       end
 
       it "does not respond with html" do
-        expect { get :show, params: params }.to raise_error ActionController::UnknownFormat
+        get :show, params: params
+        expect(response).to be_not_found
       end
 
       it "creates an AccessLog" do
@@ -81,7 +82,8 @@ describe Hub::Clients::BankAccountsController, type: :controller do
       end
 
       it "does not respond with html" do
-        expect { get :show, params: params }.to raise_error ActionController::UnknownFormat
+        get :show, params: params
+        expect(response).to be_not_found
       end
     end
   end

--- a/spec/controllers/hub/clients/secrets_controller_spec.rb
+++ b/spec/controllers/hub/clients/secrets_controller_spec.rb
@@ -32,7 +32,8 @@ describe Hub::Clients::SecretsController, type: :controller do
       end
 
       it "does not respond with html" do
-        expect { get :show, params: params }.to raise_error ActionController::UnknownFormat
+        get :show, params: params
+        expect(response).to be_not_found
       end
 
       context "AccessLogs" do
@@ -103,7 +104,8 @@ describe Hub::Clients::SecretsController, type: :controller do
       end
 
       it "does not respond with html" do
-        expect { get :hide, params: params }.to raise_error ActionController::UnknownFormat
+        get :hide, params: params
+        expect(response).to be_not_found
       end
     end
   end

--- a/spec/controllers/hub/source_params_controller_spec.rb
+++ b/spec/controllers/hub/source_params_controller_spec.rb
@@ -28,7 +28,8 @@ describe Hub::SourceParamsController do
       end
 
       it "does not respond with html" do
-        expect { post :create, params: params }.to raise_error ActionController::UnknownFormat
+        post :create, params: params
+        expect(response).to be_not_found
       end
 
       context "when the code does not already exist" do
@@ -72,7 +73,8 @@ describe Hub::SourceParamsController do
     end
 
     it "does not respond with html" do
-      expect { delete :destroy, params: params }.to raise_error ActionController::UnknownFormat
+      delete :destroy, params: params
+      expect(response).to be_not_found
     end
 
     context "when the source param exists" do

--- a/spec/controllers/hub/zip_codes_controller_spec.rb
+++ b/spec/controllers/hub/zip_codes_controller_spec.rb
@@ -28,7 +28,8 @@ describe Hub::ZipCodesController do
       end
 
       it "does not respond with html" do
-        expect { post :create, params: params }.to raise_error ActionController::UnknownFormat
+        post :create, params: params
+        expect(response).to be_not_found
       end
 
       context "when the code does not already exist" do
@@ -83,7 +84,8 @@ describe Hub::ZipCodesController do
     end
 
     it "does not respond with html" do
-      expect { delete :destroy, params: params }.to raise_error ActionController::UnknownFormat
+      delete :destroy, params: params
+      expect(response).to be_not_found
     end
 
     context "when the zip code object exists" do


### PR DESCRIPTION
Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>