### PR TITLE
W2 stuff: preserve numbers, dash, and ampersand when transforming employer name into EmployerNameControlTxt

### DIFF
--- a/app/lib/submission_builder/ty2021/documents/irs_w2.rb
+++ b/app/lib/submission_builder/ty2021/documents/irs_w2.rb
@@ -14,7 +14,7 @@ module SubmissionBuilder
           build_xml_doc("IRSW2", documentId: "IRSW2-#{w2.id}", documentName: "IRSW2") do |xml|
             xml.EmployeeSSN w2.employee_ssn
             xml.EmployerEIN w2.employer_ein
-            xml.EmployerNameControlTxt name_control_type(w2.employer_name)
+            xml.EmployerNameControlTxt employer_name_control_type(w2.employer_name)
             xml.EmployerName do |xml|
               xml.BusinessNameLine1Txt w2.employer_name
             end
@@ -98,6 +98,15 @@ module SubmissionBuilder
 
             xml.StandardOrNonStandardCd 'S'
           end
+        end
+
+        private
+
+        def employer_name_control_type(employer_name)
+          return "" unless employer_name.present?
+
+          # Restrict to just characters allowed in the BusinessNameControlType type from the schema
+          employer_name.upcase.gsub(/[^A-Z0-9\-&]/, '').first(4)
         end
       end
     end

--- a/spec/lib/submission_builder/ty2021/documents/irs_w2_spec.rb
+++ b/spec/lib/submission_builder/ty2021/documents/irs_w2_spec.rb
@@ -42,6 +42,20 @@ describe SubmissionBuilder::Ty2021::Documents::IrsW2 do
     expect(box15_node.at('LocalityNm').text).to eq("squibnocket")
   end
 
+  describe 'EmployerNameControlTxt' do
+    let(:primary_w2) { create :w2, intake: intake, employer_name: 'a & - 2 bananas' }
+
+    it "upcases and removes spaces and whatnot from employer_name to produce EmployerNameControlTxt" do
+      instance = described_class.new(submission, kwargs: { w2: primary_w2 })
+      expect(instance.schema_version).to eq "2021v5.2"
+
+      submission_builder_response = described_class.build(submission, kwargs: { w2: primary_w2 })
+      expect(submission_builder_response).to be_valid
+      xml = Nokogiri::XML::Document.parse(submission_builder_response.document.to_xml)
+      expect(xml.at('EmployerNameControlTxt').text).to eq('A&-2')
+    end
+  end
+
   context "when there are not many box14 or box15 values present" do
     let!(:w2_state_fields_group) do
       create(


### PR DESCRIPTION
previously, clients who entered a name like '0' (which is a valid EmployerName, even if it's probably wrong) would see a bundle fail because the EmployerNameControlTxt would become an empty string.

now, the EmployerNameControlTxt will be '0' which will successfully bundle even if it probably won't lead to an ideal outcome