### PR TITLE
Do not create duplicate error when the error message changes

### DIFF
--- a/spec/fixtures/files/irs_acknowledgement_rejection_with_new_error_message.xml
+++ b/spec/fixtures/files/irs_acknowledgement_rejection_with_new_error_message.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AcknowledgementList xmlns="http://www.irs.gov/efile" xmlns:efile="http://www.irs.gov/efile">
+   <Cnt>1</Cnt>
+   <Acknowledgement submissionVersionNum="2020v5.1" validatingSchemaVersionNum="2020v5.1">
+      <SubmissionId>9999992021197yrv4rvl</SubmissionId>
+      <EFIN>999999</EFIN>
+      <TaxYr>2020</TaxYr>
+      <ExtndGovernmentCd>IRS</ExtndGovernmentCd>
+      <SubmissionTyp>1040</SubmissionTyp>
+      <ExtndSubmissionCategoryCd>IND</ExtndSubmissionCategoryCd>
+      <ElectronicPostmarkTs>2021-07-16T09:42:25.953-07:00</ElectronicPostmarkTs>
+      <AcceptanceStatusTxt>Rejected</AcceptanceStatusTxt>
+      <ContainedAlertsInd>false</ContainedAlertsInd>
+      <StatusDt>2021-07-16</StatusDt>
+      <TIN>404005348</TIN>
+      <TaxPeriodEndDt>2020-12-31</TaxPeriodEndDt>
+      <SubmissionValidationCompInd>false</SubmissionValidationCompInd>
+      <EmbeddedCRC32Num>0x7adce7bb</EmbeddedCRC32Num>
+      <ComputedCRC32Num>0x7adce7bb</ComputedCRC32Num>
+      <ReservedIPAddressCd>R</ReservedIPAddressCd>
+      <ExpectedRefundAmt>0</ExpectedRefundAmt>
+      <ValidationErrorList errorCnt="2">
+         <ValidationErrorGrp errorId="1">
+            <DocumentId>NA</DocumentId>
+            <XpathContentTxt>/efile:Return/efile:ReturnHeader</XpathContentTxt>
+            <ErrorCategoryCd>Missing Data</ErrorCategoryCd>
+            <ErrorMessageTxt>A very different error message than before.</ErrorMessageTxt>
+            <RuleNum>IND-189</RuleNum>
+            <SeverityCd>Reject and Stop</SeverityCd>
+            <FieldValueTxt/>
+         </ValidationErrorGrp>
+         <ValidationErrorGrp errorId="2">
+            <DocumentId>NA</DocumentId>
+            <XpathContentTxt>/efile:Return/efile:ReturnHeader</XpathContentTxt>
+            <ErrorCategoryCd>Missing Data</ErrorCategoryCd>
+            <ErrorMessageTxt>'DeviceId' in 'AtSubmissionFilingGrp' in 'FilingSecurityInformation' in the Return Header must have a value.</ErrorMessageTxt>
+            <RuleNum>IND-190</RuleNum>
+            <SeverityCd>Reject and Stop</SeverityCd>
+            <FieldValueTxt>142111111</FieldValueTxt>
+         </ValidationErrorGrp>
+      </ValidationErrorList>
+   </Acknowledgement>
+</AcknowledgementList>

--- a/spec/lib/efile/submission_error_parser_spec.rb
+++ b/spec/lib/efile/submission_error_parser_spec.rb
@@ -17,31 +17,30 @@ describe Efile::SubmissionErrorParser do
       end
 
       context "when a matching error already exists" do
-        before do
-          EfileError.create(code: "IRS-1040-PROBS", message: "You have a problem.", source: "irs")
-        end
+        let!(:existing_error) { create(:efile_error, code: "IRS-1040-PROBS", message: "You have a problem.", source: "irs") }
 
-        let(:transition) { create :efile_submission_transition, :preparing, metadata: { error_code: "IRS-1040-PROBS" } }
+        let(:transition) { create :efile_submission_transition, :preparing, metadata: { error_code: "IRS-1040-PROBS", message: "You have a different problem.", source: "irs" } }
 
-        it "does not create a new EfileError object, but associates the existing one with the transition" do
+        it "does not create a new EfileError object, but associates the existing one with the transition, and does not update the message" do
           Efile::SubmissionErrorParser.new(transition).persist_errors
           expect(EfileError.count).to eq 1
           expect(transition.efile_errors.count).to eq 1
+          expect(existing_error.message).to eq "You have a problem."
         end
       end
     end
 
     context "when a code and message and a source are provided" do
       context "when it matches an existing code/message/source" do
-        let(:transition) { create :efile_submission_transition, :preparing, metadata: { error_code: "IRS-1040-PROBS", error_message: "You have a problem.", error_source: "irs" } }
-        before do
-          EfileError.create(code: "IRS-1040-PROBS", message: "You have a problem.", source: "irs")
-        end
+        let!(:existing_error) { create(:efile_error, code: "IRS-1040-PROBS", message: "You have a problem.", source: "irs") }
 
-        it "does not create a new EfileError object" do
+        let(:transition) { create :efile_submission_transition, :preparing, metadata: { error_code: "IRS-1040-PROBS", error_message: "You have a different problem now.", error_source: "irs" } }
+
+        it "does not create a new EfileError object, but associates the existing one with the transition and updates its message" do
           Efile::SubmissionErrorParser.new(transition).persist_errors
           expect(EfileError.count).to eq 1
           expect(transition.efile_errors.count).to eq 1
+          expect(existing_error.reload.message).to eq "You have a different problem now."
         end
       end
 
@@ -85,18 +84,21 @@ describe Efile::SubmissionErrorParser do
       end
 
       context "when the rejection errors already exist in the db" do
-        let!(:other_transition) { create :efile_submission_transition, :rejected, metadata: { raw_response: raw_response } }
+        let(:raw_response) { file_fixture("irs_acknowledgement_rejection_with_new_error_message.xml").read }
+        let!(:other_transition) { create :efile_submission_transition, :rejected, metadata: { raw_response: file_fixture("irs_acknowledgement_rejection.xml").read } }
 
         before do
           Efile::SubmissionErrorParser.new(other_transition).persist_errors
         end
 
-        it "associates the efile errors with transition, but uses the existing EfileError objects" do
+        it "associates the efile errors with transition, but uses the existing EfileError objects, and updates the messages if they changed" do
           expect {
             Efile::SubmissionErrorParser.new(transition).persist_errors
           }.to change(transition.efile_errors, :count).by(2)
                    .and change(EfileError, :count).by(0)
           expect(EfileError.count).to eq 2
+          expect(EfileError.find_by_code("IND-189").message).to eq "A very different error message than before."
+          expect(EfileError.find_by_code("IND-190").message).to eq "'DeviceId' in 'AtSubmissionFilingGrp' in 'FilingSecurityInformation' in the Return Header must have a value."
         end
 
         context "with dependent association" do


### PR DESCRIPTION
See the slack for more details: https://cfa.slack.com/archives/GT1B45BS5/p1652718087681559

When clearing out the reject queue, we discovered that an error, IND-664-02, was duplicated.

This duplication is due to the error message being updated by the IRS. We do a `find_or_create` on `EfileError` and the error message is one of the attributes that we match on. When it didn't match we created a new error.

Going forward we should not create a new error, but instead update the error message of the existing error when the IRS updates the error message copy.