### PR TITLE
Add GetCTC copy edit on dependents info page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2109,7 +2109,7 @@ en:
           info:
             filed_joint_return: This person is married and filing taxes with their spouse
             first_name: Legal first name
-            help_text: To avoid delays, please provide this person’s legal information as it is written on their identification card.
+            help_text: Enter their name exactly as it appears on their Social Security card or identification paperwork.
             last_name: Legal last name
             middle_initial: Legal middle name(s) (optional)
             relationship_to_you: What is their relationship to you?


### PR DESCRIPTION
This PR changes the subtitle copy on the dependents info page.

This is the page with the old copy:
<img width="464" alt="old" src="https://user-images.githubusercontent.com/49880002/171964571-c61530f8-bec2-4387-a94e-19b7dc3f2f82.png">

This is the page with the new copy:
<img width="453" alt="new" src="https://user-images.githubusercontent.com/49880002/171964573-a77e16a0-203f-4e77-ac00-aafd01936f26.png">

