### PR TITLE
Client model: ignore array-style denormalized tax return columns in prep for deleting them

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -12,11 +12,7 @@
 #  current_sign_in_ip                          :inet
 #  experience_survey                           :integer          default("unfilled"), not null
 #  failed_attempts                             :integer          default(0), not null
-#  filterable_tax_return_assigned_users        :integer          is an Array
 #  filterable_tax_return_properties            :jsonb
-#  filterable_tax_return_service_types         :string           is an Array
-#  filterable_tax_return_states                :string           is an Array
-#  filterable_tax_return_years                 :integer          is an Array
 #  first_unanswered_incoming_interaction_at    :datetime
 #  flagged_at                                  :datetime
 #  identity_verification_denied_at             :datetime
@@ -62,6 +58,12 @@
 #  fk_rails_...  (vita_partner_id => vita_partners.id)
 #
 class Client < ApplicationRecord
+  self.ignored_columns = [
+    :filterable_tax_return_assigned_users,
+    :filterable_tax_return_service_types,
+    :filterable_tax_return_states,
+    :filterable_tax_return_years
+  ]
   devise :lockable, :timeoutable, :trackable
 
   self.per_page = 25
@@ -125,10 +127,6 @@ class Client < ApplicationRecord
               greetable: TaxReturnStateMachine.available_states_for(role_type: GreeterRole::TYPE).values.flatten.include?(tr.current_state)
             }
           end,
-          filterable_tax_return_assigned_users: client.tax_returns.map(&:assigned_user_id).uniq,
-          filterable_tax_return_service_types: client.tax_returns.map(&:service_type).uniq,
-          filterable_tax_return_states: client.tax_returns.map(&:current_state).uniq,
-          filterable_tax_return_years: client.tax_returns.map(&:year).uniq,
           needs_to_flush_filterable_properties_set_at: nil
         }
       end

--- a/spec/factories/clients.rb
+++ b/spec/factories/clients.rb
@@ -12,11 +12,7 @@
 #  current_sign_in_ip                          :inet
 #  experience_survey                           :integer          default("unfilled"), not null
 #  failed_attempts                             :integer          default(0), not null
-#  filterable_tax_return_assigned_users        :integer          is an Array
 #  filterable_tax_return_properties            :jsonb
-#  filterable_tax_return_service_types         :string           is an Array
-#  filterable_tax_return_states                :string           is an Array
-#  filterable_tax_return_years                 :integer          is an Array
 #  first_unanswered_incoming_interaction_at    :datetime
 #  flagged_at                                  :datetime
 #  identity_verification_denied_at             :datetime

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -12,11 +12,7 @@
 #  current_sign_in_ip                          :inet
 #  experience_survey                           :integer          default("unfilled"), not null
 #  failed_attempts                             :integer          default(0), not null
-#  filterable_tax_return_assigned_users        :integer          is an Array
 #  filterable_tax_return_properties            :jsonb
-#  filterable_tax_return_service_types         :string           is an Array
-#  filterable_tax_return_states                :string           is an Array
-#  filterable_tax_return_years                 :integer          is an Array
 #  first_unanswered_incoming_interaction_at    :datetime
 #  flagged_at                                  :datetime
 #  identity_verification_denied_at             :datetime
@@ -140,13 +136,6 @@ describe Client do
         }
       ]
       expect(client.reload.filterable_tax_return_properties).to match_array(expected_json)
-      expect(client.reload.filterable_tax_return_years).to match_array([2018, 2019, 2020])
-      expect(client.reload.vita_partner).to eq(organization) # only change intended columns
-    end
-
-    it "denormalizes filterable properties onto a provided list of client ids" do
-      described_class.refresh_filterable_properties([client.id])
-      expect(client.reload.filterable_tax_return_years).to match_array([2018, 2019, 2020])
       expect(client.reload.vita_partner).to eq(organization) # only change intended columns
     end
   end

--- a/spec/models/tax_return_spec.rb
+++ b/spec/models/tax_return_spec.rb
@@ -60,7 +60,17 @@ describe TaxReturn do
 
       it "denormalizes tax return info onto the client" do
         tax_return = create :tax_return
-        expect(tax_return.client.reload.filterable_tax_return_years).to eq([tax_return.year])
+
+        expected_tax_return_properties = {
+          "active" => false,
+          "assigned_user_id" => nil,
+          "current_state" => "intake_before_consent",
+          "greetable" => false,
+          "service_type" => "online_intake",
+          "stage" => nil,
+          "year" => 2021
+        }
+        expect(tax_return.client.reload.filterable_tax_return_properties).to eq([expected_tax_return_properties])
       end
     end
   end
@@ -70,9 +80,18 @@ describe TaxReturn do
       it "denormalizes tax return info onto the client" do
         tax_return = create :tax_return
         client = tax_return.client
-        expect(client.reload.filterable_tax_return_years).to eq([tax_return.year])
+        expected_properties = {
+          "active" => false,
+          "assigned_user_id" => nil,
+          "current_state" => "intake_before_consent",
+          "greetable" => false,
+          "service_type" => "online_intake",
+          "stage" => nil,
+          "year" => 2021
+        }
+        expect(client.reload.filterable_tax_return_properties).to eq([expected_properties])
         tax_return.destroy
-        expect(client.reload.filterable_tax_return_years).to eq([])
+        expect(client.reload.filterable_tax_return_properties).to eq([])
       end
     end
   end

--- a/spec/state_machines/tax_return_state_machine_spec.rb
+++ b/spec/state_machines/tax_return_state_machine_spec.rb
@@ -80,7 +80,7 @@ describe TaxReturnStateMachine do
     it "updates the filterable properties" do
       expect do
         tax_return.transition_to!(:file_accepted)
-      end.to change { tax_return.reload.client.filterable_tax_return_states }.from(['intake_before_consent']).to(['file_accepted'])
+      end.to change { tax_return.reload.client.filterable_tax_return_properties }.from([a_hash_including("current_state" => "intake_before_consent")]).to([a_hash_including("current_state" => "file_accepted")])
     end
 
     context "to file_accepted" do


### PR DESCRIPTION
we're using the full jsonb filterable_tax_return_properties instead of these arrays