### PR TITLE
Upgrade webdrivers gem so the tests pass on newer Macs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,7 @@ group :development, :test do
   gem 'axe-matchers'
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '>= 2.15'
-  gem 'webdrivers'
+  gem 'webdrivers', '>= 5.2.0'
   gem 'rspec-rails'
   gem 'rails-controller-testing'
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -528,10 +528,11 @@ GEM
     scenic (1.6.0)
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
-    selenium-webdriver (4.1.0)
+    selenium-webdriver (4.5.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
-      rubyzip (>= 1.2.2)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     semantic_range (3.0.0)
     sentry-delayed_job (5.4.1)
       delayed_job (>= 4.0)
@@ -606,7 +607,7 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.0.0)
+    webdrivers (5.2.0)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (~> 4.0)
@@ -620,6 +621,7 @@ GEM
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
     webrick (1.7.0)
+    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -724,7 +726,7 @@ DEPENDENCIES
   valid_email2
   warning
   web-console (>= 3.3.0)
-  webdrivers
+  webdrivers (>= 5.2.0)
   webmock
   webpacker (~> 5.4.0)
   websocket-extensions (>= 0.1.5)


### PR DESCRIPTION
See e.g.
https://stackoverflow.com/questions/73900371/webdriversnetworkerror-mac64-m1-chromedriver