### PR TITLE
Add the flipper gem for feature flagging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,11 @@ gem 'redcarpet'
 gem 'platform-api'
 gem 'strong_migrations'
 
+# Use Flipper for feature flagging
+gem 'flipper'
+gem 'flipper-active_record'
+gem 'flipper-ui'
+
 group :demo, :development, :test do
   gem 'factory_bot_rails' # added to demo for creating fake data
   gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,6 +229,16 @@ GEM
     fix-db-schema-conflicts (3.1.0)
       rubocop (>= 0.38.0)
     flamegraph (0.9.5)
+    flipper (0.24.1)
+    flipper-active_record (0.24.1)
+      activerecord (>= 4.2, < 8)
+      flipper (~> 0.24.1)
+    flipper-ui (0.24.1)
+      erubi (>= 1.0.0, < 2.0.0)
+      flipper (~> 0.24.1)
+      rack (>= 1.4, < 3)
+      rack-protection (>= 1.5.3, <= 2.2.0)
+      sanitize (< 7)
     formatador (1.1.0)
     git-pair (0.1.0)
     globalid (1.0.0)
@@ -391,6 +401,8 @@ GEM
     rack (2.2.3)
     rack-mini-profiler (2.3.3)
       rack (>= 1.2.0)
+    rack-protection (2.2.0)
+      rack
     rack-proxy (0.7.2)
       rack
     rack-test (1.1.0)
@@ -498,6 +510,9 @@ GEM
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     safe_shell (1.1.0)
+    sanitize (6.0.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -653,6 +668,9 @@ DEPENDENCIES
   faker
   fix-db-schema-conflicts
   flamegraph
+  flipper
+  flipper-active_record
+  flipper-ui
   git-pair
   guard-rspec
   http_accept_language

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -25,6 +25,6 @@ end
 class CanAccessFlipperUI
   def self.matches?(request)
     current_user = request.env['warden'].user
-    current_user.present? && current_user.admin?
+    current_user.present? && current_user.admin? && current_user.email.include?("@codeforamerica.org")
   end
 end

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -1,0 +1,30 @@
+Flipper.configure do |config|
+  config.default do
+    adapter = Flipper::Adapters::ActiveRecord.new
+    Flipper.new(adapter)
+  end
+end
+
+Flipper::UI.configure do |config|
+  # Defaults to false. Set to true to show feature descriptions on the list
+  # page as well as the view page.
+  config.show_feature_description_in_list = true
+
+  if Rails.env.production?
+    config.banner_text = 'Production Environment'
+    config.banner_class = 'danger'
+  elsif Rails.env.demo?
+    config.banner_text = 'Demo Environment'
+    config.banner_class = 'warning'
+  elsif Rails.env.development?
+    config.banner_text = 'Dev Environment'
+    config.banner_class = 'info'
+  end
+end
+
+class CanAccessFlipperUI
+  def self.matches?(request)
+    current_user = request.env['warden'].user
+    current_user.present? && current_user.admin?
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -168,6 +168,11 @@ Rails.application.routes.draw do
       namespace :hub do
         # root "assigned_clients#index"
 
+        # Feature flags are admin access only
+        constraints CanAccessFlipperUI do
+          mount Flipper::UI.app(Flipper) => '/flipper'
+        end
+
         resources :metrics, only: [:index]
         resources :tax_returns, only: [:edit, :update, :show]
         resources :efile_submissions, path: "efile", only: [:index, :show] do

--- a/db/migrate/20220526161533_create_flipper_tables.rb
+++ b/db/migrate/20220526161533_create_flipper_tables.rb
@@ -1,0 +1,22 @@
+class CreateFlipperTables < ActiveRecord::Migration[7.0]
+  def self.up
+    create_table :flipper_features do |t|
+      t.string :key, null: false
+      t.timestamps null: false
+    end
+    add_index :flipper_features, :key, unique: true
+
+    create_table :flipper_gates do |t|
+      t.string :feature_key, null: false
+      t.string :key, null: false
+      t.string :value
+      t.timestamps null: false
+    end
+    add_index :flipper_gates, [:feature_key, :key, :value], unique: true
+  end
+
+  def self.down
+    drop_table :flipper_gates
+    drop_table :flipper_features
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_25_213918) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_26_161533) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -813,6 +813,22 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_25_213918) do
     t.datetime "updated_at", null: false
     t.string "visitor_id", null: false
     t.index ["visitor_id", "question_key"], name: "index_faq_surveys_on_visitor_id_and_question_key"
+  end
+
+  create_table "flipper_features", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "key", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_flipper_features_on_key", unique: true
+  end
+
+  create_table "flipper_gates", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "feature_key", null: false
+    t.string "key", null: false
+    t.datetime "updated_at", null: false
+    t.string "value"
+    t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
   create_table "fraud_indicators", force: :cascade do |t|


### PR DESCRIPTION
Adds the flipper-ui, as documented [here](https://www.flippercloud.io/docs/ui)

Accessed at `/hub/flipper` and requires an admin account.

Flipper also offers a cloud version, but that seemed like too much for our use case. Mostly we need ways to toggle something on or off. You do that by asking `Flipper.enabled?(:flag_name)`

Spec to come...

<img width="1424" alt="image" src="https://user-images.githubusercontent.com/6520735/170544644-f14a756b-17fd-4f7d-b513-904fc5af0344.png">

<img width="1251" alt="image" src="https://user-images.githubusercontent.com/6520735/170545028-5ea9e458-3a0e-44f8-b8f2-91d978f3d0af.png">

