### PR TITLE
Hub notifications page: cache client counts on bulk client messages

### DIFF
--- a/app/controllers/hub/user_notifications_controller.rb
+++ b/app/controllers/hub/user_notifications_controller.rb
@@ -4,16 +4,23 @@ module Hub
     before_action :require_sign_in
     layout "hub"
 
+    after_action :flush_memoized_data, only: [:index]
+
     def index
       @page_title = I18n.t("hub.clients.navigation.notifications")
       @user_notifications = current_user.notifications.order(created_at: :desc).page(params[:page])
-      @user_notifications.each(&:flush_memoized_data)
     end
 
     def mark_all_notifications_read
       current_user.notifications.unread.update_all(read: true)
 
       redirect_to hub_user_notifications_path
+    end
+
+    private
+
+    def flush_memoized_data
+      @user_notifications.each(&:flush_memoized_data) if @user_notifications
     end
   end
 end

--- a/spec/controllers/hub/user_notifications_controller_spec.rb
+++ b/spec/controllers/hub/user_notifications_controller_spec.rb
@@ -43,9 +43,23 @@ RSpec.describe Hub::UserNotificationsController, type: :controller do
         let(:bulk_client_message) { create :bulk_client_message }
         let!(:notification) { create :user_notification, user: user, notifiable: bulk_client_message }
         before do
-          allow_any_instance_of(BulkClientMessage).to receive(:clients_with_no_successfully_sent_messages).and_return Client.where(id: failed_clients)
-          allow_any_instance_of(BulkClientMessage).to receive(:clients_with_successfully_sent_messages).and_return Client.where(id: successful_clients)
-          allow_any_instance_of(BulkClientMessage).to receive(:clients_with_in_progress_messages).and_return Client.where(id: in_progress_clients)
+          @expensive_call_count = 0
+          allow_any_instance_of(BulkClientMessage).to receive(:clients_with_no_successfully_sent_messages) do
+            @expensive_call_count += 1
+            Client.where(id: failed_clients)
+          end
+          allow_any_instance_of(BulkClientMessage).to receive(:clients_with_successfully_sent_messages) do
+            @expensive_call_count += 1
+            Client.where(id: successful_clients)
+          end
+          allow_any_instance_of(BulkClientMessage).to receive(:clients_with_in_progress_messages) do
+            @expensive_call_count += 1
+            Client.where(id: in_progress_clients)
+          end
+          allow_any_instance_of(BulkClientMessage).to receive(:clients).and_wrap_original do |original_method, *args, &b|
+            @expensive_call_count += 1
+            original_method.call(*args, &b)
+          end
         end
 
         context "with any number of failed clients" do
@@ -84,18 +98,10 @@ RSpec.describe Hub::UserNotificationsController, type: :controller do
             end
 
             describe 'caching' do
-              before do
-                @expensive_call_count = 0
-                allow_any_instance_of(BulkClientMessage).to receive(:clients_with_no_successfully_sent_messages).and_wrap_original do |original_method, *args, &b|
-                  @expensive_call_count += 1
-                  original_method.call(*args, &b)
-                end
-              end
-
               it "flushes cached counts so subsequent requests are faster" do
                 expect do
                   get :index
-                end.to change { @expensive_call_count }.from(0).to(1)
+                end.to change { @expensive_call_count }
 
                 expect do
                   get :index
@@ -136,22 +142,14 @@ RSpec.describe Hub::UserNotificationsController, type: :controller do
             end
 
             describe 'caching' do
-              before do
-                @expensive_call_count = 0
-                allow_any_instance_of(BulkClientMessage).to receive(:clients_with_no_successfully_sent_messages).and_wrap_original do |original_method, *args, &b|
-                  @expensive_call_count += 1
-                  original_method.call(*args, &b)
-                end
-              end
-
               it "does not flush cached counts because they still might change" do
                 expect do
                   get :index
-                end.to change { @expensive_call_count }.by(1)
+                end.to change { @expensive_call_count }
 
                 expect do
                   get :index
-                end.to change { @expensive_call_count }.by(1)
+                end.to change { @expensive_call_count }
               end
             end
           end


### PR DESCRIPTION
we were calling the cache flush too early!! after render is better!!

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>