### PR TITLE
let rack-mini-profiler use redis if it exists

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,9 @@ group :demo, :development, :test do
 end
 
 group :demo, :development, :heroku, :staging, :production do
+  # for storing results of rack-mini-profiler
+  gem 'redis'
+
   gem 'rack-mini-profiler'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,7 @@ GEM
       matrix
       ruby-rc4 (>= 0.1.5)
     concurrent-ruby (1.1.10)
+    connection_pool (2.3.0)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -453,6 +454,10 @@ GEM
     recaptcha (5.10.0)
       json
     redcarpet (3.5.1)
+    redis (5.0.5)
+      redis-client (>= 0.9.0)
+    redis-client (0.10.0)
+      connection_pool
     regexp_parser (2.5.0)
     request_store (1.5.1)
       rack (>= 1.4)
@@ -697,6 +702,7 @@ DEPENDENCIES
   rails_autolink
   recaptcha
   redcarpet
+  redis
   rspec-rails
   rspec_junit_formatter
   rubocop (~> 0.82.0)

--- a/config/initializers/rack_profiler.rb
+++ b/config/initializers/rack_profiler.rb
@@ -2,3 +2,8 @@ if Rails.env.heroku? || Rails.env.demo? || Rails.env.production?
   # Use the "Alt+P" keyboard shortcut to toggle visibility
   Rack::MiniProfiler.config.start_hidden = true
 end
+
+if ENV['MINI_PROFILER_REDIS_URL'].present?
+  Rack::MiniProfiler.config.storage_options = { url: ENV["MINI_PROFILER_REDIS_URL"] }
+  Rack::MiniProfiler.config.storage = Rack::MiniProfiler::RedisStore
+end


### PR DESCRIPTION
environments with more than one container need some way to store their results that isn't a MemoryStore