### PR TITLE
Enforce limit of 22 chars in both W-2 city fields [#183510308]

### DIFF
--- a/app/forms/ctc/w2s/employee_info_form.rb
+++ b/app/forms/ctc/w2s/employee_info_form.rb
@@ -14,7 +14,7 @@ module Ctc
 
       validates :employee, presence: true, inclusion: { in: W2.employees.keys - ['unfilled'], allow_blank: true }
       validates :employee_street_address, irs_street_address_type: true
-      validates :employee_city, presence: true, format: { with: /\A([A-Za-z] ?)*[A-Za-z]\z/, message: -> (*_args) { I18n.t('validators.alpha') }}
+      validates :employee_city, presence: true, irs_city_type: true
       validates :employee_state, presence: true, inclusion: { in: States.keys }
       validates :employee_zip_code, presence: true, format: { with: /\A[0-9]{5}(([0-9]{4})|([0-9]{7}))?\z/, message: -> (*_args) { I18n.t('validators.zip_code_with_optional_extra_digits') } }
     end

--- a/app/forms/ctc/w2s/employer_info_form.rb
+++ b/app/forms/ctc/w2s/employer_info_form.rb
@@ -16,7 +16,7 @@ module Ctc
 
       validates :employer_ein, presence: true, format: { with: /\A[0-9]{9}\z/, message: ->(*_args) { I18n.t('validators.ein') } }
       validates :employer_name, presence: true
-      validates :employer_city, presence: true, format: { with: /\A([A-Za-z] ?)*[A-Za-z]\z/, message: -> (*_args) { I18n.t('validators.alpha') }}
+      validates :employer_city, presence: true, irs_city_type: true
       validates :employer_state, presence: true, inclusion: { in: States.keys }
       validates :employer_zip_code, presence: true, format: { with: /\A[0-9]{5}(([0-9]{4})|([0-9]{7}))?\z/, message: -> (*_args) { I18n.t('validators.zip_code_with_optional_extra_digits') } }
       validates :employer_street_address, irs_street_address_type: true

--- a/app/validators/irs_city_type_validator.rb
+++ b/app/validators/irs_city_type_validator.rb
@@ -1,0 +1,16 @@
+class IrsCityTypeValidator < ActiveModel::EachValidator
+  REGEX = /\A([A-Za-z] ?)*[A-Za-z]\z/
+  MAX_LENGTH = 22
+
+  def validate_each(record, attr_name, value)
+    return if value.nil?
+
+    unless value =~ REGEX
+      record.errors.add(attr_name, I18n.t("validators.irs_city"))
+    end
+
+    unless value.length <= MAX_LENGTH
+      record.errors.add(attr_name, I18n.t("errors.messages.too_long", count: MAX_LENGTH))
+    end
+  end
+end

--- a/app/validators/irs_city_type_validator.rb
+++ b/app/validators/irs_city_type_validator.rb
@@ -1,6 +1,5 @@
 class IrsCityTypeValidator < ActiveModel::EachValidator
   REGEX = /\A([A-Za-z] ?)*[A-Za-z]\z/
-  MAX_LENGTH = 22
 
   def validate_each(record, attr_name, value)
     return if value.nil?
@@ -9,8 +8,6 @@ class IrsCityTypeValidator < ActiveModel::EachValidator
       record.errors.add(attr_name, I18n.t("validators.irs_city"))
     end
 
-    unless value.length <= MAX_LENGTH
-      record.errors.add(attr_name, I18n.t("errors.messages.too_long", count: MAX_LENGTH))
-    end
+    ActiveModel::Validations::LengthValidator.new(maximum: 22, attributes: attributes).validate_each(record, attr_name, value)
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1683,6 +1683,7 @@ en:
     file_type: Please upload a valid document type. Accepted types include %{valid_types}.
     file_zero_length: Please upload a valid file. The file you uploaded appears to be empty.
     ip_pin: IP PINs must be a 6 digit number.
+    irs_city: Only letters A-Z, a-z, and space are accepted.
     irs_street_address: Only numbers 0-9, letters A-Z and a-z, hyphen, slash and single spaces are accepted.
     itin: Please enter a valid individual taxpayer identification number.
     legal_name: Please enter a name that only contains letters, apostrophes, hyphens, periods, and accents.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1652,6 +1652,7 @@ es:
     file_type: Por favor sube un tipo de documento válido. Los tipos aceptados incluyen %{valid_types}
     file_zero_length: Sube un archivo válido. El archivo que cargó parece estar vacío.
     ip_pin: El IP PIN debe ser un número de 6 dígitos.
+    irs_city: Solo se aceptan letras A-Z, a-z y espacio.
     irs_street_address: Sólo se aceptan los números del 0-9, las letras de la A a la Z y de la a a la Z, el guión, la barra oblicua y los espacios simples.
     itin: Por favor ingrese un Número de Identificación Personal del Contribuyente válido.
     legal_name: Ingrese un nombre que solo contenga cartas, apóstrofos, guiones, puntos y acentos.

--- a/spec/validators/irs_city_type_validator_spec.rb
+++ b/spec/validators/irs_city_type_validator_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+describe IrsCityTypeValidator do
+  before do
+    @validatable = Class.new do
+      include ActiveModel::Validations
+      validates_with IrsCityTypeValidator, attributes: :text
+      attr_accessor :text
+    end
+  end
+
+  subject { @validatable.new }
+
+  before do
+    subject.text = text
+  end
+
+  context "characters allowed" do
+    context "only allowed characters" do
+      let(:text) { "San Francisco" }
+
+      it "is valid" do
+        expect(subject).to be_valid
+      end
+    end
+
+    context "not allowed characters: any punctuation" do
+      let(:text) { "San Francisco," }
+
+      it "is not valid" do
+        expect(subject).not_to be_valid
+      end
+    end
+
+    context "not allowed characters: any numbers" do
+      let(:text) { "San Francisc0" }
+
+      it "is not valid" do
+        expect(subject).not_to be_valid
+      end
+    end
+  end
+
+  context "length" do
+    context "when 22 chars or less" do
+      let(:text) { "ABCDEFGHI ABCDEFGHI AB" }
+
+      it "is valid" do
+        expect(subject).to be_valid
+      end
+    end
+
+    context "when 23 chars or more" do
+      let(:text) { "ABCDEFGHI ABCDEFGHI ABC" }
+
+      it "is invalid" do
+        expect(subject).not_to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds an IRS CityType validator. If you want to see where the regex came from, do a search for `CityType` in RubyMine; you'll find the XSD type definition.

This fixes a live problem where clients are entering data that doesn't validate when it comes to make the IRS bundle, i.e., we get a BUNDLE-FAIL.

I want more custom validators for IRS data types in the codebase! I think it's better to have a Rails custom validator that embodies all the rules for the XML schema type, rather than have a sprinkling of validation rules in the form. One downside of this approach is we have more lines of code in the codebase, but I think the lines are good lines. I also think those custom validators should handle the length validation like this one does.

I'd like to know if people agree, or disagree, or don't care!

## Screenshots

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/67708639/195114057-952ed73f-de52-4232-8900-0c504705b518.png">

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/67708639/195114130-01478712-39e2-4712-b2c7-6640d7af73cd.png">

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/67708639/195114176-9afb5f53-d701-4d5f-baf5-c41037d4dd24.png">
