### PR TITLE
EITC W2s: split up the flow into four pages

### DIFF
--- a/app/controllers/ctc/portal/base_intake_revision_controller.rb
+++ b/app/controllers/ctc/portal/base_intake_revision_controller.rb
@@ -8,10 +8,7 @@ class Ctc::Portal::BaseIntakeRevisionController < Ctc::Portal::BaseAuthenticated
     @form = form_class.new(current_model, form_params)
     if @form.valid?
       @form.save
-      SystemNote::CtcPortalUpdate.generate!(
-        model: current_model,
-        client: current_client,
-      )
+      generate_system_note
       redirect_to next_path
     else
       render edit_template
@@ -29,6 +26,13 @@ class Ctc::Portal::BaseIntakeRevisionController < Ctc::Portal::BaseAuthenticated
   helper_method :prev_path
 
   private
+
+  def generate_system_note
+    SystemNote::CtcPortalUpdate.generate!(
+      model: current_model,
+      client: current_client,
+    )
+  end
 
   def next_path
     Ctc::Portal::PortalController.to_path_helper(action: :edit_info)

--- a/app/controllers/ctc/portal/w2s/employee_info_controller.rb
+++ b/app/controllers/ctc/portal/w2s/employee_info_controller.rb
@@ -4,17 +4,6 @@ class Ctc::Portal::W2s::EmployeeInfoController < Ctc::Portal::BaseIntakeRevision
     render edit_template
   end
 
-  def update
-    @form = form_class.new(current_model, form_params)
-    if @form.valid?
-      @form.save
-      generate_system_note
-      redirect_to next_path
-    else
-      render edit_template
-    end
-  end
-
   private
 
   def generate_system_note
@@ -53,6 +42,6 @@ class Ctc::Portal::W2s::EmployeeInfoController < Ctc::Portal::BaseIntakeRevision
   end
 
   def next_path
-    Ctc::Portal::W2s::EmployerInfoController.to_path_helper(action: :edit, id: current_model.id)
+    Ctc::Portal::W2s::WagesInfoController.to_path_helper(action: :edit, id: current_model.id)
   end
 end

--- a/app/controllers/ctc/portal/w2s/employer_info_controller.rb
+++ b/app/controllers/ctc/portal/w2s/employer_info_controller.rb
@@ -1,6 +1,4 @@
 class Ctc::Portal::W2s::EmployerInfoController < Ctc::Portal::BaseIntakeRevisionController
-  before_action :set_continue_label
-
   def edit
     @form = form_class.from_w2(current_model)
     render edit_template
@@ -20,12 +18,7 @@ class Ctc::Portal::W2s::EmployerInfoController < Ctc::Portal::BaseIntakeRevision
     @_current_model ||= current_intake.w2s.find(params[:id])
   end
 
-  def set_continue_label
-    # using presence of required field to ascertain whether this is a new W-2
-    if current_model.employer_name.present?
-      @continue_label = t("views.ctc.portal.w2s.employer_info.update_w2")
-    else
-      @continue_label = t("views.ctc.questions.w2s.employer_info.add")
-    end
+  def next_path
+    Ctc::Portal::W2s::MiscInfoController.to_path_helper(action: :edit, id: current_model.id)
   end
 end

--- a/app/controllers/ctc/portal/w2s/misc_info_controller.rb
+++ b/app/controllers/ctc/portal/w2s/misc_info_controller.rb
@@ -1,0 +1,30 @@
+class Ctc::Portal::W2s::MiscInfoController < Ctc::Portal::BaseIntakeRevisionController
+  before_action :set_continue_label
+
+  def edit
+    @form = form_class.from_w2(current_model)
+    render edit_template
+  end
+
+  private
+
+  def edit_template
+    "ctc/questions/w2s/misc_info/edit"
+  end
+
+  def form_class
+    Ctc::W2s::MiscInfoForm
+  end
+
+  def current_model
+    @_current_model ||= current_intake.w2s.find(params[:id])
+  end
+
+  def set_continue_label
+    if current_model.completed_at.present?
+      @continue_label = t("views.ctc.portal.w2s.employer_info.update_w2")
+    else
+      @continue_label = t("views.ctc.questions.w2s.employer_info.add")
+    end
+  end
+end

