### PR TITLE
Hub efile submissions index: add column for error codes and messages

### DIFF
--- a/app/views/hub/efile_submissions/index.html.erb
+++ b/app/views/hub/efile_submissions/index.html.erb
@@ -44,6 +44,9 @@
         <th scope="col" class="index-table__header sortable">
           Last updated
         </th>
+        <th scope="col" class="index-table__header">
+          Errors
+        </th>
       </tr>
       </thead>
       <tbody class="index-table__body submission-table">
@@ -61,6 +64,11 @@
             </td>
             <td class="index-table__cell">
               <%= timestamp submission.updated_at %>
+            </td>
+            <td class="index-table__cell" style="white-space: nowrap;">
+              <% if submission.in_state?(:rejected) %>
+                <%= submission.last_transition.efile_errors.pluck(:code, :message).map { |i| i.join(": ") }.join(", ") %>
+              <% end %>
             </td>
           </tr>
       <% end %>

--- a/app/views/hub/efile_submissions/index.html.erb
+++ b/app/views/hub/efile_submissions/index.html.erb
@@ -65,9 +65,15 @@
             <td class="index-table__cell">
               <%= timestamp submission.updated_at %>
             </td>
-            <td class="index-table__cell" style="white-space: nowrap;">
+            <td class="index-table__cell">
               <% if submission.in_state?(:rejected) %>
-                <%= submission.last_transition.efile_errors.pluck(:code, :message).map { |i| i.join(": ") }.join(", ") %>
+                <% submission.last_transition.efile_errors.each do |error| %>
+                  <span class="tooltip error-<%= error.id %>" data-position="left" title="<%= error.message %>">
+                    <%= link_to hub_efile_error_path(id: error.id) do %>
+                      <div class="label label--red"><%= error.code %></div>
+                    <% end %>
+                  </span>
+                <% end %>
               <% end %>
             </td>
           </tr>

--- a/spec/features/hub/efile_submissions_spec.rb
+++ b/spec/features/hub/efile_submissions_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "efile submissions" do
       let(:current_tax_year) { TaxReturn.current_tax_year }
       let!(:new_submission) { create :efile_submission, irs_submission_id: "12345200202011234567", tax_return: create(:tax_return, year: current_tax_year) }
       let!(:old_submission) { create :efile_submission, irs_submission_id: "12345200202011234568", tax_return: create(:tax_return, year: current_tax_year - 1) }
+      let!(:rejected_submission) { create(:efile_submission, :rejected, :ctc, :with_errors, tax_return: build(:tax_return, year: current_tax_year)) }
 
       before { login_as current_user }
 
@@ -15,6 +16,12 @@ RSpec.describe "efile submissions" do
           visit hub_efile_submissions_path
           expect(page).to have_text new_submission.irs_submission_id
           expect(page).not_to have_text old_submission.irs_submission_id
+        end
+
+        it "shows the reject codes for rejected efile submissions" do
+          visit hub_efile_submissions_path
+
+          expect(page).to have_text "IND-189: 'DeviceId' in 'AtSubmissionCreationGrp' in 'FilingSecurityInformation' in the Return Header must have a value., IND-190: 'DeviceId' in 'AtSubmissionFilingGrp' in 'FilingSecurityInformation' in the Return Header must have a value."
         end
       end
     end

--- a/spec/features/hub/efile_submissions_spec.rb
+++ b/spec/features/hub/efile_submissions_spec.rb
@@ -21,7 +21,19 @@ RSpec.describe "efile submissions" do
         it "shows the reject codes for rejected efile submissions" do
           visit hub_efile_submissions_path
 
-          expect(page).to have_text "IND-189: 'DeviceId' in 'AtSubmissionCreationGrp' in 'FilingSecurityInformation' in the Return Header must have a value., IND-190: 'DeviceId' in 'AtSubmissionFilingGrp' in 'FilingSecurityInformation' in the Return Header must have a value."
+          error_1 = EfileError.where(code: "IND-189").first
+          error_2 = EfileError.where(code: "IND-190").first
+          html = Nokogiri::HTML.parse(page.body)
+
+          expect(page).to have_text error_1.code
+          expect(html.at_css(".error-#{error_1.id}.tooltip").attr("title"))
+            .to eq("'DeviceId' in 'AtSubmissionCreationGrp' in 'FilingSecurityInformation' in the Return Header must have a value.")
+          expect(page).to have_link(href: hub_efile_error_path(id: error_1.id))
+
+          expect(page).to have_text error_2.code
+          expect(html.at_css(".error-#{error_2.id}.tooltip").attr("title"))
+            .to eq("'DeviceId' in 'AtSubmissionFilingGrp' in 'FilingSecurityInformation' in the Return Header must have a value.")
+          expect(page).to have_link(href: hub_efile_error_path(id: error_2.id))
         end
       end
     end


### PR DESCRIPTION
2 things:
1) the code in the view itself isn't super tested, i wonder if there are some real world cases that would cause an undefined method for nil class type of error. i did manage to locally create a submission with no errors attached and that didn't cause any problems but idk if there are other realistic cases i should have tried out.
2) i did a nowrap on the error table cell because the messages are typically pretty long. i figured this was better than wrapping it and having fat rows? i'll attach a screenshot without the nowrap in a comment.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/43800769/167500136-9fec82c0-be51-449c-bf94-fd65fdac9224.png">
