### PR TITLE
Fix business days related flake in clients_searching_sorting_and_filtering_spec

### DIFF
--- a/spec/features/hub/clients_searching_sorting_and_filtering_spec.rb
+++ b/spec/features/hub/clients_searching_sorting_and_filtering_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe "searching, sorting, and filtering clients" do
 
     before { login_as user }
 
+    around do |example|
+      Time.use_zone(user.timezone) { example.run }
+    end
+
     context "without clients" do
       scenario "I should see the empty message" do
         visit hub_clients_path


### PR DESCRIPTION
the test data was being set up in UTC but the search/sort/filter was happening in New_York time (because we use the logged in user's timezone), so they didn't agree on what was a business day. This would cause the test to fail after 5pm on Thursdays. Now it will not fail (?)

Co-authored-by: Whitney Schaefer <wschaefer@codeforamerica.org>