--- a/app/controllers/ctc/portal/w2s/wages_info_controller.rb
+++ b/app/controllers/ctc/portal/w2s/wages_info_controller.rb
@@ -1,0 +1,24 @@
+class Ctc::Portal::W2s::WagesInfoController < Ctc::Portal::BaseIntakeRevisionController
+  def edit
+    @form = form_class.from_w2(current_model)
+    render edit_template
+  end
+
+  private
+
+  def edit_template
+    "ctc/questions/w2s/wages_info/edit"
+  end
+
+  def form_class
+    Ctc::W2s::WagesInfoForm
+  end
+
+  def next_path
+    Ctc::Portal::W2s::EmployerInfoController.to_path_helper(action: :edit, id: current_model.id)
+  end
+
+  def current_model
+    @_current_model ||= current_intake.w2s.find(params[:id])
+  end
+end

--- a/app/controllers/ctc/questions/w2s/base_w2_controller.rb
+++ b/app/controllers/ctc/questions/w2s/base_w2_controller.rb
@@ -55,6 +55,10 @@ module Ctc
         def remember_last_edited_w2_id
           session[:last_edited_w2_id] = @w2&.id
         end
+
+        def illustration_path
+          "documents.svg"
+        end
       end
     end
   end

--- a/app/controllers/ctc/questions/w2s/employee_info_controller.rb
+++ b/app/controllers/ctc/questions/w2s/employee_info_controller.rb
@@ -13,12 +13,6 @@ module Ctc
                            end
                          end
         end
-
-        private
-
-        def illustration_path
-          "documents.svg"
-        end
       end
     end
   end

--- a/app/controllers/ctc/questions/w2s/misc_info_controller.rb
+++ b/app/controllers/ctc/questions/w2s/misc_info_controller.rb
@@ -1,0 +1,15 @@
+module Ctc
+  module Questions
+    module W2s
+      class MiscInfoController < BaseW2Controller
+        before_action :set_continue_label
+
+        private
+
+        def set_continue_label
+          @continue_label = t("views.ctc.questions.w2s.misc_info.submit")
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/ctc/questions/w2s/wages_info_controller.rb
+++ b/app/controllers/ctc/questions/w2s/wages_info_controller.rb
@@ -1,7 +1,7 @@
 module Ctc
   module Questions
     module W2s
-      class EmployerInfoController < BaseW2Controller
+      class WagesInfoController < BaseW2Controller
       end
     end
   end

