### PR TITLE
CTC clients can see account # and routing # in their 1040 pdf

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,0 +1,8 @@
+# For installing apt packages on Heroku
+
+# Dependencies for pdftk-java as described at https://launchpad.net/ubuntu/disco/i386/pdftk-java/3.0.2-2
+libbcprov-java
+libcommons-lang3-java
+
+# pdftk-java itself (change to apt package instead of deb if Heroku gets ubuntu 18.10+)
+https://mirrors.edge.kernel.org/ubuntu/pool/universe/p/pdftk-java/pdftk-java_3.3.2-1_all.deb

--- a/app/controllers/ctc/portal/submission_pdfs_controller.rb
+++ b/app/controllers/ctc/portal/submission_pdfs_controller.rb
@@ -5,15 +5,26 @@ class Ctc::Portal::SubmissionPdfsController < Ctc::Portal::BaseAuthenticatedCont
     @submission = current_client.efile_submissions.find_by(id: params[:id])
     error_redirect and return unless @submission.present?
 
-    submission = EfileSubmission.includes(:intake, :qualifying_dependents, :verified_address, :tax_return).find(@submission.id)
-
-    begin
-      output_file = submission.generate_filing_pdf(save: false, include_sensitive_fields: true)
-      return send_data output_file.read, filename: submission.filing_pdf_filename, disposition: 'inline'
-    rescue StandardError => e
-      DatadogApi.increment('clients.pdf_generation_failed')
-      error_redirect and return
+    @document = current_client.documents.find_by(tax_return_id: @submission.tax_return_id, document_type: DocumentTypes::Form1040.key)
+    if @submission.present? && !@document.present?
+      begin
+        @document = CreateSubmissionPdfJob.perform_now(@submission.id)
+      rescue
+        error_redirect and return
+      end
     end
+
+    pdf_basename = @document.display_name.split('.').first
+    filled_tempfile = Tempfile.new([pdf_basename, ".pdf"])
+    @document.upload.open do |original_tempfile|
+      PdfForms.new.fill_form(
+        original_tempfile.path,
+        filled_tempfile.path,
+        Irs1040Pdf.new(@submission).sensitive_fields_hash_for_pdf
+      )
+    end
+
+    send_data filled_tempfile.read, filename: @document.display_name, disposition: 'inline'
   end
 
   def error_redirect

--- a/app/lib/submission_builder/ty2021/return1040.rb
+++ b/app/lib/submission_builder/ty2021/return1040.rb
@@ -1,11 +1,6 @@
 module SubmissionBuilder
   module Ty2021
     class Return1040 < SubmissionBuilder::Shared::Return1040
-      def initialize(submission, validate: true, documents: [], include_sensitive_fields: false)
-        @include_sensitive_fields = include_sensitive_fields
-        super(submission, validate: true, documents: [])
-      end
-
       def attached_documents
         @attached_documents ||= xml_documents.map(&:xml)
       end
