### PR TITLE
Temporarily returning false in ChildResidenceExceptions show method

### DIFF
--- a/app/services/dependent_flow_service.rb
+++ b/app/services/dependent_flow_service.rb
@@ -23,8 +23,8 @@ class DependentFlowService
       eligibility = child_qualification(except: [:residence_test, :claimable_test])
       eligibility.qualifies? && !eligibility.born_in_final_six_months?
     when "Ctc::Questions::Dependents::ChildResidenceExceptionsController"
-      eligibility = child_qualification(except: [:residence_test, :claimable_test])
-      !dependent.months_in_home_6_or_more? && eligibility.qualifies?
+      # temporarily returning false in anticipation of page removal
+      false
     when "Ctc::Questions::Dependents::ChildCanBeClaimedByOtherController"
       eligibility = child_qualification(except: :claimable_test)
       eligibility.qualifies?

--- a/spec/features/ctc/dependents_spec.rb
+++ b/spec/features/ctc/dependents_spec.rb
@@ -24,11 +24,8 @@ RSpec.feature "Dependents in CTC intake", :flow_explorer_screenshot, active_job:
       click_on I18n.t('general.negative')
 
       expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.child_residence.title', name: 'Jessie', current_tax_year: current_tax_year))
-      select I18n.t("views.ctc.questions.dependents.child_residence.select_options.less_than_six")
+      select I18n.t("views.ctc.questions.dependents.child_residence.select_options.six_to_seven")
       click_on I18n.t('general.continue')
-
-      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.child_residence_exceptions.title', name: 'Jessie', current_tax_year: current_tax_year))
-      click_on I18n.t('general.affirmative')
 
       expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.child_can_be_claimed_by_other.title', name: 'Jessie'))
       click_on I18n.t('general.affirmative')
@@ -56,11 +53,8 @@ RSpec.feature "Dependents in CTC intake", :flow_explorer_screenshot, active_job:
       click_on I18n.t('general.negative')
 
       expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.child_residence.title', name: 'Jessie', current_tax_year: current_tax_year))
-      select I18n.t("views.ctc.questions.dependents.child_residence.select_options.less_than_six")
+      select I18n.t("views.ctc.questions.dependents.child_residence.select_options.six_to_seven")
       click_on I18n.t('general.continue')
-
-      expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.child_residence_exceptions.title', name: 'Jessie', current_tax_year: current_tax_year))
-      click_on I18n.t('general.affirmative')
 
       expect(page).to have_selector("h1", text: I18n.t('views.ctc.questions.dependents.child_can_be_claimed_by_other.title', name: 'Jessie'))
       click_on I18n.t('general.affirmative')


### PR DESCRIPTION
In anticipation of removing it, so that folks are not on that page when we remove it