### PR TITLE
Fix crash on sentry

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -2,6 +2,7 @@ require_relative "boot"
 require_relative "../lib/middleware/cleanup_request_host_headers"
 require_relative "../lib/middleware/cleanup_mime_type_headers"
 require_relative "../lib/middleware/reject_invalid_params"
+require_relative "../lib/middleware/reject_badly_encoded_headers"
 
 require "logger"
 require "rails"
@@ -77,6 +78,7 @@ module VitaMin
     config.middleware.use Middleware::CleanupRequestHostHeaders
     config.middleware.use Middleware::CleanupMimeTypeHeaders
     config.middleware.use Middleware::RejectInvalidParams
+    config.middleware.use Middleware::RejectBadlyEncodedHeaders
     config.gyr_current_tax_year = 2022
     config.ctc_current_tax_year = 2021
     config.product_year = 2023

--- a/lib/middleware/reject_badly_encoded_headers.rb
+++ b/lib/middleware/reject_badly_encoded_headers.rb
@@ -1,0 +1,22 @@
+module Middleware
+  class RejectBadlyEncodedHeaders
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      if valid_referer(env["HTTP_REFERER"])
+        @app.call(env)
+      else
+        [400, {'Content-Type' => "text/plain"}, ["Bad header"]]
+      end
+    end
+
+    private
+
+    def valid_referer(header_value)
+      return true if header_value.nil?
+      return true if header_value.force_encoding("UTF-8").valid_encoding?
+    end
+  end
+end

--- a/lib/middleware/reject_invalid_params.rb
+++ b/lib/middleware/reject_invalid_params.rb
@@ -9,7 +9,7 @@ module Middleware
       begin
         req.params
       rescue Rack::QueryParser::InvalidParameterError
-        return [400, {"Content-Type": "text/plain"}, ["Bad params"]]
+        return [400, {"Content-Type" => "text/plain"}, ["Bad params"]]
       end
       @app.call(env)
     end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -16,20 +16,6 @@ RSpec.describe ApplicationController do
     end
   end
 
-
-  describe "just trying to repro for now, will figure out sometime the best place to actually move this test" do
-    context "when there is invalid utf-8 in the referer" do
-      before do
-        request.headers["HTTP_REFERER"] = "\xc3"
-      end
-      it "handles the request" do
-        get :index
-
-        expect(response).to be_ok
-      end
-    end
-  end
-
   describe "#include_analytics?" do
     it "returns false" do
       expect(subject.include_analytics?).to eq false

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -16,6 +16,20 @@ RSpec.describe ApplicationController do
     end
   end
 
+
+  describe "just trying to repro for now, will figure out sometime the best place to actually move this test" do
+    context "when there is invalid utf-8 in the referer" do
+      before do
+        request.headers["HTTP_REFERER"] = "\xc3"
+      end
+      it "handles the request" do
+        get :index
+
+        expect(response).to be_ok
+      end
+    end
+  end
+
   describe "#include_analytics?" do
     it "returns false" do
       expect(subject.include_analytics?).to eq false

--- a/spec/middleware/reject_badly_encoded_headers_spec.rb
+++ b/spec/middleware/reject_badly_encoded_headers_spec.rb
@@ -1,0 +1,36 @@
+describe Middleware::RejectBadlyEncodedHeaders do
+  let(:mock_app) { double }
+  subject { described_class.new(mock_app) }
+
+  before do
+    allow(mock_app).to receive(:call)
+  end
+
+  describe "#call" do
+    context "with a valid referer" do
+      let(:env) { {"HTTP_REFERER" => "https://example.com", "rack.input" => double} }
+
+      it "calls into the app" do
+        subject.call(env)
+        expect(mock_app).to have_received(:call).with(env)
+      end
+    end
+
+    context "with invalid UTF-8 in the HTTP_REFERER" do
+      it "returns HTTP 400 Bad Request" do
+        result = subject.call({"HTTP_REFERER" => "\xc3", "rack.input" => double})
+        expect(mock_app).not_to have_received(:call)
+        expect(result[0]).to eq(400)
+      end
+    end
+
+    context "with no referer" do
+      let(:env) { {"rack.input" => double} }
+
+      it "calls into the app" do
+        subject.call(env)
+        expect(mock_app).to have_received(:call).with(env)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Created Middleware::RejectBadlyEncodedHeaders to return a 400 error when given an invalid utf-8 header referer

## Steps to repro the crash and validate the fix

