### PR TITLE
Add Street2 on pdf 182403961

### DIFF
--- a/app/lib/irs1040_pdf.rb
+++ b/app/lib/irs1040_pdf.rb
@@ -20,7 +20,7 @@ class Irs1040Pdf
       PrimaryFirstNm: @intake.primary_middle_initial.present? ? "#{@intake.primary_first_name} #{@intake.primary_middle_initial}" : @intake.primary_first_name,
       PrimaryLastNm: @intake.primary_last_name,
       PrimarySSN: @xml_document.at("PrimarySSN")&.text,
-      AddressLine1Txt: @address.street_address,
+      AddressLine1Txt: [@address.street_address, @address.street_address2].join(" "),
       CityNm: @address.city,
       StateAbbreviationCd: @address.state,
       ZipCd: @address.zip_code,

--- a/app/lib/irs1040_pdf.rb
+++ b/app/lib/irs1040_pdf.rb
@@ -20,7 +20,7 @@ class Irs1040Pdf
       PrimaryFirstNm: @intake.primary_middle_initial.present? ? "#{@intake.primary_first_name} #{@intake.primary_middle_initial}" : @intake.primary_first_name,
       PrimaryLastNm: @intake.primary_last_name,
       PrimarySSN: @xml_document.at("PrimarySSN")&.text,
-      AddressLine1Txt: [@address.street_address, @address.street_address2].join(" "),
+      AddressLine1Txt: [@address.street_address, @address.street_address2].compact.join(" "),
       CityNm: @address.city,
       StateAbbreviationCd: @address.state,
       ZipCd: @address.zip_code,

--- a/spec/lib/irs1040_pdf_spec.rb
+++ b/spec/lib/irs1040_pdf_spec.rb
@@ -191,7 +191,21 @@ RSpec.describe Irs1040Pdf do
           "PrimaryBlindInd" => "Off",
         ))
       end
+    context "with no verified address" do
+      before do
+        submission.update(verified_address: nil)
+        submission.intake.update(street_address2: "UNIT 2", street_address: "850 Mission St")
+      end
 
+      it "puts street_address and street_address2 onto the document" do
+        output_file = pdf.output_file
+        result = filled_in_values(output_file.path)
+        expect(result).to match(hash_including(
+                                    "AddressLine1Txt" => "850 Mission St UNIT 2",
+                                    ))
+      end
+    end
+    
     it 'renders fields that have to be from the db instead of xml because the xml is truncated or weird' do
       output_file = pdf.output_file
       result = filled_in_values(output_file.path)


### PR DESCRIPTION
When we use a verified_address, the street is already combined into one line (not totally sure why we do this), but before we verify the address they're separated out.