### PR TITLE
Quick fix for tests failing on main due to us crossing `config.end_of_login` timestamp

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -128,6 +128,7 @@ RSpec.configure do |config|
     allow(Rails.application).to receive(:credentials).and_return(@test_environment_credentials)
     allow_any_instance_of(ApplicationController).to receive(:open_for_ctc_intake?).and_return(true)
     allow_any_instance_of(ApplicationController).to receive(:open_for_ctc_login?).and_return(true)
+    allow(Rails.configuration).to receive(:end_of_login).and_return(2.days.from_now)
     # Stub valid_email2's network-dependent functionality per https://github.com/micke/valid_email2
     allow_any_instance_of(ValidEmail2::Address).to receive(:valid_mx?) { true }
     # Stub DNS implementation to avoid network calls from test suite; valid_email2 uses this


### PR DESCRIPTION
Many of our tests are written assuming that we are still within the login window; this stubs the timestamp for all tests to ensure it is in the future.

In the future we could do something more thoughtful?