### PR TITLE
Remove TaxReturn#status column

### DIFF
--- a/app/models/tax_return.rb
+++ b/app/models/tax_return.rb
@@ -37,8 +37,6 @@
 #  fk_rails_...  (client_id => clients.id)
 #
 class TaxReturn < ApplicationRecord
-  self.ignored_columns = [:status]
-
   has_many :tax_return_transitions, dependent: :destroy, autosave: false
   include Statesman::Adapters::ActiveRecordQueries[
               transition_class: TaxReturnTransition,

--- a/db/migrate/20220510182528_drop_status_from_tax_returns.rb
+++ b/db/migrate/20220510182528_drop_status_from_tax_returns.rb
@@ -1,0 +1,7 @@
+class DropStatusFromTaxReturns < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      remove_column :tax_returns, :status, :integer, default: 100, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_09_230303) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_10_182528) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -1395,7 +1395,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_09_230303) do
     t.string "spouse_signature"
     t.datetime "spouse_signed_at", precision: nil
     t.inet "spouse_signed_ip"
-    t.integer "status", default: 100, null: false
     t.datetime "updated_at", null: false
     t.integer "year", null: false
     t.index ["assigned_user_id"], name: "index_tax_returns_on_assigned_user_id"


### PR DESCRIPTION
the same information now exists as a string on TaxReturn#current_state

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>