### PR TITLE
RemoveUnconsentedClientsJob only operates on new-style client/intake combos

### DIFF
--- a/app/jobs/remove_unconsented_clients_job.rb
+++ b/app/jobs/remove_unconsented_clients_job.rb
@@ -1,6 +1,6 @@
 class RemoveUnconsentedClientsJob < ApplicationJob
   def perform(created_before: 14.days.ago)
-    Client.where("created_at < ?", created_before).where(consented_to_service_at: nil).find_in_batches do |clients|
+    Client.where("clients.created_at < ?", created_before).joins(:intake).where(consented_to_service_at: nil).find_in_batches do |clients|
       ActiveRecord::Base.connection.execute(ApplicationRecord.sanitize_sql([<<~SQL, clients.pluck('id')]))
         INSERT INTO abandoned_pre_consent_intakes(id, client_id, created_at, updated_at, source)
           (SELECT id, client_id, created_at, updated_at, source from intakes WHERE client_id IN (?))

--- a/spec/jobs/remove_unconsented_clients_job_spec.rb
+++ b/spec/jobs/remove_unconsented_clients_job_spec.rb
@@ -3,10 +3,11 @@ require "rails_helper"
 describe RemoveUnconsentedClientsJob do
   describe "#perform" do
     context 'when there are barely started intakes' do
-      let!(:old_unconsented_gyr_intake) { create(:intake, source: 'llama', client: build(:client, created_at: 19.days.ago, consented_to_service_at: nil)) }
-      let!(:old_unconsented_ctc_intake) { create(:ctc_intake, source: 'giraffe', client: build(:client, created_at: 19.days.ago, consented_to_service_at: nil)) }
-      let!(:new_unconsented_ctc_intake) { create(:intake, source: 'porcupine', client: build(:client, created_at: 1.hour.ago, consented_to_service_at: nil)) }
-      let!(:old_consented_gyr_intake) { create(:intake, source: 'fox', primary_consented_to_service: "yes", client: build(:client, created_at: 3.days.ago, consented_to_service_at: DateTime.now)) }
+      let!(:archived_intake) { create(:archived_2021_gyr_intake, id: 1, source: 'elephant', client: build(:client, created_at: 349.days.ago, consented_to_service_at: nil)) }
+      let!(:old_unconsented_gyr_intake) { create(:intake, id: 2, source: 'llama', client: build(:client, created_at: 19.days.ago, consented_to_service_at: nil)) }
+      let!(:old_unconsented_ctc_intake) { create(:ctc_intake, id: 3, source: 'giraffe', client: build(:client, created_at: 19.days.ago, consented_to_service_at: nil)) }
+      let!(:new_unconsented_ctc_intake) { create(:intake, id: 4, source: 'porcupine', client: build(:client, created_at: 1.hour.ago, consented_to_service_at: nil)) }
+      let!(:old_consented_gyr_intake) { create(:intake, id: 5, source: 'fox', primary_consented_to_service: "yes", client: build(:client, created_at: 3.days.ago, consented_to_service_at: DateTime.now)) }
 
       it 'deletes clients where primary has not consented were created more than 2 days ago' do
         expect(Intake.all.map(&:id)).to match_array([old_unconsented_gyr_intake, old_unconsented_ctc_intake, new_unconsented_ctc_intake, old_consented_gyr_intake].map(&:id))
@@ -16,10 +17,16 @@ describe RemoveUnconsentedClientsJob do
         expect(Intake.all.map(&:id)).to match_array([new_unconsented_ctc_intake, old_consented_gyr_intake].map(&:id))
 
         expect(AbandonedPreConsentIntake.all.map(&:id)).to match_array([old_unconsented_gyr_intake, old_unconsented_ctc_intake].map(&:id))
-        expect(AbandonedPreConsentIntake.find_by(id: old_unconsented_gyr_intake.id).source).to eq('llama')
-        expect(AbandonedPreConsentIntake.find_by(id: old_unconsented_gyr_intake.id).client_id).to eq(old_unconsented_gyr_intake.client_id)
-        expect(AbandonedPreConsentIntake.find_by(id: old_unconsented_ctc_intake.id).source).to eq('giraffe')
-        expect(AbandonedPreConsentIntake.find_by(id: old_unconsented_ctc_intake.id).client_id).to eq(old_unconsented_ctc_intake.client_id)
+        abandoned_pre_consent_gyr_intake = AbandonedPreConsentIntake.find_by(id: old_unconsented_gyr_intake.id)
+        expect(abandoned_pre_consent_gyr_intake.source).to eq('llama')
+        expect(abandoned_pre_consent_gyr_intake.client_id).to eq(old_unconsented_gyr_intake.client_id)
+
+        abandoned_pre_consent_ctc_intake = AbandonedPreConsentIntake.find_by(id: old_unconsented_ctc_intake.id)
+        expect(abandoned_pre_consent_ctc_intake.source).to eq('giraffe')
+        expect(abandoned_pre_consent_ctc_intake.client_id).to eq(old_unconsented_ctc_intake.client_id)
+
+        # Oldschool archived clients/intakes are not deleted at this time
+        expect(archived_intake.reload).to be
       end
     end
   end


### PR DESCRIPTION
Archived::Intake2021 records get more complicated because they don't all have the consent to service bit set properly (some clients that were created by hub users are marked as not consented but have attached documents, for example)

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>