### PR TITLE
Archiving: add product_year to intakes for new archiving strategy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ gem 'intercom', '4.1.3' # potential issue with 4.2.0
 gem 'statesman', '~> 9.0'
 gem 'redcarpet'
 gem 'platform-api'
+gem 'data_migrate'
 gem 'strong_migrations'
 gem 'fraud-gem', git: 'https://github.com/codeforamerica/fraud-gem.git', tag: 'v1.0.5', require: ["fraud_gem"]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,6 +173,9 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    data_migrate (8.5.0)
+      activerecord (>= 5.0)
+      railties (>= 5.0)
     database_cleaner (2.0.1)
       database_cleaner-active_record (~> 2.0.0)
     database_cleaner-active_record (2.0.1)
@@ -664,6 +667,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   cfa-styleguide (= 0.10.5)!
   combine_pdf
+  data_migrate
   database_cleaner
   ddtrace (~> 1.0.0)
   delayed_job_active_record

--- a/app/controllers/flows_controller.rb
+++ b/app/controllers/flows_controller.rb
@@ -276,6 +276,7 @@ class FlowsController < ApplicationController
 
       intake_attributes = {
         type: Intake::CtcIntake.to_s,
+        product_year: 2022,
         visitor_id: SecureRandom.hex(26),
         filed_prior_tax_year: 'did_not_file',
         primary_birth_date: 30.years.ago,
@@ -420,6 +421,7 @@ class FlowsController < ApplicationController
 
       intake_attributes = {
         type: Intake::GyrIntake.to_s,
+        product_year: 2022,
         visitor_id: SecureRandom.hex(26),
         filed_prior_tax_year: 'did_not_file',
         primary_birth_date: 30.years.ago,

--- a/app/controllers/flows_controller.rb
+++ b/app/controllers/flows_controller.rb
@@ -276,7 +276,7 @@ class FlowsController < ApplicationController
 
       intake_attributes = {
         type: Intake::CtcIntake.to_s,
-        product_year: 2022,
+        product_year: Rails.configuration.product_year,
         visitor_id: SecureRandom.hex(26),
         filed_prior_tax_year: 'did_not_file',
         primary_birth_date: 30.years.ago,
@@ -421,7 +421,7 @@ class FlowsController < ApplicationController
 
       intake_attributes = {
         type: Intake::GyrIntake.to_s,
-        product_year: 2022,
+        product_year: Rails.configuration.product_year,
         visitor_id: SecureRandom.hex(26),
         filed_prior_tax_year: 'did_not_file',
         primary_birth_date: 30.years.ago,

--- a/app/forms/concerns/initial_ctc_form_attributes.rb
+++ b/app/forms/concerns/initial_ctc_form_attributes.rb
@@ -16,7 +16,7 @@ module InitialCtcFormAttributes
     validates_presence_of :device_id, :user_agent, :browser_language, :platform, :timezone_offset, :client_system_time, :ip_address, :timezone
 
     def initial_intake_save
-      @intake.assign_attributes(attributes_for(:intake).merge(locale: I18n.locale, timezone: timezone))
+      @intake.assign_attributes(attributes_for(:intake).merge(locale: I18n.locale, timezone: timezone, product_year: MultiTenantService.new(:ctc).current_product_year))
       @intake.build_client(
         tax_returns_attributes: [{ year: MultiTenantService.new(:ctc).current_tax_year, is_ctc: true }],
         efile_security_informations_attributes: [attributes_for(:efile_security_information)],

--- a/app/forms/concerns/initial_ctc_form_attributes.rb
+++ b/app/forms/concerns/initial_ctc_form_attributes.rb
@@ -16,7 +16,7 @@ module InitialCtcFormAttributes
     validates_presence_of :device_id, :user_agent, :browser_language, :platform, :timezone_offset, :client_system_time, :ip_address, :timezone
 
     def initial_intake_save
-      @intake.assign_attributes(attributes_for(:intake).merge(locale: I18n.locale, timezone: timezone, product_year: Rails.configuration.product_year)
+      @intake.assign_attributes(attributes_for(:intake).merge(locale: I18n.locale, timezone: timezone, product_year: Rails.configuration.product_year))
       @intake.build_client(
         tax_returns_attributes: [{ year: MultiTenantService.new(:ctc).current_tax_year, is_ctc: true }],
         efile_security_informations_attributes: [attributes_for(:efile_security_information)],

--- a/app/forms/concerns/initial_ctc_form_attributes.rb
+++ b/app/forms/concerns/initial_ctc_form_attributes.rb
@@ -16,7 +16,7 @@ module InitialCtcFormAttributes
     validates_presence_of :device_id, :user_agent, :browser_language, :platform, :timezone_offset, :client_system_time, :ip_address, :timezone
 
     def initial_intake_save
-      @intake.assign_attributes(attributes_for(:intake).merge(locale: I18n.locale, timezone: timezone, product_year: MultiTenantService.new(:ctc).current_product_year))
+      @intake.assign_attributes(attributes_for(:intake).merge(locale: I18n.locale, timezone: timezone, product_year: Rails.configuration.product_year)
       @intake.build_client(
         tax_returns_attributes: [{ year: MultiTenantService.new(:ctc).current_tax_year, is_ctc: true }],
         efile_security_informations_attributes: [attributes_for(:efile_security_information)],

--- a/app/forms/hub/create_client_form.rb
+++ b/app/forms/hub/create_client_form.rb
@@ -111,7 +111,7 @@ module Hub
         visitor_id: SecureRandom.hex(26),
         primary_consented_to_service: "yes",
         completed_at: DateTime.now,
-        product_year: MultiTenantService.new(:gyr).current_product_year
+        product_year: Rails.configuration.product_year
       }
     end
 

--- a/app/forms/hub/create_client_form.rb
+++ b/app/forms/hub/create_client_form.rb
@@ -110,7 +110,8 @@ module Hub
         type: "Intake::GyrIntake",
         visitor_id: SecureRandom.hex(26),
         primary_consented_to_service: "yes",
-        completed_at: DateTime.now
+        completed_at: DateTime.now,
+        product_year: MultiTenantService.new(:gyr).current_product_year
       }
     end
 

--- a/app/forms/personal_info_form.rb
+++ b/app/forms/personal_info_form.rb
@@ -33,7 +33,7 @@ class PersonalInfoForm < QuestionsForm
   def save
     state = ZipCodes.details(zip_code)[:state]
     client = Client.create!(
-      intake_attributes: attributes_for(:intake).merge(type: @intake.type, state_of_residence: state, product_year: MultiTenantService.new(:gyr).current_product_year)
+      intake_attributes: attributes_for(:intake).merge(type: @intake.type, state_of_residence: state, product_year: Rails.configuration.product_year)
     )
     @intake = client.intake
 

--- a/app/forms/personal_info_form.rb
+++ b/app/forms/personal_info_form.rb
@@ -33,7 +33,7 @@ class PersonalInfoForm < QuestionsForm
   def save
     state = ZipCodes.details(zip_code)[:state]
     client = Client.create!(
-      intake_attributes: attributes_for(:intake).merge(type: @intake.type, state_of_residence: state)
+      intake_attributes: attributes_for(:intake).merge(type: @intake.type, state_of_residence: state, product_year: MultiTenantService.new(:gyr).current_product_year)
     )
     @intake = client.intake
 

--- a/app/lib/client_sorter.rb
+++ b/app/lib/client_sorter.rb
@@ -39,7 +39,7 @@ class ClientSorter
               end
     # Filter on product_year to only show clients who used this-year's product
     if @use_product_year
-      clients = clients.where(intake: Intake.where(type: "Intake::CtcIntake", product_year: MultiTenantService.new(:ctc).current_product_year).or(Intake.where(type: "Intake::GyrIntake", product_year: MultiTenantService.new(:gyr).current_product_year)))
+      clients = clients.where(filterable_product_year: Rails.configuration.product_year)
     end
     clients = clients.where(intake: Intake.where(type: "Intake::CtcIntake")) if @filters[:ctc_client].present?
     clients = clients.where.not(flagged_at: nil) if @filters[:flagged].present?

--- a/app/lib/seeder.rb
+++ b/app/lib/seeder.rb
@@ -453,6 +453,8 @@ class Seeder
 
   def find_or_create_intake_and_client(intake_type, attributes)
     attributes[:preferred_name] = attributes[:primary_first_name] if attributes[:preferred_name].blank?
+    attributes[:product_year] = 2022 if attributes[:product_year].blank?
+
     attributes[:visitor_id] = SecureRandom.hex(26)
 
     finder_columns = [:primary_first_name, :primary_last_name, :preferred_name]

--- a/app/lib/seeder.rb
+++ b/app/lib/seeder.rb
@@ -453,7 +453,7 @@ class Seeder
 
   def find_or_create_intake_and_client(intake_type, attributes)
     attributes[:preferred_name] = attributes[:primary_first_name] if attributes[:preferred_name].blank?
-    attributes[:product_year] = 2022 if attributes[:product_year].blank?
+    attributes[:product_year] = Rails.configuration.product_year if attributes[:product_year].blank?
 
     attributes[:visitor_id] = SecureRandom.hex(26)
 

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -15,6 +15,7 @@
 #  filterable_number_of_required_documents              :integer          default(3)
 #  filterable_number_of_required_documents_uploaded     :integer          default(0)
 #  filterable_percentage_of_required_documents_uploaded :decimal(5, 2)    default(0.0)
+#  filterable_product_year                              :integer
 #  filterable_tax_return_properties                     :jsonb
 #  first_unanswered_incoming_interaction_at             :datetime
 #  flagged_at                                           :datetime
@@ -47,6 +48,11 @@
 #
 #  index_clients_on_consented_to_service_at                      (consented_to_service_at)
 #  index_clients_on_filterable_tax_return_properties             (filterable_tax_return_properties) USING gin
+#  index_clients_on_fpy_and_first_uii_at                         (filterable_product_year,first_unanswered_incoming_interaction_at) WHERE (consented_to_service_at IS NOT NULL)
+#  index_clients_on_fpy_and_in_progress_survey_sent_at           (filterable_product_year,in_progress_survey_sent_at) WHERE (consented_to_service_at IS NOT NULL)
+#  index_clients_on_fpy_and_last_outgoing_communication_at       (filterable_product_year,last_outgoing_communication_at) WHERE (consented_to_service_at IS NOT NULL)
+#  index_clients_on_fpy_and_required_docs_uploaded               (filterable_product_year,filterable_percentage_of_required_documents_uploaded) WHERE (consented_to_service_at IS NOT NULL)
+#  index_clients_on_fpy_and_updated_at                           (filterable_product_year,updated_at) WHERE (consented_to_service_at IS NOT NULL)
 #  index_clients_on_in_progress_survey_sent_at                   (in_progress_survey_sent_at)
 #  index_clients_on_last_outgoing_communication_at               (last_outgoing_communication_at)
 #  index_clients_on_login_token                                  (login_token)

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -118,7 +118,6 @@
 #  navigator_name                                       :string
 #  need_itin_help                                       :integer          default(0), not null
 #  needs_help_2016                                      :integer          default(0), not null
-#  needs_help_2017                                      :integer          default(0), not null
 #  needs_help_2018                                      :integer          default(0), not null
 #  needs_help_2019                                      :integer          default(0), not null
 #  needs_help_2020                                      :integer          default(0), not null
@@ -166,6 +165,7 @@
 #  primary_suffix                                       :string
 #  primary_tin_type                                     :integer
 #  primary_us_citizen                                   :integer          default(0), not null
+#  product_year                                         :integer          not null
 #  received_advance_ctc_payment                         :integer
 #  received_alimony                                     :integer          default(0), not null
 #  received_homebuyer_credit                            :integer          default(0), not null
@@ -290,8 +290,6 @@
 #
 
 class Intake < ApplicationRecord
-  self.ignored_columns = ["primary_consented_to_service_at"]
-
   include PgSearch::Model
 
   def self.searchable_fields
@@ -313,6 +311,7 @@ class Intake < ApplicationRecord
   validates :email_address, 'valid_email_2/email': true
   validates :phone_number, :sms_phone_number, allow_blank: true, e164_phone: true
   validates_presence_of :visitor_id
+  validates_presence_of :product_year
 
   before_validation do
     self.primary_ssn = self.primary_ssn.remove(/\D/) if primary_ssn_changed? && self.primary_ssn
@@ -379,7 +378,7 @@ class Intake < ApplicationRecord
     }
   }
 
-  scope :accessible_intakes, -> { where(primary_consented_to_service: "yes") }
+  scope :accessible_intakes, -> { where(primary_consented_to_service: "yes", product_year: MultiTenantService.new(:gyr).current_product_year) }
 
   def duplicates
     return itin_duplicates if itin_applicant?
@@ -534,7 +533,7 @@ class Intake < ApplicationRecord
   end
 
   def set_navigator(param)
-    _, navigator_type = NAVIGATOR_TYPES.find { | _, type| type[:param] == param }
+    _, navigator_type = NAVIGATOR_TYPES.find { |_, type| type[:param] == param }
     return unless navigator_type
 
     self.update(navigator_type[:field_name] => true)
@@ -626,4 +625,12 @@ class Intake < ApplicationRecord
       parts.join(' ')
     end
   end
+
+  def self.archived_columns
+    ["needs_help_2017"]
+  end
+  delegate *archived_columns, to: :intake_archive, allow_nil: true
+  has_one :intake_archive, foreign_key: :id
+
+  self.ignored_columns = ["primary_consented_to_service_at"] + archived_columns
 end

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -378,7 +378,7 @@ class Intake < ApplicationRecord
     }
   }
 
-  scope :accessible_intakes, -> { where(primary_consented_to_service: "yes", product_year: MultiTenantService.new(:gyr).current_product_year) }
+  scope :accessible_intakes, -> { where(primary_consented_to_service: "yes", product_year: Rails.configuration.product_year) }
 
   def duplicates
     return itin_duplicates if itin_applicant?

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -323,7 +323,7 @@ class Intake::CtcIntake < Intake
     sms_verified = where.not(sms_phone_number_verified_at: nil)
     email_verified = where.not(email_address_verified_at: nil)
     navigator_verified = where.not(navigator_has_verified_client_identity: nil)
-    sms_verified.or(email_verified).or(navigator_verified).where(product_year: MultiTenantService.new(:ctc).current_product_year)
+    sms_verified.or(email_verified).or(navigator_verified).where(product_year: Rails.configuration.product_year)
   end
   has_one :bank_account, inverse_of: :intake, foreign_key: :intake_id, dependent: :destroy
   belongs_to :primary_drivers_license, class_name: "DriversLicense", optional: true

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -118,7 +118,6 @@
 #  navigator_name                                       :string
 #  need_itin_help                                       :integer          default(0), not null
 #  needs_help_2016                                      :integer          default(0), not null
-#  needs_help_2017                                      :integer          default(0), not null
 #  needs_help_2018                                      :integer          default(0), not null
 #  needs_help_2019                                      :integer          default(0), not null
 #  needs_help_2020                                      :integer          default(0), not null
@@ -166,6 +165,7 @@
 #  primary_suffix                                       :string
 #  primary_tin_type                                     :integer
 #  primary_us_citizen                                   :integer          default(0), not null
+#  product_year                                         :integer          not null
 #  received_advance_ctc_payment                         :integer
 #  received_alimony                                     :integer          default(0), not null
 #  received_homebuyer_credit                            :integer          default(0), not null
@@ -323,7 +323,7 @@ class Intake::CtcIntake < Intake
     sms_verified = where.not(sms_phone_number_verified_at: nil)
     email_verified = where.not(email_address_verified_at: nil)
     navigator_verified = where.not(navigator_has_verified_client_identity: nil)
-    sms_verified.or(email_verified).or(navigator_verified)
+    sms_verified.or(email_verified).or(navigator_verified).where(product_year: MultiTenantService.new(:ctc).current_product_year)
   end
   has_one :bank_account, inverse_of: :intake, foreign_key: :intake_id, dependent: :destroy
   belongs_to :primary_drivers_license, class_name: "DriversLicense", optional: true
@@ -391,7 +391,7 @@ class Intake::CtcIntake < Intake
   def is_ctc?
     true
   end
-  
+
   def default_tax_return
     tax_returns.find_by(year: MultiTenantService.new(:ctc).current_tax_year)
   end

--- a/app/models/intake/gyr_intake.rb
+++ b/app/models/intake/gyr_intake.rb
@@ -118,7 +118,6 @@
 #  navigator_name                                       :string
 #  need_itin_help                                       :integer          default("unfilled"), not null
 #  needs_help_2016                                      :integer          default("unfilled"), not null
-#  needs_help_2017                                      :integer          default("unfilled"), not null
 #  needs_help_2018                                      :integer          default("unfilled"), not null
 #  needs_help_2019                                      :integer          default("unfilled"), not null
 #  needs_help_2020                                      :integer          default("unfilled"), not null
@@ -166,6 +165,7 @@
 #  primary_suffix                                       :string
 #  primary_tin_type                                     :integer
 #  primary_us_citizen                                   :integer          default("unfilled"), not null
+#  product_year                                         :integer          not null
 #  received_advance_ctc_payment                         :integer
 #  received_alimony                                     :integer          default("unfilled"), not null
 #  received_homebuyer_credit                            :integer          default("unfilled"), not null

--- a/app/models/intake_archive.rb
+++ b/app/models/intake_archive.rb
@@ -1,0 +1,15 @@
+# == Schema Information
+#
+# Table name: intake_archives
+#
+#  id              :bigint           not null, primary key
+#  needs_help_2017 :integer
+#
+# Foreign Keys
+#
+#  fk_rails_...  (id => intakes.id)
+#
+class IntakeArchive < ApplicationRecord
+  belongs_to :intake, foreign_key: :id
+  enum needs_help_2017: { unfilled: 0, yes: 1, no: 2 }, _prefix: :needs_help_2017
+end

--- a/app/services/multi_tenant_service.rb
+++ b/app/services/multi_tenant_service.rb
@@ -74,8 +74,4 @@ class MultiTenantService
   def backtax_years
     filing_years.without(current_tax_year)
   end
-
-  def current_product_year
-    2022
-  end
 end

--- a/app/services/multi_tenant_service.rb
+++ b/app/services/multi_tenant_service.rb
@@ -75,4 +75,7 @@ class MultiTenantService
     filing_years.without(current_tax_year)
   end
 
+  def current_product_year
+    2022
+  end
 end

--- a/app/services/search_indexer.rb
+++ b/app/services/search_indexer.rb
@@ -47,6 +47,7 @@ class SearchIndexer
               greetable: TaxReturnStateMachine.available_states_for(role_type: GreeterRole::TYPE).values.flatten.include?(tr.current_state)
             }
           end,
+          filterable_product_year: client.intake.product_year,
           filterable_number_of_required_documents_uploaded: client.number_of_required_documents_uploaded,
           filterable_number_of_required_documents: client.number_of_required_documents,
           filterable_percentage_of_required_documents_uploaded: client.number_of_required_documents_uploaded / client.number_of_required_documents.to_f,

--- a/app/services/search_indexer.rb
+++ b/app/services/search_indexer.rb
@@ -47,7 +47,7 @@ class SearchIndexer
               greetable: TaxReturnStateMachine.available_states_for(role_type: GreeterRole::TYPE).values.flatten.include?(tr.current_state)
             }
           end,
-          filterable_product_year: client.intake.product_year,
+          filterable_product_year: client.intake&.product_year, # we expect clients to always have an intake, it's only in factory-land that this is needed
           filterable_number_of_required_documents_uploaded: client.number_of_required_documents_uploaded,
           filterable_number_of_required_documents: client.number_of_required_documents,
           filterable_percentage_of_required_documents_uploaded: client.number_of_required_documents_uploaded / client.number_of_required_documents.to_f,

--- a/config/application.rb
+++ b/config/application.rb
@@ -65,6 +65,7 @@ module VitaMin
     config.middleware.use Middleware::RejectInvalidParams
     config.gyr_current_tax_year = 2022
     config.ctc_current_tax_year = 2021
+    config.product_year = 2022
 
     # These defaults can be overridden per-environment if needed
     config.start_of_unique_links_only_intake = Time.find_zone('America/Los_Angeles').parse('2023-01-24 09:59:59')

--- a/db/create_analytics_views.sql
+++ b/db/create_analytics_views.sql
@@ -155,6 +155,10 @@ CREATE VIEW analytics.incoming_emails AS
     SELECT id, attachment_count, client_id, created_at, received_at, updated_at
     FROM public.incoming_emails;
 
+CREATE VIEW analytics.intake_archives AS
+SELECT id, needs_help_2017
+FROM public.intake_archives;
+
 CREATE VIEW analytics.intakes AS
     SELECT id, adopted_child, already_applied_for_stimulus, already_filed, balance_pay_from_bank,
            bank_account_type, bought_energy_efficient_items, bought_health_insurance, city,
@@ -174,7 +178,7 @@ CREATE VIEW analytics.intakes AS
            had_self_employment_income, had_social_security_income, had_social_security_or_retirement,
            had_student_in_family, had_tax_credit_disallowed, had_tips, had_unemployment_income, had_wages, home_location,
            income_over_limit, issued_identity_pin, job_count, lived_with_spouse, locale,
-           made_estimated_tax_payments, married, multiple_states, needs_help_2016, needs_help_2017, needs_help_2018,
+           made_estimated_tax_payments, married, multiple_states, needs_help_2016, needs_help_2018,
            needs_help_2019, needs_help_2020, no_eligibility_checks_apply, no_ssn, paid_alimony,
            paid_charitable_contributions, paid_dependent_care, paid_local_tax, paid_medical_expenses,
            paid_mortgage_interest, paid_retirement_contributions, paid_school_supplies, paid_student_loan_interest,

--- a/db/data/20230109214025_copy_intakes_product_year_to_clients.rb
+++ b/db/data/20230109214025_copy_intakes_product_year_to_clients.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class CopyIntakesProductYearToClients < ActiveRecord::Migration[7.0]
+  class Intake < ApplicationRecord
+    self.inheritance_column = 'not_a_real_column'
+
+    belongs_to :client, inverse_of: :intake, optional: true
+  end
+
+  class Client < ApplicationRecord
+    has_one :intake, inverse_of: :client, dependent: :destroy
+  end
+
+  def up
+    intake_product_years = Intake.group(:product_year).count.keys
+    if intake_product_years != [2022]
+      raise "This data migration expects that all the intakes are for product year 2022 but your DB has the product years #{intake_product_years.inspect}"
+    end
+
+    Client.joins(:intake).in_batches(of: 10_000) do |client_batch|
+      client_batch.update_all('filterable_product_year = 2022')
+    end
+  end
+
+  def down
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,0 +1,1 @@
+DataMigrate::Data.define(version: 20230109214025)

--- a/db/migrate/20221219201329_create_intake_archives.rb
+++ b/db/migrate/20221219201329_create_intake_archives.rb
@@ -1,8 +1,6 @@
 class CreateIntakeArchives < ActiveRecord::Migration[7.0]
   def change
-    create_table :intake_archives do |t|
-      # t.integer :needs_help_2017
-    end
+    create_table :intake_archives
 
     # Adding a foreign key blocks writes on both tables. There are not many writes on these tables during December 2022.
     safety_assured {

--- a/db/migrate/20221219201329_create_intake_archives.rb
+++ b/db/migrate/20221219201329_create_intake_archives.rb
@@ -1,0 +1,12 @@
+class CreateIntakeArchives < ActiveRecord::Migration[7.0]
+  def change
+    create_table :intake_archives do |t|
+      # t.integer :needs_help_2017
+    end
+
+    # Adding a foreign key blocks writes on both tables. There are not many writes on these tables during December 2022.
+    safety_assured {
+      add_foreign_key :intake_archives, :intakes, column: :id, primary_key: :id
+    }
+  end
+end

--- a/db/migrate/20221219205356_archive_needs_help2017_column.rb
+++ b/db/migrate/20221219205356_archive_needs_help2017_column.rb
@@ -1,0 +1,18 @@
+class ArchiveNeedsHelp2017Column < ActiveRecord::Migration[7.0]
+  def change
+    add_column :intake_archives, :needs_help_2017, :integer
+    reversible do |direction|
+      direction.up do
+        safety_assured do
+          # Safe for migrations because this is an INSERT into a column we are creating in this transactional migration.
+          execute <<~SQL
+            INSERT INTO intake_archives(id, needs_help_2017)
+              (SELECT id, needs_help_2017 from intakes)
+            ON CONFLICT (id) DO
+              UPDATE SET needs_help_2017=EXCLUDED.needs_help_2017
+          SQL
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20221219230651_add_product_year_to_intakes.rb
+++ b/db/migrate/20221219230651_add_product_year_to_intakes.rb
@@ -1,0 +1,7 @@
+class AddProductYearToIntakes < ActiveRecord::Migration[7.0]
+  def change
+    # Safe enough for migrations since in Dec 2022 there aren't a lot of reads & writes on the web app.
+    add_column :intakes, :product_year, :integer, null: false, default: 2022
+    change_column_default :intakes, :product_year, from: 2022, to: nil
+  end
+end

--- a/db/migrate/20230109211139_add_filterable_product_year_to_clients.rb
+++ b/db/migrate/20230109211139_add_filterable_product_year_to_clients.rb
@@ -1,0 +1,5 @@
+class AddFilterableProductYearToClients < ActiveRecord::Migration[7.0]
+  def change
+    add_column :clients, :filterable_product_year, :integer
+  end
+end

--- a/db/migrate/20230109211326_add_filterable_product_year_indexes_to_clients.rb
+++ b/db/migrate/20230109211326_add_filterable_product_year_indexes_to_clients.rb
@@ -1,0 +1,41 @@
+class AddFilterableProductYearIndexesToClients < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index(
+      :clients,
+      [:filterable_product_year, :in_progress_survey_sent_at],
+      name: :index_clients_on_fpy_and_in_progress_survey_sent_at,
+      where: 'consented_to_service_at IS NOT NULL',
+      algorithm: :concurrently
+    )
+    add_index(
+      :clients,
+      [:filterable_product_year, :updated_at],
+      name: :index_clients_on_fpy_and_updated_at,
+      where: 'consented_to_service_at IS NOT NULL',
+      algorithm: :concurrently
+    )
+    add_index(
+      :clients,
+      [:filterable_product_year, :filterable_percentage_of_required_documents_uploaded],
+      name: :index_clients_on_fpy_and_required_docs_uploaded,
+      where: 'consented_to_service_at IS NOT NULL',
+      algorithm: :concurrently
+    )
+    add_index(
+      :clients,
+      [:filterable_product_year, :first_unanswered_incoming_interaction_at],
+      name: :index_clients_on_fpy_and_first_uii_at,
+      where: 'consented_to_service_at IS NOT NULL',
+      algorithm: :concurrently
+    )
+    add_index(
+      :clients,
+      [:filterable_product_year, :last_outgoing_communication_at],
+      name: :index_clients_on_fpy_and_last_outgoing_communication_at,
+      where: 'consented_to_service_at IS NOT NULL',
+      algorithm: :concurrently
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_19_230651) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_09_211326) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -551,6 +551,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_19_230651) do
     t.integer "filterable_number_of_required_documents", default: 3
     t.integer "filterable_number_of_required_documents_uploaded", default: 0
     t.decimal "filterable_percentage_of_required_documents_uploaded", precision: 5, scale: 2, default: "0.0"