--- a/app/forms/ctc/w2s/employee_info_form.rb
+++ b/app/forms/ctc/w2s/employee_info_form.rb
@@ -3,10 +3,7 @@ module Ctc
     class EmployeeInfoForm < W2Form
       set_attributes_for(
         :w2,
-        :wages_amount,
-        :federal_income_tax_withheld,
         :employee_street_address,
-        :employee_street_address2,
         :employee_city,
         :employee_state,
         :employee_zip_code,
@@ -15,9 +12,6 @@ module Ctc
 
       validates :employee, presence: true, inclusion: { in: W2.employees.keys - ['unfilled'], allow_blank: true }
       validates :employee_street_address, irs_street_address_type: true
-      validates :employee_street_address2, irs_street_address_type: true, allow_blank: true
-      validates :wages_amount, gyr_numericality: true, presence: true
-      validates :federal_income_tax_withheld, gyr_numericality: true, presence: true
       validates :employee_city, presence: true, format: { with: /\A([A-Za-z] ?)*[A-Za-z]\z/, message: -> (*_args) { I18n.t('validators.alpha') }}
       validates :employee_state, presence: true, inclusion: { in: States.keys }
       validates :employee_zip_code, presence: true, format: { with: /\A[0-9]{5}(([0-9]{4})|([0-9]{7}))?\z/, message: -> (*_args) { I18n.t('validators.zip_code_with_optional_extra_digits') } }

--- a/app/forms/ctc/w2s/misc_info_form.rb
+++ b/app/forms/ctc/w2s/misc_info_form.rb
@@ -1,0 +1,15 @@
+module Ctc
+  module W2s
+    class MiscInfoForm < W2Form
+      set_attributes_for(
+        :w2,
+      )
+
+      def save
+        extra_attributes = w2.completed_at.nil? ? {completed_at: DateTime.now} : {}
+        @w2.assign_attributes(attributes_for(:w2).merge(extra_attributes))
+        @w2.save!
+      end
+    end
+  end
+end

--- a/app/forms/ctc/w2s/wages_info_form.rb
+++ b/app/forms/ctc/w2s/wages_info_form.rb
@@ -1,0 +1,14 @@
+module Ctc
+  module W2s
+    class WagesInfoForm < W2Form
+      set_attributes_for(
+        :w2,
+        :wages_amount,
+        :federal_income_tax_withheld,
+      )
+
+      validates :wages_amount, gyr_numericality: true, presence: true
+      validates :federal_income_tax_withheld, gyr_numericality: true, presence: true
+    end
+  end
+end

--- a/app/lib/ctc_question_navigation.rb
+++ b/app/lib/ctc_question_navigation.rb
@@ -62,7 +62,9 @@ class CtcQuestionNavigation
     # Looping W2 flow for EITC
     Ctc::Questions::W2sController,
     Ctc::Questions::W2s::EmployeeInfoController,
+    Ctc::Questions::W2s::WagesInfoController,
     Ctc::Questions::W2s::EmployerInfoController,
+    Ctc::Questions::W2s::MiscInfoController,
     Ctc::Questions::ConfirmW2sController,
 
     # EITC income exceptions

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -437,7 +437,7 @@ class Intake::CtcIntake < Intake
   end
 
   def total_wages_amount
-    w2s.sum { |w2| w2.wages_amount.round } if w2s.any?
+    w2s.completed.sum { |w2| w2.wages_amount.round } if w2s.any?
   end
 
   def total_withholding_amount

--- a/app/models/w2.rb
+++ b/app/models/w2.rb
@@ -3,6 +3,7 @@
 # Table name: w2s
 #
 #  id                            :bigint           not null, primary key
+#  completed_at                  :datetime
 #  creation_token                :string
 #  employee                      :integer          default("unfilled"), not null
 #  employee_city                 :string
@@ -31,6 +32,8 @@
 #
 class W2 < ApplicationRecord
   belongs_to :intake
+
+  scope :completed, -> { where.not(completed_at: nil) }
 
   enum employee: { unfilled: 0, primary: 1, spouse: 2 }, _prefix: :employee
 

--- a/app/views/ctc/questions/w2s/employee_info/edit.html.erb
+++ b/app/views/ctc/questions/w2s/employee_info/edit.html.erb
@@ -1,4 +1,4 @@
-<% @main_question = t("views.ctc.questions.w2s.employee_info.title", count: current_intake.filer_count, name: current_intake.primary.first_name) %>
+<% @main_question = t("views.ctc.questions.w2s.employee_info.title", count: current_intake.filer_count, name: current_intake.primary.first_and_last_name) %>
 <% content_for :page_title, @main_question %>
 
 <% content_for :card do %>
@@ -13,10 +13,7 @@
       <%= f.hidden_field :employee, value: 'primary' %>
     <% end %>
 
-    <%= f.cfa_input_field(:wages_amount, t("views.ctc.questions.w2s.employee_info.wages_amount"), classes: ["form-width--long"]) %>
-    <%= f.cfa_input_field(:federal_income_tax_withheld, t("views.ctc.questions.w2s.employee_info.federal_income_tax_withheld"), classes: ["form-width--long"]) %>
     <%= f.cfa_input_field(:employee_street_address, t("views.ctc.questions.w2s.employee_info.employee_street_address"), classes: ["form-width--long"]) %>
-    <%= f.cfa_input_field(:employee_street_address2, t("views.ctc.questions.w2s.employee_info.employee_street_address2"), classes: ["form-width--zip"]) %>
     <%= f.cfa_input_field(:employee_city, t("views.ctc.questions.w2s.employee_info.employee_city"), classes: ["form-width--long"]) %>
     <%= f.cfa_select(:employee_state, t("views.ctc.questions.w2s.employee_info.employee_state"), States.name_value_pairs, include_blank: true) %>
     <%= f.cfa_input_field(:employee_zip_code, t("views.ctc.questions.w2s.employee_info.employee_zip_code"), classes: ["form-width--zip"]) %>

--- a/app/views/ctc/questions/w2s/employer_info/edit.html.erb
+++ b/app/views/ctc/questions/w2s/employer_info/edit.html.erb
@@ -16,6 +16,6 @@
     <%= f.cfa_input_field(:employer_zip_code, t("views.ctc.questions.w2s.employer_info.employer_zip_code"), classes: ["form-width--zip"]) %>
     <%= f.cfa_select(:standard_or_non_standard_code, t("views.ctc.questions.w2s.employer_info.standard_or_non_standard_code"), [%w[S S], %w[N N]]) %>
 
-    <%= f.continue @continue_label %>
+    <%= f.continue %>
   <% end %>
 <% end %>

--- a/app/views/ctc/questions/w2s/misc_info/edit.html.erb
+++ b/app/views/ctc/questions/w2s/misc_info/edit.html.erb
@@ -1,0 +1,11 @@
+<% @main_question = t("views.ctc.questions.w2s.misc_info.title", name: @form.w2.employee_obj.first_and_last_name) %>
+<% content_for :page_title, @main_question %>
+
+<% content_for :card do %>
+  <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder, html: { class: "form-card form-card--long" } do |f| %>
+
+    <h1 class="h2"><%= @main_question %></h1>
+
+    <%= f.continue @continue_label %>
+  <% end %>
+<% end %>

--- a/app/views/ctc/questions/w2s/wages_info/edit.html.erb
+++ b/app/views/ctc/questions/w2s/wages_info/edit.html.erb
@@ -1,0 +1,21 @@
+<% @main_question = t("views.ctc.questions.w2s.wages_info.title", name: @form.w2.employee_obj.first_and_last_name) %>
+<% content_for :page_title, @main_question %>
+
+<% content_for :card do %>
+  <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder, html: { class: "form-card form-card--long" } do |f| %>
+
+    <h1 class="h2"><%= @main_question %></h1>
+
+    <div class="info-box spacing-below-15">
+      <%= image_tag("icons/exclamation-black.svg", alt: "", class: "info-box__title-image") %>
+      <p class="spacing-below-15 text--bold"><%= t("views.ctc.questions.w2s.wages_info.info_box.requirement_title") %></p>
+
+      <div><%= t("views.ctc.questions.w2s.wages_info.info_box.requirement_description_html") %></div>
+    </div>
+
+    <%= f.cfa_input_field(:wages_amount, t("views.ctc.questions.w2s.wages_info.wages_amount"), classes: ["form-width--long"]) %>
+    <%= f.cfa_input_field(:federal_income_tax_withheld, t("views.ctc.questions.w2s.wages_info.federal_income_tax_withheld"), classes: ["form-width--long"]) %>
+
+    <%= f.continue %>
+  <% end %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2702,18 +2702,15 @@ en:
           done_adding: Finished adding all W-2s
           dont_add_w2: I don't want to add any income
           employee_info:
-            employee_city: City
+            employee_city: 'Box e: City'
             employee_legal_name: 'Select the legal name on the W2:'
-            employee_state: State
+            employee_state: 'Box e: State'
             employee_street_address: 'Box e: Employee street address or P.O. box'
-            employee_street_address2: Apartment number (optional)
-            employee_zip_code: Zip code
-            federal_income_tax_withheld: 'Box 2: Federal Income Tax Withheld'
+            employee_zip_code: 'Box e: Zip code'
             help_text: Your W-2 has lettered and numbered boxes. You will match and enter this information below.
             title:
               one: Let’s start by entering some basic info for %{name}.
               other: Let’s start by entering some basic info.
-            wages_amount: 'Box 1: Wages Amount'
           employer_info:
             add: Add W-2
             employer_city: City
@@ -2730,6 +2727,9 @@ en:
               one: A W-2 is an official tax form given to you by your employer. Enter all of your W-2s to get the Earned Income Tax Credit and avoid delays.
               other: A W-2 is an official tax form given to you by your employer. Enter all of you and your spouse’s W-2s to get the Earned Income Tax Credit and avoid delays.
             p2: The form you enter must have W-2 printed on top or it will not be accepted.
+          misc_info:
+            submit: Submit W-2
+            title: Let’s finish entering %{name}’s W-2 information.
           note_html: "<strong>Note:</strong> If you do not add a W-2 you will not receive the Earned Income Tax Credit. However, you can still claim the other credits if available to you."
           reveal:
             content:
@@ -2743,6 +2743,13 @@ en:
             title: What if I have a 1099?
           title: Please share the income from your W-2.
           wages: Wages
+          wages_info:
+            federal_income_tax_withheld: 'Box 2: Federal Income Tax Withheld'
+            info_box:
+              requirement_description_html: Please enter the information <strong>exactly</strong> as it appears on your W-2. If there are blank boxes on your W-2, please leave them blank in the boxes below as well.
+              requirement_title: 'Requirement:'
+            title: Great! Please enter all of %{name}’s wages, tips, and taxes withheld from this W-2.
+            wages_amount: 'Box 1: Wages Amount'
       shared:
         ssn_not_valid_for_employment: This person's SSN card has "Not valid for employment" printed on it. (This is rare)
     ctc_pages:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2662,18 +2662,15 @@ es:
           done_adding: Se ha terminado de añadir todas las formas W-2
           dont_add_w2: No deseo añadir ningún ingreso
           employee_info:
-            employee_city: Ciudad
+            employee_city: 'Casilla e: Ciudad'
             employee_legal_name: 'Seleccione el nombre legal en el W2:'
-            employee_state: Estado
+            employee_state: 'Casilla e: Estado'
             employee_street_address: 'Casilla e: Dirección del empleado o apartado postal'
-            employee_street_address2: Número de apartamento (opcional)
-            employee_zip_code: Código postal
-            federal_income_tax_withheld: 'Casilla 2: Impuesto sobre el impuesto federal retenido'
+            employee_zip_code: 'Casilla e: Código postal'
             help_text: Su forma W-2 tiene casillas con letras y números. A continuación, deberá hacer que coincidan e introducir esta información.
             title:
               one: Comencemos ingresando información básica para %{name}.
               other: Comencemos ingresando información básica.
-            wages_amount: 'Casilla 1: Importe de los salarios'
           employer_info:
             add: Agregar la forma W-2
             employer_city: Ciudad
@@ -2691,6 +2688,9 @@ es:
               one: Un W-2 es una forma oficial de impuestos que le entrega su empleador. Introduzca todos los W-2 suyos y de su cónyuge para obtener el crédito tributario por ingresos del trabajo y evitar retrasos.
               other: La W-2 es una forma oficial de impuestos que le entrega su empleador. Introduzca todos los W-2 suyos y de su cónyuge para obtener el crédito tributario por ingresos del trabajo y evitar retrasos.
             p2: El formulario que introduzca debe tener impreso el W-2 en la parte superior. De otra manera no será aceptado.
+          misc_info:
+            submit: Enviar W-2
+            title: Terminemos de ingresar la información W-2 de %{name}.
           note_html: "<strong>Aviso:</strong> Si no incluye la forma W-2, no recibirá el Crédito Tributario Ingreso del Trabajo. Sin embargo, puede solicitar los demás créditos si están disponibles para usted."
           reveal:
             content:
@@ -2704,6 +2704,13 @@ es:
             title: "¿Qué pasa si tengo una forma 1099?"
           title: Por favor, indique los ingresos de su forma W-2.
           wages: Sueldo
+          wages_info:
+            federal_income_tax_withheld: 'Casilla 2: Impuesto sobre el impuesto federal retenido'
+            info_box:
+              requirement_description_html: Ingrese la información <strong>exactamente</strong> como aparece en su W-2. Si hay casillas en blanco en su W-2, déjelas también en blanco en las casillas a continuación.
+              requirement_title: 'Requisito:'
+            title: "¡Excelente! Ingrese todos los salarios, propinas e impuestos de %{name} retenidos de este W-2."
+            wages_amount: 'Casilla 1: Importe de los salarios'
       shared:
         ssn_not_valid_for_employment: La tarjeta del Número de Seguro Social, o SSN,  de esta persona tiene escrito "No válido para el empleo". (Esto se ve raramente)
     ctc_pages:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -438,8 +438,12 @@ Rails.application.routes.draw do
           resources :w2s do
             get 'w2s-employee-info', on: :member, to: "w2s/employee_info#edit"
             put 'w2s-employee-info', on: :member, to: "w2s/employee_info#update"
+            get 'w2s-wages-info', on: :member, to: "w2s/wages_info#edit"
+            put 'w2s-wages-info', on: :member, to: "w2s/wages_info#update"
             get 'w2s-employer-info', on: :member, to: "w2s/employer_info#edit"
             put 'w2s-employer-info', on: :member, to: "w2s/employer_info#update"
+            get 'w2s-misc-info', on: :member, to: "w2s/misc_info#edit"
+            put 'w2s-misc-info', on: :member, to: "w2s/misc_info#update"
           end
 
           get "verification", to: "verification_attempts#edit", as: "verification_attempt"

--- a/db/migrate/20220921230705_add_completed_at_to_w2s.rb
+++ b/db/migrate/20220921230705_add_completed_at_to_w2s.rb
@@ -1,0 +1,5 @@
+class AddCompletedAtToW2s < ActiveRecord::Migration[7.0]
+  def change
+    add_column :w2s, :completed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_15_232842) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_21_230705) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -1602,6 +1602,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_15_232842) do
   end
 
   create_table "w2s", force: :cascade do |t|
