### PR TITLE
Efiling: include W2 documents and W2 fields on the 1040 if W2_SUPPORT env is set to 'true'

### DIFF
--- a/app/controllers/flows_controller.rb
+++ b/app/controllers/flows_controller.rb
@@ -233,7 +233,7 @@ class FlowsController < ApplicationController
         filed_prior_tax_year: 'did_not_file',
         primary_birth_date: 30.years.ago,
         primary_tin_type: 'ssn',
-        primary_ssn: '555112222',
+        primary_ssn: '555002222',
         primary_last_four_ssn: '2222',
         primary_first_name: first_name,
         primary_last_name: last_name,
@@ -268,7 +268,7 @@ class FlowsController < ApplicationController
         client.intake.update(
           spouse_tin_type: 'ssn',
           spouse_birth_date: 31.years.ago + 51.days,
-          spouse_ssn: '555113333',
+          spouse_ssn: '555003333',
           spouse_last_four_ssn: '3333',
           spouse_first_name: "#{first_name}Spouse",
           spouse_last_name: last_name,
@@ -291,7 +291,7 @@ class FlowsController < ApplicationController
           cant_be_claimed_by_other: 'yes',
           birth_date: 12.years.ago,
           tin_type: 'ssn',
-          ssn: '555114444'
+          ssn: '555004444'
         )
         client.intake.dependents.create(
           first_name: 'Relly',

--- a/app/lib/efile/submission_error_parser.rb
+++ b/app/lib/efile/submission_error_parser.rb
@@ -66,7 +66,7 @@ module Efile
     end
 
     def persist_bundle_errors_from_raw_response_metadata
-      if @transition.metadata["raw_response"].to_s.match?(/(RoutingTransitNum|DepositorAccountNum)/)
+      if @transition.metadata["raw_response"].to_s.match?(/(RoutingTransitNum|DepositorAccountNum).*is not accepted by the pattern/)
         error = EfileError.find_by(
           code: "BANK-DETAILS"
         )

--- a/app/lib/submission_builder/ty2021/documents/irs_w2.rb
+++ b/app/lib/submission_builder/ty2021/documents/irs_w2.rb
@@ -1,0 +1,42 @@
+module SubmissionBuilder
+  module Ty2021
+    module Documents
+      class IrsW2 < SubmissionBuilder::Document
+        include SubmissionBuilder::FormattingMethods
+
+        def schema_file
+          File.join(Rails.root, "vendor", "irs", "unpacked", @schema_version, "IndividualIncomeTax", "Common", "IRSW2", "IRSW2.xsd")
+        end
+
+        def document
+          intake = submission.intake
+
+          build_xml_doc("IRSW2", documentId: "IRSW2", documentName: "IRSW2") do |xml|
+            xml.EmployeeSSN intake.primary_ssn
+            xml.EmployerEIN '000001234'
+            xml.EmployerNameControlTxt 'CFA'
+            xml.EmployerName do |xml|
+              xml.BusinessNameLine1Txt 'Code for America'
+            end
+            xml.EmployerUSAddress do |xml|
+              xml.AddressLine1Txt '123 Main St'
+              xml.CityNm 'San Francisco'
+              xml.StateAbbreviationCd 'CA'
+              xml.ZIPCd '94121'
+            end
+            xml.EmployeeNm intake.primary_full_name
+            xml.EmployeeUSAddress do |xml|
+              xml.AddressLine1Txt '124 Main St'
+              xml.CityNm 'San Francisco'
+              xml.StateAbbreviationCd 'CA'
+              xml.ZIPCd '94121'
+            end
+            xml.WagesAmt 1000
+            xml.WithholdingAmt 100
+            xml.StandardOrNonStandardCd 'S'
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/submission_builder/ty2021/return1040.rb
+++ b/app/lib/submission_builder/ty2021/return1040.rb
@@ -18,7 +18,7 @@ module SubmissionBuilder
       end
 
       def supported_documents
-        [
+        result = [
           {
             xml: SubmissionBuilder::Ty2021::Documents::Irs1040,
             pdf: Irs1040Pdf,
@@ -45,8 +45,17 @@ module SubmissionBuilder
             xml: SubmissionBuilder::Ty2021::Documents::ScheduleLep,
             pdf: Irs1040ScheduleLepPdf,
             include: @submission.intake.irs_language_preference.present? && @submission.intake.irs_language_preference != "english"
-          }
+          },
         ]
+
+        if ENV['W2_SUPPORT'] == 'true'
+          result << {
+            xml: SubmissionBuilder::Ty2021::Documents::IrsW2,
+            include: true
+          }
+        end
+
+        result
       end
     end
   end

--- a/app/services/efile/gyr_efiler_service.rb
+++ b/app/services/efile/gyr_efiler_service.rb
@@ -83,7 +83,7 @@ module Efile
       system!("unzip -o #{config_zip_path} -d #{Rails.root.join("tmp", "gyr_efiler")}")
 
       local_efiler_repo_config_path = File.expand_path('../gyr-efiler/gyr_efiler_config', Rails.root)
-      if Rails.env.development?
+      if Rails.env.development? && File.exists?(local_efiler_repo_config_path)
         begin
           FileUtils.cp(File.join(local_efiler_repo_config_path, 'gyr_secrets.properties'), config_dir)
           FileUtils.cp(File.join(local_efiler_repo_config_path, 'secret_key_and_cert.p12.key'), config_dir)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -107,7 +107,7 @@ Rails.application.configure do
   config.hide_ctc = false
   config.ctc_url = "http://ctc.localhost:3000"
   config.gyr_url = "http://localhost:3000"
-  config.efile_environment = ""
+  config.efile_environment = "test"
 
   config.ctc_soft_launch = Time.find_zone("America/New_York").parse("2022-03-01 09:00:00")
   config.ctc_full_launch = Time.find_zone("America/New_York").parse("2022-04-01 09:00:00")


### PR DESCRIPTION
we are using hardcoded values for now, but this set of properties
is sufficient to get an accepted return on the IRS test server

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>