+    t.integer "filterable_product_year"
     t.jsonb "filterable_tax_return_properties"
     t.datetime "first_unanswered_incoming_interaction_at", precision: nil
     t.datetime "flagged_at", precision: nil
@@ -578,6 +579,11 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_19_230651) do
     t.datetime "updated_at", null: false
     t.bigint "vita_partner_id"
     t.index ["consented_to_service_at"], name: "index_clients_on_consented_to_service_at"
+    t.index ["filterable_product_year", "filterable_percentage_of_required_documents_uploaded"], name: "index_clients_on_fpy_and_required_docs_uploaded", where: "(consented_to_service_at IS NOT NULL)"
+    t.index ["filterable_product_year", "first_unanswered_incoming_interaction_at"], name: "index_clients_on_fpy_and_first_uii_at", where: "(consented_to_service_at IS NOT NULL)"
+    t.index ["filterable_product_year", "in_progress_survey_sent_at"], name: "index_clients_on_fpy_and_in_progress_survey_sent_at", where: "(consented_to_service_at IS NOT NULL)"
+    t.index ["filterable_product_year", "last_outgoing_communication_at"], name: "index_clients_on_fpy_and_last_outgoing_communication_at", where: "(consented_to_service_at IS NOT NULL)"
+    t.index ["filterable_product_year", "updated_at"], name: "index_clients_on_fpy_and_updated_at", where: "(consented_to_service_at IS NOT NULL)"
     t.index ["filterable_tax_return_properties"], name: "index_clients_on_filterable_tax_return_properties", using: :gin
     t.index ["in_progress_survey_sent_at"], name: "index_clients_on_in_progress_survey_sent_at"
     t.index ["last_outgoing_communication_at"], name: "index_clients_on_last_outgoing_communication_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_15_230435) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_19_230651) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -993,6 +993,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_15_230435) do
     t.index ["created_at"], name: "index_incoming_text_messages_on_created_at"
   end
 
