### PR TITLE
Archive unused relationships instead of removing them

### DIFF
--- a/app/helpers/relationships_helper.rb
+++ b/app/helpers/relationships_helper.rb
@@ -2,7 +2,7 @@ module RelationshipsHelper
   # provides a list of relationship options for dependents, and pushes the client's provided free-form answer
   # to the list if necessary.
   def dependent_relationship_options(current_relationship: nil)
-    options = Efile::Relationship.all.map { |relationship| [I18n.t("general.dependent_relationships.#{relationship.id}"), relationship.id] }
+    options = Efile::Relationship.active.map { |relationship| [I18n.t("general.dependent_relationships.#{relationship.id}"), relationship.id] }
     if current_relationship.present? && Efile::Relationship.find(current_relationship).nil?
       options.push(["#{I18n.t("general.dependent_relationships.other_freefill")}: #{current_relationship}", current_relationship])
     end

--- a/app/lib/efile/relationship.rb
+++ b/app/lib/efile/relationship.rb
@@ -1,11 +1,12 @@
 module Efile
   class Relationship
-    attr_reader :id, :relationship, :irs_enum
+    attr_reader :id, :relationship, :irs_enum, :archived
+    alias_method :archived?, :archived
 
     def self.import(filename)
       @@relationships =
         YAML.load_file(filename)['relationships'].map do |relationship|
-          new(relationship["id"], relationship["relationship"].to_sym, relationship["irs_enum"], relationship["skip_relative_household_test"])
+          new(relationship["id"], relationship["relationship"].to_sym, relationship["irs_enum"], relationship["skip_relative_household_test"], relationship["archived"])
         end
     end
 
@@ -13,17 +14,22 @@ module Efile
       @@relationships
     end
 
+    def self.active
+      all.reject(&:archived?)
+    end
+
     def self.find(id)
       @@relationships.find { |relationship| id == relationship.id }
     end
 
-    def initialize(id, relationship, irs_enum, skip_relative_household_test)
+    def initialize(id, relationship, irs_enum, skip_relative_household_test, archived)
       @id = id
       relationships = [:qualifying_relative, :qualifying_child, :ineligible]
       raise "Invalid relationship. Relationship #{relationship} must be in: #{relationships}" unless relationship.in? relationships
       @relationship = relationship
       @irs_enum = irs_enum
       @skip_relative_household_test = ActiveModel::Type::Boolean.new.cast(skip_relative_household_test)
+      @archived = ActiveModel::Type::Boolean.new.cast(archived || false)
     end
 
     def qualifying_child_relationship?

--- a/app/lib/efile/relationships.yml
+++ b/app/lib/efile/relationships.yml
@@ -68,10 +68,11 @@ relationships:
     relationship: qualifying_relative
     irs_enum: GRANDPARENT
     skip_relative_household_test: true
-#  - id: great_grandchild
-#    relationship: qualifying_child
-#    irs_enum: OTHER
-#    skip_relative_household_test: true
+  - id: great_grandchild
+    relationship: qualifying_child
+    irs_enum: OTHER
+    skip_relative_household_test: true
+    archived: true
   - id: step_parent
     relationship: qualifying_relative
     irs_enum: OTHER
@@ -80,10 +81,11 @@ relationships:
     relationship: qualifying_relative
     irs_enum: OTHER
     skip_relative_household_test: true
-#  - id: siblings_descendant
-#    relationship: qualifying_child
-#    irs_enum: OTHER
-#    skip_relative_household_test: false
+  - id: siblings_descendant
+    relationship: qualifying_child
+    irs_enum: OTHER
+    skip_relative_household_test: false
+    archived: true
   - id: other
     relationship: qualifying_relative
     irs_enum: OTHER

--- a/spec/lib/efile/relationship_spec.rb
+++ b/spec/lib/efile/relationship_spec.rb
@@ -5,7 +5,7 @@ describe Efile::Relationship do
     context "when the passed in irs relationship category is not in the list of supported relationships" do
       it "raises an error" do
         expect {
-          described_class.new("daughter", :qualifying_friend, "DAUGHTER", true)
+          described_class.new("daughter", :qualifying_friend, "DAUGHTER", true, nil)
         }.to raise_error RuntimeError
       end
     end
@@ -56,8 +56,26 @@ describe Efile::Relationship do
 
       context "from instantiation" do
         it "is true" do
-          instance = described_class.new("other", :qualifying_relative, "OTHER", false)
+          instance = described_class.new("other", :qualifying_relative, "OTHER", false, nil)
           expect(instance.qualifying_relative_requires_member_of_household_test?).to eq true
+        end
+      end
+    end
+  end
+
+  describe "#archived?" do
+    context "from a yml relationship" do
+      it "is accessible based on value in yml" do
+        expect(described_class.find("other").archived?).to eq false
+        expect(described_class.find("siblings_descendant").archived?).to eq true
+      end
+    end
+
+    context "from instantiation" do
+      context "when nil" do
+        it "is accessible with value of false" do
+          instance = described_class.new("other", :qualifying_relative, "OTHER", false, nil)
+          expect(instance.archived?).to eq false
         end
       end
     end


### PR DESCRIPTION
This will both fix the client pages affected by this bug (since they can now retrieve relationship info) while also ensuring that we still don't see these relationships in the dropdown.