### PR TITLE
Fix display of account type for nil bank account type

### DIFF
--- a/app/views/hub/clients/_displayed_bank_account_info.html.erb
+++ b/app/views/hub/clients/_displayed_bank_account_info.html.erb
@@ -6,7 +6,7 @@
   </div>
   <div class="field-display">
     <span class="form-question"><%= t("hub.bank_accounts.account_type") %>:</span>
-    <span class="label-value"><%=  t("hub.bank_accounts.#{@bank_account.account_type}", default: "N/A") %> </span>
+    <span class="label-value"><%=  t("hub.bank_accounts.#{@bank_account.account_type || "empty"}") %> </span>
   </div>
   <div class="field-display">
     <span class="form-question"><%= t("hub.bank_accounts.account_number") %>:</span>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -107,6 +107,7 @@ ignore_unused:
   - 'devise.failure.*'
   - 'hub.tax_returns.stage.*'
   - 'hub.tax_returns.status.*'
+  - 'hub.bank_accounts.*'
   - 'hub.status_macros.*'
   - 'hub.user_notifications.bulk_client_message.*'
   - 'hub.user_notifications.bulk_tax_return_update.*'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -533,6 +533,7 @@ en:
       account_type: Account type
       bank_name: Bank name
       checking: Checking
+      empty: N/A
       info_displayed: Displaying bank account information
       routing_number: Routing number
       routing_number_confirmation: Confirm routing number

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -533,6 +533,7 @@ es:
       account_type: Tipo de cuenta
       bank_name: Nombre del banco
       checking: Cuenta Corriente
+      empty: N/A
       info_displayed: Visualización de la información de la cuenta bancaria
       routing_number: Número de ruta bancaria
       routing_number_confirmation: Confirmar número de ruta bancaria

--- a/spec/features/hub/toggle_client_bank_account_info_spec.rb
+++ b/spec/features/hub/toggle_client_bank_account_info_spec.rb
@@ -51,5 +51,6 @@ RSpec.feature "Toggle bank account info" do
         expect(page).not_to have_text client.intake.bank_account_type
       end
     end
+
   end
 end


### PR DESCRIPTION
The i18n key fallback wasn't working the way that I expected it would. Instead of not matching and returning the default value provided when the interpolated piece was nil, it was instead outputting all of the translations for the bank_account node in yaml. This fixes it to return the string of 'empty" instead, so that it can match the "empty" value in the translations