+  create_table "intake_archives", force: :cascade do |t|
+    t.integer "needs_help_2017"
+  end
+
   create_table "intakes", force: :cascade do |t|
     t.string "additional_info"
     t.integer "adopted_child", default: 0, null: false
@@ -1160,6 +1164,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_15_230435) do
     t.string "primary_suffix"
     t.integer "primary_tin_type"
     t.integer "primary_us_citizen", default: 0, null: false
+    t.integer "product_year", null: false
     t.integer "received_advance_ctc_payment"
     t.integer "received_alimony", default: 0, null: false
     t.integer "received_homebuyer_credit", default: 0, null: false
@@ -1782,6 +1787,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_15_230435) do
   add_foreign_key "greeter_organization_join_records", "greeter_roles"
   add_foreign_key "greeter_organization_join_records", "vita_partners"
   add_foreign_key "incoming_text_messages", "clients"
+  add_foreign_key "intake_archives", "intakes", column: "id"
   add_foreign_key "intakes", "clients"
   add_foreign_key "intakes", "vita_partners"
   add_foreign_key "notes", "clients"

--- a/spec/factories/clients.rb
+++ b/spec/factories/clients.rb
@@ -15,6 +15,7 @@
 #  filterable_number_of_required_documents              :integer          default(3)
 #  filterable_number_of_required_documents_uploaded     :integer          default(0)
 #  filterable_percentage_of_required_documents_uploaded :decimal(5, 2)    default(0.0)
