### PR TITLE
Check that dependent IP pin exists before adding it to Schedule EIC

### DIFF
--- a/app/lib/submission_builder/ty2021/documents/irs1040.rb
+++ b/app/lib/submission_builder/ty2021/documents/irs1040.rb
@@ -99,9 +99,7 @@ module SubmissionBuilder
             xml.DependentFirstNm person_name_type(dependent.first_name)
             xml.DependentLastNm person_name_type(dependent.last_name)
             xml.DependentNameControlTxt name_control_type(dependent.last_name)
-            if dependent.ip_pin.present?
-              xml.IdentityProtectionPIN dependent.ip_pin
-            end
+            xml.IdentityProtectionPIN dependent.ip_pin if dependent.ip_pin.present?
             xml.DependentSSN dependent.ssn
             xml.DependentRelationshipCd dependent.irs_relationship_enum
             xml.EligibleForChildTaxCreditInd "X" if dependent.qualifying_ctc?

--- a/app/lib/submission_builder/ty2021/documents/schedule_eic.rb
+++ b/app/lib/submission_builder/ty2021/documents/schedule_eic.rb
@@ -17,7 +17,7 @@ module SubmissionBuilder
                   xml.PersonFirstNm person_name_type(dependent.first_name)
                   xml.PersonLastNm person_name_type(dependent.last_name)
                 }
-                xml.IdentityProtectionPIN dependent.ip_pin
+                xml.IdentityProtectionPIN dependent.ip_pin if dependent.ip_pin.present?
                 xml.QualifyingChildSSN dependent.ssn
                 xml.ChildBirthYr dependent.birth_date.year
                 xml.ChildIsAStudentUnder24Ind dependent.full_time_student_yes? && dependent.age_during_tax_year < 24


### PR DESCRIPTION
Since we weren't checking, when testing the XML for EITC we were getting the following error:

```
["157:0: ERROR: Element '{http://www.irs.gov/efile}IdentityProtectionPIN': [facet 'length'] The value has a length of '0'; this differs from the allowed length of '6'.", "157:0: ERROR: Element '{http://www.irs.gov/efile}IdentityProtectionPIN': [facet 'pattern'] The value '' is not accepted by the pattern '([!-~£§ÁÉÍÑÓ×ÚÜáéíñóúü] ?)*[!-~£§ÁÉÍÑÓ×ÚÜáéíñóúü]'."] 
```

Checking that it is present fixes the issue.