### PR TITLE
Flow explorer: capture spanish screenshots in a new tab

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,8 +16,9 @@ module ApplicationHelper
 
   def link_to_locale(locale, label, additional_attributes = {})
     link_to(label,
-            { :locale=>locale, :params=>request.query_parameters },
+            { locale: locale, params: request.query_parameters },
             lang: locale,
+            id: "locale_switcher_#{locale}",
             "data-track-click": "intake-language-changed",
             "data-track-attributes-to_locale": locale,
             "data-track-attributes_from_locale": I18n.locale,

--- a/lib/tasks/flow_explorer.rake
+++ b/lib/tasks/flow_explorer.rake
@@ -4,9 +4,7 @@ namespace :flow_explorer do
     all_passed = true
 
     [
-      "rspec --tag flow_explorer_screenshot --tag flow_explorer_screenshot_i18n_friendly",
-      # "FLOW_EXPLORER_LOCALE=en rspec --tag flow_explorer_screenshot_i18n_friendly",
-      # "FLOW_EXPLORER_LOCALE=es rspec --tag flow_explorer_screenshot_i18n_friendly",
+      "rspec --tag flow_explorer_screenshot",
     ].each do |cmd|
       puts "RUNNING: #{cmd}"
       result = system(cmd)

--- a/spec/features/ctc/address_validation_spec.rb
+++ b/spec/features/ctc/address_validation_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "CTC Intake", :flow_explorer_screenshot_i18n_friendly, active_job: true, requires_default_vita_partners: true, do_not_stub_usps: true do
+RSpec.feature "CTC Intake", :flow_explorer_screenshot, active_job: true, requires_default_vita_partners: true, do_not_stub_usps: true do
   include CtcIntakeFeatureHelper
   let(:usps_api_response_body) { file_fixture("usps_address_validation_body.xml").read }
   let!(:intake_with_verified_address) { create(:ctc_intake, usps_address_verified_at: 5.minutes.ago) }

--- a/spec/features/ctc/complete_intake_spec.rb
+++ b/spec/features/ctc/complete_intake_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "CTC Intake", :flow_explorer_screenshot_i18n_friendly, active_job: true, requires_default_vita_partners: true do
+RSpec.feature "CTC Intake", :flow_explorer_screenshot, active_job: true, requires_default_vita_partners: true do
   include CtcIntakeFeatureHelper
 
   before do

--- a/spec/features/ctc/ctc_beta_spec.rb
+++ b/spec/features/ctc/ctc_beta_spec.rb
@@ -29,7 +29,7 @@ def begin_intake
   click_on I18n.t('general.negative')
 end
 
-RSpec.feature "CTC Beta intake", :flow_explorer_screenshot_i18n_friendly, active_job: true, requires_default_vita_partners: true do
+RSpec.feature "CTC Beta intake", :flow_explorer_screenshot, active_job: true, requires_default_vita_partners: true do
   around do |example|
     freeze_time do
       example.run

--- a/spec/features/ctc/ctc_intake_offboarding_paths_spec.rb
+++ b/spec/features/ctc/ctc_intake_offboarding_paths_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "CTC Intake", :flow_explorer_screenshot_i18n_friendly, active_job: true, requires_default_vita_partners: true do
+RSpec.feature "CTC Intake", :flow_explorer_screenshot, active_job: true, requires_default_vita_partners: true do
   include CtcIntakeFeatureHelper
 
   before do

--- a/spec/features/ctc/eitc_spec.rb
+++ b/spec/features/ctc/eitc_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "CTC Intake", :flow_explorer_screenshot_i18n_friendly, active_job: true, requires_default_vita_partners: true do
+RSpec.feature "CTC Intake", :flow_explorer_screenshot, active_job: true, requires_default_vita_partners: true do
   include CtcIntakeFeatureHelper
 
   before do

--- a/spec/features/ctc/puerto_rico_spec.rb
+++ b/spec/features/ctc/puerto_rico_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Puerto Rico", :flow_explorer_screenshot_i18n_friendly, active_job: true, requires_default_vita_partners: true do
+RSpec.feature "Puerto Rico", :flow_explorer_screenshot, active_job: true, requires_default_vita_partners: true do
   include CtcIntakeFeatureHelper
   before do
     allow_any_instance_of(Routes::CtcDomain).to receive(:matches?).and_return(true)

--- a/spec/features/ctc/rrc_intake_questions_spec.rb
+++ b/spec/features/ctc/rrc_intake_questions_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "CTC Intake", :flow_explorer_screenshot_i18n_friendly, active_job: true, requires_default_vita_partners: true do
+RSpec.feature "CTC Intake", :flow_explorer_screenshot, active_job: true, requires_default_vita_partners: true do
   include CtcIntakeFeatureHelper
   
   before do

--- a/spec/features/web_intake/document_help_flow_spec.rb
+++ b/spec/features/web_intake/document_help_flow_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Document Help Flow", :flow_explorer_screenshot_i18n_friendly, active_job: true do
+RSpec.feature "Document Help Flow", :flow_explorer_screenshot, active_job: true do
   let(:client) do
     create :client,
            intake: (create :intake, bought_health_insurance: "yes", had_retirement_income: "yes", sms_notification_opt_in: "yes", sms_phone_number: "+15105551234")

--- a/spec/features/web_intake/new_joint_filers_spec.rb
+++ b/spec/features/web_intake/new_joint_filers_spec.rb
@@ -64,7 +64,7 @@ RSpec.feature "Web Intake Joint Filers", :flow_explorer_screenshot do
 
     screenshot_after do
       # Notification Preference
-      expect(intake.reload.current_step).to eq("/en/questions/notification-preference")
+      expect(intake.reload.current_step).to end_with("/questions/notification-preference")
       check "Email Me"
       check "Text Me"
       click_on "Continue"
@@ -562,7 +562,7 @@ RSpec.feature "Web Intake Joint Filers", :flow_explorer_screenshot do
     end
     click_on "Great!"
 
-    expect(intake.reload.current_step).to eq("/en/questions/feedback")
+    expect(intake.reload.current_step).to end_with("/questions/feedback")
     fill_in "Thank you for sharing your experience.", with: "I am a joint filer. I file with my spouse."
     click_on "Continue"
 

--- a/spec/features/web_intake/new_single_filer_spec.rb
+++ b/spec/features/web_intake/new_single_filer_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot, active_job: 
     click_on "Continue"
 
     # Ask about backtaxes
-    expect(intake.reload.current_step).to eq("/en/questions/backtaxes")
+    expect(intake.reload.current_step).to end_with("/questions/backtaxes")
     expect(page).to have_selector("h1", text: I18n.t("views.questions.backtaxes.title"))
     check "#{TaxReturn.current_tax_year}"
     check "#{TaxReturn.current_tax_year - 3}"
@@ -45,7 +45,7 @@ RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot, active_job: 
     click_on "Continue"
 
     # Interview time preferences
-    expect(intake.reload.current_step).to eq("/en/questions/interview-scheduling")
+    expect(intake.reload.current_step).to end_with("/questions/interview-scheduling")
     fill_in "Do you have any time preferences for your interview phone call?", with: "Wednesday or Tuesday nights"
     expect(page).to have_select(
       "What is your preferred language for the review?", selected: "English"
@@ -54,7 +54,7 @@ RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot, active_job: 
     click_on "Continue"
 
     # Notification Preference
-    expect(intake.reload.current_step).to eq("/en/questions/notification-preference")
+    expect(intake.reload.current_step).to end_with("/questions/notification-preference")
     expect(page).to have_text(I18n.t("views.questions.notification_preference.title"))
     check "Email Me"
     check "Text Me"
@@ -150,7 +150,7 @@ RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot, active_job: 
     click_on "No"
 
     # Dependents
-    expect(intake.reload.current_step).to eq("/en/questions/had-dependents")
+    expect(intake.reload.current_step).to end_with("/questions/had-dependents")
     expect(page).to have_selector("h1", text: "Would you like to claim anyone for #{TaxReturn.current_tax_year}?")
     click_on "No"
 
@@ -167,7 +167,7 @@ RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot, active_job: 
     click_on "No"
 
     # Income from working
-    expect(intake.reload.current_step).to eq("/en/questions/job-count")
+    expect(intake.reload.current_step).to end_with("/questions/job-count")
     select "3 jobs", from: "In #{TaxReturn.current_tax_year}, how many jobs did you have?"
     click_on "Continue"
     expect(page).to have_selector("h1", text: "In #{TaxReturn.current_tax_year}, did you live or work in any other states besides Virginia?")
@@ -190,7 +190,7 @@ RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot, active_job: 
     click_on "Yes"
 
     # Retirement income/contributions
-    expect(intake.reload.current_step).to eq("/en/questions/social-security-or-retirement")
+    expect(intake.reload.current_step).to end_with("/questions/social-security-or-retirement")
     expect(page).to have_selector("h1", text: "In #{TaxReturn.current_tax_year}, did you have Social Security income, retirement income, or retirement contributions?")
     click_on "No"
 
@@ -238,7 +238,7 @@ RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot, active_job: 
     click_on "Yes"
 
     # Miscellaneous
-    expect(intake.reload.current_step).to eq("/en/questions/disaster-loss")
+    expect(intake.reload.current_step).to end_with("/questions/disaster-loss")
     expect(page).to have_selector("h1", text: "In #{TaxReturn.current_tax_year}, did you have a loss related to a declared Federal Disaster Area?")
     click_on "No"
     expect(page).to have_selector("h1", text: "In #{TaxReturn.current_tax_year}, did you have debt cancelled or forgiven by a lender?")
@@ -259,7 +259,7 @@ RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot, active_job: 
     choose "Direct deposit (fastest)"
     click_on "Continue"
     # Savings Options
-    expect(intake.reload.current_step).to eq("/en/questions/savings-options")
+    expect(intake.reload.current_step).to end_with("/questions/savings-options")
     expect(page).to have_selector("h1", text: "If due a refund, are you interested in using these savings options?")
     check "Purchase United States Savings Bond"
     click_on "Continue"
@@ -275,7 +275,7 @@ RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot, active_job: 
     click_on "Continue"
 
     # Contact information
-    expect(intake.reload.current_step).to eq("/en/questions/mailing-address")
+    expect(intake.reload.current_step).to end_with("/questions/mailing-address")
     expect(page).to have_text("What is your mailing address?")
     fill_in "Street address", with: "123 Main St."
     fill_in "City", with: "Anytown"
@@ -284,7 +284,7 @@ RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot, active_job: 
     click_on "Continue"
 
     # Overview: Documents
-    expect(intake.reload.current_step).to eq("/en/questions/overview-documents")
+    expect(intake.reload.current_step).to end_with("/questions/overview-documents")
 
     expect(page).to have_selector("h1", text: "Collect all your documents and have them with you.")
     click_on "Continue"
@@ -298,16 +298,16 @@ RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot, active_job: 
     upload_file("document_type_upload_form_upload", Rails.root.join("spec", "fixtures", "files", "picture_id.jpg"))
     click_on "Continue"
 
-    expect(intake.reload.current_step).to eq("/en/documents/selfie-instructions")
+    expect(intake.reload.current_step).to end_with("/documents/selfie-instructions")
     expect(page).to have_selector("h1", text: "Confirm your identity with a photo of yourself")
     click_on I18n.t('views.documents.selfie_instructions.submit_photo')
 
-    expect(intake.reload.current_step).to eq("/en/documents/selfies")
+    expect(intake.reload.current_step).to end_with("/documents/selfies")
     expect(page).to have_selector("h1", text: I18n.t('views.documents.selfies.title'))
     upload_file("document_type_upload_form_upload", Rails.root.join("spec", "fixtures", "files", "picture_id.jpg"))
     click_on "Continue"
 
-    expect(intake.reload.current_step).to eq("/en/documents/ssn-itins")
+    expect(intake.reload.current_step).to end_with("/documents/ssn-itins")
     expect(page).to have_selector("h1", text: I18n.t('views.documents.ssn_itins.title'))
     upload_file("document_type_upload_form_upload", Rails.root.join("spec", "fixtures", "files", "picture_id.jpg"))
     click_on "Continue"
@@ -333,23 +333,23 @@ RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot, active_job: 
     expect(page).to have_content("test-pattern.png")
     click_on "Continue"
 
-    expect(intake.reload.current_step).to eq("/en/documents/overview")
+    expect(intake.reload.current_step).to end_with("/documents/overview")
     expect(page).to have_selector("h1", text: "Great work! Here's a list of what we've collected.")
     click_on "I've shared all my documents"
 
     # Final Information
-    expect(intake.reload.current_step).to eq("/en/questions/final-info")
+    expect(intake.reload.current_step).to end_with("/questions/final-info")
     fill_in "Anything else you'd like your tax preparer to know about your situation?", with: "One of my kids moved away for college, should I include them as a dependent?"
     expect {
       click_on "Submit"
     }.to change(OutgoingTextMessage, :count).by(1).and change(OutgoingEmail, :count).by(1)
 
-    expect(intake.reload.current_step).to eq("/en/questions/successfully-submitted")
+    expect(intake.reload.current_step).to end_with("/questions/successfully-submitted")
     expect(page).to have_selector("h1", text: "Success! Your tax information has been submitted.")
     expect(page).to have_text("Your confirmation number is: #{intake.client_id}")
     click_on "Great!"
 
-    expect(intake.reload.current_step).to eq("/en/questions/feedback")
+    expect(intake.reload.current_step).to end_with("/questions/feedback")
     fill_in "Thank you for sharing your experience.", with: "I am the single filer. I file alone."
     click_on "Continue"
 
@@ -368,7 +368,7 @@ RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot, active_job: 
     expect(page).to have_text("Are you or your spouse a veteran of the U.S. Armed Forces?")
     choose "Yes"
     click_on "Continue"
-    expect(intake.reload.current_step).to eq("/en/questions/demographic-primary-race")
+    expect(intake.reload.current_step).to end_with("/questions/demographic-primary-race")
     expect(page).to have_selector("h1", text: "What is your race?")
     check "Asian"
     check "White"
@@ -381,7 +381,7 @@ RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot, active_job: 
 
     # going back to another page after submit redirects to client login, does not reset current_step
     visit "/questions/work-situations"
-    expect(intake.reload.current_step).to eq("/en/questions/demographic-primary-ethnicity")
+    expect(intake.reload.current_step).to end_with("/questions/demographic-primary-ethnicity")
     expect(page).to have_selector("h1", text: "To view your progress, we’ll send you a secure code.")
   end
 end

--- a/spec/features/web_intake/returning_filer_spec.rb
+++ b/spec/features/web_intake/returning_filer_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Web Intake Returning Filer", :flow_explorer_screenshot_i18n_friendly do
+RSpec.feature "Web Intake Returning Filer", :flow_explorer_screenshot do
   let(:gyr_ssn) { "123-45-6789" }
   let!(:original_gyr_intake) do
     create(

--- a/spec/features/web_intake/routing_spec.rb
+++ b/spec/features/web_intake/routing_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-feature "Intake Routing Spec", :flow_explorer_screenshot_i18n_friendly, :active_job do
+feature "Intake Routing Spec", :flow_explorer_screenshot, :active_job do
   include MockTwilio
 
   def fill_out_notification_preferences(fill_out_optional_consent: true)

--- a/spec/features/web_intake/triage_spec.rb
+++ b/spec/features/web_intake/triage_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature "triage flow" do
 
       @test_cases = rows.map { |row| TriageFlowTestCase.new(row) }
 
-      # flag certain test cases as `flow_explorer_screenshot_i18n_friendly` to ensure we screenshot
+      # flag certain test cases as `flow_explorer_screenshot` to ensure we screenshot
       # every page at least once, without having to run every single test case through headless chrome
       # (which takes like 10 minutes as of the writing of this comment)
       seen_controllers = {}
@@ -70,7 +70,7 @@ RSpec.feature "triage flow" do
     end
 
     def rspec_metadata
-      screenshot ? { flow_explorer_screenshot_i18n_friendly: true } : { }
+      screenshot ? { flow_explorer_screenshot: true } : { }
     end
 
     def final_page

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -138,7 +138,7 @@ RSpec.configure do |config|
     Flipper.instance = Flipper.new(Flipper::Adapters::Memory.new)
   end
 
-  if config.filter.rules[:flow_explorer_screenshot] || config.filter.rules[:flow_explorer_screenshot_i18n_friendly]
+  if config.filter.rules[:flow_explorer_screenshot]
     FlowExplorerScreenshots.hook!(config)
   end
 end
@@ -156,7 +156,7 @@ RSpec.configure do |config|
   end
 
   config.before(type: :feature) do |example|
-    if config.filter.rules[:flow_explorer_screenshot] || config.filter.rules[:flow_explorer_screenshot_i18n_friendly]
+    if config.filter.rules[:flow_explorer_screenshot] || config.filter.rules[:flow_explorer_screenshot]
       example.metadata[:js] = true
       Capybara.current_driver = Capybara.javascript_driver
       Capybara.page.current_window.resize_to(2000, 4000)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -135,7 +135,6 @@ RSpec.configure do |config|
     allow(fake_dns).to receive(:open) { raise StandardError, "Cannot use DNS from test suite" }
     allow(fake_dns).to receive(:close)
     allow(Resolv::DNS).to receive(:new).and_return(fake_dns)
-    Flipper.instance = Flipper.new(Flipper::Adapters::Memory.new)
   end
 
   if config.filter.rules[:flow_explorer_screenshot]
@@ -174,6 +173,12 @@ RSpec.configure do |config|
           timezone: "America/New_York"
         }
       )
+    end
+  end
+
+  config.before(:each) do
+    unless Capybara.current_driver == Capybara.javascript_driver
+      Flipper.instance = Flipper.new(Flipper::Adapters::Memory.new)
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -155,7 +155,7 @@ RSpec.configure do |config|
   end
 
   config.before(type: :feature) do |example|
-    if config.filter.rules[:flow_explorer_screenshot] || config.filter.rules[:flow_explorer_screenshot]
+    if config.filter.rules[:flow_explorer_screenshot]
       example.metadata[:js] = true
       Capybara.current_driver = Capybara.javascript_driver
       Capybara.page.current_window.resize_to(2000, 4000)


### PR DESCRIPTION
Previously, `:flow_explorer_screenshot` tests captured spanish
screenshots by clicking 'Español' in the header, taking a screenshot,
then clicking 'English' in the header

This meant we incurred ~3 pageloads for every screenshot we wanted
to take (initial english, spanish, then english again)

This change keeps a dedicated second tab open in the Chrome browser,
so that every time we want to capture the Spanish version of the page
we load the /es/... URL in that tab, capture the screenshot, and switch
back to the original tab