### PR TITLE
Hub all clients table: wrap cell contents without making all cells too narrow

### DIFF
--- a/app/assets/stylesheets/components/_index-table.scss
+++ b/app/assets/stylesheets/components/_index-table.scss
@@ -119,7 +119,7 @@ It expects to be the primary content of the given page (full width).
 
   &__cell {
     padding: 0.8rem $s25/2;
-    white-space: nowrap;
+    min-width: 15rem;
 
     &:first-child {
       padding-left: 3rem;
@@ -131,6 +131,10 @@ It expects to be the primary content of the given page (full width).
     &--center {
       text-align: center;
     }
+  }
+
+  &__cell.narrow {
+    min-width: unset;
   }
 
   &__vertical_align {

--- a/app/assets/stylesheets/components/_index-table.scss
+++ b/app/assets/stylesheets/components/_index-table.scss
@@ -119,7 +119,6 @@ It expects to be the primary content of the given page (full width).
 
   &__cell {
     padding: 0.8rem $s25/2;
-    min-width: 15rem;
 
     &:first-child {
       padding-left: 3rem;
@@ -131,10 +130,6 @@ It expects to be the primary content of the given page (full width).
     &--center {
       text-align: center;
     }
-  }
-
-  &__cell.narrow {
-    min-width: unset;
   }
 
   &__vertical_align {

--- a/app/assets/stylesheets/components/_tax-return-list.scss
+++ b/app/assets/stylesheets/components/_tax-return-list.scss
@@ -171,6 +171,7 @@
   line-height: $font-size-18;
   padding: $s5 $s10;
   border: 1px solid $color-green-money;
+  white-space: nowrap;
 
   // More info about styling with data attributes can be found at
   // https://css-tricks.com/a-complete-guide-to-data-attributes/

--- a/app/assets/stylesheets/components/_tax-return-list.scss
+++ b/app/assets/stylesheets/components/_tax-return-list.scss
@@ -171,7 +171,6 @@
   line-height: $font-size-18;
   padding: $s5 $s10;
   border: 1px solid $color-green-money;
-  white-space: nowrap;
 
   // More info about styling with data attributes can be found at
   // https://css-tricks.com/a-complete-guide-to-data-attributes/

--- a/app/views/hub/clients/index.html.erb
+++ b/app/views/hub/clients/index.html.erb
@@ -96,7 +96,7 @@
         <tbody class="index-table__body clients-table">
         <% @clients.map { |client| Hub::ClientsController::HubClientPresenter.new(client) }.each do |client| %>
           <tr id="client-<%= client.id %>" class="index-table__row client-row">
-            <td class="index-table__cell narrow client-attribute__needs-response">
+            <td class="index-table__cell client-attribute__needs-response">
               <%= render "shared/urgent_icon", client: client %>
             </td>
             <%= tag.th(
@@ -115,13 +115,13 @@
                 <% end %>
               <% end %>
             <% end %>
-            <td class="index-table__cell narrow"><%= client.id %></td>
+            <td class="index-table__cell"><%= client.id %></td>
             <td class="index-table__cell">
               <%= client.vita_partner&.name || t("general.none") %>
             </td>
             <td class="index-table__cell"><%= client.preferred_language ? t("general.language_options.#{client.preferred_language}") : t('general.NA') %></td>
-            <td class="index-table__cell narrow"><%= "✓" if client.intake.had_unemployment_income == "yes" %></td>
-            <td class="index-table__cell"><%= formatted_datetime(client.updated_at) %></td>
+            <td class="index-table__cell"><%= "✓" if client.intake.had_unemployment_income == "yes" %></td>
+            <td class="index-table__cell text--no-wrap"><%= formatted_datetime(client.updated_at) %></td>
 
             <% if client.last_outgoing_communication_at.present? %>
               <% business_days_count = business_days_ago(client.last_outgoing_communication_at) %>
@@ -143,8 +143,8 @@
               <td class="index-table__cell"><%= t("general.update") %></td>
             <% end %>
 
-            <td class="index-table__cell"><%= formatted_datetime(client.intake.created_at) || "-" %> </td>
-            <td class="index-table__cell narrow"><%= client.intake.state_of_residence %></td>
+            <td class="index-table__cell text--no-wrap"><%= formatted_datetime(client.intake.created_at) || "-" %> </td>
+            <td class="index-table__cell"><%= client.intake.state_of_residence %></td>
             <td class="index-table__cell">
               <%= render "shared/tax_return_list", client: client, show_checkboxes: true %>
             </td>

--- a/app/views/hub/clients/index.html.erb
+++ b/app/views/hub/clients/index.html.erb
@@ -96,7 +96,7 @@
         <tbody class="index-table__body clients-table">
         <% @clients.map { |client| Hub::ClientsController::HubClientPresenter.new(client) }.each do |client| %>
           <tr id="client-<%= client.id %>" class="index-table__row client-row">
-            <td class="index-table__cell client-attribute__needs-response">
+            <td class="index-table__cell narrow client-attribute__needs-response">
               <%= render "shared/urgent_icon", client: client %>
             </td>
             <%= tag.th(
@@ -115,12 +115,12 @@
                 <% end %>
               <% end %>
             <% end %>
-            <td class="index-table__cell"><%= client.id %></td>
+            <td class="index-table__cell narrow"><%= client.id %></td>
             <td class="index-table__cell">
               <%= client.vita_partner&.name || t("general.none") %>
             </td>
             <td class="index-table__cell"><%= client.preferred_language ? t("general.language_options.#{client.preferred_language}") : t('general.NA') %></td>
-            <td class="index-table__cell"><%= "✓" if client.intake.had_unemployment_income == "yes" %></td>
+            <td class="index-table__cell narrow"><%= "✓" if client.intake.had_unemployment_income == "yes" %></td>
             <td class="index-table__cell"><%= formatted_datetime(client.updated_at) %></td>
 
             <% if client.last_outgoing_communication_at.present? %>
@@ -144,7 +144,7 @@
             <% end %>
 
             <td class="index-table__cell"><%= formatted_datetime(client.intake.created_at) || "-" %> </td>
-            <td class="index-table__cell"><%= client.intake.state_of_residence %></td>
+            <td class="index-table__cell narrow"><%= client.intake.state_of_residence %></td>
             <td class="index-table__cell">
               <%= render "shared/tax_return_list", client: client, show_checkboxes: true %>
             </td>


### PR DESCRIPTION
this styling is a little far-reaching (as it applies to most table cells in the hub) and as such feels like it has the potential for some unexpected consequences when applied to real data. i tried to think of edge cases but would appreciate it if any reviewers look for ones i may have missed!

before:
![Screen Shot 2022-04-29 at 3 12 03 PM](https://user-images.githubusercontent.com/43800769/166075472-86ba3b81-d4cb-4423-bfc2-75ce7464cb3b.png)

after:
![Screen Shot 2022-04-29 at 3 11 46 PM](https://user-images.githubusercontent.com/43800769/166075492-68b6f818-658c-4a8e-90db-72da41fda34c.png)

