### PR TITLE
Autofocus on adding item to list in fraud indicators

### DIFF
--- a/app/views/hub/fraud_indicators/base/create.js.erb
+++ b/app/views/hub/fraud_indicators/base/create.js.erb
@@ -1,8 +1,10 @@
 $(".flash-alerts").html("<%= j render 'shared/flash_alerts', flash: flash %>");
 <% if @resource.persisted? %>
   $(".data-table tbody").append("<%= j render 'hub/fraud_indicators/table_row', resource: @resource %>");
-  $(".resource-form").html("<%= j render 'hub/fraud_indicators/form', resource: resource_class.new %>")
-<% else %>
-  $(".resource-form").html("<%= j render 'hub/fraud_indicators/form', resource: @resource %>")
-<% end %>
+  $(".resource-form").html("<%= j render 'hub/fraud_indicators/form', resource: resource_class.new %>");
+  $(".resource-form input[type!=hidden]:first").focus();
 
+<% else %>
+  $(".resource-form").html("<%= j render 'hub/fraud_indicators/form', resource: @resource %>");
+  $(".resource-form input[type!=hidden]:first").focus();
+<% end %>


### PR DESCRIPTION
This allows us to add domains/entries much faster than having to click into the box again, since we're often adding many entries in succession.