### PR TITLE
Fix crash when sending intercom handoff message

### DIFF
--- a/app/lib/send_automated_message.rb
+++ b/app/lib/send_automated_message.rb
@@ -64,8 +64,4 @@ class SendAutomatedMessage
       sent_messages << sent_message if sent_message.present?
     end
   end
-
-  def self.send_messages(*args)
-    new(*args).send_messages
-  end
 end

--- a/app/services/intercom_service.rb
+++ b/app/services/intercom_service.rb
@@ -30,12 +30,12 @@ class IntercomService
   def self.inform_client_of_handoff(client:, send_sms:, send_email:)
     return if client.blank?
 
-    SendAutomatedMessage.send_messages(
+    SendAutomatedMessage.new(
       message: AutomatedMessage::IntercomForwarding,
       sms: send_sms,
       email: send_email,
       client: client
-    )
+    ).send_messages
   end
 
   private

--- a/spec/services/intercom_service_spec.rb
+++ b/spec/services/intercom_service_spec.rb
@@ -213,27 +213,30 @@ RSpec.describe IntercomService do
   end
 
   describe ".inform_client_of_handoff" do
+    let(:fake_send_automated_message) { instance_double(SendAutomatedMessage, send_messages: nil) }
+
     before do
-      allow(SendAutomatedMessage).to receive(:send_messages)
+      allow(SendAutomatedMessage).to receive(:new).and_return(fake_send_automated_message)
     end
 
     it "returns if no client is provided" do
       described_class.inform_client_of_handoff(client: nil, send_sms: nil, send_email: nil)
-      expect(SendAutomatedMessage).not_to have_received(:send_messages)
+      expect(SendAutomatedMessage).not_to have_received(:new)
     end
 
     it "sends an automated message" do
       client = create(:client)
       described_class.inform_client_of_handoff(client: client, send_sms: true, send_email: true)
       expect(SendAutomatedMessage).to(
-        have_received(:send_messages)
-          .with({
+        have_received(:new)
+          .with(
                   message: AutomatedMessage::IntercomForwarding,
                   sms: true,
                   email: true,
                   client: client
-                })
+                )
       )
+      expect(fake_send_automated_message).to have_received(:send_messages)
     end
   end
 end


### PR DESCRIPTION
The SendAutomatedMessage#send_messages did some argument forwarding that is less straightforward in Ruby 3+, so we have removed it since it was only used in one place