+    t.datetime "completed_at"
     t.datetime "created_at", null: false
     t.string "creation_token"
     t.integer "employee", default: 0, null: false

--- a/spec/factories/w2s.rb
+++ b/spec/factories/w2s.rb
@@ -3,6 +3,7 @@
 # Table name: w2s
 #
 #  id                            :bigint           not null, primary key
+#  completed_at                  :datetime
 #  creation_token                :string
 #  employee                      :integer          default("unfilled"), not null
 #  employee_city                 :string
@@ -46,5 +47,6 @@ FactoryBot.define do
     wages_amount { 100.10 }
     federal_income_tax_withheld { 20.34 }
     standard_or_non_standard_code { "S" }
+    completed_at { DateTime.now }
   end
 end

--- a/spec/features/ctc/eitc_spec.rb
+++ b/spec/features/ctc/eitc_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "CTC Intake", :flow_explorer_screenshot, active_job: true, require
 
     click_on I18n.t('general.back')
 
-    fill_in_w2("Gary", filing_status: 'single')
+    fill_in_w2("Gary Mango III", filing_status: 'single')
 
     expect(page).to have_text(I18n.t('views.ctc.questions.w2s.title'))
     expect(page).to have_text 'lumen inc'

--- a/spec/features/ctc/portal_spec.rb
+++ b/spec/features/ctc/portal_spec.rb
@@ -318,9 +318,15 @@ RSpec.feature "CTC Intake", :js, :active_job, requires_default_vita_partners: tr
         expect(page).to have_selector("h1", text: I18n.t("views.ctc.questions.w2s.employee_info.title", count: 2))
         click_on I18n.t("general.continue")
 