+#  filterable_product_year                              :integer
 #  filterable_tax_return_properties                     :jsonb
 #  first_unanswered_incoming_interaction_at             :datetime
 #  flagged_at                                           :datetime
@@ -47,6 +48,11 @@
 #
 #  index_clients_on_consented_to_service_at                      (consented_to_service_at)
 #  index_clients_on_filterable_tax_return_properties             (filterable_tax_return_properties) USING gin
+#  index_clients_on_fpy_and_first_uii_at                         (filterable_product_year,first_unanswered_incoming_interaction_at) WHERE (consented_to_service_at IS NOT NULL)
+#  index_clients_on_fpy_and_in_progress_survey_sent_at           (filterable_product_year,in_progress_survey_sent_at) WHERE (consented_to_service_at IS NOT NULL)
+#  index_clients_on_fpy_and_last_outgoing_communication_at       (filterable_product_year,last_outgoing_communication_at) WHERE (consented_to_service_at IS NOT NULL)
+#  index_clients_on_fpy_and_required_docs_uploaded               (filterable_product_year,filterable_percentage_of_required_documents_uploaded) WHERE (consented_to_service_at IS NOT NULL)
+#  index_clients_on_fpy_and_updated_at                           (filterable_product_year,updated_at) WHERE (consented_to_service_at IS NOT NULL)
 #  index_clients_on_in_progress_survey_sent_at                   (in_progress_survey_sent_at)
 #  index_clients_on_last_outgoing_communication_at               (last_outgoing_communication_at)
 #  index_clients_on_login_token                                  (login_token)

