### PR TITLE
[Part 2] Remove encrypted routing number

### DIFF
--- a/app/models/bank_account.rb
+++ b/app/models/bank_account.rb
@@ -13,6 +13,7 @@
 #  encrypted_routing_number_iv :string
 #  hashed_account_number       :string
 #  hashed_routing_number       :string
+#  routing_number              :string
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #  intake_id                   :bigint
@@ -31,7 +32,6 @@ class BankAccount < ApplicationRecord
   belongs_to :intake
   has_one :client, through: :intake
   attr_encrypted :bank_name, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }
-  attr_encrypted :routing_number, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }
   attr_encrypted :account_number, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }
   # Enum values are acceptable BankAccountType values to be sent to the IRS (See efileTypes.xsd)
   enum account_type: { checking: 1, savings: 2 }
@@ -42,14 +42,15 @@ class BankAccount < ApplicationRecord
     self.class.account_types[account_type]
   end
 
+  def routing_number
+    read_attribute(:routing_number) || _routing_number
+  end
+
   def duplicates
     DeduplificationService.duplicates(self, :hashed_routing_number, :hashed_account_number, from_scope: self.class)
   end
 
   def hash_data
-    # WIP because we need to get everything written onto the _routing_number version before we can proceed.
-    # Then, we will remove the attr_encrypted and change the name of the column from _routing_number to routing_number
-    self._routing_number = routing_number if routing_number_changed?
     [:routing_number, :account_number].each do |attr|
       if send("#{attr}_changed?") && send(attr).present?
         assign_attributes("hashed_#{attr}" => DeduplificationService.sensitive_attribute_hashed(self, attr))

--- a/db/migrate/20220506203715_add_routing_number_to_bank_account_without_underscore.rb
+++ b/db/migrate/20220506203715_add_routing_number_to_bank_account_without_underscore.rb
@@ -1,0 +1,5 @@
+class AddRoutingNumberToBankAccountWithoutUnderscore < ActiveRecord::Migration[7.0]
+  def change
+    add_column :bank_accounts, :routing_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_06_195927) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_06_203715) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -437,6 +437,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_06_195927) do
     t.string "hashed_account_number"
     t.string "hashed_routing_number"
     t.bigint "intake_id"
+    t.string "routing_number"
     t.datetime "updated_at", null: false
     t.index ["hashed_account_number"], name: "index_bank_accounts_on_hashed_account_number"
     t.index ["hashed_routing_number"], name: "index_bank_accounts_on_hashed_routing_number"

--- a/lib/tasks/backfill_routing_numbers.rake
+++ b/lib/tasks/backfill_routing_numbers.rake
@@ -1,8 +1,8 @@
 namespace :routing_number do
   desc "backfill routing numbers"
   task backfill: :environment do
-    BankAccount.where(_routing_number: nil).find_each do |ba|
-      ba.update(_routing_number: ba.routing_number)
+    BankAccount.where.not(_routing_number: nil).find_each do |ba|
+      ba.update(routing_number: ba._routing_number) unless ba.routing_number.present?
     end
   end
 end

--- a/spec/factories/bank_accounts.rb
+++ b/spec/factories/bank_accounts.rb
@@ -13,6 +13,7 @@
 #  encrypted_routing_number_iv :string
 #  hashed_account_number       :string
 #  hashed_routing_number       :string
+#  routing_number              :string
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #  intake_id                   :bigint

--- a/spec/models/bank_account_spec.rb
+++ b/spec/models/bank_account_spec.rb
@@ -13,6 +13,7 @@
 #  encrypted_routing_number_iv :string
 #  hashed_account_number       :string
 #  hashed_routing_number       :string
+#  routing_number              :string
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #  intake_id                   :bigint
@@ -80,6 +81,27 @@ describe BankAccount do
     end
   end
 
+  describe "#routing_number" do
+    context "when routing_number is saved directly" do
+      before do
+        allow_any_instance_of(BankAccount).to receive(:read_attribute).and_call_original
+      end
+
+      it "reads from that attribute" do
+        bank_account = described_class.new(routing_number: "123456789")
+        expect(bank_account.routing_number).to eq "123456789"
+        expect(bank_account).to have_received(:read_attribute).with(:routing_number)
+      end
+    end
+
+    context "when routing_number is saved on _routing_number" do
+      it "reads from that attribute" do
+        bank_account = described_class.new(_routing_number: "123456788")
+        expect(bank_account.routing_number).to eq "123456788"
+      end
+    end
+  end
+
   describe "before_save" do
     context "when routing number changes" do
       let(:bank_account) { create :bank_account, routing_number: "123456789" }
@@ -88,13 +110,6 @@ describe BankAccount do
         expect {
           bank_account.update(routing_number: "123456781")
         }.to change(bank_account, :hashed_routing_number)
-      end
-
-      it "sets _routing_number" do
-        expect {
-          bank_account.update(routing_number: "123456781")
-        }.to change(bank_account, :_routing_number)
-        expect(bank_account._routing_number).to eq(bank_account.routing_number)
       end
     end
 

--- a/spec/models/fraud/indicators/routing_number_spec.rb
+++ b/spec/models/fraud/indicators/routing_number_spec.rb
@@ -17,7 +17,6 @@ describe Fraud::Indicators::RoutingNumber do
       described_class.create(routing_number: "123456789", bank_name: "Bank of Taxes", activated_at: DateTime.now)
       described_class.create(routing_number: "111111111", bank_name: "Bank of Money", activated_at: DateTime.now)
       described_class.create(routing_number: "111111112", bank_name: "Bank of Things", activated_at: nil)
-      allow(EnvironmentCredentials).to receive(:dig).with(:duplicate_hashing_key).and_return "1"
     end
 
     it "returns a list of all activated routing_number entries" do


### PR DESCRIPTION
This is part 2 of the steps necessary to remove the encryption on routing number and instead store the raw routing numbers