### PR TITLE
Flow explorer: show GYR dependents controller at the appropriate spot

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,6 +23,10 @@ class ApplicationController < ActionController::Base
     "views.#{controller_path.tr('/', '.')}"
   end
 
+  def self.flow_explorer_actions
+    [:edit]
+  end
+
   def self.to_path_helper(options = {})
     action = options.delete(:action) || :edit
     Rails.application.routes.url_helpers.url_for({

--- a/app/controllers/dependents_controller.rb
+++ b/app/controllers/dependents_controller.rb
@@ -3,6 +3,10 @@ class DependentsController < ApplicationController
 
   helper_method :next_path
 
+  def self.flow_explorer_actions
+    [:index, :new]
+  end
+
   def index
     @dependents = current_intake.dependents
   end

--- a/app/views/flows/_flow.html.erb
+++ b/app/views/flows/_flow.html.erb
@@ -10,13 +10,13 @@
 </p>
 
 <ul>
-  <% flow_params.controllers.decorated.each do |decorated_controller| %>
+  <% flow_params.controllers.controller_actions.each do |decorated_controller_action| %>
     <li>
       <div class="flow-explorer-line spacing-below-10">
         <div class="flow-explorer-screenshot">
           <%=
             image_tag(
-              screenshot_path(decorated_controller),
+              decorated_controller_action.screenshot_path,
               onerror: "this.onerror = null; this.style.display = 'none'"
             )
           %>
@@ -24,28 +24,28 @@
         <div style="padding-left: 20px;">
           <%=
             link_to(
-              decorated_controller.controller_url,
+              decorated_controller_action.controller_url,
               class: 'flow-explorer-link',
-              style: flow_params.reference_object && decorated_controller.unreachable?(controller) ? 'font-style: italic; color: #aaa;' : ''
+              style: flow_params.reference_object && decorated_controller_action.unreachable?(controller) ? 'font-style: italic; color: #aaa;' : ''
             ) do %>
-            <% navigation_entry_action_title = decorated_controller.navigation_entry_action_title(flow_params.title_i18n_params) %>
-            <% if navigation_entry_action_title.is_a?(Hash) %>
+            <% page_title = decorated_controller_action.page_title(flow_params.title_i18n_params) %>
+            <% if page_title.is_a?(Hash) %>
               <ul>
-                <% navigation_entry_action_title.each do |k, v| %>
+                <% page_title.each do |k, v| %>
                   <li><strong>(<%= k.upcase %>)</strong>: <%= v %></li>
                 <% end %>
               </ul>
             <% else %>
-              <%= navigation_entry_action_title %>
+              <%= page_title %>
             <% end %>
           <% end %>
           <div>
-            <%= decorated_controller %>
-            <% if decorated_controller.methods(false).include?(:show?) %>
+            <%= decorated_controller_action.pretty_name %>
+            <% if decorated_controller_action.methods(false).include?(:show?) %>
               <div class="reveal">
                 <span class="text--small"><a href="#" class="reveal__link"><%= 'Show Conditions' %></a></span>
                 <div class="reveal__content">
-                  <pre><%= decorated_controller.__getobj__.method(:show?).source %></pre>
+                  <pre><%= decorated_controller_action.__getobj__.method(:show?).source %></pre>
                 </div>
               </div>
             <% end %>


### PR DESCRIPTION
it's not in the actual navigation order so we have to splice it in

also includes some improvements to deal with controllers that don't just have an #edit (which is just this one, I guess)