### PR TITLE
GYR intake: ensure sms_phone_number exists before sending validation code

### DIFF
--- a/app/controllers/questions/phone_verification_controller.rb
+++ b/app/controllers/questions/phone_verification_controller.rb
@@ -16,6 +16,8 @@ module Questions
     private
 
     def send_verification_code
+      return redirect_to Questions::CellPhoneNumberController.to_path_helper if current_intake.sms_phone_number.blank?
+
       RequestVerificationCodeTextMessageJob.perform_later(
         phone_number: current_intake.sms_phone_number,
         locale: I18n.locale,

--- a/spec/controllers/questions/phone_verification_controller_spec.rb
+++ b/spec/controllers/questions/phone_verification_controller_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 
 RSpec.describe Questions::PhoneVerificationController, requires_default_vita_partners: true do
+  let(:sms_phone_number) { "+15125551234" }
   let(:visitor_id) { "asdfasdfa" }
-  let(:client) { create :client, intake: (create :intake, sms_phone_number: "+15125551234", visitor_id: visitor_id, locale: locale) }
+  let(:client) { create :client, intake: (create :intake, sms_phone_number: sms_phone_number, visitor_id: visitor_id, locale: locale) }
   let(:intake) { client.intake }
   let(:locale) { "en" }
 
@@ -12,6 +13,16 @@ RSpec.describe Questions::PhoneVerificationController, requires_default_vita_par
   end
 
   context 'before rendering edit' do
+    context "if the sms phone number was blank" do
+      let(:sms_phone_number) { nil }
+
+      it "redirects back to the SMS phone number entry screen " do
+        expect(
+          get :edit, params: {}
+        ).to redirect_to(Questions::CellPhoneNumberController.to_path_helper)
+      end
+    end
+
     it "enqueues a job to send a verification code" do
       expect {
         get :edit, params: {}


### PR DESCRIPTION
A very small number of clients have jumped over the SMS phone number entry page, maybe because they were doing the intake in multiple tabs or fooling with their history through the back button.