### PR TITLE
Drop primary_consented_to_service_at on intake, and index the enum

### DIFF
--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -154,7 +154,6 @@
 #  primary_active_armed_forces                          :integer          default(0), not null
 #  primary_birth_date                                   :date
 #  primary_consented_to_service                         :integer          default("unfilled"), not null
-#  primary_consented_to_service_at                      :datetime
 #  primary_consented_to_service_ip                      :inet
 #  primary_first_name                                   :string
 #  primary_last_name                                    :string
@@ -262,7 +261,7 @@
 #  index_intakes_on_hashed_primary_ssn                     (hashed_primary_ssn)
 #  index_intakes_on_needs_to_flush_searchable_data_set_at  (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_intakes_on_phone_number                           (phone_number)
-#  index_intakes_on_primary_consented_to_service_at        (primary_consented_to_service_at)
+#  index_intakes_on_primary_consented_to_service           (primary_consented_to_service)
 #  index_intakes_on_primary_drivers_license_id             (primary_drivers_license_id)
 #  index_intakes_on_searchable_data                        (searchable_data) USING gin
 #  index_intakes_on_sms_phone_number                       (sms_phone_number)
@@ -279,7 +278,6 @@
 
 class Intake < ApplicationRecord
   self.ignored_columns = ["primary_consented_to_service_at"]
-
   include PgSearch::Model
 
   def self.searchable_fields

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -154,7 +154,6 @@
 #  primary_active_armed_forces                          :integer          default("unfilled"), not null
 #  primary_birth_date                                   :date
 #  primary_consented_to_service                         :integer          default("unfilled"), not null
-#  primary_consented_to_service_at                      :datetime
 #  primary_consented_to_service_ip                      :inet
 #  primary_first_name                                   :string
 #  primary_last_name                                    :string
@@ -262,7 +261,7 @@
 #  index_intakes_on_hashed_primary_ssn                     (hashed_primary_ssn)
 #  index_intakes_on_needs_to_flush_searchable_data_set_at  (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_intakes_on_phone_number                           (phone_number)
-#  index_intakes_on_primary_consented_to_service_at        (primary_consented_to_service_at)
+#  index_intakes_on_primary_consented_to_service           (primary_consented_to_service)
 #  index_intakes_on_primary_drivers_license_id             (primary_drivers_license_id)
 #  index_intakes_on_searchable_data                        (searchable_data) USING gin
 #  index_intakes_on_sms_phone_number                       (sms_phone_number)

--- a/app/models/intake/gyr_intake.rb
+++ b/app/models/intake/gyr_intake.rb
@@ -154,7 +154,6 @@
 #  primary_active_armed_forces                          :integer          default(0), not null
 #  primary_birth_date                                   :date
 #  primary_consented_to_service                         :integer          default("unfilled"), not null
-#  primary_consented_to_service_at                      :datetime
 #  primary_consented_to_service_ip                      :inet
 #  primary_first_name                                   :string
 #  primary_last_name                                    :string
@@ -262,7 +261,7 @@
 #  index_intakes_on_hashed_primary_ssn                     (hashed_primary_ssn)
 #  index_intakes_on_needs_to_flush_searchable_data_set_at  (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_intakes_on_phone_number                           (phone_number)
-#  index_intakes_on_primary_consented_to_service_at        (primary_consented_to_service_at)
+#  index_intakes_on_primary_consented_to_service           (primary_consented_to_service)
 #  index_intakes_on_primary_drivers_license_id             (primary_drivers_license_id)
 #  index_intakes_on_searchable_data                        (searchable_data) USING gin
 #  index_intakes_on_sms_phone_number                       (sms_phone_number)

--- a/db/create_analytics_views.sql
+++ b/db/create_analytics_views.sql
@@ -68,7 +68,7 @@ CREATE VIEW analytics.archived_intakes_2021 AS
            needs_help_2019, needs_help_2020, no_eligibility_checks_apply, no_ssn, paid_alimony,
            paid_charitable_contributions, paid_dependent_care, paid_local_tax, paid_medical_expenses,
            paid_mortgage_interest, paid_retirement_contributions, paid_school_supplies, paid_student_loan_interest,
-           phone_number_can_receive_texts, preferred_interview_language, primary_consented_to_service, primary_consented_to_service_at, primary_tin_type,
+           phone_number_can_receive_texts, preferred_interview_language, primary_consented_to_service, primary_tin_type,
            received_alimony, received_irs_letter, refund_payment_method, reported_asset_sale_loss,
            reported_self_employment_loss, satisfaction_face,
            savings_purchase_bond, savings_split_refund, separated, separated_year, signature_method,
@@ -84,7 +84,7 @@ CREATE VIEW analytics.client_success_roles AS
     FROM public.client_success_roles;
 
 CREATE VIEW analytics.clients AS
