### PR TITLE
Add non-monitored response for archived clients with no current intake emails

### DIFF
--- a/app/controllers/mailgun_webhooks_controller.rb
+++ b/app/controllers/mailgun_webhooks_controller.rb
@@ -10,13 +10,24 @@ class MailgunWebhooksController < ActionController::Base
     clients = Client.joins(:intake).where(intakes: { email_address: sender_email })
     client_count = clients.count
     if client_count.zero?
-      DatadogApi.increment("mailgun.incoming_emails.client_not_found")
+      archived_intake = Archived::Intake2021.where(email_address: sender_email).first
+      if archived_intake.present?
+        locale = archived_intake.locale || "en"
+        archived_intake.client.outgoing_emails.create!(
+          to: sender_email,
+          subject: AutomatedMessage::UnmonitoredReplies.new.email_subject(locale: locale),
+          body: AutomatedMessage::UnmonitoredReplies.new.email_body(locale: locale, support_email: Rails.configuration.email_from[:support][:gyr])
+        )
+        DatadogApi.increment("mailgun.outgoing_emails.sent_replies_not_monitored")
+      else
+        DatadogApi.increment("mailgun.incoming_emails.client_not_found")
 
-      IntercomService.create_intercom_message(
-        email_address: sender_email,
-        inform_of_handoff: false,
-        body: params["stripped-text"] || params["body-plain"]
-      )
+        IntercomService.create_intercom_message(
+          email_address: sender_email,
+          inform_of_handoff: false,
+          body: params["stripped-text"] || params["body-plain"]
+        )
+      end
 
       return head :ok
     elsif client_count == 1


### PR DESCRIPTION
Co-authored-by: Nishi Nelson <nnelson@codeforamerica.org>