### PR TITLE
Include optimizely on most client-facing prod pages and enable in prod

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   around_action :switch_locale
   before_action :check_maintenance_mode
   after_action :track_page_view
-  helper_method :include_analytics?, :current_intake, :current_tax_year, :prior_tax_year, :show_progress?, :show_offseason_banner?, :canonical_url, :hreflang_url, :hub?, :open_for_gyr_intake?, :open_for_soft_launch?, :open_for_ctc_intake?, :open_for_ctc_login?, :wrapping_layout
+  helper_method :include_analytics?, :include_optimizely?, :current_intake, :current_tax_year, :prior_tax_year, :show_progress?, :show_offseason_banner?, :canonical_url, :hreflang_url, :hub?, :open_for_gyr_intake?, :open_for_soft_launch?, :open_for_ctc_intake?, :open_for_ctc_login?, :wrapping_layout
   # This needs to be a class method for the devise controller to have access to it
   # See: http://stackoverflow.com/questions/12550564/how-to-pass-locale-parameter-to-devise
   def self.default_url_options
@@ -66,6 +66,11 @@ class ApplicationController < ActionController::Base
   end
 
   def include_analytics?
+    false
+  end
+
+  def include_optimizely?
+    # Adding Optimizely to a page increases risk; controller subclasses can opt-in to that.
     false
   end
 

--- a/app/controllers/ctc/ctc_pages_controller.rb
+++ b/app/controllers/ctc/ctc_pages_controller.rb
@@ -82,6 +82,10 @@ module Ctc
       @in_intake_flow = true
     end
 
+    def include_optimizely?
+      true
+    end
+
     private
 
     def markdown_content_from_file(file_name)

--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -6,6 +6,10 @@ class PublicPagesController < ApplicationController
     true
   end
 
+  def include_optimizely?
+    true
+  end
+
   def redirect_locale_home
     redirect_to root_path
   end

--- a/app/controllers/questions/questions_controller.rb
+++ b/app/controllers/questions/questions_controller.rb
@@ -14,6 +14,10 @@ module Questions
       @form = initialized_edit_form
     end
 
+    def include_optimizely?
+      (form_class.attribute_names || []).none? { |attribute| Rails.application.config.filter_parameters.include?(attribute) }
+    end
+
     def update
       @form = initialized_update_form
       if @form.valid?

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="<%= I18n.locale %>" <% if content_for :html_class %>class="<%= yield :html_class %>"<% end %>>
   <head>
-    <% if Rails.configuration.include_optimizely %>
+    <% if Rails.configuration.optimizely_available && include_optimizely? %>
       <link rel="preload" href="//cdn.optimizely.com/js/21316291320.js" as="script">
       <link rel="preconnect" href="//logx.optimizely.com">
     <% end %>
@@ -51,7 +51,7 @@
 
     <%= stylesheet_pack_tag 'application', media: 'all' %>
 
-    <% if Rails.configuration.include_optimizely %>
+    <% if Rails.configuration.optimizely_available && include_optimizely? %>
       <script src="https://cdn.optimizely.com/js/21316291320.js"></script>
     <% end %>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -64,7 +64,7 @@ module VitaMin
     config.ctc_end_of_intake = Time.find_zone("America/New_York").parse("2022-10-15 17:00:00")
     config.ctc_end_of_login = Time.find_zone("America/New_York").parse("2022-10-19 17:00:00")
 
-    config.include_optimizely = false
+    config.optimizely_available = false
 
     config.allow_magic_verification_code = (Rails.env.demo? || Rails.env.development? || Rails.env.heroku?)
   end

--- a/config/environments/demo.rb
+++ b/config/environments/demo.rb
@@ -24,5 +24,5 @@ Rails.application.configure do
   config.ctc_soft_launch = Time.find_zone("America/New_York").parse("2022-03-01 09:00:00")
   config.ctc_full_launch = Time.find_zone("America/New_York").parse("2022-04-01 09:00:00")
 
-  config.include_optimizely = true
+  config.optimizely_available = true
 end

--- a/config/environments/heroku.rb
+++ b/config/environments/heroku.rb
@@ -23,5 +23,5 @@ Rails.application.configure do
   Rails.application.default_url_options = config.action_mailer.default_url_options
   config.efile_environment = "test"
 
-  config.include_optimizely = true
+  config.optimizely_available = true
 end

--- a/spec/controllers/questions/questions_controller_spec.rb
+++ b/spec/controllers/questions/questions_controller_spec.rb
@@ -25,6 +25,24 @@ RSpec.describe Questions::QuestionsController do
     end
   end
 
+  describe '#include_optimizely?' do
+    describe "when the controller's form_class references sensitive fields like ssn" do
+      controller(Ctc::Questions::LegalConsentController) { }
+
+      it "is false" do
+        expect(subject).not_to be_include_optimizely
+      end
+    end
+
+    describe "when the controller's form_class references no sensitive fields" do
+      controller(Ctc::Questions::FiledPriorTaxYearController) { }
+
+      it "is true" do
+        expect(subject).to be_include_optimizely
+      end
+    end
+  end
+
   describe ".to_path_helper" do
     context "with a random child controller" do
       let(:controller_class) { Documents::IdsController }


### PR DESCRIPTION
intake pages are only included if they don't have params we would filter
out of mixpanel, e.g. primary_ssn

Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>