### PR TITLE
RemoveUnconsentedClientsJob skips clients with attached incoming_text_messages or documents

### DIFF
--- a/app/jobs/remove_unconsented_clients_job.rb
+++ b/app/jobs/remove_unconsented_clients_job.rb
@@ -1,6 +1,13 @@
 class RemoveUnconsentedClientsJob < ApplicationJob
   def perform(created_before: 14.days.ago)
-    Client.where("clients.created_at < ?", created_before).joins(:intake).where(consented_to_service_at: nil).find_in_batches do |clients|
+    clients_to_remove = Client
+      .where("clients.created_at < ?", created_before)
+      .joins(:intake)
+      .where(consented_to_service_at: nil)
+      .where.missing(:incoming_text_messages)
+      .where.missing(:documents)
+
+    clients_to_remove.find_in_batches do |clients|
       ActiveRecord::Base.connection.execute(ApplicationRecord.sanitize_sql([<<~SQL, clients.pluck('id')]))
         INSERT INTO abandoned_pre_consent_intakes(id, client_id, created_at, updated_at, source)
           (SELECT id, client_id, created_at, updated_at, source from intakes WHERE client_id IN (?))

--- a/app/jobs/remove_unconsented_clients_job.rb
+++ b/app/jobs/remove_unconsented_clients_job.rb
@@ -1,13 +1,6 @@
 class RemoveUnconsentedClientsJob < ApplicationJob
   def perform(created_before: 14.days.ago)
-    clients_to_remove = Client
-      .where("clients.created_at < ?", created_before)
-      .joins(:intake)
-      .where(consented_to_service_at: nil)
-      .where.missing(:incoming_text_messages)
-      .where.missing(:documents)
-
-    clients_to_remove.find_in_batches do |clients|
+    clients_to_remove(created_before).find_in_batches do |clients|
       ActiveRecord::Base.connection.execute(ApplicationRecord.sanitize_sql([<<~SQL, clients.pluck('id')]))
         INSERT INTO abandoned_pre_consent_intakes(id, client_id, created_at, updated_at, source)
           (SELECT id, client_id, created_at, updated_at, source from intakes WHERE client_id IN (?))
@@ -16,5 +9,21 @@ class RemoveUnconsentedClientsJob < ApplicationJob
       SQL
       clients.each(&:destroy)
     end
+  end
+
+  private
+
+  def clients_to_remove(created_before)
+    base_query = Client
+      .where("clients.created_at < ?", created_before)
+      .joins(:intake)
+      .where(consented_to_service_at: nil)
+      .where.missing(:incoming_text_messages)
+      .where.missing(:incoming_emails)
+      .where.missing(:documents)
+
+    base_query.where('jsonb_array_length(filterable_tax_return_properties) = 0').or(
+      base_query.where('jsonb_array_length(filterable_tax_return_properties) = 1').where("filterable_tax_return_properties @> ?::jsonb", [{current_state: 'intake_before_consent'}].to_json)
+    )
   end
 end

--- a/app/jobs/remove_unconsented_clients_job.rb
+++ b/app/jobs/remove_unconsented_clients_job.rb
@@ -2,10 +2,21 @@ class RemoveUnconsentedClientsJob < ApplicationJob
   def perform(created_before: 14.days.ago)
     clients_to_remove(created_before).find_in_batches do |clients|
       ActiveRecord::Base.connection.execute(ApplicationRecord.sanitize_sql([<<~SQL, clients.pluck('id')]))
-        INSERT INTO abandoned_pre_consent_intakes(id, client_id, created_at, updated_at, source)
-          (SELECT id, client_id, created_at, updated_at, source from intakes WHERE client_id IN (?))
+        INSERT INTO abandoned_pre_consent_intakes(id, client_id, created_at, updated_at, source, visitor_id, referrer, intake_type, triage_filing_frequency, triage_filing_status, triage_income_level, triage_vita_income_ineligible)
+          (SELECT id, client_id, created_at, updated_at, source, visitor_id, referrer, type as intake_type, triage_filing_frequency, triage_filing_status, triage_income_level, triage_vita_income_ineligible from intakes WHERE client_id IN (?))
         ON CONFLICT (id) DO
