### PR TITLE
Remove non-working Honeycrisp routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,8 +53,6 @@ Rails.application.routes.draw do
   end
 
   constraints(Routes::GyrDomain.new) do
-    mount Cfa::Styleguide::Engine => "/cfa"
-
     # In order to disambiguate versions of english pages with and without locales, we redirect to URLs including the locale
     # If we redirect here in the route declarations, we can't inspect accept headers to determine the proper default locale,
     # hence the redirect actions in public_pages.


### PR DESCRIPTION
Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>

Visiting https://demo.getyourrefund.org/cfa/styleguide results in https://sentry.io/organizations/codeforamerica/issues/3081202291/?referrer=slack 