### PR TITLE
Update ddtracer, enabling log-trace correlation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'lograge'
 gem 'fix-db-schema-conflicts', require: false
 gem 'valid_email2'
 gem 'auto_strip_attributes'
-gem 'ddtrace', '~> 0.41.0'
+gem 'ddtrace', '~> 1.0.0'
 gem 'dogapi'
 gem 'http_accept_language'
 gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,8 +173,11 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
-    ddtrace (0.41.0)
+    ddtrace (1.0.0)
+      debase-ruby_core_source (<= 0.10.15)
+      libddwaf (~> 1.3.0.0.0.a)
       msgpack
+    debase-ruby_core_source (0.10.15)
     delayed_job (4.1.10)
       activesupport (>= 3.0, < 8.0)
     delayed_job_active_record (4.1.7)
@@ -307,6 +310,8 @@ GEM
       addressable (~> 2.7)
     letter_opener (1.7.0)
       launchy (~> 2.2)
+    libddwaf (1.3.0.0.0)
+      ffi (~> 1.0)
     libv8-node (15.14.0.1)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -653,7 +658,7 @@ DEPENDENCIES
   cfa-styleguide (= 0.10.5)!
   combine_pdf
   database_cleaner
-  ddtrace (~> 0.41.0)
+  ddtrace (~> 1.0.0)
   delayed_job_active_record
   device_detector
   devise

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,9 +1,9 @@
 Datadog.configure do |c|
   c.service = 'getyourrefund-app'
   c.env = Rails.env
-  c.use :rails
-  c.use :aws
-  c.use :delayed_job
+  c.tracing.instrument :rails
+  c.tracing.instrument :aws
+  c.tracing.instrument :delayed_job
   c.tracing.enabled = Rails.env.staging? || Rails.env.demo? || Rails.env.production?
   c.tracing hostname: Rails.application.credentials.dig(:datadog_agent_host)
 end

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -4,6 +4,6 @@ Datadog.configure do |c|
   c.use :rails
   c.use :aws
   c.use :delayed_job
-  c.tracer.enabled = Rails.env.staging? || Rails.env.demo? || Rails.env.production?
-  c.tracer hostname: Rails.application.credentials.dig(:datadog_agent_host)
+  c.tracing.enabled = Rails.env.staging? || Rails.env.demo? || Rails.env.production?
+  c.tracing hostname: Rails.application.credentials.dig(:datadog_agent_host)
 end

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,9 +1,9 @@
 Datadog.configure do |c|
   c.service = 'getyourrefund-app'
   c.env = Rails.env
+  c.agent.host = Rails.application.credentials.dig(:datadog_agent_host)
+  c.tracing.enabled = Rails.env.staging? || Rails.env.demo? || Rails.env.production?
   c.tracing.instrument :rails
   c.tracing.instrument :aws
   c.tracing.instrument :delayed_job
-  c.tracing.enabled = Rails.env.staging? || Rails.env.demo? || Rails.env.production?
-  c.tracing hostname: Rails.application.credentials.dig(:datadog_agent_host)
 end


### PR DESCRIPTION
Turns out we were using a pretty old version of `ddtracer` (0.42.0), and newer versions include log-trace correlation by default (if using `lograge`)

More details found [here](https://docs.datadoghq.com/tracing/setup_overview/setup/ruby/#for-logging-in-rails-applications)