### PR TITLE
Limit org active_client_count to only include current product year clients

### DIFF
--- a/db/migrate/20230123232048_update_organization_capacities_to_version_8.rb
+++ b/db/migrate/20230123232048_update_organization_capacities_to_version_8.rb
@@ -1,0 +1,5 @@
+class UpdateOrganizationCapacitiesToVersion8 < ActiveRecord::Migration[7.0]
+  def change
+    update_view :organization_capacities, version: 8, revert_to_version: 7
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1859,7 +1859,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_24_195432) do
            SELECT DISTINCT tax_returns.client_id
              FROM (tax_returns
                JOIN intakes ON ((intakes.client_id = tax_returns.client_id)))
-            WHERE ((tax_returns.current_state)::text <> ALL (ARRAY[('intake_before_consent'::character varying)::text, ('intake_in_progress'::character varying)::text, ('intake_greeter_info_requested'::character varying)::text, ('intake_needs_doc_help'::character varying)::text, ('file_mailed'::character varying)::text, ('file_accepted'::character varying)::text, ('file_not_filing'::character varying)::text, ('file_hold'::character varying)::text, ('file_fraud_hold'::character varying)::text]))
+            WHERE (((tax_returns.current_state)::text <> ALL ((ARRAY['intake_before_consent'::character varying, 'intake_in_progress'::character varying, 'intake_greeter_info_requested'::character varying, 'intake_needs_doc_help'::character varying, 'file_mailed'::character varying, 'file_accepted'::character varying, 'file_not_filing'::character varying, 'file_hold'::character varying, 'file_fraud_hold'::character varying])::text[])) AND ((intakes.product_year)::numeric = EXTRACT(year FROM now())))
           ), partner_and_client_counts AS (
            SELECT organization_id_by_vita_partner_id.organization_id,
               count(clients.id) AS active_client_count

--- a/db/views/organization_capacities_v08.sql
+++ b/db/views/organization_capacities_v08.sql
@@ -1,0 +1,24 @@
+WITH
+    organization_id_by_vita_partner_id AS (
+        select id, (CASE WHEN parent_organization_id IS NULL THEN id ELSE parent_organization_id END) AS organization_id
+        from vita_partners
+    ),
+    client_ids AS
+        (
+            select distinct tax_returns.client_id
+            from tax_returns
+                     INNER JOIN intakes ON (intakes.client_id) = tax_returns.client_id
+
+            where tax_returns.current_state NOT IN ('intake_before_consent', 'intake_in_progress', 'intake_greeter_info_requested', 'intake_needs_doc_help', 'file_mailed', 'file_accepted', 'file_not_filing', 'file_hold', 'file_fraud_hold')
+            AND intakes.product_year = extract(year from now())
+        ),
+    partner_and_client_counts AS (
+        SELECT organization_id, count(clients.id) as active_client_count
+        FROM organization_id_by_vita_partner_id
+                 LEFT OUTER JOIN clients ON organization_id_by_vita_partner_id.id = clients.vita_partner_id
+        WHERE clients.id IN (select client_id from client_ids) GROUP BY organization_id
+    )
+SELECT id as vita_partner_id, capacity_limit, CASE WHEN partner_and_client_counts.active_client_count IS NULL THEN 0 ELSE partner_and_client_counts.active_client_count END
+FROM vita_partners
+         LEFT OUTER JOIN partner_and_client_counts ON vita_partners.id=partner_and_client_counts.organization_id WHERE parent_organization_id IS NULL;
+

--- a/spec/models/organization_capacity_spec.rb
+++ b/spec/models/organization_capacity_spec.rb
@@ -33,21 +33,37 @@ describe OrganizationCapacity do
       end
     end
 
-    context "when intake associated with client is archived" do
-      let(:organization) { create :organization }
-      before do
-        client = create :client, :with_gyr_return, tax_return_state: :prep_ready_for_prep, vita_partner: organization
-        create :archived_2021_gyr_intake, client: client
+    context "archiving" do
+      context "when intake associated with client is archived in the old way" do
+        let(:organization) { create :organization }
+        before do
+          client = create :client, :with_gyr_return, tax_return_state: :prep_ready_for_prep, vita_partner: organization
+          create :archived_2021_gyr_intake, client: client
+        end
+
+        it "does not include the client in the client count" do
+          expect(described_class.find(organization.id).active_client_count).to eq 0
+        end
       end
 
-      it "does not include the client in the client count" do
-        expect(described_class.find(organization.id).active_client_count).to eq 0
+      context "when intake associated with client is archived in the new way" do
+        let(:organization) { create :organization }
+        before do
+          client = create :client, :with_gyr_return, tax_return_state: :prep_ready_for_prep, vita_partner: organization
+          create :intake, client: client, product_year: 2022
+        end
+
+        it "does not include the client in the client count" do
+          expect(described_class.find(organization.id).active_client_count).to eq 0
+        end
       end
     end
 
     context "when intake associated with client is not archived" do
       let(:organization) { create :organization }
-      let(:intake) { create :intake }
+      # The organization_capacities view checks product year based on current year because we don't have access
+      # to rails config :(
+      let(:intake) { create :intake, product_year: Time.zone.now.year }
       before do
         create :client, :with_gyr_return, tax_return_state: :prep_ready_for_prep, vita_partner: organization, intake: intake
       end


### PR DESCRIPTION
Unfortunately we can't access the config value for product_year in the view so we're going based on current year

Co-authored-by: Jenny Heath <jheath@codeforamerica.org>
Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>