### PR TITLE
Show eitc age test page based on primary and spouse ages if mfj

### DIFF
--- a/app/controllers/ctc/questions/eitc_qualifiers_controller.rb
+++ b/app/controllers/ctc/questions/eitc_qualifiers_controller.rb
@@ -6,9 +6,10 @@ module Ctc
       layout "intake"
 
       def self.show?(intake)
+        benefits_eligibility = Efile::BenefitsEligibility.new(tax_return: intake.default_tax_return, dependents: intake.dependents)
         Flipper.enabled?(:eitc) &&
           intake.exceeded_investment_income_limit_no? &&
-          intake.primary_birth_date > 24.years.ago &&
+          benefits_eligibility.filers_younger_than_twenty_four? &&
           intake.dependents.none?(&:qualifying_eitc?)
       end
 

--- a/app/lib/efile/benefits_eligibility.rb
+++ b/app/lib/efile/benefits_eligibility.rb
@@ -135,7 +135,7 @@ module Efile
     private
 
     def eitc_qualifications_passes_age_test?
-      return true if primary_age_at_end_of_tax_year >= 24
+      return true unless filers_younger_than_twenty_four?
       return true if dependents.any?(&:qualifying_eitc?)
 
       if intake.former_foster_youth_yes? || intake.homeless_youth_yes?

--- a/app/lib/efile/benefits_eligibility.rb
+++ b/app/lib/efile/benefits_eligibility.rb
@@ -115,30 +115,44 @@ module Efile
     end
 
     def qualified_for_eitc?
-      intake.exceeded_investment_income_limit_no? && eitc_qualifications_passes_age_test? && intake.primary_tin_type == "ssn"
+      intake.exceeded_investment_income_limit_no? &&
+        eitc_qualifications_passes_age_test? &&
+        intake.primary_tin_type == "ssn"
     end
 
     def youngish_without_eitc_dependents?
-      intake.primary_birth_date >= Date.new(1998, 1, 2) && intake.primary_birth_date <= Date.new(2004, 1, 1) && dependents.none?(&:qualifying_eitc?)
+      primary_age_at_end_of_tax_year < 24 && primary_age_at_end_of_tax_year >= 18 && dependents.none?(&:qualifying_eitc?)
+    end
+
+    def filers_younger_than_twenty_four?
+      if intake.filing_jointly?
+        primary_age_at_end_of_tax_year < 24 && spouse_age_at_end_of_tax_year < 24
+      else
+        primary_age_at_end_of_tax_year < 24
+      end
     end
 
     private
 
     def eitc_qualifications_passes_age_test?
-      return true if age_at_end_of_tax_year >= 24
+      return true if primary_age_at_end_of_tax_year >= 24
       return true if dependents.any?(&:qualifying_eitc?)
 
       if intake.former_foster_youth_yes? || intake.homeless_youth_yes?
-        age_at_end_of_tax_year >= 18
+        primary_age_at_end_of_tax_year >= 18
       elsif intake.not_full_time_student_yes? || intake.full_time_student_less_than_four_months_yes?
-        age_at_end_of_tax_year >= 19
+        primary_age_at_end_of_tax_year >= 19
       else
         false
       end
     end
 
-    def age_at_end_of_tax_year
+    def primary_age_at_end_of_tax_year
       tax_return.year - intake.primary_birth_date.year
+    end
+
+    def spouse_age_at_end_of_tax_year
+      tax_return.year - intake.spouse_birth_date.year
     end
 
     def rrc_eligible_filer_count

--- a/spec/features/ctc/eitc_spec.rb
+++ b/spec/features/ctc/eitc_spec.rb
@@ -132,7 +132,7 @@ RSpec.feature "CTC Intake", :flow_explorer_screenshot, active_job: true, require
     fill_in_can_use_ctc
     fill_in_eligibility
     fill_in_basic_info(birthdate: 23.years.ago)
-    fill_in_spouse_info
+    fill_in_spouse_info(birthdate: 23.years.ago)
 
     # EITC investment question
     expect(page).to have_selector("h1", text:I18n.t('views.ctc.questions.investment_income.married_title'))

--- a/spec/lib/efile/benefits_eligibility_spec.rb
+++ b/spec/lib/efile/benefits_eligibility_spec.rb
@@ -388,6 +388,17 @@ describe Efile::BenefitsEligibility do
       context "when they have no qualifying children" do
         let(:dependents) { [] }
 
+        context "when their spouse is over 24" do
+          before do
+            intake.default_tax_return.update(filing_status: "married_filing_jointly")
+            intake.update(spouse_birth_date: Date.new(2021, 12, 31) - 25.years)
+          end
+
+          it "returns true" do
+            expect(subject.qualified_for_eitc?).to eq true
+          end
+        end
+
         context "they are a former foster or homeless youth" do
           [:homeless_youth, :former_foster_youth].each do |qualifier|
             before do

--- a/spec/support/helpers/ctc_intake_feature_helper.rb
+++ b/spec/support/helpers/ctc_intake_feature_helper.rb
@@ -115,15 +115,15 @@ module CtcIntakeFeatureHelper
     click_on I18n.t("views.ctc.questions.verification.verify")
   end
 
-  def fill_in_spouse_info(home_location: nil)
+  def fill_in_spouse_info(home_location: nil, birthdate: DateTime.new(1995, 1, 11))
     # =========== SPOUSE INFO ===========
     expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.spouse_info.title'))
     fill_in I18n.t('views.ctc.questions.spouse_info.spouse_first_name'), with: "Peter"
     fill_in I18n.t('views.ctc.questions.spouse_info.spouse_middle_initial'), with: "P"
     fill_in I18n.t('views.ctc.questions.spouse_info.spouse_last_name'), with: "Pepper"
-    fill_in "ctc_spouse_info_form[spouse_birth_date_month]", with: "01"
-    fill_in "ctc_spouse_info_form[spouse_birth_date_day]", with: "11"
-    fill_in "ctc_spouse_info_form[spouse_birth_date_year]", with: "1995"
+    fill_in "ctc_spouse_info_form[spouse_birth_date_month]", with: birthdate.month
+    fill_in "ctc_spouse_info_form[spouse_birth_date_day]", with: birthdate.day
+    fill_in "ctc_spouse_info_form[spouse_birth_date_year]", with: birthdate.year
     select I18n.t('general.tin.ssn')
     fill_in I18n.t('views.ctc.questions.spouse_info.spouse_ssn_itin'), with: "222-33-4444"
     fill_in I18n.t('views.ctc.questions.spouse_info.spouse_ssn_itin_confirmation'), with: "222-33-4444"
@@ -141,7 +141,7 @@ module CtcIntakeFeatureHelper
 
     expect(page).to have_text(I18n.t('views.ctc.questions.spouse_review.title'))
     expect(page).to have_text("Peter Pepper")
-    expect(page).to have_text(I18n.t('views.ctc.questions.spouse_review.spouse_birthday', dob: "1/11/1995"))
+    expect(page).to have_text(I18n.t('views.ctc.questions.spouse_review.spouse_birthday', dob: birthdate.strftime("%-m/%-d/%Y")))
     expect(page).to have_text(I18n.t('views.ctc.questions.spouse_review.spouse_ssn', ssn: "4444"))
     click_on I18n.t('general.edit').downcase
 


### PR DESCRIPTION
Both must be under 24 to see the page. Only the primary age is used for the exceptions though.

Update the `youngish_without_eitc_dependents?` method for checking the 27a checkbox in the 1040 to use the same 18/24 age boundaries we use everywhere else (based on the age on the last day of the current tax year)

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>