### PR TITLE
Use encrypted cookie for visitor_id #184653844

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -119,7 +119,7 @@ class ApplicationController < ActionController::Base
 
   def legacy_visitor_id_cookie
     val = cookies[:visitor_id]
-    if !val.nil? && val.valid_encoding? && val.present? && val.length <= 52
+    if !val.nil? && val.force_encoding("UTF-8").valid_encoding? && val.present? && val.length <= 52
       val
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -94,14 +94,18 @@ class ApplicationController < ActionController::Base
   end
 
   def set_visitor_id
-    if visitor_record&.visitor_id.present?
-      cookies.permanent[:visitor_id] = { value: visitor_record.visitor_id, httponly: true }
-    elsif cookies[:visitor_id].present?
-      visitor_id = cookies[:visitor_id]
-    else
-      visitor_id = SecureRandom.hex(26)
-      cookies.permanent[:visitor_id] = { value: visitor_id, httponly: true }
-    end
+    visitor_id =
+      if visitor_record&.visitor_id.present?
+        visitor_record.visitor_id
+      elsif legacy_visitor_id_cookie.present?
+        legacy_visitor_id_cookie
+      elsif cookies.encrypted[:visitor_id].present?
+        cookies.encrypted[:visitor_id]
+      else
+        SecureRandom.hex(26)
+      end
+    cookies.encrypted.permanent[:visitor_id] = { value: visitor_id, httponly: true }
+
     # If we run into cases where the intake does not have an associated visitor_id persisted onto it,
     # let's make sure it gets updated onto the record.
     if visitor_record.present? && visitor_record.persisted? && visitor_record.visitor_id.blank?
@@ -110,7 +114,14 @@ class ApplicationController < ActionController::Base
   end
 
   def visitor_id
-    visitor_record&.visitor_id || cookies[:visitor_id]
+    visitor_record&.visitor_id || cookies.encrypted[:visitor_id]
+  end
+
+  def legacy_visitor_id_cookie
+    val = cookies[:visitor_id]
+    if !val.nil? && val.valid_encoding? && val.present? && val.length <= 52
+      val
+    end
   end
 
   def source

--- a/app/controllers/concerns/first_page_of_ctc_intake_concern.rb
+++ b/app/controllers/concerns/first_page_of_ctc_intake_concern.rb
@@ -33,7 +33,7 @@ module FirstPageOfCtcIntakeConcern
 
   def current_intake
     @intake ||= Intake::CtcIntake.new(
-      visitor_id: cookies[:visitor_id],
+      visitor_id: cookies.encrypted[:visitor_id],
       source: session[:source],
       referrer: session[:referrer]
     )

--- a/spec/controllers/ctc/questions/overview_controller_spec.rb
+++ b/spec/controllers/ctc/questions/overview_controller_spec.rb
@@ -5,7 +5,7 @@ describe Ctc::Questions::OverviewController do
     let(:params) { {} }
 
     before do
-      cookies[:visitor_id] = "visitor_id"
+      cookies.encrypted[:visitor_id] = "visitor_id"
       allow(MixpanelService).to receive(:send_event)
     end
 

--- a/spec/controllers/questions/personal_info_controller_spec.rb
+++ b/spec/controllers/questions/personal_info_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Questions::PersonalInfoController do
       before do
         session[:source] = "source_from_session"
         session[:referrer] = "referrer_from_session"
-        cookies[:visitor_id] = "some_visitor_id"
+        cookies.encrypted[:visitor_id] = "some_visitor_id"
       end
 
       context "without an intake in the session" do
@@ -112,4 +112,3 @@ RSpec.describe Questions::PersonalInfoController do
     end
   end
 end
-

--- a/spec/controllers/questions/triage_income_level_controller_spec.rb
+++ b/spec/controllers/questions/triage_income_level_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Questions::TriageIncomeLevelController do
     before do
       session[:source] = "source_from_session"
       session[:referrer] = "referrer_from_session"
-      cookies[:visitor_id] = "some_visitor_id"
+      cookies.encrypted[:visitor_id] = "some_visitor_id"
     end
 
     context "with valid params" do

--- a/spec/support/shared_examples/first_page_of_ctc_intake_concern.rb
+++ b/spec/support/shared_examples/first_page_of_ctc_intake_concern.rb
@@ -19,7 +19,7 @@ shared_context :first_page_of_ctc_intake_update_context do |form_name:, addition
 
   before do
     request.remote_ip = ip_address
-    cookies[:visitor_id] = "visitor-id"
+    cookies.encrypted[:visitor_id] = "visitor-id"
     session[:source] = "some-source"
     session[:referrer] = "https://www.goggles.com/get-tax-refund"
   end


### PR DESCRIPTION
Migrate legacy unencrypted cookie when its value seems OK