### PR TITLE
Include soft deleted dependents when delegating from efile submission dependents

### DIFF
--- a/app/models/efile_submission_dependent.rb
+++ b/app/models/efile_submission_dependent.rb
@@ -19,7 +19,7 @@
 #  index_efile_submission_dependents_on_efile_submission_id  (efile_submission_id)
 #
 class EfileSubmissionDependent < ApplicationRecord
-  belongs_to :dependent
+  belongs_to :dependent, -> { with_deleted }
   belongs_to :efile_submission
   has_one :intake, through: :efile_submission
 

--- a/spec/models/efile_submission_dependent_spec.rb
+++ b/spec/models/efile_submission_dependent_spec.rb
@@ -60,6 +60,14 @@ describe EfileSubmissionDependent do
         allow(eligibility_double).to receive(:age).and_return 5
       end
 
+      it "delegates some attributes to the original dependent, even if soft-deleted" do
+        efile_submission_dependent = EfileSubmissionDependent.create_qualifying_dependent(submission, dependent)
+        expect(efile_submission_dependent.first_name).to eq(dependent.first_name)
+
+        dependent.touch(:soft_deleted_at)
+        expect(efile_submission_dependent.reload.first_name).to eq(dependent.reload.first_name)
+      end
+
       it "calculates eligibility" do
         EfileSubmissionDependent.create_qualifying_dependent(submission, dependent)
         expect(eligibility_double).to have_received(:qualifying_eitc?).exactly(1).times


### PR DESCRIPTION
Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>