### PR TITLE
Tweak the filterable_product_year data migration to no-op instead of raise

### DIFF
--- a/db/data/20230109214025_copy_intakes_product_year_to_clients.rb
+++ b/db/data/20230109214025_copy_intakes_product_year_to_clients.rb
@@ -13,12 +13,10 @@ class CopyIntakesProductYearToClients < ActiveRecord::Migration[7.0]
 
   def up
     intake_product_years = Intake.group(:product_year).count.keys
-    if intake_product_years != [2022]
-      raise "This data migration expects that all the intakes are for product year 2022 but your DB has the product years #{intake_product_years.inspect}"
-    end
-
-    Client.joins(:intake).in_batches(of: 10_000) do |client_batch|
-      client_batch.update_all('filterable_product_year = 2022')
+    if intake_product_years == [2022]
+      Client.joins(:intake).in_batches(of: 10_000) do |client_batch|
+        client_batch.update_all('filterable_product_year = 2022')
+      end
     end
   end
 


### PR DESCRIPTION
after we change product_year to 2023 any newly reset dev db will only have 2023 items, but we still want to be able to data:migrate without incident (until we delete this migration)