--- a/spec/factories/intakes.rb
+++ b/spec/factories/intakes.rb
@@ -262,6 +262,7 @@ FactoryBot.define do
   end
 
   factory :ctc_intake, class: Intake::CtcIntake do
+    product_year { MultiTenantService.new(:ctc).current_product_year }
     sequence(:visitor_id) { |n| "visitor_id_#{n}" }
     primary_birth_date { Date.new(1988, 12, 20) }
     spouse_birth_date { Date.new(1976, 12, 20) }
@@ -278,6 +279,7 @@ FactoryBot.define do
   end
 
   factory :intake, class: Intake::GyrIntake do
+    product_year { MultiTenantService.new(:gyr).current_product_year }
     had_wages { :unfilled }
     client { create :client, consented_to_service_at: nil }
     sequence(:visitor_id) { |n| "visitor_id_#{n}" }

--- a/spec/factories/intakes.rb
+++ b/spec/factories/intakes.rb
@@ -262,7 +262,7 @@ FactoryBot.define do
   end
 
   factory :ctc_intake, class: Intake::CtcIntake do
-    product_year { MultiTenantService.new(:ctc).current_product_year }
+    product_year { Rails.configuration.product_year }
     sequence(:visitor_id) { |n| "visitor_id_#{n}" }
     primary_birth_date { Date.new(1988, 12, 20) }
     spouse_birth_date { Date.new(1976, 12, 20) }
