### PR TITLE
CTC Puerto Rico: collect 'Urbanization code' and send it to the USPS

### DIFF
--- a/app/controllers/hub/clients_controller.rb
+++ b/app/controllers/hub/clients_controller.rb
@@ -199,6 +199,10 @@ module Hub
         end
       end
 
+      def urbanization
+        @intake.urbanization if @intake.respond_to?(:urbanization)
+      end
+
       def editable?
         !!@client.intake
       end

--- a/app/forms/ctc/mailing_address_form.rb
+++ b/app/forms/ctc/mailing_address_form.rb
@@ -10,15 +10,10 @@ module Ctc
 
     def save
       if address_service.has_verified_address?
-        attrs = {
-          zip_code: address_service.zip_code,
-          urbanization: address_service.urbanization,
-          street_address: address_service.street_address,
+        attrs = address_service.verified_address_attributes.merge(
           street_address2: nil,
-          state: address_service.state,
-          city: address_service.city,
           usps_address_verified_at: DateTime.now,
-        }
+        )
         @intake.update(attrs)
       else
         @intake.update(attributes_for(:intake))

--- a/app/forms/ctc/mailing_address_form.rb
+++ b/app/forms/ctc/mailing_address_form.rb
@@ -1,6 +1,6 @@
 module Ctc
   class MailingAddressForm < QuestionsForm
-    set_attributes_for :intake, :street_address, :street_address2, :state, :city, :zip_code
+    set_attributes_for :intake, :urbanization, :street_address, :street_address2, :state, :city, :zip_code
 
     validates_presence_of :street_address
     validates_presence_of :city
