### PR TITLE
ActcWithoutDependents offboarding requires authentication

### DIFF
--- a/app/controllers/ctc/offboarding/actc_without_dependents_controller.rb
+++ b/app/controllers/ctc/offboarding/actc_without_dependents_controller.rb
@@ -1,6 +1,8 @@
 module Ctc
   module Offboarding
     class ActcWithoutDependentsController < CtcController
+      include AuthenticatedCtcClientConcern
+
       helper_method :illustration_path, :illustration_folder, :prev_path
 
       layout "intake"


### PR DESCRIPTION
Because the view needs a current_intake to be present