### PR TITLE
Scope stats to this year #182029118

### DIFF
--- a/spec/tasks/stats_spec.rb
+++ b/spec/tasks/stats_spec.rb
@@ -37,7 +37,7 @@ describe "stats:monitor_delayed_efile_submissions" do
   include_context "rake"
   include MockDogapi
 
-  let(:fake_time) { DateTime.new(2022, 3, 1, 0, 0, 0) }
+  let(:fake_time) { DateTime.new(2022, 5, 10, 0, 0, 0) }
   let(:newer_timestamp_preparing) { 18.hours.ago }
   let(:timestamp_preparing) { 1.day.ago }
   let(:timestamp_bundling) { 14.hours.ago }


### PR DESCRIPTION
First commit: makes sure we don't catch submissions from last year in our DD latency stats

Second commit: i was trying to transition a submission from last year that is in `preparing` to `cancelled` and couldn't because the clearest path is through `fraud_hold`, but `after_transition(to: :fraud_hold)` throws a nil class error when trying to get the locale from the nonexistent intake. (i tried some other paths to `cancelled` but they proved to be complicated.