### PR TITLE
Disable reline in non-dev environments (prod, heroku)

### DIFF
--- a/.github/workflows/heroku-pull-request.yml
+++ b/.github/workflows/heroku-pull-request.yml
@@ -85,6 +85,15 @@ jobs:
         if: github.event.action != 'closed'
         run: heroku git:remote --app=${{ env.HEROKU_APP_NAME }}
 
+      - name: Disable Reline autocomplete
+        if: github.event.action != 'closed'
+        run: |
+          echo "IRB.conf[:USE_AUTOCOMPLETE] = false" > .irbrc && \
+            git add .irbrc && \
+            git config user.name "GitHub Actions" && \
+            git config user.email "nobody@example.com" && \
+            git commit -m "Disable Reline autocomplete"
+
       - name: Push to Heroku
         if: github.event.action != 'closed'
         run: git push heroku ${{ github.head_ref }}:main --force

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,8 @@ RUN set -a \
  && . ./.aptible.env \
  && bundle exec rake assets:precompile
 
+RUN echo "IRB.conf[:USE_AUTOCOMPLETE] = false" > ./.irbrc
+
 EXPOSE 3000
 
 CMD ["bundle", "exec", "rails", "s", "-b", "0.0.0.0", "-p", "3000"]


### PR DESCRIPTION
It behaves pretty poorly over a remote console and also I don't like it