### PR TITLE
Remove link through submission id if there is no submission id

### DIFF
--- a/app/views/hub/efile_submissions/index.html.erb
+++ b/app/views/hub/efile_submissions/index.html.erb
@@ -52,7 +52,7 @@
         <% tax_return = submission.tax_return %>
           <tr class="index-table__row">
             <td class="index-table__cell status"><%= link_to submission.current_state.humanize(capitalize: false), efile_hub_client_path(id: tax_return.client.id, anchor: "body"), class: "underline" %></td>
-            <td class="index-table__cell"><%= link_to(submission.irs_submission_id, efile_hub_client_path(id: tax_return.client.id, anchor: "body") if submission.irs_submission_id.present? %></td>
+            <td class="index-table__cell"><%= submission.irs_submission_id.present? ? link_to(submission.irs_submission_id, efile_hub_client_path(id: tax_return.client.id, anchor: "body") : "" %></td>
             <td class="index-table__cell">
               <%= link_to tax_return.client.legal_name, efile_hub_client_path(id: tax_return.client.id, anchor: "body"), class: "underline" %>
             </td>

--- a/app/views/hub/efile_submissions/index.html.erb
+++ b/app/views/hub/efile_submissions/index.html.erb
@@ -52,7 +52,7 @@
         <% tax_return = submission.tax_return %>
           <tr class="index-table__row">
             <td class="index-table__cell status"><%= link_to submission.current_state.humanize(capitalize: false), efile_hub_client_path(id: tax_return.client.id, anchor: "body"), class: "underline" %></td>
-            <td class="index-table__cell"><%= link_to submission.irs_submission_id, efile_hub_client_path(id: tax_return.client.id, anchor: "body") %></td>
+            <td class="index-table__cell"><%= link_to(submission.irs_submission_id, efile_hub_client_path(id: tax_return.client.id, anchor: "body") if submission.irs_submission_id.present? %></td>
             <td class="index-table__cell">
               <%= link_to tax_return.client.legal_name, efile_hub_client_path(id: tax_return.client.id, anchor: "body"), class: "underline" %>
             </td>

--- a/app/views/hub/efile_submissions/index.html.erb
+++ b/app/views/hub/efile_submissions/index.html.erb
@@ -52,7 +52,7 @@
         <% tax_return = submission.tax_return %>
           <tr class="index-table__row">
             <td class="index-table__cell status"><%= link_to submission.current_state.humanize(capitalize: false), efile_hub_client_path(id: tax_return.client.id, anchor: "body"), class: "underline" %></td>
-            <td class="index-table__cell"><%= submission.irs_submission_id.present? ? link_to(submission.irs_submission_id, efile_hub_client_path(id: tax_return.client.id, anchor: "body") : "" %></td>
+            <td class="index-table__cell"><%= submission.irs_submission_id.present? ? link_to(submission.irs_submission_id, efile_hub_client_path(id: tax_return.client.id, anchor: "body")) : "" %></td>
             <td class="index-table__cell">
               <%= link_to tax_return.client.legal_name, efile_hub_client_path(id: tax_return.client.id, anchor: "body"), class: "underline" %>
             </td>


### PR DESCRIPTION
![Screen Shot 2022-05-09 at 3 39 47 PM](https://user-images.githubusercontent.com/4494389/167510530-1586c668-3641-472f-853f-02296ac9f502.png)

Some efile submissions dont have IRS ids, so we should remove the link so it doesnt show up messy like.