### PR TITLE
Hub: fix crash viewing archived intakes that were filing jointly

### DIFF
--- a/app/controllers/hub/clients_controller.rb
+++ b/app/controllers/hub/clients_controller.rb
@@ -195,6 +195,7 @@ module Hub
           @intake = Intake::GyrIntake.new(client_id: @client.id)
           @intake.readonly!
         end
+        @intake = HubIntakePresenter.new(@intake)
       end
 
       def urbanization
@@ -231,6 +232,25 @@ module Hub
         return false if archived?
 
         intake.itin_applicant?
+      end
+    end
+
+    class HubIntakePresenter < SimpleDelegator
+      def initialize(intake)
+        @intake = intake
+        __setobj__(intake)
+      end
+
+      def primary
+        return @intake.primary if @intake.is_a?(Intake)
+
+        Intake::Person.new(@intake, :primary)
+      end
+
+      def spouse
+        return @intake.spouse if @intake.is_a?(Intake)
+
+        Intake::Person.new(@intake, :spouse)
       end
     end
   end

--- a/app/views/hub/clients/show.html.erb
+++ b/app/views/hub/clients/show.html.erb
@@ -42,7 +42,7 @@
             <% if @client.intake.is_ctc? %>
               <div class="field-display">
                 <span class="form-question">Date of Birth:</span>
-                <span class="label-value"><%= default_date_format(@client.intake.primary_birth_date) %></span>
+                <span class="label-value"><%= default_date_format(@client.intake.primary.birth_date) %></span>
               </div>
             <% else %>
               <div class="field-display">
@@ -55,8 +55,8 @@
               <span class="form-question">
                   <%= t("general.ssn_itin") %>:
               </span>
-              <% if @client.intake.primary_ssn.present? %>
-                <%= render 'togglable_single_field', masked_value: @client.intake.primary_ssn.present? ? mask(@client.intake.primary_ssn, 0) : nil, secret_name: :primary_ssn %>
+              <% if @client.intake.primary.ssn.present? %>
+                <%= render 'togglable_single_field', masked_value: @client.intake.primary.ssn.present? ? mask(@client.intake.primary.ssn, 0) : nil, secret_name: :primary_ssn %>
               <% else %>
                 <span class="label-value"><%= t("general.NA") %></span>
               <% end %>
@@ -232,12 +232,12 @@
               <div class="field-display">
                 <span class="form-question"><%= t(".legal_name") %>:</span>
                 <span class="label-value">
-                <%= "#{@client.intake&.spouse_first_name} #{@client.intake&.spouse_last_name}" %>
+                <%= @client.intake.spouse.first_and_last_name %>
               </span>
               </div>
               <div class="field-display">
                 <span class="form-question"><%= t(".email") %>:</span>
-                <span class="label-value"><%= @client.intake&.spouse_email_address %> </span>
+                <span class="label-value"><%= @client.intake.spouse_email_address %> </span>
               </div>
               <% if @client.intake.is_ctc? %>
                 <div class="field-display">

--- a/spec/features/hub/client/show_client_spec.rb
+++ b/spec/features/hub/client/show_client_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "a user viewing a client" do
 
     context "for a client with an archived 2021 GYR intake" do
       let(:intake) { nil }
-      let!(:archived_intake) {  create(:archived_2021_gyr_intake, client: client) }
+      let!(:archived_intake) { create(:archived_2021_gyr_intake, client: client, filing_joint: 'yes') }
       let!(:archived_dependent) { create(:archived_2021_dependent, intake: archived_intake) }
 
       it "can view intake information" do


### PR DESCRIPTION
HubClientPresenter#intake now returns a HubIntakePresenter that normalizes any differences between current and archived intakes