+        expect(page).to have_selector("h1", text: I18n.t("views.ctc.questions.w2s.wages_info.title", name: "Mangonada Mangonada"))
+        click_on I18n.t("general.continue")
+
         expect(page).to have_selector("h1", text: I18n.t("views.ctc.questions.w2s.employer_info.title"))
         expect(page).to have_text(I18n.t("views.ctc.questions.w2s.employer_info.employer_name"))
         fill_in I18n.t("views.ctc.questions.w2s.employer_info.employer_name"), with: "Cod for America"
+        click_on I18n.t("general.continue")
+
+        expect(page).to have_selector("h1", text: I18n.t("views.ctc.questions.w2s.misc_info.title", name: "Mangonada Mangonada"))
         click_on I18n.t("views.ctc.portal.w2s.employer_info.update_w2")
 
         within ".w2s-shared" do
@@ -335,12 +341,15 @@ RSpec.feature "CTC Intake", :js, :active_job, requires_default_vita_partners: tr
 
         expect(page).to have_text(I18n.t('views.ctc.questions.w2s.employee_info.title', count: 2))
         select "Mangonada Mangonada", from: I18n.t("views.ctc.questions.w2s.employee_info.employee_legal_name")
-        fill_in I18n.t('views.ctc.questions.w2s.employee_info.wages_amount'), with: '123.45'
-        fill_in I18n.t('views.ctc.questions.w2s.employee_info.federal_income_tax_withheld'), with: '12.01'
         fill_in I18n.t('views.ctc.questions.w2s.employee_info.employee_street_address'), with: '123 Cool St'
         fill_in I18n.t('views.ctc.questions.w2s.employee_info.employee_city'), with: 'City Town'
         select "California", from: I18n.t('views.ctc.questions.w2s.employee_info.employee_state')
         fill_in I18n.t('views.ctc.questions.w2s.employee_info.employee_zip_code'), with: '94110'
