### PR TITLE
Try to replace our OrganizationCapacity view with a with_capacity scope on Organization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'sass-rails', '~> 5.0'
 gem 'cfa-styleguide', '0.10.5', git: 'https://github.com/codeforamerica/honeycrisp-gem', branch: 'main', ref: '4c6f873f55704ec34fd518906f131133b290e56a'
 gem 'nokogiri', '>= 1.10.8'
 gem 'recaptcha'
-gem "activerecord-cte"
+gem "activerecord-cte" # Can be removed when we move to Rails 7.1
 
 # Adding this removes some deprecation warnings, caused by double-loading of the net-protocol library
 # (see https://github.com/ruby/net-imap/issues/16)

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'sass-rails', '~> 5.0'
 gem 'cfa-styleguide', '0.10.5', git: 'https://github.com/codeforamerica/honeycrisp-gem', branch: 'main', ref: '4c6f873f55704ec34fd518906f131133b290e56a'
 gem 'nokogiri', '>= 1.10.8'
 gem 'recaptcha'
+gem "activerecord-cte"
 
 # Adding this removes some deprecation warnings, caused by double-loading of the net-protocol library
 # (see https://github.com/ruby/net-imap/issues/16)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,8 @@ GEM
     activerecord (7.0.4.2)
       activemodel (= 7.0.4.2)
       activesupport (= 7.0.4.2)
+    activerecord-cte (0.3.0)
+      activerecord
     activerecord-postgis-adapter (8.0.1)
       activerecord (~> 7.0.0)
       rgeo-activerecord (~> 7.0.0)
@@ -652,6 +654,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-cte
   activerecord-postgis-adapter
   annotate
   auto_strip_attributes

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -65,13 +65,13 @@ class Organization < VitaPartner
     ).joins(
       'LEFT OUTER JOIN partner_and_client_counts ON vita_partners.id=partner_and_client_counts.organization_id_for_capacity'
     ).select(
-      'vita_partners.*, CASE WHEN partner_and_client_counts.pacc_active_client_count IS NULL THEN 0 ELSE partner_and_client_counts.pacc_active_client_count END as active_client_count'
+      'vita_partners.*, COALESCE(partner_and_client_counts.pacc_active_client_count, 0) AS active_client_count'
     )
   end
 
   scope :with_capacity, -> do
     with_computed_client_count.where(capacity_limit: nil).or(
-      where('vita_partners.capacity_limit > ?', 0).where('CASE WHEN partner_and_client_counts.pacc_active_client_count IS NULL THEN 0 ELSE partner_and_client_counts.pacc_active_client_count END < vita_partners.capacity_limit')
+      where('vita_partners.capacity_limit > ?', 0).where('COALESCE(partner_and_client_counts.pacc_active_client_count, 0) < vita_partners.capacity_limit')
     )
   end
 

--- a/app/presenters/hub/organizations_presenter.rb
+++ b/app/presenters/hub/organizations_presenter.rb
@@ -2,10 +2,10 @@ module Hub
   class OrganizationsPresenter
     attr_reader :current_ability, :organizations, :target_entries, :coalitions, :state_routing_targets
 
-    def initialize(current_ability)
+    def initialize(current_ability, capacity_algorithm: ENV['NEW_ORGANIZATION_CAPACITY'] ? :cte : :view)
       @current_ability = current_ability
       accessible_organizations = Organization.accessible_by(current_ability)
-      if ENV['NEW_ORGANIZATION_CAPACITY']
+      if capacity_algorithm == :cte
         @organizations = accessible_organizations.includes(:child_sites).with_computed_client_count.load
       else
         @organizations = accessible_organizations.includes(:child_sites, :organization_capacity).load

--- a/app/presenters/hub/organizations_presenter.rb
+++ b/app/presenters/hub/organizations_presenter.rb
@@ -35,7 +35,7 @@ module Hub
       return unless current_ability.can?(:read, organization)
 
       if ENV['NEW_ORGANIZATION_CAPACITY']
