### PR TITLE
When destroying client, also destroy soft deleted dependents

### DIFF
--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -327,7 +327,7 @@ class Intake < ApplicationRecord
   end
 
   before_destroy do
-    dependents.with_deleted.destroy_all
+    dependents.with_deleted.each(&:destroy!)
   end
 
   attr_encrypted :primary_last_four_ssn, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -326,6 +326,10 @@ class Intake < ApplicationRecord
     end
   end
 
+  before_destroy do
+    dependents.with_deleted.destroy_all
+  end
+
   attr_encrypted :primary_last_four_ssn, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }
   attr_encrypted :spouse_last_four_ssn, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }
   attr_encrypted :primary_ssn, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }


### PR DESCRIPTION
There is a `dependent: :destroy` on intake for dependents, but `dependent: :destroy` uses the `default_scope` and the `default_scope` on `Dependent` does not include soft deleted records. 

The main solution I found was "don't use `default_scope`" but we have already gone pretty far down that rabbit hole, in terms of how we leverage it to not display soft deleted dependents. 
