### PR TITLE
Hub: restrict tax return creation form to use proper client visibility

### DIFF
--- a/app/controllers/hub/tax_returns_controller.rb
+++ b/app/controllers/hub/tax_returns_controller.rb
@@ -6,8 +6,8 @@ module Hub
     before_action :require_sign_in
     load_and_authorize_resource except: [:new, :create]
     # on new/create, authorize through client but initialize tax return object
-    authorize_resource :client, parent: false, only: [:new, :create]
     before_action :load_client, only: [:new, :create]
+    authorize_resource :client, parent: false, only: [:new, :create]
     before_action :load_assignable_users, except: [:show]
     before_action :load_and_authorize_assignee, only: [:update]
 
@@ -63,7 +63,7 @@ module Hub
     private
 
     def load_client
-      @client = Client.find(params[:client_id])
+      @client = Client.accessible_to_user(current_user).find(params[:client_id])
     end
 
     def load_assignable_users

--- a/spec/controllers/hub/tax_returns_controller_spec.rb
+++ b/spec/controllers/hub/tax_returns_controller_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Hub::TaxReturnsController, type: :controller do
   let!(:organization_lead) { create :organization_lead_user, organization: organization }
   let!(:site_coordinator) { create :site_coordinator_user, site: site, name: "Barbara" }
   let!(:team_member) { create :team_member_user, site: site, name: "Aaron" }
+  let!(:unauthorized_team_member) { create :team_member_user }
 
   let(:currently_assigned_coalition_lead) { create :coalition_lead_user, coalition: coalition }
   let(:user) { currently_assigned_coalition_lead }
@@ -24,6 +25,18 @@ RSpec.describe Hub::TaxReturnsController, type: :controller do
     end
 
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :new
+
+    context "an unauthorized user" do
+      before do
+        sign_in unauthorized_team_member
+      end
+
+      it "is not allowed to access the page" do
+        expect do
+          get :new, params: params
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
 
     context "an authenticated user" do
       let(:user) { create :admin_user }


### PR DESCRIPTION
Otherwise, any hub user could create a tax return on a client they couldn't see, potentially giving them the ability to see it