### PR TITLE
OutgoingTextMessage only saves status if it is further than the old one

### DIFF
--- a/app/controllers/twilio_webhooks_controller.rb
+++ b/app/controllers/twilio_webhooks_controller.rb
@@ -6,7 +6,7 @@ class TwilioWebhooksController < ActionController::Base
   def update_outgoing_text_message
     status = params["MessageStatus"]
     DatadogApi.increment("twilio.outgoing_text_messages.updated.status.#{status}")
-    OutgoingTextMessage.find(params[:id]).update!(twilio_status: status)
+    OutgoingTextMessage.find(params[:id]).update_status_if_further(status)
     head :ok
   end
 

--- a/app/jobs/send_outgoing_text_message_job.rb
+++ b/app/jobs/send_outgoing_text_message_job.rb
@@ -4,7 +4,6 @@ class SendOutgoingTextMessageJob < ApplicationJob
 
   def perform(outgoing_text_message_id)
     outgoing_text_message = OutgoingTextMessage.find(outgoing_text_message_id)
-
     message = TwilioService.send_text_message(
       to: outgoing_text_message.to_phone_number,
       body: outgoing_text_message.body,
@@ -14,10 +13,10 @@ class SendOutgoingTextMessageJob < ApplicationJob
 
     if message
       outgoing_text_message.update(
-        twilio_status: message.status,
         twilio_sid: message.sid,
         sent_at: DateTime.now
       )
+      outgoing_text_message.update_status_if_further(message.status)
     end
   end
 

--- a/crontab
+++ b/crontab
@@ -6,3 +6,4 @@
 20 21 * * 1-5 bundle exec rake client_surveys:send_client_in_progress_surveys
 15 20 * * * bundle exec rake not_ready_reminders:remind
 */10 * * * * bundle exec rake efile:poll_and_get_acknowledgments
+17 * * * * bundle exec rake outgoing_messages:backfill_twilio_statuses

--- a/spec/models/outgoing_text_message_spec.rb
+++ b/spec/models/outgoing_text_message_spec.rb
@@ -164,6 +164,26 @@ RSpec.describe OutgoingTextMessage, type: :model do
     end
   end
 
+  describe "#update_status_if_further" do
+    context "when updating to a later status" do
+      let(:outgoing_text_message) { create(:outgoing_text_message, twilio_status: "sending") }
+      it "saves the change" do
+        expect {
+          outgoing_text_message.update_status_if_further("sent")
+        }.to change(outgoing_text_message, :twilio_status).from("sending").to("sent")
+      end
+    end
+
+    context "when updating to an earlier status" do
+      let(:outgoing_text_message) { create(:outgoing_text_message, twilio_status: "sent") }
+      it "does not save" do
+        expect {
+          outgoing_text_message.update_status_if_further("sending")
+        }.not_to change(outgoing_text_message, :twilio_status)
+      end
+    end
+  end
+
   describe "scopes for statuses" do
     let!(:undelivered) { create :outgoing_text_message, twilio_status: "undelivered" }
     let!(:failed) { create :outgoing_text_message, twilio_status: "failed" }


### PR DESCRIPTION
previously we were probably overwriting 'sent' with 'queued' if the initial message create API request got its response AFTER the 'sent' webhook came in

we only want to record the furthest status, so we check the index in this cool array we made