-    SELECT id, attention_needed_since, created_at, current_sign_in_at, failed_attempts, first_unanswered_incoming_interaction_at, flagged_at, last_incoming_interaction_at, last_internal_or_outgoing_interaction_at, last_sign_in_at, locked_at, login_requested_at, routing_method, sign_in_count, updated_at, vita_partner_id
+    SELECT id, attention_needed_since, consented_to_service_at, created_at, current_sign_in_at, failed_attempts, first_unanswered_incoming_interaction_at, flagged_at, last_incoming_interaction_at, last_internal_or_outgoing_interaction_at, last_sign_in_at, locked_at, login_requested_at, routing_method, sign_in_count, updated_at, vita_partner_id
     FROM public.clients;
 
 CREATE VIEW analytics.coalition_lead_roles AS

--- a/db/migrate/20220615204444_add_index_to_primary_consented_to_service.rb
+++ b/db/migrate/20220615204444_add_index_to_primary_consented_to_service.rb
@@ -1,7 +1,7 @@
 class AddIndexToPrimaryConsentedToService < ActiveRecord::Migration[7.0]
   disable_ddl_transaction!
   def change
-    remove_index :intakes, :primary_consented_to_service_at
     add_index :intakes, :primary_consented_to_service, algorithm: :concurrently
+    remove_column :intakes, :primary_consented_to_service_at
   end
 end

--- a/db/migrate/20220615204444_add_index_to_primary_consented_to_service.rb
+++ b/db/migrate/20220615204444_add_index_to_primary_consented_to_service.rb
@@ -2,6 +2,6 @@ class AddIndexToPrimaryConsentedToService < ActiveRecord::Migration[7.0]
   disable_ddl_transaction!
   def change
     add_index :intakes, :primary_consented_to_service, algorithm: :concurrently
-    remove_column :intakes, :primary_consented_to_service_at
+    safety_assured { remove_column :intakes, :primary_consented_to_service_at }
   end
 end

--- a/db/migrate/20220615204444_add_index_to_primary_consented_to_service.rb
+++ b/db/migrate/20220615204444_add_index_to_primary_consented_to_service.rb
@@ -1,0 +1,7 @@
+class AddIndexToPrimaryConsentedToService < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+  def change
+    remove_index :intakes, :primary_consented_to_service_at
+    add_index :intakes, :primary_consented_to_service, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_07_193139) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_15_204444) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -921,6 +921,37 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_07_193139) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "idme_users", force: :cascade do |t|
+    t.string "birth_date"
+    t.string "city"
+    t.integer "consented_to_service", default: 0, null: false
+    t.datetime "consented_to_service_at", precision: nil
+    t.string "consented_to_service_ip"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "current_sign_in_at", precision: nil
+    t.inet "current_sign_in_ip"
+    t.string "email"
+    t.integer "email_notification_opt_in", default: 0, null: false
+    t.string "encrypted_ssn"
+    t.string "encrypted_ssn_iv"
+    t.string "first_name"
+    t.bigint "intake_id", null: false
+    t.boolean "is_spouse", default: false
+    t.string "last_name"
+    t.datetime "last_sign_in_at", precision: nil
+    t.inet "last_sign_in_ip"
+    t.string "phone_number"
+    t.string "provider"
+    t.integer "sign_in_count", default: 0, null: false
+    t.integer "sms_notification_opt_in", default: 0, null: false
+    t.string "state"
+    t.string "street_address"
+    t.string "uid"
+    t.datetime "updated_at", precision: nil, null: false
+    t.string "zip_code"
+    t.index ["intake_id"], name: "index_idme_users_on_intake_id"
+  end
+
   create_table "incoming_emails", force: :cascade do |t|
     t.integer "attachment_count"
     t.string "body_html"
@@ -962,6 +993,26 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_07_193139) do
     t.datetime "updated_at", null: false
     t.index ["client_id"], name: "index_incoming_text_messages_on_client_id"
     t.index ["created_at"], name: "index_incoming_text_messages_on_created_at"
+  end
+
+  create_table "intake_site_drop_offs", force: :cascade do |t|
+    t.string "additional_info"
+    t.string "certification_level"
+    t.datetime "created_at", precision: nil
+    t.string "email"
+    t.boolean "hsa", default: false
+    t.string "intake_site", null: false
+    t.string "name", null: false
+    t.string "organization"
+    t.string "phone_number"
+    t.date "pickup_date"
+    t.bigint "prior_drop_off_id"
+    t.string "signature_method", null: false
+    t.string "state"
+    t.string "timezone"
+    t.datetime "updated_at", precision: nil
+    t.string "zendesk_ticket_id"
+    t.index ["prior_drop_off_id"], name: "index_intake_site_drop_offs_on_prior_drop_off_id"
   end
 
   create_table "intakes", force: :cascade do |t|
