### PR TITLE
Allow spouse to edit AGI even if they filed with spouse in answers

### DIFF
--- a/app/views/ctc/questions/confirm_information/_spouse_prior_year_agi.html.erb
+++ b/app/views/ctc/questions/confirm_information/_spouse_prior_year_agi.html.erb
@@ -3,7 +3,7 @@
   <div>
     <%= number_to_currency(intake.spouse_prior_year_agi_amount_computed) %>
   </div>
-  <% if intake.spouse_filed_prior_tax_year_filed_full_separate? && defined?(edit_controller) %>
+  <% if defined?(edit_controller) %>
     <%= link_to t("general.edit").downcase, edit_controller.to_path_helper, class: "review-box__edit review-box__edit-button" %>
   <% end %>
 </div>

--- a/spec/features/ctc/portal_spec.rb
+++ b/spec/features/ctc/portal_spec.rb
@@ -368,13 +368,13 @@ RSpec.feature "CTC Intake", :js, :active_job, requires_default_vita_partners: tr
       context "when the spouse filed with the primary the prior year" do
         let(:spouse_filed_prior_tax_year) { :filed_together }
 
-        scenario "they cannot edit the spouse AGI" do
+        scenario "they can still edit the spouse AGI independently" do
           log_in_to_ctc_portal
 
           click_on I18n.t("views.ctc.portal.home.correct_info")
 
           within ".spouse-prior-year-agi" do
-            expect(page).not_to have_selector("a", text: I18n.t("general.edit").downcase)
+            expect(page).to have_selector("a", text: I18n.t("general.edit").downcase)
           end
         end
       end


### PR DESCRIPTION
Remove restrictions on which married people can edit spouse AGI so that everyone can edit this value if they need/want to.