### PR TITLE
Heroku review apps: ensure that predestroy happens when cleaning up old apps

### DIFF
--- a/.github/remove_old_heroku_review_apps.js
+++ b/.github/remove_old_heroku_review_apps.js
@@ -5,6 +5,13 @@ const execSync = require('child_process').execSync;
 let apps = execSync("heroku apps:list --org getyourrefund | grep gyr-review-app").toString()
 let prs = JSON.parse(execSync("gh pr list --json number")).map(function (line) { return line.number })
 
+function removeReviewApp(number) {
+   let app_name = `gyr-review-app-${number}`
+   console.log(`Gonna delete ${app_name}`)
+   execSync(`heroku run rails heroku:review_app_predestroy --app=${ app_name }`)
+   execSync(`heroku apps:destroy --app=${ app_name } --confirm=${ app_name }`)
+}
+
 apps.split("\n").forEach(function (app) {
    let match = app.match(/-(\d+)/)
    if (!match) {
@@ -12,8 +19,6 @@ apps.split("\n").forEach(function (app) {
    }
    let number = parseInt(match[1], 10)
    if (!prs.includes(number)) {
-      let app_name = `gyr-review-app-${number}`
-      console.log(`Gonna delete ${app_name}`)
-      execSync(`heroku apps:destroy --app=${ app_name } --confirm=${ app_name }`)
+      removeReviewApp(number)
    }
 });

--- a/.github/workflows/heroku-pull-request.yml
+++ b/.github/workflows/heroku-pull-request.yml
@@ -24,7 +24,7 @@ jobs:
           heroku_app_name: ${{ env.HEROKU_APP_NAME }}
           justlogin: true
 
-      - name: Clean up unused old heroku apps
+      - name: Clean up unused old heroku apps, including this one if it's being closed
         run: .github/remove_old_heroku_review_apps.js
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -81,15 +81,8 @@ jobs:
         run: heroku addons:create heroku-postgresql:mini --app ${{ env.HEROKU_APP_NAME }}
 
       - name: Add Heroku remote
-        continue-on-error: true
-        id: add-remote
+        if: github.event.action != 'closed'
         run: heroku git:remote --app=${{ env.HEROKU_APP_NAME }}
-
-      - name: Retry Add Heroku remote if failed while trying to close the PR and destroy the app
-        if: github.event.action == 'closed' && steps.add-remote.outcome=='failure'
-        run: |
-          sleep 10
-          heroku git:remote --app=${{ env.HEROKU_APP_NAME }}
 
       - name: Push to Heroku
         if: github.event.action != 'closed'
@@ -113,11 +106,3 @@ jobs:
           gh pr comment ${{ github.event.number }} --body '[Heroku app](https://dashboard.heroku.com/apps/${{ env.HEROKU_APP_NAME }}): https://${{ env.HEROKU_APP_NAME }}.herokuapp.com<br/>View logs: `heroku logs --app ${{ env.HEROKU_APP_NAME }}` (optionally add `--tail`)'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pre-destroy - clean up the hostnames (GYR and CTC)
-        if: github.event.action == 'closed'
-        run: heroku run rails heroku:review_app_predestroy
-
-      - name: Destroy Heroku app
-        if: github.event.action == 'closed'
-        run: heroku apps:destroy --app=${{ env.HEROKU_APP_NAME }} --confirm=${{ env.HEROKU_APP_NAME }}

--- a/.github/workflows/heroku-pull-request.yml
+++ b/.github/workflows/heroku-pull-request.yml
@@ -17,7 +17,7 @@ jobs:
           ref: ${{ github.event.action != 'closed' && github.head_ref || '' }}
 
       - name: Login to Heroku
-        uses: akhileshns/heroku-deploy@v3.12.12
+        uses: akhileshns/heroku-deploy@v3.12.13
         with:
           heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
           heroku_email: wschaefer@codeforamerica.org


### PR DESCRIPTION
remove existing destroy steps at the end of the action; all the destruction should now happen in the 'Clean up unused old heroku apps' phase

prior to this, on PR close, the existing PR would be removed in the 'Clean up unused old heroku apps' phase, then later error out when it tried to destroy it again