### PR TITLE
Drop unused user columns and removes temporary code from bank account

### DIFF
--- a/app/models/bank_account.rb
+++ b/app/models/bank_account.rb
@@ -2,19 +2,15 @@
 #
 # Table name: bank_accounts
 #
-#  id                          :bigint           not null, primary key
-#  account_number              :text
-#  account_type                :integer
-#  bank_name                   :string
-#  encrypted_account_number    :string
-#  encrypted_account_number_iv :string
-#  encrypted_bank_name         :string
-#  encrypted_bank_name_iv      :string
-#  hashed_account_number       :string
-#  routing_number              :string
-#  created_at                  :datetime         not null
-#  updated_at                  :datetime         not null
-#  intake_id                   :bigint
+#  id                    :bigint           not null, primary key
+#  account_number        :text
+#  account_type          :integer
+#  bank_name             :string
+#  hashed_account_number :string
+#  routing_number        :string
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  intake_id             :bigint
 #
 # Indexes
 #
@@ -27,25 +23,14 @@
 #  fk_rails_...  (intake_id => intakes.id)
 #
 class BankAccount < ApplicationRecord
+  self.ignored_columns = [:encrypted_account_number, :encrypted_account_number_iv, :encrypted_bank_name, :encrypted_bank_name_iv]
   belongs_to :intake
   has_one :client, through: :intake
-
   # Enum values are acceptable BankAccountType values to be sent to the IRS (See efileTypes.xsd)
   enum account_type: { checking: 1, savings: 2 }
   before_save :hash_account_number
 
-  attr_encrypted :attr_encrypted_account_number, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }, attribute: "encrypted_account_number"
-  attr_encrypted :attr_encrypted_bank_name, key: ->(_) { EnvironmentCredentials.dig(:db_encryption_key) }, attribute: "encrypted_bank_name"
-
   encrypts :account_number
-
-  def account_number
-    read_attribute(:account_number) || attr_encrypted_account_number
-  end
-
-  def bank_name
-    read_attribute(:bank_name) || attr_encrypted_bank_name
-  end
 
   # map string enum value back to the corresponding integer
   def account_type_code

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,7 +46,6 @@
 class User < ApplicationRecord
   include PgSearch::Model
   # prepare to drop -- unused columns from old zendesk integration
-  self.ignored_columns = ["encrypted_access_token", "encrypted_access_token_iv"]
   devise :database_authenticatable, :lockable, :validatable, :timeoutable, :trackable, :invitable, :recoverable
 
   pg_search_scope :search, against: [

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,7 +45,6 @@
 #
 class User < ApplicationRecord
   include PgSearch::Model
-  # prepare to drop -- unused columns from old zendesk integration
   devise :database_authenticatable, :lockable, :validatable, :timeoutable, :trackable, :invitable, :recoverable
 
   pg_search_scope :search, against: [

--- a/db/migrate/20220803202132_remove_encrypted_access_token_from_user.rb
+++ b/db/migrate/20220803202132_remove_encrypted_access_token_from_user.rb
@@ -1,0 +1,8 @@
+class RemoveEncryptedAccessTokenFromUser < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      remove_column :users, :encrypted_access_token_iv, :string
+      remove_column :users, :encrypted_access_token, :string
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_02_182512) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_03_202132) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -1510,8 +1510,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_02_182512) do
     t.datetime "current_sign_in_at", precision: nil
     t.string "current_sign_in_ip"
     t.citext "email", null: false
-    t.string "encrypted_access_token"
-    t.string "encrypted_access_token_iv"
     t.string "encrypted_password", default: "", null: false
     t.integer "failed_attempts", default: 0, null: false
     t.datetime "invitation_accepted_at", precision: nil

--- a/spec/factories/bank_accounts.rb
+++ b/spec/factories/bank_accounts.rb
@@ -2,19 +2,15 @@
 #
 # Table name: bank_accounts
 #
-#  id                          :bigint           not null, primary key
-#  account_number              :text
-#  account_type                :integer
-#  bank_name                   :string
-#  encrypted_account_number    :string
-#  encrypted_account_number_iv :string
-#  encrypted_bank_name         :string
-#  encrypted_bank_name_iv      :string
-#  hashed_account_number       :string
-#  routing_number              :string
-#  created_at                  :datetime         not null
-#  updated_at                  :datetime         not null
-#  intake_id                   :bigint
+#  id                    :bigint           not null, primary key
+#  account_number        :text
+#  account_type          :integer
+#  bank_name             :string
+#  hashed_account_number :string
+#  routing_number        :string
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  intake_id             :bigint
 #
 # Indexes
 #

--- a/spec/models/bank_account_spec.rb
+++ b/spec/models/bank_account_spec.rb
@@ -2,19 +2,15 @@
 #
 # Table name: bank_accounts
 #
-#  id                          :bigint           not null, primary key
-#  account_number              :text
-#  account_type                :integer
-#  bank_name                   :string
-#  encrypted_account_number    :string
-#  encrypted_account_number_iv :string
-#  encrypted_bank_name         :string
-#  encrypted_bank_name_iv      :string
-#  hashed_account_number       :string
-#  routing_number              :string
-#  created_at                  :datetime         not null
-#  updated_at                  :datetime         not null
-#  intake_id                   :bigint
+#  id                    :bigint           not null, primary key
+#  account_number        :text
+#  account_type          :integer
+#  bank_name             :string
+#  hashed_account_number :string
+#  routing_number        :string
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  intake_id             :bigint
 #
 # Indexes
 #

--- a/spec/models/bank_account_spec.rb
+++ b/spec/models/bank_account_spec.rb
@@ -25,34 +25,6 @@
 require "rails_helper"
 
 describe BankAccount do
-
-  describe "#account_number" do
-    let(:bank_account) { create :bank_account, attr_encrypted_account_number: "12345678910", account_number: nil }
-    it "can read account_number when there is only an old encrypted value" do
-      expect(bank_account.read_attribute(:account_number)).to eq nil
-      expect(bank_account.account_number).to eq "12345678910"
-    end
-
-    it "can write account_number to the new encrypted field" do
-      bank_account.update(account_number: "123456789101")
-      expect(bank_account.attr_encrypted_account_number).to eq "12345678910"
-      expect(bank_account.account_number).to eq "123456789101"
-    end
-  end
-
-  describe "#bank_name" do
-    let(:bank_account) { create :bank_account, attr_encrypted_bank_name: "Some bank", bank_name: nil }
-    it "can read account_number from encrypted field only" do
-      expect(bank_account.bank_name).to eq "Some bank"
-    end
-
-    it "can write bank_name to the new unencrypted field" do
-      bank_account.update(bank_name: "Any bank")
-      expect(bank_account.read_attribute(:bank_name)).to eq "Any bank"
-      expect(bank_account.bank_name).to eq "Any bank"
-    end
-  end
-
   describe "#account_type_code" do
     context "when checking" do
       let(:bank_account) { create :bank_account, account_type: "checking" }


### PR DESCRIPTION
Co-authored-by: Maria Quadri <mquadri@codeforamerica.org>

Now that we've run the migration for moving bank account data, we can remove the custom readers and attr_encrypted references.

We can also run migrations to remove the ignored columns from the previous run, and add the columns for the encrypted columns we want to drop in an upcoming release to ignored_columns