### PR TITLE
Update experience survey send out

### DIFF
--- a/app/models/automated_message/ctc_experience_survey.rb
+++ b/app/models/automated_message/ctc_experience_survey.rb
@@ -9,9 +9,9 @@ module AutomatedMessage
     end
 
     def self.survey_link(client)
-      ctc_rejected_status = client.intake.default_tax_return.current_state == "file_rejected" ? 'TRUE' : 'FALSE'
+      ctc_not_filing_status = client.intake.default_tax_return.current_state == "file_not_filing" ? 'TRUE' : 'FALSE'
 
-      "https://codeforamerica.co1.qualtrics.com/jfe/form/SV_cHN2H3IWcxAEKPA?&ExternalDataReference=#{client.id}&ctcRejected=#{ctc_rejected_status}&expGroup=#{client.ctc_experience_survey_variant}"
+      "https://codeforamerica.co1.qualtrics.com/jfe/form/SV_cHN2H3IWcxAEKPA?&ExternalDataReference=#{client.id}&ctcNotFiling=#{ctc_not_filing_status}&expGroup=#{client.ctc_experience_survey_variant}"
     end
 
     def sms_body(*args)

--- a/app/state_machines/tax_return_state_machine.rb
+++ b/app/state_machines/tax_return_state_machine.rb
@@ -65,8 +65,13 @@ class TaxReturnStateMachine
   end
 
   after_transition(to: "file_rejected") do |tax_return, _|
-    tax_return.enqueue_experience_survey
+    tax_return.enqueue_experience_survey unless tax_return.is_ctc
     MixpanelService.send_file_completed_event(tax_return, "filing_rejected")
+  end
+
+  after_transition(to: "file_not_filing") do |tax_return, _|
+    tax_return.enqueue_experience_survey
+    MixpanelService.send_file_completed_event(tax_return, "not_filing")
   end
 
   after_transition(to: "file_mailed") do |tax_return, _|

--- a/spec/jobs/send_client_ctc_experience_survey_job_spec.rb
+++ b/spec/jobs/send_client_ctc_experience_survey_job_spec.rb
@@ -89,12 +89,12 @@ RSpec.describe SendClientCtcExperienceSurveyJob, type: :job do
           allow(ClientMessagingService).to receive(:contact_methods).and_return({email: "example@example.com", sms_phone_number: "+14155551212"})
         end
 
-        it "includes something in the URL saying it was not rejected" do
+        it "includes something in the URL saying it was not `not-filing`" do
           described_class.perform_now(client)
 
           expect(ClientMessagingService).to have_received(:send_system_email).with(
               client: client,
-              body: a_string_including("ctcRejected=FALSE"),
+              body: a_string_including("ctcNotFiling=FALSE"),
               subject: I18n.t('messages.surveys.ctc_experience.email.subject', locale: :es),
               locale: "es"
           )
@@ -102,8 +102,8 @@ RSpec.describe SendClientCtcExperienceSurveyJob, type: :job do
         end
       end
 
-      context "with a client whose efile submission was rejected" do
-        let!(:tax_return) { create :tax_return, :file_rejected, client: client, year: TaxReturn.current_tax_year }
+      context "with a client whose efile submission was cancelled" do
+        let!(:tax_return) { create :tax_return, :file_not_filing, client: client, year: TaxReturn.current_tax_year }
 
         before do
           allow(ClientMessagingService).to receive(:contact_methods).and_return({email: "example@example.com", sms_phone_number: "+14155551212"})
@@ -114,7 +114,7 @@ RSpec.describe SendClientCtcExperienceSurveyJob, type: :job do
 
           expect(ClientMessagingService).to have_received(:send_system_email).with(
               client: client,
-              body: a_string_including("ctcRejected=TRUE"),
+              body: a_string_including("ctcNotFiling=TRUE"),
               subject: I18n.t('messages.surveys.ctc_experience.email.subject', locale: :es),
               locale: "es"
           )


### PR DESCRIPTION
Per a conversation with Yvonne, `rejected` isn't really considered a terminal status for CTC tax returns, and so we want to update to send out the experience survey once a CTC tax return enters the `not_filing` status (which appears as cancelled in the efile dashboard)

Along with this change, we want to maintain sending out experience surveys to `rejected` GYR clients, as it IS used as a terminal status for GYR.

Finally, it was decided that we want to begin sending experience surveys to `not_filing` tax returns clients for GYR as well.