### PR TITLE
MessageCsvImportJob: handle unexpected errors and empty tax return selections

### DIFF
--- a/app/models/bulk_message_csv.rb
+++ b/app/models/bulk_message_csv.rb
@@ -23,7 +23,7 @@ class BulkMessageCsv < ApplicationRecord
   has_one_attached :upload
   belongs_to :tax_return_selection, optional: true
   belongs_to :user
-  enum status: { queued: 0, ready: 100}
+  enum status: { queued: 0, empty: 10, failed: 90, ready: 100}
 
   validate :must_contain_client_id_header
 

--- a/spec/controllers/flows_controller_spec.rb
+++ b/spec/controllers/flows_controller_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe FlowsController do
       end
     end
 
-    context 'for a nonexistant flow' do
+    context 'for a nonexistent flow' do
       it 'renders 404' do
         expect do
           get :show, params: { id: :aardvark }

--- a/spec/jobs/bulk_action/message_csv_import_job_spec.rb
+++ b/spec/jobs/bulk_action/message_csv_import_job_spec.rb
@@ -14,15 +14,18 @@ describe BulkAction::MessageCsvImportJob do
   end
 
   let(:optional_bom) { '' }
-
-  around do |example|
-    @filename = Rails.root.join("tmp", "bulk-client-message-test-#{SecureRandom.hex}.csv")
-    File.write(@filename, <<~CSV)
+  let(:csv_content) do
+    <<~CSV
       #{optional_bom}client_id
       #{email_and_phone_client.id}
       #{email_client.id}
       #{archived_2021_email_client.id}
     CSV
+  end
+
+  around do |example|
+    @filename = Rails.root.join("tmp", "bulk-client-message-test-#{SecureRandom.hex}.csv")
+    File.write(@filename, csv_content)
     example.run
     File.unlink(@filename)
   end
@@ -31,7 +34,10 @@ describe BulkAction::MessageCsvImportJob do
     let(:bulk_message_csv) { BulkMessageCsv.create(upload: { filename: 'really_good_csv.csv', io: File.open(@filename) }, user: user) }
 
     it "creates a tax return selection for the appropriate client ids" do
-      described_class.perform_now(bulk_message_csv)
+      expect do
+        described_class.perform_now(bulk_message_csv)
+      end.to change { bulk_message_csv.reload.status }.to('ready')
+
       expect(TaxReturnSelection.last.clients).to match_array([email_and_phone_client, email_client, archived_2021_email_client])
     end
 
@@ -41,6 +47,41 @@ describe BulkAction::MessageCsvImportJob do
       it "creates the tax return selection as normal" do
         described_class.perform_now(bulk_message_csv)
         expect(TaxReturnSelection.last.clients).to match_array([email_and_phone_client, email_client, archived_2021_email_client])
+      end
+    end
+
+    context "when the file does not contain any client ids with tax returns" do
+      let!(:no_tax_returns_client_id) { create(:client).id }
+      let(:nonexistant_client_id) { -1000 }
+
+      let(:csv_content) do
+        <<~CSV
+          client_id
+          #{no_tax_returns_client_id}
+          #{nonexistant_client_id}
+        CSV
+      end
+
+      it "sets the status to 'empty'" do
+        expect do
+          expect do
+            described_class.perform_now(bulk_message_csv)
+          end.not_to change(TaxReturnSelection, :count)
+        end.to change { bulk_message_csv.reload.status }.to('empty')
+      end
+    end
+
+    context "when the import fails for an unexpected reason" do
+      before do
+        allow(TaxReturn).to receive(:find_by_sql).and_raise(ArgumentError)
+      end
+
+      it "sets the status to 'failed' and still raises the error" do
+        expect do
+          described_class.perform_now(bulk_message_csv)
+        end.to change { bulk_message_csv.reload.status }.to('failed').and(
+          raise_error(ArgumentError)
+        )
       end
     end
   end

--- a/spec/jobs/bulk_action/message_csv_import_job_spec.rb
+++ b/spec/jobs/bulk_action/message_csv_import_job_spec.rb
@@ -52,13 +52,13 @@ describe BulkAction::MessageCsvImportJob do
 
     context "when the file does not contain any client ids with tax returns" do
       let!(:no_tax_returns_client_id) { create(:client).id }
-      let(:nonexistant_client_id) { -1000 }
+      let(:nonexistent_client_id) { -1000 }
 
       let(:csv_content) do
         <<~CSV
           client_id
           #{no_tax_returns_client_id}
-          #{nonexistant_client_id}
+          #{nonexistent_client_id}
         CSV
       end
 


### PR DESCRIPTION
now the status could change to 'empty' or 'failed'

Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>