### PR TITLE
Add anchors to IrsStreetAddressTypeValidator regex

### DIFF
--- a/app/forms/ctc/w2s/employee_info_form.rb
+++ b/app/forms/ctc/w2s/employee_info_form.rb
@@ -10,6 +10,8 @@ module Ctc
         :employee
       )
 
+      before_validation_squish(:employee_street_address, :employee_city)
+
       validates :employee, presence: true, inclusion: { in: W2.employees.keys - ['unfilled'], allow_blank: true }
       validates :employee_street_address, irs_street_address_type: true
       validates :employee_city, presence: true, format: { with: /\A([A-Za-z] ?)*[A-Za-z]\z/, message: -> (*_args) { I18n.t('validators.alpha') }}

--- a/app/forms/ctc/w2s/employer_info_form.rb
+++ b/app/forms/ctc/w2s/employer_info_form.rb
@@ -12,6 +12,8 @@ module Ctc
         :box_d_control_number
       )
 
+      before_validation_squish(:employer_city, :employer_street_address)
+
       validates :employer_ein, presence: true, format: { with: /\A[0-9]{9}\z/, message: ->(*_args) { I18n.t('validators.ein') } }
       validates :employer_name, presence: true
       validates :employer_city, presence: true, format: { with: /\A([A-Za-z] ?)*[A-Za-z]\z/, message: -> (*_args) { I18n.t('validators.alpha') }}

--- a/app/validators/irs_street_address_type_validator.rb
+++ b/app/validators/irs_street_address_type_validator.rb
@@ -1,5 +1,5 @@
 class IrsStreetAddressTypeValidator < ActiveModel::EachValidator
-  ADDRESS_REGEX = /[A-Za-z0-9]( ?[A-Za-z0-9\-\/])*/
+  ADDRESS_REGEX = /\A[A-Za-z0-9]( ?[A-Za-z0-9\- \/])*\z/
 
   def validate_each(record, attr_name, value)
     unless value =~ ADDRESS_REGEX

--- a/spec/validators/irs_street_address_type_validator_spec.rb
+++ b/spec/validators/irs_street_address_type_validator_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+describe IrsStreetAddressTypeValidator do
+  before do
+    @validatable = Class.new do
+      include ActiveModel::Validations
+      validates_with IrsStreetAddressTypeValidator, attributes: :text
+      attr_accessor  :text
+    end
+  end
+
+  subject { @validatable.new }
+
+  before do
+    subject.text = text
+  end
+
+  context "only allowed characters" do
+    let(:text) { "123 Mid-Island St" }
+
+    it "is valid" do
+      expect(subject).to be_valid
+    end
+  end
+
+  context "not allowed characters: pound sign" do
+    let(:text) { "123 Mid-Island St #Frnt" }
+
+    it "is not valid" do
+      expect(subject).not_to be_valid
+    end
+  end
+
+  context "not allowed characters: period" do
+    let(:text) { "123 Mid-Island St." }
+
+    it "is not valid" do
+      expect(subject).not_to be_valid
+    end
+  end
+end


### PR DESCRIPTION
- squish address, city in employee/employer forms

Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>