### PR TITLE
Rescue URI parsing errors

### DIFF
--- a/app/controllers/ajax_mixpanel_events_controller.rb
+++ b/app/controllers/ajax_mixpanel_events_controller.rb
@@ -24,12 +24,17 @@ class AjaxMixpanelEventsController < ApplicationController
 
   def controller_and_path_data
     controller, action = event_params[:controller_action].split("#", 2)
+    begin
+      path = URI(event_params[:full_path]).path
+    rescue URI::InvalidURIError
+      path = ""
+    end
     {
-      full_path: event_params[:full_path],
-      path: URI(event_params[:full_path]).path,
-      controller_action: event_params[:controller_action],
-      controller_action_name: action,
-      controller_name: controller.sub("Controller", ""),
-    }
+        full_path: event_params[:full_path],
+        path: path,
+        controller_action: event_params[:controller_action],
+        controller_action_name: action,
+        controller_name: controller.sub("Controller", ""),
+      }
   end
 end

--- a/spec/controllers/ajax_mixpanel_events_controller_spec.rb
+++ b/spec/controllers/ajax_mixpanel_events_controller_spec.rb
@@ -53,6 +53,27 @@ RSpec.describe AjaxMixpanelEventsController, type: :controller do
         )
       end
     end
+
+    context "when the incoming URL can't be parsed but params are otherwise fine" do
+      before do
+        allow(subject).to receive(:URI) { raise URI::InvalidURIError }
+      end
+
+      it "sends all the values but keeps path empty" do
+        post :create,  params: { event: valid_params }
+
+        expect(subject).to have_received(:send_mixpanel_event).with(
+          event_name: "clicked_link",
+          data: {
+            path: "",
+            full_path: "/page?key=value",
+            controller_action: "Questions::TestQuestionController#edit",
+            controller_action_name: "edit",
+            controller_name: "Questions::TestQuestion",
+          }
+        )
+      end
+    end
   end
 
   context "with invalid params" do


### PR DESCRIPTION
Other parties have begun security scanning us (presumably for nefarious purposes). And it creates a whole bunch of noise. We should rescue some of these raises rather than alerting on them. This exception was the biggest contributor to noisy alerts.