### PR TITLE
Add rack-mini-profiler in demo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,7 @@ group :demo, :development, :test do
   gem 'faker'
 end
 
-group :demo, :development do
+group :demo, :development, :heroku, :staging do
   gem 'rack-mini-profiler'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,10 @@ group :demo, :development, :test do
   gem 'faker'
 end
 
+group :demo, :development do
+  gem 'rack-mini-profiler'
+end
+
 group :development, :test do
   gem 'awesome_print'
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
@@ -114,7 +118,6 @@ group :development do
   gem 'spring'
   gem 'git-pair'
   gem 'annotate'
-  gem 'rack-mini-profiler'
   gem 'flamegraph'
   gem 'stackprof'
   gem 'memory_profiler'

--- a/config/initializers/rack_profiler.rb
+++ b/config/initializers/rack_profiler.rb
@@ -1,4 +1,4 @@
-if Rails.env.demo?
+if Rails.env.demo? || Rails.env.heroku? || Rails.env.staging?
   # Use the "Alt+P" keyboard shortcut to toggle visibility
   Rack::MiniProfiler.config.start_hidden = true
 end

--- a/config/initializers/rack_profiler.rb
+++ b/config/initializers/rack_profiler.rb
@@ -1,0 +1,4 @@
+if Rails.env.demo?
+  # Use the "Alt+P" keyboard shortcut to toggle visibility
+  Rack::MiniProfiler.config.start_hidden = true
+end


### PR DESCRIPTION
It would be helpful to see this little tab in demo.

<img width="481" alt="image" src="https://user-images.githubusercontent.com/6520735/169152331-97b87bda-b4f1-408a-ba20-0aaa8e5e2236.png">
