### PR TITLE
1040 for Puerto Rico puts a special attribute on the 'TotalItemizedOrStandardDedAmt' node

### DIFF
--- a/app/lib/submission_builder/ty2021/documents/irs1040.rb
+++ b/app/lib/submission_builder/ty2021/documents/irs1040.rb
@@ -32,7 +32,11 @@ module SubmissionBuilder
             xml.OtherDependentsListedCnt qualifying_dependents.count { |qd| qd.qualifying_relative? }
 
             xml.TotalExemptionsCnt filer_exemption_count + qualifying_dependents.length
-            xml.TotalItemizedOrStandardDedAmt tax_return.standard_deduction unless tax_return.standard_deduction.nil? # line 12a in 2021v5.2/IndividualIncomeTax/Ind1040/IRS1040/IRS1040.xsd
+            if intake.home_location_puerto_rico?
+              xml.TotalItemizedOrStandardDedAmt 0, {modifiedStandardDeductionInd: 'SECT 933'}
+            else
+              xml.TotalItemizedOrStandardDedAmt tax_return.standard_deduction
+            end
             xml.TotDedCharitableContriAmt tax_return.standard_deduction unless tax_return.standard_deduction.nil? # 12c
             xml.TotalDeductionsAmt tax_return.standard_deduction unless tax_return.standard_deduction.nil? # 14
             xml.TaxableIncomeAmt 0 unless intake.home_location_puerto_rico? # 15

--- a/spec/lib/submission_builder/ty2021/documents/irs1040_spec.rb
+++ b/spec/lib/submission_builder/ty2021/documents/irs1040_spec.rb
@@ -134,9 +134,10 @@ describe SubmissionBuilder::Ty2021::Documents::Irs1040 do
         submission.intake.update(home_location: :puerto_rico)
       end
 
-      it "leaves certain fields blank" do
+      it "leaves certain fields blank and puts a special attribute on standard deduction amount" do
         xml = Nokogiri::XML::Document.parse(described_class.build(submission).document.to_xml)
-        expect(xml.at("TotalItemizedOrStandardDedAmt")).to be_nil
+        expect(xml.at("TotalItemizedOrStandardDedAmt").text).to eq("0")
+        expect(xml.at("TotalItemizedOrStandardDedAmt").attributes['modifiedStandardDeductionInd'].value).to eq('SECT 933')
         expect(xml.at("TotDedCharitableContriAmt")).to be_nil
         expect(xml.at("TotalDeductionsAmt")).to be_nil
         expect(xml.at("RecoveryRebateCreditAmt")).to be_nil


### PR DESCRIPTION
Co-authored-by: Shannon Byrne <sbyrne@codeforamerica.org>