### PR TITLE
Deflake "assigns message_summaries" test in assigned_clients_controller_spec

### DIFF
--- a/spec/controllers/hub/assigned_clients_controller_spec.rb
+++ b/spec/controllers/hub/assigned_clients_controller_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe Hub::AssignedClientsController do
         it "assigns message_summaries" do
           get :index
           expect(assigns(:message_summaries)).to eq(fake_message_summaries)
-          expect(RecentMessageSummaryService).to have_received(:messages).with([assigned_to_me.id, assigned_to_me_two_trs.id])
+          expect(RecentMessageSummaryService).to have_received(:messages).with(a_collection_containing_exactly(assigned_to_me.id, assigned_to_me_two_trs.id))
         end
       end
 


### PR DESCRIPTION
have_received(:messages).with([...]) is order-dependent, but I don't think we actually care about the order.

It didn't flake all the time, but this should make it flake none of the time