### PR TITLE
Consolidate and refactor file type validation logic

### DIFF
--- a/app/controllers/documents/document_upload_question_controller.rb
+++ b/app/controllers/documents/document_upload_question_controller.rb
@@ -71,12 +71,12 @@ module Documents
     end
 
     def track_document_upload
-      return unless @form.document.present?
+      return unless @form.upload.present?
 
       send_mixpanel_event(event_name: "document_uploaded", data: {
         document_type: document_type_key,
-        file_extension: File.extname(@form.document.original_filename),
-        file_content_type: @form.document.content_type,
+        file_extension: File.extname(@form.upload.original_filename),
+        file_content_type: @form.upload.content_type,
       })
     end
 

--- a/app/controllers/mailgun_webhooks_controller.rb
+++ b/app/controllers/mailgun_webhooks_controller.rb
@@ -50,7 +50,7 @@ class MailgunWebhooksController < ActionController::Base
         size = attachment.tempfile.size
 
         processed_attachments <<
-          if (FileTypeAllowedValidator::VALID_MIME_TYPES.include? attachment.content_type) && (size > 0)
+          if (Document::VALID_MIME_TYPES.include? attachment.content_type) && (size > 0)
             {
                 io: attachment,
                 filename: attachment.original_filename,

--- a/app/controllers/mailgun_webhooks_controller.rb
+++ b/app/controllers/mailgun_webhooks_controller.rb
@@ -50,7 +50,7 @@ class MailgunWebhooksController < ActionController::Base
         size = attachment.tempfile.size
 
         processed_attachments <<
-          if (Document::VALID_MIME_TYPES.include? attachment.content_type) && (size > 0)
+          if (FileTypeAllowedValidator.mime_types(Document).include? attachment.content_type) && (size > 0)
             {
                 io: attachment,
                 filename: attachment.original_filename,

--- a/app/forms/document_type_upload_form.rb
+++ b/app/forms/document_type_upload_form.rb
@@ -1,6 +1,7 @@
 class DocumentTypeUploadForm < QuestionsForm
-  set_attributes_for :intake, :document
-  validate :instantiate_document
+  set_attributes_for :intake, :upload
+  before_validation :instantiate_document
+  validate :validate_document
 
   def initialize(document_type, *args, **kwargs)
     @document_type = document_type
@@ -10,35 +11,26 @@ class DocumentTypeUploadForm < QuestionsForm
   def save
     return false unless valid?
 
-    @doc.save!
+    @document.save!
   end
 
   private
 
   def instantiate_document
-    document_file_upload = attributes_for(:intake)[:document]
-    if document_file_upload.blank?
-      errors.add(:document, I18n.t("validators.file_type", valid_types: FileTypeAllowedValidator.extensions(Document).to_sentence))
-      return
-    end
-
-    # Rewind to avoid IntegrityError
-    document_file_upload.tempfile.rewind
-    doc = @intake.documents.new(
-        document_type: @document_type,
-        client: @intake.client,
-        uploaded_by: @intake.client,
-        upload: {
-          io: document_file_upload.tempfile,
-          # Remove non-utf-8 characters from the original filename
-          filename: document_file_upload.original_filename.encode("UTF-8", invalid: :replace, replace: ""),
-          content_type: document_file_upload.content_type
-        }
+    @upload.tempfile.rewind if @upload.present?
+    @document = @intake.documents.new(
+      document_type: @document_type,
+      client: @intake.client,
+      uploaded_by: @intake.client,
+      upload: @upload.present? ? {
+        io: @upload.tempfile, # Rewind to avoid integrity error
+        filename: @upload.original_filename.encode("UTF-8", invalid: :replace, replace: ""), # Remove non-utf-8 characters from the original filename
+        content_type: @upload.content_type
+      } : nil
     )
-    if doc.valid?
-      @doc = doc
-    else
-      doc.errors.map { |error| error.message }.flatten.each { |msg| errors.add(:document, msg) }
-    end
+  end
+
+  def validate_document
+    errors.copy!(@document.errors) unless @document.valid?
   end
 end

--- a/app/forms/document_type_upload_form.rb
+++ b/app/forms/document_type_upload_form.rb
@@ -1,6 +1,5 @@
 class DocumentTypeUploadForm < QuestionsForm
   set_attributes_for :intake, :document
-  validates :document, file_type_allowed: true
   validate :instantiate_document
 
   def initialize(document_type, *args, **kwargs)
@@ -19,7 +18,7 @@ class DocumentTypeUploadForm < QuestionsForm
   def instantiate_document
     document_file_upload = attributes_for(:intake)[:document]
     if document_file_upload.blank?
-      errors.add(:document, I18n.t("validators.file_type", valid_types: Document::VALID_FILE_TYPES.to_sentence))
+      errors.add(:document, I18n.t("validators.file_type", valid_types: FileTypeAllowedValidator.extensions(Document).to_sentence))
       return
     end
 

--- a/app/forms/document_type_upload_form.rb
+++ b/app/forms/document_type_upload_form.rb
@@ -19,8 +19,7 @@ class DocumentTypeUploadForm < QuestionsForm
   def instantiate_document
     document_file_upload = attributes_for(:intake)[:document]
     if document_file_upload.blank?
-      # TODO: has access to locale?
-      errors.add(:document, I18n.t("validators.file_type", valid_types: Document::VALID_FILE_TYPES.to_sentence(locale: locale)))
+      errors.add(:document, I18n.t("validators.file_type", valid_types: Document::VALID_FILE_TYPES.to_sentence))
       return
     end
 

--- a/app/forms/document_type_upload_form.rb
+++ b/app/forms/document_type_upload_form.rb
@@ -19,7 +19,8 @@ class DocumentTypeUploadForm < QuestionsForm
   def instantiate_document
     document_file_upload = attributes_for(:intake)[:document]
     if document_file_upload.blank?
-      errors.add(:document, I18n.t("validators.file_type"))
+      # TODO: has access to locale?
+      errors.add(:document, I18n.t("validators.file_type", valid_types: Document::VALID_FILE_TYPES.to_sentence(locale: locale)))
       return
     end
 

--- a/app/forms/requested_document_upload_form.rb
+++ b/app/forms/requested_document_upload_form.rb
@@ -1,6 +1,7 @@
 class RequestedDocumentUploadForm < QuestionsForm
-  set_attributes_for :documents_request, :document, :document_type
-  validate :instantiate_document
+  set_attributes_for :documents_request, :upload, :document_type
+  before_validation :instantiate_document
+  validate :validate_document
 
   def initialize(documents_request, *args, **kwargs)
     @documents_request = documents_request
@@ -10,27 +11,26 @@ class RequestedDocumentUploadForm < QuestionsForm
   def save
     return false unless valid?
 
-    @doc.save!
+    @document.save!
   end
 
   private
 
-  def instantiate_document
-    document_file_upload = attributes_for(:documents_request)[:document]
-    document_type = attributes_for(:documents_request)[:document_type] || DocumentTypes::RequestedLater
-    if document_file_upload.present?
-      doc = @documents_request.documents.new(
-        uploaded_by: @documents_request.client,
-        document_type: document_type.key,
-        client: @documents_request.client,
-        upload: document_file_upload,
-      )
-    end
+  def validate_document
+    errors.copy!(@document.errors) unless @document.valid?
+  end
 
-    if doc.valid?
-      @doc = doc
-    else
-      doc.errors.map { |error| error.message }.flatten.each { |msg| errors.add(:document, msg) }
-    end
+  def instantiate_document
+    @upload.tempfile.rewind if @upload.present?
+    @document = @documents_request.documents.new(
+      document_type: @document_type || DocumentTypes::RequestedLater,
+      client: @documents_request.client,
+      uploaded_by: @documents_request.client,
+      upload: @upload.present? ? {
+          io: @upload.tempfile, # Rewind to avoid integrity error
+          filename: @upload.original_filename.encode("UTF-8", invalid: :replace, replace: ""), # Remove non-utf-8 characters from the original filename
+          content_type: @upload.content_type
+      } : nil
+    )
   end
 end

--- a/app/forms/requested_document_upload_form.rb
+++ b/app/forms/requested_document_upload_form.rb
@@ -1,6 +1,6 @@
 class RequestedDocumentUploadForm < QuestionsForm
   set_attributes_for :documents_request, :document, :document_type
-  # validates :document, file_type_allowed: true
+  validate :instantiate_document
 
   def initialize(documents_request, *args, **kwargs)
     @documents_request = documents_request
@@ -8,6 +8,14 @@ class RequestedDocumentUploadForm < QuestionsForm
   end
 
   def save
+    return false unless valid?
+
+    @doc.save!
+  end
+
+  private
+
+  def instantiate_document
     document_file_upload = attributes_for(:documents_request)[:document]
     document_type = attributes_for(:documents_request)[:document_type] || DocumentTypes::RequestedLater
     if document_file_upload.present?
@@ -20,7 +28,7 @@ class RequestedDocumentUploadForm < QuestionsForm
     end
 
     if doc.valid?
-      @documents_request = doc
+      @doc = doc
     else
       doc.errors.map { |error| error.message }.flatten.each { |msg| errors.add(:document, msg) }
     end

--- a/app/forms/requested_document_upload_form.rb
+++ b/app/forms/requested_document_upload_form.rb
@@ -1,6 +1,6 @@
 class RequestedDocumentUploadForm < QuestionsForm
   set_attributes_for :documents_request, :document, :document_type
-  validates :document, file_type_allowed: true
+  # validates :document, file_type_allowed: true
 
   def initialize(documents_request, *args, **kwargs)
     @documents_request = documents_request
@@ -11,12 +11,18 @@ class RequestedDocumentUploadForm < QuestionsForm
     document_file_upload = attributes_for(:documents_request)[:document]
     document_type = attributes_for(:documents_request)[:document_type] || DocumentTypes::RequestedLater
     if document_file_upload.present?
-      @documents_request.documents.create(
+      doc = @documents_request.documents.new(
         uploaded_by: @documents_request.client,
         document_type: document_type.key,
         client: @documents_request.client,
         upload: document_file_upload,
       )
+    end
+
+    if doc.valid?
+      @documents_request = doc
+    else
+      doc.errors.map { |error| error.message }.flatten.each { |msg| errors.add(:document, msg) }
     end
   end
 end

--- a/app/lib/f15080_vita_consent_to_disclose_pdf.rb
+++ b/app/lib/f15080_vita_consent_to_disclose_pdf.rb
@@ -6,7 +6,7 @@ class F15080VitaConsentToDisclosePdf
   end
 
   def output_filename
-    "F15080 - VITA Consent To Disclose"
+    "F15080 - VITA Consent To Disclose.pdf"
   end
 
   def document_type

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -35,6 +35,8 @@
 require "mini_magick"
 
 class Document < ApplicationRecord
+  VALID_FILE_TYPES = [".jpg", ".jpeg", ".pdf", ".png", ".heic", ".bmp", ".txt", ".tiff", ".gif"].freeze
+  VALID_MIME_TYPES = ["image/jpeg", "image/png", "application/pdf", "image/heic", "image/bmp", "text/plain", "image/tiff", "image/gif"].freeze
   belongs_to :intake, optional: true
   belongs_to :client, touch: true
   belongs_to :documents_request, optional: true

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -73,7 +73,7 @@ class Document < ApplicationRecord
   # has_one_attached needs to be called after defining any callbacks that access attachments, like
   # the HEIC conversion; see https://github.com/rails/rails/issues/37304
   has_one_attached :upload
-  validates :upload, file_type_allowed: true
+  validates :upload, file_type_allowed: true, if: -> { upload.present? }
 
   def is_pdf?
     upload&.content_type == "application/pdf"
@@ -98,7 +98,7 @@ class Document < ApplicationRecord
 
     jpg_image = image.format("jpg")
 
-    upload.attach(io: File.open(jpg_image.path), filename: "#{display_name}.jpg", content_type: "image/jpg")
+    upload.attach(io: File.open(jpg_image.path), filename: "#{display_name}.jpg", content_type: "image/jpeg")
     update!(display_name: upload.attachment.filename)
   end
 

--- a/app/models/verification_attempt.rb
+++ b/app/models/verification_attempt.rb
@@ -40,8 +40,8 @@ class VerificationAttempt < ApplicationRecord
   scope :reviewing, -> { in_state(:pending, :escalated, :restricted) }
 
   validate :only_one_open_attempt_per_client, on: :create
-  validates :selfie, file_type_allowed: true
-  validates :photo_identification, file_type_allowed: true
+  validates :selfie, file_type_allowed: true, if: -> { selfie.present? }
+  validates :photo_identification, file_type_allowed: true, if: -> { photo_identification.present? }
 
   def only_one_open_attempt_per_client
     errors.add(:client, "only one open attempt is allowed per client") if client.verification_attempts.open.exists?

--- a/app/models/verification_attempt.rb
+++ b/app/models/verification_attempt.rb
@@ -13,6 +13,9 @@
 #  index_verification_attempts_on_client_id  (client_id)
 #
 class VerificationAttempt < ApplicationRecord
+  VALID_FILE_TYPES = [".jpg", ".pdf", ".png"].freeze
+  # TODO: check this list?
+  VALID_MIME_TYPES = ["image/jpeg", "image/png", "image/heic", "image/bmp", "text/plain", "image/tiff", "image/gif"].freeze
   belongs_to :client
   has_one :intake, through: :client
   has_one_attached :selfie
@@ -44,8 +47,8 @@ class VerificationAttempt < ApplicationRecord
   def attachment_file_types
     [selfie, photo_identification].each do |attachment|
       if attachment.present?
-        unless FileTypeAllowedValidator::VALID_MIME_TYPES.include?(attachment.content_type)
-          errors.add(attachment.name, I18n.t("validators.file_type"))
+        unless VALID_MIME_TYPES.include?(attachment.content_type)
+          errors.add(attachment.name, I18n.t("validators.file_type", valid_types: VALID_FILE_TYPES.to_sentence(locale: I18n.locale)))
         end
       end
     end

--- a/app/models/verification_attempt.rb
+++ b/app/models/verification_attempt.rb
@@ -13,9 +13,7 @@
 #  index_verification_attempts_on_client_id  (client_id)
 #
 class VerificationAttempt < ApplicationRecord
-  VALID_FILE_TYPES = [".jpg", ".pdf", ".png"].freeze
-  # TODO: check this list?
-  VALID_MIME_TYPES = ["image/jpeg", "image/png", "image/heic", "image/bmp", "text/plain", "image/tiff", "image/gif"].freeze
+  ACCEPTED_FILE_TYPES = [:browser_native_image]
   belongs_to :client
   has_one :intake, through: :client
   has_one_attached :selfie
@@ -42,7 +40,9 @@ class VerificationAttempt < ApplicationRecord
   scope :reviewing, -> { in_state(:pending, :escalated, :restricted) }
 
   validate :only_one_open_attempt_per_client, on: :create
-  validate :attachment_file_types
+  validates :selfie, file_type_allowed: true
+  validates :photo_identification, file_type_allowed: true
+  # validate :attachment_file_types
 
   def attachment_file_types
     [selfie, photo_identification].each do |attachment|

--- a/app/models/verification_attempt.rb
+++ b/app/models/verification_attempt.rb
@@ -42,17 +42,6 @@ class VerificationAttempt < ApplicationRecord
   validate :only_one_open_attempt_per_client, on: :create
   validates :selfie, file_type_allowed: true
   validates :photo_identification, file_type_allowed: true
-  # validate :attachment_file_types
-
-  def attachment_file_types
-    [selfie, photo_identification].each do |attachment|
-      if attachment.present?
-        unless VALID_MIME_TYPES.include?(attachment.content_type)
-          errors.add(attachment.name, I18n.t("validators.file_type", valid_types: VALID_FILE_TYPES.to_sentence))
-        end
-      end
-    end
-  end
 
   def only_one_open_attempt_per_client
     errors.add(:client, "only one open attempt is allowed per client") if client.verification_attempts.open.exists?

--- a/app/models/verification_attempt.rb
+++ b/app/models/verification_attempt.rb
@@ -48,7 +48,7 @@ class VerificationAttempt < ApplicationRecord
     [selfie, photo_identification].each do |attachment|
       if attachment.present?
         unless VALID_MIME_TYPES.include?(attachment.content_type)
-          errors.add(attachment.name, I18n.t("validators.file_type", valid_types: VALID_FILE_TYPES.to_sentence(locale: I18n.locale)))
+          errors.add(attachment.name, I18n.t("validators.file_type", valid_types: VALID_FILE_TYPES.to_sentence))
         end
       end
     end

--- a/app/services/twilio_service.rb
+++ b/app/services/twilio_service.rb
@@ -28,7 +28,7 @@ class TwilioService
         content_type = params["MediaContentType#{i}"]
         attachment = fetch_attachment(params["MediaUrl#{i}"])
 
-        if Document::VALID_MIME_TYPES.include?(content_type) && !attachment[:body].empty?
+        if FileTypeAllowedValidator.mime_types(Document).include?(content_type) && !attachment[:body].empty?
           {
             content_type: params["MediaContentType#{i}"],
             filename: attachment[:filename],

--- a/app/services/twilio_service.rb
+++ b/app/services/twilio_service.rb
@@ -28,7 +28,7 @@ class TwilioService
         content_type = params["MediaContentType#{i}"]
         attachment = fetch_attachment(params["MediaUrl#{i}"])
 
-        if FileTypeAllowedValidator::VALID_MIME_TYPES.include?(content_type) && !attachment[:body].empty?
+        if Document::VALID_MIME_TYPES.include?(content_type) && !attachment[:body].empty?
           {
             content_type: params["MediaContentType#{i}"],
             filename: attachment[:filename],

--- a/app/validators/file_type_allowed_validator.rb
+++ b/app/validators/file_type_allowed_validator.rb
@@ -2,15 +2,19 @@ class FileTypeAllowedValidator < ActiveModel::EachValidator
   # The list of allowed types is security sensitive because it may allow files with script
   # capabilities to be uploaded leading to XSS attacks. Please be sure to know what you are
   # doing when modifying this list.
-  VALID_FILE_EXTENSIONS = [".jpg", ".jpeg", ".pdf", ".png", ".heic", ".bmp", ".txt", ".tiff", ".gif"]
-  VALID_MIME_TYPES = ["image/jpeg", "image/png", "application/pdf", "image/heic", "image/bmp", "text/plain", "image/tiff", "image/gif"]
+
+  # TODO: remove these
+  # VALID_FILE_EXTENSIONS = [".jpg", ".jpeg", ".pdf", ".png", ".heic", ".bmp", ".txt", ".tiff", ".gif"]
+  # VALID_MIME_TYPES = ["image/jpeg", "image/png", "application/pdf", "image/heic", "image/bmp", "text/plain", "image/tiff", "image/gif"]
 
   def validate_each(record, attr_name, value)
     return if !value
 
     extension = File.extname(value.path)
-    unless VALID_FILE_EXTENSIONS.include?(extension.downcase)
-      record.errors.add(attr_name, I18n.t("validators.file_type"))
+    valid_types_from_record = record.classify.constantize::VALID_FILE_TYPES
+    unless valid_types_from_record.include?(extension.downcase)
+      # TODO: has access to locale?
+      record.errors.add(attr_name, I18n.t("validators.file_type", valid_types: valid_types_from_record.to_sentence(locale: locale)))
     end
   end
 end

--- a/app/validators/file_type_allowed_validator.rb
+++ b/app/validators/file_type_allowed_validator.rb
@@ -22,10 +22,6 @@ class FileTypeAllowedValidator < ActiveModel::EachValidator
     model::ACCEPTED_FILE_TYPES.map { |group| FILE_TYPE_GROUPS[group][:extensions] }.flatten
   end
 
-  # TODO: remove these
-  # VALID_FILE_EXTENSIONS = [".jpg", ".jpeg", ".pdf", ".png", ".heic", ".bmp", ".txt", ".tiff", ".gif"]
-  # VALID_MIME_TYPES = ["image/jpeg", "image/png", "application/pdf", "image/heic", "image/bmp", "text/plain", "image/tiff", "image/gif"]
-
   def validate_each(record, attr_name, value)
     return if !value
 

--- a/app/validators/file_type_allowed_validator.rb
+++ b/app/validators/file_type_allowed_validator.rb
@@ -22,6 +22,10 @@ class FileTypeAllowedValidator < ActiveModel::EachValidator
     model::ACCEPTED_FILE_TYPES.map { |group| FILE_TYPE_GROUPS[group][:extensions] }.flatten
   end
 
+  def self.mime_types(model)
+    model::ACCEPTED_FILE_TYPES.map { |group| FILE_TYPE_GROUPS[group][:mime_type] }.flatten
+  end
+
   def validate_each(record, attr_name, value)
     return if !value
 

--- a/app/validators/file_type_allowed_validator.rb
+++ b/app/validators/file_type_allowed_validator.rb
@@ -5,8 +5,8 @@ class FileTypeAllowedValidator < ActiveModel::EachValidator
 
   FILE_TYPE_GROUPS = {
     browser_native_image: {
-      extensions: [".jpg", ".jpeg", ".png", ".gif", ".bmp", ".tiff", ".gif"],
-      mime_type: ["image/jpeg", "image/png", "image/gif", "image/bmp", "image/tiff", "image/gif"]
+      extensions: [".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".gif"],
+      mime_type: ["image/jpeg", "image/png", "image/bmp", "image/tiff", "image/gif"]
     },
     other_image: {
       extensions: [".heic"],

--- a/app/views/ctc/portal/verification_attempts/edit.html.erb
+++ b/app/views/ctc/portal/verification_attempts/edit.html.erb
@@ -39,7 +39,7 @@
             </div>
           <% end %>
         <% end %>
-        <span class="is-tablet-hidden--inline text--small"><%= t("views.layouts.document_upload.accepted_file_types") %></span>
+        <span class="is-tablet-hidden--inline text--small"><%= t("views.layouts.document_upload.accepted_file_types", accepted_types: VerificationAttempt::VALID_FILE_TYPES.to_sentence(locale: locale)) %></span>
       </div>
     </div>
 

--- a/app/views/ctc/portal/verification_attempts/edit.html.erb
+++ b/app/views/ctc/portal/verification_attempts/edit.html.erb
@@ -39,7 +39,7 @@
             </div>
           <% end %>
         <% end %>
-        <span class="is-tablet-hidden--inline text--small"><%= t("views.layouts.document_upload.accepted_file_types", accepted_types: VerificationAttempt::VALID_FILE_TYPES.to_sentence(locale: locale)) %></span>
+        <span class="is-tablet-hidden--inline text--small"><%= t("views.layouts.document_upload.accepted_file_types", accepted_types: FileTypeAllowedValidator.extensions(VerificationAttempt).to_sentence) %></span>
       </div>
     </div>
 

--- a/app/views/layouts/document_upload.html.erb
+++ b/app/views/layouts/document_upload.html.erb
@@ -70,7 +70,7 @@
                     <%= t("views.layouts.document_upload.take_picture") %>
                   </span>
                 <% end %>
-                <span class="is-tablet-hidden--inline text--small"><%= t("views.layouts.document_upload.accepted_file_types") %></span>
+                <span class="is-tablet-hidden--inline text--small"><%= t("views.layouts.document_upload.accepted_file_types", accepted_types: Document::VALID_FILE_TYPES.to_sentence(locale: locale)) %></span>
               </div>
             </div>
 

--- a/app/views/layouts/document_upload.html.erb
+++ b/app/views/layouts/document_upload.html.erb
@@ -70,7 +70,7 @@
                     <%= t("views.layouts.document_upload.take_picture") %>
                   </span>
                 <% end %>
-                <span class="is-tablet-hidden--inline text--small"><%= t("views.layouts.document_upload.accepted_file_types", accepted_types: Document::VALID_FILE_TYPES.to_sentence(locale: locale)) %></span>
+                <span class="is-tablet-hidden--inline text--small"><%= t("views.layouts.document_upload.accepted_file_types", accepted_types: FileTypeAllowedValidator.extensions(Document).to_sentence) %></span>
               </div>
             </div>
 

--- a/app/views/layouts/document_upload.html.erb
+++ b/app/views/layouts/document_upload.html.erb
@@ -59,8 +59,8 @@
           <%= form_with model: @form, url: current_path, method: "put", local: true, builder: VitaMinFormBuilder, id: "file-upload-form" do |f| %>
             <div class="document-upload">
               <div class="file-upload">
-                <%= f.file_field(:document, class: "form__documentuploader file-input", data: { "upload-immediately" => true}) %>
-                <%= f.label(:document, class: "button button--wide button--icon js-only", style: "display: none !important;") do %>
+                <%= f.file_field(:upload, class: "form__documentuploader file-input", data: { "upload-immediately" => true}) %>
+                <%= f.label(:upload, class: "button button--wide button--icon js-only", style: "display: none !important;") do %>
                   <span class="is-tablet-hidden--inline">
                     <%= image_tag "upload.svg", alt: "" %>
                     <%= t("views.layouts.document_upload.select_file") %>
@@ -74,7 +74,7 @@
               </div>
             </div>
 
-            <% if @form.errors[:document].any? %>
+            <% if @form.errors.any? %>
               <div class="form-group form-group--error">
                 <% @form.errors.map { |error| error.message }.flatten.each do |error_message| %>
                   <p class="text--error"><i class="icon-warning"></i>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1655,7 +1655,7 @@ en:
   validators:
     account_number: This account number is not valid for direct deposit transactions. Please review your account number or switch to check payments.
     atin: Please enter a valid adoption taxpayer identification number.
-    file_type: Please upload a valid document type. Accepted types include jpg, pdf, and png.
+    file_type: Please upload a valid document type. Accepted types include %{valid_types}.
     file_zero_length: Please upload a valid file. The file you uploaded appears to be empty.
     ip_pin: IP PINs must be a 6 digit number.
     itin: Please enter a valid individual taxpayer identification number.
@@ -2906,7 +2906,7 @@ en:
         meta:
           description: Cash in your family’s pocket every month for the things you need.
       document_upload:
-        accepted_file_types: Accepted types include .jpg, .pdf., and .png
+        accepted_file_types: Accepted types include %{accepted_types}
         dont_have: I don't have this right now.
         remove_confirmation: Are you sure you want to remove "%{filename}"?
         select_file: Select a file

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1618,7 +1618,7 @@ es:
   validators:
     account_number: Este número de cuenta no es válido para transacciones de depósito directo. Revise su número de cuenta o cambie a pagos con cheque.
     atin: Por favor, indique un número de identificación fiscal válido de adopción.
-    file_type: Por favor, sube un tipo de documento válido. Los tipos aceptados incluyen jpg, pdf y png.
+    file_type: Por favor, sube un tipo de documento válido. Los tipos aceptados incluyen %{valid_types}.
     file_zero_length: Sube un archivo válido. El archivo que cargó parece estar vacío.
     ip_pin: El IP PIN debe ser un número de 6 dígitos.
     itin: Por favor ingrese un Número de Identificación Personal del Contribuyente válido.
@@ -2868,7 +2868,7 @@ es:
         meta:
           description: Dinero en efectivo en el bolsillo de su familia cada mes para las cosas que necesita
       document_upload:
-        accepted_file_types: Los tipos aceptados incluyen .jpg, .pdf y .png
+        accepted_file_types: Los tipos aceptados incluyen %{accepted_types}
         dont_have: No lo tengo ahora
         remove_confirmation: ¿Está seguro de que desea quitar "%{filename}"?
         select_file: Elija un archivo

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,10 +93,7 @@ Rails.application.routes.draw do
       end
 
       namespace :documents do
-        get "/add/:token", to: redirect { |_, request| "/#{request.params[:locale] || "en"}/portal/login" }, as: :add_requested_documents
         get "/doc-help/:doc_type", to: "documents_help#show", as: :help
-        post '/doc-help/send-reminder', to: 'documents_help#send_reminder' # remove after next release
-        post '/doc-help/request-doc-help', to: 'documents_help#request_doc_help' # remove after next release
         post '/send-reminder', to: 'documents_help#send_reminder', as: :send_reminder
         post '/request-doc-help', to: 'documents_help#request_doc_help', as: :request_doc_help
       end

--- a/spec/controllers/documents/additional_documents_controller_spec.rb
+++ b/spec/controllers/documents/additional_documents_controller_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Documents::AdditionalDocumentsController do
       let(:valid_params) do
         {
           document_type_upload_form: {
-            document: fixture_file_upload("test-pattern.png")
+              upload: fixture_file_upload("test-pattern.png")
           }
         }
       end

--- a/spec/controllers/documents/employment_controller_spec.rb
+++ b/spec/controllers/documents/employment_controller_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Documents::EmploymentController, type: :controller do
       let(:valid_params) do
         {
             document_type_upload_form: {
-                document: fixture_file_upload("test-pattern.png", "image/png")
+                upload: fixture_file_upload("test-pattern.png", "image/png")
             }
         }
       end

--- a/spec/controllers/documents/ids_controller_spec.rb
+++ b/spec/controllers/documents/ids_controller_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Documents::IdsController do
       let(:params) do
         {
           document_type_upload_form: {
-            document: fixture_file_upload("test-pattern.html")
+              upload: fixture_file_upload("test-pattern.html")
           }
         }
       end

--- a/spec/features/ctc/client_verification_attempt_spec.rb
+++ b/spec/features/ctc/client_verification_attempt_spec.rb
@@ -44,14 +44,14 @@ RSpec.feature "CTC Intake", :js, :active_job, requires_default_vita_partners: tr
     scenario "they see the verification attempt page" do
       visit "/en/portal"
       expect(page).to have_content(I18n.t("views.ctc.portal.verification.title"))
-      expect(page).to have_text(I18n.t("views.layouts.document_upload.accepted_file_types"))
+      expect(page).to have_text(I18n.t("views.layouts.document_upload.accepted_file_types", accepted_types: FileTypeAllowedValidator.extensions(VerificationAttempt).to_sentence))
       within "form#file-upload-form" do
         expect(page).to have_text(I18n.t("views.ctc.portal.verification.selfie_label"))
         expect(page).not_to have_text(I18n.t("views.ctc.portal.verification.resubmission"))
 
         # Try to add invalid document type
         upload_file("verification_attempt_selfie", Rails.root.join("spec", "fixtures", "files", "test-pattern.html"))
-        expect(page).to have_text(I18n.t("validators.file_type"))
+        expect(page).to have_text(I18n.t("validators.file_type", valid_types: FileTypeAllowedValidator.extensions(VerificationAttempt).to_sentence))
 
         # Add a selfie
         upload_file("verification_attempt_selfie", Rails.root.join("spec", "fixtures", "files", "picture_id.jpg"))
@@ -74,7 +74,7 @@ RSpec.feature "CTC Intake", :js, :active_job, requires_default_vita_partners: tr
 
         # Try to add invalid document type
         upload_file("verification_attempt_photo_identification", Rails.root.join("spec", "fixtures", "files", "test-pattern.html"))
-        expect(page).to have_text(I18n.t("validators.file_type"))
+        expect(page).to have_text(I18n.t("validators.file_type", valid_types: FileTypeAllowedValidator.extensions(VerificationAttempt).to_sentence))
 
         # Add a photo ID picture
         upload_file("verification_attempt_photo_identification", Rails.root.join("spec", "fixtures", "files", "picture_id.jpg"))

--- a/spec/features/portal/client_portal_dashboard_spec.rb
+++ b/spec/features/portal/client_portal_dashboard_spec.rb
@@ -336,7 +336,7 @@ RSpec.feature "a client on their portal" do
       click_link "Submit additional documents"
       expect(page).to have_text "Please share any additional documents."
 
-      upload_file("requested_document_upload_form[document]", Rails.root.join("spec", "fixtures", "files", "test-pattern.png"))
+      upload_file("requested_document_upload_form[upload]", Rails.root.join("spec", "fixtures", "files", "test-pattern.png"))
       expect(page).to have_content("test-pattern.png")
 
       expect(client.documents.where(document_type: "Other").length).to eq 1

--- a/spec/features/web_intake/new_joint_filers_spec.rb
+++ b/spec/features/web_intake/new_joint_filers_spec.rb
@@ -481,8 +481,8 @@ RSpec.feature "Web Intake Joint Filers", :flow_explorer_screenshot do
 
     screenshot_after do
       expect(page).to have_selector("h1", text: "Attach photos of ID cards")
-      upload_file("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "files", "picture_id.jpg"))
-      upload_file("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "files", "picture_id.jpg"))
+      upload_file("document_type_upload_form[upload]", Rails.root.join("spec", "fixtures", "files", "picture_id.jpg"))
+      upload_file("document_type_upload_form[upload]", Rails.root.join("spec", "fixtures", "files", "picture_id.jpg"))
     end
     click_on "Continue"
 
@@ -493,13 +493,13 @@ RSpec.feature "Web Intake Joint Filers", :flow_explorer_screenshot do
 
     screenshot_after do
       expect(page).to have_selector("h1", text: I18n.t('views.documents.selfies.title'))
-      upload_file("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "files", "picture_id.jpg"))
+      upload_file("document_type_upload_form[upload]", Rails.root.join("spec", "fixtures", "files", "picture_id.jpg"))
     end
     click_on "Continue"
 
     screenshot_after do
       expect(page).to have_selector("h1", text: I18n.t('views.documents.ssn_itins.title'))
-      upload_file("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "files", "picture_id.jpg"))
+      upload_file("document_type_upload_form[upload]", Rails.root.join("spec", "fixtures", "files", "picture_id.jpg"))
     end
     click_on "Continue"
 
@@ -511,18 +511,18 @@ RSpec.feature "Web Intake Joint Filers", :flow_explorer_screenshot do
 
     screenshot_after do
       expect(page).to have_selector("h1", text: I18n.t('views.documents.form1095as.title'))
-      upload_file("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "files", "picture_id.jpg"))
+      upload_file("document_type_upload_form[upload]", Rails.root.join("spec", "fixtures", "files", "picture_id.jpg"))
     end
     click_on "Continue"
 
     screenshot_after do
       expect(page).to have_selector("h1", text: "Share your employment documents")
-      upload_file("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "files", "test-pattern.png"))
+      upload_file("document_type_upload_form[upload]", Rails.root.join("spec", "fixtures", "files", "test-pattern.png"))
 
       expect(page).to have_content("test-pattern.png")
       expect(page).to have_link("Remove")
 
-      upload_file("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "files", "picture_id.jpg"))
+      upload_file("document_type_upload_form[upload]", Rails.root.join("spec", "fixtures", "files", "picture_id.jpg"))
 
       expect(page).to have_content("test-pattern.png")
       expect(page).to have_content("picture_id.jpg")
@@ -531,7 +531,7 @@ RSpec.feature "Web Intake Joint Filers", :flow_explorer_screenshot do
 
     screenshot_after do
       expect(page).to have_selector("h1", text: "Attach your 1099-R's")
-      upload_file("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "files", "picture_id.jpg"))
+      upload_file("document_type_upload_form[upload]", Rails.root.join("spec", "fixtures", "files", "picture_id.jpg"))
     end
     expect do
       click_on "Continue"
@@ -539,7 +539,7 @@ RSpec.feature "Web Intake Joint Filers", :flow_explorer_screenshot do
 
     screenshot_after do
       expect(page).to have_selector("h1", text: "Please share any additional documents.")
-      upload_file("document_type_upload_form[document]", Rails.root.join("spec", "fixtures", "files", "test-pattern.png"))
+      upload_file("document_type_upload_form[upload]", Rails.root.join("spec", "fixtures", "files", "test-pattern.png"))
       expect(page).to have_content("test-pattern.png")
     end
     click_on "Continue"

--- a/spec/features/web_intake/new_single_filer_spec.rb
+++ b/spec/features/web_intake/new_single_filer_spec.rb
@@ -294,7 +294,7 @@ RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot, active_job: 
     click_on "Continue"
 
     expect(page).to have_selector("h1", text: "Attach a photo of your ID card")
-    expect(page).to have_text(I18n.t('views.layouts.document_upload.accepted_file_types'))
+    expect(page).to have_text(I18n.t('views.layouts.document_upload.accepted_file_types', accepted_types: FileTypeAllowedValidator.extensions(Document).to_sentence))
     upload_file("document_type_upload_form_document", Rails.root.join("spec", "fixtures", "files", "picture_id.jpg"))
     click_on "Continue"
 

--- a/spec/features/web_intake/new_single_filer_spec.rb
+++ b/spec/features/web_intake/new_single_filer_spec.rb
@@ -295,7 +295,7 @@ RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot, active_job: 
 
     expect(page).to have_selector("h1", text: "Attach a photo of your ID card")
     expect(page).to have_text(I18n.t('views.layouts.document_upload.accepted_file_types', accepted_types: FileTypeAllowedValidator.extensions(Document).to_sentence))
-    upload_file("document_type_upload_form_document", Rails.root.join("spec", "fixtures", "files", "picture_id.jpg"))
+    upload_file("document_type_upload_form_upload", Rails.root.join("spec", "fixtures", "files", "picture_id.jpg"))
     click_on "Continue"
 
     expect(intake.reload.current_step).to eq("/en/documents/selfie-instructions")
@@ -304,12 +304,12 @@ RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot, active_job: 
 
     expect(intake.reload.current_step).to eq("/en/documents/selfies")
     expect(page).to have_selector("h1", text: I18n.t('views.documents.selfies.title'))
-    upload_file("document_type_upload_form_document", Rails.root.join("spec", "fixtures", "files", "picture_id.jpg"))
+    upload_file("document_type_upload_form_upload", Rails.root.join("spec", "fixtures", "files", "picture_id.jpg"))
     click_on "Continue"
 
     expect(intake.reload.current_step).to eq("/en/documents/ssn-itins")
     expect(page).to have_selector("h1", text: I18n.t('views.documents.ssn_itins.title'))
-    upload_file("document_type_upload_form_document", Rails.root.join("spec", "fixtures", "files", "picture_id.jpg"))
+    upload_file("document_type_upload_form_upload", Rails.root.join("spec", "fixtures", "files", "picture_id.jpg"))
     click_on "Continue"
 
     # Documents: Intro
@@ -317,19 +317,19 @@ RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot, active_job: 
     click_on "Continue"
 
     expect(page).to have_selector("h1", text: "Share your employment documents")
-    upload_file("document_type_upload_form_document", Rails.root.join("spec", "fixtures", "files", "test-pattern.png"))
+    upload_file("document_type_upload_form_upload", Rails.root.join("spec", "fixtures", "files", "test-pattern.png"))
 
     expect(page).to have_content("test-pattern.png")
     expect(page).to have_link("Remove")
 
-    upload_file("document_type_upload_form_document", Rails.root.join("spec", "fixtures", "files", "picture_id.jpg"))
+    upload_file("document_type_upload_form_upload", Rails.root.join("spec", "fixtures", "files", "picture_id.jpg"))
 
     expect(page).to have_content("test-pattern.png")
     expect(page).to have_content("picture_id.jpg")
     click_on "Continue"
 
     expect(page).to have_selector("h1", text: "Please share any additional documents.")
-    upload_file("document_type_upload_form_document", Rails.root.join("spec", "fixtures", "files", "test-pattern.png"))
+    upload_file("document_type_upload_form_upload", Rails.root.join("spec", "fixtures", "files", "test-pattern.png"))
     expect(page).to have_content("test-pattern.png")
     click_on "Continue"
 

--- a/spec/features/web_intake/requested_documents_token_spec.rb
+++ b/spec/features/web_intake/requested_documents_token_spec.rb
@@ -1,9 +1,0 @@
-require "rails_helper"
-
-RSpec.feature "Client uploads a requested document", :flow_explorer_screenshot do
-  scenario "client goes to the follow up documents token link, it redirects to login" do
-    visit "/documents/add/1234ABCDEF"
-
-    expect(page).to have_selector("h1", text: "To view your progress, we’ll send you a secure code.")
-  end
-end

--- a/spec/models/verification_attempt_spec.rb
+++ b/spec/models/verification_attempt_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe VerificationAttempt, type: :model do
           )
 
           expect(verification_attempt.valid?).to eq false
-          expect(verification_attempt.errors[:selfie]).to include("Please upload a valid document type. Accepted types include jpg, pdf, and png.")
-          expect(verification_attempt.errors[:photo_identification]).to include("Please upload a valid document type. Accepted types include jpg, pdf, and png.")
+          expect(verification_attempt.errors[:selfie]).to include(I18n.t("validators.file_type", valid_types: FileTypeAllowedValidator.extensions(VerificationAttempt).to_sentence))
+          expect(verification_attempt.errors[:photo_identification]).to include(I18n.t("validators.file_type", valid_types: FileTypeAllowedValidator.extensions(VerificationAttempt).to_sentence))
         end
       end
 

--- a/spec/validators/file_type_allowed_validator_spec.rb
+++ b/spec/validators/file_type_allowed_validator_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe FileTypeAllowedValidator do
 
   let!(:record) { OpenStruct.new(errors: ActiveModel::Errors.new(nil)) }
 
+  before do
+    stub_const("OpenStruct::ACCEPTED_FILE_TYPES", [:browser_native_image, :other_image, :document])
+  end
+
   context "png" do
     let(:valid_document) { fixture_file_upload("test-pattern.png") }
 

--- a/spec/validators/file_type_allowed_validator_spec.rb
+++ b/spec/validators/file_type_allowed_validator_spec.rb
@@ -10,10 +10,11 @@ RSpec.describe FileTypeAllowedValidator do
   end
 
   context "png" do
-    let(:valid_document) { fixture_file_upload("test-pattern.png") }
+    # let(:valid_document) { fixture_file_upload("test-pattern.png") }
+    let(:valid_document) { build :document, upload_path: Rails.root.join("spec", "fixtures", "files", "test-pattern.png") }
 
     it "is a valid file type" do
-      assert_valid(valid_document)
+      assert_valid(valid_document.upload)
     end
   end
 

--- a/spec/validators/file_type_allowed_validator_spec.rb
+++ b/spec/validators/file_type_allowed_validator_spec.rb
@@ -1,45 +1,55 @@
 require "rails_helper"
 
 RSpec.describe FileTypeAllowedValidator do
-  subject { described_class.new(attributes: [:document]) }
+  let(:attr_name) { :document }
+  subject { described_class.new(attributes: [attr_name]) }
 
   let!(:record) { OpenStruct.new(errors: ActiveModel::Errors.new(nil)) }
-
+  let(:attachment) do
+    ActiveStorage::Blob.create_and_upload!(
+      io: File.open(Rails.root.join("spec", "fixtures", "files", filename), 'rb'),
+      filename: filename,
+      content_type: content_type
+    )
+  end
   before do
     stub_const("OpenStruct::ACCEPTED_FILE_TYPES", [:browser_native_image, :other_image, :document])
   end
 
   context "png" do
-    let(:valid_document) { build :document, upload_path: Rails.root.join("spec", "fixtures", "files", "test-pattern.png") }
+    let(:filename) { "test-pattern.png" }
+    let(:content_type) { "image/png" }
 
     it "is a valid file type" do
-      assert_valid(valid_document.upload)
+      assert_valid(attachment)
     end
   end
 
   context "all caps extension JPG" do
-    let(:valid_document) { build :document, upload_path: Rails.root.join("spec", "fixtures", "files", "test-pattern.JPG") }
+    let(:filename) { "test-pattern.JPG" }
+    let(:content_type) { "image/jpeg" }
 
     it "is a valid file type after downcase" do
-      assert_valid(valid_document.upload)
+      assert_valid(attachment)
     end
   end
 
   context "html" do
-    let(:invalid_document) { build :document, upload_path: Rails.root.join("spec", "fixtures", "files", "test-pattern.html") }
+    let(:filename) { "test-pattern.html" }
+    let(:content_type) { "text/html" }
 
     it "is not a valid file type" do
-      assert_invalid(invalid_document.upload)
+      assert_invalid(attachment)
     end
   end
 
   def assert_invalid(value)
-    subject.validate_each(record, :document, value)
+    subject.validate_each(record, attr_name, value)
     expect(record.errors[:document]).to include I18n.t("validators.file_type", valid_types: described_class.extensions(record.class).to_sentence)
   end
 
   def assert_valid(value)
-    subject.validate_each(record, :document, value)
+    subject.validate_each(record, attr_name, value)
     expect(record.errors[:document]).to eq []
   end
 end

--- a/spec/validators/file_type_allowed_validator_spec.rb
+++ b/spec/validators/file_type_allowed_validator_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe FileTypeAllowedValidator do
   end
 
   context "png" do
-    # let(:valid_document) { fixture_file_upload("test-pattern.png") }
     let(:valid_document) { build :document, upload_path: Rails.root.join("spec", "fixtures", "files", "test-pattern.png") }
 
     it "is a valid file type" do
@@ -19,24 +18,24 @@ RSpec.describe FileTypeAllowedValidator do
   end
 
   context "all caps extension JPG" do
-    let(:valid_document) { fixture_file_upload("test-pattern.JPG") }
+    let(:valid_document) { build :document, upload_path: Rails.root.join("spec", "fixtures", "files", "test-pattern.JPG") }
 
     it "is a valid file type after downcase" do
-      assert_valid(valid_document)
+      assert_valid(valid_document.upload)
     end
   end
 
   context "html" do
-    let(:invalid_document) { fixture_file_upload("test-pattern.html") }
+    let(:invalid_document) { build :document, upload_path: Rails.root.join("spec", "fixtures", "files", "test-pattern.html") }
 
     it "is not a valid file type" do
-      assert_invalid(invalid_document)
+      assert_invalid(invalid_document.upload)
     end
   end
 
   def assert_invalid(value)
     subject.validate_each(record, :document, value)
-    expect(record.errors[:document]).to include I18n.t("validators.file_type")
+    expect(record.errors[:document]).to include I18n.t("validators.file_type", valid_types: described_class.extensions(record.class).to_sentence)
   end
 
   def assert_valid(value)


### PR DESCRIPTION
This started as a fairly innocent refactor and snowballed a bit, but hopefully the finished product is intuitive enough and consolidates some logic around what file types we allow for what models.

I left one comment on something I feel unsure about.

Also, I am now at the end of the day realizing that we didn't remove the file type lists from the validation error like we said we would. (the idea was to only list valid file types in the help text and have a more generic "file type invalid" type of message for the error)