### PR TITLE
Ignore `TaxReturn#status` column, which we will soon delete

### DIFF
--- a/app/controllers/portal/still_needs_helps_controller.rb
+++ b/app/controllers/portal/still_needs_helps_controller.rb
@@ -13,7 +13,7 @@ module Portal
 
       if current_client.update(update_params)
         if current_client.still_needs_help_yes?
-          current_client.tax_returns.where(status: "file_not_filing").each { |tax_return| tax_return.transition_to(:file_hold) }
+          current_client.tax_returns.where(current_state: "file_not_filing").each { |tax_return| tax_return.transition_to(:file_hold) }
           InteractionTrackingService.record_incoming_interaction(current_client)
           redirect_to portal_still_needs_help_upload_documents_path
         elsif current_client.still_needs_help_no?

--- a/app/forms/hub/take_action_form.rb
+++ b/app/forms/hub/take_action_form.rb
@@ -89,7 +89,7 @@ module Hub
     end
 
     def state_has_changed
-      errors.add(:status, I18n.t("forms.errors.status_must_change")) if status == tax_return&.status
+      errors.add(:status, I18n.t("forms.errors.status_must_change")) if status == tax_return&.current_state
     end
 
     def belongs_to_client

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,14 +1,6 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
-  # Add a fake ignored column to cause Rails to not do "SELECT *";
-  # this avoids PreparedStatementCacheExpired exceptions.
-  # Based on https://flexport.engineering/avoiding-activerecord-preparedstatementcacheexpired-errors-4499a4f961cf
-  #
-  # Migrate to enumerate_columns_in_select_statements when we switch to Rails 7
-  # https://www.bigbinary.com/blog/rails-7-adds-setting-for-enumerating-columns-in-select-statements
-  class_attribute :ignored_columns, default: [:__fake_column__]
-
   # Allow counting up to a max number; see https://alexcastano.com/the-hidden-cost-of-the-invisible-queries-in-rails/#how-far-do-you-plan-to-count
   scope :count_greater_than?, ->(n) { limit(n + 1).count > n }
 end

--- a/app/models/tax_return.rb
+++ b/app/models/tax_return.rb
@@ -4,7 +4,7 @@
 #
 #  id                  :bigint           not null, primary key
 #  certification_level :integer
-#  current_state       :string
+#  current_state       :string           default("intake_before_consent")
 #  filing_status       :integer
 #  filing_status_note  :text
 #  internal_efile      :boolean          default(FALSE), not null
@@ -18,7 +18,6 @@
 #  spouse_signature    :string
 #  spouse_signed_at    :datetime
 #  spouse_signed_ip    :inet
-#  status              :integer          default("intake_before_consent"), not null
 #  year                :integer          not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
@@ -70,11 +69,6 @@ class TaxReturn < ApplicationRecord
 
   delegate :can_transition_to?, :history, :last_transition, :last_transition_to,
            :transition_to!, :transition_to, :in_state?, :advance_to, :previous_transition, :previous_state, :last_changed_by, to: :state_machine
-
-  def current_state
-    # Before we've done a state transition, only the state machine holds the default state
-    read_attribute(:current_state) || state_machine.current_state
-  end
 
   def current_state=(_)
     raise("Avoid writing to TaxReturn#current_state directly. Instead, use #transition_to or #transition_to!")

--- a/app/services/still_needs_help_service.rb
+++ b/app/services/still_needs_help_service.rb
@@ -5,7 +5,7 @@ class StillNeedsHelpService
 
   def self.trigger_still_needs_help_flow(client)
     client.triggered_still_needs_help_at = Time.now
-    client.tax_returns.where(status: may_need_help_statuses).each { |tr| tr.transition_to!(:file_not_filing) }
+    client.tax_returns.where(current_state: may_need_help_statuses).each { |tr| tr.transition_to!(:file_not_filing) }
     client.save
     send_still_need_help_notification(client)
   end

