### PR TITLE
Flow explorer: tweak display of links on flows index page

### DIFF
--- a/app/assets/stylesheets/templates/_flow-explorer.scss
+++ b/app/assets/stylesheets/templates/_flow-explorer.scss
@@ -66,7 +66,8 @@
 }
 
 .flow-explorer-card {
-  background-color: white;
+  background-color: $color-grey-light;
+  border: 1px solid $color-grey-medium;
   padding: $s25;
   border-radius: 10px;
 }


### PR DESCRIPTION
the css is originally lifted from GCF which had an off-white background with white cards, since we have a white background there was no separation between the links. now they have an off-white background and border

# before

![Screen Shot 2022-11-16 at 9 41 40 AM](https://user-images.githubusercontent.com/30675659/202254054-acf4e40a-6f95-4560-bdeb-235075202c0b.png)

# after

![Screen Shot 2022-11-16 at 9 41 32 AM](https://user-images.githubusercontent.com/30675659/202254091-e4b576af-cf53-4c2b-8a88-345aeb480798.png)