+        click_on I18n.t('general.continue')
+
+        expect(page).to have_text(I18n.t('views.ctc.questions.w2s.wages_info.title', name: "Mangonada Mangonada"))
+        fill_in I18n.t('views.ctc.questions.w2s.wages_info.wages_amount'), with: '123.45'
+        fill_in I18n.t('views.ctc.questions.w2s.wages_info.federal_income_tax_withheld'), with: '12.01'
         click_on I18n.t('general.continue')
 
         expect(page).to have_text(I18n.t('views.ctc.questions.w2s.employer_info.title'))
@@ -351,6 +360,9 @@ RSpec.feature "CTC Intake", :js, :active_job, requires_default_vita_partners: tr
         select "California", from: I18n.t('views.ctc.questions.w2s.employer_info.employer_state')
         fill_in I18n.t('views.ctc.questions.w2s.employer_info.employer_zip_code'), with: '94105'
         select "S", from: I18n.t('views.ctc.questions.w2s.employer_info.standard_or_non_standard_code')
+        click_on I18n.t('general.continue')
+
+        expect(page).to have_selector("h1", text: I18n.t("views.ctc.questions.w2s.misc_info.title", name: "Mangonada Mangonada"))
         click_on I18n.t('views.ctc.questions.w2s.employer_info.add')
 
         expect(page).to have_selector("p", text: I18n.t("views.ctc.portal.edit_info.help_text"))
