### PR TITLE
Remove duplicated submission status note for verification attempt

### DIFF
--- a/app/lib/synthetic_note.rb
+++ b/app/lib/synthetic_note.rb
@@ -15,10 +15,6 @@ class SyntheticNote
     notes = []
     verification_attempts = client.verification_attempts.includes(:transitions).order(created_at: :asc)
     verification_attempts.each do |attempt|
-      notes << SyntheticNote.new(
-        created_at: attempt.created_at,
-        contact_record: attempt
-      )
       attempt.transitions.each do |transition|
         notes << SyntheticNote.new(
           created_at: transition.created_at,

--- a/app/views/hub/notes/_note.html.erb
+++ b/app/views/hub/notes/_note.html.erb
@@ -9,9 +9,7 @@
   </div>
 
   <div class="note__body">
-    <% if note.is_a?(SyntheticNote) && note.contact_record.is_a?(VerificationAttempt) %>
-      <%= render "system_note_verification_attempt", verification_attempt: note.contact_record %>
-    <% elsif note.is_a?(SyntheticNote) && note.contact_record.is_a?(VerificationAttemptTransition) %>
+    <% if note.is_a?(SyntheticNote) && note.contact_record.is_a?(VerificationAttemptTransition) %>
       <%= render "system_note_verification_attempt_transition", transition: note.contact_record %>
     <% elsif note.is_a? SystemNote::DocumentHelp %>
       <%= render "system_note_document_help", note: note %>

--- a/app/views/hub/notes/_system_note_verification_attempt.erb
+++ b/app/views/hub/notes/_system_note_verification_attempt.erb
@@ -1,3 +1,0 @@
-<p>
-  <%= verification_attempt.client.preferred_name %> submitted <%= link_to "verification attempt", hub_verification_attempt_path(id: verification_attempt.id) %>.
-</p>

--- a/app/views/hub/notes/_system_note_verification_attempt_transition.erb
+++ b/app/views/hub/notes/_system_note_verification_attempt_transition.erb
@@ -5,9 +5,9 @@
   <% elsif transition.to_state == "requested_replacements" %>
     <%= transition.initiated_by.name_with_role %> <%= I18n.t("messages.new_photos_requested.admin_note") %> for <%= link_to "verification attempt", hub_verification_attempt_path(id: transition.verification_attempt.id) %>
   <% elsif transition.to_state == "restricted" %>
-    Client <%= link_to "verification attempt", hub_verification_attempt_path(id: transition.verification_attempt.id) %> transitioned to restricted state due to fraud score.
+    <%= transition.verification_attempt.client.preferred_name&.titleize %> <%= link_to "verification attempt", hub_verification_attempt_path(id: transition.verification_attempt.id) %> transitioned to restricted state due to fraud score.
   <% elsif transition.to_state == "pending" %>
-    Client submitted <%= link_to "verification attempt", hub_verification_attempt_path(id: transition.verification_attempt.id) %>
+    <%= transition.verification_attempt.client.preferred_name&.titleize %> submitted <%= link_to "verification attempt", hub_verification_attempt_path(id: transition.verification_attempt.id) %>
   <% else %>
     <%= transition.initiated_by.name_with_role %> <%= transition.to_state %> <%= link_to "verification attempt", hub_verification_attempt_path(id: transition.verification_attempt.id) %>.
   <% end %>


### PR DESCRIPTION
When we first implemented verification attempts, there was not a persisted transition for the creation of a submission. Now there is, so we have duplicated entries! We can remove one of them.
![Screen Shot 2022-05-09 at 5 55 01 PM](https://user-images.githubusercontent.com/4494389/167740794-b78033c4-2298-492d-969f-4b839096b747.png)

