### PR TITLE
Hub messages page: include both the 'stripped_text' and 'stripped_signature' of incoming emails

### DIFF
--- a/app/models/incoming_email.rb
+++ b/app/models/incoming_email.rb
@@ -36,7 +36,7 @@ class IncomingEmail < ApplicationRecord
   after_create { InteractionTrackingService.record_incoming_interaction(client) }
 
   def body
-    stripped_text || body_plain
+    stripped_text.present? ? [stripped_text, stripped_signature].map(&:presence).compact.join("\n") : body_plain
   end
 
   def datetime

--- a/spec/controllers/mailgun_webhooks_controller_spec.rb
+++ b/spec/controllers/mailgun_webhooks_controller_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe MailgunWebhooksController do
                 end.to change(IncomingEmail, :count).by(1).and change(Client, :count).by(0)
                 expect(IntercomService).to have_received(:create_message).with(
                   email_address: actual_email,
-                  body: "Hi Alice,\n\nThis is Bob.\n\nI also attached a file.",
+                  body: "Hi Alice,\n\nThis is Bob.\n\nI also attached a file.\nThanks,\nBob",
                   phone_number: nil,
                   client: client,
                   has_documents: true

--- a/spec/models/incoming_email_spec.rb
+++ b/spec/models/incoming_email_spec.rb
@@ -30,6 +30,46 @@
 require 'rails_helper'
 
 describe IncomingEmail do
+  describe '#body' do
+    context 'when stripped_text and stripped_signature are present' do
+      let(:subject) do
+        build(
+          :incoming_email,
+          stripped_text: "My name is Tax Person",
+          stripped_signature: "Sincerely, Tax Person",
+          body_plain: "My name is Tax Person\nSincerely, Tax Person\nA lot of other stuff we don't care about"
+        )
+      end
+
+      it 'returns stripped_text and stripped_signature smashed together' do
+        expect(subject.body).to eq("My name is Tax Person\nSincerely, Tax Person")
+      end
+    end
+
+    context 'when stripped_text is present but stripped_signature is blank' do
+      let(:subject) do
+        build(
+          :incoming_email,
+          stripped_text: "My name is Tax Person",
+          stripped_signature: '',
+          body_plain: "My name is Tax Person\nA lot of other stuff we don't care about"
+        )
+      end
+
+      it 'returns stripped_text' do
+        expect(subject.body).to eq("My name is Tax Person")
+      end
+    end
+
+    context 'when stripped_text is absent' do
+      let(:subject) { build(:incoming_email, stripped_text: nil, stripped_signature: nil, body_plain: "I love sending emails to websites") }
+
+      it 'returns body_plain' do
+        expect(subject.body).to eq("I love sending emails to websites")
+      end
+    end
+  end
+
   context "interaction tracking" do
     it_behaves_like "an incoming interaction" do
       let(:subject) { build(:incoming_email) }


### PR DESCRIPTION
Mailgun attempts to parse out all the quoted email content, and also chops up the remaining body into stripped_text and stripped_signature

Historically we have only presented stripped_text, but sometimes the info we're asking clients looks a lot like a signature, so we're gonna include all of it.

There are historical examples of clients where this wasn't sufficient, because some content lived in body_plain but didn't make it into either of the stripped_ fields. Hopefully this fixes the majority of the problems but there could be more problems!

one example is the incoming email on client 2859639 which got a date chopped off

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>