### PR TITLE
Hub: optimize 'assigned to' filter and friends to work better when many users are in the DB

### DIFF
--- a/app/helpers/tax_return_assignable_users_helper.rb
+++ b/app/helpers/tax_return_assignable_users_helper.rb
@@ -1,6 +1,9 @@
 module TaxReturnAssignableUsersHelper
   def assignable_user_options(assignable_users)
-    options = [[t("hub.bulk_actions.change_assignee_and_status.edit.keep_assignee"), BulkTaxReturnUpdate::KEEP], [t("hub.bulk_actions.change_assignee_and_status.edit.remove_assignee"), BulkTaxReturnUpdate::REMOVE]]
-    options.concat(assignable_users&.map { |u| [u.name_with_role, u.id] })
+    assignable_users.pluck(:id, :role_type, :name, Arel.sql('suspended_at IS NOT NULL as suspended')).map do |id, role_type, name, suspended|
+      name = suspended ? I18n.t("hub.suspended_user_name", name: name) : name
+      role = (role_type || "").gsub("Role", "").underscore.humanize.titlecase
+      ["#{name} (#{role})", id]
+    end
   end
 end

--- a/app/views/hub/bulk_actions/change_assignee_and_status/edit.html.erb
+++ b/app/views/hub/bulk_actions/change_assignee_and_status/edit.html.erb
@@ -13,7 +13,7 @@
             <%= @current_tr_statuses.map { |status| t("hub.tax_returns.status.#{status}")}.join(", ") + "." %>
           </p>
 
-          <%= f.cfa_select :assigned_user_id, t(".new_assignee"), assignable_user_options(@assignable_users) %>
+          <%= f.cfa_select :assigned_user_id, t(".new_assignee"), [[t("hub.bulk_actions.change_assignee_and_status.edit.keep_assignee"), BulkTaxReturnUpdate::KEEP], [t("hub.bulk_actions.change_assignee_and_status.edit.remove_assignee"), BulkTaxReturnUpdate::REMOVE], *assignable_user_options(@assignable_users)] %>
           <%= f.cfa_select :status, t(".new_status"), grouped_status_options_for_select.unshift(["No change", [[t(".keep_status"), BulkTaxReturnUpdate::KEEP]]]) %>
 
           <hr class="hr">

--- a/app/views/shared/_client_filters.html.erb
+++ b/app/views/shared/_client_filters.html.erb
@@ -62,8 +62,8 @@
         <div class="select">
           <select name="assigned_user_id" class="select__element" id="assignee-filter">
             <option value></option>
-            <% @users.each do |user| %>
-              <option value="<%= user.id %>" <%= filters[:assigned_user_id] == user.id.to_s && "selected" %>><%= user.name_with_role %></option>
+            <% assignable_user_options(@users).each do |(name, id)| %>
+              <option value="<%= id %>" <%= filters[:assigned_user_id] == id.to_s && "selected" %>><%= name %></option>
             <% end %>
           </select>
         </div>


### PR DESCRIPTION
Currently for an admin (who can see 10,000 users to assign to) it takes 2+ seconds to render all the <option> tags for the 'Assigned to' <select>

someday we might replace this with something better than a <select>, but for now there's a substantial savings if we only .pluck the minimal required stuff from the DB rather than letting ActiveRecord instantiate 10k things.

Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>