### PR TITLE
Set consented_to_service_at for clients created in /flows

### DIFF
--- a/app/controllers/flows_controller.rb
+++ b/app/controllers/flows_controller.rb
@@ -250,6 +250,7 @@ class FlowsController < ApplicationController
       }
       client = Client.create!(
         intake_attributes: intake_attributes,
+        consented_to_service_at: Time.zone.now,
         efile_security_informations_attributes: [{
           ip_address: '127.0.0.1',
           device_id: "7BA1E530D6503F380F1496A47BEB6F33E40403D1",

--- a/app/views/flows/_flow.html.erb
+++ b/app/views/flows/_flow.html.erb
@@ -1,6 +1,8 @@
 <p>
   <% if flow_params.reference_object %>
     Reference Object: <strong><%= flow_params.pretty_reference_object %></strong>
+    <br/>
+    <%= link_to 'View client in hub', url_for(host: MultiTenantService.new(:gyr).host, controller: "/hub/clients", action: 'show', id: flow_params.reference_object.client_id), target: "_blank" %>
   <% else %>
     <strong>No Reference Object -- Showing All Pages</strong>
   <% end %>


### PR DESCRIPTION
This allows them to be visible in the hub

- Add a convenience link to the client's hub page from /flows