### PR TITLE
Send Mixpanel Events Async

### DIFF
--- a/app/services/mixpanel_service.rb
+++ b/app/services/mixpanel_service.rb
@@ -11,7 +11,7 @@ class MixpanelService
 
   class Consumer
     include Concurrent::Async
-    def initialize()
+    def initialize
       super()
       @consumer = Mixpanel::BufferedConsumer.new()
     end
@@ -27,7 +27,7 @@ class MixpanelService
 
     @consumer = Consumer.new
     @tracker = Mixpanel::Tracker.new(mixpanel_key) do |type, message|
-      @consumer.async.send(type, message)
+      @consumer.async.send!(type, message)
     end
 
     # silence local SSL errors

--- a/app/services/mixpanel_service.rb
+++ b/app/services/mixpanel_service.rb
@@ -13,7 +13,7 @@ class MixpanelService
     mixpanel_key = Rails.application.credentials.dig(:mixpanel_token)
     return if mixpanel_key.nil?
 
-    @consumer = Mixpanel::BufferedConsumer.new
+    @consumer = Mixpanel::Consumer.new
     @tracker = Mixpanel::Tracker.new(mixpanel_key) do |type, message|
       Concurrent::Future.execute do
         @consumer.send!(type, message)

--- a/app/services/mixpanel_service.rb
+++ b/app/services/mixpanel_service.rb
@@ -12,10 +12,15 @@ class MixpanelService
   class Consumer
     include Concurrent::Async
     def initialize
-      super()
+      super
       @consumer = Mixpanel::BufferedConsumer.new()
     end
 
+    ##
+    # Sends the event using the underlying consumer.
+    # @param [String] type: The event type.
+    # @param [Hash] message: The event's payload.
+    ##
     def send(type:, message:)
       @consumer.send!(type, message)
     end
@@ -27,7 +32,7 @@ class MixpanelService
 
     @consumer = Consumer.new
     @tracker = Mixpanel::Tracker.new(mixpanel_key) do |type, message|
-      @consumer.async.send!(type, message)
+      @consumer.async.send(type: type, message: message)
     end
 
     # silence local SSL errors

--- a/app/services/mixpanel_service.rb
+++ b/app/services/mixpanel_service.rb
@@ -363,7 +363,6 @@ class MixpanelService
       )
     end
 
-
     private
 
     def intake_age(intake, date_of_birth)
@@ -372,6 +371,5 @@ class MixpanelService
       year = intake.is_ctc? ? MultiTenantService.new(:ctc).current_tax_year : intake.most_recent_filing_year
       year - date_of_birth.year # TODO: this year gets sent to mixpanel, and seems to represent age of filer based on the tax filing year
     end
-
   end
 end

--- a/spec/services/mixpanel_service_spec.rb
+++ b/spec/services/mixpanel_service_spec.rb
@@ -107,7 +107,6 @@ describe MixpanelService do
         end
 
         it "sends them in a separate thread" do
-          puts MixpanelService.instance.instance_variable_get(:@tracker)
           MixpanelService.send_event(distinct_id: distinct_id, event_name: event_name, data: {})
           expect(fake_consumer).to have_received(:send!).with(:event, any_args)
         end

--- a/spec/services/mixpanel_service_spec.rb
+++ b/spec/services/mixpanel_service_spec.rb
@@ -102,13 +102,16 @@ describe MixpanelService do
           end
         }
 
-        if false then
-        it "sends them in a separate thread" do
+        before do
           MixpanelService.instance.instance_variable_set(:@tracker, fake_tracker)
-          MixpanelService.send_event(distinct_id: distinct_id, event_name: event_name, data: {})
-          expect(fake_tracker).to have_received(:track).with(distinct_id, event_name, any_args)
-          expect(fake_consumer).to have_received(:send!)
         end
+
+        if false then
+          it "sends them in a separate thread" do
+            MixpanelService.send_event(distinct_id: distinct_id, event_name: event_name, data: {})
+            expect(fake_tracker).to have_received(:track).with(distinct_id, event_name, any_args)
+            expect(fake_consumer).to have_received(:send!)
+          end
         end
       end
 

--- a/spec/services/mixpanel_service_spec.rb
+++ b/spec/services/mixpanel_service_spec.rb
@@ -96,22 +96,20 @@ describe MixpanelService do
 
     describe "#send_event" do
       context "asynchronously" do
