### PR TITLE
Validate primary and spouse middle initial is only one letter character

### DIFF
--- a/app/forms/ctc/base_primary_filer_form.rb
+++ b/app/forms/ctc/base_primary_filer_form.rb
@@ -4,7 +4,7 @@ module Ctc
 
     validates :primary_first_name, presence: true, legal_name: true
     validates :primary_last_name, presence: true, legal_name: true
-    validates :primary_middle_initial, length: { maximum: 1 }, legal_name: true
+    validates :primary_middle_initial, length: { maximum: 1 }, format: { with: /\A[A-Za-z]\z/.freeze, message: I18n.t('validators.alpha'), allow_blank: true }
     validate  :primary_birth_date_is_valid_date
     validates :primary_ssn, social_security_number: true, if: -> { ["ssn", "ssn_no_employment"].include? primary_tin_type }
     validates :primary_ssn, individual_taxpayer_identification_number: true, if: -> { primary_tin_type == "itin" }

--- a/app/forms/ctc/base_spouse_form.rb
+++ b/app/forms/ctc/base_spouse_form.rb
@@ -4,7 +4,7 @@ module Ctc
 
     validates :spouse_first_name, presence: true, legal_name: true
     validates :spouse_last_name, presence: true, legal_name: true
-    validates :spouse_middle_initial, length: { maximum: 1 }, legal_name: true
+    validates :spouse_middle_initial, length: { maximum: 1 }, format: { with: /\A[A-Za-z]\z/.freeze, message: I18n.t('validators.alpha'), allow_blank: true }
     validate  :spouse_birth_date_is_valid_date
     validates :spouse_ssn, social_security_number: true, if: -> { ["ssn", "ssn_no_employment"].include?(spouse_tin_type) && spouse_ssn.present? }
     validates :spouse_ssn, individual_taxpayer_identification_number: true, if: -> { spouse_tin_type == "itin" }

--- a/app/forms/hub/update_ctc_client_form.rb
+++ b/app/forms/hub/update_ctc_client_form.rb
@@ -4,6 +4,7 @@ module Hub
     include CtcClientFormAttributes
     set_attributes_for :intake,
                        :primary_first_name,
+                       :primary_middle_initial,
                        :primary_last_name,
                        :primary_suffix,
                        :primary_prior_year_agi_amount,
@@ -29,6 +30,7 @@ module Hub
                        :sms_notification_opt_in,
                        :email_notification_opt_in,
                        :spouse_first_name,
+                       :spouse_middle_initial,
                        :spouse_last_name,
                        :spouse_suffix,
                        :spouse_email_address,
@@ -81,6 +83,9 @@ module Hub
     validate :at_least_one_taxpayer_id_type_selected, if: -> { @client.tax_returns.any? { |tax_return| tax_return.service_type == "drop_off" } }
     validate :valid_primary_birth_date
     validate :valid_spouse_birth_date, if: -> { filing_status == "married_filing_jointly" }
+
+    validates :primary_middle_initial, length: { maximum: 1 }, format: { with: /\A[A-Za-z]\z/.freeze, message: I18n.t('validators.alpha'), allow_blank: true }
+    validates :spouse_middle_initial, length: { maximum: 1 }, format: { with: /\A[A-Za-z]\z/.freeze, message: I18n.t('validators.alpha'), allow_blank: true }
 
     def initialize(client, params = {})
       @client = client

--- a/app/views/shared/_client_primary_info_fields.html.erb
+++ b/app/views/shared/_client_primary_info_fields.html.erb
@@ -4,6 +4,7 @@
   <div class="hub-form__card card-small">
     <h3><%= t("hub.clients.fields.primary_contact_info") %></h3>
     <%= f.cfa_input_field(:primary_first_name, t("hub.clients.fields.legal_first_name")) %>
+    <%= f.cfa_input_field(:primary_middle_initial, t("hub.clients.fields.middle_initial"), classes: ["form-width--short"]) %>
     <%= f.cfa_input_field(:primary_last_name, t("hub.clients.fields.legal_last_name")) %>
     <%= f.cfa_input_field(:preferred_name, t("hub.clients.fields.preferred_name")) %>
 

--- a/app/views/shared/_client_spouse_info_fields.html.erb
+++ b/app/views/shared/_client_spouse_info_fields.html.erb
@@ -9,6 +9,7 @@
     <% end %>
     <div>
       <%= f.cfa_input_field(:spouse_first_name, t("hub.clients.fields.legal_first_name")) %>
+      <%= f.cfa_input_field(:spouse_middle_initial, t("hub.clients.fields.middle_initial"), classes: ["form-width--short"]) %>
       <%= f.cfa_input_field(:spouse_last_name, t("hub.clients.fields.legal_last_name")) %>
       <% if is_ctc %>
         <%= f.cfa_select(:spouse_suffix, t("hub.clients.fields.suffix"), suffix_options_for_select, include_blank: true) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -637,6 +637,7 @@ en:
         legal_last_name: Legal last name
         mailing_address: Mailing Address
         marital_status: Marital Status
