### PR TITLE
[#183573810] Filter X-Forwarded-Host header since we do not need it

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,4 +1,5 @@
 require_relative "boot"
+require_relative "../lib/middleware/cleanup_request_host_headers"
 require_relative "../lib/middleware/cleanup_mime_type_headers"
 require_relative "../lib/middleware/reject_invalid_params"
 
@@ -59,6 +60,7 @@ module VitaMin
     # the framework and any gems in your application.
     #
     #
+    config.middleware.use Middleware::CleanupRequestHostHeaders
     config.middleware.use Middleware::CleanupMimeTypeHeaders
     config.middleware.use Middleware::RejectInvalidParams
     config.current_tax_year = 2021

--- a/lib/middleware/cleanup_request_host_headers.rb
+++ b/lib/middleware/cleanup_request_host_headers.rb
@@ -1,0 +1,17 @@
+module Middleware
+  class CleanupRequestHostHeaders
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      # Filter out client-submitted "X-Forwarded-Host" headers; Rails trusts them but
+      # our deployment on Aptible does not send them.
+      #
+      # Similar to https://github.com/pusher/rack-headers_filter but retains all the headers
+      # Aptible does actually send: https://deploy-docs.aptible.com/docs/http-request-headers
+      env.delete("HTTP_X_FORWARDED_HOST")
+      @app.call(env)
+    end
+  end
+end

--- a/spec/middleware/cleanup_request_host_headers_spec.rb
+++ b/spec/middleware/cleanup_request_host_headers_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+require_relative '../../lib/middleware/cleanup_request_host_headers'
+
+describe Middleware::CleanupRequestHostHeaders do
+  let(:mock_app) do
+    Class.new do
+      attr_reader :computed_host
+
+      def call(env)
+        @computed_host = Rack::Request.new(env).host
+      end
+    end.new
+  end
+  subject { described_class.new(mock_app) }
+
+  before do
+    allow(mock_app).to receive(:call).and_call_original
+  end
+
+  describe "#call" do
+    it "filters HTTP_X_FORWARDED_HOST so request.host comes from the Host header" do
+      subject.call({ "HTTP_HOST" => "example.com", "HTTP_X_FORWARDED_HOST" => "example.org" })
+      expect(mock_app).to have_received(:call).with({ "HTTP_HOST" => "example.com" })
+      expect(mock_app.computed_host).to eq("example.com")
+    end
+  end
+end


### PR DESCRIPTION
This will address a low-severity warning raised by Detectify.

The issue is reported as an open redirect, but it is not really one since web browser clients don't send the X-Forwarded-Host header. In the interest of resolving the issue in Detectify to avoid being pinged about it in the future, I recommend we merge this PR.

Here is how you can reproduce the bad behavior:

```
❯ curl -H "X-Forwarded-Host: example.com" https://demo.getyourrefund.org/                 
<html><body>You are being <a href="https://example.com/en">redirected</a>.</body></html>
```

The bad behavior exists on other Heroku review apps:

```
❯ curl -H "X-Forwarded-Host: example.com" -H "X-Forwarded-Port: 8443" -H "X-Forwarded-For: 1.2.3.4,5.6.7.8" https://gyr-review-app-3201.herokuapp.com/
<html><body>You are being <a href="https://example.com/en">redirected</a>.</body></html>%                                                                       
```

The bad behavior is fixed on this Heroku review app.

```
❯ curl -H "X-Forwarded-Host: example.com" -H "X-Forwarded-Port: 8443" -H "X-Forwarded-For: 1.2.3.4,5.6.7.8" https://gyr-review-app-3202.herokuapp.com/
<html><body>You are being <a href="https://gyr-review-app-3202.herokuapp.com/en">redirected</a>.</body></html>%                                                 
```

## Alternatives considered

I assessed a few other options for how to fix it. None of them seemed better than this approach. The other ideas were:

* Make PublicPagesController#locale_redirect_home always redirect to a canonical hostname like demo.getyourrefund.org or ctc.demo.getyourrefund.org. This seemed sorta good, but on our Heroku environment, it's convenient to use the Heroku URL while waiting for Route 53 to create the slicker URLs. Additionally, Detectify might try other URLs that `redirect_to root_path` and then Detectify will re-raise the alert. I'd prefer to fix this once rather than numerous times.

* Use `config.hosts` to only allow certain `request.host` values. This is the most Rails-esque way to do it as far as I can tell. However, we use securitymetrics.com to do web app vulnerability detection, and they seem to surf to the IP addresses we give them, which means they're using "Host:" headers of those IP addresses (not e.g. www.getctc.org) which means if we want to get any use out of their scanning, we should respond to those requests. I asked them if they can set a `Host` header in their requests, but they can't.

* Add some middleware that redirects to a canonical hostname. Similar problems as previous bullet.

* Add a gem that does this kind of filtering. I found https://github.com/pusher/rack-headers_filter but it removes some headers Aptible actually uses, e.g. X-Forwarded-Proto https://deploy-docs.aptible.com/docs/https-redirect .

* Do nothing and silence the alert since I have assessed the risk and there is none. This was an appealing option, but I suspect Detectify will re-raise it in a different way so I figure it's just as good to fix it once here confidently.