### PR TITLE
Reformat credits section

### DIFF
--- a/app/views/hub/clients/show.html.erb
+++ b/app/views/hub/clients/show.html.erb
@@ -136,7 +136,7 @@
           <!-- Recovery rebate credit -->
           <% if @client.intake.is_ctc? %>
             <div class="client-profile__field-group client-recovery-rebate-credit-amount">
-              <h2 class="text--bold"><%= t("hub.clients.fields.recovery_rebate_credit") %></h2>
+              <h2 class="text--bold">Refund and Credits</h2>
               <% if @client.intake.eip1_amount_received.present? && @client.intake.eip2_amount_received.present? %>
                 <div class="field-display">
                   <span class="form-question"><%= t("hub.recovery_rebate_credit_amount.amount_1") %>:</span>
@@ -145,12 +145,6 @@
                 <div class="field-display">
                   <span class="form-question"><%= t("hub.recovery_rebate_credit_amount.amount_2") %>:</span>
                   <span class="label-value">$<%= @client.intake.eip2_amount_received %> </span>
-                </div>
-              <% end %>
-              <% if !@client.archived? && @client.intake.eip3_amount_received.present? %>
-                <div class="field-display">
-                  <span class="form-question"><%= t("hub.recovery_rebate_credit_amount.amount_3") %>:</span>
-                  <span class="label-value">$<%= @client.intake.eip3_amount_received %> </span>
                 </div>
               <% end %>
               <% if @client.intake.drop_off? && @client.intake.eip1_and_2_amount_received_confidence.present? %>
@@ -164,24 +158,20 @@
                 <% if tax_return %>
                   <% benefits = Efile::BenefitsEligibility.new(tax_return: tax_return, dependents: @client.intake.dependents) %>
                   <div class="field-display">
-                    <span class="form-question"> Outstanding RRC / Claimed RRC: </span>
-                    <span class="label-value"><%= "$#{benefits.outstanding_recovery_rebate_credit}" if benefits.outstanding_recovery_rebate_credit %></span>
-                    /
-                    <span class="label-value"><%= "$#{benefits.claimed_recovery_rebate_credit}" if benefits.claimed_recovery_rebate_credit %></span>
+                    <span class="form-question"> Received RRC / Owed RRC / Claimed RRC: </span>
+                    <br/>
+                    <span class="label-value"><%= @client.archived? ? "N/A" : "$#{@client.intake.eip3_amount_received}" %></span> /
+                    <span class="label-value"><%= "$#{benefits.outstanding_recovery_rebate_credit}" if benefits.outstanding_recovery_rebate_credit %></span> /
+                    <span class="label-value text--bold"><%= "$#{benefits.claimed_recovery_rebate_credit}" if benefits.claimed_recovery_rebate_credit %></span>
                   </div>
-                  <% unless @client.intake.advance_ctc_amount_received.nil? %>
-                    <div class="field-display">
-                      <span class="form-question">Outstanding CTC / Advance CTC Received:</span>
-                      <span class="label-value"><%= "$#{benefits.outstanding_ctc_amount}" if benefits.outstanding_ctc_amount %></span>
-                      /
-                      <span class="label-value"><%= "$#{benefits.advance_ctc_amount_received}" if benefits.advance_ctc_amount_received %></span>
-                    </div>
-                  <% end %>
+                  <div class="field-display">
+                    <span class="form-question">Received CTC / Owed CTC / Claimed CTC:</span>
+                    </br>
+                    <span class="label-value"><%= "$#{benefits.advance_ctc_amount_received}" if benefits.advance_ctc_amount_received %></span> /
+                    <span class="label-value"><%= "$#{benefits.ctc_amount}" if benefits.outstanding_ctc_amount %></span> /
+                    <span class="label-value text--bold"><%= "$#{benefits.outstanding_ctc_amount}" if benefits.outstanding_ctc_amount %></span>
+                  </div>
                 <% end %>
-                <div class="field-display">
-                  <span class="form-question">Claim credit:</span>
-                  <span class="label-value"><%= @client.intake.claim_owed_stimulus_money&.titleize %></span>
-                </div>
               <% end %>
             </div>
           <% end %>


### PR DESCRIPTION
There were two areas that talked about how much money people get this year, formatted similarly but showing different information. After the update, both the CTC credit and RRC amount claimed should be more clear and mirror each other.

Also removes the separate section for EIP3 amount claimed (consolidates into the RRC claimed section), and removes the "Claim Credit" which is not used.

## BEFORE
![Screen Shot 2022-05-16 at 3 46 21 PM](https://user-images.githubusercontent.com/4494389/168696578-2a583181-fd4e-41c3-bc37-a02af95552c4.png)


## AFTER
<img width="374" alt="Screen Shot 2022-05-16 at 4 05 22 PM" src="https://user-images.githubusercontent.com/4494389/168696587-a87635ec-b03e-496a-971f-87efc2f8920f.png">
