### PR TITLE
Hub clients index: speed up counting for pagination by targeting eager loads more precisely

### DIFF
--- a/app/controllers/hub/assigned_clients_controller.rb
+++ b/app/controllers/hub/assigned_clients_controller.rb
@@ -14,7 +14,7 @@ module Hub
       @page_title = I18n.t("hub.assigned_clients.index.title")
       @client_sorter.filters[:assigned_to_me] = true
       @tax_return_count = TaxReturn.where(client: @client_sorter.filtered_clients.with_eager_loaded_associations.without_pagination).size
-      @clients = @client_sorter.filtered_and_sorted_clients.with_eager_loaded_associations.page(params[:page]).load
+      @clients = @client_sorter.filtered_and_sorted_clients.page(params[:page]).load
       @message_summaries = RecentMessageSummaryService.messages(@clients.map(&:id))
       render "hub/clients/index"
     end

--- a/app/controllers/hub/clients_controller.rb
+++ b/app/controllers/hub/clients_controller.rb
@@ -16,7 +16,7 @@ module Hub
     def index
       @page_title = I18n.t("hub.clients.index.title")
 
-      @clients = @client_sorter.filtered_and_sorted_clients.with_eager_loaded_associations.page(params[:page]).load
+      @clients = @client_sorter.filtered_and_sorted_clients.page(params[:page]).load
       @message_summaries = RecentMessageSummaryService.messages(@clients.map(&:id))
     end
 

--- a/app/controllers/hub/tax_return_selections_controller.rb
+++ b/app/controllers/hub/tax_return_selections_controller.rb
@@ -30,7 +30,7 @@ module Hub
     end
 
     def new
-      @clients = Client.accessible_by(current_ability).with_eager_loaded_associations
+      @clients = Client.accessible_by(current_ability)
       @client_sorter = ClientSorter.new(@clients, current_user, params, {})
       @tr_ids = (new_params.dig(:create_tax_return_selection, :action_type) == "all-filtered-clients") ? TaxReturn.where(client: @client_sorter.filtered_and_sorted_clients.reorder(nil)).pluck(:id) : new_params[:tr_ids]
       @client_count = @clients.distinct.joins(:tax_returns).where(tax_returns: { id: @tr_ids }).size

--- a/app/controllers/hub/unattended_clients_controller.rb
+++ b/app/controllers/hub/unattended_clients_controller.rb
@@ -16,9 +16,9 @@ module Hub
       @page_title = "Clients who haven't received a response in #{day_param} business days"
       @breach_date = day_param.business_days.ago
       @client_sorter.filters[:sla_breach_date] = @breach_date
-      @tax_return_count = TaxReturn.where(client: @client_sorter.filtered_clients.with_eager_loaded_associations.without_pagination).size
+      @tax_return_count = TaxReturn.where(client: @client_sorter.filtered_clients.without_pagination).size
       @clients = @client_sorter.filtered_and_sorted_clients.first_unanswered_incoming_interaction_between(...@breach_date)
-      @clients = @clients.with_eager_loaded_associations.page(params[:page]).load
+      @clients = @clients.page(params[:page]).load
       @message_summaries = RecentMessageSummaryService.messages(@clients.map(&:id))
       render "hub/clients/index"
     end

--- a/app/views/hub/clients/index.html.erb
+++ b/app/views/hub/clients/index.html.erb
@@ -98,7 +98,7 @@
         </thead>
 
         <tbody class="index-table__body clients-table">
-        <% @clients.map { |client| Hub::ClientsController::HubClientPresenter.new(client) }.each do |client| %>
+        <% @clients.with_eager_loaded_associations.map { |client| Hub::ClientsController::HubClientPresenter.new(client) }.each do |client| %>
           <tr id="client-<%= client.id %>" class="index-table__row client-row">
             <td class="index-table__cell client-attribute__needs-response">
               <%= render "shared/urgent_icon", client: client %>


### PR DESCRIPTION
ActiveRecord does counts a little differently depending on whether you have just @clients.where(stuff).count or @clients.includes(things).where(stuff).count

The .includes() seems to invoke a LEFT OUTER JOIN of everything being included, which has to be DISTINCT-ified afterwards

We only need the eager loading when rendering the actual `<tr>`s with client data, so we should make sure the Client relation that we send to will_paginate hasn't had any eager loading

OLD:

```SQL
SELECT COUNT(*)
FROM (SELECT DISTINCT "clients"."id"
      FROM "clients"
               INNER JOIN "intakes" ON "intakes"."client_id" = "clients"."id"
               LEFT OUTER JOIN "vita_partners" ON "vita_partners"."id" = "clients"."vita_partner_id"
               LEFT OUTER JOIN "tax_returns" ON "tax_returns"."client_id" = "clients"."id"
               LEFT OUTER JOIN "users" ON "users"."id" = "tax_returns"."assigned_user_id"
      WHERE "clients"."consented_to_service_at" IS NOT NULL
        AND (filterable_tax_return_properties @> '[{}]'::jsonb)) subquery_for_count;
```
Time: 2975.586 ms (00:02.976)

NEW:

```SQL
SELECT COUNT(*)
FROM "clients"
         INNER JOIN "intakes" ON "intakes"."client_id" = "clients"."id"
WHERE "clients"."consented_to_service_at" IS NOT NULL
  AND (filterable_tax_return_properties @> '[{}]'::jsonb);
```
Time: 1866.623 ms (00:01.867)