### PR TITLE
TaxReturnStateMachine flushes transition status changes onto Client

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -104,7 +104,7 @@ class Client < ApplicationRecord
         if client_ids.nil?
           where('needs_to_flush_filterable_properties_set_at < ?', Time.current).limit(limit).pluck(:id)
         else
-          where(id: client_ids).includes(:tax_returns)
+          where(id: client_ids)
         end
 
       attributes = where(id: client_ids).includes(:tax_returns).map do |client|

--- a/app/state_machines/tax_return_state_machine.rb
+++ b/app/state_machines/tax_return_state_machine.rb
@@ -55,6 +55,7 @@ class TaxReturnStateMachine
 
   after_transition(after_commit: true) do |tax_return, transition|
     tax_return.update_columns(current_state: transition.to_state)
+    Client.refresh_filterable_properties([tax_return.client_id])
     InteractionTrackingService.record_internal_interaction(tax_return.client) # manually run since the update_columns doesn't run callbacks
     MixpanelService.send_tax_return_event(tax_return, "status_change", { from_status: tax_return.previous_state })
   end

--- a/spec/factories/tax_returns.rb
+++ b/spec/factories/tax_returns.rb
@@ -53,6 +53,7 @@ FactoryBot.define do
         after :create do |tax_return, evaluator|
           create :tax_return_transition, state, tax_return: tax_return, metadata: evaluator.metadata
           tax_return.update_columns(current_state: state)
+          Client.refresh_filterable_properties([tax_return.client_id])
         end
       end
     end


### PR DESCRIPTION
since the state is being updated in an `update_column`, it wasn't otherwise triggering the `after_save_commit` on TaxReturn