### PR TITLE
GYR triage: offboarding link to CTC says 'Choose' instead of 'Sign up for'

### DIFF
--- a/app/views/questions/triage/_ctc_tile.erb
+++ b/app/views/questions/triage/_ctc_tile.erb
@@ -22,7 +22,7 @@
     <%= t('.warning_html') %>
   </p>
   <div class="spacing-above-35">
-    <%= link_to t('.sign_up_for_ctc'),
+    <%= link_to open_for_ctc_intake? ? t('.choose_ctc') : t('.sign_up_for_ctc'),
                 url_for(host: MultiTenantService.new(:ctc).host, controller: "/public_pages", action: 'source_routing', source: "gyr"),
                 class: "button button--wide text--centered",
                 "data-track-click": click_tracking_event_name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1553,8 +1553,9 @@ en:
         additional_credits: Additional State Credits
         ctc: Child Tax Credit
         eitc: Earned Income Tax Credit
-        missing_stimulus: Missing Stimulus Payments
+        missing_stimulus: Missing third stimulus payment
       ctc_tile:
+        choose_ctc: Choose GetCTC
         description: File quickly online on your own!
         sign_up_for_ctc: Sign up for GetCTC
         timeframe: 15 minutes to file

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1515,8 +1515,9 @@ es:
         additional_credits: Créditos estatales adicionales
         ctc: Crédito Tributario por Hijos
         eitc: Crédito tributario por ingresos del trabajo
-        missing_stimulus: Pagos de estímulos faltantes
+        missing_stimulus: Falta el tercer pago de estímulo
       ctc_tile:
+        choose_ctc: Elija GetCTC
         description: También mejor conocido como “File Myself” en inglés. Declare rápidamente por su cuenta para 2021.
         sign_up_for_ctc: Regístrese para recibir GetCTC
         timeframe: 15 minutos para declarar


### PR DESCRIPTION
Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>