### PR TITLE
Flow explorer: fix spanish screenshot generation

### DIFF
--- a/lib/tasks/flow_explorer.rake
+++ b/lib/tasks/flow_explorer.rake
@@ -4,9 +4,9 @@ namespace :flow_explorer do
     all_passed = true
 
     [
-      "rspec --tag flow_explorer_screenshot",
-      "FLOW_EXPLORER_LOCALE=en rspec --tag flow_explorer_screenshot_i18n_friendly",
-      "FLOW_EXPLORER_LOCALE=es rspec --tag flow_explorer_screenshot_i18n_friendly",
+      "rspec --tag flow_explorer_screenshot --tag flow_explorer_screenshot_i18n_friendly",
+      # "FLOW_EXPLORER_LOCALE=en rspec --tag flow_explorer_screenshot_i18n_friendly",
+      # "FLOW_EXPLORER_LOCALE=es rspec --tag flow_explorer_screenshot_i18n_friendly",
     ].each do |cmd|
       puts "RUNNING: #{cmd}"
       result = system(cmd)

--- a/spec/support/helpers/ctc_intake_feature_helper.rb
+++ b/spec/support/helpers/ctc_intake_feature_helper.rb
@@ -302,6 +302,7 @@ module CtcIntakeFeatureHelper
     expect(page).not_to have_selector("div", text: "#{I18n.t('general.date_of_birth')}: 1/11/#{dependent_birth_year}")
 
     if head_of_household
+      click_on I18n.t("views.ctc.questions.confirm_dependents.other_benefits_reveal.title")
       click_on "click here"
       expect(page).to have_text I18n.t("views.ctc.questions.head_of_household.title")
       click_on I18n.t("views.ctc.questions.head_of_household.claim_hoh")


### PR DESCRIPTION
FLOW_EXPLORER_LOCALE/flow_explorer_screenshot_i18n_friendly apparently never worked
(nothing is telling Rails to render using that locale, it just affects where the
screenshots get saved), so this changes the rake task to just run a single `rspec`
run with both flow_explorer_* tags for now