### PR TITLE
Show middle initial for primary and spouse in CTC client portal and rename full_name methods to more accurate

### DIFF
--- a/app/controllers/ctc/questions/remove_spouse_controller.rb
+++ b/app/controllers/ctc/questions/remove_spouse_controller.rb
@@ -7,7 +7,7 @@ module Ctc
       layout "intake"
 
       def edit
-        redirect_to next_path unless current_intake.spouse_full_name.present?
+        redirect_to next_path unless current_intake.spouse_first_and_last_name.present?
 
         super
       end

--- a/app/controllers/documents/document_upload_question_controller.rb
+++ b/app/controllers/documents/document_upload_question_controller.rb
@@ -85,7 +85,7 @@ module Documents
     end
 
     def set_filer_names
-      @names = [current_intake.primary_full_name]
+      @names = [current_intake.primary_first_and_last_name]
       if current_intake.filing_joint_yes?
         @names << current_intake.spouse_name_or_placeholder
       end

--- a/app/controllers/documents/ssn_itins_controller.rb
+++ b/app/controllers/documents/ssn_itins_controller.rb
@@ -9,7 +9,7 @@ module Documents
     private
 
     def set_household_names
-      @names = [current_intake.primary_full_name]
+      @names = [current_intake.primary_first_and_last_name]
       if current_intake.filing_joint_yes?
         @names << current_intake.spouse_name_or_placeholder
       end

