### PR TITLE
Remove rails-erb-loader JS dependency

### DIFF
--- a/app/javascript/lib/ajax_mixpanel_events.js
+++ b/app/javascript/lib/ajax_mixpanel_events.js
@@ -4,6 +4,7 @@ const AjaxMixpanelEvents = (function () {
   const init = function () {
     $(document).ready(function() {
       $("[data-track-click]").on("click", function (e, options) {
+        const pageData = document.querySelector("#mixpanelData").dataset;
         const clickedElement = $(e.target).closest("a");
         const dataAttributes = clickedElement.data();
         const elementText = clickedElement.text().trim();
@@ -20,12 +21,13 @@ const AjaxMixpanelEvents = (function () {
         });
 
         eventData.append("event[event_name]", eventName);
-        eventData.append("event[controller_action]", window.mixpanelData.controller_action);
-        eventData.append("event[full_path]", window.mixpanelData.full_path);
+        eventData.append("event[controller_action]", pageData.controllerAction);
+        eventData.append("event[full_path]", pageData.fullPath);
         eventData.append("event[data][call_to_action]", elementText);
         eventData.append(Rails.csrfParam(), Rails.csrfToken());
-
-        navigator.sendBeacon("/ajax_mixpanel_events", eventData);
+        if (pageData.sendMixpanelBeacon) {
+          navigator.sendBeacon("/ajax_mixpanel_events", eventData);
+        }
       });
     });
   };

--- a/app/javascript/listeners/index.js
+++ b/app/javascript/listeners/index.js
@@ -22,30 +22,28 @@ const Listeners =  (function(){
     return {
         init: function () {
             window.addEventListener("load", function() {
-                if (!window.appData) {
-                    return;
-                }
+                const { controllerAction } = document.querySelector("#mixpanelData").dataset;
                 ClientMenuComponent();
 
                 documentSubmittingIndicator.init(); // extend styling on honeyCrisp's default ajax upload functionality.
 
-                if (window.appData.controller_action == "Hub::Users::InvitationsController#edit") {
+                if (controllerAction == "Hub::Users::InvitationsController#edit") {
                     helpers.setDefaultTimezone();
                 }
 
-                if (window.appData.controller_action == "Hub::MessagesController#index") {
+                if (controllerAction == "Hub::MessagesController#index") {
                     consumer.subscriptions.create(getChannelName(window.location.href), callback);
                 }
 
-                if (["Hub::ClientsController#edit_take_action", "Hub::ClientsController#update_take_action"].includes(window.appData.controller_action)) {
+                if (["Hub::ClientsController#edit_take_action", "Hub::ClientsController#update_take_action"].includes(controllerAction)) {
                     initTakeActionOnChangeHandlers("take_action");
                 }
 
-                if (["Hub::BulkActions::ChangeAssigneeAndStatusController#edit", "Hub::BulkActions::ChangeAssigneeAndStatusController#update"].includes(window.appData.controller_action)) {
+                if (["Hub::BulkActions::ChangeAssigneeAndStatusController#edit", "Hub::BulkActions::ChangeAssigneeAndStatusController#update"].includes(controllerAction)) {
                     initTakeActionOnChangeHandlers("bulk_action");
                 }
 
-                if(["Hub::StateRoutingsController#edit", "Hub::StateRoutingsController#update"].includes(window.appData.controller_action)) {
+                if(["Hub::StateRoutingsController#edit", "Hub::StateRoutingsController#update"].includes(controllerAction)) {
                     initStateRoutingsListeners();
                 }
 
@@ -54,7 +52,7 @@ const Listeners =  (function(){
                     getEfileSecurityInformation(form.dataset.formName);
                 }
 
-                if(window.appData.controller_action == "Hub::EfileSubmissionsController#index") {
+                if(controllerAction == "Hub::EfileSubmissionsController#index") {
                     fetchEfileStateCounts();
                 }
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -17,19 +17,9 @@ window.$ = $;
 RailsUJS.start();
 ActiveStorage.start();
 
-// *
-// IMPLEMENTATION NOTE 2/22/21
-// I want us to be able to import honeycrisp JS directly from honeycrisp, but the main JS we need is all included
-// right inside of the cfa_styleguide_main sprockets JS file. I'm planning on making a PR to honeycrisp to change this imminently. - SB
-//
-//import "<%#= File.join(Gem.loaded_specs['cfa-styleguide'].full_gem_path, 'app', 'assets', 'javascripts', 'honeycrisp') %>";
-
 import "../lib/honeycrisp";
 
-// *
-<% unless Rails.env.test? %>
-  AjaxMixpanelEvents.init();
-<% end %>
+AjaxMixpanelEvents.init();
 Listeners.init();
 
 import jMaskGlobals from "jquery-mask-plugin";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -47,10 +47,8 @@
     <%= stylesheet_link_tag 'application', media: 'all' %>
 
     <%= render 'shared/favicon' %>
-    <%= render 'shared/app_data_mixpanel_data_script' %>
-
+    <%= render 'shared/mixpanel_configuration' %>
     <%= stylesheet_pack_tag 'application', media: 'all' %>
-
     <% if include_optimizely? %>
       <script src="https://cdn.optimizely.com/js/21316291320.js"></script>
     <% end %>

--- a/app/views/layouts/hub.html.erb
+++ b/app/views/layouts/hub.html.erb
@@ -36,7 +36,7 @@
   <%= stylesheet_link_tag 'hub', media: 'all' %>
 
   <%= render 'shared/favicon' %>
-  <%= render 'shared/app_data_mixpanel_data_script' %>
+  <%= render 'shared/mixpanel_configuration' %>
 
   <%= stylesheet_pack_tag 'application', media: 'all' %>
 

--- a/app/views/shared/_app_data_mixpanel_data_script.html.erb
+++ b/app/views/shared/_app_data_mixpanel_data_script.html.erb
@@ -1,7 +1,0 @@
-<script>
-    window.appData = JSON.parse(<%= JSON.generate(
-        controller_action: "#{controller.class.name}##{action_name}",
-        full_path: request.fullpath
-      ).inspect.html_safe %>);
-    window.mixpanelData = window.appData;
-</script>

--- a/app/views/shared/_mixpanel_configuration.html.erb
+++ b/app/views/shared/_mixpanel_configuration.html.erb
@@ -1,0 +1,5 @@
+<%= tag(:meta, id: "mixpanelData", data: {
+  controller_action: "#{controller.class.name}##{action_name}",
+  full_path: request.fullpath,
+  send_mixpanel_beacon: !Rails.env.test?,
+}) %>

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "jquery-mask-plugin": "^1.14.16",
     "jquery-ui": "^1.13.2",
     "mini-css-extract-plugin": "^1.4.0",
-    "rails-erb-loader": "^5.5.2",
     "regenerator-runtime": "^0.13.7",
     "stickybits": "^3.7.9",
     "style-loader": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6181,11 +6181,6 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
-lodash.defaults@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
-  integrity sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=
-
 lodash.get@^4.0:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
@@ -8076,14 +8071,6 @@ queue@6.0.2:
   integrity sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==
   dependencies:
     inherits "~2.0.3"
-
-rails-erb-loader@^5.5.2:
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/rails-erb-loader/-/rails-erb-loader-5.5.2.tgz#db3fa8ac89600f09d179a1a70a2ca18c592576ea"
-  integrity sha512-cjQH9SuSvRPhnWkvjmmAW/S4AFVDfAtYnQO4XpKJ8xpRdZayT73iXoE+IPc3VzN03noZXhVmyvsCvKvHj4LY6w==
-  dependencies:
-    loader-utils "^1.1.0"
-    lodash.defaults "^4.2.0"
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
It was last updated 4 years ago, and we do not need it. In the process, change how we store Mixpanel data in the DOM.