### PR TITLE
Procfile: use 'exec' for web, worker, etc

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 // Deployment procfile for Aptible and Heroku
-web: bundle exec rails s -b 0.0.0.0 -p ${PORT:-3000}
-worker: bundle exec rails jobs:work
+web: exec bin/rails s -b 0.0.0.0 -p ${PORT:-3000}
+worker: exec bin/rails jobs:work
 cron: exec supercronic /app/crontab
-release: bin/rails heroku:release
+release: exec bin/rails heroku:release


### PR DESCRIPTION
we think this will make the worker more responsive to signals, such as during a deploy, and maybe more likely to unlock Delayed::Job rows.

Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>