### PR TITLE
Fix dependent eligibility bug

### DIFF
--- a/app/lib/efile/dependent_eligibility/base.rb
+++ b/app/lib/efile/dependent_eligibility/base.rb
@@ -4,7 +4,7 @@ module Efile
       attr_accessor :age, :dependent, :tax_year, :test_results, :except, :prequalified
 
       def initialize(dependent, tax_year, except: nil)
-        @age = tax_year - dependent.birth_date.year
+        @age = dependent.respond_to?(:age_during_tax_year) ? dependent.age_during_tax_year : tax_year - dependent.birth_date.year
         @tax_year = tax_year
         @dependent = dependent
         @except = *except

--- a/app/lib/efile/dependent_eligibility/child_tax_credit.rb
+++ b/app/lib/efile/dependent_eligibility/child_tax_credit.rb
@@ -30,13 +30,11 @@ module Efile
       private
 
       def is_qualifying_child?
-        return dependent.qualifying_child if dependent.is_a? EfileSubmissionDependent
-
         (@child_eligibility || Efile::DependentEligibility::QualifyingChild.new(dependent, tax_year)).qualifies?
       end
 
       def prequalifying_attribute
-        "qualifying_child"
+        "qualifying_ctc"
       end
     end
   end

--- a/app/lib/efile/dependent_eligibility/eip_one.rb
+++ b/app/lib/efile/dependent_eligibility/eip_one.rb
@@ -27,6 +27,8 @@ module Efile
       end
 
       def is_qualifying_child?
+        return dependent.qualifying_child if dependent.is_a? EfileSubmissionDependent
+
         (@child_eligibility || Efile::DependentEligibility::QualifyingChild.new(dependent, tax_year)).qualifies?
       end
 

--- a/app/lib/efile/dependent_eligibility/eip_three.rb
+++ b/app/lib/efile/dependent_eligibility/eip_three.rb
@@ -18,6 +18,8 @@ module Efile
       end
 
       def is_qualifying_child?
+        return dependent.qualifying_child if dependent.is_a? EfileSubmissionDependent
+
         (@child_eligibility || Efile::DependentEligibility::QualifyingChild.new(dependent, tax_year)).qualifies?
       end
 

--- a/app/lib/efile/dependent_eligibility/eip_two.rb
+++ b/app/lib/efile/dependent_eligibility/eip_two.rb
@@ -27,6 +27,8 @@ module Efile
       end
 
       def is_qualifying_child?
+        return dependent.qualifying_child if dependent.is_a? EfileSubmissionDependent
+
         (@child_eligibility || Efile::DependentEligibility::QualifyingChild.new(dependent, tax_year)).qualifies?
       end
 

--- a/spec/factories/efile_submission_dependents.rb
+++ b/spec/factories/efile_submission_dependents.rb
@@ -1,0 +1,11 @@
+
+FactoryBot.define do
+  factory :efile_submission_dependent do
+    efile_submission
+    dependent
+    qualifying_child { true }
+    qualifying_ctc { true }
+    qualifying_relative { false }
+    age_during_tax_year { 12 }
+  end
+end

--- a/spec/lib/efile/dependent_eligibility/child_tax_credit_spec.rb
+++ b/spec/lib/efile/dependent_eligibility/child_tax_credit_spec.rb
@@ -25,7 +25,29 @@ describe Efile::DependentEligibility::ChildTaxCredit do
     it "instantiates a new eligibility object" do
       described_class.new(dependent, TaxReturn.current_tax_year)
       expect(child_eligibility).not_to have_received(:qualifies?)
+    end
+  end
 
+  context "prequalifying attribute" do
+    subject { described_class.new(efile_submission_dependent, TaxReturn.current_tax_year) }
+    before do
+      allow(subject).to receive(:run_tests).and_call_original
+    end
+    context "when the object is a SubmissionDependent and qualifying_ctc is true" do
+      let!(:efile_submission_dependent) { create :efile_submission_dependent, qualifying_ctc: true }
+
+      it "returns true for qualifying, without running all qualifying logic again" do
+        expect(subject).not_to have_received(:run_tests)
+        expect(subject.qualifies?).to eq true
+      end
+    end
+
+    context "when the object is an EfileSubmissionDependent and qualifying_ctc false" do
+      let!(:efile_submission_dependent) { create :efile_submission_dependent, qualifying_ctc: false }
+      it "returns false for qualifying, without running qualifying logic again" do
+        expect(subject).not_to have_received(:run_tests)
+        expect(subject.qualifies?).to eq false
+      end
     end
   end
 end


### PR DESCRIPTION
The EfileSubmissionDependent 'prequalifying' logic looked at the wrong attribute. Instead of looking at qualifying_ctc, it was looking at qualifying_child.