--- a/app/state_machines/tax_return_state_machine.rb
+++ b/app/state_machines/tax_return_state_machine.rb
@@ -54,7 +54,7 @@ class TaxReturnStateMachine
   FORWARD_TO_INTERCOM_STATES = [:file_accepted, :file_mailed, :file_not_filing]
 
   after_transition(after_commit: true) do |tax_return, transition|
-    tax_return.update_columns(current_state: transition.to_state, status: TaxReturnStatus::STATUSES[transition.to_state.to_sym]) # save the integer version, too, for now. (Backwards compatability for data science reports)
+    tax_return.update_columns(current_state: transition.to_state)
     InteractionTrackingService.record_internal_interaction(tax_return.client) # manually run since the update_columns doesn't run callbacks
     MixpanelService.send_tax_return_event(tax_return, "status_change", { from_status: tax_return.previous_state })
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,8 @@ module VitaMin
   class Application < Rails::Application
     config.load_defaults 6.1
 
+    config.active_record.enumerate_columns_in_select_statements = true
+
     config.i18n.default_locale = :en
     config.i18n.fallbacks = [I18n.default_locale]
     config.i18n.available_locales = [:en, :es]

--- a/db/create_analytics_views.sql
+++ b/db/create_analytics_views.sql
@@ -228,7 +228,7 @@ CREATE VIEW analytics.system_notes AS
 CREATE VIEW analytics.tax_returns AS
     SELECT id, assigned_user_id, certification_level, client_id, created_at, is_hsa,
            primary_signature, primary_signed_at, ready_for_prep_at, service_type, spouse_signature, spouse_signed_at,
-           status, updated_at, year, is_ctc
+           current_state, status, updated_at, year, is_ctc
     FROM public.tax_returns;
 
 CREATE VIEW analytics.team_member_roles AS

--- a/db/migrate/20220509230303_add_default_to_tax_return_current_state.rb
+++ b/db/migrate/20220509230303_add_default_to_tax_return_current_state.rb
@@ -1,0 +1,5 @@
+class AddDefaultToTaxReturnCurrentState < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :tax_returns, :current_state, from: nil, to: "intake_before_consent"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_09_222202) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_09_230303) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -1381,7 +1381,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_09_222202) do
     t.integer "certification_level"
     t.bigint "client_id", null: false
     t.datetime "created_at", null: false
-    t.string "current_state"
+    t.string "current_state", default: "intake_before_consent"
     t.integer "filing_status"
     t.text "filing_status_note"
     t.boolean "internal_efile", default: false, null: false

--- a/spec/controllers/concerns/client_sortable_spec.rb
+++ b/spec/controllers/concerns/client_sortable_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe ClientSortable, type: :controller do
 
       it "creates a query for the search and scopes by other provided queries" do
         expect(subject.filtered_and_sorted_clients).to eq clients_query_double
-        expect(clients_query_double).to have_received(:where).with({ tax_returns: { status: params[:status] } })
+        expect(clients_query_double).to have_received(:where).with({ tax_returns: { current_state: params[:status] } })
         expect(clients_query_double).to have_received(:where).with(intake: intakes_query_double)
       end
     end

--- a/spec/controllers/ctc/questions/confirm_payment_controller_spec.rb
+++ b/spec/controllers/ctc/questions/confirm_payment_controller_spec.rb
@@ -20,7 +20,7 @@ describe Ctc::Questions::ConfirmPaymentController do
   describe '#do_not_file' do
     it "moves the tax return object to the 'file_not_filing' status" do
       patch :do_not_file
-      expect(tax_return.reload.status).to eq "file_not_filing"
+      expect(tax_return.reload.current_state).to eq "file_not_filing"
     end
 
     it "shows a flash notice alerting the client that we will not file their return and redirects to the ctc home page" do

--- a/spec/controllers/documents/additional_documents_controller_spec.rb
+++ b/spec/controllers/documents/additional_documents_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Documents::AdditionalDocumentsController do
     it "advances the tax returns to 'Ready for review' status" do
       get :edit
 