@@ -1118,7 +1169,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_07_193139) do
     t.integer "primary_active_armed_forces", default: 0, null: false
     t.date "primary_birth_date"
     t.integer "primary_consented_to_service", default: 0, null: false
-    t.datetime "primary_consented_to_service_at", precision: nil
     t.inet "primary_consented_to_service_ip"
     t.bigint "primary_drivers_license_id"
     t.string "primary_first_name"
@@ -1221,7 +1271,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_07_193139) do
     t.index ["hashed_primary_ssn"], name: "index_intakes_on_hashed_primary_ssn"
     t.index ["needs_to_flush_searchable_data_set_at"], name: "index_intakes_on_needs_to_flush_searchable_data_set_at", where: "(needs_to_flush_searchable_data_set_at IS NOT NULL)"
     t.index ["phone_number"], name: "index_intakes_on_phone_number"
-    t.index ["primary_consented_to_service_at"], name: "index_intakes_on_primary_consented_to_service_at"
+    t.index ["primary_consented_to_service"], name: "index_intakes_on_primary_consented_to_service"
     t.index ["primary_drivers_license_id"], name: "index_intakes_on_primary_drivers_license_id"
     t.index ["searchable_data"], name: "index_intakes_on_searchable_data", using: :gin
     t.index ["sms_phone_number"], name: "index_intakes_on_sms_phone_number"
@@ -1369,6 +1419,31 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_07_193139) do
     t.index ["target_type", "target_id"], name: "index_state_routing_targets_on_target"
   end
 
+  create_table "states", primary_key: "abbreviation", id: :string, force: :cascade do |t|
+    t.string "name"
+    t.index ["name"], name: "index_states_on_name"
+  end
+
+  create_table "states_vita_partners", id: false, force: :cascade do |t|
+    t.string "state_abbreviation"
+    t.integer "vita_partner_id"
+    t.index ["state_abbreviation"], name: "index_states_vita_partners_on_state_abbreviation"
+    t.index ["vita_partner_id"], name: "index_states_vita_partners_on_vita_partner_id"
+  end
+
+  create_table "stimulus_triages", force: :cascade do |t|
+    t.integer "chose_to_file", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.integer "filed_prior_years", default: 0, null: false
+    t.integer "filed_recently", default: 0, null: false
+    t.integer "need_to_correct", default: 0, null: false
+    t.integer "need_to_file", default: 0, null: false
+    t.string "referrer"
+    t.string "source"
+    t.datetime "updated_at", null: false
+    t.string "visitor_id"
+  end
+
   create_table "system_notes", force: :cascade do |t|
     t.text "body"
     t.bigint "client_id", null: false
@@ -1473,6 +1548,18 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_07_193139) do
     t.index ["visitor_id"], name: "index_text_message_login_requests_on_visitor_id"
   end
 
+  create_table "ticket_statuses", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "eip_status"
+    t.integer "intake_id"
+    t.string "intake_status"
+    t.string "return_status"
+    t.integer "ticket_id"
+    t.datetime "updated_at", null: false
+    t.boolean "verified_change", default: true
+    t.index ["intake_id"], name: "index_ticket_statuses_on_intake_id"
+  end
+
   create_table "triages", force: :cascade do |t|
     t.integer "assistance_in_person", default: 0, null: false
     t.integer "assistance_phone_review_english", default: 0, null: false
@@ -1543,6 +1630,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_07_193139) do
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["role_type", "role_id"], name: "index_users_on_role_type_and_role_id", unique: true
+  end
+
+  create_table "users_vita_partners", id: false, force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "vita_partner_id", null: false
+    t.index ["user_id"], name: "index_users_vita_partners_on_user_id"
+    t.index ["vita_partner_id"], name: "index_users_vita_partners_on_vita_partner_id"
   end
 
   create_table "verification_attempt_transitions", force: :cascade do |t|
@@ -1646,6 +1740,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_07_193139) do
   add_foreign_key "greeter_organization_join_records", "greeter_roles"
   add_foreign_key "greeter_organization_join_records", "vita_partners"
   add_foreign_key "incoming_text_messages", "clients"
+  add_foreign_key "intake_site_drop_offs", "intake_site_drop_offs", column: "prior_drop_off_id"
   add_foreign_key "intakes", "clients"
   add_foreign_key "intakes", "vita_partners"
   add_foreign_key "notes", "clients"
@@ -1689,7 +1784,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_07_193139) do
            SELECT DISTINCT tax_returns.client_id
              FROM (tax_returns
                JOIN intakes ON ((intakes.client_id = tax_returns.client_id)))
