### PR TITLE
Wait for heroku review app to be created before closing

### DIFF
--- a/.github/workflows/heroku-pull-request.yml
+++ b/.github/workflows/heroku-pull-request.yml
@@ -61,7 +61,15 @@ jobs:
         run: heroku addons:create heroku-postgresql:hobby-dev --app ${{ env.HEROKU_APP_NAME }}
 
       - name: Add Heroku remote
+        continue-on-error: true
+        id: add-remote
         run: heroku git:remote --app=${{ env.HEROKU_APP_NAME }}
+
+      - name: Retry Add Heroku remote if failed while trying to close the PR and destroy the app
+        if: github.event.action == 'closed' && steps.add-remote.outcome=='failure'
+        run: |
+          sleep 10
+          heroku git:remote --app=${{ env.HEROKU_APP_NAME }}
 
       - name: Push to Heroku
         if: github.event.action != 'closed'


### PR DESCRIPTION
This should solve the problem where when transifex opens and immediately closes PRs the heroku apps don't get cleaned up.