### PR TITLE
GYR portal sends clients who would see 'at-capacity' back to the '/consent' page for another chance

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -39,6 +39,10 @@ class ApplicationController < ActionController::Base
     }.merge(default_url_options).merge(options))
   end
 
+  def self.all_localized_paths
+    Rails.configuration.i18n.available_locales.map { |locale| to_path_helper(locale: locale) }
+  end
+
   def canonical_url(locale=I18n.locale)
     # Leave the locale out of canonical URLs in the default locale (works ok either way but needs to be consistent)
     url_for(only_path: false, locale: locale)

--- a/app/controllers/portal/portal_controller.rb
+++ b/app/controllers/portal/portal_controller.rb
@@ -10,7 +10,12 @@ module Portal
       @ask_for_answers = ask_for_answers?
       @itin_filer_ready_to_mail = current_intake.itin_applicant? && current_intake.tax_returns.any? { |tr| tr.current_state == 'file_mailed' }
       @can_submit_additional_documents = !@itin_filer_ready_to_mail
-      @current_step = current_intake.current_step if ask_for_answers?
+      if ask_for_answers?
+        @current_step = current_intake.current_step
+        if @current_step.in?(Questions::AtCapacityController.all_localized_paths)
+          @current_step = Questions::ConsentController.to_path_helper
+        end
+      end
       @document_count = current_client.documents.where(uploaded_by: current_client).count
       @tax_returns = show_tax_returns? ? current_client.tax_returns.order(year: :desc) : []
     end

--- a/spec/features/web_intake/at_capacity_spec.rb
+++ b/spec/features/web_intake/at_capacity_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Web Intake Client matches with partner who is at capacity", :flow_explorer_screenshot do
-  module AtCapacitySpecHelper
+  include(Module.new do
     def intake_up_to_at_capacity_page
       # at first, sees at capacity page when resuming.
       # After updating routing method, does not see at capacity page.
@@ -60,8 +60,7 @@ RSpec.feature "Web Intake Client matches with partner who is at capacity", :flow
       select "1971", from: "consent_form_birth_date_year"
       click_on I18n.t("views.questions.consent.cta")
     end
-  end
-  include AtCapacitySpecHelper
+  end)
 
   context "when there are no partners with capacity" do
     before do
@@ -88,7 +87,7 @@ RSpec.feature "Web Intake Client matches with partner who is at capacity", :flow
       expect(Intake.last.continued_at_capacity).to be_falsey
     end
 
-    it "allows the client to log in again and see the at capacity page" do
+    it "allows the client to log in again, start at the consent page, and see the at capacity page" do
       within ".toolbar" do
         click_on "Login"
       end
@@ -106,6 +105,8 @@ RSpec.feature "Web Intake Client matches with partner who is at capacity", :flow
 
       expect(page).to have_text "Welcome back"
       click_on "Complete all tax questions"
+      expect(page).to have_selector("h1", text: I18n.t('views.questions.consent.title'))
+      click_on I18n.t("views.questions.consent.cta")
       expect(page).to have_content "GetYourRefund's tax preparation partners are currently at capacity."
     end
 
@@ -131,8 +132,54 @@ RSpec.feature "Web Intake Client matches with partner who is at capacity", :flow
 
         expect(page).to have_text "Welcome back"
         click_on "Complete all tax questions"
-        expect(page).to have_selector("h1", text: I18n.t("views.questions.optional_consent.title"))
+        expect(page).to have_selector("h1", text: I18n.t("views.questions.consent.title"))
       end
+    end
+  end
+
+  context "when a vita partner becomes available after the client has seen the at capacity page" do
+    let(:overflow_organization) { create :organization }
+
+    it "allows the client to log in, start from the consent page, and get routed to a vita partner" do
+      routing_service_double = instance_double(PartnerRoutingService)
+      allow(PartnerRoutingService).to receive(:new).and_return routing_service_double
+
+      # no one has capacity
+      allow(routing_service_double).to receive(:routing_method).and_return :at_capacity
+      allow(routing_service_double).to receive(:determine_partner).and_return nil
+
+      # first time client tries to do intake
+      intake_up_to_at_capacity_page
+
+      # national overflow becomes available
+      allow(routing_service_double).to receive(:routing_method).and_return :national_overflow
+      allow(routing_service_double).to receive(:determine_partner).and_return overflow_organization
+
+      # client comes back through the portal
+      within ".toolbar" do
+        click_on "Login"
+      end
+      fill_in "Email address", with: "gary.gardengnome@example.green"
+      click_on I18n.t("portal.client_logins.new.send_code")
+      perform_enqueued_jobs
+      mail = ActionMailer::Base.deliveries.last
+      code = mail.html_part.body.to_s.match(/\s(\d{6})[.]/)[1]
+
+      fill_in "Enter 6 digit code", with: code
+      click_on "Verify"
+
+      fill_in "Client ID or Last 4 of SSN/ITIN", with: "6789"
+      click_on "Continue"
+
+      expect(page).to have_text "Welcome back"
+      click_on "Complete all tax questions"
+      expect(page).to have_selector("h1", text: I18n.t('views.questions.consent.title'))
+
+      expect do
+        click_on I18n.t("views.questions.consent.cta")
+      end.to change { Client.last.vita_partner }.to(overflow_organization)
+
+      expect(page).to have_selector("h1", text: I18n.t("views.questions.optional_consent.title"))
     end
   end
 end


### PR DESCRIPTION
otherwise if clients get to the 'at-capacity' screen that have no way to proceed even if the vita partner they were matched to later gains capacity (unless a hub user explicitly assigned them to another vita partner)

Co-authored-by: Jenny Heath <jheath@codeforamerica.org>