-        organization = organization(organization)
+        organization = organization(organization.id)
         Capacity.new(
           organization.active_client_count || 0,
           organization.capacity_limit || 0

--- a/app/presenters/hub/organizations_presenter.rb
+++ b/app/presenters/hub/organizations_presenter.rb
@@ -12,6 +12,7 @@ module Hub
       end
       @coalitions = Coalition.accessible_by(current_ability)
       @state_routing_targets = StateRoutingTarget.where(target: accessible_organizations).or(StateRoutingTarget.where(target: @coalitions)).load.group_by(&:state_abbreviation)
+      @capacity_algorithm = capacity_algorithm
     end
 
     Capacity = Struct.new(:current_count, :total_capacity) do
@@ -34,7 +35,7 @@ module Hub
     def organization_capacity(organization)
       return unless current_ability.can?(:read, organization)
 
-      if ENV['NEW_ORGANIZATION_CAPACITY']
+      if @capacity_algorithm == :cte
         organization = organization(organization.id)
         Capacity.new(
           organization.active_client_count || 0,

--- a/app/presenters/hub/organizations_presenter.rb
+++ b/app/presenters/hub/organizations_presenter.rb
@@ -35,6 +35,7 @@ module Hub
       return unless current_ability.can?(:read, organization)
 
       if ENV['NEW_ORGANIZATION_CAPACITY']
+        organization = organization(organization)
         Capacity.new(
           organization.active_client_count || 0,
           organization.capacity_limit || 0

--- a/app/presenters/hub/organizations_presenter.rb
+++ b/app/presenters/hub/organizations_presenter.rb
@@ -4,9 +4,9 @@ module Hub
 
     def initialize(current_ability)
       @current_ability = current_ability
-      @organizations = Organization.accessible_by(current_ability).includes(:child_sites, :organization_capacity).load
+      @organizations = Organization.accessible_by(current_ability).includes(:child_sites).with_capacity.load
       @coalitions = Coalition.accessible_by(current_ability)
-      @state_routing_targets = StateRoutingTarget.where(target: @organizations).or(StateRoutingTarget.where(target: @coalitions)).load.group_by(&:state_abbreviation)
+      @state_routing_targets = StateRoutingTarget.where(target: Organization.accessible_by(current_ability)).or(StateRoutingTarget.where(target: @coalitions)).load.group_by(&:state_abbreviation)
     end
 
     Capacity = Struct.new(:current_count, :total_capacity) do
@@ -30,8 +30,8 @@ module Hub
       return unless current_ability.can?(:read, organization)
 
       Capacity.new(
-        organization.organization_capacity.active_client_count || 0,
-        organization.organization_capacity.capacity_limit || 0
+        organization.active_client_count || 0,
+        organization.capacity_limit || 0
       )
     end
 

--- a/app/services/partner_routing_service.rb
+++ b/app/services/partner_routing_service.rb
@@ -93,9 +93,15 @@ class PartnerRoutingService
   def vita_partner_from_zip_code
     return unless @zip_code.present?
 
-    eligible_with_capacity = VitaPartnerZipCode.where(zip_code: @zip_code).joins(organization: :organization_capacity).merge(
-      OrganizationCapacity.with_capacity
-    )
+    if ENV['NEW_ORGANIZATION_CAPACITY']
+      eligible_with_capacity = VitaPartnerZipCode.where(zip_code: @zip_code).joins(:organization).where(
+        vita_partner_id: Organization.with_capacity.pluck('vita_partners.id')
+      )
+    else
+      eligible_with_capacity = VitaPartnerZipCode.where(zip_code: @zip_code).joins(organization: :organization_capacity).merge(
+        OrganizationCapacity.with_capacity
+      )
+    end
 
     vita_partner = eligible_with_capacity.first&.vita_partner
 

--- a/app/services/partner_routing_service.rb
+++ b/app/services/partner_routing_service.rb
@@ -119,9 +119,10 @@ class PartnerRoutingService
                                                      .where(state_routing_targets: { state_abbreviation: state })
     # get state routing fractions associated with organizations that have capacity
     if @capacity_algorithm == :cte
+      organization_ids_with_capacity = Organization.with_capacity.pluck('id')
       with_capacity_organization_fractions = in_state_routing_fractions
         .joins(:organization)
-        .where(organization: Organization.with_capacity.pluck('id'))
+        .where(organization: organization_ids_with_capacity)
     else
       with_capacity_organization_fractions = in_state_routing_fractions
         .joins(organization: :organization_capacity)
@@ -133,7 +134,7 @@ class PartnerRoutingService
     site_fractions = in_state_routing_fractions.joins(:site)
     site_parent_ids = site_fractions.map(&:site).pluck(:parent_organization_id)
     if @capacity_algorithm == :cte
-      parents_with_capacity_ids = Organization.with_capacity.where(id: site_parent_ids).pluck(:id)
+      parents_with_capacity_ids = organization_ids_with_capacity.intersection(site_parent_ids)
     else
       parents_with_capacity_ids = OrganizationCapacity.with_capacity.where(organization: site_parent_ids).pluck(:vita_partner_id)
     end

--- a/cli/gyr_cli.rb
+++ b/cli/gyr_cli.rb
@@ -27,9 +27,72 @@ class GyrCli < Thor
     system("git --no-pager diff #{old_decrypted.path} #{new_decrypted.path}")
   end
 
+  desc "test_capacity_algorithms", "Compare capacity calculations before and after cte refactor"
+  def test_capacity_algorithms
+    load_rails_env!
+
+    user = User.find_by(role_type: 'AdminRole')
+
+    old_org_presenter = Hub::OrganizationsPresenter.new(Ability.new(user), capacity_algorithm: :view)
+    old_partner_routing_service = PartnerRoutingService.new(capacity_algorithm: :view)
+
+    new_org_presenter = Hub::OrganizationsPresenter.new(Ability.new(user), capacity_algorithm: :cte)
+    new_partner_routing_service = PartnerRoutingService.new(capacity_algorithm: :cte)
+
+    all_results = []
+    [
+      CapacityTestCase.new("old", old_org_presenter),
+      CapacityTestCase.new("new", new_org_presenter)
+    ].each do |test_case|
+      org_presenter = test_case.presenter
+
+      results = {'UNROUTED' => {}}
+      time_took = Benchmark.realtime do
+        States.hash.each do |abbreviation, full|
+          results[abbreviation] = {}
+
+          (org_presenter.accessible_entities_for(abbreviation) || []).each do |entity|
+            if entity.is_a? Coalition
+              orgs = org_presenter.organizations_in_coalition(entity)
+            else
+              orgs = [entity]
+            end
+
+            orgs.each do |org|
+              results[abbreviation][org.id] = {name: org.name, capacity: org_presenter.organization_capacity(org)}
+            end
+          end
+        end
+
+        org_presenter.unrouted_independent_organizations.each do |org|
+          results['UNROUTED'][org.id] = {name: org.name, capacity: org_presenter.organization_capacity(org)}
+        end
+
+        org_presenter.unrouted_coalitions.each do |coalition|
+          org_presenter.organizations_in_coalition(coalition).each do |org|
+            results['UNROUTED'][org.id] = {name: org.name, capacity: org_presenter.organization_capacity(org)}
+          end
+        end
+
+        results.each do |state_or_unrouted, orgs_and_capacities|
+          orgs_and_capacities.each do |org_id, data|
+            puts "#{org_id} #{data[:name]} #{data[:capacity].current_count} / #{data[:capacity].total_capacity}"
+          end
+        end
+      end
+
+      puts "'#{test_case.name}' total time: #{time_took}"
+      all_results << results
+      puts
+    end
+    puts "Did they match? #{all_results[0] == all_results[1]}"
+  end
+
   no_commands do
     def load_rails_env!
       require File.expand_path('../config/environment', File.dirname(__FILE__))
     end
   end
+
+  CapacityTestCase = Struct.new(:name, :presenter)
 end

--- a/spec/presenters/hub/organizations_presenter_spec.rb
+++ b/spec/presenters/hub/organizations_presenter_spec.rb
@@ -51,7 +51,7 @@ describe Hub::OrganizationsPresenter do
 
     describe "#organization_capacity" do
       it "returns the capacity figures" do
-        capacity = subject.organization_capacity(Organization.with_capacity.find(organization.id))
+        capacity = subject.organization_capacity(organization)
         expect(capacity.total_capacity).to eq 250
         expect(capacity.current_count).to eq 1
       end
@@ -102,7 +102,7 @@ describe Hub::OrganizationsPresenter do
     describe "#organization_capacity" do
       context "when there is access to the organization" do
         it "returns the capacity figures" do
-          capacity = subject.organization_capacity(Organization.with_capacity.find(organization.id))
+          capacity = subject.organization_capacity(organization)
           expect(capacity.total_capacity).to eq 250
           expect(capacity.current_count).to eq 1
         end

--- a/spec/presenters/hub/organizations_presenter_spec.rb
+++ b/spec/presenters/hub/organizations_presenter_spec.rb
@@ -51,7 +51,7 @@ describe Hub::OrganizationsPresenter do
 
     describe "#organization_capacity" do
       it "returns the capacity figures" do
-        capacity = subject.organization_capacity(organization)
+        capacity = subject.organization_capacity(Organization.with_capacity.find(organization.id))
         expect(capacity.total_capacity).to eq 250
         expect(capacity.current_count).to eq 1
       end
@@ -102,7 +102,7 @@ describe Hub::OrganizationsPresenter do
     describe "#organization_capacity" do
       context "when there is access to the organization" do
         it "returns the capacity figures" do
-          capacity = subject.organization_capacity(organization)
+          capacity = subject.organization_capacity(Organization.with_capacity.find(organization.id))
           expect(capacity.total_capacity).to eq 250
           expect(capacity.current_count).to eq 1
         end


### PR DESCRIPTION
We're using the activerecord-cte gem, when Rails 7.1 is released it can be removed because the very same '.with' syntax will be in rails

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>