### PR TITLE
CircleCI: skip annotations for vita_providers table so we can create db with setup_test_db like normal

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
     steps:
       - checkout
       - install_ruby_dependencies
-      - run: bundle exec rails db:test:prepare
+      - setup_test_db
       - run: bundle exec annotate --frozen
   run_ruby_tests:
     executor: rails_executor

--- a/app/models/vita_provider.rb
+++ b/app/models/vita_provider.rb
@@ -1,31 +1,4 @@
-# == Schema Information
-#
-# Table name: vita_providers
-#
-#  id               :bigint           not null, primary key
-#  appointment_info :string
-#  archived         :boolean          default(FALSE), not null
-#  coordinates      :geography        point, 4326
-#  dates            :string
-#  details          :string
-#  hours            :string
-#  languages        :string
-#  name             :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  irs_id           :string           not null
-#  last_scrape_id   :bigint
-#
-# Indexes
-#
-#  index_vita_providers_on_irs_id          (irs_id) UNIQUE
-#  index_vita_providers_on_last_scrape_id  (last_scrape_id)
-#
-# Foreign Keys
-#
-#  fk_rails_...  (last_scrape_id => provider_scrapes.id)
-#
-
+# -*- SkipSchemaAnnotations
 class VitaProvider < ApplicationRecord
   belongs_to :last_scrape, class_name: "ProviderScrape", optional: true
 


### PR DESCRIPTION
seems like without this, we were having some trouble with the database.
maybe doing it this way will be less trouble?

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>