@@ -27,8 +22,7 @@ module SubmissionBuilder
           {
             xml: SubmissionBuilder::Ty2021::Documents::Irs1040,
             pdf: Irs1040Pdf,
-            include: true,
-            kwargs: { include_sensitive_fields: @include_sensitive_fields }
+            include: true
           },
           {
             xml: nil,

--- a/app/lib/submission_builder/ty2021/return1040.rb
+++ b/app/lib/submission_builder/ty2021/return1040.rb
@@ -1,6 +1,11 @@
 module SubmissionBuilder
   module Ty2021
     class Return1040 < SubmissionBuilder::Shared::Return1040
+      def initialize(submission, validate: true, documents: [], include_sensitive_fields: false)
+        @include_sensitive_fields = include_sensitive_fields
+        super(submission, validate: true, documents: [])
+      end
+
       def attached_documents
         @attached_documents ||= xml_documents.map(&:xml)
       end
@@ -22,7 +27,8 @@ module SubmissionBuilder
           {
             xml: SubmissionBuilder::Ty2021::Documents::Irs1040,
             pdf: Irs1040Pdf,
-            include: true
+            include: true,
+            kwargs: { include_sensitive_fields: @include_sensitive_fields }
           },
           {
             xml: nil,

--- a/app/models/efile_submission.rb
+++ b/app/models/efile_submission.rb
@@ -138,28 +138,21 @@ class EfileSubmission < ApplicationRecord
     Efile::BenefitsEligibility.new(tax_return: tax_return, dependents: qualifying_dependents).outstanding_ctc_amount.positive?
   end
 
-  def filing_pdf_filename
+  def generate_filing_pdf
     slug = irs_submission_id[6..] if  irs_submission_id.present?
     filename = "IRS 1040 - TY#{tax_return.year}"
     filename += slug ? " - #{slug}.pdf" : ".pdf"
-    filename
-  end
-
-  def generate_filing_pdf(save: true, include_sensitive_fields: false)
-    pdf_documents = SubmissionBuilder::Ty2021::Return1040.new(self, include_sensitive_fields: include_sensitive_fields).pdf_documents
-    output_file = Tempfile.new([filing_pdf_filename, ".pdf"], "tmp/")
+    pdf_documents = SubmissionBuilder::Ty2021::Return1040.new(self).pdf_documents
+    output_file = Tempfile.new([filename, ".pdf"], "tmp/")
     filled_out_documents = pdf_documents.map { |document| document.pdf.new(self, **document.kwargs).output_file }
     PdfForms.new.cat(*filled_out_documents.push(output_file.path))
-    if save
-      ClientPdfDocument.create_or_update(
-        output_file: output_file,
-        document_type: DocumentTypes::Form1040,
-        client: client,
-        filename: filing_pdf_filename,
-        tax_return: tax_return
-      )
-    end
-    output_file
+    ClientPdfDocument.create_or_update(
+      output_file: output_file,
+      document_type: DocumentTypes::Form1040,
+      client: client,
+      filename: filename,
+      tax_return: tax_return
+    )
   end
 
   def bundle_class

--- a/app/models/efile_submission.rb
+++ b/app/models/efile_submission.rb
@@ -138,22 +138,28 @@ class EfileSubmission < ApplicationRecord
     Efile::BenefitsEligibility.new(tax_return: tax_return, dependents: qualifying_dependents).outstanding_ctc_amount.positive?
   end
 
-  def generate_filing_pdf
+  def filing_pdf_filename
     slug = irs_submission_id[6..] if  irs_submission_id.present?
     filename = "IRS 1040 - TY#{tax_return.year}"
     filename += slug ? " - #{slug}.pdf" : ".pdf"
+    filename
+  end
 
-    pdf_documents = SubmissionBuilder::Ty2021::Return1040.new(self).pdf_documents
-    output_file = Tempfile.new([filename, ".pdf"], "tmp/")
+  def generate_filing_pdf(save: true, include_sensitive_fields: false)
+    pdf_documents = SubmissionBuilder::Ty2021::Return1040.new(self, include_sensitive_fields: include_sensitive_fields).pdf_documents
+    output_file = Tempfile.new([filing_pdf_filename, ".pdf"], "tmp/")
     filled_out_documents = pdf_documents.map { |document| document.pdf.new(self, **document.kwargs).output_file }
     PdfForms.new.cat(*filled_out_documents.push(output_file.path))
-    ClientPdfDocument.create_or_update(
-      output_file: output_file,
-      document_type: DocumentTypes::Form1040,
-      client: client,
-      filename: filename,
-      tax_return: tax_return
-    )
+    if save
+      ClientPdfDocument.create_or_update(
+        output_file: output_file,
+        document_type: DocumentTypes::Form1040,
+        client: client,
+        filename: filing_pdf_filename,
+        tax_return: tax_return
+      )
+    end
+    output_file
   end
 
   def bundle_class

--- a/app/models/efile_submission.rb
+++ b/app/models/efile_submission.rb
@@ -138,19 +138,23 @@ class EfileSubmission < ApplicationRecord
     Efile::BenefitsEligibility.new(tax_return: tax_return, dependents: qualifying_dependents).outstanding_ctc_amount.positive?
   end
 
-  def generate_filing_pdf
-    slug = irs_submission_id[6..] if  irs_submission_id.present?
+  def pdf_bundle_filename
+    slug = irs_submission_id[6..] if irs_submission_id.present?
     filename = "IRS 1040 - TY#{tax_return.year}"
     filename += slug ? " - #{slug}.pdf" : ".pdf"
+    filename
+  end
+
+  def generate_filing_pdf
     pdf_documents = SubmissionBuilder::Ty2021::Return1040.new(self).pdf_documents
-    output_file = Tempfile.new([filename, ".pdf"], "tmp/")
+    output_file = Tempfile.new([pdf_bundle_filename, ".pdf"], "tmp/")
     filled_out_documents = pdf_documents.map { |document| document.pdf.new(self, **document.kwargs).output_file }
     PdfForms.new.cat(*filled_out_documents.push(output_file.path))
     ClientPdfDocument.create_or_update(
       output_file: output_file,
       document_type: DocumentTypes::Form1040,
       client: client,
-      filename: filename,
+      filename: pdf_bundle_filename,
       tax_return: tax_return
     )
   end

--- a/app/views/ctc/portal/portal/home.html.erb
+++ b/app/views/ctc/portal/portal/home.html.erb
@@ -73,7 +73,7 @@
         <%= link_to t("views.ctc.portal.home.complete_form"), @current_step, class: "button button--full-width spacing-below-0" %>
       <% end %>
       <% if @submission.present? %>
-        <%= link_to ctc_portal_submission_pdf_path(id: @submission.id), target: "_blank", rel: "no_opener", class: "button button--full-width" do %>
+        <%= link_to filename_ctc_portal_submission_pdf_path(id: @submission.id, filename: @submission.pdf_bundle_filename), target: "_blank", rel: "no_opener", class: "button button--full-width" do %>
           <%= t("views.ctc.portal.home.download_tax_return") %>
         <% end %>
       <% end %>

--- a/app/views/ctc/portal/verification_attempts/paper_file.html.erb
+++ b/app/views/ctc/portal/verification_attempts/paper_file.html.erb
@@ -7,7 +7,7 @@
   <p><%= t("views.ctc.portal.verification.paper_file.info") %></p>
   <p><%= link_to t("views.ctc.portal.verification.paper_file.paper_file_instructions"), url_for(host: MultiTenantService.new(:gyr).host, controller: "/faq", action: "show", section_key: "paper_filing", question_key: "how_do_i_paper_file"), "data-track-click": "verification-how-do-i-paper-file", target: "_blank"  %></p>
   <p class="spacing-below-60"><%= t("views.ctc.portal.verification.paper_file.warning") %></p>
-  <%= link_to ctc_portal_submission_pdf_path(id: @submission.id), target: "_blank", rel: "no_opener", class: "button button--wide text--centered", "data-track-click": "verification-download-1040" do %>
+  <%= link_to filename_ctc_portal_submission_pdf_path(id: @submission.id, filename: @submission.pdf_bundle_filename), target: "_blank", rel: "no_opener", class: "button button--wide text--centered", "data-track-click": "verification-download-1040" do %>
     <%= t("views.ctc.portal.verification.paper_file.download_link_text") %>
   <% end %>
   <%= link_to t("views.ctc.portal.verification.paper_file.go_back"), ctc_portal_verification_attempt_path, class: "button button--wide text--centered", "data-track-click": "verification-go-back-to-submit-documents" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -440,7 +440,11 @@ Rails.application.routes.draw do
           end
           resources :messages, only: [:new, :create]
           resources :documents, only: [:show]
-          resources :submission_pdfs, only: [:show]
+          resources :submission_pdfs, only: [:show] do
+            member do
+              get ':filename', to: 'submission_pdfs#show', as: "filename"
+            end
+          end
           resources :upload_documents, only: [:destroy]
           match 'upload-documents', to: 'upload_documents#edit', via: :get, as: :edit_upload_documents
           match 'upload-documents', to: 'upload_documents#update', via: :put

--- a/spec/controllers/ctc/portal/submission_pdfs_controller_spec.rb
+++ b/spec/controllers/ctc/portal/submission_pdfs_controller_spec.rb
@@ -1,17 +1,18 @@
 require "rails_helper"
 
 describe Ctc::Portal::SubmissionPdfsController do
+  include PdfSpecHelper
+
   describe "#show" do
     let(:params) {{ id: 1 }}
     let(:client) { create :client_with_ctc_intake_and_return }
     let(:back) { "http://www.test.example.com/en" }
-    let(:transient_url) { "https://somethingaws.something.something.com/123465198234"}
 
     it_behaves_like :a_get_action_for_authenticated_clients_only, action: :show
 
     before do
+      client.intake.update(refund_payment_method: 'direct_deposit')
       request.env["HTTP_REFERER"] = back
-      allow(subject).to receive(:transient_storage_url).and_return(transient_url)
     end
 
     context "with an authenticated client" do
@@ -34,49 +35,33 @@ describe Ctc::Portal::SubmissionPdfsController do
           client.tax_returns.last.efile_submissions.create
         end
 
-        context "when the pdf document already exists" do
-          let!(:existing_document) { create(:document, document_type: DocumentTypes::Form1040.key, tax_return: client.tax_returns.last, client: client) }
+        context "when it can be generated" do
+          let!(:bank_account) { create :bank_account, intake: client.intake }
 
-          before do
-            allow(CreateSubmissionPdfJob).to receive(:perform_now)
-          end
-
-          it "uses the existing document without generating another one" do
+          it "generates the document and redirects to the document path" do
             get :show, params: { id: efile_submission.id }
 
-            expect(CreateSubmissionPdfJob).not_to have_received(:perform_now)
-            expect(subject).to have_received(:transient_storage_url).with(existing_document.upload.blob)
-            expect(response).to redirect_to transient_url
+            tempfile = Tempfile.new('output.pdf')
+            tempfile.write(response.body)
+
+            expect(filled_in_values(tempfile.path)).to match(a_hash_including(
+                                                            "RoutingTransitNum35b" => bank_account.routing_number,
+                                                            "DepositorAccountNum35d" => bank_account.account_number,
+                                                            "BankAccountTypeCd" => "Checking",
+                                                            ))
           end
         end
 
-        context "when the pdf document does not already exist" do
-          let(:document) { create :document }
+        context "when an error was raised while generating the document" do
           before do
-            allow(CreateSubmissionPdfJob).to receive(:perform_now).and_return document
+            allow_any_instance_of(EfileSubmission).to receive(:generate_filing_pdf).and_raise StandardError
           end
 
-          context "when it can be generated" do
-            it "generates the document and redirects to the document path" do
-              get :show, params: { id: efile_submission.id }
+          it "redirects and flashes a message" do
+            get :show, params: { id: efile_submission.id }
 
-              expect(CreateSubmissionPdfJob).to have_received(:perform_now).with(efile_submission.id)
-              expect(subject).to have_received(:transient_storage_url).with(document.upload.blob)
-              expect(response).to redirect_to transient_url
-            end
-          end
-
-          context "when an error was raised while generating the document" do
-            before do
-              allow(CreateSubmissionPdfJob).to receive(:perform_now).and_raise StandardError
-            end
-
-            it "redirects and flashes a message" do
-              get :show, params: { id: efile_submission.id }
-
-              expect(response).to redirect_to back
-              expect(flash[:alert]).to eq "We encountered a problem generating your tax return pdf. For assistance, please reach out to GetCTC client support."
-            end
+            expect(response).to redirect_to back
+            expect(flash[:alert]).to eq "We encountered a problem generating your tax return pdf. For assistance, please reach out to GetCTC client support."
           end
         end
       end

--- a/spec/lib/irs1040_pdf_spec.rb
+++ b/spec/lib/irs1040_pdf_spec.rb
@@ -387,7 +387,7 @@ RSpec.describe Irs1040Pdf do
       end
     end
 
-    describe "bank account fields" do
+    describe "#sensitive_fields_for_pdf" do
       let(:optional_xml_fields) do
         lambda do |xml|
           xml.RoutingTransitNum '12345'
@@ -396,28 +396,12 @@ RSpec.describe Irs1040Pdf do
         end
       end
 
-      context "when the viewer is the client" do
-        it "renders the pdf with the bank account information" do
-          output_file = described_class.new(submission, include_sensitive_fields: true).output_file
-          result = filled_in_values(output_file.path)
-          expect(result).to match(hash_including(
-                                    "RoutingTransitNum35b" => "12345",
-                                    "BankAccountTypeCd" => "Checking",
-                                    "DepositorAccountNum35d" => "54321",
-                                    ))
-        end
-      end
-
-      context "when the viewer is a hub user" do
-        it "renders the pdf without the bank account information" do
-          output_file = described_class.new(submission).output_file
-          result = filled_in_values(output_file.path)
-          expect(result).to match(hash_including(
-                                    "RoutingTransitNum35b" => nil,
-                                    "BankAccountTypeCd" => nil,
-                                    "DepositorAccountNum35d" => nil,
-                                    ))
-        end
+      it "includes bank account information" do
+        expect(described_class.new(submission).sensitive_fields_hash_for_pdf).to eq(
+          RoutingTransitNum35b: "12345",
+          BankAccountTypeCd: "Checking",
+          DepositorAccountNum35d: "54321"
+        )
       end
     end
 

--- a/spec/lib/irs1040_pdf_spec.rb
+++ b/spec/lib/irs1040_pdf_spec.rb
@@ -386,5 +386,40 @@ RSpec.describe Irs1040Pdf do
         ))
       end
     end
