### PR TITLE
RemoveUnconsentedClientsJob runs a max of 5000 clients then re-queues itself

### DIFF
--- a/crontab
+++ b/crontab
@@ -1,5 +1,6 @@
 0 0 * * 0 bundle exec rake vita_providers:scrape_vita_providers
 * * * * * bundle exec rake search:refresh
+0 2 * * * bundle exec rake cleanup:remove_unconsented_clients
 * * * * * bundle exec rake stats:track_metrics
 */5 * * * * bundle exec rake client_status_updates:send_completion_surveys
 */20 * * * * bundle exec rake client_status_updates:send_client_in_progress_automated_messages

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -1,0 +1,6 @@
+namespace :cleanup do
+  desc 'Remove clients/intakes/etc that are not consented to service'
+  task remove_unconsented_clients: [:environment] do
+    RemoveUnconsentedClientsJob.perform_later
+  end
+end


### PR DESCRIPTION
on prod, this job seems to keep gobbling up memory for an unknown reason

if we limit the amount of records touched in one `perform`, hopefully it will not do that

Also: this commit adds a cron line to run it once a day at 2am (utc?)