@@ -279,7 +279,7 @@ FactoryBot.define do
   end
 
   factory :intake, class: Intake::GyrIntake do
-    product_year { MultiTenantService.new(:gyr).current_product_year }
+    product_year { Rails.configuration.product_year }
     had_wages { :unfilled }
     client { create :client, consented_to_service_at: nil }
     sequence(:visitor_id) { |n| "visitor_id_#{n}" }

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -15,6 +15,7 @@
 #  filterable_number_of_required_documents              :integer          default(3)
 #  filterable_number_of_required_documents_uploaded     :integer          default(0)
 #  filterable_percentage_of_required_documents_uploaded :decimal(5, 2)    default(0.0)
+#  filterable_product_year                              :integer
 #  filterable_tax_return_properties                     :jsonb
 #  first_unanswered_incoming_interaction_at             :datetime
 #  flagged_at                                           :datetime
@@ -47,6 +48,11 @@
 #
 #  index_clients_on_consented_to_service_at                      (consented_to_service_at)
 #  index_clients_on_filterable_tax_return_properties             (filterable_tax_return_properties) USING gin
+#  index_clients_on_fpy_and_first_uii_at                         (filterable_product_year,first_unanswered_incoming_interaction_at) WHERE (consented_to_service_at IS NOT NULL)
+#  index_clients_on_fpy_and_in_progress_survey_sent_at           (filterable_product_year,in_progress_survey_sent_at) WHERE (consented_to_service_at IS NOT NULL)
+#  index_clients_on_fpy_and_last_outgoing_communication_at       (filterable_product_year,last_outgoing_communication_at) WHERE (consented_to_service_at IS NOT NULL)
+#  index_clients_on_fpy_and_required_docs_uploaded               (filterable_product_year,filterable_percentage_of_required_documents_uploaded) WHERE (consented_to_service_at IS NOT NULL)
+#  index_clients_on_fpy_and_updated_at                           (filterable_product_year,updated_at) WHERE (consented_to_service_at IS NOT NULL)
 #  index_clients_on_in_progress_survey_sent_at                   (in_progress_survey_sent_at)
 #  index_clients_on_last_outgoing_communication_at               (last_outgoing_communication_at)
 #  index_clients_on_login_token                                  (login_token)