+
+    describe "bank account fields" do
+      let(:optional_xml_fields) do
+        lambda do |xml|
+          xml.RoutingTransitNum '12345'
+          xml.BankAccountTypeCd '1'
+          xml.DepositorAccountNum '54321'
+        end
+      end
+
+      context "when the viewer is the client" do
+        it "renders the pdf with the bank account information" do
+          output_file = described_class.new(submission, include_sensitive_fields: true).output_file
+          result = filled_in_values(output_file.path)
+          expect(result).to match(hash_including(
+                                    "RoutingTransitNum35b" => "12345",
+                                    "BankAccountTypeCd" => "Checking",
+                                    "DepositorAccountNum35d" => "54321",
+                                    ))
+        end
+      end
+
+      context "when the viewer is a hub user" do
+        it "renders the pdf without the bank account information" do
+          output_file = described_class.new(submission).output_file
+          result = filled_in_values(output_file.path)
+          expect(result).to match(hash_including(
+                                    "RoutingTransitNum35b" => nil,
+                                    "BankAccountTypeCd" => nil,
+                                    "DepositorAccountNum35d" => nil,
+                                    ))
+        end
+      end
+    end
+
   end
 end


### PR DESCRIPTION
we changed the controller to generate the bundle just-in-time,
which saves us from having to re-generate all these documents
and allows us to present the versions with account number *only*
to the client, not every hub user.

it does mean the web request for bundling the PDF will take longer,
perhaps too long ?? we can see

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>