Create a headers.txt for curl that contains invalid UTF-8
```
➜  ~ python3
Python 3.10.8 (main, Oct 13 2022, 09:48:40) [Clang 14.0.0 (clang-1400.0.29.102)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> fd = open('headers.txt', 'wb')
>>> fd.write(b'Referer: ')
9
>>> fd.write(b'\xc3')
1
>>> fd.close()
```

Observe the HTTP 500

```
➜  vita-min git:(fix-sentry-crash-184653624) git checkout main
Switched to branch 'main'
Your branch is up to date with 'origin/main'.

➜  vita-min git:(main) rails s
=> Booting Puma
=> Rails 7.0.4.2 application starting in development
=> Run `bin/rails server --help` for more startup options
Puma starting in single mode...
* Puma version: 5.6.4 (ruby 3.2.1-p31) ("Birdie's Version")
*  Min threads: 5
*  Max threads: 5
*  Environment: development
*          PID: 6888
* Listening on http://127.0.0.1:3000
* Listening on http://[::1]:3000
Use Ctrl-C to stop
```
Then in another terminal window run this:
```
➜  ~ curl -v -H @headers.txt http://localhost:3000/en  > /dev/null

*   Trying 127.0.0.1:3000...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0* Connected to localhost (127.0.0.1) port 3000 (#0)
> GET /en HTTP/1.1
> Host: localhost:3000
> User-Agent: curl/7.85.0
> Accept: */*
> Referer: �
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 500 Internal Server Error
< Content-Type: text/html; charset=UTF-8
< X-Web-Console-Session-Id: b7ffb653321990ea8ac46a8565ac9e7d
< X-Web-Console-Mount-Point: /__web_console
< X-Request-Id: 4ecdd7fe-a1c5-4724-acd3-09f1c8adebff
< X-Runtime: 0.906290
< Server-Timing: sql.active_record;dur=37.60, start_processing.action_controller;dur=0.06, render_partial.action_view;dur=366.28, render_template.action_view;dur=498.02, render_layout.action_view;dur=556.42, process_action.action_controller;dur=677.10
< Set-Cookie: __profilin=p%3Dt; path=/; HttpOnly; SameSite=Lax
< Content-Length: 132745
<
{ [97992 bytes data]
100  129k  100  129k    0     0   136k      0 --:--:-- --:--:-- --:--:--  137k
* Connection #0 to host localhost left intact
```

Observe that with this branch it's a HTTP 400

```
➜  vita-min git:(main) git checkout fix-sentry-crash-184653624
Switched to branch 'fix-sentry-crash-184653624'
Your branch is up to date with 'origin/fix-sentry-crash-184653624'.

➜  vita-min git:(fix-sentry-crash-184653624) rails s
=> Booting Puma
=> Rails 7.0.4.2 application starting in development
=> Run `bin/rails server --help` for more startup options
Puma starting in single mode...
* Puma version: 5.6.4 (ruby 3.2.1-p31) ("Birdie's Version")
*  Min threads: 5
*  Max threads: 5
*  Environment: development
*          PID: 10346
* Listening on http://127.0.0.1:3000
* Listening on http://[::1]:3000
Use Ctrl-C to stop
```
Then in another terminal window run this:
```
➜  ~ curl -v -H @headers.txt http://localhost:3000/en  > /dev/null

*   Trying 127.0.0.1:3000...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0* Connected to localhost (127.0.0.1) port 3000 (#0)
> GET /en HTTP/1.1
> Host: localhost:3000
> User-Agent: curl/7.85.0
> Accept: */*
> Referer: �
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 400 Bad Request
< Content-Type: text/plain
< Cache-Control: no-cache
< Content-Security-Policy: frame-ancestors 'self' *
< X-Request-Id: 1514ea71-e432-4ea8-9eba-7381ba04c673
< X-Runtime: 0.071051
< Server-Timing: sql.active_record;dur=51.93
< Set-Cookie: __profilin=p%3Dt; path=/; HttpOnly; SameSite=Lax
< Transfer-Encoding: chunked
<
{ [20 bytes data]
100    10    0    10    0     0     91      0 --:--:-- --:--:-- --:--:--    94
* Connection #0 to host localhost left intact
```

Observe that a non-broken Referer header results in HTTP 200 OK

stay in fix-sentry-crash-184653624 with server running

