### PR TITLE
Revert Intercom gem to 4.1.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ gem 'ice_nine'
 gem 'business_time'
 gem 'scenic'
 gem 'rubyzip'
-gem 'intercom', '~> 4.1'
+gem 'intercom', '4.1.3' # potential issue with 4.2.0
 gem 'statesman', '~> 9.0'
 gem 'redcarpet'
 gem 'platform-api'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,7 +298,7 @@ GEM
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
-    intercom (4.2.0)
+    intercom (4.1.3)
     jaro_winkler (1.5.4)
     jmespath (1.6.1)
     jquery-rails (4.5.0)
@@ -688,7 +688,7 @@ DEPENDENCIES
   i18n-tasks
   ice_nine
   image_processing
-  intercom (~> 4.1)
+  intercom (= 4.1.3)
   letter_opener
   listen (>= 3.4.0)
   lograge


### PR DESCRIPTION
GCF has potentially been seeing issues with .find_all in 4.2.0