### PR TITLE
Decimal types (like w2s.wages_amount) accept commas

### DIFF
--- a/config/initializers/types.rb
+++ b/config/initializers/types.rb
@@ -1,3 +1,14 @@
 Rails.application.reloader.to_prepare do
+  module DecimalCleaner
+    def cast(value)
+      if value.is_a?(String)
+        super(value.gsub(/[$,]/, ''))
+      else
+        super
+      end
+    end
+  end
+  ActiveRecord::Type::Decimal.prepend(DecimalCleaner)
+
   ActiveRecord::Type.register(:money, MoneyType)
 end


### PR DESCRIPTION
the default rails implementation of decimal does "12,345".to_d, which just returns "12"

this monkeypatches Decimal to always remove dollar signs and commas so we will get the full dollar value instead

Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>