### PR TITLE
Client search indexing: don't crash if current_state is nil

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -121,7 +121,7 @@ class Client < ApplicationRecord
               current_state: tr.current_state,
               assigned_user_id: tr.assigned_user_id,
               stage: TaxReturnStateMachine::STAGES_BY_STATE[tr.current_state],
-              active: !TaxReturnStateMachine::EXCLUDED_FROM_SLA.include?(tr.current_state.to_sym),
+              active: tr.current_state.present? && !TaxReturnStateMachine::EXCLUDED_FROM_SLA.include?(tr.current_state&.to_sym),
               greetable: TaxReturnStateMachine.available_states_for(role_type: GreeterRole::TYPE).values.flatten.include?(tr.current_state)
             }
           end,


### PR DESCRIPTION
there are 1537 TaxReturn records with a nil current_state on prod and 230 on demo