### PR TITLE
Change order of reveals on filing status page

### DIFF
--- a/app/views/ctc/questions/filing_status/edit.html.erb
+++ b/app/views/ctc/questions/filing_status/edit.html.erb
@@ -17,15 +17,15 @@
           <% end %>
         </div>
       </div>
-
-      <div class="reveal-shrink-wrapper">
-        <%= render('components/molecules/reveal', title: t("views.ctc.questions.filing_status.mfs_reveal.title")) do %>
-          <p><%= t("views.ctc.questions.filing_status.mfs_reveal.body") %></p>
-        <% end %>
-      </div>
+      
       <div class="reveal-shrink-wrapper">
         <%= render('components/molecules/reveal', title: t("views.ctc.questions.filing_status.irs_reveal.title")) do %>
           <p><%= t("views.ctc.questions.filing_status.irs_reveal.body_html") %></p>
+        <% end %>
+      </div>
+      <div class="reveal-shrink-wrapper">
+        <%= render('components/molecules/reveal', title: t("views.ctc.questions.filing_status.mfs_reveal.title")) do %>
+          <p><%= t("views.ctc.questions.filing_status.mfs_reveal.body") %></p>
         <% end %>
       </div>
       <div class="reveal-shrink-wrapper">


### PR DESCRIPTION
The reveal order should be swapped, per ticket.