### PR TITLE
CircleCI: try to use base images cimg/ruby instead of deprecated circleci/ruby

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,17 @@
 ---
 version: 2.1
 
+orbs:
+  browser-tools: circleci/browser-tools@1.3.0
 executors:
   ruby_executor:
     working_directory: /mnt/ramdisk
     docker:
-      - image: circleci/ruby:2.7.5-node-browsers
+      - image: cimg/ruby:2.7.5-browsers
   rails_executor:
     working_directory: /mnt/ramdisk
     docker:
-      - image: circleci/ruby:2.7.5-node-browsers
+      - image: cimg/ruby:2.7.5-browsers
         environment:
           PGHOST: 127.0.0.1
           PGUSER: root
@@ -47,15 +49,25 @@ commands:
     description: "Install Ruby dependencies"
     steps:
       - restore_cache:
-          key: bundle-{{ checksum "Gemfile.lock" }}
+          key: bundle-cachebreaker_2-{{ checksum "Gemfile.lock" }}
       - run:
           name: install bundler & ruby dependencies
           command: |
             gem install bundler:2.3.5 --no-document && \
             bundle install --jobs=4 --retry=3 --path vendor/bundle
       - save_cache:
-          key: bundle-{{ checksum "Gemfile.lock" }}
+          key: bundle-cachebreaker_2-{{ checksum "Gemfile.lock" }}
           paths: [/mnt/ramdisk/vendor/bundle]
+  install_chrome:
+    description: "Install Chrome and Chromedriver"
+    steps:
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
+      - run:
+          command: |
+            google-chrome --version
+            chromedriver --version
+          name: Check install
   install_efile_schemas:
     description: "Install IRS e-File schemas"
     steps:
@@ -102,6 +114,7 @@ jobs:
       - install_js_dependencies
       - install_system_dependencies
       - install_ruby_dependencies
+      - install_chrome
       - install_efile_schemas
       - setup_test_db
       - run: |
@@ -127,6 +140,7 @@ jobs:
       - install_js_dependencies
       - install_system_dependencies
       - install_ruby_dependencies
+      - install_chrome
       - setup_test_db
       - run: bundle exec rake assets:precompile
       - run: bundle exec rake flow_explorer:capture_screenshots flow_explorer:upload_screenshots


### PR DESCRIPTION
Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>