### PR TITLE
[#182012324] efile submissions showing out of order

### DIFF
--- a/app/controllers/hub/efile_submissions_controller.rb
+++ b/app/controllers/hub/efile_submissions_controller.rb
@@ -20,7 +20,8 @@ module Hub
       client = Client.find(params[:id])
       @client = Hub::ClientsController::HubClientPresenter.new(client)
       authorize! :read, client
-      @tax_returns = client.tax_returns.joins(:efile_submissions).eager_load(efile_submissions: :fraud_score).uniq # get all tax returns with submissions
+      # Eager-load tax returns with submissions and data we may need to render
+      @tax_returns = client.tax_returns.includes(:efile_submissions, efile_submissions: :fraud_score).where.not(tax_returns: {efile_submissions: nil}).load
       @fraud_indicators = Fraud::Indicator.unscoped
       redirect_to hub_client_path(id: @client.id) and return unless @tax_returns.present?
     end


### PR DESCRIPTION
Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>

## Summary

The efile page in the client profile shows "Resubmit"/"Investigate" buttons based on the efile_submissions.last.current_state. When this is sorted incorrectly, this is the wrong efile_submission, which breaks those buttons.

_Usually_ the efile submissions are sorted correctly. However, sometimes (e.g. https://demo.getyourrefund.org/en/hub/clients/54832/efile ) they are sorted incorrectly.

The EfileSubmission model has a default sort order since https://github.com/codeforamerica/vita-min/pull/1427 . However, the EfileSubmissionsController doesn't end up using that sort order, so the sort order is arbitrarily imposed on us by the database. This pull request uses `includes` rather than `joins` to allow Rails to confidently stay in control of the queries and retain the sort order.

## Generated SQL

With the existing `joins`-based query, we see this SQL:

```
$ rails c
> client = Client.find(10)
> puts client.tax_returns.joins(:efile_submissions).eager_load(efile_submissions: :fraud_score).to_sql
SELECT "tax_returns"."id" AS t0_r0, "tax_returns"."assigned_user_id" AS t0_r1, "tax_returns"."certification_level" AS t0_r2, "tax_returns"."client_id" AS t0_r3, "tax_returns"."created_at" AS t0_r4, "tax_returns"."current_state" AS t0_r5, "tax_returns"."filing_status" AS t0_r6, "tax_returns"."filing_status_note" AS t0_r7, "tax_returns"."internal_efile" AS t0_r8, "tax_returns"."is_ctc" AS t0_r9, "tax_returns"."is_hsa" AS t0_r10, "tax_returns"."primary_signature" AS t0_r11, "tax_returns"."primary_signed_at" AS t0_r12, "tax_returns"."primary_signed_ip" AS t0_r13, "tax_returns"."ready_for_prep_at" AS t0_r14, "tax_returns"."service_type" AS t0_r15, "tax_returns"."spouse_signature" AS t0_r16, "tax_returns"."spouse_signed_at" AS t0_r17, "tax_returns"."spouse_signed_ip" AS t0_r18, "tax_returns"."status" AS t0_r19, "tax_returns"."updated_at" AS t0_r20, "tax_returns"."year" AS t0_r21, "efile_submissions"."id" AS t1_r0, "efile_submissions"."created_at" AS t1_r1, "efile_submissions"."irs_submission_id" AS t1_r2, "efile_submissions"."last_checked_for_ack_at" AS t1_r3, "efile_submissions"."tax_return_id" AS t1_r4, "efile_submissions"."updated_at" AS t1_r5, "fraud_scores"."id" AS t2_r0, "fraud_scores"."created_at" AS t2_r1, "fraud_scores"."efile_submission_id" AS t2_r2, "fraud_scores"."score" AS t2_r3, "fraud_scores"."snapshot" AS t2_r4, "fraud_scores"."updated_at" AS t2_r5 FROM "tax_returns" INNER JOIN "efile_submissions" ON "efile_submissions"."tax_return_id" = "tax_returns"."id" LEFT OUTER JOIN "fraud_scores" ON "fraud_scores"."efile_submission_id" = "efile_submissions"."id" WHERE "tax_returns"."client_id" = 10
```

Or without `to_sql` (in case you want to see it with `uniq):

```
irb(main):024:0> client = Client.find(10)
irb(main):023:0> client.tax_returns.joins(:efile_submissions).eager_load(efile_submissions: :fraud_score).uniq
SQL (1.3ms)  SELECT "tax_returns"."id" AS t0_r0, "tax_returns"."assigned_user_id" AS t0_r1, "tax_returns"."certification_level" AS t0_r2, "tax_returns"."client_id" AS t0_r3, "tax_returns"."created_at" AS t0_r4, "tax_returns"."current_state" AS t0_r5, "tax_returns"."filing_status" AS t0_r6, "tax_returns"."filing_status_note" AS t0_r7, "tax_returns"."internal_efile" AS t0_r8, "tax_returns"."is_ctc" AS t0_r9, "tax_returns"."is_hsa" AS t0_r10, "tax_returns"."primary_signature" AS t0_r11, "tax_returns"."primary_signed_at" AS t0_r12, "tax_returns"."primary_signed_ip" AS t0_r13, "tax_returns"."ready_for_prep_at" AS t0_r14, "tax_returns"."service_type" AS t0_r15, "tax_returns"."spouse_signature" AS t0_r16, "tax_returns"."spouse_signed_at" AS t0_r17, "tax_returns"."spouse_signed_ip" AS t0_r18, "tax_returns"."status" AS t0_r19, "tax_returns"."updated_at" AS t0_r20, "tax_returns"."year" AS t0_r21, "efile_submissions"."id" AS t1_r0, "efile_submissions"."created_at" AS t1_r1, "efile_submissions"."irs_submission_id" AS t1_r2, "efile_submissions"."last_checked_for_ack_at" AS t1_r3, "efile_submissions"."tax_return_id" AS t1_r4, "efile_submissions"."updated_at" AS t1_r5, "fraud_scores"."id" AS t2_r0, "fraud_scores"."created_at" AS t2_r1, "fraud_scores"."efile_submission_id" AS t2_r2, "fraud_scores"."score" AS t2_r3, "fraud_scores"."snapshot" AS t2_r4, "fraud_scores"."updated_at" AS t2_r5 FROM "tax_returns" INNER JOIN "efile_submissions" ON "efile_submissions"."tax_return_id" = "tax_returns"."id" LEFT OUTER JOIN "fraud_scores" ON "fraud_scores"."efile_submission_id" = "efile_submissions"."id" WHERE "tax_returns"."client_id" = $1  [["client_id", 10]]
=> [#<TaxReturn id: 11, assigned_user_id: nil, certification_level: nil, client_id: 10, created_at: "2022-04-25 18:53:46.914299000 +0000", current_state: "file_ready_to_file", filing_status: "single", filing_status_note: nil, internal_efile: false, is_ctc: true, is_hsa: nil, primary_signature: nil, primary_signed_at: nil, primary_signed_ip: nil, ready_for_prep_at: nil, service_type: "online_intake", spouse_signature: nil, spouse_signed_at: nil, spouse_signed_ip: nil, status: "file_ready_to_file", updated_at: "2022-04-25 18:53:46.951746000 +0000", year: 2021>]
```

You can use Cmd-F to validate that there's no ORDER in this query.

The new code results in the following queries:

```
irb(main):020:0> client.tax_returns.includes(:efile_submissions, efile_submissions: :fraud_score).where.not(tax_returns: {efile_submissions: nil}).load
  TaxReturn Load (0.6ms)  SELECT "tax_returns"."id", "tax_returns"."assigned_user_id", "tax_returns"."certification_level", "tax_returns"."client_id", "tax_returns"."created_at", "tax_returns"."current_state", "tax_returns"."filing_status", "tax_returns"."filing_status_note", "tax_returns"."internal_efile", "tax_returns"."is_ctc", "tax_returns"."is_hsa", "tax_returns"."primary_signature", "tax_returns"."primary_signed_at", "tax_returns"."primary_signed_ip", "tax_returns"."ready_for_prep_at", "tax_returns"."service_type", "tax_returns"."spouse_signature", "tax_returns"."spouse_signed_at", "tax_returns"."spouse_signed_ip", "tax_returns"."status", "tax_returns"."updated_at", "tax_returns"."year" FROM "tax_returns" WHERE "tax_returns"."client_id" = $1 AND "tax_returns"."id" IS NOT NULL  [["client_id", 10]]
  EfileSubmission Load (2.9ms)  SELECT "efile_submissions"."id", "efile_submissions"."created_at", "efile_submissions"."irs_submission_id", "efile_submissions"."last_checked_for_ack_at", "efile_submissions"."tax_return_id", "efile_submissions"."updated_at" FROM "efile_submissions" WHERE "efile_submissions"."tax_return_id" = $1 ORDER BY "efile_submissions"."id" ASC  [["tax_return_id", 11]]
  Fraud::Score Load (4.5ms)  SELECT "fraud_scores"."id", "fraud_scores"."created_at", "fraud_scores"."efile_submission_id", "fraud_scores"."score", "fraud_scores"."snapshot", "fraud_scores"."updated_at" FROM "fraud_scores" WHERE "fraud_scores"."efile_submission_id" IN ($1, $2, $3, $4, $5, $6, $7)  [["efile_submission_id", 3], ["efile_submission_id", 4], ["efile_submission_id", 5], ["efile_submission_id", 6], ["efile_submission_id", 7], ["efile_submission_id", 8], ["efile_submission_id", 9]]
=> #<ActiveRecord::AssociationRelation [#<TaxReturn id: 11, assigned_user_id: nil, certification_level: nil, client_id: 10, created_at: "2022-04-25 18:53:46.914299000 +0000", current_state: "file_ready_to_file", filing_status: "single", filing_status_note: nil, internal_efile: false, is_ctc: true, is_hsa: nil, primary_signature: nil, primary_signed_at: nil, primary_signed_ip: nil, ready_for_prep_at: nil, service_type: "online_intake", spouse_signature: nil, spouse_signed_at: nil, spouse_signed_ip: nil, status: "file_ready_to_file", updated_at: "2022-04-25 18:53:46.951746000 +0000", year: 2021>]>
```

You can see there's an ORDER to the `efile_submissions`.