-          UPDATE SET client_id=EXCLUDED.client_id, created_at=EXCLUDED.created_at, updated_at=EXCLUDED.updated_at, source=EXCLUDED.source
+          UPDATE SET
+            client_id=EXCLUDED.client_id,
+            created_at=EXCLUDED.created_at,
+            updated_at=EXCLUDED.updated_at,
+            source=EXCLUDED.source,
+            visitor_id=EXCLUDED.visitor_id,
+            referrer=EXCLUDED.referrer,
+            intake_type=EXCLUDED.intake_type,
+            triage_filing_frequency=EXCLUDED.triage_filing_frequency,
+            triage_filing_status=EXCLUDED.triage_filing_status,
+            triage_income_level=EXCLUDED.triage_income_level,
+            triage_vita_income_ineligible=EXCLUDED.triage_vita_income_ineligible
       SQL
       clients.each(&:destroy)
     end

--- a/app/models/abandoned_pre_consent_intake.rb
+++ b/app/models/abandoned_pre_consent_intake.rb
@@ -2,11 +2,31 @@
 #
 # Table name: abandoned_pre_consent_intakes
 #
-#  id         :bigint           not null, primary key
-#  source     :string
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  client_id  :bigint
+#  id                            :bigint           not null, primary key
+#  intake_type                   :string
+#  referrer                      :string
+#  source                        :string
+#  triage_filing_frequency       :integer
+#  triage_filing_status          :integer
+#  triage_income_level           :integer
+#  triage_vita_income_ineligible :integer
+#  created_at                    :datetime         not null
+#  updated_at                    :datetime         not null
+#  client_id                     :bigint
+#  visitor_id                    :string
 #
 class AbandonedPreConsentIntake < ApplicationRecord
+  enum triage_income_level: {
+    "unfilled" => 0,
+    "zero" => 1,
+    "1_to_12500" => 2,
+    "12500_to_25000" => 3,
+    "25000_to_40000" => 4,
+    "40000_to_65000" => 5,
+    "65000_to_73000" => 6,
+    "over_73000" => 7,
+  }, _prefix: :triage_income_level
+  enum triage_filing_status: { unfilled: 0, single: 1, jointly: 2 }, _prefix: :triage_filing_status
+  enum triage_filing_frequency: { unfilled: 0, every_year: 1, some_years: 2, not_filed: 3 }, _prefix: :triage_filing_frequency
+  enum triage_vita_income_ineligible: { unfilled: 0, yes: 1, no: 2 }, _prefix: :triage_vita_income_ineligible
 end

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -316,7 +316,7 @@ class Intake < ApplicationRecord
   has_many :dependents, -> { order(created_at: :asc) }, inverse_of: :intake, dependent: :destroy
   has_many :completed_w2s, -> { order(created_at: :asc).where.not(completed_at: nil) }, class_name: 'W2', inverse_of: :intake, dependent: :destroy
   has_many :w2s_including_incomplete, -> { order(created_at: :asc) }, class_name: 'W2', inverse_of: :intake, dependent: :destroy
-  has_one :triage
+  has_one :triage, dependent: :destroy
   belongs_to :client, inverse_of: :intake, optional: true
   has_many :tax_returns, through: :client
   has_one :vita_partner, through: :client

--- a/db/migrate/20230131225607_add_more_columns_to_abandoned_intakes.rb
+++ b/db/migrate/20230131225607_add_more_columns_to_abandoned_intakes.rb
@@ -1,0 +1,11 @@
+class AddMoreColumnsToAbandonedIntakes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :abandoned_pre_consent_intakes, :triage_filing_frequency, :integer
+    add_column :abandoned_pre_consent_intakes, :triage_filing_status, :integer
+    add_column :abandoned_pre_consent_intakes, :triage_income_level, :integer
+    add_column :abandoned_pre_consent_intakes, :triage_vita_income_ineligible, :integer
+    add_column :abandoned_pre_consent_intakes, :referrer, :string
+    add_column :abandoned_pre_consent_intakes, :intake_type, :string
+    add_column :abandoned_pre_consent_intakes, :visitor_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_26_194012) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_31_225607) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -19,8 +19,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_26_194012) do
   create_table "abandoned_pre_consent_intakes", force: :cascade do |t|
     t.bigint "client_id"
     t.datetime "created_at", null: false
