### PR TITLE
Remove link from DIY back to GYR

### DIFF
--- a/app/controllers/questions/consent_controller.rb
+++ b/app/controllers/questions/consent_controller.rb
@@ -2,6 +2,7 @@ module Questions
   class ConsentController < QuestionsController
     include AnonymousIntakeConcern
     layout "intake"
+    before_action :check_required_attributes
 
     def illustration_path; end
 
@@ -40,6 +41,14 @@ module Questions
       end
 
       sign_in current_intake.client unless current_intake.client.routing_method_at_capacity?
+    end
+
+    private
+
+    def check_required_attributes
+      if current_intake.primary_ssn.blank?
+        redirect_to Questions::WelcomeController.to_path_helper
+      end
     end
   end
 end

--- a/app/views/diy/file_yourself/edit.html.erb
+++ b/app/views/diy/file_yourself/edit.html.erb
@@ -28,7 +28,6 @@
         </div>
 
         <%= link_to t("general.continue"), diy_email_path, class: "button button--primary text--centered button--wide spacing-above-60" %>
-        <%= link_to t(".assistance"), backtaxes_questions_path %>
       </main>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,7 +89,6 @@ en:
         title: To access this site, please provide your e-mail address.
     file_yourself:
       edit:
-        assistance: Actually, I need assistance filing.
         info: You selected our do it yourself option. We'll provide the tools so you can file yourself.
         right_option:
           description:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -89,7 +89,6 @@ es:
         title: Para acceder a este sitio, indique su dirección de correo electrónico.
     file_yourself:
       edit:
-        assistance: De hecho, necesito ayuda para declarar.
         info: Seleccionaste la opción para hacerlo usted mismo. Le proveeremos las herramientas necesarias para que pueda hacer su propia declaración.
         right_option:
           description:


### PR DESCRIPTION
The old link skipped the SSN page

Also don't allow a client to consent to service if they don't have a primary_ssn

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>