### PR TITLE
Remove mini_racer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,6 @@ gem 'rails', '~> 7.0.3.1'
 gem 'puma', '>= 5.3.2'
 gem 'sass-rails', '~> 5.0'
 gem 'cfa-styleguide', '0.10.5', git: 'https://github.com/codeforamerica/honeycrisp-gem', branch: 'main', ref: '4c6f873f55704ec34fd518906f131133b290e56a'
-# See https://github.com/rails/execjs#readme for more supported runtimes
-gem 'mini_racer', '~> 0.4.0', platforms: :ruby
 gem 'nokogiri', '>= 1.10.8'
 gem 'recaptcha'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -320,7 +320,6 @@ GEM
       launchy (>= 2.2, < 3)
     libddwaf (1.3.0.0.0)
       ffi (~> 1.0)
-    libv8-node (15.14.0.1)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -347,8 +346,6 @@ GEM
     mini_magick (4.11.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
-    mini_racer (0.4.0)
-      libv8-node (~> 15.14.0.0)
     minitest (5.16.2)
     mixpanel-ruby (2.2.2)
     moneta (1.0.0)
@@ -698,7 +695,6 @@ DEPENDENCIES
   lograge
   mailgun-ruby
   memory_profiler
-  mini_racer (~> 0.4.0)
   mixpanel-ruby
   net-http
   nokogiri (>= 1.10.8)


### PR DESCRIPTION
I think the modern solution is to just expect every env to have some version of `node` installed

let's see if we can swing that