### PR TITLE
Add risky routing number list

### DIFF
--- a/app/models/bank_account.rb
+++ b/app/models/bank_account.rb
@@ -12,6 +12,7 @@
 #  encrypted_routing_number_iv :string
 #  hashed_account_number       :string
 #  hashed_routing_number       :string
+#  routing_number              :string
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #  intake_id                   :bigint
@@ -34,7 +35,7 @@ class BankAccount < ApplicationRecord
   attr_encrypted :account_number, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }
   # Enum values are acceptable BankAccountType values to be sent to the IRS (See efileTypes.xsd)
   enum account_type: { checking: 1, savings: 2 }
-  before_save :hash_data
+  before_save :hash_account_number
 
   # map string enum value back to the corresponding integer
   def account_type_code
@@ -42,10 +43,13 @@ class BankAccount < ApplicationRecord
   end
 
   def duplicates
-    DeduplificationService.duplicates(self, :hashed_routing_number, :hashed_account_number, from_scope: self.class)
+    DeduplificationService.duplicates(self, :routing_number, :hashed_account_number, from_scope: self.class)
   end
 
   def hash_data
+    # WIP because we need to get everything written onto the raw version before we can proceed.
+    # Then, we will remove the attr_encrypted and change the name of the column from raw_routing_number to routing_number
+    self.raw_routing_number = routing_number if routing_number_changed?
     [:routing_number, :account_number].each do |attr|
       if send("#{attr}_changed?") && send(attr).present?
         assign_attributes("hashed_#{attr}" => DeduplificationService.sensitive_attribute_hashed(self, attr))

--- a/app/models/fraud/indicators/routing_number.rb
+++ b/app/models/fraud/indicators/routing_number.rb
@@ -1,0 +1,20 @@
+module Fraud
+  module Indicators
+    class RoutingNumber < ApplicationRecord
+      self.table_name = "fraud_indicators_routing_numbers"
+
+      default_scope { where.not(activated_at: nil) }
+
+      validates :routing_number, length: { is: 9 }, uniqueness: true
+      validates :bank_name, presence: true
+
+      def self.riskylist
+        all.map { |instance| DeduplificationService.sensitive_attribute_hashed(instance, :routing_number) }
+      end
+
+      def active
+        activated_at?
+      end
+    end
+  end
+end

--- a/app/models/fraud/indicators/routing_number.rb
+++ b/app/models/fraud/indicators/routing_number.rb
@@ -20,7 +20,7 @@ module Fraud
       validates :bank_name, presence: true
 
       def self.riskylist
-        all.map { |instance| DeduplificationService.sensitive_attribute_hashed(instance, :routing_number) }
+        all.pluck(:routing_number)
       end
 
       def active

--- a/app/models/fraud/indicators/routing_number.rb
+++ b/app/models/fraud/indicators/routing_number.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: fraud_indicators_routing_numbers
+#
+#  id             :bigint           not null, primary key
+#  activated_at   :datetime
+#  bank_name      :string
+#  routing_number :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
 module Fraud
   module Indicators
     class RoutingNumber < ApplicationRecord

--- a/db/migrate/20220505171013_create_fraud_indicators_routing_numbers.rb
+++ b/db/migrate/20220505171013_create_fraud_indicators_routing_numbers.rb
@@ -1,0 +1,10 @@
+class CreateFraudIndicatorsRoutingNumbers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :fraud_indicators_routing_numbers do |t|
+      t.string :routing_number
+      t.string :bank_name
+      t.timestamp :activated_at
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220506195927_add_routing_number_to_bank_account.rb
+++ b/db/migrate/20220506195927_add_routing_number_to_bank_account.rb
@@ -1,0 +1,5 @@
+class AddRoutingNumberToBankAccount < ActiveRecord::Migration[7.0]
+  def change
+    add_column :bank_accounts, :raw_routing_number, :string
+  end
+end

--- a/db/migrate/20220506195927_add_routing_number_to_bank_account.rb
+++ b/db/migrate/20220506195927_add_routing_number_to_bank_account.rb
@@ -1,5 +1,5 @@
 class AddRoutingNumberToBankAccount < ActiveRecord::Migration[7.0]
   def change
-    add_column :bank_accounts, :raw_routing_number, :string
+    add_column :bank_accounts, :_routing_number, :string
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_05_171013) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_06_195927) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -436,6 +436,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_05_171013) do
     t.string "hashed_account_number"
     t.string "hashed_routing_number"
     t.bigint "intake_id"
+    t.string "routing_number"
     t.datetime "updated_at", null: false
     t.index ["hashed_account_number"], name: "index_bank_accounts_on_hashed_account_number"
     t.index ["hashed_routing_number"], name: "index_bank_accounts_on_hashed_routing_number"
@@ -840,11 +841,11 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_05_171013) do
   end
 
   create_table "fraud_indicators_routing_numbers", force: :cascade do |t|
