### PR TITLE
Silence double-loading messages from net-protocol by explicitly requiring net-http gem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ commands:
       - run:
           name: install bundler & ruby dependencies
           command: |
-            gem install bundler:2.2.5 --no-document && \
+            gem install bundler:2.3.5 --no-document && \
             bundle install --jobs=4 --retry=3 --path vendor/bundle
       - save_cache:
           key: bundle-{{ checksum "Gemfile.lock" }}

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,12 @@ gem 'mini_racer', '~> 0.4.0', platforms: :ruby
 gem 'nokogiri', '>= 1.10.8'
 gem 'recaptcha'
 
+# Adding this removes some deprecation warnings, caused by double-loading of the net-protocol library
+# (see https://github.com/ruby/net-imap/issues/16)
+# we *might* be able to remove this after upgrading to Ruby 3
+gem 'net-http'
+gem 'uri', '0.10.0' # force us to get the default version from Ruby 2.7
+
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,6 +328,8 @@ GEM
     msgpack (1.4.5)
     multi_json (1.15.0)
     nenv (0.3.0)
+    net-http (0.2.2)
+      uri
     net-imap (0.2.3)
       digest
       net-protocol
@@ -579,6 +581,7 @@ GEM
       unf_ext
     unf_ext (0.0.8)
     unicode-display_width (1.8.0)
+    uri (0.10.0)
     valid_email2 (4.0.3)
       activemodel (>= 3.2)
       mail (~> 2.5)
@@ -665,6 +668,7 @@ DEPENDENCIES
   memory_profiler
   mini_racer (~> 0.4.0)
   mixpanel-ruby
+  net-http
   nokogiri (>= 1.10.8)
   parallel_tests
   pdf-forms (~> 1.3.0)
@@ -707,6 +711,7 @@ DEPENDENCIES
   turbo_tests
   twilio-ruby
   tzinfo-data
+  uri (= 0.10.0)
   valid_email2
   warning
   web-console (>= 3.3.0)


### PR DESCRIPTION
See https://github.com/ruby/net-imap/issues/16

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>