### PR TITLE
GYR doc upload: the 'upload' button should only show if JS is disabled

### DIFF
--- a/app/javascript/lib/honeycrisp.js
+++ b/app/javascript/lib/honeycrisp.js
@@ -148,6 +148,7 @@ var immediateUpload = (function() {
         $formInputs.each(function(index, formInput) {
             var $form = $(formInput).closest('form');
             $form.find("button[type=submit]").hide();
+            $form.find("input[type=submit]").hide();
             $form.find('label[for=' + formInput.id + ']').show();
             $(formInput).addClass('file-upload__input');
         }).change(function(event) {


### PR DESCRIPTION
Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>