--- a/spec/models/intake/gyr_intake_spec.rb
+++ b/spec/models/intake/gyr_intake_spec.rb
@@ -118,7 +118,6 @@
 #  navigator_name                                       :string
 #  need_itin_help                                       :integer          default("unfilled"), not null
 #  needs_help_2016                                      :integer          default("unfilled"), not null
-#  needs_help_2017                                      :integer          default("unfilled"), not null
 #  needs_help_2018                                      :integer          default("unfilled"), not null
 #  needs_help_2019                                      :integer          default("unfilled"), not null
 #  needs_help_2020                                      :integer          default("unfilled"), not null
@@ -166,6 +165,7 @@
 #  primary_suffix                                       :string
 #  primary_tin_type                                     :integer
 #  primary_us_citizen                                   :integer          default("unfilled"), not null
+#  product_year                                         :integer          not null
 #  received_advance_ctc_payment                         :integer
 #  received_alimony                                     :integer          default("unfilled"), not null
 #  received_homebuyer_credit                            :integer          default("unfilled"), not null

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -118,7 +118,6 @@
 #  navigator_name                                       :string
 #  need_itin_help                                       :integer          default(0), not null
 #  needs_help_2016                                      :integer          default(0), not null
-#  needs_help_2017                                      :integer          default(0), not null
 #  needs_help_2018                                      :integer          default(0), not null
 #  needs_help_2019                                      :integer          default(0), not null
 #  needs_help_2020                                      :integer          default(0), not null