+    t.string "intake_type"
+    t.string "referrer"
     t.string "source"
+    t.integer "triage_filing_frequency"
+    t.integer "triage_filing_status"
+    t.integer "triage_income_level"
+    t.integer "triage_vita_income_ineligible"
     t.datetime "updated_at", null: false
+    t.string "visitor_id"
   end
 
   create_table "accepted_tax_return_analytics", force: :cascade do |t|

--- a/spec/jobs/remove_unconsented_clients_job_spec.rb
+++ b/spec/jobs/remove_unconsented_clients_job_spec.rb
@@ -5,8 +5,8 @@ describe RemoveUnconsentedClientsJob do
     context 'when there are barely started intakes' do
       # The id juggling is just because we want to resemble prod, where Archived::Intake2021 records have ids that are strictly smaller than ones in the Intake table
       let!(:archived_intake) { create(:archived_2021_gyr_intake, id: 11, source: 'elephant', client: build(:client, created_at: 349.days.ago, consented_to_service_at: nil)) }
-      let!(:old_unconsented_gyr_intake) { create(:intake, id: 12, source: 'llama', client: build(:client, created_at: 19.days.ago, consented_to_service_at: nil)) }
-      let!(:old_unconsented_ctc_intake) { create(:ctc_intake, id: 13, source: 'giraffe', client: build(:client, created_at: 19.days.ago, consented_to_service_at: nil)) }
+      let!(:old_unconsented_ctc_intake) { create(:ctc_intake, id: 12, source: 'llama', client: build(:client, created_at: 19.days.ago, consented_to_service_at: nil)) }
+      let!(:old_unconsented_gyr_intake) { create(:intake, id: 13, source: 'giraffe', referrer: 'https://example.com/', triage_filing_frequency: "unfilled", triage_filing_status: "single", triage_income_level: "unfilled", triage_vita_income_ineligible: "yes", client: build(:client, created_at: 19.days.ago, consented_to_service_at: nil)) }
       let!(:old_unconsented_ctc_intake_with_message) { create(:ctc_intake, id: 14, source: 'marmoset', client: build(:client, created_at: 19.days.ago, consented_to_service_at: nil)) }
       let!(:old_unconsented_ctc_intake_with_docs) { create(:ctc_intake, id: 15, source: 'pelican', client: build(:client, created_at: 19.days.ago, consented_to_service_at: nil)) }
       let!(:new_unconsented_ctc_intake) { create(:intake, id: 16, source: 'porcupine', client: build(:client, created_at: 1.hour.ago, consented_to_service_at: nil)) }
@@ -32,16 +32,23 @@ describe RemoveUnconsentedClientsJob do
         expect(Intake.all.map(&:id)).to match_array([new_unconsented_ctc_intake, old_consented_gyr_intake, old_unconsented_ctc_intake_with_message, old_unconsented_ctc_intake_with_docs].map(&:id))
 
         expect(AbandonedPreConsentIntake.pluck('id')).to match_array([old_unconsented_gyr_intake, old_unconsented_ctc_intake].map(&:id))
-        expect(AbandonedPreConsentIntake.find_by(id: old_unconsented_gyr_intake.id).attributes).to match(a_hash_including(
-                                                                                                           'client_id' => old_unconsented_gyr_intake.client_id,
+        expect(AbandonedPreConsentIntake.find_by(id: old_unconsented_ctc_intake.id).attributes).to match hash_including(
+                                                                                                           'client_id' => old_unconsented_ctc_intake.client_id,
+                                                                                                           'intake_type' => 'Intake::CtcIntake',
                                                                                                            'source' => 'llama'
-                                                                                                         ))
+                                                                                                         )
 
