### PR TITLE
Intercom bad-request bug

### DIFF
--- a/app/services/intercom_service.rb
+++ b/app/services/intercom_service.rb
@@ -8,14 +8,15 @@ class IntercomService
     return nil if body.blank?
 
     contact = contact_from_client(client) || contact_from_email(email_address) || contact_from_sms(phone_number)
+    most_recent_convo = most_recent_conversation(contact.id)
 
-    if contact.present? && most_recent_conversation(contact.id).present?
+    if contact.present? && most_recent_convo.present?
       # Per https://developers.intercom.com/intercom-api-reference/reference/reply-to-a-conversation
       # type is always user and message_type is always comment.
       Rails.logger.info("Replying to intercom conversation -- intercom contact id ##{contact.id}")
       intercom_api(:conversations,
-                   :reply,
-                   { id: 'last',
+                   :reply_to_last,
+                   { id: most_recent_convo.id,
                      intercom_user_id: contact.id,
                      type: 'user',
                      message_type: 'comment',


### PR DESCRIPTION
IntercomService's create messages has flaky `Intercom::BadRequestError (No conversation for this user)` errors when trying to reply to clients' last message even though we are able to find the last message. 