@@ -12,6 +12,7 @@ module Ctc
       if address_service.has_verified_address?
         attrs = {
           zip_code: address_service.zip_code,
+          urbanization: address_service.urbanization,
           street_address: address_service.street_address,
           street_address2: nil,
           state: address_service.state,

--- a/app/forms/hub/update_ctc_client_form.rb
+++ b/app/forms/hub/update_ctc_client_form.rb
@@ -16,6 +16,7 @@ module Hub
                        :email_address,
                        :phone_number,
                        :sms_phone_number,
+                       :urbanization,
                        :street_address,
                        :street_address2,
                        :city,

--- a/app/lib/irs1040_pdf.rb
+++ b/app/lib/irs1040_pdf.rb
@@ -15,12 +15,15 @@ class Irs1040Pdf
   end
 
   def hash_for_pdf
+    urbanization = @address.urbanization
+    urbanization += "," if urbanization.present?
+
     answers = {
       FilingStatus: @xml_document.at("IndividualReturnFilingStatusCd")&.text,
       PrimaryFirstNm: @intake.primary_middle_initial.present? ? "#{@intake.primary_first_name} #{@intake.primary_middle_initial}" : @intake.primary_first_name,
       PrimaryLastNm: @intake.primary_last_name,
       PrimarySSN: @xml_document.at("PrimarySSN")&.text,
-      AddressLine1Txt: [@address.street_address, @address.street_address2].compact.join(" "),
+      AddressLine1Txt: [urbanization, @address.street_address, @address.street_address2].compact.join(" "),
       CityNm: @address.city,
       StateAbbreviationCd: @address.state,
       ZipCd: @address.zip_code,

--- a/app/lib/submission_builder/shared/return_header1040.rb
+++ b/app/lib/submission_builder/shared/return_header1040.rb
@@ -73,7 +73,7 @@ module SubmissionBuilder
               xml.USAddress {
                 # IRS provides no information on how to shorten addresses
                 # but requires that they be < 36 characters long
-                xml.AddressLine1Txt trim([address.urbanization, address.street_address].map(&:present).compact.join(", "), 35)
+                xml.AddressLine1Txt trim([address.urbanization, address.street_address].map(&:presence).compact.join(", "), 35)
                 xml.CityNm trim(address.city, 22)
                 xml.StateAbbreviationCd address.state
                 xml.ZIPCd address.zip_code

--- a/app/lib/submission_builder/shared/return_header1040.rb
+++ b/app/lib/submission_builder/shared/return_header1040.rb
@@ -73,7 +73,7 @@ module SubmissionBuilder
               xml.USAddress {
                 # IRS provides no information on how to shorten addresses
                 # but requires that they be < 36 characters long
-                xml.AddressLine1Txt trim(address.street_address, 35)
+                xml.AddressLine1Txt trim([address.urbanization, address.street_address].map(&:present).compact.join(", "), 35)
                 xml.CityNm trim(address.city, 22)
                 xml.StateAbbreviationCd address.state
                 xml.ZIPCd address.zip_code

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -9,6 +9,7 @@
 #  state                :string
 #  street_address       :string
 #  street_address2      :string
+#  urbanization         :string
 #  zip_code             :string
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
@@ -25,7 +26,7 @@ class Address < ApplicationRecord
 
   def to_s
     <<~ADDRESS
-      #{street_address} #{street_address2}
+      #{urbanization} #{street_address} #{street_address2}
       #{city}, #{state} #{zip_code}
     ADDRESS
   end

--- a/app/models/efile_submission.rb
+++ b/app/models/efile_submission.rb
@@ -129,13 +129,7 @@ class EfileSubmission < ApplicationRecord
     end
 
     if address_service.valid?
-      attrs = {
-        zip_code: address_service.zip_code,
-        street_address: address_service.street_address,
-        state: address_service.state,
-        city: address_service.city
-      }
-      create_verified_address!(attrs)
+      create_verified_address!(address_service.verified_address_attributes)
     end
     address_service # return the service object so that we can get errors if there are any
   end

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -221,6 +221,7 @@
 #  triage_income_level                                  :integer          default(0), not null
 #  triage_vita_income_ineligible                        :integer          default(0), not null
 #  type                                                 :string
+#  urbanization                                         :string
 #  use_primary_name_for_name_control                    :boolean          default(FALSE)
 #  used_itin_certifying_acceptance_agent                :boolean          default(FALSE), not null
 #  usps_address_late_verification_attempts              :integer          default(0)

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -221,6 +221,7 @@
 #  triage_income_level                                  :integer          default(0), not null
 #  triage_vita_income_ineligible                        :integer          default(0), not null
 #  type                                                 :string
+#  urbanization                                         :string
 #  use_primary_name_for_name_control                    :boolean          default(FALSE)
 #  used_itin_certifying_acceptance_agent                :boolean          default(FALSE), not null
 #  usps_address_late_verification_attempts              :integer          default(0)

--- a/app/models/intake/gyr_intake.rb
+++ b/app/models/intake/gyr_intake.rb
@@ -221,6 +221,7 @@
 #  triage_income_level                                  :integer          default("unfilled"), not null
 #  triage_vita_income_ineligible                        :integer          default("unfilled"), not null
 #  type                                                 :string
+#  urbanization                                         :string
 #  use_primary_name_for_name_control                    :boolean          default(FALSE)
 #  used_itin_certifying_acceptance_agent                :boolean          default(FALSE), not null
 #  usps_address_late_verification_attempts              :integer          default(0)

--- a/app/services/standardize_address_service.rb
+++ b/app/services/standardize_address_service.rb
@@ -79,11 +79,12 @@ class StandardizeAddressService
 
   def build_standardized_address
     usps_address_xml = get_usps_address_xml
+    puts usps_address_xml.xpath("//Address/Urbanization").inspect
     return {} unless usps_address_xml
 
     {
       street_address: usps_address_xml.xpath("//Address/Address2").text,
-      urbanization: usps_address_xml.xpath("//Address/Urbanization")&.text,
+      urbanization: usps_address_xml.xpath("//Address/Urbanization").presence&.text,
       city: usps_address_xml.xpath("//Address/City").text,
       state: usps_address_xml.xpath("//Address/State").text,
       zip_code: usps_address_xml.xpath("//Address/Zip5").text,

--- a/app/services/standardize_address_service.rb
+++ b/app/services/standardize_address_service.rb
@@ -89,7 +89,6 @@ class StandardizeAddressService
 
   def build_standardized_address
     usps_address_xml = get_usps_address_xml
-    puts usps_address_xml.xpath("//Address/Urbanization").inspect
     return {} unless usps_address_xml
 
     {

--- a/app/services/standardize_address_service.rb
+++ b/app/services/standardize_address_service.rb
@@ -13,6 +13,7 @@ class StandardizeAddressService
     @_city = intake.city
     @_state = intake.state
     @_zip_code = intake.zip_code
+    @_urbanization = intake.urbanization
 
     @result = build_standardized_address
     log_errors
@@ -34,6 +35,10 @@ class StandardizeAddressService
 
   def zip_code
     @result[:zip_code]
+  end
+
+  def urbanization
+    @result[:urbanization]
   end
 
   def error_message
@@ -78,6 +83,7 @@ class StandardizeAddressService
 
     {
       street_address: usps_address_xml.xpath("//Address/Address2").text,
+      urbanization: usps_address_xml.xpath("//Address/Urbanization")&.text,
       city: usps_address_xml.xpath("//Address/City").text,
       state: usps_address_xml.xpath("//Address/State").text,
       zip_code: usps_address_xml.xpath("//Address/Zip5").text,
@@ -96,6 +102,7 @@ class StandardizeAddressService
           xml.Address2 @_street_address
           xml.City @_city
           xml.State @_state
+          xml.Urbanization @_urbanization if @_urbanization
           xml.Zip5 @_zip_code
           xml.Zip4
         }

--- a/app/services/standardize_address_service.rb
+++ b/app/services/standardize_address_service.rb
@@ -41,6 +41,16 @@ class StandardizeAddressService
     @result[:urbanization]
   end
 
+  def verified_address_attributes
+    {
+      zip_code: zip_code,
+      street_address: street_address,
+      state: state,
+      city: city,
+      urbanization: urbanization
+    }
+  end
+
   def error_message
     return nil unless @result[:error_message]
 

--- a/app/views/ctc/portal/mailing_address/edit.html.erb
+++ b/app/views/ctc/portal/mailing_address/edit.html.erb
@@ -14,6 +14,9 @@
         <%= render 'ctc/questions/mailing_address/address_notices' %>
 
         <div class="form-card__content">
+          <% if current_intake.home_location_puerto_rico? %>
+            <%= f.cfa_input_field(:urbanization, t("views.questions.mailing_address.urbanization")) %>
+          <% end %>
           <%= f.cfa_input_field(:street_address, t("views.questions.mailing_address.street_address"), classes: ["form-width--long"]) %>
           <%= f.cfa_input_field(:street_address2, t("views.questions.mailing_address.street_address2"), classes: ["form-width--zip"]) %>
           <%= f.cfa_input_field(:city, t("views.questions.mailing_address.city"), classes: ["form-width--long"]) %>

--- a/app/views/ctc/questions/confirm_information/_mailing_address.html.erb
+++ b/app/views/ctc/questions/confirm_information/_mailing_address.html.erb
@@ -1,6 +1,9 @@
 <h2 class="review-box__title"><%= t("views.ctc.questions.confirm_mailing_address.mailing_address") %></h2>
 <div class="review-box__space-between address-info">
   <div class="form-group <%= intake.usps_address_verified_at ? "" : "form-group--error" %>">
+    <% if intake.urbanization.present? %>
+      <div><%= intake.urbanization %></div>
+    <% end %>
     <div><%= intake.street_address %></div>
     <% if intake.street_address2.present? %>
       <div><%= intake.street_address2 %></div>

--- a/app/views/ctc/questions/confirm_mailing_address/edit.html.erb
+++ b/app/views/ctc/questions/confirm_mailing_address/edit.html.erb
@@ -13,6 +13,9 @@
         <%= link_to t("general.edit").downcase, prev_path, class: "review-box__edit-button" %>
       </div>
       <div class="review-box__body">
+        <% if current_intake.urbanization.present? %>
+          <div><%= current_intake.urbanization %></div>
+        <% end %>
         <div><%= current_intake.street_address %></div>
         <% if current_intake.street_address2.present? %>
           <div><%= current_intake.street_address2 %></div>

--- a/app/views/ctc/questions/mailing_address/edit.html.erb
+++ b/app/views/ctc/questions/mailing_address/edit.html.erb
@@ -15,7 +15,10 @@
     <%= render 'address_notices' %>
 
     <div class="form-card__content">
-      <%= f.cfa_input_field(:street_address, t("views.questions.mailing_address.street_address"), ) %>
+      <% if current_intake.home_location_puerto_rico? %>
+        <%= f.cfa_input_field(:urbanization, t("views.questions.mailing_address.urbanization")) %>
+      <% end %>
+      <%= f.cfa_input_field(:street_address, t("views.questions.mailing_address.street_address")) %>
       <%= f.cfa_input_field(:street_address2, t("views.questions.mailing_address.street_address2"), classes: ["form-width--zip"]) %>
       <%= f.cfa_input_field(:city, t("views.questions.mailing_address.city")) %>
       <%= f.cfa_select(:state, t("views.questions.mailing_address.state"), States.name_value_pairs) %>

--- a/app/views/hub/clients/show.html.erb
+++ b/app/views/hub/clients/show.html.erb
@@ -207,7 +207,7 @@
             <div class="field-display">
               <span class="form-question"><%= t(".mailing_address") %>:</span>
               <div class="label-indented spacing-above-10">
-                <div><%= @client.intake.urbanization if @client.intake.urbanization.present? %></div>
+                <div><%= @client.urbanization if @client.urbanization.present? %></div>
                 <div><%= @client.intake.street_address %></div>
                 <div><%= @client.intake.street_address2 if @client.intake.street_address2.present? %></div>
                 <div><%= @client.intake.city %>, <%= @client.intake.state %> <%= @client.intake.zip_code %></div>

--- a/app/views/hub/clients/show.html.erb
+++ b/app/views/hub/clients/show.html.erb
@@ -207,7 +207,8 @@
             <div class="field-display">
               <span class="form-question"><%= t(".mailing_address") %>:</span>
               <div class="label-indented spacing-above-10">
-                <div> <%= @client.intake&.street_address %></div>
+                <div><%= @client.intake.urbanization if @client.intake.urbanization.present? %></div>
+                <div><%= @client.intake.street_address %></div>
                 <div><%= @client.intake.street_address2 if @client.intake.street_address2.present? %></div>
                 <div><%= @client.intake.city %>, <%= @client.intake.state %> <%= @client.intake.zip_code %></div>
               </div>

--- a/app/views/shared/_address_fields.html.erb
+++ b/app/views/shared/_address_fields.html.erb
@@ -1,7 +1,7 @@
 <% is_ctc ||= false %>
 <div id="address-fields" class="hub-form__card card-small">
   <h3><%= t("hub.clients.fields.mailing_address") %></h3>
-  <%= f.cfa_input_field(:urbanization, t("general.urbanization")) if f.object.client&.intake&.home_location_puerto_rico? || f.object.client&.intake&.urbanization.present? %>
+  <%= f.cfa_input_field(:urbanization, t("general.urbanization")) if is_ctc && f.object.client&.intake&.home_location_puerto_rico? || f.object.client&.intake&.urbanization.present? %>
   <%= f.cfa_input_field(:street_address, t("general.street_address")) %>
   <% if is_ctc %>
     <%= f.cfa_input_field(:street_address2, t("general.street_address2")) %>

--- a/app/views/shared/_address_fields.html.erb
+++ b/app/views/shared/_address_fields.html.erb
@@ -1,7 +1,7 @@
 <% is_ctc ||= false %>
 <div id="address-fields" class="hub-form__card card-small">
   <h3><%= t("hub.clients.fields.mailing_address") %></h3>
-  <%= f.cfa_input_field(:urbanization, t("general.urbanization")) if f.object.client&.intake&.home_location_puerto_rico? %>
+  <%= f.cfa_input_field(:urbanization, t("general.urbanization")) if f.object.client&.intake&.home_location_puerto_rico? || f.object.client&.intake&.urbanization.present? %>
   <%= f.cfa_input_field(:street_address, t("general.street_address")) %>
   <% if is_ctc %>
     <%= f.cfa_input_field(:street_address2, t("general.street_address2")) %>

--- a/app/views/shared/_address_fields.html.erb
+++ b/app/views/shared/_address_fields.html.erb
@@ -1,6 +1,7 @@
 <% is_ctc ||= false %>
 <div id="address-fields" class="hub-form__card card-small">
   <h3><%= t("hub.clients.fields.mailing_address") %></h3>
+  <%= f.cfa_input_field(:urbanization, t("general.urbanization")) if f.object.intake&.home_location_puerto_rico? %>
   <%= f.cfa_input_field(:street_address, t("general.street_address")) %>
   <% if is_ctc %>
     <%= f.cfa_input_field(:street_address2, t("general.street_address2")) %>

--- a/app/views/shared/_address_fields.html.erb
+++ b/app/views/shared/_address_fields.html.erb
@@ -1,7 +1,7 @@
 <% is_ctc ||= false %>
 <div id="address-fields" class="hub-form__card card-small">
   <h3><%= t("hub.clients.fields.mailing_address") %></h3>
-  <%= f.cfa_input_field(:urbanization, t("general.urbanization")) if f.object.intake&.home_location_puerto_rico? %>
+  <%= f.cfa_input_field(:urbanization, t("general.urbanization")) if f.object.client&.intake&.home_location_puerto_rico? %>
   <%= f.cfa_input_field(:street_address, t("general.street_address")) %>
   <% if is_ctc %>
     <%= f.cfa_input_field(:street_address2, t("general.street_address2")) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -233,6 +233,7 @@ en:
     admin: Admin
     admin_controls: Admin Controls
     affirmative: 'Yes'
+    urbanization: Urbanization code
     all_organizations: All organizations
     and: and
     assign: Assign
@@ -4172,6 +4173,7 @@ en:
       mailing_address:
         city: City
         state: State or US Territory
+        urbanization: Urbanization code
         street_address: Street address or P.O. box
         street_address2: Apartment number (optional)
         title: What is your mailing address?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -233,7 +233,6 @@ en:
     admin: Admin
     admin_controls: Admin Controls
     affirmative: 'Yes'
-    urbanization: Urbanization code
     all_organizations: All organizations
     and: and
     assign: Assign
@@ -510,6 +509,7 @@ en:
     update: Update
     updated_at: Updated At
     upload: Upload
+    urbanization: Urbanization code
     used_navigator: Used navigator
     very_well: Very well
     visit_free_file: Visit IRS Free File
@@ -4173,11 +4173,11 @@ en:
       mailing_address:
         city: City
         state: State or US Territory
-        urbanization: Urbanization code
         street_address: Street address or P.O. box
         street_address2: Apartment number (optional)
         title: What is your mailing address?
         unable_to_validate: An error occurred while contacting the US Postal Service. Please submit your address again.
+        urbanization: Urbanization code
         zip_code: ZIP code
       married:
         help_text: This includes registered domestic partnerships, civil unions, other formal relationships under state law or legal separation.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -225,6 +225,7 @@ es:
         is_hsa: es HSA
   general:
     NA: N/A
+    urbanization: Código de urbanización
     access_denied: Usted no está autorizado a tomar esta acción.
     activate_all: Activar todo
     active: activos
@@ -4181,6 +4182,7 @@ es:
       mailing_address:
         city: Ciudad
         state: Estado o territorio de EE. UU.
+        urbanization: Código de urbanización
         street_address: Dirección o apartado postal
         street_address2: Número de apartamento (opcional)
         title: "¿Cuál es su dirección postal?"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -225,7 +225,6 @@ es:
         is_hsa: es HSA
   general:
     NA: N/A
-    urbanization: Código de urbanización
     access_denied: Usted no está autorizado a tomar esta acción.
     activate_all: Activar todo
     active: activos
@@ -511,6 +510,7 @@ es:
     update: Actualizar
     updated_at: Actualizado en
     upload: Subir
+    urbanization: Código de urbanización
     used_navigator: Navegador usado
     very_well: Muy bien
     visit_free_file: Visite el sitio de declaración de impuestos gratuita del IRS
@@ -4182,11 +4182,11 @@ es:
       mailing_address:
         city: Ciudad
         state: Estado o territorio de EE. UU.
-        urbanization: Código de urbanización
         street_address: Dirección o apartado postal
         street_address2: Número de apartamento (opcional)
         title: "¿Cuál es su dirección postal?"
         unable_to_validate: Ocurrió un error al comunicarse con el Servicio Postal de EE. UU. Por favor, envíe su dirección de nuevo.
+        urbanization: Código de urbanización
         zip_code: Código postal
       married:
         help_text: Esto incluye sociedades domésticas registradas, uniones civiles, otras relaciones formales bajo la ley estatal o separación legal.

--- a/db/migrate/20220713183147_add_urbanization_to_intakes.rb
+++ b/db/migrate/20220713183147_add_urbanization_to_intakes.rb
@@ -1,0 +1,5 @@
+class AddUrbanizationToIntakes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :intakes, :urbanization, :string
+  end
+end

--- a/db/migrate/20220713210511_add_urbanization_to_addresses.rb
+++ b/db/migrate/20220713210511_add_urbanization_to_addresses.rb
@@ -1,0 +1,5 @@
+class AddUrbanizationToAddresses < ActiveRecord::Migration[7.0]
+  def change
+    add_column :addresses, :urbanization, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_13_183147) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_13_210511) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -92,6 +92,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_13_183147) do
     t.string "street_address"
     t.string "street_address2"
     t.datetime "updated_at", null: false
+    t.string "urbanization"
     t.string "zip_code"
     t.index ["record_type", "record_id"], name: "index_addresses_on_record_type_and_record_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_30_180747) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_13_183147) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -1175,6 +1175,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_30_180747) do
     t.integer "triage_vita_income_ineligible", default: 0, null: false
     t.string "type"
     t.datetime "updated_at", null: false
+    t.string "urbanization"
     t.boolean "use_primary_name_for_name_control", default: false
     t.boolean "used_itin_certifying_acceptance_agent", default: false, null: false
     t.integer "usps_address_late_verification_attempts", default: 0

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -9,6 +9,7 @@
 #  state                :string
 #  street_address       :string
 #  street_address2      :string
+#  urbanization         :string
 #  zip_code             :string
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
@@ -25,5 +26,11 @@ FactoryBot.define do
     zip_code { "77494" }
     state { "TX" }
     city { "KATY" }
+    trait :with_urbanization do
+      zip_code { "00797" }
+      state { "PR" }
+      city { "SAN JUAN" }
+      urbanization { "URB PICARD" }
+    end
   end
 end

--- a/spec/factories/intakes.rb
+++ b/spec/factories/intakes.rb
@@ -221,6 +221,7 @@
 #  triage_income_level                                  :integer          default(0), not null
 #  triage_vita_income_ineligible                        :integer          default(0), not null
 #  type                                                 :string
+#  urbanization                                         :string
 #  use_primary_name_for_name_control                    :boolean          default(FALSE)
 #  used_itin_certifying_acceptance_agent                :boolean          default(FALSE), not null
 #  usps_address_late_verification_attempts              :integer          default(0)

--- a/spec/fixtures/files/usps_address_validation_body_with_urbanization.xml
+++ b/spec/fixtures/files/usps_address_validation_body_with_urbanization.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AddressValidateResponse>
+  <Address ID="0">
+    <Address2>1-23 CALLE 1</Address2>
+    <City>BAYAMON</City>
+    <State>PR</State>
+    <Urbanization>URB SIERRA BAYAMON</Urbanization>
+    <Zip5>00961</Zip5>
+    <Zip4/>
+    <CarrierRoute>C027</CarrierRoute>
+    <Footnotes>N</Footnotes>
+    <DPVConfirmation>N</DPVConfirmation>
+    <DPVFalse>N</DPVFalse>
+    <DPVFootnotes>AAM3</DPVFootnotes>
+    <CentralDeliveryPoint>N</CentralDeliveryPoint>
+  </Address>
+</AddressValidateResponse>

--- a/spec/forms/ctc/mailing_address_form_spec.rb
+++ b/spec/forms/ctc/mailing_address_form_spec.rb
@@ -123,12 +123,14 @@ describe Ctc::MailingAddressForm do
       before do
         allow(StandardizeAddressService).to receive(:new).and_return(address_service_double)
         allow(address_service_double).to receive(:valid?).and_return true
-        allow(address_service_double).to receive(:street_address).and_return "123 Main Street STE 5"
-        allow(address_service_double).to receive(:state).and_return state
-        allow(address_service_double).to receive(:zip_code).and_return "77494"
-        allow(address_service_double).to receive(:city).and_return "Newton-John"
         allow(address_service_double).to receive(:has_verified_address?).and_return true
-        allow(address_service_double).to receive(:urbanization).and_return(nil)
+        allow(address_service_double).to receive(:verified_address_attributes).and_return({
+          street_address: "123 Main Street STE 5",
+          state: state,
+          zip_code: "77494",
+          city: "Newton-John",
+          urbanization: nil,
+        })
       end
 
       it "saves the values returned from the API" do
@@ -148,7 +150,13 @@ describe Ctc::MailingAddressForm do
         let(:state) { "PR" }
         before do
           params.merge!(urbanization: "Urb Picard")
-          allow(address_service_double).to receive(:urbanization).and_return("URB PICARD")
+          allow(address_service_double).to receive(:verified_address_attributes).and_return({
+            street_address: "123 Main Street STE 5",
+            state: state,
+            zip_code: "77494",
+            city: "Newton-John",
+            urbanization: "URB PICARD",
+          })
         end
 
         it "saves the urbanization into the intake" do

--- a/spec/forms/ctc/mailing_address_form_spec.rb
+++ b/spec/forms/ctc/mailing_address_form_spec.rb
@@ -119,14 +119,16 @@ describe Ctc::MailingAddressForm do
     # as it will be combined with street_address when pulled from the API
     context "when the address was successfully verified with the USPS API" do
       let(:address_service_double) { double }
+      let(:state) { "TX" }
       before do
         allow(StandardizeAddressService).to receive(:new).and_return(address_service_double)
         allow(address_service_double).to receive(:valid?).and_return true
         allow(address_service_double).to receive(:street_address).and_return "123 Main Street STE 5"
-        allow(address_service_double).to receive(:state).and_return "TX"
-        allow(address_service_double).to receive(:zip_code).and_return "77494-1111"
+        allow(address_service_double).to receive(:state).and_return state
+        allow(address_service_double).to receive(:zip_code).and_return "77494"
         allow(address_service_double).to receive(:city).and_return "Newton-John"
         allow(address_service_double).to receive(:has_verified_address?).and_return true
+        allow(address_service_double).to receive(:urbanization).and_return(nil)
       end
 
       it "saves the values returned from the API" do
@@ -136,10 +138,30 @@ describe Ctc::MailingAddressForm do
         }.to change(intake, :street_address).to("123 Main Street STE 5")
          .and change(intake, :city).to("Newton-John")
          .and change(intake, :state).to("TX")
-         .and change(intake, :zip_code).to("77494-1111")
+         .and change(intake, :zip_code).to("77494")
          .and not_change(intake, :street_address2)
         expect(intake.street_address2).to be_nil
         expect(intake.usps_address_verified_at).to be_within(1.second).of(DateTime.now)
+      end
+
+      context "with a Puerto Rico urbanization code" do
+        let(:state) { "PR" }
+        before do
+          params.merge!(urbanization: "Urb Picard")
+          allow(address_service_double).to receive(:urbanization).and_return("URB PICARD")
+        end
+
+        it "saves the urbanization into the intake" do
+          form = described_class.new(intake, params)
+          expect {
+            form.save
+          }.to change(intake, :street_address).to("123 Main Street STE 5")
+            .and change(intake, :city).to("Newton-John")
+            .and change(intake, :state).to(state)
+            .and change(intake, :zip_code).to("77494")
+            .and change(intake, :urbanization).to("URB PICARD")
+            .and not_change(intake, :street_address2)
+        end
       end
     end
 
@@ -161,6 +183,26 @@ describe Ctc::MailingAddressForm do
          .and change(intake, :city).to("Newton")
          .and change(intake, :state).to("TX")
          .and change(intake, :zip_code).to("77494")
+      end
+
+
+      context "with a Puerto Rico urbanization code" do
+        before do
+          params.merge!(state: "PR")
+          params.merge!(urbanization: "Urb Picard")
+        end
+
+        it "saves the urbanization into the intake" do
+          form = described_class.new(intake, params)
+          expect {
+            form.save
+          }.to change(intake, :street_address).to("123 Main St")
+            .and change(intake, :street_address2).to("STE 5")
+            .and change(intake, :city).to("Newton")
+            .and change(intake, :state).to("PR")
+            .and change(intake, :zip_code).to("77494")
+            .and change(intake, :urbanization).to("Urb Picard")
+        end
       end
     end
   end

--- a/spec/forms/hub/update_ctc_client_form_spec.rb
+++ b/spec/forms/hub/update_ctc_client_form_spec.rb
@@ -263,6 +263,21 @@ RSpec.describe Hub::UpdateCtcClientForm, requires_default_vita_partners: true do
           end.to change(intake, :was_blind).to("yes").and change(intake, :spouse_was_blind).to("yes")
         end
       end
+
+      context "updating urbanization code for Puerto Rico client" do
+        before do
+          intake.update!(home_location: "puerto_rico")
+          form_attributes[:urbanization] = "URB PICARD"
+        end
+
+        it "persists the change" do
+          expect do
+            form = described_class.new(client, form_attributes)
+            form.save
+            intake.reload
+          end.to change(intake, :urbanization).to("URB PICARD")
+        end
+      end
     end
   end
 

--- a/spec/lib/submission_builder/shared/return_header1040_spec.rb
+++ b/spec/lib/submission_builder/shared/return_header1040_spec.rb
@@ -277,6 +277,23 @@ describe SubmissionBuilder::Shared::ReturnHeader1040 do
           expect(response).not_to be_valid
         end
       end
+
+      context "with a Puerto Rico address containing an urbanization" do
+        before do
+          submission.update(verified_address: build(:address, :with_urbanization, record: submission))
+        end
+
+        it "includes the urbanization in address line 1" do
+          response = described_class.build(submission)
+          expect(response).to be_an_instance_of SubmissionBuilder::Response
+          xml = Nokogiri::XML::Document.parse(response.document.to_xml)
+          expect(xml.at("AddressLine1Txt").text).to eq "URB PICARD, 23627 HAWKINS CREEK CT"
+          expect(xml.at("CityNm").text).to eq "SAN JUAN"
+          expect(xml.at("StateAbbreviationCd").text).to eq "PR"
+          expect(xml.at("ZIPCd").text).to eq "00797"
+          expect(response).not_to be_valid
+        end
+      end
     end
 
     context "filing requesting a check payment" do

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -9,6 +9,7 @@
 #  state                :string
 #  street_address       :string
 #  street_address2      :string
+#  urbanization         :string
 #  zip_code             :string
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null

--- a/spec/models/intake/gyr_intake_spec.rb
+++ b/spec/models/intake/gyr_intake_spec.rb
@@ -221,6 +221,7 @@
 #  triage_income_level                                  :integer          default("unfilled"), not null
 #  triage_vita_income_ineligible                        :integer          default("unfilled"), not null
 #  type                                                 :string
+#  urbanization                                         :string
 #  use_primary_name_for_name_control                    :boolean          default(FALSE)
 #  used_itin_certifying_acceptance_agent                :boolean          default(FALSE), not null
 #  usps_address_late_verification_attempts              :integer          default(0)

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -221,6 +221,7 @@
 #  triage_income_level                                  :integer          default(0), not null
 #  triage_vita_income_ineligible                        :integer          default(0), not null
 #  type                                                 :string
+#  urbanization                                         :string
 #  use_primary_name_for_name_control                    :boolean          default(FALSE)
 #  used_itin_certifying_acceptance_agent                :boolean          default(FALSE), not null
 #  usps_address_late_verification_attempts              :integer          default(0)

--- a/spec/services/standardize_address_service_spec.rb
+++ b/spec/services/standardize_address_service_spec.rb
@@ -18,6 +18,7 @@ describe StandardizeAddressService, do_not_stub_usps: true do
       expect(service.valid?).to eq true
       expect(service.street_address).to eq "43 VICKSBURG ST UNIT B"
       expect(service.city).to eq "SAN FRANCISCO"
+      expect(service.urbanization).to be_nil
       expect(service.state).to eq "CA"
       expect(service.zip_code).to eq "94114"
     end
@@ -46,6 +47,20 @@ describe StandardizeAddressService, do_not_stub_usps: true do
         expect(service.city).to eq "SAN FRANCISCO"
         expect(service.state).to eq "CA"
         expect(service.zip_code).to eq "94114"
+      end
+    end
+
+    context 'when the result contains urbanization code' do
+      let(:usps_api_response_body) { file_fixture("usps_address_validation_body_with_urbanization.xml") }
+
+      it 'is valid and has standardized address fields including urbanization' do
+        service = described_class.new(intake)
+        expect(service.valid?).to eq true
+        expect(service.street_address).to eq "1-23 CALLE 1"
+        expect(service.city).to eq "BAYAMON"
+        expect(service.urbanization).to eq "URB SIERRA BAYAMON"
+        expect(service.state).to eq "PR"
+        expect(service.zip_code).to eq "00961"
       end
     end
 


### PR DESCRIPTION
There are apparently some addresses where just street+zip is insufficent,
so you need the urbanization code to disambiguate.

The urbanization code field should show up when entering/editing the
address, just for `.home_location_puerto_rico?` clients.