-
-        expect(AbandonedPreConsentIntake.find_by(id: old_unconsented_ctc_intake.id).attributes).to match(a_hash_including(
-                                                                                                        'client_id' => old_unconsented_ctc_intake.client_id,
+        expect(AbandonedPreConsentIntake.find_by(id: old_unconsented_gyr_intake.id).attributes).to match hash_including(
+                                                                                                        'client_id' => old_unconsented_gyr_intake.client_id,
+                                                                                                        'visitor_id' => old_unconsented_gyr_intake.visitor_id,
+                                                                                                        'referrer' => old_unconsented_gyr_intake.referrer,
+                                                                                                        'triage_filing_frequency' => old_unconsented_gyr_intake.triage_filing_frequency,
+                                                                                                        'triage_filing_status' => old_unconsented_gyr_intake.triage_filing_status,
+                                                                                                        'triage_income_level' => old_unconsented_gyr_intake.triage_income_level,
+                                                                                                        'triage_vita_income_ineligible' => old_unconsented_gyr_intake.triage_vita_income_ineligible,
+                                                                                                        'intake_type' => 'Intake::GyrIntake',
                                                                                                         'source' => 'giraffe'
-                                                                                                      ))
+                                                                                                      )
 
         # Oldschool archived clients/intakes are not deleted at this time
         expect(archived_intake.reload).to be

--- a/spec/jobs/remove_unconsented_clients_job_spec.rb
+++ b/spec/jobs/remove_unconsented_clients_job_spec.rb
@@ -3,27 +3,43 @@ require "rails_helper"
 describe RemoveUnconsentedClientsJob do
   describe "#perform" do
     context 'when there are barely started intakes' do
-      let!(:archived_intake) { create(:archived_2021_gyr_intake, id: 1, source: 'elephant', client: build(:client, created_at: 349.days.ago, consented_to_service_at: nil)) }
-      let!(:old_unconsented_gyr_intake) { create(:intake, id: 2, source: 'llama', client: build(:client, created_at: 19.days.ago, consented_to_service_at: nil)) }
-      let!(:old_unconsented_ctc_intake) { create(:ctc_intake, id: 3, source: 'giraffe', client: build(:client, created_at: 19.days.ago, consented_to_service_at: nil)) }
-      let!(:new_unconsented_ctc_intake) { create(:intake, id: 4, source: 'porcupine', client: build(:client, created_at: 1.hour.ago, consented_to_service_at: nil)) }
-      let!(:old_consented_gyr_intake) { create(:intake, id: 5, source: 'fox', primary_consented_to_service: "yes", client: build(:client, created_at: 3.days.ago, consented_to_service_at: DateTime.now)) }
+      # The id juggling is just because we want to resemble prod, where Archived::Intake2021 records have ids that are strictly smaller than ones in the Intake table
+      let!(:archived_intake) { create(:archived_2021_gyr_intake, id: 11, source: 'elephant', client: build(:client, created_at: 349.days.ago, consented_to_service_at: nil)) }
+      let!(:old_unconsented_gyr_intake) { create(:intake, id: 12, source: 'llama', client: build(:client, created_at: 19.days.ago, consented_to_service_at: nil)) }
+      let!(:old_unconsented_ctc_intake) { create(:ctc_intake, id: 13, source: 'giraffe', client: build(:client, created_at: 19.days.ago, consented_to_service_at: nil)) }
+      let!(:old_unconsented_ctc_intake_with_message) { create(:ctc_intake, id: 14, source: 'marmoset', client: build(:client, created_at: 19.days.ago, consented_to_service_at: nil)) }
+      let!(:old_unconsented_ctc_intake_with_docs) { create(:ctc_intake, id: 15, source: 'pelican', client: build(:client, created_at: 19.days.ago, consented_to_service_at: nil)) }
+      let!(:new_unconsented_ctc_intake) { create(:intake, id: 16, source: 'porcupine', client: build(:client, created_at: 1.hour.ago, consented_to_service_at: nil)) }
+      let!(:old_consented_gyr_intake) { create(:intake, id: 17, source: 'fox', primary_consented_to_service: "yes", client: build(:client, created_at: 3.days.ago, consented_to_service_at: DateTime.now)) }
+
+      let!(:old_unconsented_ctc_intake_with_message_message) { create(:incoming_text_message, client: old_unconsented_ctc_intake_with_message.client) }
+      let!(:old_unconsented_ctc_intake_with_docs_doc) { create(:document, intake: old_unconsented_ctc_intake_with_docs, client: old_unconsented_ctc_intake_with_docs.client) }
 
       it 'deletes clients where primary has not consented were created more than 2 days ago' do
