### PR TITLE
ApplicationCable: rescue and ignore warden UncaughtThrowError

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -8,6 +8,12 @@ module ApplicationCable
 
     def current_user
       @current_user ||= env['warden'].user
+    rescue UncaughtThrowError => e
+      raise unless e.tag == 'warden'
+
+      # 'uncaught throw :warden' is fired in certain circumstances, this here is to silence it
+      DatadogApi.increment "application_cable.uncaught_throw_warden_error"
+      reject_unauthorized_connection
     end
   end
 end

--- a/spec/channels/application_cable/connection_spec.rb
+++ b/spec/channels/application_cable/connection_spec.rb
@@ -24,5 +24,24 @@ RSpec.describe ApplicationCable::Connection, type: :channel do
       expect { connect "/cable" }.not_to raise_error
       expect(connection.current_user).to eq(user)
     end
+
+    context 'if an UncaughtThrowError occurs' do
+      include MockDogapi
+
+      before do
+        enable_datadog_and_stub_emit_point
+        allow(warden).to receive(:user) do
+          throw 'warden'
+        end
+      end
+
+      it "avoids the crash and increments a datadog metric" do
+        expect { connect "/cable" }.to raise_error(ActionCable::Connection::Authorization::UnauthorizedError)
+
+        expect(@emit_point_params).to eq([
+                                           ["vita-min.dogapi.application_cable.uncaught_throw_warden_error", 1, {:tags=>["env:test"], :type=>"count"}]
+                                         ])
+      end
+    end
   end
 end


### PR DESCRIPTION
We've been silencing this in Sentry for months and not doing anything about it, so this is doing something (?) about it

It seems to have been caused by bumping some gems a couple months ago, but it's not certain which gem or whether that's really true