-            WHERE ((tax_returns.current_state)::text <> ALL ((ARRAY['intake_before_consent'::character varying, 'intake_in_progress'::character varying, 'intake_greeter_info_requested'::character varying, 'intake_needs_doc_help'::character varying, 'file_mailed'::character varying, 'file_accepted'::character varying, 'file_not_filing'::character varying, 'file_hold'::character varying, 'file_fraud_hold'::character varying])::text[]))
+            WHERE ((tax_returns.current_state)::text <> ALL (ARRAY[('intake_before_consent'::character varying)::text, ('intake_in_progress'::character varying)::text, ('intake_greeter_info_requested'::character varying)::text, ('intake_needs_doc_help'::character varying)::text, ('file_mailed'::character varying)::text, ('file_accepted'::character varying)::text, ('file_not_filing'::character varying)::text, ('file_hold'::character varying)::text, ('file_fraud_hold'::character varying)::text]))
           ), partner_and_client_counts AS (
            SELECT organization_id_by_vita_partner_id.organization_id,
               count(clients.id) AS active_client_count

--- a/spec/factories/intakes.rb
+++ b/spec/factories/intakes.rb
@@ -154,7 +154,6 @@
 #  primary_active_armed_forces                          :integer          default(0), not null
 #  primary_birth_date                                   :date
 #  primary_consented_to_service                         :integer          default("unfilled"), not null
-#  primary_consented_to_service_at                      :datetime
 #  primary_consented_to_service_ip                      :inet
 #  primary_first_name                                   :string
 #  primary_last_name                                    :string
@@ -262,7 +261,7 @@
 #  index_intakes_on_hashed_primary_ssn                     (hashed_primary_ssn)
 #  index_intakes_on_needs_to_flush_searchable_data_set_at  (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_intakes_on_phone_number                           (phone_number)
-#  index_intakes_on_primary_consented_to_service_at        (primary_consented_to_service_at)
+#  index_intakes_on_primary_consented_to_service           (primary_consented_to_service)
 #  index_intakes_on_primary_drivers_license_id             (primary_drivers_license_id)
 #  index_intakes_on_searchable_data                        (searchable_data) USING gin
 #  index_intakes_on_sms_phone_number                       (sms_phone_number)

--- a/spec/models/intake/gyr_intake_spec.rb
+++ b/spec/models/intake/gyr_intake_spec.rb
@@ -154,7 +154,6 @@
 #  primary_active_armed_forces                          :integer          default(0), not null
 #  primary_birth_date                                   :date
 #  primary_consented_to_service                         :integer          default("unfilled"), not null
-#  primary_consented_to_service_at                      :datetime
 #  primary_consented_to_service_ip                      :inet
 #  primary_first_name                                   :string
 #  primary_last_name                                    :string
@@ -262,7 +261,7 @@
 #  index_intakes_on_hashed_primary_ssn                     (hashed_primary_ssn)
 #  index_intakes_on_needs_to_flush_searchable_data_set_at  (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_intakes_on_phone_number                           (phone_number)
-#  index_intakes_on_primary_consented_to_service_at        (primary_consented_to_service_at)
+#  index_intakes_on_primary_consented_to_service           (primary_consented_to_service)
 #  index_intakes_on_primary_drivers_license_id             (primary_drivers_license_id)
 #  index_intakes_on_searchable_data                        (searchable_data) USING gin
 #  index_intakes_on_sms_phone_number                       (sms_phone_number)

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -154,7 +154,6 @@
 #  primary_active_armed_forces                          :integer          default(0), not null
 #  primary_birth_date                                   :date
 #  primary_consented_to_service                         :integer          default("unfilled"), not null
-#  primary_consented_to_service_at                      :datetime
 #  primary_consented_to_service_ip                      :inet
 #  primary_first_name                                   :string
 #  primary_last_name                                    :string
@@ -262,7 +261,7 @@
 #  index_intakes_on_hashed_primary_ssn                     (hashed_primary_ssn)
 #  index_intakes_on_needs_to_flush_searchable_data_set_at  (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_intakes_on_phone_number                           (phone_number)
-#  index_intakes_on_primary_consented_to_service_at        (primary_consented_to_service_at)
+#  index_intakes_on_primary_consented_to_service           (primary_consented_to_service)
 #  index_intakes_on_primary_drivers_license_id             (primary_drivers_license_id)
 #  index_intakes_on_searchable_data                        (searchable_data) USING gin
 #  index_intakes_on_sms_phone_number                       (sms_phone_number)


### PR DESCRIPTION
We actually use the enum for "accessible_intakes" which is core to how we handle querying only consented intakes for fraud work. This is already happening in prod and doesnt seem to be totally slow, but it probably would help to add an index on that column.