### PR TITLE
Efiling: send a different message depending on whether a submission was 'rejected' vs 'rejected and cancelled'

### DIFF
--- a/app/controllers/hub/automated_messages_controller.rb
+++ b/app/controllers/hub/automated_messages_controller.rb
@@ -19,6 +19,7 @@ module Hub
           [AutomatedMessage::EfileAcceptance, {}],
           [AutomatedMessage::EfilePreparing, {}],
           [AutomatedMessage::EfileRejected, {}],
+          [AutomatedMessage::EfileRejectedAndCancelled, {}],
           [AutomatedMessage::EfileFailed, {}],
           [AutomatedMessage::CtcGettingStarted, {}],
           [AutomatedMessage::ClosingSoon, {}],

--- a/app/jobs/after_transition_tasks_for_rejected_return_job.rb
+++ b/app/jobs/after_transition_tasks_for_rejected_return_job.rb
@@ -7,11 +7,6 @@ class AfterTransitionTasksForRejectedReturnJob < ApplicationJob
     Efile::SubmissionErrorParser.persist_errors(transition)
 
     if transition.efile_errors.any?
-      ClientMessagingService.send_system_message_to_all_opted_in_contact_methods(
-        client: submission.client,
-        message: AutomatedMessage::EfileRejected,
-        locale: submission.client.intake.locale
-      )
       submission.transition_to!(:cancelled) if transition.efile_errors.any?(&:auto_cancel)
       submission.transition_to!(:waiting) if transition.efile_errors.all?(&:auto_wait)
       if transition.efile_errors.all? { |efile_error| EfileError.error_codes_to_retry_once.include?(efile_error.code) }
@@ -21,8 +16,25 @@ class AfterTransitionTasksForRejectedReturnJob < ApplicationJob
           submission.transition_to!(:resubmitted, {auto_resubmitted: true})
         end
       end
+      message_class = message_class_for_state(submission.current_state)
+      if message_class
+        ClientMessagingService.send_system_message_to_all_opted_in_contact_methods(
+          client: submission.client,
+          message: message_class,
+          locale: submission.client.intake.locale
+        )
+      end
     end
 
     EfileSubmissionStateMachine.send_mixpanel_event(submission, "ctc_efile_return_rejected")
+  end
+
+  private
+
+  def message_class_for_state(state)
+    return if state == 'resubmitted'
+    return AutomatedMessage::EfileRejectedAndCancelled if state == 'cancelled'
+
+    AutomatedMessage::EfileRejected
   end
 end

--- a/app/models/automated_message/efile_rejected_and_cancelled.rb
+++ b/app/models/automated_message/efile_rejected_and_cancelled.rb
@@ -1,0 +1,20 @@
+module AutomatedMessage
+  class EfileRejectedAndCancelled < AutomatedMessage
+
+    def self.name
+      'messages.efile.rejected_and_cancelled'.freeze
+    end
+
+    def sms_body(**args)
+      I18n.t("messages.efile.rejected_and_cancelled.sms", **args)
+    end
+
+    def email_subject(**args)
+      I18n.t("messages.efile.rejected_and_cancelled.email.subject", **args)
+    end
+
+    def email_body(**args)
+      I18n.t("messages.efile.rejected_and_cancelled.email.body", **args)
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1261,6 +1261,22 @@ en:
         sms: |
           Hello <<Client.PreferredName>>,
           Thank you for filing your taxes with GetCTC! Unfortunately, your taxes have been rejected by the IRS. Sign in here <<Client.LoginLink>> to see next steps for correcting your tax information.
+      rejected_and_cancelled:
+        email:
+          body: |
+            Hello <<Client.PreferredName>>,
+
+            Thank you for filing your taxes with GetCTC! Unfortunately, your tax return has been rejected by the IRS.
+
+            Sign in to see why your return was not accepted: <<Client.LoginLink>>
+
+            Replies to this address are not monitored. If you need additional assistance, please write support@getyourrefund.org.
+
+            Your tax team at GetCTC.org
+          subject: GetCTC Return Status Update
+        sms: |
+          Hello <<Client.PreferredName>>,
+          Thank you for filing your taxes with GetCTC! Unfortunately, your taxes have been rejected by the IRS. Sign in here <<Client.LoginLink>> to learn more. (Replies not monitored. Write support@getyourrefund.org for assistance.)
     fraud_hold:
       email:
         body: |

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1263,6 +1263,22 @@ es:
           ¡Gracias por declarar sus impuestos con GetCTC! Desafortunadamente, sus impuestos han sido rechazados por el IRS.
           Inicie sesión para ver los siguientes pasos para corregir y volver a enviar su información fiscal: <<Client.LoginLink>>
           ¡Estamos aquí para ayudarle!
+      rejected_and_cancelled:
+        email:
+          body: |
+            Hola <<Client.PreferredName>>,
+
+            ¡Gracias por presentar sus impuestos con GetCTC! Desafortunadamente, su declaración de impuestos ha sido rechazada por el IRS.
+
+            Inicie sesión para ver por qué no se aceptó su devolución: <<Client.LoginLink>>
+
+            Las respuestas a esta dirección no se controlan. Si necesita asistencia adicional, escriba a support@getyourrefund.org.
+
+            Su equipo de impuestos en GetCTC.org
+          subject: Actualización de estado de devolución de GetCTC
+        sms: |
+          Hola <<Client.PreferredName>>,
+          ¡Gracias por presentar sus impuestos con GetCTC! Desafortunadamente, sus impuestos han sido rechazados por el IRS. Inicie sesión aquí <<Client.LoginLink>> para obtener más información. (Respuestas no supervisadas. Escriba a support@getyourrefund.org para obtener ayuda).
     fraud_hold:
       email:
         body: "Hola <<Client.PreferredName>>,\n\nSu entrega requiere una revisión adicional. Para empezar con su revisión, inicie sesión en <<Client.LoginLink>> y haga clic en \"Cargar documentos adicionales\" y envíe una foto de usted con su identificación oficial con foto emitida por el gobierno. \n\nAtentamente, \nEl equipo de GetCTC.org\n"


### PR DESCRIPTION
Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>