### PR TITLE
Try to speed up notifications page a little

### DIFF
--- a/app/models/tax_return_selection.rb
+++ b/app/models/tax_return_selection.rb
@@ -11,6 +11,6 @@ class TaxReturnSelection < ApplicationRecord
   has_many :tax_returns, through: :tax_return_selection_tax_returns
 
   def clients
-    Client.joins(:tax_returns).where(tax_returns: { id: tax_returns.pluck(:id) }).distinct
+    Client.joins(:tax_returns).where(tax_returns: { id: tax_returns.select(:id) }).distinct
   end
 end

--- a/app/views/hub/user_notifications/_bulk_client_message.html.erb
+++ b/app/views/hub/user_notifications/_bulk_client_message.html.erb
@@ -28,24 +28,24 @@
       </p>
     <% end %>
 
-    <% if notification.notifiable.clients_with_successfully_sent_messages.size > 0 %>
+    <% if (count = notification.notifiable.clients_with_successfully_sent_messages.size) > 0 %>
       <p class="succeeded">
         <%= t(".succeeded_body_html",
               tax_return_selection_link:
             link_to(
-              t("hub.clients.count", count: notification.notifiable.clients_with_successfully_sent_messages.size),
+              t("hub.clients.count", count: count),
               hub_bulk_client_message_path(id: notification.notifiable.id, status: BulkClientMessage::SUCCEEDED)
             )
         ) %>
       </p>
     <% end %>
 
-    <% if notification.notifiable.clients_with_no_successfully_sent_messages.size > 0 %>
+    <% if (count = notification.notifiable.clients_with_no_successfully_sent_messages.size) > 0 %>
       <p class="failed">
         <%= t(".failed_body_html",
               tax_return_selection_link:
                 link_to(
-                  t("hub.clients.count", count: notification.notifiable.clients_with_no_successfully_sent_messages.size),
+                  t("hub.clients.count", count: count),
                   hub_bulk_client_message_path(id: notification.notifiable.id, status: BulkClientMessage::FAILED)
                 )
             ) %>


### PR DESCRIPTION
TaxReturnSelection#clients uses inner-selects rather then sending arrays of IDs Convert some double-counts into single-counts in the template

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>