### PR TITLE
oneliner script in `bin/` to start `foreman` but without the server

### DIFF
--- a/bin/foreman_except_server
+++ b/bin/foreman_except_server
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+foreman start -m all=1,server=0


### PR DESCRIPTION
It's easier to do command line debuggery things if `rails s` is running outside of foreman

I can never remember the syntax to do this myself so committing it means the computer can remember instead