### PR TITLE
Don't try to get flow explorer screenshots for address_validation_spec

### DIFF
--- a/spec/features/ctc/address_validation_spec.rb
+++ b/spec/features/ctc/address_validation_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "CTC Intake", :flow_explorer_screenshot, active_job: true, requires_default_vita_partners: true, do_not_stub_usps: true do
+RSpec.feature "CTC Intake", active_job: true, requires_default_vita_partners: true, do_not_stub_usps: true do
   include CtcIntakeFeatureHelper
   let(:usps_api_response_body) { file_fixture("usps_address_validation_body.xml").read }
   let!(:intake_with_verified_address) { create(:ctc_intake, usps_address_verified_at: 5.minutes.ago) }


### PR DESCRIPTION
a recent change made it so this file fails when run in `js: true` mode --
we could hack our way around that, but it doesn't seem like this file is
generating any unique screenshots so we can just not include it in the
daily screenshot build