### PR TITLE
Limit potential duplicate clients to match the same product year

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -270,7 +270,7 @@ class Client < ApplicationRecord
   def clients_with_dupe_ssn(service_class)
     return Client.none unless intake && intake.hashed_primary_ssn.present?
 
-    matching_intakes = service_class.accessible_intakes.where(hashed_primary_ssn: intake.hashed_primary_ssn)
+    matching_intakes = service_class.accessible_intakes.where(hashed_primary_ssn: intake.hashed_primary_ssn, product_year: intake.product_year)
 
     Client.where.not(id: id).where(intake: matching_intakes)
   end

--- a/spec/features/hub/client/show_client_spec.rb
+++ b/spec/features/hub/client/show_client_spec.rb
@@ -112,7 +112,6 @@ RSpec.describe "a user viewing a client" do
     let(:primary_ssn) { "1112223333" }
     let(:client) { create :client, vita_partner: first_org, intake: create(:intake, :with_contact_info, primary_ssn: primary_ssn) }
     let!(:intake_with_ssn_match) { create :intake, primary_consented_to_service: "yes", primary_ssn: primary_ssn, client: create(:client, :with_gyr_return, tax_return_state: "intake_ready") }
-    let!(:ctc_intake_with_ssn_match) { create :ctc_intake, primary_ssn: primary_ssn, sms_phone_number_verified_at: DateTime.now }
     let!(:second_org) { create :organization, coalition: coalition }
     before { login_as user }
 
@@ -163,7 +162,6 @@ RSpec.describe "a user viewing a client" do
 
       within ".client-header" do
         expect(page).to have_text(I18n.t('hub.has_duplicates'))
-        expect(page).to have_text "CTC: ##{ctc_intake_with_ssn_match.client.id}"
         expect(page).to have_text "GYR: ##{intake_with_ssn_match.client.id}"
         click_on "##{intake_with_ssn_match.client.id}"
       end


### PR DESCRIPTION
We had been getting this behavior for free with the accessible_intakes scope limiting to the current product year for GYR but CTC's current product year is still last year