### PR TITLE
DependentsController is in GyrQuestionNavigation

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,7 +23,7 @@ class ApplicationController < ActionController::Base
     "views.#{controller_path.tr('/', '.')}"
   end
 
-  def self.flow_explorer_actions
+  def self.navigation_actions
     [:edit]
   end
 

--- a/app/controllers/dependents_controller.rb
+++ b/app/controllers/dependents_controller.rb
@@ -3,7 +3,11 @@ class DependentsController < ApplicationController
 
   helper_method :next_path
 
-  def self.flow_explorer_actions
+  def self.show?(intake)
+    intake.had_dependents_yes?
+  end
+
+  def self.navigation_actions
     [:index, :new]
   end
 

--- a/app/controllers/flows_controller.rb
+++ b/app/controllers/flows_controller.rb
@@ -74,9 +74,6 @@ class FlowsController < ApplicationController
         doc_overview_index = gyr_flow.index(Questions::OverviewDocumentsController)
         gyr_flow.insert(doc_overview_index + 1, *DocumentNavigation::FLOW)
 
-        had_dependents_index = gyr_flow.index(Questions::HadDependentsController)
-        gyr_flow.insert(had_dependents_index + 1, DependentsController)
-
         FlowParams.new(
           controller: controller,
           reference_object: controller.current_intake&.is_a?(Intake::GyrIntake) ? controller.current_intake : nil,
@@ -129,7 +126,7 @@ class FlowsController < ApplicationController
 
     def controller_actions
       @controllers.map do |controller_class|
-        controller_class.flow_explorer_actions.map do |controller_action|
+        controller_class.navigation_actions.map do |controller_action|
           DecoratedController.new(controller_class, controller_action, @current_controller)
         end
       end.flatten

--- a/app/controllers/questions/had_dependents_controller.rb
+++ b/app/controllers/questions/had_dependents_controller.rb
@@ -4,14 +4,6 @@ module Questions
 
     layout "yes_no_question"
 
-    def next_path
-      if current_intake.had_dependents_yes?
-        dependents_path
-      else
-        super
-      end
-    end
-
     def illustration_path
       "dependents.svg"
     end

--- a/app/controllers/questions/questions_controller.rb
+++ b/app/controllers/questions/questions_controller.rb
@@ -38,12 +38,12 @@ module Questions
 
     def next_path
       next_step = form_navigation.next
-      next_step&.to_path_helper
+      next_step&.to_path_helper(action: next_step.navigation_actions.first)
     end
 
     def prev_path
       prev_step = form_navigation&.prev
-      prev_step&.to_path_helper
+      prev_step&.to_path_helper(action: prev_step.navigation_actions.first)
     end
 
     def has_unsure_option?

--- a/app/lib/gyr_question_navigation.rb
+++ b/app/lib/gyr_question_navigation.rb
@@ -81,7 +81,7 @@ class GyrQuestionNavigation
       # Dependents
       Questions::HadDependentsController,
 
-      # DependentsController (if they had dependents)
+      DependentsController,
 
       # Dependent related questions
       Questions::DependentCareController,

--- a/spec/support/flow_explorer_screenshots.rb
+++ b/spec/support/flow_explorer_screenshots.rb
@@ -36,7 +36,7 @@ class FlowExplorerScreenshots
   end
 
   def create_flow_explorer_screenshot
-    if @controller_class&.flow_explorer_actions&.include?(@controller_action)
+    if @controller_class&.navigation_actions&.include?(@controller_action)
       if ENV['FLOW_EXPLORER_LOCALE'].present?
         create_controller_card_screenshot(locale: ENV['FLOW_EXPLORER_LOCALE'].to_sym)
       else


### PR DESCRIPTION
controllers can now implement a `navigation_actions` array though DependentsController is the only one that has an interesting one

fixes crash in the flow controller from the previous attempt to add it to the flow which was too hacky and crashed

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>