### PR TITLE
Add additional validations for drivers license year - Drivers license years must be 4 digits and start with either 19 or 20 for issue date or 20 for expiration date

### DIFF
--- a/app/forms/ctc/drivers_license_form.rb
+++ b/app/forms/ctc/drivers_license_form.rb
@@ -56,7 +56,7 @@ module Ctc
     end
 
     def expiration_date_is_valid_date
-      valid_text_date(expiration_date_year, expiration_date_month, expiration_date_day, :expiration_date)
+      valid_expiration_date(expiration_date_year, expiration_date_month, expiration_date_day)
     end
   end
 end

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -25,22 +25,37 @@ module DateHelper
   def valid_text_birth_date(birth_date_year, birth_date_month, birth_date_day, key = :birth_date)
     parsed_birth_date = parse_date_params(birth_date_year, birth_date_month, birth_date_day)
     unless parsed_birth_date.present?
-      self.errors.add(key, I18n.t('errors.attributes.birth_date.blank'))
+      errors.add(key, I18n.t('errors.attributes.birth_date.blank'))
       return false
     end
 
     if parsed_birth_date.year < 1900 || parsed_birth_date.year > Date.today.year
-      self.errors.add(key, I18n.t('errors.attributes.birth_date.blank'))
+      errors.add(key, I18n.t('errors.attributes.birth_date.blank'))
       return false
     end
 
     true
   end
 
+  def valid_expiration_date(date_year, date_month, date_day, key = :expiration_date)
+    if date_year.present? && date_year.starts_with?("19")
+      errors.add(key, I18n.t('errors.attributes.expiration_date.format'))
+      return false
+    end
+    valid_text_date(date_year, date_month, date_day, key)
+  end
+
   def valid_text_date(date_year, date_month, date_day, key = :date)
+    if date_year.present?
+      unless date_year.length == 4 && (date_year.starts_with?("19") || date_year.starts_with?("20"))
+        errors.add(key, I18n.t('errors.attributes.date.format'))
+        return false
+      end
+    end
+
     parsed_date = parse_date_params(date_year, date_month, date_day)
     unless parsed_date.present?
-      self.errors.add(key, I18n.t('errors.attributes.birth_date.blank'))
+      errors.add(key, I18n.t('errors.attributes.birth_date.blank'))
       return false
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -128,6 +128,8 @@ en:
         blank: Please enter a valid date.
       certification_level:
         inclusion: Please select a certification level.
+      date:
+        format: Please enter a date in the format MM-DD-YYYY.
       demographic_disability:
         blank: Please answer or click "Skip question"
       demographic_english_conversation:
@@ -146,6 +148,8 @@ en:
         invalid: Please enter a valid email address.
       email_address_confirmation:
         confirmation: Please double check that the email addresses match.
+      expiration_date:
+        format: Please enter an expiration date in the format MM-DD-2YYY.
       first_name:
         blank: Please enter a first name.
       intake_site:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -128,6 +128,8 @@ es:
         blank: Por favor, introduzca una fecha válida.
       certification_level:
         inclusion: Por favor, seleccione un nivel de certificación.
+      date:
+        format: Ingrese una fecha en el formato MM-DD-YYYY.
       demographic_disability:
         blank: Por favor, responda o haga clic en "Saltar pregunta"
       demographic_english_conversation:
@@ -146,6 +148,8 @@ es:
         invalid: Por favor, introduzca una dirección de correo electrónico válida.
       email_address_confirmation:
         confirmation: Por favor, revise que las direcciones de correo electrónico sean iguales.
+      expiration_date:
+        format: Ingrese una fecha de vencimiento en el formato MM-DD-2YYY.
       first_name:
         blank: Por favor, introduzca un nombre.
       intake_site:

--- a/spec/forms/ctc/drivers_license_form_spec.rb
+++ b/spec/forms/ctc/drivers_license_form_spec.rb
@@ -42,6 +42,66 @@ describe Ctc::DriversLicenseForm do
         expect(form.errors.attribute_names).to include :issue_date, :expiration_date
       end
     end
+
+    context "when the year is a two digit number" do
+      let(:params) {
+        {
+            issue_date_year: "1999",
+            issue_date_month: "12",
+            issue_date_day: "01",
+            expiration_date_year: "19",
+            expiration_date_month: "12",
+            expiration_date_day: "13",
+            state: "CA",
+            license_number: "YT12345",
+        }
+      }
+
+      it "includes the correct error attributes" do
+        form.valid?
+        expect(form.errors.attribute_names).to include :expiration_date
+      end
+    end
+
+    context "when the year is before the year 2000" do
+      let(:params) {
+        {
+            issue_date_year: "1999",
+            issue_date_month: "12",
+            issue_date_day: "01",
+            expiration_date_year: "1999",
+            expiration_date_month: "12",
+            expiration_date_day: "13",
+            state: "CA",
+            license_number: "YT12345",
+        }
+      }
+
+      it "includes the correct error attributes" do
+        form.valid?
+        expect(form.errors.attribute_names).to include :expiration_date
+      end
+    end
+
+    # If this app makes it to the year 2100, make this test fail on Jan 1.
+    context "when the year is this year" do
+      let(:params) {
+        {
+            issue_date_year: "1999",
+            issue_date_month: "12",
+            issue_date_day: "01",
+            expiration_date_year: Date.today.year.to_s,
+            expiration_date_month: "12",
+            expiration_date_day: "13",
+            state: "CA",
+            license_number: "YT12345",
+        }
+      }
+
+      it "includes the correct error attributes" do
+        expect(form.valid?).to eq true
+      end
+    end
   end
 
   describe "#existing_attributes" do


### PR DESCRIPTION
We're checking the string version of the provided date in some of these validations which, to my knowledge, should be fine since they're always coming in from http request form params.