-        expect(Intake.all.map(&:id)).to match_array([old_unconsented_gyr_intake, old_unconsented_ctc_intake, new_unconsented_ctc_intake, old_consented_gyr_intake].map(&:id))
+        expect(Intake.all.map(&:id)).to match_array([
+                                                      old_unconsented_gyr_intake,
+                                                      old_unconsented_ctc_intake,
+                                                      old_unconsented_ctc_intake_with_message,
+                                                      old_unconsented_ctc_intake_with_docs,
+                                                      new_unconsented_ctc_intake,
+                                                      old_consented_gyr_intake
+                                                    ].map(&:id))
 
         RemoveUnconsentedClientsJob.new.perform
 
-        expect(Intake.all.map(&:id)).to match_array([new_unconsented_ctc_intake, old_consented_gyr_intake].map(&:id))
+        expect(Intake.all.map(&:id)).to match_array([new_unconsented_ctc_intake, old_consented_gyr_intake, old_unconsented_ctc_intake_with_message, old_unconsented_ctc_intake_with_docs].map(&:id))
 
-        expect(AbandonedPreConsentIntake.all.map(&:id)).to match_array([old_unconsented_gyr_intake, old_unconsented_ctc_intake].map(&:id))
-        abandoned_pre_consent_gyr_intake = AbandonedPreConsentIntake.find_by(id: old_unconsented_gyr_intake.id)
-        expect(abandoned_pre_consent_gyr_intake.source).to eq('llama')
-        expect(abandoned_pre_consent_gyr_intake.client_id).to eq(old_unconsented_gyr_intake.client_id)
+        expect(AbandonedPreConsentIntake.pluck('id')).to match_array([old_unconsented_gyr_intake, old_unconsented_ctc_intake].map(&:id))
+        expect(AbandonedPreConsentIntake.find_by(id: old_unconsented_gyr_intake.id).attributes).to match(a_hash_including(
+                                                                                                           'client_id' => old_unconsented_gyr_intake.client_id,
+                                                                                                           'source' => 'llama'
+                                                                                                         ))
 
-        abandoned_pre_consent_ctc_intake = AbandonedPreConsentIntake.find_by(id: old_unconsented_ctc_intake.id)
-        expect(abandoned_pre_consent_ctc_intake.source).to eq('giraffe')
-        expect(abandoned_pre_consent_ctc_intake.client_id).to eq(old_unconsented_ctc_intake.client_id)
+
+        expect(AbandonedPreConsentIntake.find_by(id: old_unconsented_ctc_intake.id).attributes).to match(a_hash_including(
+                                                                                                        'client_id' => old_unconsented_ctc_intake.client_id,
+                                                                                                        'source' => 'giraffe'
+                                                                                                      ))
 
         # Oldschool archived clients/intakes are not deleted at this time
         expect(archived_intake.reload).to be

--- a/spec/jobs/remove_unconsented_clients_job_spec.rb
+++ b/spec/jobs/remove_unconsented_clients_job_spec.rb
@@ -32,23 +32,23 @@ describe RemoveUnconsentedClientsJob do
         expect(Intake.all.map(&:id)).to match_array([new_unconsented_ctc_intake, old_consented_gyr_intake, old_unconsented_ctc_intake_with_message, old_unconsented_ctc_intake_with_docs].map(&:id))
 
         expect(AbandonedPreConsentIntake.pluck('id')).to match_array([old_unconsented_gyr_intake, old_unconsented_ctc_intake].map(&:id))
