### PR TITLE
With certain CA-related source params, redirect to /stimulus

### DIFF
--- a/app/controllers/ctc/ctc_pages_controller.rb
+++ b/app/controllers/ctc/ctc_pages_controller.rb
@@ -16,11 +16,11 @@ module Ctc
       redirect_to root_path and return if params[:source].present?
 
       case session[:source]
-      when "cactc", "fed", "child"
+      when "fed", "child"
         redirect_to action: :help
-      when "eip", "cagov", "state"
+      when "eip", "state"
         redirect_to action: :stimulus_navigator
-      when "credit", "ca", "castate"
+      when "ca", "cactc", "cagov", "castate", "cdss", "credit"
         redirect_to action: :stimulus
       end
     end

--- a/spec/controllers/ctc/ctc_pages_controller_spec.rb
+++ b/spec/controllers/ctc/ctc_pages_controller_spec.rb
@@ -13,14 +13,15 @@ describe Ctc::CtcPagesController do
 
     context "CDSS landing page content" do
       [
-        %w( cactc /en/help ),
-        %w( fed   /en/help ),
-        %w( eip /en/stimulus-navigator ),
-        %w( cagov /en/stimulus-navigator ),
-        %w( state /en/stimulus-navigator ),
-        %w( credit  /en/stimulus ),
+        %w( fed     /en/help ),
+        %w( eip     /en/stimulus-navigator ),
+        %w( state   /en/stimulus-navigator ),
         %w( ca      /en/stimulus ),
+        %w( cactc   /en/stimulus ),
+        %w( cagov   /en/stimulus),
         %w( castate /en/stimulus),
+        %w( cdss    /en/stimulus),
+        %w( credit  /en/stimulus ),
       ].each do |source, location, show_needs_help|
         describe "When client visits from source param #{source}" do
           it "redirects to #{location}" do


### PR DESCRIPTION
here's the whole story description:

> WHY:
>
> a major outreach partner is sketched out by getctc.org/stimulus?s=source links and wants to send people to getctc.org/source links instead. If they can't, they might not link to us, and we would miss out on thousands of returns.
> 
> WHAT:
> 
> make getctc.org/source redirect to getctc.org/stimulus?s=source (or, equivalently, redirect to getctc.org/stimulus and store the source) for the following:
> GetCTC.org/cdss
> GetCTC.org/ca
> GetCTC.org/cactc
> GetCTC.org/cagov