### PR TITLE
Simplify the mobile navigation bar on the home pages for GYR and CTC

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -7,7 +7,7 @@
         <% end %>
       </div>
       <% if variation == "gyr" %>
-        <div class="toolbar__item">
+        <div class="toolbar__item is-mobile-hidden--inline">
           <%= link_to faq_path do %>
             <%= t("general.faq") %>
           <% end %>
@@ -28,7 +28,7 @@
       <% else %>
         <%= link_to t("general.sign_in"), new_portal_client_login_path, class: "toolbar__item text--small text--bold" %>
         <% if !@in_intake_flow && ((variation == "gyr" && open_for_gyr_intake?) || (variation == "ctc" && open_for_ctc_intake?)) %>
-          <%= link_to t("general.get_started"), question_path(id: variation == "gyr" ? GyrQuestionNavigation.first : CtcQuestionNavigation.first), class: "toolbar__item button button--toolbar button--small" %>
+          <%= link_to t("general.get_started"), question_path(id: variation == "gyr" ? GyrQuestionNavigation.first : CtcQuestionNavigation.first), class: "toolbar__item button button--toolbar button--small is-mobile-hidden--inline" %>
         <% end %>
     <% end %>
     </div>


### PR DESCRIPTION
Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>

It looks like this now
<img width="423" alt="image" src="https://user-images.githubusercontent.com/6520735/167036039-b17976d5-db02-4414-91ef-be8e12a70d61.png">
