### PR TITLE
Remove comma from urbanization in address [#182705742]

### DIFF
--- a/app/lib/irs1040_pdf.rb
+++ b/app/lib/irs1040_pdf.rb
@@ -15,15 +15,12 @@ class Irs1040Pdf
   end
 
   def hash_for_pdf
-    urbanization = @address.urbanization
-    urbanization += "," if urbanization.present?
-
     answers = {
       FilingStatus: @xml_document.at("IndividualReturnFilingStatusCd")&.text,
       PrimaryFirstNm: @intake.primary_middle_initial.present? ? "#{@intake.primary_first_name} #{@intake.primary_middle_initial}" : @intake.primary_first_name,
       PrimaryLastNm: @intake.primary_last_name,
       PrimarySSN: @xml_document.at("PrimarySSN")&.text,
-      AddressLine1Txt: [urbanization, @address.street_address, @address.street_address2].compact.join(" "),
+      AddressLine1Txt: [@address.urbanization, @address.street_address, @address.street_address2].compact.join(" "),
       CityNm: @address.city,
       StateAbbreviationCd: @address.state,
       ZipCd: @address.zip_code,

--- a/app/lib/submission_builder/shared/return_header1040.rb
+++ b/app/lib/submission_builder/shared/return_header1040.rb
@@ -73,7 +73,7 @@ module SubmissionBuilder
               xml.USAddress {
                 # IRS provides no information on how to shorten addresses
                 # but requires that they be < 36 characters long
-                xml.AddressLine1Txt trim([address.urbanization, address.street_address].map(&:presence).compact.join(", "), 35)
+                xml.AddressLine1Txt trim([address.urbanization, address.street_address].map(&:presence).compact.join(" "), 35)
                 xml.CityNm trim(address.city, 22)
                 xml.StateAbbreviationCd address.state
                 xml.ZIPCd address.zip_code

--- a/spec/lib/irs1040_pdf_spec.rb
+++ b/spec/lib/irs1040_pdf_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe Irs1040Pdf do
         output_file = pdf.output_file
         result = filled_in_values(output_file.path)
         expect(result).to match(hash_including(
-          "AddressLine1Txt" => "Urb Picard, 23627 HAWKINS CREEK CT",
+          "AddressLine1Txt" => "Urb Picard 23627 HAWKINS CREEK CT",
         ))
       end
     end

--- a/spec/lib/submission_builder/shared/return_header1040_spec.rb
+++ b/spec/lib/submission_builder/shared/return_header1040_spec.rb
@@ -287,11 +287,11 @@ describe SubmissionBuilder::Shared::ReturnHeader1040 do
           response = described_class.build(submission)
           expect(response).to be_an_instance_of SubmissionBuilder::Response
           xml = Nokogiri::XML::Document.parse(response.document.to_xml)
-          expect(xml.at("AddressLine1Txt").text).to eq "URB PICARD, 23627 HAWKINS CREEK CT"
+          expect(xml.at("AddressLine1Txt").text).to eq "URB PICARD 23627 HAWKINS CREEK CT"
           expect(xml.at("CityNm").text).to eq "SAN JUAN"
           expect(xml.at("StateAbbreviationCd").text).to eq "PR"
           expect(xml.at("ZIPCd").text).to eq "00797"
-          expect(response).not_to be_valid
+          expect(response).to be_valid
         end
       end
     end


### PR DESCRIPTION
This is required for the address to conform to the IRS 1040 XML schema rules.