run curl with valid utf-8 in the other terminal window:
```
➜  ~ curl -v -H "Referer: https://abc.com" http://localhost:3000/en  > /dev/null

*   Trying 127.0.0.1:3000...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0* Connected to localhost (127.0.0.1) port 3000 (#0)
> GET /en HTTP/1.1
> Host: localhost:3000
> User-Agent: curl/7.85.0
> Accept: */*
> Referer: https://abc.com
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< X-Frame-Options: SAMEORIGIN
< X-XSS-Protection: 0
< X-Content-Type-Options: nosniff
< X-Download-Options: noopen
< X-Permitted-Cross-Domain-Policies: none
< Referrer-Policy: strict-origin-when-cross-origin
< Link: </assets/application.self-15d525d5d18c7cd0d35e34f4ea0fa78caa26a64d2a72c916dcc2cf08a594741a.css?body=1>; rel=preload; as=style; nopush
< Content-Type: text/html; charset=utf-8
< Vary: Accept
< Cache-Control: no-store, must-revalidate, private, max-age=0
< Content-Security-Policy: frame-ancestors 'self' *
< Set-Cookie: visitor_id=dcedc891ddbfa3df105e559fc650a0112e21629486a273f3b962; path=/; expires=Mon, 09 Mar 2043 19:15:47 GMT; HttpOnly; SameSite=Lax
< Set-Cookie: _vita_min_session=PwLw0jftNscNIBK6iz0N86MSfr5oxnTlHP1Fv1bDzKovVm0oWHVdt%2Bm%2FgLACcwkd%2FVe6iiN0Q07sS%2B0n%2Fu95Pfq7%2BYCHSByllS3z7yexPiJ8PYwKUx4DcO7R%2FzszyZ%2FhnTP9boi3VlpSW%2F8W33CDLiqWXG56ayJLaXq5AoBljdUAgrayGUuQ3fDdouG2zAhPwFeNi3V4uj0%2FWuGklkrfwkT6nurn7ZUTFEMvMV0czSZ1oAL7PAkahhHlpFaZTvcqG57dTER2mOkF0LBpI%2FKIF3ugr1LKz87%2Fp2AUvmLQmsfGo3qOIM4Wv65IsYc4tNY3h%2BRk9MFj1pZ3RoOEnQ%3D%3D--Dgl8f3U6%2FSwcm8AQ--NdCBe8Iig3QILUTAU5xBjg%3D%3D; path=/; HttpOnly; SameSite=Lax
< Set-Cookie: __profilin=p%3Dt; path=/; HttpOnly; SameSite=Lax
< X-Request-Id: 3afb5862-44a9-469b-8e3b-a6254ad54ede
< X-Runtime: 1.187470
< Server-Timing: sql.active_record;dur=40.25, start_processing.action_controller;dur=0.09, render_partial.action_view;dur=382.73, render_template.action_view;dur=570.42, render_layout.action_view;dur=632.54, process_action.action_controller;dur=1063.45
< X-MiniProfiler-Original-Cache-Control: max-age=0, private, must-revalidate
< X-MiniProfiler-Ids: 37hb2zfoegyd3bxvy26x,s3d7nzl2hacx7cjlb1jl,bwqhli64g41ffj8mi3go,em70839uiqkieygoxm6x,kzg8qrto4ikex8azxdsg,l2xazg822zf6mfkhq9bs,cqpjmufziw05afasqqoc,ddeaqvz21mzrji2c546h,ju3tbzlge4voww9x8iko,1udtrhack6ywyeu2gy3k,jgxzw29v06zq409iqsr8,j0mjuv6fhtotpy5c1t9h,ittuxlmbhq39x9jysaa1,vs3kqzmmg6dnrejpni46,kz3ptxa5d9mrkyluan2w,mh196ctm6xgz7602ldq2,t6h793ndhmwyfkcjk26l,hfyq4nzqfudxu0jigbdk,te1i794iqtwpnhvfakj5,yf86cf44iaypo1gjjvu9
< Content-Length: 28599
<
{ [28599 bytes data]
100 28599  100 28599    0     0  23828      0  0:00:01  0:00:01 --:--:-- 23932
* Connection #0 to host localhost left intact
```


## Nature of the crash

When we ran the curl command, we got a crash with `session` and `cookie` and `JSON` in the stacktrace. We noticed that when we commented-out the `session[:referrer] = header_value.slice(0, 200)` line in `ApplicationController#set_referrer`, the crash went away. This seemed to be the significant part of the crash. We think the underlying cause is that session cookies are serialized with JSON, and if we put this value in the cookie, Rails can't encode the session cookie due to the JSON library crashing b/c it can't encode invalid UTF-8.

Separately we noticed the Mixpanel service had a problem sending analytics events with this garbage referer header. This seemed not to crash the app, though, but instead trigger a warning that was logged.

## Nature of the fix

By dropping this request and serving a HTTP 400, we're not making the app behavior _worse_ since right now people get a HTTP 500. This approach lets us avoid having to fix all the various places in the code that might touch the `referer` header to make them handle badly-encoded nonsense.