-      expect(tax_return.reload.status).to eq "intake_ready"
+      expect(tax_return.reload.current_state).to eq "intake_ready"
     end
 
     context "with no docs that might be needed" do

--- a/spec/controllers/questions/consent_controller_spec.rb
+++ b/spec/controllers/questions/consent_controller_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Questions::ConsentController do
         it "creates tax returns in the intake in progress status for years indicated as needing help" do
           post :update, params: params
 
-          expect(intake.tax_returns.pluck(:status).uniq).to eq ["intake_in_progress"]
+          expect(intake.tax_returns.pluck(:current_state).uniq).to eq ["intake_in_progress"]
           expect(intake.tax_returns.count).to eq 2
           expect(intake.tax_returns.pluck(:year)).to match_array([2021, 2020])
         end

--- a/spec/factories/tax_returns.rb
+++ b/spec/factories/tax_returns.rb
@@ -5,7 +5,7 @@
 #
 #  id                  :bigint           not null, primary key
 #  certification_level :integer
-#  current_state       :string
+#  current_state       :string           default("intake_before_consent")
 #  filing_status       :integer
 #  filing_status_note  :text
 #  internal_efile      :boolean          default(FALSE), not null
@@ -19,7 +19,6 @@
 #  spouse_signature    :string
 #  spouse_signed_at    :datetime
 #  spouse_signed_ip    :inet
-#  status              :integer          default("intake_before_consent"), not null
 #  year                :integer          not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null

--- a/spec/factories/tax_returns.rb
+++ b/spec/factories/tax_returns.rb
@@ -52,7 +52,7 @@ FactoryBot.define do
       trait state.to_sym do
         after :create do |tax_return, evaluator|
           create :tax_return_transition, state, tax_return: tax_return, metadata: evaluator.metadata
-          tax_return.update_columns(current_state: state, status: TaxReturnStatus::STATUSES[state.to_sym])
+          tax_return.update_columns(current_state: state)
         end
       end
     end

--- a/spec/features/web_intake/new_joint_filers_spec.rb
+++ b/spec/features/web_intake/new_joint_filers_spec.rb
@@ -124,7 +124,7 @@ RSpec.feature "Web Intake Joint Filers", :flow_explorer_screenshot do
     click_on "I agree"
     # create tax returns only after client has consented
     expect(intake.client.tax_returns.map(&:year)).to match_array [TaxReturn.current_tax_year - 3, TaxReturn.current_tax_year]
-    expect(intake.reload.client.tax_returns.pluck(:status)).to eq ["intake_in_progress", "intake_in_progress"]
+    expect(intake.reload.client.tax_returns.pluck(:current_state)).to eq ["intake_in_progress", "intake_in_progress"]
 
     screenshot_after do
       # Optional consent form
@@ -535,7 +535,7 @@ RSpec.feature "Web Intake Joint Filers", :flow_explorer_screenshot do
     end
     expect do
       click_on "Continue"
-    end.to change { intake.client.tax_returns.pluck(:status) }.from(["intake_in_progress", "intake_in_progress"]).to(["intake_ready", "intake_ready"])
+    end.to change { intake.client.tax_returns.pluck(:current_state) }.from(["intake_in_progress", "intake_in_progress"]).to(["intake_ready", "intake_ready"])
 
     screenshot_after do
       expect(page).to have_selector("h1", text: "Please share any additional documents.")

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -815,7 +815,7 @@ describe Client do
          .and change(assigned_user_b.notifications, :count).by(1)
         expect(assigned_user_a.notifications.last.notifiable).to eq SystemNote::DocumentHelp.last
         expect(assigned_user_b.notifications.last.notifiable).to eq SystemNote::DocumentHelp.last
-        expect(client.tax_returns.map(&:status).uniq).to eq ["intake_needs_doc_help"]
+        expect(client.tax_returns.map(&:current_state).uniq).to eq ["intake_needs_doc_help"]
       end
     end
 