@@ -166,6 +165,7 @@
 #  primary_suffix                                       :string
 #  primary_tin_type                                     :integer
 #  primary_us_citizen                                   :integer          default(0), not null
+#  product_year                                         :integer          not null
 #  received_advance_ctc_payment                         :integer
 #  received_alimony                                     :integer          default(0), not null
 #  received_homebuyer_credit                            :integer          default(0), not null
@@ -342,9 +342,9 @@ describe Intake do
     end
 
     context "mandatory fields" do
-      it "requires visitor_id" do
+      it "requires visitor_id and product_year" do
         expect(Intake.new).not_to be_valid
-        expect(Intake.new(visitor_id: "present")).to be_valid
+        expect(Intake.new(visitor_id: "present", product_year: 2022)).to be_valid
       end
     end
   end
@@ -426,36 +426,38 @@ describe Intake do
 
   end
 
+  let(:required_fields) { { visitor_id: "visitor_id", product_year: 2022 } }
+
   describe "canonical_email_address" do
     it "is persisted when the intake is saved" do
-      example_intake = Intake.create!(email_address: "a.REAL.email@example.com", visitor_id: "visitor_id")
+      example_intake = Intake.create!(email_address: "a.REAL.email@example.com", **required_fields)
       expect(example_intake.canonical_email_address).to eq('a.real.email@example.com')
 
-      gmail_intake = Intake.create!(email_address: "a.REAL.email@gmail.com", visitor_id: "visitor_id")
+      gmail_intake = Intake.create!(email_address: "a.REAL.email@gmail.com", **required_fields)
       expect(gmail_intake.canonical_email_address).to eq('arealemail@gmail.com')
     end
   end
 
   describe "email_address" do
     it "searches case-insensitively" do
-      intake = Intake.create!(email_address: "eXample@EXAMPLE.COM", visitor_id: "visitor_id")
+      intake = Intake.create!(email_address: "eXample@EXAMPLE.COM", **required_fields)
       expect(Intake.where(email_address: "example@example.com")).to include(intake)
     end
   end
 
   describe "email_domain" do
     it "is persisted when the intake is saved" do
-      example_intake = Intake.create!(email_address: "a.REAL.email@example.com", visitor_id: "visitor_id")
+      example_intake = Intake.create!(email_address: "a.REAL.email@example.com", **required_fields)
       expect(example_intake.email_domain).to eq('example.com')
 
-      gmail_intake = Intake.create!(email_address: "a.REAL.email@gmail.com", visitor_id: "visitor_id")
+      gmail_intake = Intake.create!(email_address: "a.REAL.email@gmail.com", **required_fields)
       expect(gmail_intake.email_domain).to eq('gmail.com')
     end
   end
 
   describe "spouse_email_address" do
     it "searches case-insensitively" do
-      intake = Intake.create!(spouse_email_address: "eXample@EXAMPLE.COM", visitor_id: "visitor_id")
+      intake = Intake.create!(spouse_email_address: "eXample@EXAMPLE.COM", **required_fields)
       expect(Intake.where(spouse_email_address: "example@example.com")).to include(intake)
     end
   end


### PR DESCRIPTION
we query using product_year in the ClientSorter and when checking for dupes with the 'accessible_intakes' scope

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>