+        middle_initial: Legal middle initial (optional)
         navigator:
           general: General
           incarcerated: Incarcerated/reentry
@@ -1661,6 +1662,7 @@ en:
       subheader: Please sign up here to receive a notification when we open in January 2022.
   validators:
     account_number: This account number is not valid for direct deposit transactions. Please review your account number or switch to check payments.
+    alpha: Only letters A-Z and a-z are accepted.
     alphanumeric: Only numbers 0-9 and letters A-Z and a-z are accepted.
     atin: Please enter a valid adoption taxpayer identification number.
     file_type: Please upload a valid document type. Accepted types include %{valid_types}.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -646,6 +646,7 @@ es:
         legal_last_name: Apellido legal
         mailing_address: Dirección postal
         marital_status: Estado civil
+        middle_initial: Inicial del segundo nombre (opcional)
         navigator:
           general: General
           incarcerated: Incarcerated/reentry
@@ -1632,6 +1633,7 @@ es:
       subheader: Favor de registrarse aquí para recibir una notificación cuando iniciemos en enero del 2022.
   validators:
     account_number: Este número de cuenta no es válido para transacciones de depósito directo. Revise su número de cuenta o cambie a pagos con cheque.
+    alpha: Solo se aceptan las letras A-Z y a-z.
     alphanumeric: Solo se aceptan los números del 0 al 9 y las letras A-Z y a-z.
     atin: Por favor, ingrese un número de identificación fiscal válido de adopción.
     file_type: Por favor sube un tipo de documento válido. Los tipos aceptados incluyen %{valid_types}

--- a/spec/forms/ctc/legal_consent_form_spec.rb
+++ b/spec/forms/ctc/legal_consent_form_spec.rb
@@ -86,6 +86,28 @@ describe Ctc::LegalConsentForm, requires_default_vita_partners: true do
       end
     end
 
+    context "middle initial" do
+      context "when middle initial is not a single letter" do
+        before do
+          params[:primary_middle_initial] = '.'
+        end
+
+        it "is invalid" do
+          expect(described_class.new(intake, params)).not_to be_valid
+        end
+      end
+
+      context "when middle initial is blank" do
+        before do
+          params[:primary_middle_initial] = ''
+        end
+
+        it "is invalid" do
+          expect(described_class.new(intake, params)).to be_valid
+        end
+      end
+    end
+
     context "when itin format is correct" do
       before do
         params[:primary_tin_type] = "itin"

--- a/spec/forms/ctc/spouse_info_form_spec.rb
+++ b/spec/forms/ctc/spouse_info_form_spec.rb
@@ -56,6 +56,28 @@ describe Ctc::SpouseInfoForm do
         end
       end
     end
+
+    context "middle initial" do
+      context "when middle initial is not a single letter" do
+        before do
+          params[:spouse_middle_initial] = '.'
+        end
+
+        it "is invalid" do
+          expect(described_class.new(intake, params)).not_to be_valid
+        end
+      end
+
+      context "when middle initial is blank" do
+        before do
+          params[:spouse_middle_initial] = ''
+        end
+
+        it "is invalid" do
+          expect(described_class.new(intake, params)).to be_valid
+        end
+      end
+    end
   end
 
   describe "#existing_attributes" do

--- a/spec/forms/hub/update_ctc_client_form_spec.rb
+++ b/spec/forms/hub/update_ctc_client_form_spec.rb
@@ -179,6 +179,56 @@ RSpec.describe Hub::UpdateCtcClientForm, requires_default_vita_partners: true do
         end
       end
 
+      context "primary middle initial" do
+        context "with a non-alpha character" do
+          before do
+            form_attributes[:primary_middle_initial] = '.'
+          end
+
+          it "is not valid" do
+            form = described_class.new(client, form_attributes)
+            form.valid?
+            expect(form.errors.attribute_names).to include(:primary_middle_initial)
+          end
+        end
+
+        context "with blank value" do
+          before do
+            form_attributes[:primary_middle_initial] = ''
+          end
+
+          it "is valid" do
+            form = described_class.new(client, form_attributes)
+            expect(form).to be_valid
+          end
+        end
+      end
+
+      context "spouse middle initial" do
+        context "with a non-alpha character" do
+          before do
+            form_attributes[:spouse_middle_initial] = '.'
+          end
+
+          it "is not valid" do
+            form = described_class.new(client, form_attributes)
+            form.valid?
+            expect(form.errors.attribute_names).to include(:spouse_middle_initial)
+          end
+        end
+
+        context "with blank value" do
+          before do
+            form_attributes[:spouse_middle_initial] = ''
+          end
+
+          it "is valid" do
+            form = described_class.new(client, form_attributes)
+            expect(form).to be_valid
+          end
+        end
+      end
+
       context "updating the filing_status" do
         before do
           form_attributes[:filing_status] = "single"


### PR DESCRIPTION
Add the ability for hub users to edit middle initials

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>