-    t.datetime "activated_at"
+    t.datetime "activated_at", precision: nil
     t.string "bank_name"
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", null: false
     t.string "routing_number"
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "fraud_indicators_timezones", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_04_213020) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_05_171013) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -839,6 +839,14 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_04_213020) do
     t.index ["safe"], name: "index_fraud_indicators_domains_on_safe"
   end
 
+  create_table "fraud_indicators_routing_numbers", force: :cascade do |t|
+    t.datetime "activated_at"
+    t.string "bank_name"
+    t.datetime "created_at", precision: 6, null: false
+    t.string "routing_number"
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "fraud_indicators_timezones", force: :cascade do |t|
     t.datetime "activated_at", precision: nil
     t.datetime "created_at", null: false
@@ -1643,7 +1651,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_04_213020) do
            SELECT DISTINCT tax_returns.client_id
              FROM (tax_returns
                JOIN intakes ON ((intakes.client_id = tax_returns.client_id)))
-            WHERE ((tax_returns.current_state)::text <> ALL (ARRAY[('intake_before_consent'::character varying)::text, ('intake_in_progress'::character varying)::text, ('intake_greeter_info_requested'::character varying)::text, ('intake_needs_doc_help'::character varying)::text, ('file_mailed'::character varying)::text, ('file_accepted'::character varying)::text, ('file_not_filing'::character varying)::text, ('file_hold'::character varying)::text, ('file_fraud_hold'::character varying)::text]))
+            WHERE ((tax_returns.current_state)::text <> ALL ((ARRAY['intake_before_consent'::character varying, 'intake_in_progress'::character varying, 'intake_greeter_info_requested'::character varying, 'intake_needs_doc_help'::character varying, 'file_mailed'::character varying, 'file_accepted'::character varying, 'file_not_filing'::character varying, 'file_hold'::character varying, 'file_fraud_hold'::character varying])::text[]))
           ), partner_and_client_counts AS (
            SELECT organization_id_by_vita_partner_id.organization_id,
               count(clients.id) AS active_client_count

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -425,6 +425,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_06_195927) do
   end
 
   create_table "bank_accounts", force: :cascade do |t|
+    t.string "_routing_number"
     t.integer "account_type"
     t.datetime "created_at", null: false
     t.string "encrypted_account_number"
@@ -436,7 +437,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_06_195927) do
     t.string "hashed_account_number"
     t.string "hashed_routing_number"
     t.bigint "intake_id"
-    t.string "routing_number"
     t.datetime "updated_at", null: false
     t.index ["hashed_account_number"], name: "index_bank_accounts_on_hashed_account_number"
     t.index ["hashed_routing_number"], name: "index_bank_accounts_on_hashed_routing_number"

--- a/lib/tasks/backfill_routing_numbers.rake
+++ b/lib/tasks/backfill_routing_numbers.rake
@@ -1,0 +1,8 @@
+namespace :routing_number do
+  desc "backfill routing numbers"
+  task backfill: :environment do
+    BankAccount.where(_routing_number: nil).find_each do |ba|
+      ba.update(_routing_number: ba.routing_number)
+    end
+  end
+end

--- a/spec/factories/bank_accounts.rb
+++ b/spec/factories/bank_accounts.rb
@@ -12,6 +12,7 @@
 #  encrypted_routing_number_iv :string
 #  hashed_account_number       :string
 #  hashed_routing_number       :string
+#  routing_number              :string
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #  intake_id                   :bigint

--- a/spec/factories/bank_accounts.rb
+++ b/spec/factories/bank_accounts.rb
@@ -3,6 +3,7 @@
 # Table name: bank_accounts
 #
 #  id                          :bigint           not null, primary key
+#  _routing_number             :string
 #  account_type                :integer
 #  encrypted_account_number    :string
 #  encrypted_account_number_iv :string
@@ -12,7 +13,6 @@
 #  encrypted_routing_number_iv :string
 #  hashed_account_number       :string
 #  hashed_routing_number       :string
-#  routing_number              :string
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #  intake_id                   :bigint

--- a/spec/models/bank_account_spec.rb
+++ b/spec/models/bank_account_spec.rb
@@ -12,6 +12,7 @@
 #  encrypted_routing_number_iv :string
 #  hashed_account_number       :string
 #  hashed_routing_number       :string
+#  routing_number              :string
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #  intake_id                   :bigint

--- a/spec/models/bank_account_spec.rb
+++ b/spec/models/bank_account_spec.rb
@@ -90,11 +90,11 @@ describe BankAccount do
         }.to change(bank_account, :hashed_routing_number)
       end
 
-      it "sets raw_routing_number" do
+      it "sets _routing_number" do
         expect {
           bank_account.update(routing_number: "123456781")
-        }.to change(bank_account, :raw_routing_number)
-        expect(bank_account.raw_routing_number).to eq(bank_account.routing_number)
+        }.to change(bank_account, :_routing_number)
+        expect(bank_account._routing_number).to eq(bank_account.routing_number)
       end
     end
 

--- a/spec/models/bank_account_spec.rb
+++ b/spec/models/bank_account_spec.rb
@@ -3,6 +3,7 @@
 # Table name: bank_accounts
 #
 #  id                          :bigint           not null, primary key
