### PR TITLE
Logging: set the formatter for the config.logger to be json in prod-like environments

### DIFF
--- a/config/environments/shared_deployment_config.rb
+++ b/config/environments/shared_deployment_config.rb
@@ -103,6 +103,15 @@ Rails.application.configure do
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
     config.logger = ActiveSupport::Logger.new(STDOUT)
+    config.logger.formatter = proc do | severity, timestamp, _progname, message |
+      data = {
+        level: severity,
+        time: timestamp,
+        message: message
+      }
+      "#{data.to_json}\n"
+    end
+    Rails.logger = config.logger
   end
 
   # Do not dump schema after migrations.


### PR DESCRIPTION
it will have {level, time, message} properties so we can easily see the level in Datadog

Co-authored-by: Whitney Schaefer <wschaefer@codeforamerica.org>