### PR TITLE
Add a custom match_rows RSpec matcher mostly for asserting on table column data

### DIFF
--- a/app/views/hub/clients/index.html.erb
+++ b/app/views/hub/clients/index.html.erb
@@ -103,11 +103,11 @@
             <td class="index-table__cell client-attribute__needs-response">
               <%= render "shared/urgent_icon", client: client %>
             </td>
-            <%= tag.th(
+            <%= tag.td(
               scope: "row",
               class: "index-table__row-header index-table__row-header--sticky index-table__header--tooltip-z-positioning #{'index-table__row-header--tooltip-has-text' unless @message_summaries[client.id].nil?} client-attribute__name",
             ) do %>
-              <%= tag.span(
+              <%= tag.strong(
                 class: "tooltip",
                 data: { position: "right" },
                 title: @message_summaries[client.id] ? render("shared/message_summary", message_summary: @message_summaries[client.id]) : t(".no_message")) do %>

--- a/spec/features/hub/clients_searching_sorting_and_filtering_spec.rb
+++ b/spec/features/hub/clients_searching_sorting_and_filtering_spec.rb
@@ -34,14 +34,22 @@ RSpec.describe "searching, sorting, and filtering clients" do
         visit hub_clients_path
 
         expect(page).to have_text "All Clients"
-        within ".client-table" do
-          # Default sort order
-          expect(page.all('.client-row')[0]).to have_text(alan_intake_in_progress.preferred_name)
-          expect(page.all('.client-row')[1]).to have_text(zach_prep_ready_for_call.preferred_name)
-          expect(page.all('.client-row')[2]).to have_text(patty_prep_ready_for_call.preferred_name)
-          expect(page.all('.client-row')[3]).to have_text(marty_ctc.preferred_name)
-          expect(page.all('.client-row')[4]).to have_text(betty_intake_in_progress.preferred_name)
-        end
+
+        # Default sort order
+        expected_rows = [
+          {
+            "Name" => a_string_including(alan_intake_in_progress.preferred_name),
+          }, {
+            "Name" => a_string_including(zach_prep_ready_for_call.preferred_name),
+          }, {
+            "Name" => a_string_including(patty_prep_ready_for_call.preferred_name),
+          }, {
+            "Name" => a_string_including(marty_ctc.preferred_name),
+          }, {
+            "Name" => a_string_including(betty_intake_in_progress.preferred_name),
+          },
+        ]
+        expect(table_contents(page.find('.client-table'))).to match_rows(expected_rows)
 
         # search for client
         fill_in "Search", with: "Zach"
@@ -127,36 +135,58 @@ RSpec.describe "searching, sorting, and filtering clients" do
           click_button "Filter results"
           expect(page).to have_select("status-filter", selected: "Ready for prep")
         end
-        within ".client-table" do
-          expect(page.all('.client-row').length).to eq 3
 
-          # Sort one direction
-          click_link "sort-preferred_name"
-          expect(page.all('.client-row').length).to eq 3 # make sure filter is retained
-          expect(page.all('.client-row')[0]).to have_text(marty_ctc.preferred_name)
-          expect(page.all('.client-row')[1]).to have_text(patty_prep_ready_for_call.preferred_name)
-          expect(page.all('.client-row')[2]).to have_text(zach_prep_ready_for_call.preferred_name)
+        # Sort one direction
+        click_link "sort-preferred_name"
+        expected_rows = [
+          {
+            "Name" => a_string_including(marty_ctc.preferred_name),
+          }, {
+            "Name" => a_string_including(patty_prep_ready_for_call.preferred_name),
+          }, {
+            "Name" => a_string_including(zach_prep_ready_for_call.preferred_name),
+          },
+        ]
+        expect(table_contents(page.find('.client-table'))).to match_rows(expected_rows)
 
-          # Sort opposite direction
-          click_link "sort-preferred_name"
-          expect(page.all('.client-row').length).to eq 3 # make sure filter is retained
-          expect(page.all('.client-row')[2]).to have_text(marty_ctc.preferred_name)
-          expect(page.all('.client-row')[1]).to have_text(patty_prep_ready_for_call.preferred_name)
-          expect(page.all('.client-row')[0]).to have_text(zach_prep_ready_for_call.preferred_name)
+        # Sort opposite direction
+        click_link "sort-preferred_name"
+        expected_rows = [
+          {
+            "Name" => a_string_including(zach_prep_ready_for_call.preferred_name),
+          }, {
+            "Name" => a_string_including(patty_prep_ready_for_call.preferred_name),
+          }, {
+            "Name" => a_string_including(marty_ctc.preferred_name),
+          },
+        ]
+        expect(table_contents(page.find('.client-table'))).to match_rows(expected_rows)
 
-          #zach, betty, patty (oldest to youngest created at)
-          click_link "sort-created_at"
-          expect(page.all('.client-row').length).to eq 3 # make sure filter is retained
-          expect(page.all('.client-row')[0]).to have_text(marty_ctc.preferred_name)
-          expect(page.all('.client-row')[1]).to have_text(zach_prep_ready_for_call.preferred_name)
-          expect(page.all('.client-row')[2]).to have_text(patty_prep_ready_for_call.preferred_name)
+        #zach, betty, patty (oldest to youngest created at)
+        click_link "sort-created_at"
+        expected_rows = [
+          {
+            "Name" => a_string_including(marty_ctc.preferred_name),
+          }, {
+            "Name" => a_string_including(zach_prep_ready_for_call.preferred_name),
+          }, {
+            "Name" => a_string_including(patty_prep_ready_for_call.preferred_name),
+          },
+        ]
+        expect(table_contents(page.find('.client-table'))).to match_rows(expected_rows)
 
-          click_link "sort-created_at"
-          expect(page.all('.client-row').length).to eq 3 # make sure filter is retained
-          expect(page.all('.client-row')[0]).to have_text(patty_prep_ready_for_call.preferred_name)
-          expect(page.all('.client-row')[1]).to have_text(zach_prep_ready_for_call.preferred_name)
-          expect(page.all('.client-row')[2]).to have_text(marty_ctc.preferred_name)
-        end
+        click_link "sort-created_at"
+        expected_rows = [
+          {
+            "Name" => a_string_including(patty_prep_ready_for_call.preferred_name),
+          }, {
+            "Name" => a_string_including(zach_prep_ready_for_call.preferred_name),
+          }, {
+            "Name" => a_string_including(marty_ctc.preferred_name),
+          },
+        ]
+        expect(table_contents(page.find('.client-table'))).to match_rows(expected_rows)
+
         within ".filter-form" do
           click_link "Clear"
         end
@@ -168,12 +198,25 @@ RSpec.describe "searching, sorting, and filtering clients" do
 
         # sort by state of residence ASC
         click_link "sort-state_of_residence"
-        expect(page.all('.client-row').length).to eq 5 # make sure filter is retained
-        expect(page.all('.client-row')[0]).to have_text(patty_prep_ready_for_call.preferred_name) # AL
-        expect(page.all('.client-row')[1]).to have_text(alan_intake_in_progress.preferred_name) # CA
-        expect(page.all('.client-row')[2]).to have_text(marty_ctc.preferred_name) # ME
-        expect(page.all('.client-row')[3]).to have_text(betty_intake_in_progress.preferred_name) # TX
-        expect(page.all('.client-row')[4]).to have_text(zach_prep_ready_for_call.preferred_name) # WI
+        expected_rows = [
+          {
+            "Name" => a_string_including(patty_prep_ready_for_call.preferred_name),
+            "State" => "AL"
+          }, {
+            "Name" => a_string_including(alan_intake_in_progress.preferred_name),
+            "State" => "CA"
+          }, {
+            "Name" => a_string_including(marty_ctc.preferred_name),
+            "State" => "ME"
+          }, {
+            "Name" => a_string_including(betty_intake_in_progress.preferred_name),
+            "State" => "TX"
+          }, {
+            "Name" => a_string_including(zach_prep_ready_for_call.preferred_name),
+            "State" => "WI"
+          },
+        ]
+        expect(table_contents(page.find('.client-table'))).to match_rows(expected_rows)
 
         # sort by state of residence DESC
         click_link "sort-state_of_residence"
@@ -182,32 +225,50 @@ RSpec.describe "searching, sorting, and filtering clients" do
 
         # return to default sort order
         click_link "sort-last_outgoing_communication_at"
-        expect(page.all('.client-row')[0]).to have_text(alan_intake_in_progress.preferred_name)
-        expect(page.all('.client-row')[0]).to have_text("7 days")
         expect(page.all('.client-row')[0]).to have_css(".text--red-bold")
-        expect(page.all('.client-row')[1]).to have_text(zach_prep_ready_for_call.preferred_name)
         expect(page.all('.client-row')[1]).to have_css(".text--red-bold")
-        expect(page.all('.client-row')[1]).to have_text("4 days")
-        expect(page.all('.client-row')[2]).to have_text(patty_prep_ready_for_call.preferred_name)
-        expect(page.all('.client-row')[2]).to have_text("1 day")
-        expect(page.all('.client-row')[3]).to have_text(marty_ctc.preferred_name)
-        expect(page.all('.client-row')[3]).to have_text("1 day")
         expect(page.all('.client-row')[4]).not_to have_css(".text--red-bold")
-        expect(page.all('.client-row')[4]).to have_text(betty_intake_in_progress.preferred_name)
-        expect(page.all('.client-row')[4]).to have_text("1 day")
+        expected_rows = [
+          {
+            "Name" => a_string_including(alan_intake_in_progress.preferred_name),
+            "Last contact" => "7 days"
+          }, {
+            "Name" => a_string_including(zach_prep_ready_for_call.preferred_name),
+            "Last contact" => "4 days"
+          }, {
+            "Name" => a_string_including(patty_prep_ready_for_call.preferred_name),
+            "Last contact" => "1 day"
+          }, {
+            "Name" => a_string_including(marty_ctc.preferred_name),
+            "Last contact" => "1 day"
+          }, {
+            "Name" => a_string_including(betty_intake_in_progress.preferred_name),
+            "Last contact" => "1 day"
+          },
+        ]
+        expect(table_contents(page.find('.client-table'))).to match_rows(expected_rows)
 
         # sort by "waiting on" puts updates at the bottom and orders responses by first_unanswered_incoming_interaction_at
         click_link "sort-first_unanswered_incoming_interaction_at"
-        expect(page.all('.client-row')[0]).to have_text(alan_intake_in_progress.preferred_name)
-        expect(page.all('.client-row')[0]).to have_text("Response")
-        expect(page.all('.client-row')[1]).to have_text(betty_intake_in_progress.preferred_name)
-        expect(page.all('.client-row')[1]).to have_text("Response")
-        expect(page.all('.client-row')[2]).to have_text(patty_prep_ready_for_call.preferred_name)
-        expect(page.all('.client-row')[2]).to have_text("Response")
-        expect(page.all('.client-row')[3]).to have_text(marty_ctc.preferred_name)
-        expect(page.all('.client-row')[3]).to have_text("Response")
-        expect(page.all('.client-row')[4]).to have_text(zach_prep_ready_for_call.preferred_name)
-        expect(page.all('.client-row')[4]).to have_text("Update")
+        expected_rows = [
+          {
+            "Name" => a_string_including(alan_intake_in_progress.preferred_name),
+            "Waiting on" => "Response"
+          }, {
+            "Name" => a_string_including(betty_intake_in_progress.preferred_name),
+            "Waiting on" => "Response"
+          }, {
+            "Name" => a_string_including(patty_prep_ready_for_call.preferred_name),
+            "Waiting on" => "Response"
+          }, {
+            "Name" => a_string_including(marty_ctc.preferred_name),
+            "Waiting on" => "Response"
+          }, {
+            "Name" => a_string_including(zach_prep_ready_for_call.preferred_name),
+            "Waiting on" => "Update"
+          },
+        ]
+        expect(table_contents(page.find('.client-table'))).to match_rows(expected_rows)
 
         # sort by "waiting on" in reverse puts updates at the top
         click_link "sort-first_unanswered_incoming_interaction_at"

--- a/spec/support/helpers/feature_helpers.rb
+++ b/spec/support/helpers/feature_helpers.rb
@@ -93,6 +93,25 @@ module FeatureHelpers
     end
   end
 
+  def table_contents(element_or_doc)
+    rows = []
+    if element_or_doc.class.name.start_with?('Nokogiri')
+      nokotable = element_or_doc
+    else
+      result_table_text = element_or_doc["outerHTML"]
+      nokotable = Nokogiri::HTML(result_table_text)
+    end
+
+    nokotable.css('tr').each do |row|
+      cell_tag = row.css('th').any? ? 'th' : 'td'
+      rows << (row.css(cell_tag).map(&:text).map(&:strip))
+    end
+
+    return [] if rows.size < 2
+
+    rows[1..].map { |row| Hash[rows[0].zip(row)] }
+  end
+
   def changes_table_contents(selector)
     contents = {}
 

--- a/spec/support/matchers/match_rows.rb
+++ b/spec/support/matchers/match_rows.rb
@@ -1,0 +1,16 @@
+RSpec::Matchers.define :match_rows do |expected|
+  match do |actual|
+    columns_to_check = expected.map(&:keys).flatten.uniq
+    @actual = actual.map do |row|
+      row.select do |column_name, _value|
+        columns_to_check.include?(column_name)
+      end
+    end
+
+    # Note that this cares about order, if we want order-insensitive matching
+    # we have to mimic more of what's happening in the built-in ContainExactly module
+    values_match?(expected, @actual)
+  end
+
+  diffable
+end


### PR DESCRIPTION
With the normal RSpec matchers, if you make an assertion like this

expect(table_row_data).to match([{"Name" => "Kermit"}])

...the output from failure will include all table_row_data and no useful diff.

This matcher only compares against the hash keys (table columns) in table_row_data that are included in the expectation, so the diff is likely to look better.