### PR TITLE
Include archived intakes in bulk client messages page

### DIFF
--- a/app/controllers/hub/bulk_client_messages_controller.rb
+++ b/app/controllers/hub/bulk_client_messages_controller.rb
@@ -1,7 +1,6 @@
 module Hub
   class BulkClientMessagesController < ApplicationController
     include AccessControllable
-    include ClientSortable
 
     layout "hub"
 
@@ -9,11 +8,11 @@ module Hub
     before_action :load_bulk_message, :load_selection, :load_clients, only: [:show]
 
     def show
-      @client_filter_form_path = hub_clients_path
+      @hide_filters = true
       @client_index_help_text = I18n.t("hub.tax_return_selections.help_text", count: @clients.size)
       @missing_results_message = I18n.t("hub.tax_return_selections.help_text_missing_results", count: @inaccessible_clients_count) unless @inaccessible_clients_count == 0
 
-      @clients = filtered_and_sorted_clients.page(params[:page]).load
+      @clients = @clients.page(params[:page]).load
       @message_summaries = RecentMessageSummaryService.messages(@clients.map(&:id))
       @page_title = I18n.t("hub.tax_return_selections.page_title", count: @selection.clients.size, id: @selection.id)
       render "hub/clients/index"

--- a/app/controllers/hub/clients_controller.rb
+++ b/app/controllers/hub/clients_controller.rb
@@ -221,6 +221,12 @@ module Hub
         intake.itin_applicant? ? I18n.t("general.affirmative") : I18n.t("general.negative")
       end
 
+      def preferred_language
+        return intake.preferred_interview_language if intake.preferred_interview_language && intake.preferred_interview_language != "en"
+
+        intake.locale || intake.preferred_interview_language
+      end
+
       def needs_itin_help_yes?
         return false if archived?
 

--- a/app/controllers/hub/tax_return_selections_controller.rb
+++ b/app/controllers/hub/tax_return_selections_controller.rb
@@ -38,7 +38,7 @@ module Hub
     end
 
     def show
-      @client_filter_form_path = hub_clients_path
+      @hide_filters = true
       @clients = @selection.clients.accessible_by(current_ability)
       @client_index_help_text = I18n.t("hub.tax_return_selections.help_text", count: @clients.size)
       inaccessible_client_count = @selection.clients.where.not(id: @clients).size

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -264,12 +264,6 @@ class Client < ApplicationRecord
     Client.where.not(id: id).where(intake: matching_intakes)
   end
 
-  def preferred_language
-    return intake.preferred_interview_language if intake.preferred_interview_language && intake.preferred_interview_language != "en"
-
-    intake.locale || intake.preferred_interview_language
-  end
-
   def request_document_help(doc_type:, help_type:)
     note = SystemNote::DocumentHelp.generate!(client: self, doc_type: doc_type, help_type: help_type)
     tax_returns.map(&:assigned_user).uniq.each do |user|

--- a/app/views/hub/clients/index.html.erb
+++ b/app/views/hub/clients/index.html.erb
@@ -1,12 +1,15 @@
 <% content_for :page_title, @page_title %>
-<% content_for :filters do %>
-  <%= render "shared/client_filters" %>
+<% unless @hide_filters %>
+  <% content_for :filters do %>
+    <%= render "shared/client_filters" %>
+  <% end %>
 <% end %>
 <% content_for :card do %>
   <section class="slab clients-header">
     <div>
       <h1> <%= @page_title %> </h1>
-      <div class="text--no-wrap quick-filters">
+      <% unless @hide_filters %>
+        <div class="text--no-wrap quick-filters">
         <label>Quick Filters:</label>
         <% ClientSortable::QUICK_FILTERS.each do |(filter_values, filter_label)| %>
           <% selected = filtering_only_by?(filter_values) %>
@@ -16,6 +19,7 @@
           <% end %>
         <% end %>
       </div>
+      <% end %>
     </div>
     <div class="text--no-wrap">
       <%= link_to t("general.add_client"), new_hub_client_path, class: "button" %>
@@ -169,7 +173,7 @@
     <section class="take-action-box bulk-action-footer" id="take-action-footer" style="display: none;">
       <span id="take-action-all-returns" style="display: none;">
          <%= form_with(url: new_hub_tax_return_selection_path, local: true, method: :get, builder: VitaMinFormBuilder) do |form| %>
-              <% @filters.each do |key, value| %>
+              <% @filters&.each do |key, value| %>
                 <%= form.hidden_field(key, value: value, id: "#{key}_bulk") %>
               <% end %>
               <button type="submit" name="create_tax_return_selection[action_type]" value="all-filtered-clients" class="button--link">

--- a/app/views/shared/_client_filters.html.erb
+++ b/app/views/shared/_client_filters.html.erb
@@ -1,5 +1,5 @@
 <div class="filters-wrapper">
