### PR TITLE
Fix link helper to deal with two word table names

### DIFF
--- a/app/helpers/fraud_indicators_helper.rb
+++ b/app/helpers/fraud_indicators_helper.rb
@@ -10,9 +10,9 @@ module FraudIndicatorsHelper
            else
              return nil
            end
-    table = fraud_indicator.list_model_name.split("::").last.downcase
-    path_with_type = "hub_#{type}_#{table}s_path"
-    path_without_type = "hub_#{table}s_path"
+    table = fraud_indicator.list_model_name.split("::").last.tableize
+    path_with_type = "hub_#{type}_#{table}_path"
+    path_without_type = "hub_#{table}_path"
 
     matching_path = nil
     matching_path = path_with_type if respond_to?(path_with_type)

--- a/spec/helpers/fraud_indicators_helper_spec.rb
+++ b/spec/helpers/fraud_indicators_helper_spec.rb
@@ -37,6 +37,13 @@ describe FraudIndicatorsHelper do
           expect(link_to_indicator_list(indicator)).to eq "<a href=\"/en/hub/fraud-indicators/timezones\"><i class=\"icon-\">list_alt</i></a>"
         end
       end
+
+      context "hub_routing_numbers" do
+        let(:indicator) { build :fraud_indicator, list_model_name: "Fraud::Indicator::RoutingNumber", indicator_type: "in_riskylist"}
+        it "returns a link to the page" do
+          expect(link_to_indicator_list(indicator)).to eq "<a href=\"/en/hub/fraud-indicators/routing-numbers\"><i class=\"icon-\">list_alt</i></a>"
+        end
+      end
     end
   end
 


### PR DESCRIPTION
RoutingNumber was converting to routingnumber instead of routing_number