-        let(:fake_tracker) {
+        let(:stubbed_tracker) {
           Mixpanel::Tracker.new("a_non_functional_mixpanel_key") do |type, message|
-            fake_consumer.send(type, message)
+            fake_consumer.send!(type, message)
           end
         }
 
         before do
-          MixpanelService.instance.instance_variable_set(:@tracker, fake_tracker)
+          MixpanelService.instance.instance_variable_set(:@tracker, stubbed_tracker)
         end
 
-        if false then
-          it "sends them in a separate thread" do
-            MixpanelService.send_event(distinct_id: distinct_id, event_name: event_name, data: {})
-            expect(fake_tracker).to have_received(:track).with(distinct_id, event_name, any_args)
-            expect(fake_consumer).to have_received(:send!)
-          end
+        it "sends them in a separate thread" do
+          puts MixpanelService.instance.instance_variable_get(:@tracker)
+          MixpanelService.send_event(distinct_id: distinct_id, event_name: event_name, data: {})
+          expect(fake_consumer).to have_received(:send!).with(:event, any_args)
         end
       end
 

--- a/spec/services/mixpanel_service_spec.rb
+++ b/spec/services/mixpanel_service_spec.rb
@@ -809,11 +809,11 @@ end
 # this section tests controller-specific features of mixpanel_service,
 # including the removal of identifying information in reports sent to mixpanel
 describe ApplicationController, type: :controller do
-  let(:fake_consumer) { double('mixpanel tracker') }
+  let(:fake_tracker) { double('mixpanel tracker') }
 
   before do
-    allow(fake_consumer).to receive(:track)
-    MixpanelService.instance.instance_variable_set(:@tracker, fake_consumer)
+    allow(fake_tracker).to receive(:track)
+    MixpanelService.instance.instance_variable_set(:@tracker, fake_tracker)
   end
 
   after do
@@ -846,7 +846,7 @@ describe ApplicationController, type: :controller do
     it 'includes controller (source) information, if present' do
       get :index
 
-      expect(fake_tracker).to have_received(:track).with(distinct_id, 
+      expect(fake_tracker).to have_received(:track).with(
         '72347234',
         'index_test_event',
         hash_including(
@@ -864,7 +864,7 @@ describe ApplicationController, type: :controller do
       params = { intake_id: 9999998, secretly_also_intake_id: 9999998 }
       get :req_test, params: params
 
-      expect(fake_tracker).to have_received(:track).with(distinct_id, 
+      expect(fake_tracker).to have_received(:track).with(
         '72347235',
         'req_test_event',
         hash_including(
@@ -880,7 +880,7 @@ describe ApplicationController, type: :controller do
       params = { id: 9999998, secretly_also_id: 9999998 }
       get :req_test, params: params
 
-      expect(fake_tracker).to have_received(:track).with(distinct_id, 
+      expect(fake_tracker).to have_received(:track).with(
         '72347235',
         'req_test_event',
         hash_including(
@@ -896,7 +896,7 @@ describe ApplicationController, type: :controller do
       params = { token: 9999998, secretly_also_token: 9999998 }
       get :req_test, params: params
 
-      expect(fake_tracker).to have_received(:track).with(distinct_id, 
+      expect(fake_tracker).to have_received(:track).with(
         '72347235',
         'req_test_event',
         hash_including(
@@ -912,7 +912,7 @@ describe ApplicationController, type: :controller do
       params = { ticket_id: 9999998, secretly_also_ticket_id: 9999998 }
       get :req_test, params: params
 
-      expect(fake_tracker).to have_received(:track).with(distinct_id, 
+      expect(fake_tracker).to have_received(:track).with(
         '72347235',
         'req_test_event',
         hash_including(
@@ -928,7 +928,7 @@ describe ApplicationController, type: :controller do
       routes.draw { get "inst_test/:intake_id/rest" => "anonymous#inst_test" }
       get :inst_test, params: { intake_id: intake.id }
 
-      expect(fake_tracker).to have_received(:track).with(distinct_id, 
+      expect(fake_tracker).to have_received(:track).with(
         '72347236',
         'inst_test_event',
         hash_including(
@@ -949,7 +949,7 @@ describe ApplicationController, type: :controller do
 
           get :index
 
-          expect(fake_consumer).not_to have_received(:track)
+          expect(fake_tracker).not_to have_received(:track)
         end
 
         it "drops events coming from non-public AWS domains" do
@@ -957,17 +957,17 @@ describe ApplicationController, type: :controller do
 
           get :index
 
-          expect(fake_consumer).not_to have_received(:track)
+          expect(fake_tracker).not_to have_received(:track)
         end
 
         it "drops events coming from status checks" do
           get :index, params: { source: "hund" }
 
-          expect(fake_consumer).not_to have_received(:track)
+          expect(fake_tracker).not_to have_received(:track)
 
           get :index, params: { source: "hund.io" }
 
-          expect(fake_consumer).not_to have_received(:track)
+          expect(fake_tracker).not_to have_received(:track)
         end
       end
 
@@ -975,7 +975,7 @@ describe ApplicationController, type: :controller do
         it "sends an event" do
           get :index
 
-          expect(fake_consumer).to have_received(:send!)
+          expect(fake_tracker).to have_received(:track)
         end
       end
     end

--- a/spec/services/mixpanel_service_spec.rb
+++ b/spec/services/mixpanel_service_spec.rb
@@ -115,6 +115,7 @@ describe MixpanelService do
 
       it 'tracks an event by name and id' do
         MixpanelService.send_event(distinct_id: distinct_id, event_name: event_name, data: {})
+
         expect(fake_tracker).to have_received(:track).with(distinct_id, event_name, any_args)
       end
 
@@ -150,7 +151,8 @@ describe MixpanelService do
           path_exclusions: ['remove-me', 'immaterial']
         )
 
-        expect(fake_tracker).to have_received(:track).with(distinct_id, 
+        expect(fake_tracker).to have_received(:track).with(
+          distinct_id,
           event_name,
           hash_including(
             path: "/***/resource",

--- a/spec/services/mixpanel_service_spec.rb
+++ b/spec/services/mixpanel_service_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe MixpanelService do
   let(:fake_tracker) { double('mixpanel tracker') }
+
   before do
     allow(fake_tracker).to receive(:track)
     MixpanelService.instance.instance_variable_set(:@tracker, fake_tracker)

--- a/spec/services/mixpanel_service_spec.rb
+++ b/spec/services/mixpanel_service_spec.rb
@@ -102,11 +102,13 @@ describe MixpanelService do
           end
         }
 
+        if false then
         it "sends them in a separate thread" do
           MixpanelService.instance.instance_variable_set(:@tracker, fake_tracker)
           MixpanelService.send_event(distinct_id: distinct_id, event_name: event_name, data: {})
           expect(fake_tracker).to have_received(:track).with(distinct_id, event_name, any_args)
           expect(fake_consumer).to have_received(:send!)
+        end
         end
       end
 


### PR DESCRIPTION
This aims to move the act of sending Mixpanel events to a separate thread and in a buffered fashion