### PR TITLE
Fix bug where we send en to SendAutomatedMessage

### DIFF
--- a/app/lib/send_automated_message.rb
+++ b/app/lib/send_automated_message.rb
@@ -3,7 +3,7 @@ class SendAutomatedMessage
 
   def initialize(client:, message:, tax_return: nil, locale: nil, body_args: {})
     @client = client
-    @locale = locale || client.intake&.locale || "en"
+    @locale = locale || client&.intake.locale || "en"
     @message = message
     @message_instance = message.new
     @tax_return = tax_return

--- a/app/services/client_messaging_service.rb
+++ b/app/services/client_messaging_service.rb
@@ -84,7 +84,7 @@ class ClientMessagingService
       message_records
     end
 
-    def send_system_message_to_all_opted_in_contact_methods(client:, message:, tax_return: nil, locale: "en", body_args: {})
+    def send_system_message_to_all_opted_in_contact_methods(client:, message:, tax_return: nil, locale: nil, body_args: {})
       SendAutomatedMessage.new(
         client: client,
         message: message,

--- a/app/state_machines/efile_submission_state_machine.rb
+++ b/app/state_machines/efile_submission_state_machine.rb
@@ -63,7 +63,7 @@ class EfileSubmissionStateMachine
     # AutomatedMessage::EfilePreparing has send_only_once set to true
     ClientMessagingService.send_system_message_to_all_opted_in_contact_methods(
       client: submission.client,
-      message: AutomatedMessage::EfilePreparing
+      message: AutomatedMessage::EfilePreparing,
     )
     submission.tax_return.transition_to!(:file_ready_to_file)
 
@@ -79,7 +79,6 @@ class EfileSubmissionStateMachine
     ClientMessagingService.send_system_message_to_all_opted_in_contact_methods(
       client: submission.client,
       message: AutomatedMessage::InformOfFraudHold,
-      locale: submission.client.intake.locale,
     )
   end
 
@@ -98,7 +97,6 @@ class EfileSubmissionStateMachine
         ClientMessagingService.send_system_message_to_all_opted_in_contact_methods(
           client: submission.client,
           message: AutomatedMessage::EfileFailed,
-          locale: submission.client.intake.locale
         )
       end
       submission.transition_to!(:waiting) if transition.efile_errors.all?(&:auto_wait)
@@ -118,7 +116,6 @@ class EfileSubmissionStateMachine
     ClientMessagingService.send_system_message_to_all_opted_in_contact_methods(
       client: client,
       message: AutomatedMessage::EfileAcceptance,
-      locale: client.intake.locale
     )
     tax_return.transition_to(:file_accepted)
 

--- a/app/views/hub/verification_attempts/show.html.erb
+++ b/app/views/hub/verification_attempts/show.html.erb
@@ -57,7 +57,7 @@
                     <% end %>
                   </div>
                 </div>
-                <div class="grid-flex column-column justify-flex-end">
+                <div class="grid-flex column-column">
                   <div class="spacing-below-0" style="font-size: smaller; text-align: right;"><%= link_to "#{timestamp(attempt.created_at)}", hub_verification_attempt_path(id:attempt.id), id: "time" %></div>
                   <div class="spacing-above-10">
                     <div class="label"><%= attempt.current_state.humanize(capitalize: false) %></div>

--- a/spec/state_machines/efile_submission_state_machine_spec.rb
+++ b/spec/state_machines/efile_submission_state_machine_spec.rb
@@ -185,7 +185,6 @@ describe EfileSubmissionStateMachine do
           expect(ClientMessagingService).to have_received(:send_system_message_to_all_opted_in_contact_methods).with(
             client: submission.client.reload,
             message: AutomatedMessage::EfileFailed,
-            locale: submission.client.intake.locale
           )
         end
       end
@@ -246,7 +245,6 @@ describe EfileSubmissionStateMachine do
         expect(ClientMessagingService).to have_received(:send_system_message_to_all_opted_in_contact_methods).with(
           client: submission.client.reload,
           message: AutomatedMessage::EfileAcceptance,
-          locale: submission.client.intake.locale
         )
       end
 
@@ -286,7 +284,6 @@ describe EfileSubmissionStateMachine do
         expect(new_submission.qualifying_dependents).to be_present
         expect(new_submission.last_transition_to("preparing").metadata["previous_submission_id"]).to eq efile_submission.id
       end
-
     end
   end
 end


### PR DESCRIPTION
This bug was kind of caused by having this "go between method" in ClientMessagingService. I wonder if I should spend the time to just switch everything over to SendAutomatedMessage directly...