@@ -421,6 +433,11 @@ RSpec.feature "CTC Intake", :js, :active_job, requires_default_vita_partners: tr
         })
 
         expect(changes_table_contents(".changes-note-#{notes[8].id}")).to match({
+          "federal_income_tax_withheld" => ["nil", "12.01"],
+          "wages_amount" => ["nil", "123.45"],
+        })
+
+        expect(changes_table_contents(".changes-note-#{notes[9].id}")).to match({
           "employer_city" => ["nil", "Citytown"],
           "employer_ein" => ["nil", "123112222"],
           "employer_name" => ["nil", "Fruit Stand"],
@@ -428,6 +445,10 @@ RSpec.feature "CTC Intake", :js, :active_job, requires_default_vita_partners: tr
           "employer_street_address" => ["nil", "123 Easy St"],
           "employer_zip_code" => ["nil", "94105"],
           "standard_or_non_standard_code" => ["nil", "S"],
+        })
+
+        expect(changes_table_contents(".changes-note-#{notes[10].id}")).to match({
+          "completed_at" => ["nil", an_instance_of(String)],
         })
 
         expect(page).to have_content("Client initiated resubmission of their tax return.")

--- a/spec/forms/ctc/w2s/employee_info_form_spec.rb
+++ b/spec/forms/ctc/w2s/employee_info_form_spec.rb
@@ -11,26 +11,6 @@ describe Ctc::W2s::EmployeeInfoForm do
       expect(form.errors.attribute_names).to include(:employee)
     end
 
-    it "requires wages to be present and look like money" do
-      form = described_class.new(w2, {})
-      expect(form).not_to be_valid
-      expect(form.errors.attribute_names).to include(:wages_amount)
-
-      form = described_class.new(w2, { wages_amount: 'RUTABAGA'})
-      expect(form).not_to be_valid
-      expect(form.errors.attribute_names).to include(:wages_amount)
-    end
-
-    it "requires federal_income_tax_withheld to be present and look like money" do
-      form = described_class.new(w2, {})
-      expect(form).not_to be_valid
-      expect(form.errors.attribute_names).to include(:federal_income_tax_withheld)
-
-      form = described_class.new(w2, { federal_income_tax_withheld: 'RUTABAGA'})
-      expect(form).not_to be_valid
-      expect(form.errors.attribute_names).to include(:federal_income_tax_withheld)
-    end
-
     it "requires city, state, and zip code" do
       form = described_class.new(w2, {})
       expect(form).not_to be_valid

--- a/spec/forms/ctc/w2s/misc_info_form_spec.rb
+++ b/spec/forms/ctc/w2s/misc_info_form_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe Ctc::W2s::MiscInfoForm do
+  context "when completing the form for the first time" do
+    let(:w2) { create(:w2, completed_at: nil) }
+
+    it "saves completed_at" do
+      freeze_time do
+        expect {
+          described_class.new(w2, {}).save
+        }.to change { w2.reload.completed_at }.from(nil).to(DateTime.now)
+      end
+    end
+  end
+
+  context "when completing it a second time" do
+    let(:w2) { create(:w2, completed_at: 1.day.ago) }
+
+    it "does not change completed_at" do
+      expect {
+        described_class.new(w2, {}).save
+      }.not_to change { w2.reload.completed_at }
+    end
+  end
+end

