### PR TITLE
Hub clients page: don't show the count in 'take action on all returns'

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -50,7 +50,6 @@
 @import "components/sticky-action-footer";
 @import "components/tab-bar";
 @import "components/toolbar";
-@import "components/take-action-box";
 @import "components/tax-return-list";
 @import "components/urgent";
 @import "components/messages-and-notes";

--- a/app/assets/stylesheets/hub.scss
+++ b/app/assets/stylesheets/hub.scss
@@ -1,4 +1,7 @@
 /*
 *= require_self
  */
+@import 'honeycrisp/atoms/variables';
+@import "atoms/variables";
 @import "components/MainMenu";
+@import "components/take-action-box";

--- a/app/controllers/hub/clients_controller.rb
+++ b/app/controllers/hub/clients_controller.rb
@@ -16,9 +16,6 @@ module Hub
     def index
       @page_title = I18n.t("hub.clients.index.title")
 
-      # Compute the count of tax returns, up to a maximum amount. Postgres is slow at computing counts if they are very large.
-      tax_return_count = TaxReturn.where(client: @client_sorter.filtered_clients.with_eager_loaded_associations.without_pagination.reorder(nil)).limit(MAX_COUNT + 1).size
-      @tax_return_count = tax_return_count > MAX_COUNT ? "" : tax_return_count.to_s
       @clients = @client_sorter.filtered_and_sorted_clients.with_eager_loaded_associations.page(params[:page]).load
       @message_summaries = RecentMessageSummaryService.messages(@clients.map(&:id))
     end

--- a/app/javascript/lib/bulk_action.js
+++ b/app/javascript/lib/bulk_action.js
@@ -19,14 +19,6 @@ function handleCheckboxChange(formEl, takeActionCountEl, takeActionFooterEl) {
     }
 }
 
-function showTakeActionAll(formEl, totalTaxReturnsCount, takeActionAllEl) {
-    if (getCheckedNum(formEl) == totalTaxReturnsCount) {
-        changeElDisplay(takeActionAllEl, "none");
-    } else {
-        changeElDisplay(takeActionAllEl, "");
-    }
-}
-
 export function initBulkAction() {
     const selectAllEl = document.querySelector('#bulk-edit-select-all');
     const allCheckboxEls = [...document.querySelectorAll("[id^='tr_ids_']")];
@@ -34,19 +26,22 @@ export function initBulkAction() {
     const takeActionFooterEl = document.querySelector('#take-action-footer');
     const takeActionCountEl = document.querySelector('#take-action-count');
     const takeActionAllEl = document.querySelector('#take-action-all-returns');
-    const totalTaxReturnsCount = document.querySelector('#take-action-all-count').textContent;
 
     handleCheckboxChange(formEl, takeActionCountEl, takeActionFooterEl);
 
     if (selectAllEl) {
         selectAllEl.addEventListener('change', () => {
+            const useTakeActionAllEl = selectAllEl.dataset['multiPage'] === 'true';
             if (selectAllEl.checked) {
                 allCheckboxEls.forEach(checkboxEl => checkboxEl.checked = true);
-                showTakeActionAll(formEl, totalTaxReturnsCount, takeActionAllEl)
+                if (useTakeActionAllEl) {
+                    takeActionAllEl.classList.remove('hidden')
+                }
             } else {
                 allCheckboxEls.forEach(checkboxEl => checkboxEl.checked = false);
-                // Hide take action all no matter what
-                changeElDisplay(takeActionAllEl, "none");
+                if (useTakeActionAllEl) {
+                    takeActionAllEl.classList.add('hidden')
+                }
             }
 
             handleCheckboxChange(formEl, takeActionCountEl, takeActionFooterEl);

--- a/app/views/hub/clients/index.html.erb
+++ b/app/views/hub/clients/index.html.erb
@@ -90,7 +90,7 @@
           <th scope="col" class="index-table__header index-table__header-filing_year" style="width: 100%; display: flex; align-items: center; justify-content: space-between;">
             <span><%= t(".filing_year") %>, <%= t("general.assignee") %>, <%= t("general.certification") %>, <%= t("general.status") %></span>
             <label class="checkbox--gyr">
-              <input id="bulk-edit-select-all" type="checkbox" name="add-all">
+              <input id="bulk-edit-select-all" type="checkbox" name="add-all" data-multi-page="<%= @clients.total_pages > 1 %>">
               <span><%= t('.select') %></span>
             </label>
           </th>
@@ -171,7 +171,7 @@
   </section>
   <div class="sticky-action-footer">
     <section class="take-action-box bulk-action-footer" id="take-action-footer" style="display: none;">
-      <span id="take-action-all-returns" style="display: none;">
+      <span id="take-action-all-returns" class="hidden">
          <%= form_with(url: new_hub_tax_return_selection_path, local: true, method: :get, builder: VitaMinFormBuilder) do |form| %>
               <% @client_sorter&.filters&.each do |key, value| %>
                 <%= form.hidden_field(key, value: value, id: "#{key}_bulk") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -712,7 +712,7 @@ en:
         organization: Organization/site
         select: Select
         stage_status: Stage/Status
-        take_action_on_all_html: Take action on all <span id="take-action-all-count">%{count}</span> returns
+        take_action_on_all_html: Take action on all returns
         title: All Clients
         unassigned: Unassigned
       navigation:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -721,7 +721,7 @@ es:
         organization: Organización/Sitio
         select: Seleccione
         stage_status: Etapa/Estado
-        take_action_on_all_html: Actúe en las <span id="take-action-all-count">%{count}</span> devoluciones
+        take_action_on_all_html: Actúe en las devoluciones
         title: Todos los Clientes
         unassigned: No asignado
       navigation:

--- a/spec/controllers/hub/clients_controller_spec.rb
+++ b/spec/controllers/hub/clients_controller_spec.rb
@@ -610,35 +610,6 @@ RSpec.describe Hub::ClientsController do
         end
       end
 
-      context "tax return count" do
-        let!(:over_pagination_clients) { create_list :client_with_intake_and_return, 50, vita_partner: organization }
-        let(:params) do
-          {
-            page: "1"
-          }
-        end
-
-        context "when there are less than 1000 tax returns" do
-          it "shows the full amount of tax returns" do
-            get :index, params: params
-
-            expect(assigns(:tax_return_count)).to eq "50"
-          end
-        end
-
-        context "when there 1000 or more tax returns" do
-          before do
-            stub_const("Hub::ClientsController::MAX_COUNT", 10)
-          end
-          it "returns an empty string" do
-            get :index, params: params
-
-            expect(assigns(:tax_return_count)).to eq ""
-          end
-        end
-
-      end
-
       context "ordering tax returns" do
         let(:client) { (create :intake).client }
         let!(:tax_return_2020) { create :tax_return, :intake_in_progress, client: client }

--- a/spec/features/hub/filtered_clients_bulk_action_spec.rb
+++ b/spec/features/hub/filtered_clients_bulk_action_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Filtering clients for bulk actions", active_job: true do
 
     find("#bulk-edit-select-all").click
     expect(page).to have_text "Displaying clients 1 - 25 of 30"
-    click_on "Take action on all 31 returns"
+    click_on "Take action on all returns"
 
     expect(page).to have_text "Choose your bulk action"
 


### PR DESCRIPTION
it was expensive to compute, is rarely seen, and you can see the count by clicking the button to go to the bulk actions page

we changed the way the button's visibility works to use some fancy css instead of javascript

Co-authored-by: Asheesh Laroia <alaroia@codeforamerica.org>