-  <%= form_with method: "get", local: true, builder: VitaMinFormBuilder, url: @client_filter_form_path, class: "filter-form" do |f| %>
+  <%= form_with method: "get", local: true, builder: VitaMinFormBuilder, class: "filter-form" do |f| %>
     <%= f.hidden_field :order, value: @sort_order %>
     <%= f.hidden_field :column, value: @sort_column %>
 

--- a/spec/controllers/hub/clients_controller_spec.rb
+++ b/spec/controllers/hub/clients_controller_spec.rb
@@ -1484,6 +1484,40 @@ RSpec.describe Hub::ClientsController do
       end
     end
 
+    describe "#preferred_language" do
+      context "when preferred language is set to something other than english" do
+        let(:intake) { create :intake, preferred_interview_language: "de", locale: "es" }
+
+        it "it uses preferred language" do
+          expect(presenter.preferred_language).to eq "de"
+        end
+      end
+
+      context "when preferred language is set to english" do
+        let(:intake) { create :intake, preferred_interview_language: "en", locale: "es" }
+
+        it "falls through to locale" do
+          expect(presenter.preferred_language).to eq "es"
+        end
+      end
+
+      context "when preferred language not set" do
+        let(:intake) { create :intake, locale: "en" }
+
+        it "falls through to locale" do
+          expect(presenter.preferred_language).to eq "en"
+        end
+      end
+
+      context "when preferred language is set to en, and locale is not set" do
+        let(:intake) { create :intake, locale: nil, preferred_interview_language: "en" }
+
+        it "falls through to locale" do
+          expect(presenter.preferred_language).to eq "en"
+        end
+      end
+    end
+
     describe "#needs_itin_help_text and #needs_itin_help_yes?" do
       context "when intake is need_itin_help_yes?" do
         let(:intake) { create :intake, need_itin_help: "yes" }

--- a/spec/controllers/hub/tax_return_selections_controller_spec.rb
+++ b/spec/controllers/hub/tax_return_selections_controller_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe Hub::TaxReturnSelectionsController do
 
           expect(response).to be_ok
           html = Nokogiri::HTML.parse(response.body)
-          expect(html.at_css(".filter-form")["action"]).to eq hub_clients_path
           expect(html.at_css(".count-wrapper .text--help").text.strip).to eq "You are viewing 3 results from your saved search"
         end
       end

--- a/spec/features/hub/bulk_message_csv_spec.rb
+++ b/spec/features/hub/bulk_message_csv_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Uploading a CSV for bulk client messaging", active_job: true do
   let!(:email_and_phone_client) { create :client_with_intake_and_return, tax_return_state: "prep_info_requested" }
   let!(:email_client) { create :client_with_intake_and_return, tax_return_state: "intake_reviewing" }
   let!(:archived_2021_email_client) { create(:client, tax_returns: [build(:tax_return, year: 2018)], intake: nil) }
-  let!(:archived_2021_email_intake) { create(:archived_2021_gyr_intake, client: archived_2021_email_client, email_address: "someone_archived@example.com", email_notification_opt_in: "yes", locale: 'es') }
+  let!(:archived_2021_email_intake) { create(:archived_2021_gyr_intake, client: archived_2021_email_client, preferred_name: "Archivio", email_address: "someone_archived@example.com", email_notification_opt_in: "yes", locale: 'es') }
 
   before do
     login_as user
@@ -55,6 +55,10 @@ RSpec.describe "Uploading a CSV for bulk client messaging", active_job: true do
     within ".in-progress" do
       click_on "3 clients"
     end
+
+    # Archived clients show up
+    expect(page).to have_text "Archivio"
+
     click_on "Nombre"
     click_on "Messages"
     expect(page).to have_text "Naranja es la mejor"

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -635,40 +635,6 @@ describe Client do
     end
   end
 
-  describe "#preferred_language" do
-    context "when preferred language is set to something other than english" do
-      let(:client) { create :client, intake: (create :intake, preferred_interview_language: "de", locale: "es")}
-
-      it "it uses preferred language" do
-        expect(client.preferred_language).to eq "de"
-      end
-    end
-
-    context "when preferred language is set to english" do
-      let(:client) { create :client, intake: (create :intake, preferred_interview_language: "en", locale: "es")}
-
-      it "falls through to locale" do
-        expect(client.preferred_language).to eq "es"
-      end
-    end
-
-    context "when preferred language not set" do
-      let(:client) { create :client, intake: (create :intake, locale: "en")}
-
-      it "falls through to locale" do
-        expect(client.preferred_language).to eq "en"
-      end
-    end
-
-    context "when preferred language is set to en, and locale is not set" do
-      let(:client) { create :client, intake: (create :intake, locale: nil, preferred_interview_language: "en")}
-
-      it "falls through to locale" do
-        expect(client.preferred_language).to eq "en"
-      end
-    end
-  end
-
   describe ".locale_counts" do
     let(:organization) { create(:organization) }
     context "with all languages present" do


### PR DESCRIPTION
Don't include filter section because they don't completely work with archived intakes

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>