--- a/spec/forms/ctc/w2s/wages_info_form_spec.rb
+++ b/spec/forms/ctc/w2s/wages_info_form_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+describe Ctc::W2s::WagesInfoForm do
+  let(:w2) { create :w2, intake: intake }
+  let(:intake) { create :ctc_intake }
+
+  context "validations" do
+    it "requires wages to be present and look like money" do
+      form = described_class.new(w2, {})
+      expect(form).not_to be_valid
+      expect(form.errors.attribute_names).to include(:wages_amount)
+
+      form = described_class.new(w2, { wages_amount: 'RUTABAGA'})
+      expect(form).not_to be_valid
+      expect(form.errors.attribute_names).to include(:wages_amount)
+    end
+
+    it "requires federal_income_tax_withheld to be present and look like money" do
+      form = described_class.new(w2, {})
+      expect(form).not_to be_valid
+      expect(form.errors.attribute_names).to include(:federal_income_tax_withheld)
+
+      form = described_class.new(w2, { federal_income_tax_withheld: 'RUTABAGA'})
+      expect(form).not_to be_valid
+      expect(form.errors.attribute_names).to include(:federal_income_tax_withheld)
+    end
+  end
+end

--- a/spec/models/w2_spec.rb
+++ b/spec/models/w2_spec.rb
@@ -3,6 +3,7 @@
 # Table name: w2s
 #
 #  id                            :bigint           not null, primary key
+#  completed_at                  :datetime
 #  creation_token                :string
 #  employee                      :integer          default("unfilled"), not null
 #  employee_city                 :string

--- a/spec/support/helpers/ctc_intake_feature_helper.rb
+++ b/spec/support/helpers/ctc_intake_feature_helper.rb
@@ -341,12 +341,15 @@ module CtcIntakeFeatureHelper
       expect(page).to have_text(I18n.t('views.ctc.questions.w2s.employee_info.title', count: 2))
       select employee_name, from: I18n.t('views.ctc.questions.w2s.employee_info.employee_legal_name')
     end
-    fill_in I18n.t('views.ctc.questions.w2s.employee_info.wages_amount'), with: wages
-    fill_in I18n.t('views.ctc.questions.w2s.employee_info.federal_income_tax_withheld'), with: '12.01'
     fill_in I18n.t('views.ctc.questions.w2s.employee_info.employee_street_address'), with: '123 Cool St'
     fill_in I18n.t('views.ctc.questions.w2s.employee_info.employee_city'), with: 'City Town'
     select "California", from: I18n.t('views.ctc.questions.w2s.employee_info.employee_state')
     fill_in I18n.t('views.ctc.questions.w2s.employee_info.employee_zip_code'), with: '94110'
+    click_on I18n.t('general.continue')
+
+    expect(page).to have_text(I18n.t('views.ctc.questions.w2s.wages_info.title', name: employee_name))
+    fill_in I18n.t('views.ctc.questions.w2s.wages_info.wages_amount'), with: wages
+    fill_in I18n.t('views.ctc.questions.w2s.wages_info.federal_income_tax_withheld'), with: '12.01'
     click_on I18n.t('general.continue')
 
     expect(page).to have_text(I18n.t('views.ctc.questions.w2s.employer_info.title'))
@@ -357,7 +360,10 @@ module CtcIntakeFeatureHelper
     select "California", from: I18n.t('views.ctc.questions.w2s.employer_info.employer_state')
     fill_in I18n.t('views.ctc.questions.w2s.employer_info.employer_zip_code'), with: '94105'
     select "S", from: I18n.t('views.ctc.questions.w2s.employer_info.standard_or_non_standard_code')
-    click_on I18n.t('views.ctc.questions.w2s.employer_info.add')
+    click_on I18n.t('general.continue')
+
+    # misc stuff
+    click_on I18n.t('views.ctc.questions.w2s.misc_info.submit')
   end
 
   def fill_in_advance_child_tax_credit


### PR DESCRIPTION
set a completed_at timestamp when finishing the last page so we can display later on if you're creating or updating

Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>