### PR TITLE
GYR portal: fix bug where uploading documents with spanish locale wouldn't work

### DIFF
--- a/app/controllers/documents/documents_help_controller.rb
+++ b/app/controllers/documents/documents_help_controller.rb
@@ -11,7 +11,7 @@ module Documents
         client: current_intake.client,
         message: AutomatedMessage::DocumentsReminderLink,
         locale: I18n.locale,
-        body_args: { doc_type: document_type_from_param }
+        body_args: { doc_type: document_type_from_param.label }
       )
       flash[:notice] = I18n.t("documents.reminder_link.notice")
       redirect_to(next_path)

--- a/app/controllers/portal/upload_documents_controller.rb
+++ b/app/controllers/portal/upload_documents_controller.rb
@@ -61,7 +61,9 @@ module Portal
     end
 
     def form_params
-      params.fetch(form_class.form_param, {}).permit(form_class.attribute_names).merge(document_type: document_type)
+      params.fetch(form_class.form_param, {}).permit(form_class.attribute_names).merge(
+        document_type: document_type.key
+      )
     end
 
     def find_or_create_document_request

--- a/app/forms/requested_document_upload_form.rb
+++ b/app/forms/requested_document_upload_form.rb
@@ -23,7 +23,7 @@ class RequestedDocumentUploadForm < QuestionsForm
   def instantiate_document
     @upload.tempfile.rewind if @upload.present?
     @document = @documents_request.documents.new(
-      document_type: @document_type || DocumentTypes::RequestedLater,
+      document_type: @document_type || DocumentTypes::RequestedLater.key,
       client: @documents_request.client,
       uploaded_by: @documents_request.client,
       upload: @upload.present? ? {

--- a/app/lib/document_type.rb
+++ b/app/lib/document_type.rb
@@ -55,10 +55,6 @@ class DocumentType
       I18n.t("general.document_types.with_descriptions.#{to_param}", default: key, locale: locale)
     end
 
-    def to_s
-      label
-    end
-
     def needed_for_spouse
       false
     end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -322,7 +322,7 @@ class Client < ApplicationRecord
     intake.relevant_document_types.select(&:needed_if_relevant?).each_with_object({}) do |document_type, result|
       required_count = document_type.required_persons(intake).length
       provided_count = documents.select { |d| d.document_type == document_type.key }.length
-      result[document_type.to_s] = {
+      result[document_type.key] = {
         required_count: required_count,
         provided_count: provided_count,
         clamped_provided_count: [required_count, provided_count].min

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -86,7 +86,7 @@ class Document < ApplicationRecord
   end
 
   def document_type_label
-    document_type_class || document_type
+    document_type_class.label || document_type
   end
 
   def set_display_name

--- a/app/views/documents/additional_documents/edit.html.erb
+++ b/app/views/documents/additional_documents/edit.html.erb
@@ -12,7 +12,7 @@
         <ul class="document-list list--bulleted">
           <% current_intake.document_types_possibly_needed.map do |document_type| %>
             <li>
-              <h3 class="text--small"><%= document_type %></h3>
+              <h3 class="text--small"><%= document_type.label %></h3>
             </li>
           <% end %>
         </ul>

--- a/app/views/documents/intro/edit.html.erb
+++ b/app/views/documents/intro/edit.html.erb
@@ -20,7 +20,7 @@
               <%= image_tag "paper.svg", alt: "", class: "document-intro-list__icon" %>
             </div>
             <h3 class="document-intro-list__item-text">
-              <%= type %>
+              <%= type.label %>
             </h3>
           </li>
         <% end %>

--- a/spec/controllers/documents/documents_help_controller_spec.rb
+++ b/spec/controllers/documents/documents_help_controller_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Documents::DocumentsHelpController, type: :controller do
       expect(ClientMessagingService).to have_received(:send_system_message_to_all_opted_in_contact_methods).with(
         client: client,
         message: AutomatedMessage::DocumentsReminderLink,
-        body_args: { doc_type: DocumentTypes::Identity },
+        body_args: { doc_type: DocumentTypes::Identity.translated_label(:en) },
         locale: :en
       )
     end
@@ -64,7 +64,7 @@ RSpec.describe Documents::DocumentsHelpController, type: :controller do
         expect(ClientMessagingService).to have_received(:send_system_message_to_all_opted_in_contact_methods).with(
           client: client,
           message: AutomatedMessage::DocumentsReminderLink,
-          body_args: { doc_type: DocumentTypes::Identity },
+          body_args: { doc_type: DocumentTypes::Identity.translated_label(:es) },
           locale: :es
         )
       end

--- a/spec/features/portal/client_portal_dashboard_spec.rb
+++ b/spec/features/portal/client_portal_dashboard_spec.rb
@@ -368,8 +368,8 @@ RSpec.feature "a client on their portal" do
     let(:tax_return) { create :gyr_tax_return, :file_mailed, client: client }
 
     before do
-      create(:document, document_type: DocumentTypes::FinalTaxDocument, tax_return: tax_return, client: client)
-      create(:document, document_type: DocumentTypes::FormW7, client: client)
+      create(:document, document_type: DocumentTypes::FinalTaxDocument.key, tax_return: tax_return, client: client)
+      create(:document, document_type: DocumentTypes::FormW7.key, client: client)
 
       login_as client, scope: :client
     end
@@ -387,7 +387,7 @@ RSpec.feature "a client on their portal" do
 
     context "when the client was helped by a certifying acceptance agent", js: true do
       before do
-        create(:document, document_type: DocumentTypes::FormW7Coa, client: client)
+        create(:document, document_type: DocumentTypes::FormW7Coa.key, client: client)
 
         login_as create :admin_user
         visit hub_client_path(id: client.id)

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -42,7 +42,7 @@ describe Document do
     context "when a document is created or is updated" do
       it "denormalizes document info onto the client" do
         intake = create :intake
-        document = create :document, document_type: DocumentTypes::Selfie, intake: intake
+        document = create :document, document_type: DocumentTypes::Selfie.key, intake: intake
 
         client = document.client.reload
         expect(client.filterable_percentage_of_required_documents_uploaded).to be_within(0.1).of(1 / 3.0)

--- a/spec/models/tax_return_spec.rb
+++ b/spec/models/tax_return_spec.rb
@@ -610,10 +610,10 @@ describe TaxReturn do
 
     context "with final tax documents" do
       before do
-        create :document, document_type: DocumentTypes::FinalTaxDocument, tax_return: tax_return, client: tax_return.client
-        create :document, document_type: DocumentTypes::Other, tax_return: tax_return, client: tax_return.client
-        create :document, document_type: DocumentTypes::Other, tax_return: tax_return, client: tax_return.client, archived: true
-        create :document, document_type: DocumentTypes::FinalTaxDocument, tax_return: tax_return, client: tax_return.client
+        create :document, document_type: DocumentTypes::FinalTaxDocument.key, tax_return: tax_return, client: tax_return.client
+        create :document, document_type: DocumentTypes::Other.key, tax_return: tax_return, client: tax_return.client
+        create :document, document_type: DocumentTypes::Other.key, tax_return: tax_return, client: tax_return.client, archived: true
+        create :document, document_type: DocumentTypes::FinalTaxDocument.key, tax_return: tax_return, client: tax_return.client
       end
 
       it "returns all documents of type DocumentTypes::FinalTaxDocument associated with the tax return that are not archived" do


### PR DESCRIPTION
Internally we were trying to set the document_type to 'Otro' instead of 'Other'

This was because code relied on a `.to_s` of the DocumentType model, which was actually returning the localized `.label`. What we want in most cases is the `.key`

removed DocumentType#to_s any any implicit usage thereof so we are less likely to goof this up in the future