### PR TITLE
Add a wants_to_claim_test to QualifiedRelative

### DIFF
--- a/app/lib/efile/dependent_eligibility/qualifying_relative.rb
+++ b/app/lib/efile/dependent_eligibility/qualifying_relative.rb
@@ -4,6 +4,10 @@ module Efile
       def self.rules
         {
             # Ctc::Questions::Dependents::Info
+            want_to_claim_test: [
+              :claim_anyway_yes?,
+              :claim_anyway_unfilled?
+            ],
             birth_test: :alive_during_tax_year?,
             married_filing_joint_test: [
                 :filed_joint_return_no?,

--- a/app/lib/efile/dependent_eligibility/qualifying_relative.rb
+++ b/app/lib/efile/dependent_eligibility/qualifying_relative.rb
@@ -4,7 +4,7 @@ module Efile
       def self.rules
         {
             # Ctc::Questions::Dependents::Info
-            want_to_claim_test: [
+            wants_to_claim_test: [
               :claim_anyway_yes?,
               :claim_anyway_unfilled?
             ],

--- a/spec/controllers/ctc/questions/dependents/child_claim_anyway_controller_spec.rb
+++ b/spec/controllers/ctc/questions/dependents/child_claim_anyway_controller_spec.rb
@@ -34,7 +34,7 @@ describe Ctc::Questions::Dependents::ChildClaimAnywayController do
           post :update, params: params
 
           expect(dependent.reload.claim_anyway).to eq "no"
-          expect(response).to redirect_to Ctc::Questions::Dependents::DoesNotQualifyCtcController.to_path_helper
+          expect(response).to redirect_to does_not_qualify_ctc_questions_dependent_path(id: params[:id])
         end
       end
     end

--- a/spec/controllers/ctc/questions/dependents/child_claim_anyway_controller_spec.rb
+++ b/spec/controllers/ctc/questions/dependents/child_claim_anyway_controller_spec.rb
@@ -31,7 +31,9 @@ describe Ctc::Questions::Dependents::ChildClaimAnywayController do
         let(:claim_anyway) { "no" }
 
         it "redirects out of the dependent flow" do
-          expect(dependent.reload.claim_anyway).to eq "yes"
+          post :update, params: params
+
+          expect(dependent.reload.claim_anyway).to eq "no"
           expect(response).to redirect_to Ctc::Questions::Dependents::DoesNotQualifyCtcController.to_path_helper
         end
       end

--- a/spec/controllers/ctc/questions/dependents/child_claim_anyway_controller_spec.rb
+++ b/spec/controllers/ctc/questions/dependents/child_claim_anyway_controller_spec.rb
@@ -14,15 +14,26 @@ describe Ctc::Questions::Dependents::ChildClaimAnywayController do
         {
           id: dependent.id,
           ctc_dependents_child_claim_anyway_form: {
-            claim_anyway: "yes"
+            claim_anyway: claim_anyway
           }
         }
       end
+
+      let(:claim_anyway) { "yes" }
 
       it "updates the dependent and moves to the next page" do
         post :update, params: params
 
         expect(dependent.reload.claim_anyway).to eq "yes"
+      end
+
+      context "with a no answer" do
+        let(:claim_anyway) { "no" }
+
+        it "redirects out of the dependent flow" do
+          expect(dependent.reload.claim_anyway).to eq "yes"
+          expect(response).to redirect_to Ctc::Questions::Dependents::DoesNotQualifyCtcController.to_path_helper
+        end
       end
     end
 

--- a/spec/lib/efile/dependent_eligibility/qualifying_relative_spec.rb
+++ b/spec/lib/efile/dependent_eligibility/qualifying_relative_spec.rb
@@ -6,7 +6,8 @@ describe Efile::DependentEligibility::QualifyingRelative do
   context 'with a totally qualifying relative' do
     let(:dependent) { create :qualifying_relative }
     let(:test_result) do
-      {   birth_test: true,
+      {   wants_to_claim_test: true,
+          birth_test: true,
           married_filing_joint_test: true,
           is_supported_test: true,
           relationship_test: true,

--- a/spec/lib/efile/dependent_eligibility/qualifying_relative_spec.rb
+++ b/spec/lib/efile/dependent_eligibility/qualifying_relative_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe Efile::DependentEligibility::QualifyingRelative do
-  subject { described_class.new(dependent, TaxReturn.current_tax_year)}
+  subject { described_class.new(dependent, TaxReturn.current_tax_year) }
 
   context 'with a totally qualifying relative' do
     let(:dependent) { create :qualifying_relative }


### PR DESCRIPTION
We ask clients to confirm whether they would like to continue claiming a dependent that may already be claimed by someone else, but we don't factor that answer into the QR qualifications. If a client doesn't want to claim a dependent anyway, we should not forward them to the QR flow, so I added another test to QR. It has to be distinct from `claimable` because that is not considered until later on in the flow, whereas this should block entry into the QR flow entirely.