### PR TITLE
Remove unneeded eitc dependent conditions

### DIFF
--- a/app/lib/efile/dependent_eligibility/earned_income_tax_credit.rb
+++ b/app/lib/efile/dependent_eligibility/earned_income_tax_credit.rb
@@ -9,8 +9,6 @@ module Efile
       # Keys with multiple conditions must be OR conditions, as only one must pass to remain eligible
       def self.rules
         {
-            primary_tin_type_ssn: :primary_tin_type_ssn?,
-            investment_limit_test: :primary_under_investment_limit?,
             qc_test: :is_qualifying_child?,
             tin_test: :tin_type_ssn?,
         }
@@ -20,14 +18,6 @@ module Efile
 
       def is_qualifying_child?
         (@child_eligibility || Efile::DependentEligibility::QualifyingChild.new(dependent, tax_year)).qualifies?
-      end
-
-      def primary_under_investment_limit?
-        dependent.intake.exceeded_investment_income_limit_no?
-      end
-
-      def primary_tin_type_ssn?
-        dependent.intake.primary_tin_type_ssn?
       end
 
       def prequalifying_attribute


### PR DESCRIPTION
They are tied to the primary and we check them at the intake level
so we don't need to check them for each dependent