--- a/spec/models/tax_return_spec.rb
+++ b/spec/models/tax_return_spec.rb
@@ -4,7 +4,7 @@
 #
 #  id                  :bigint           not null, primary key
 #  certification_level :integer
-#  current_state       :string
+#  current_state       :string           default("intake_before_consent")
 #  filing_status       :integer
 #  filing_status_note  :text
 #  internal_efile      :boolean          default(FALSE), not null
@@ -18,7 +18,6 @@
 #  spouse_signature    :string
 #  spouse_signed_at    :datetime
 #  spouse_signed_ip    :inet
-#  status              :integer          default("intake_before_consent"), not null
 #  year                :integer          not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null

--- a/spec/state_machines/efile_submission_state_machine_spec.rb
+++ b/spec/state_machines/efile_submission_state_machine_spec.rb
@@ -81,7 +81,7 @@ describe EfileSubmissionStateMachine do
         it "transitions the tax return status and submission status to hold" do
           submission.transition_to!(:preparing)
           expect(submission.current_state).to eq "fraud_hold"
-          expect(submission.tax_return.status).to eq("file_fraud_hold")
+          expect(submission.tax_return.current_state).to eq("file_fraud_hold")
         end
       end
     end
@@ -95,7 +95,7 @@ describe EfileSubmissionStateMachine do
           client: submission.client.reload,
           message: AutomatedMessage::EfilePreparing,
         )
-        expect(submission.tax_return.status).to eq("file_ready_to_file")
+        expect(submission.tax_return.current_state).to eq("file_ready_to_file")
 
       end
     end
@@ -105,7 +105,7 @@ describe EfileSubmissionStateMachine do
 
       it "updates the tax return status" do
         submission.transition_to!(:transmitted)
-        expect(submission.tax_return.status).to eq("file_efiled")
+        expect(submission.tax_return.current_state).to eq("file_efiled")
       end
     end
 
@@ -119,7 +119,7 @@ describe EfileSubmissionStateMachine do
 
       it "updates the tax return status" do
         submission.transition_to!(:failed, error_code: efile_error.code)
-        expect(submission.tax_return.status).to eq("file_needs_review")
+        expect(submission.tax_return.current_state).to eq("file_needs_review")
       end
 
       context "with an exposed error" do
@@ -159,7 +159,7 @@ describe EfileSubmissionStateMachine do
       it "transitions the tax return status to on hold" do
         expect {
           submission.transition_to!(:investigating)
-        }.to change(submission.tax_return, :status).to("file_hold")
+        }.to change(submission.tax_return, :current_state).to("file_hold")
       end
     end
 
@@ -168,7 +168,7 @@ describe EfileSubmissionStateMachine do
       it "transitions the tax return status to on hold" do
         expect {
           submission.transition_to!(:waiting)
-        }.to change(submission.tax_return, :status).to("file_hold")
+        }.to change(submission.tax_return, :current_state).to("file_hold")
       end
     end
 
@@ -195,7 +195,7 @@ describe EfileSubmissionStateMachine do
 
       it "updates the tax return status" do
         submission.transition_to!(:accepted)
-        expect(submission.tax_return.status).to eq("file_accepted")
+        expect(submission.tax_return.current_state).to eq("file_accepted")
       end
 
 

--- a/spec/state_machines/tax_return_state_machine_spec.rb
+++ b/spec/state_machines/tax_return_state_machine_spec.rb
@@ -85,7 +85,6 @@ describe TaxReturnStateMachine do
       it "sets current_state and status as well" do
         tax_return.transition_to(:file_accepted)
         expect(tax_return.read_attribute(:current_state)).to eq "file_accepted"
-        expect(tax_return.read_attribute(:status)).to eq "file_accepted"
       end
 
       it "enqueues the experience survey" do


### PR DESCRIPTION
The information previously stored as a integer in this column
is now stored as a string in `TaxReturn#current_state`

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>