### PR TITLE
Do not require authentication for local or heroku uses of feature flags

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -19,11 +19,16 @@ Flipper::UI.configure do |config|
   elsif Rails.env.development?
     config.banner_text = 'Dev Environment'
     config.banner_class = 'info'
+  elsif Rails.env.heroku?
+    config.banner_text = 'Heroku Environment'
+    config.banner_class = 'info'
   end
 end
 
 class CanAccessFlipperUI
   def self.matches?(request)
+    return true if Rails.env.development? || Rails.env.heroku?
+
     current_user = request.env['warden'].user
     current_user.present? && current_user.admin? && current_user.email.include?("@codeforamerica.org")
   end


### PR DESCRIPTION
It was kind of hard to use and there's no need to authenticate for local uses or on heroku since dev + product are the only ones with access to those.