### PR TITLE
Puerto Rico: only allow alphanumeric characters in the urbanization field

### DIFF
--- a/app/forms/ctc/mailing_address_form.rb
+++ b/app/forms/ctc/mailing_address_form.rb
@@ -5,6 +5,7 @@ module Ctc
     validates_presence_of :street_address
     validates_presence_of :city
     validates_presence_of :state
+    validates :urbanization, format: { with: /\A[A-Za-z0-9 ]+\z/, message: I18n.t('validators.alphanumeric'), allow_blank: true }
     validates :zip_code, us_or_puerto_rico_zip_code: true
     validate :usps_valid_address
 

--- a/app/forms/ctc/mailing_address_form.rb
+++ b/app/forms/ctc/mailing_address_form.rb
@@ -5,7 +5,7 @@ module Ctc
     validates_presence_of :street_address
     validates_presence_of :city
     validates_presence_of :state
-    validates :urbanization, format: { with: /\A[A-Za-z0-9 ]+\z/, message: I18n.t('validators.alphanumeric'), allow_blank: true }
+    validates :urbanization, format: { with: /\A[A-Za-z0-9\- ]+\z/, message: I18n.t('validators.urbanization'), allow_blank: true }
     validates :zip_code, us_or_puerto_rico_zip_code: true
     validate :usps_valid_address
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1675,6 +1675,7 @@ en:
     signature_pin: Signature PIN must be a 5 digit number.
     signature_pin_zeros: 00000 is not a valid PIN.
     ssn: Please enter a valid social security number.
+    urbanization: Only numbers 0-9, letters A-Z and a-z, spaces and dashes are accepted.
     zip: Please enter a valid 5-digit zip code.
   verification_code_mailer:
     no_match:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1646,6 +1646,7 @@ es:
     signature_pin: El PIN debe ser un número de 5 dígitos.
     signature_pin_zeros: 00000 no es un pin válido
     ssn: Por favor, ingrese un número de seguro social válido.
+    urbanization: Solo se aceptan números del 0 al 9, letras A-Z y a-z, espacios y guiones.
     zip: Por favor, ingrese un código postal válido de 5 dígitos.
   verification_code_mailer:
     no_match:

--- a/spec/forms/ctc/mailing_address_form_spec.rb
+++ b/spec/forms/ctc/mailing_address_form_spec.rb
@@ -85,6 +85,44 @@ describe Ctc::MailingAddressForm do
       end
     end
 
+    context "urbanization" do
+      context "blank value" do
+        before do
+          params[:urbanization] = ""
+        end
+
+        it "is valid" do
+          expect(
+            described_class.new(intake, params)
+          ).to be_valid
+        end
+      end
+
+      context "with only alphanumeric characters and spaces" do
+        before do
+          params[:urbanization] = "URB Royal Oaks 1"
+        end
+
+        it "is valid" do
+          expect(
+            described_class.new(intake, params)
+          ).to be_valid
+        end
+      end
+
+      context "with any other characters" do
+        before do
+          params[:urbanization] = "URB. Royal Oaks"
+        end
+
+        it "is not valid" do
+          expect(
+            described_class.new(intake, params)
+          ).not_to be_valid
+        end
+      end
+    end
+
     context "when not valid with USPS service" do
       before do
         allow(address_service_double).to receive(:valid?).and_return false

--- a/spec/forms/ctc/mailing_address_form_spec.rb
+++ b/spec/forms/ctc/mailing_address_form_spec.rb
@@ -98,9 +98,9 @@ describe Ctc::MailingAddressForm do
         end
       end
 
-      context "with only alphanumeric characters and spaces" do
+      context "with allowed characters (alphanumeric, dash, and spaces)" do
         before do
-          params[:urbanization] = "URB Royal Oaks 1"
+          params[:urbanization] = "URB Royal Oaks 1-23"
         end
 
         it "is valid" do


### PR DESCRIPTION
In cases where the urbanization code is not required to disambiguate the address,
the USPS API just returns whatever the client originally entered, which can
include all sorts of punctuation characters that the IRS won't accept.

Urbanization code is *probably* just alpha + spaces, but the USPS website
accepts numbers too so we will also accept numbers

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>