--- a/app/lib/consent_pdf.rb
+++ b/app/lib/consent_pdf.rb
@@ -20,8 +20,8 @@ class ConsentPdf
   def hash_for_pdf
     return {} unless @intake.primary_consented_to_service_at.present?
     data = {
-      primary_name: @intake.primary_full_name,
-      primary_signature: @intake.primary_full_name,
+      primary_name: @intake.primary_first_and_last_name,
+      primary_signature: @intake.primary_first_and_last_name,
       primary_consented_at: strftime_date(@intake.primary_consented_to_service_at),
       primary_consented_ip: @intake.primary_consented_to_service_ip,
       primary_dob: strftime_date(@intake.primary_birth_date),
@@ -31,8 +31,8 @@ class ConsentPdf
     }
     if @intake.spouse_consented_to_service_at.present?
       data.merge!(
-        spouse_name: @intake.spouse_full_name,
-        spouse_signature: @intake.spouse_full_name,
+        spouse_name: @intake.spouse_first_and_last_name,
+        spouse_signature: @intake.spouse_first_and_last_name,
         spouse_consented_at: strftime_date(@intake.spouse_consented_to_service_at),
         spouse_consented_ip: @intake.spouse_consented_to_service_ip,
         spouse_dob: strftime_date(@intake.spouse_birth_date),

--- a/app/lib/f15080_vita_consent_to_disclose_pdf.rb
+++ b/app/lib/f15080_vita_consent_to_disclose_pdf.rb
@@ -21,12 +21,12 @@ class F15080VitaConsentToDisclosePdf
     return {} unless @intake.primary_consented_to_service_at.present?
 
     data = {
-        primary_legal_name: @intake.primary_full_name,
+        primary_legal_name: @intake.primary_first_and_last_name,
         primary_consented_at: strftime_date(@intake.primary_consented_to_service_at),
     }
     if @intake.spouse_consented_to_service_at.present?
       data.merge!(
-        spouse_legal_name: @intake.spouse_full_name,
+        spouse_legal_name: @intake.spouse_first_and_last_name,
         spouse_consented_at: strftime_date(@intake.spouse_consented_to_service_at),
       )
     end

--- a/app/lib/irs1040_schedule_eic_pdf.rb
+++ b/app/lib/irs1040_schedule_eic_pdf.rb
@@ -12,7 +12,7 @@ class Irs1040ScheduleEicPdf
 
   def hash_for_pdf
     answers = {
-      FullPrimaryName: @intake.primary_full_name,
+      FullPrimaryName: @intake.primary_first_and_last_name,
       PrimarySSN: @intake.primary_ssn
     }
     dependent_nodes = @xml_document.search("QualifyingChildInformation")

--- a/app/lib/irs8812_ty2021_pdf.rb
+++ b/app/lib/irs8812_ty2021_pdf.rb
@@ -6,10 +6,10 @@ class Irs8812Ty2021Pdf
   end
 
   def initialize(submission)
-    @full_names = [submission.intake.primary_full_name]
+    @full_names = [submission.intake.primary_first_and_last_name]
     @ssn = submission.intake.primary_ssn
     if submission.tax_return.filing_jointly?
-      @full_names << submission.intake.spouse_full_name
+      @full_names << submission.intake.spouse_first_and_last_name
     end
     @xml_document = SubmissionBuilder::Ty2021::Documents::Schedule8812.new(submission).document
   end

--- a/app/lib/submission_builder/ty2021/documents/schedule_lep.rb
+++ b/app/lib/submission_builder/ty2021/documents/schedule_lep.rb
@@ -9,7 +9,7 @@ module SubmissionBuilder
         def document
           intake = submission.intake
           build_xml_doc("IRS1040ScheduleLEP", documentId: "IRS1040ScheduleLEP", documentName: "IRS1040ScheduleLEP") do |xml|
-            xml.PersonNm person_name_type(intake.primary_full_name, length: 35)
+            xml.PersonNm person_name_type(intake.primary_first_and_last_name, length: 35)
             xml.SSN intake.primary_ssn
             xml.LanguagePreferenceCd intake.irs_language_preference_code
           end

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -421,14 +421,26 @@ class Intake < ApplicationRecord
     PhoneParser.normalize(sms_phone_number)
   end
 
-  def primary_full_name
+  def primary_first_and_last_name
     parts = [primary_first_name, primary_last_name]
     parts << primary_suffix if primary_suffix.present?
     parts.join(' ')
   end
 
-  def spouse_full_name
+  def primary_full_name
+    parts = [primary_first_name, primary_middle_initial, primary_last_name]
+    parts << primary_suffix if primary_suffix.present?
+    parts.join(' ')
+  end
+
+  def spouse_first_and_last_name
     parts = [spouse_first_name, spouse_last_name]
+    parts << spouse_suffix if spouse_suffix.present?
+    parts.join(' ')
+  end
+
+  def spouse_full_name
+    parts = [spouse_first_name, spouse_middle_initial, spouse_last_name]
     parts << spouse_suffix if spouse_suffix.present?
     parts.join(' ')
   end
@@ -450,12 +462,12 @@ class Intake < ApplicationRecord
 
   def spouse_name_or_placeholder
     return I18n.t("models.intake.your_spouse") unless spouse_first_name.present?
-    spouse_full_name
+    spouse_first_and_last_name
   end
 
   def student_names
     names = []
-    names << primary_full_name if was_full_time_student_yes?
+    names << primary_first_and_last_name if was_full_time_student_yes?
     names << spouse_name_or_placeholder if spouse_was_full_time_student_yes?
     names += dependents.where(was_student: "yes").map(&:full_name)
     names

--- a/app/views/ctc/portal/primary_filer/edit.html.erb
+++ b/app/views/ctc/portal/primary_filer/edit.html.erb
@@ -29,7 +29,7 @@
           <%= f.cfa_select(:primary_tin_type, t('views.ctc.portal.primary_filer.form_of_identity'), tin_options_for_select(include_itin: true), help_text: t('views.ctc.portal.primary_filer.form_of_identity_note')) %>
           <%= f.cfa_input_field(:primary_ssn, t("views.ctc.questions.legal_consent.ssn"), classes: ["form-width--long"], options: { maxlength: 11, 'data-mask': '000-00-0000'  }) %>
           <%= f.cfa_input_field(:primary_ssn_confirmation, t("views.ctc.questions.legal_consent.ssn_confirmation"), classes: ["form-width--long"], options: { maxlength: 11, 'data-mask': '000-00-0000' }) %>
-          <%= f.cfa_input_field(:primary_ip_pin, t("views.ctc.questions.ip_pin_entry.label", name: current_intake.primary_full_name), type: "tel", classes: ["form-width--long"]) %>
+          <%= f.cfa_input_field(:primary_ip_pin, t("views.ctc.questions.ip_pin_entry.label", name: current_intake.primary_first_and_last_name), type: "tel", classes: ["form-width--long"]) %>
         </div>
 
         <%= f.continue t("general.save") %>

--- a/app/views/ctc/portal/spouse/edit.html.erb
+++ b/app/views/ctc/portal/spouse/edit.html.erb
@@ -28,7 +28,7 @@
           <%= f.cfa_checkbox(:ssn_no_employment, t('views.ctc.shared.ssn_not_valid_for_employment'), options: { checked_value: "yes", unchecked_value: "no" }) %>
           <%= f.cfa_input_field(:spouse_ssn, t("views.ctc.questions.spouse_info.spouse_ssn_itin"), classes: ["form-width--long"], options: { maxlength: 11, 'data-mask': '000-00-0000' }) %>
           <%= f.cfa_input_field(:spouse_ssn_confirmation, t("views.ctc.questions.spouse_info.spouse_ssn_itin_confirmation"), classes: ["form-width--long"], options: { maxlength: 11, 'data-mask': '000-00-0000' }) %>
-          <%= f.cfa_input_field(:spouse_ip_pin, t("views.ctc.questions.ip_pin_entry.label", name: current_intake.spouse_full_name), type: "tel", classes: ["form-width--long"]) %>
+          <%= f.cfa_input_field(:spouse_ip_pin, t("views.ctc.questions.ip_pin_entry.label", name: current_intake.spouse_first_and_last_name), type: "tel", classes: ["form-width--long"]) %>
         </div>
 
         <%= f.submit t("general.save"), class: "button button--primary button--wide spacing-below-15" %>

--- a/app/views/ctc/questions/confirm_information/_primary_filer_info.html.erb
+++ b/app/views/ctc/questions/confirm_information/_primary_filer_info.html.erb
@@ -5,7 +5,7 @@
       <icon class="icon-person"></icon>
     </div>
     <div>
-      <div class="review-box__name"><%= intake.primary_full_name %></div>
+      <div class="review-box__name"><%= intake.primary_first_and_last_name %></div>
       <div class="review-box__details"><%= t("hub.clients.show.date_of_birth") %>: <%= default_date_format(intake.primary_birth_date) %></div>
       <div class="review-box__details"><%= t("general.email") %>: <%= intake.email_address %></div>
       <div class="review-box__details"><%= t("general.phone") %>: <%= intake.formatted_phone_number %></div>

--- a/app/views/ctc/questions/confirm_information/edit.html.erb
+++ b/app/views/ctc/questions/confirm_information/edit.html.erb
@@ -54,9 +54,9 @@
 
   <%= form_with model: @form, url: current_path, local: true, method: "put", builder: VitaMinFormBuilder, html: { class: "form-card form-card--long" } do |f| %>
     <p class="spacing-below-35"><%= t("views.ctc.questions.confirm_information.pin_help_text") %></p>
-    <%= f.cfa_input_field(:primary_signature_pin, t("views.ctc.questions.confirm_information.labels.signature_pin", name: current_intake.primary_full_name), options: { maxlength: 5 }, type: "tel", classes: ["form-width--long"]) %>
+    <%= f.cfa_input_field(:primary_signature_pin, t("views.ctc.questions.confirm_information.labels.signature_pin", name: current_intake.primary_first_and_last_name), options: { maxlength: 5 }, type: "tel", classes: ["form-width--long"]) %>
     <% if current_intake.filing_jointly? %>
-      <%= f.cfa_input_field(:spouse_signature_pin, t("views.ctc.questions.confirm_information.labels.signature_pin", name: current_intake.spouse_full_name), options: { maxlength: 5 }, type: "tel", classes: ["form-width--long"]) %>
+      <%= f.cfa_input_field(:spouse_signature_pin, t("views.ctc.questions.confirm_information.labels.signature_pin", name: current_intake.spouse_first_and_last_name), options: { maxlength: 5 }, type: "tel", classes: ["form-width--long"]) %>
     <% end %>
 
     <%= f.submit(t("general.continue"), class: "button button--primary button--wide spacing-above-60", disabled: @submit_disabled) %>

--- a/app/views/ctc/questions/ip_pin/edit.html.erb
+++ b/app/views/ctc/questions/ip_pin/edit.html.erb
@@ -14,9 +14,9 @@
 
   <%= form_with model: @form, url: current_path, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
     <div class="form-card__stacked-checkboxes spacing-above-0 spacing-below-15">
-      <%= f.cfa_checkbox(:has_primary_ip_pin, current_intake.primary_full_name, options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <%= f.cfa_checkbox(:has_primary_ip_pin, current_intake.primary_first_and_last_name, options: { checked_value: "yes", unchecked_value: "no" }) %>
       <% if current_intake.client.tax_returns.last.filing_status_married_filing_jointly? %>
-        <%= f.cfa_checkbox(:has_spouse_ip_pin, current_intake.spouse_full_name, options: { checked_value: "yes", unchecked_value: "no" }) %>
+        <%= f.cfa_checkbox(:has_spouse_ip_pin, current_intake.spouse_first_and_last_name, options: { checked_value: "yes", unchecked_value: "no" }) %>
       <% end %>
       <%= f.fields_for :dependents do |ff| %>
         <% if Efile::DependentEligibility::Eligibility.new(ff.object, TaxReturn.current_tax_year).test_results.values.any? %>

--- a/app/views/ctc/questions/ip_pin_entry/edit.html.erb
+++ b/app/views/ctc/questions/ip_pin_entry/edit.html.erb
@@ -9,8 +9,8 @@
 
   <%= form_with model: @form, url: current_path, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
     <div class="form-card__stacked-checkboxes spacing-above-0 spacing-below-15">
-      <%= f.cfa_input_field(:primary_ip_pin, t("views.ctc.questions.ip_pin_entry.label", name: current_intake.primary_full_name), options: { maxlength: 6 }, type: "tel") if current_intake.has_primary_ip_pin_yes? %>
-      <%= f.cfa_input_field(:spouse_ip_pin, t("views.ctc.questions.ip_pin_entry.label", name: current_intake.spouse_full_name), options: { maxlength: 6 }, type: "tel") if current_intake.has_spouse_ip_pin_yes? %>
+      <%= f.cfa_input_field(:primary_ip_pin, t("views.ctc.questions.ip_pin_entry.label", name: current_intake.primary_first_and_last_name), options: { maxlength: 6 }, type: "tel") if current_intake.has_primary_ip_pin_yes? %>
+      <%= f.cfa_input_field(:spouse_ip_pin, t("views.ctc.questions.ip_pin_entry.label", name: current_intake.spouse_first_and_last_name), options: { maxlength: 6 }, type: "tel") if current_intake.has_spouse_ip_pin_yes? %>
       <%= f.fields_for :dependents do |ff| %>
         <%= ff.cfa_input_field(:ip_pin, t("views.ctc.questions.ip_pin_entry.label", name: ff.object.full_name)) %>
       <% end %>

--- a/app/views/ctc/questions/remove_spouse/edit.html.erb
+++ b/app/views/ctc/questions/remove_spouse/edit.html.erb
@@ -1,4 +1,4 @@
-<% @main_heading = t("views.ctc.questions.remove_spouse.title_html", spouse_name: current_intake.spouse_full_name) %>
+<% @main_heading = t("views.ctc.questions.remove_spouse.title_html", spouse_name: current_intake.spouse_first_and_last_name) %>
 <% content_for :form_question, @main_heading %>
 
 <% content_for :form_card do %>

--- a/app/views/ctc/questions/spouse_info/edit.html.erb
+++ b/app/views/ctc/questions/spouse_info/edit.html.erb
@@ -32,7 +32,7 @@
       <%= image_tag("file-person.svg", alt: "") %>
       <%=t("views.ctc.questions.spouse_info.save_button") %>
     </button>
-    <% if current_intake.spouse_full_name.present? %>
+    <% if current_intake.spouse_first_and_last_name.present? %>
       <%= link_to questions_remove_spouse_path, class: "button button--wide button--danger text--centered" do %>
         <%= image_tag("remove-minus.svg", alt: "") %>
         <%= t("views.ctc.questions.spouse_info.remove_button") %>

--- a/app/views/ctc/questions/spouse_review/edit.html.erb
+++ b/app/views/ctc/questions/spouse_review/edit.html.erb
@@ -13,7 +13,7 @@
       <div class="review-box__person">
         <div><icon class="icon-person"></icon></div>
         <div>
-          <div class="review-box__name"><%= current_intake&.spouse_full_name %></div>
+          <div class="review-box__name"><%= current_intake&.spouse_first_and_last_name %></div>
           <div class="review-box__details"><%=t("views.ctc.questions.spouse_review.spouse_birthday", dob: default_date_format(current_intake&.spouse_birth_date)) %></div>
           <div class="review-box__details"><%=t("views.ctc.questions.spouse_review.spouse_ssn", ssn: current_intake&.spouse_last_four_ssn) %></div>
         </div>

--- a/spec/lib/irs8812_ty2021_pdf_spec.rb
+++ b/spec/lib/irs8812_ty2021_pdf_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Irs8812Ty2021Pdf do
         output_file = pdf.output_file
         result = filled_in_values(output_file.path)
         expect(result).to match(hash_including(
-                                  "FullPrimaryName" => submission.intake.primary_full_name,
+                                  "FullPrimaryName" => submission.intake.primary_first_and_last_name,
                                   "PrimarySSN" => submission.intake.primary_ssn,
                                   "AdjustedGrossIncomeAmt1" => "0", # 1
                                   "PRExcludedIncomeAmt2a" => "0", # 2a
@@ -130,7 +130,7 @@ RSpec.describe Irs8812Ty2021Pdf do
         output_file = pdf.output_file
         result = filled_in_values(output_file.path)
         expect(result).to match(hash_including(
-          "FullPrimaryName" => [submission.intake.primary_full_name, "Spouser Spouseperson"].join(', '),
+          "FullPrimaryName" => [submission.intake.primary_first_and_last_name, "Spouser Spouseperson"].join(', '),
           "PrimarySSN" => submission.intake.primary_ssn,
         ))
       end


### PR DESCRIPTION
Co-authored-by: Maria Quadri <mquadri@codeforamerica.org>