-        expect(AbandonedPreConsentIntake.find_by(id: old_unconsented_ctc_intake.id).attributes).to match hash_including(
-                                                                                                           'client_id' => old_unconsented_ctc_intake.client_id,
-                                                                                                           'intake_type' => 'Intake::CtcIntake',
-                                                                                                           'source' => 'llama'
-                                                                                                         )
+        expect(AbandonedPreConsentIntake.find_by(id: old_unconsented_ctc_intake.id).attributes).to include_hash(
+                                                                                                     'client_id' => old_unconsented_ctc_intake.client_id,
+                                                                                                     'intake_type' => 'Intake::CtcIntake',
+                                                                                                     'source' => 'llama'
+                                                                                                   )
 
-        expect(AbandonedPreConsentIntake.find_by(id: old_unconsented_gyr_intake.id).attributes).to match hash_including(
-                                                                                                        'client_id' => old_unconsented_gyr_intake.client_id,
-                                                                                                        'visitor_id' => old_unconsented_gyr_intake.visitor_id,
-                                                                                                        'referrer' => old_unconsented_gyr_intake.referrer,
-                                                                                                        'triage_filing_frequency' => old_unconsented_gyr_intake.triage_filing_frequency,
-                                                                                                        'triage_filing_status' => old_unconsented_gyr_intake.triage_filing_status,
-                                                                                                        'triage_income_level' => old_unconsented_gyr_intake.triage_income_level,
-                                                                                                        'triage_vita_income_ineligible' => old_unconsented_gyr_intake.triage_vita_income_ineligible,
-                                                                                                        'intake_type' => 'Intake::GyrIntake',
-                                                                                                        'source' => 'giraffe'
-                                                                                                      )
+        expect(AbandonedPreConsentIntake.find_by(id: old_unconsented_gyr_intake.id).attributes).to include_hash(
+                                                                                                     'client_id' => old_unconsented_gyr_intake.client_id,
+                                                                                                     'visitor_id' => old_unconsented_gyr_intake.visitor_id,
+                                                                                                     'referrer' => old_unconsented_gyr_intake.referrer,
+                                                                                                     'triage_filing_frequency' => old_unconsented_gyr_intake.triage_filing_frequency,
+                                                                                                     'triage_filing_status' => old_unconsented_gyr_intake.triage_filing_status,
+                                                                                                     'triage_income_level' => old_unconsented_gyr_intake.triage_income_level,
+                                                                                                     'triage_vita_income_ineligible' => old_unconsented_gyr_intake.triage_vita_income_ineligible,
+                                                                                                     'intake_type' => 'Intake::GyrIntake',
+                                                                                                     'source' => 'giraffe'
+                                                                                                   )
 
         # Oldschool archived clients/intakes are not deleted at this time
         expect(archived_intake.reload).to be

--- a/spec/jobs/remove_unconsented_clients_job_spec.rb
+++ b/spec/jobs/remove_unconsented_clients_job_spec.rb
@@ -16,6 +16,8 @@ describe RemoveUnconsentedClientsJob do
       let!(:old_unconsented_ctc_intake_with_docs_doc) { create(:document, intake: old_unconsented_ctc_intake_with_docs, client: old_unconsented_ctc_intake_with_docs.client) }
 
       it 'deletes clients where primary has not consented were created more than 2 days ago' do
+        SearchIndexer.refresh_filterable_properties(Client.all)
+
         expect(Intake.all.map(&:id)).to match_array([
                                                       old_unconsented_gyr_intake,
                                                       old_unconsented_ctc_intake,


### PR DESCRIPTION
Non-consenting client records can accumulate incoming text messages because the we attach incoming text messages to all clients regardless of whether they have `consented_to_service_at`.