### PR TITLE
Add cron job to track longest periods of time that efile submissions have been in preparing/bundling/queued states in DataDog

### DIFF
--- a/crontab
+++ b/crontab
@@ -1,7 +1,7 @@
 0 0 * * 0 bundle exec rake vita_providers:scrape_vita_providers
 * * * * * bundle exec rake search:refresh
 * * * * * bundle exec rake stats:track_metrics
-0 * * * * bundle exec rake stats:monitor_delayed_efile_submissions
+*/5 * * * * bundle exec rake stats:monitor_delayed_efile_submissions
 20 21 * * 1-5 bundle exec rake client_surveys:send_client_in_progress_surveys
 15 20 * * * bundle exec rake not_ready:remind
 */10 * * * * bundle exec rake efile:poll_and_get_acknowledgments

--- a/crontab
+++ b/crontab
@@ -1,6 +1,7 @@
 0 0 * * 0 bundle exec rake vita_providers:scrape_vita_providers
 * * * * * bundle exec rake search:refresh
 * * * * * bundle exec rake stats:track_metrics
+0 * * * * bundle exec rake stats:monitor_delayed_efile_submissions
 20 21 * * 1-5 bundle exec rake client_surveys:send_client_in_progress_surveys
 15 20 * * * bundle exec rake not_ready:remind
 */10 * * * * bundle exec rake efile:poll_and_get_acknowledgments

--- a/lib/tasks/stats.rake
+++ b/lib/tasks/stats.rake
@@ -19,4 +19,13 @@ namespace :stats do
       DatadogApi.gauge('efile_submissions.state_counts', count, tags: ["current_state:#{state}"])
     end
   end
+
+  desc "Monitor the longest periods of time that any efile submission has been in preparing, bundling, and queued"
+  task monitor_delayed_efile_submissions: :environment do
+    [:preparing, :bundling, :queued].each do |state|
+      oldest_transition_to = EfileSubmissionTransition.where(to_state: state).sort_by(&:created_at).first
+      min_since_transition = ((Time.now - oldest_transition_to.created_at)/60).to_i
+      DatadogApi.gauge('efile_submissions.transition_latencies_min', min_since_transition, tags: ["current_state:#{state}"])
+    end
+  end
 end

--- a/lib/tasks/stats.rake
+++ b/lib/tasks/stats.rake
@@ -25,7 +25,7 @@ namespace :stats do
     [:preparing, :bundling, :queued].each do |state|
       oldest_transition_to = EfileSubmissionTransition.where(most_recent: true, to_state: state).sort_by(&:created_at).first
       min_since_transition = ((Time.now - oldest_transition_to.created_at)/60).to_i
-      DatadogApi.gauge('efile_submissions.transition_latencies_min', min_since_transition, tags: ["current_state:#{state}"])
+      DatadogApi.gauge('efile_submissions.transition_latencies_minutes', min_since_transition, tags: ["current_state:#{state}"])
     end
   end
 end

--- a/lib/tasks/stats.rake
+++ b/lib/tasks/stats.rake
@@ -23,7 +23,7 @@ namespace :stats do
   desc "Monitor the longest periods of time that any efile submission has been in preparing, bundling, and queued"
   task monitor_delayed_efile_submissions: :environment do
     [:preparing, :bundling, :queued].each do |state|
-      oldest_transition_to = EfileSubmissionTransition.where(to_state: state).sort_by(&:created_at).first
+      oldest_transition_to = EfileSubmissionTransition.where(most_recent: true, to_state: state).sort_by(&:created_at).first
       min_since_transition = ((Time.now - oldest_transition_to.created_at)/60).to_i
       DatadogApi.gauge('efile_submissions.transition_latencies_min', min_since_transition, tags: ["current_state:#{state}"])
     end

--- a/spec/factories/efile_submission_transitions.rb
+++ b/spec/factories/efile_submission_transitions.rb
@@ -30,7 +30,6 @@ FactoryBot.define do
     EfileSubmissionStateMachine.states.each do |state|
       trait state.to_sym do
         to_state { state }
-
       end
     end
   end

--- a/spec/tasks/stats_spec.rb
+++ b/spec/tasks/stats_spec.rb
@@ -44,16 +44,16 @@ describe "stats:monitor_delayed_efile_submissions" do
   let(:timestamp_queued) { 2.hours.ago }
   let(:newer_preparing_efile_submission) { create :efile_submission, :preparing }
   let(:preparing_efile_submission) { create :efile_submission, :preparing }
-  let(:bundling_efile_submission) { create :efile_submission, :bundling }
+  let(:bundling_efile_submission) { create :efile_submission, :bundling, efile_submission_transitions: [create(:efile_submission_transition, :preparing, created_at: fake_time - 3.days, most_recent: false)] }
   let(:queued_efile_submission) { create :efile_submission, :queued }
 
   before do
     enable_datadog_and_stub_emit_point
     Timecop.freeze(fake_time) do
-      newer_preparing_efile_submission.last_transition.update(created_at: newer_timestamp_preparing)
-      preparing_efile_submission.last_transition.update(created_at: timestamp_preparing)
-      bundling_efile_submission.last_transition.update(created_at: timestamp_bundling)
-      queued_efile_submission.last_transition.update(created_at: timestamp_queued)
+      newer_preparing_efile_submission.last_transition.update(created_at: newer_timestamp_preparing, most_recent: true)
+      preparing_efile_submission.last_transition.update(created_at: timestamp_preparing, most_recent: true)
+      bundling_efile_submission.last_transition.update(created_at: timestamp_bundling, most_recent: true)
+      queued_efile_submission.last_transition.update(created_at: timestamp_queued, most_recent: true)
     end
   end
 

--- a/spec/tasks/stats_spec.rb
+++ b/spec/tasks/stats_spec.rb
@@ -64,9 +64,9 @@ describe "stats:monitor_delayed_efile_submissions" do
 
     expect(@emit_point_params).to match_array(
 [
-        ["vita-min.dogapi.efile_submissions.transition_latencies_min", 1440, tags: ["current_state:preparing", "env:test"], type: "gauge"],
-        ["vita-min.dogapi.efile_submissions.transition_latencies_min", 840, tags: ["current_state:bundling", "env:test"], type: "gauge"],
-        ["vita-min.dogapi.efile_submissions.transition_latencies_min", 120, tags: ["current_state:queued", "env:test"], type: "gauge"],
+        ["vita-min.dogapi.efile_submissions.transition_latencies_minutes", 1440, tags: ["current_state:preparing", "env:test"], type: "gauge"],
+        ["vita-min.dogapi.efile_submissions.transition_latencies_minutes", 840, tags: ["current_state:bundling", "env:test"], type: "gauge"],
+        ["vita-min.dogapi.efile_submissions.transition_latencies_minutes", 120, tags: ["current_state:queued", "env:test"], type: "gauge"],
       ]
     )
   end


### PR DESCRIPTION
Discussed the strategy with Asheesh, solo'd on writing the code. Two things:
1. I chose to send a number of minutes somewhat arbitrarily, maybe it should be seconds or hours or something? Not sure. The threshold the alert will be set at is a day, but that could change in future. Also I'm somewhat concerned that "min" will be read as "minimum" so maybe I should write out "minutes" if it stays minutes.
2. The cron job running hourly is also somewhat arbitrary because I can't remember what Asheesh and I said over tuple, I just know it was supposed to be less frequent than every minute (which is how often the stats:track_metrics task runs)

UPDATE: "min" is now "minutes" and the cron job runs every 5 min