+#  _routing_number             :string
 #  account_type                :integer
 #  encrypted_account_number    :string
 #  encrypted_account_number_iv :string
@@ -12,7 +13,6 @@
 #  encrypted_routing_number_iv :string
 #  hashed_account_number       :string
 #  hashed_routing_number       :string
-#  routing_number              :string
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #  intake_id                   :bigint
@@ -88,6 +88,13 @@ describe BankAccount do
         expect {
           bank_account.update(routing_number: "123456781")
         }.to change(bank_account, :hashed_routing_number)
+      end
+
+      it "sets raw_routing_number" do
+        expect {
+          bank_account.update(routing_number: "123456781")
+        }.to change(bank_account, :raw_routing_number)
+        expect(bank_account.raw_routing_number).to eq(bank_account.routing_number)
       end
     end
 

--- a/spec/models/fraud/indicators/routing_number_spec.rb
+++ b/spec/models/fraud/indicators/routing_number_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+describe Fraud::Indicators::RoutingNumber do
+  describe "#riskylist" do
+    before do
+      described_class.create(routing_number: "123456789", bank_name: "Bank of Taxes", activated_at: DateTime.now)
+      described_class.create(routing_number: "111111111", bank_name: "Bank of Money", activated_at: DateTime.now)
+      described_class.create(routing_number: "111111111", bank_name: "Bank of Things", activated_at: nil)
+      allow(EnvironmentCredentials).to receive(:dig).with(:duplicate_hashing_key).and_return "1"
+    end
+
+    it "converts entries into a list of their hashed versions" do
+      expect(described_class.riskylist).to eq ["4e1cbd2bad5ec1241a99af0ad298c080fc1358c9aba120e33d73a9c96d4445c6", "ebbcb9796f3f6e771f0599ea197d212c34050b8040eb565830514694eec035d0"]
+    end
+  end
+end

--- a/spec/models/fraud/indicators/routing_number_spec.rb
+++ b/spec/models/fraud/indicators/routing_number_spec.rb
@@ -16,12 +16,14 @@ describe Fraud::Indicators::RoutingNumber do
     before do
       described_class.create(routing_number: "123456789", bank_name: "Bank of Taxes", activated_at: DateTime.now)
       described_class.create(routing_number: "111111111", bank_name: "Bank of Money", activated_at: DateTime.now)
-      described_class.create(routing_number: "111111111", bank_name: "Bank of Things", activated_at: nil)
+      described_class.create(routing_number: "111111112", bank_name: "Bank of Things", activated_at: nil)
       allow(EnvironmentCredentials).to receive(:dig).with(:duplicate_hashing_key).and_return "1"
     end
 
-    it "converts entries into a list of their hashed versions" do
-      expect(described_class.riskylist).to eq ["4e1cbd2bad5ec1241a99af0ad298c080fc1358c9aba120e33d73a9c96d4445c6", "ebbcb9796f3f6e771f0599ea197d212c34050b8040eb565830514694eec035d0"]
+    it "returns a list of all activated routing_number entries" do
+      expect(described_class.riskylist).to include "123456789"
+      expect(described_class.riskylist).to include "111111111"
+      expect(described_class.riskylist).not_to include "111111112"
     end
   end
 end

--- a/spec/models/fraud/indicators/routing_number_spec.rb
+++ b/spec/models/fraud/indicators/routing_number_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: fraud_indicators_routing_numbers
+#
+#  id             :bigint           not null, primary key
+#  activated_at   :datetime
+#  bank_name      :string
+#  routing_number :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
 require "rails_helper"
 
 describe Fraud::Indicators::RoutingNumber do


### PR DESCRIPTION

This needs to be a multistep process because due to the soft launch we already have 11 BankAccount objects on prod.

- we cannot just add an attribute called routing_number to the db without causing funky name collisions with the attr_encrypted gem that uses routing_number. Thus, I will dual write to `_routing_number` and leave all other things equal (that is included in this PR)
- Then I will run a backfill for the Bank Accounts that already exist in the db so that all elements have raw routing number written. (rake task included in this pr)
- Then, I will write another PR. In this one, I will remove the `attr_encrypted :routing_number` on bank account and then. there will be a method on bank account called `routing_number` that reads from `_routing_number` and will probably need to update some of the `_changed?` logic for the hashed routing number (must continue to read from hashed routing number because i need hashed_routing_number to exist for the purposes of the current fraud check, which i guess I could update to look at raw_routing_number temporarily but it removes a step to just rely on hashed_routing_number. It will also include adding an attribute called routing_number (that PR is here: https://github.com/codeforamerica/vita-min/pull/2474)

- Once that PR is out and the code is live, I will be able to update the bank_account fraud rule to look at `[:routing_number, :hashed_account_number]` instead of the hashed routing number.
- Once that is done on demo and production, I will do another PR that drops `:_routing_number` and `:hashed_routing_number` so that everything reads from routing_number and we have no vestiges of content that has raw and hashed or encrypted versions on the table.