### PR TITLE
CTC: calculate and save spouse agi amount on first submission

### DIFF
--- a/app/lib/submission_builder/business_logic_methods.rb
+++ b/app/lib/submission_builder/business_logic_methods.rb
@@ -56,7 +56,7 @@ module SubmissionBuilder
         raise "spouse_prior_year_agi only works for current tax year"
       end
 
-      intake.spouse_prior_year_agi_amount_computed
+      intake.spouse_prior_year_agi_amount
     end
 
     def primary_prior_year_agi(intake, tax_year)

--- a/app/lib/submission_builder/business_logic_methods.rb
+++ b/app/lib/submission_builder/business_logic_methods.rb
@@ -56,7 +56,7 @@ module SubmissionBuilder
         raise "spouse_prior_year_agi only works for current tax year"
       end
 
-      intake.spouse_prior_year_agi_amount
+      intake.spouse_prior_year_agi_amount || 0
     end
 
     def primary_prior_year_agi(intake, tax_year)

--- a/app/state_machines/efile_submission_state_machine.rb
+++ b/app/state_machines/efile_submission_state_machine.rb
@@ -43,6 +43,9 @@ class EfileSubmissionStateMachine
 
   after_transition(to: :preparing) do |submission|
     submission.create_qualifying_dependents
+    if submission.first_submission? && submission.intake.filing_jointly?
+      submission.intake.update(spouse_prior_year_agi_amount: submission.intake.spouse_prior_year_agi_amount_computed)
+    end
 
     fraud_score = Fraud::Score.create_from(submission)
     bypass_fraud_check = submission.admin_resubmission? || submission.client.identity_verified_at


### PR DESCRIPTION
This allows people to come back for a resubmission and modify it as needed
while ensuring that the initial values are computed correctly

Co-authored-by: Shannon Byrne <sbyrne@codeforamerica.org>