### PR TITLE
Client#filterable_tax_return_properties contains active, stage and greetable

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -120,6 +120,9 @@ class Client < ApplicationRecord
               service_type: tr.service_type,
               current_state: tr.current_state,
               assigned_user_id: tr.assigned_user_id,
+              stage: TaxReturnStateMachine::STAGES_BY_STATE[tr.current_state],
+              active: !TaxReturnStateMachine::EXCLUDED_FROM_SLA.include?(tr.current_state.to_sym),
+              greetable: TaxReturnStateMachine.available_states_for(role_type: GreeterRole::TYPE).values.flatten.include?(tr.current_state)
             }
           end,
           filterable_tax_return_assigned_users: client.tax_returns.map(&:assigned_user_id).uniq,

--- a/app/state_machines/tax_return_state_machine.rb
+++ b/app/state_machines/tax_return_state_machine.rb
@@ -44,7 +44,12 @@ class TaxReturnStateMachine
                         stages[stage].push(status)
                       end
                       stages
-                    end.freeze
+  end.freeze
+  STAGES_BY_STATE = STATES_BY_STAGE.invert.each_with_object({}) do |(states, stage), hsh|
+    states.each do |state|
+      hsh[state] = stage
+    end
+  end.freeze
 
   STAGES = STATES_BY_STAGE.keys.freeze
   EXCLUDED_FROM_SLA = [:intake_before_consent, :file_accepted, :file_not_filing, :file_hold, :file_mailed].freeze
@@ -101,7 +106,7 @@ class TaxReturnStateMachine
   end
 
   def self.available_states_for(role_type:)
-    return STATES_BY_STAGE.slice("intake").merge({ "file" => [:file_not_filing, :file_hold] }.freeze) if role_type == GreeterRole::TYPE
+    return STATES_BY_STAGE.slice("intake").merge({ "file" => %w[file_not_filing file_hold] }.freeze) if role_type == GreeterRole::TYPE
 
     STATES_BY_STAGE
   end

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -104,8 +104,24 @@ describe Client do
       client.touch(:needs_to_flush_filterable_properties_set_at)
       described_class.refresh_filterable_properties
       expected_json = [
-        { "year" => 2019, "assigned_user_id" => user.id, "current_state" => "intake_before_consent", "service_type" => "online_intake" },
-        { "year" => 2020, "assigned_user_id" => nil, "current_state" => "file_needs_review", "service_type" => "online_intake" }
+        {
+          "active" => false,
+          "year" => 2019,
+          "assigned_user_id" => user.id,
+          "current_state" => "intake_before_consent",
+          "greetable" => false,
+          "service_type" => "online_intake",
+          "stage" => nil
+        },
+        {
+          "active" => true,
+          "year" => 2020,
+          "assigned_user_id" => nil,
+          "current_state" => "file_needs_review",
+          "greetable" => false,
+          "service_type" => "online_intake",
+          "stage" => "file"
+        }
       ]
       expect(client.reload.filterable_tax_return_properties).to eq(expected_json)
       expect(client.reload.filterable_tax_return_years).to eq([2019, 2020])

--- a/spec/state_machines/tax_return_state_machine_spec.rb
+++ b/spec/state_machines/tax_return_state_machine_spec.rb
@@ -62,7 +62,7 @@ describe TaxReturnStateMachine do
         expect(result.keys.first).to eq "intake"
         expect(result.keys.last).to eq "file"
         expect(result["intake"]).to eq TaxReturnStateMachine::STATES_BY_STAGE["intake"]
-        expect(result["file"]).to eq [:file_not_filing, :file_hold]
+        expect(result["file"]).to eq ["file_not_filing", "file_hold"]
       end
     end
 


### PR DESCRIPTION
it's easier to query on this jsonb field if there's single bits rather than arrays of different possible stages