### PR TITLE
Returning clients can be put in an experiment that lets them skip ID docs

### DIFF
--- a/app/controllers/documents/id_guidance_controller.rb
+++ b/app/controllers/documents/id_guidance_controller.rb
@@ -2,6 +2,10 @@ module Documents
   class IdGuidanceController < DocumentUploadQuestionController
     layout "intake"
 
+    def self.show?(intake)
+      !ReturningClientExperimentService.new(intake).skip_identity_documents?
+    end
+
     def edit; end
 
     def self.document_type

--- a/app/controllers/documents/intro_controller.rb
+++ b/app/controllers/documents/intro_controller.rb
@@ -7,6 +7,11 @@ module Documents
     end
 
     def edit
+      if ReturningClientExperimentService.new(current_intake).skip_identity_documents?
+        current_intake.tax_returns.each do |tax_return|
+          tax_return.advance_to(:intake_ready) if tax_return.current_state.to_sym != :intake_ready
+        end
+      end
       data = MixpanelService.data_from([current_intake.client, current_intake])
 
       MixpanelService.send_event(

--- a/app/controllers/documents/selfie_instructions_controller.rb
+++ b/app/controllers/documents/selfie_instructions_controller.rb
@@ -3,7 +3,8 @@ module Documents
     layout "intake"
 
     def self.show?(intake)
-      !IdVerificationExperimentService.new(intake).skip_selfies?
+      !(IdVerificationExperimentService.new(intake).skip_selfies? ||
+        ReturningClientExperimentService.new(intake).skip_identity_documents?)
     end
 
     def self.document_type

--- a/app/controllers/questions/chat_with_us_controller.rb
+++ b/app/controllers/questions/chat_with_us_controller.rb
@@ -4,11 +4,22 @@ module Questions
     layout "intake"
 
     def edit
-      ExperimentService.find_or_assign_treatment(
-        key: ExperimentService::ID_VERIFICATION_EXPERIMENT,
-        record: current_intake,
-        vita_partner_id: current_intake.vita_partner.id
-      )
+      returning_client_treatment = if current_intake.matching_previous_year_intake.present?
+        ExperimentService.find_or_assign_treatment(
+          key: ExperimentService::RETURNING_CLIENT_EXPERIMENT,
+          record: current_intake,
+          vita_partner_id: current_intake.vita_partner.id
+        )
+      end
+
+      if returning_client_treatment != "skip_identity_documents"
+        ExperimentService.find_or_assign_treatment(
+          key: ExperimentService::ID_VERIFICATION_EXPERIMENT,
+          record: current_intake,
+          vita_partner_id: current_intake.vita_partner.id
+        )
+      end
+
       @zip_name = ZipCodes.details(current_intake.zip_code)&.fetch(:name)
       @returning_client = current_intake.client.routing_method_returning_client?
     end

--- a/app/controllers/questions/ssn_itin_controller.rb
+++ b/app/controllers/questions/ssn_itin_controller.rb
@@ -11,5 +11,9 @@ module Questions
     def tracking_data
       {}
     end
+
+    def after_update_success
+      current_intake.update(matching_previous_year_intake: current_intake.matching_previous_year_intakes&.first)
+    end
   end
 end

--- a/app/lib/document_types/identity.rb
+++ b/app/lib/document_types/identity.rb
@@ -1,8 +1,8 @@
 module DocumentTypes
   class Identity < DocumentType
     class << self
-      def relevant_to?(_intake)
-        true
+      def relevant_to?(intake)
+        !ReturningClientExperimentService.new(intake).skip_identity_documents?
       end
 
       def key

--- a/app/lib/document_types/selfie.rb
+++ b/app/lib/document_types/selfie.rb
@@ -2,7 +2,8 @@ module DocumentTypes
   class Selfie < DocumentType
     class << self
       def relevant_to?(intake)
-        !IdVerificationExperimentService.new(intake).skip_selfies?
+        !(IdVerificationExperimentService.new(intake).skip_selfies? ||
+          ReturningClientExperimentService.new(intake).skip_identity_documents?)
       end
 
       def key

--- a/app/lib/document_types/ssn_itin.rb
+++ b/app/lib/document_types/ssn_itin.rb
@@ -1,8 +1,8 @@
 module DocumentTypes
   class SsnItin < DocumentType
     class << self
-      def relevant_to?(_intake)
-        true
+      def relevant_to?(intake)
+        !ReturningClientExperimentService.new(intake).skip_identity_documents?
       end
 
       def key

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -267,6 +267,7 @@
 #  created_at                                           :datetime         not null
 #  updated_at                                           :datetime         not null
 #  client_id                                            :bigint
+#  matching_previous_year_intake_id                     :bigint
 #  primary_drivers_license_id                           :bigint
 #  spouse_drivers_license_id                            :bigint
 #  visitor_id                                           :string
@@ -287,6 +288,7 @@
 #  index_intakes_on_email_address                          (email_address)
 #  index_intakes_on_email_domain                           (email_domain)
 #  index_intakes_on_hashed_primary_ssn                     (hashed_primary_ssn)
+#  index_intakes_on_matching_previous_year_intake_id       (matching_previous_year_intake_id)
 #  index_intakes_on_needs_to_flush_searchable_data_set_at  (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_intakes_on_phone_number                           (phone_number)
 #  index_intakes_on_primary_consented_to_service           (primary_consented_to_service)
@@ -301,6 +303,7 @@
 # Foreign Keys
 #
 #  fk_rails_...  (client_id => clients.id)
+#  fk_rails_...  (matching_previous_year_intake_id => intakes.id)
 #  fk_rails_...  (vita_partner_id => vita_partners.id)
 #
 

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -267,6 +267,7 @@
 #  created_at                                           :datetime         not null
 #  updated_at                                           :datetime         not null
 #  client_id                                            :bigint
+#  matching_previous_year_intake_id                     :bigint
 #  primary_drivers_license_id                           :bigint
 #  spouse_drivers_license_id                            :bigint
 #  visitor_id                                           :string
@@ -287,6 +288,7 @@
 #  index_intakes_on_email_address                          (email_address)
 #  index_intakes_on_email_domain                           (email_domain)
 #  index_intakes_on_hashed_primary_ssn                     (hashed_primary_ssn)
+#  index_intakes_on_matching_previous_year_intake_id       (matching_previous_year_intake_id)
 #  index_intakes_on_needs_to_flush_searchable_data_set_at  (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_intakes_on_phone_number                           (phone_number)
 #  index_intakes_on_primary_consented_to_service           (primary_consented_to_service)
@@ -301,6 +303,7 @@
 # Foreign Keys
 #
 #  fk_rails_...  (client_id => clients.id)
+#  fk_rails_...  (matching_previous_year_intake_id => intakes.id)
 #  fk_rails_...  (vita_partner_id => vita_partners.id)
 #
 class Intake::CtcIntake < Intake

--- a/app/models/intake/gyr_intake.rb
+++ b/app/models/intake/gyr_intake.rb
@@ -267,6 +267,7 @@
 #  created_at                                           :datetime         not null
 #  updated_at                                           :datetime         not null
 #  client_id                                            :bigint
+#  matching_previous_year_intake_id                     :bigint
 #  primary_drivers_license_id                           :bigint
 #  spouse_drivers_license_id                            :bigint
 #  visitor_id                                           :string
@@ -287,6 +288,7 @@
 #  index_intakes_on_email_address                          (email_address)
 #  index_intakes_on_email_domain                           (email_domain)
 #  index_intakes_on_hashed_primary_ssn                     (hashed_primary_ssn)
+#  index_intakes_on_matching_previous_year_intake_id       (matching_previous_year_intake_id)
 #  index_intakes_on_needs_to_flush_searchable_data_set_at  (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_intakes_on_phone_number                           (phone_number)
 #  index_intakes_on_primary_consented_to_service           (primary_consented_to_service)
@@ -301,6 +303,7 @@
 # Foreign Keys
 #
 #  fk_rails_...  (client_id => clients.id)
+#  fk_rails_...  (matching_previous_year_intake_id => intakes.id)
 #  fk_rails_...  (vita_partner_id => vita_partners.id)
 #
 class Intake::GyrIntake < Intake
@@ -428,6 +431,8 @@ class Intake::GyrIntake < Intake
   enum receive_written_communication: { unfilled: 0, yes: 1, no: 2 }, _prefix: :receive_written_communication
   enum presidential_campaign_fund_donation: { unfilled: 0, primary: 1, spouse: 2, primary_and_spouse: 3 }, _prefix: :presidential_campaign_fund_donation
   enum register_to_vote: { unfilled: 0, yes: 1, no: 2 }, _prefix: :register_to_vote
+
+  belongs_to :matching_previous_year_intake, class_name: "Intake::GyrIntake", optional: true
 
   scope :previous_year_completed_intakes, -> { where.not(product_year: Rails.configuration.product_year).joins(:tax_returns).where(tax_returns: {current_state: TaxReturnStateMachine::INCLUDED_IN_PREVIOUS_YEAR_COMPLETED_INTAKES})}
 

--- a/app/services/experiment_service.rb
+++ b/app/services/experiment_service.rb
@@ -1,6 +1,7 @@
 class ExperimentService
   ID_VERIFICATION_EXPERIMENT = "id_verification_experiment"
   DIY_SUPPORT_LEVEL_EXPERIMENT = "diy_high_and_low_experiment"
+  RETURNING_CLIENT_EXPERIMENT = "returning_client_experiment"
 
   CONFIG = {
     DIY_SUPPORT_LEVEL_EXPERIMENT => {
@@ -17,6 +18,13 @@ class ExperimentService
         no_selfie: 1,
         expanded_id: 1,
         expanded_id_and_no_selfie: 1,
+      }
+    },
+    RETURNING_CLIENT_EXPERIMENT => {
+      name: "Returning client experiment to skip all identity verification",
+      treatment_weights: {
+        control: 1,
+        skip_identity_documents: 1
       }
     }
   }

--- a/app/services/returning_client_experiment_service.rb
+++ b/app/services/returning_client_experiment_service.rb
@@ -1,0 +1,17 @@
+class ReturningClientExperimentService
+  def initialize(intake)
+    @intake = intake
+  end
+
+  def skip_identity_documents?
+    treatment == 'skip_identity_documents'
+  end
+
+  private
+
+  def treatment
+    experiment = Experiment.find_by(key: ExperimentService::RETURNING_CLIENT_EXPERIMENT)
+    return unless experiment
+    ExperimentParticipant.find_by(experiment: experiment, record: @intake)&.treatment
+  end
+end

--- a/app/state_machines/tax_return_state_machine.rb
+++ b/app/state_machines/tax_return_state_machine.rb
@@ -57,7 +57,7 @@ class TaxReturnStateMachine
   EXCLUDED_FROM_CAPACITY = [:intake_before_consent, :intake_in_progress, :intake_greeter_info_requested, :intake_needs_doc_help, :file_mailed, :file_accepted, :file_not_filing, :file_hold, :file_fraud_hold].freeze
   INCLUDED_IN_CAPACITY = (states - EXCLUDED_FROM_CAPACITY).freeze
   FORWARD_TO_INTERCOM = [:file_accepted, :file_mailed, :file_not_filing].freeze
-  INCLUDED_IN_PREVIOUS_YEAR_COMPLETED_INTAKES = [:prep_ready_for_prep, :prep_preparing, :review_ready_for_qr, :review_reviewing, :intake_ready_for_call, :review_signature_requested, :file_ready_to_file, :file_efiled, :file_rejected].freeze
+  INCLUDED_IN_PREVIOUS_YEAR_COMPLETED_INTAKES = [:prep_ready_for_prep, :prep_preparing, :review_ready_for_qr, :review_reviewing, :intake_ready_for_call, :review_signature_requested, :file_ready_to_file, :file_efiled, :file_accepted, :file_rejected].freeze
 
   after_transition(after_commit: true) do |tax_return, transition|
     tax_return.update_columns(current_state: transition.to_state)

--- a/app/views/hub/admin/experiments/index.html.erb
+++ b/app/views/hub/admin/experiments/index.html.erb
@@ -59,7 +59,11 @@
 
         <% @experiment_participants.each do |participant| %>
           <tr>
-            <td><%= participant.record_type %>#<%= participant.record_id %></td>
+            <% if participant.record_type == "Intake" %>
+              <td>Client#<%= participant.record.client_id %></td>
+            <% else %>
+              <td><%= participant.record_type %>#<%= participant.record_id %></td>
+            <% end %>
             <td><%= participant.treatment %></td>
             <% unless Rails.env.production? %><td><%= link_to "Edit", edit_hub_admin_experiment_participant_path(participant) %></td><% end %>
           </tr>

--- a/db/migrate/20230316211535_add_matching_previous_year_intake_to_intake.rb
+++ b/db/migrate/20230316211535_add_matching_previous_year_intake_to_intake.rb
@@ -1,0 +1,7 @@
+class AddMatchingPreviousYearIntakeToIntake < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :intakes, :matching_previous_year_intake, index: { algorithm: :concurrently }
+  end
+end

--- a/db/migrate/20230316211845_add_matching_previous_year_intake_foreign_key_to_intake.rb
+++ b/db/migrate/20230316211845_add_matching_previous_year_intake_foreign_key_to_intake.rb
@@ -1,0 +1,5 @@
+class AddMatchingPreviousYearIntakeForeignKeyToIntake < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :intakes, :intakes, column: :matching_previous_year_intake_id, validate: false
+  end
+end

--- a/db/migrate/20230316212444_validate_matching_previous_year_intake.rb
+++ b/db/migrate/20230316212444_validate_matching_previous_year_intake.rb
@@ -1,0 +1,5 @@
+class ValidateMatchingPreviousYearIntake < ActiveRecord::Migration[7.0]
+  def change
+    validate_foreign_key :intakes, :intakes, column: :matching_previous_year_intake_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_15_180648) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_16_212444) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -1182,6 +1182,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_15_180648) do
     t.integer "made_estimated_tax_payments", default: 0, null: false
     t.decimal "made_estimated_tax_payments_amount", precision: 12, scale: 2
     t.integer "married", default: 0, null: false
+    t.bigint "matching_previous_year_intake_id"
     t.integer "multiple_states", default: 0, null: false
     t.boolean "navigator_has_verified_client_identity"
     t.string "navigator_name"
@@ -1340,6 +1341,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_15_180648) do
     t.index ["email_address"], name: "index_intakes_on_email_address"
     t.index ["email_domain"], name: "index_intakes_on_email_domain"
     t.index ["hashed_primary_ssn"], name: "index_intakes_on_hashed_primary_ssn"
+    t.index ["matching_previous_year_intake_id"], name: "index_intakes_on_matching_previous_year_intake_id"
     t.index ["needs_to_flush_searchable_data_set_at"], name: "index_intakes_on_needs_to_flush_searchable_data_set_at", where: "(needs_to_flush_searchable_data_set_at IS NOT NULL)"
     t.index ["phone_number"], name: "index_intakes_on_phone_number"
     t.index ["primary_consented_to_service"], name: "index_intakes_on_primary_consented_to_service"
@@ -1874,6 +1876,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_15_180648) do
   add_foreign_key "incoming_text_messages", "clients"
   add_foreign_key "intake_archives", "intakes", column: "id"
   add_foreign_key "intakes", "clients"
+  add_foreign_key "intakes", "intakes", column: "matching_previous_year_intake_id"
   add_foreign_key "intakes", "vita_partners"
   add_foreign_key "notes", "clients"
   add_foreign_key "notes", "users"

--- a/spec/models/intake/gyr_intake_spec.rb
+++ b/spec/models/intake/gyr_intake_spec.rb
@@ -267,6 +267,7 @@
 #  created_at                                           :datetime         not null
 #  updated_at                                           :datetime         not null
 #  client_id                                            :bigint
+#  matching_previous_year_intake_id                     :bigint
 #  primary_drivers_license_id                           :bigint
 #  spouse_drivers_license_id                            :bigint
 #  visitor_id                                           :string
@@ -287,6 +288,7 @@
 #  index_intakes_on_email_address                          (email_address)
 #  index_intakes_on_email_domain                           (email_domain)
 #  index_intakes_on_hashed_primary_ssn                     (hashed_primary_ssn)
+#  index_intakes_on_matching_previous_year_intake_id       (matching_previous_year_intake_id)
 #  index_intakes_on_needs_to_flush_searchable_data_set_at  (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_intakes_on_phone_number                           (phone_number)
 #  index_intakes_on_primary_consented_to_service           (primary_consented_to_service)
@@ -301,6 +303,7 @@
 # Foreign Keys
 #
 #  fk_rails_...  (client_id => clients.id)
+#  fk_rails_...  (matching_previous_year_intake_id => intakes.id)
 #  fk_rails_...  (vita_partner_id => vita_partners.id)
 #
 require "rails_helper"
@@ -509,7 +512,7 @@ describe Intake::GyrIntake do
     end
   end
 
-  describe ".returning_matching_previous_year_intakes" do
+  describe ".previous_year_completed_intakes" do
     let!(:intake_current_year) { create :intake, product_year: Rails.configuration.product_year }
     let!(:intake_2022_bad_tax_return_state) { create :intake, product_year: "2022", client: create(:client, tax_returns: [create(:gyr_tax_return, :file_mailed)]) }
     let!(:intake_2022) { create :intake, product_year: "2022", client: create(:client, tax_returns: [create(:gyr_tax_return, :intake_ready_for_call)]) }

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -267,6 +267,7 @@
 #  created_at                                           :datetime         not null
 #  updated_at                                           :datetime         not null
 #  client_id                                            :bigint
+#  matching_previous_year_intake_id                     :bigint
 #  primary_drivers_license_id                           :bigint
 #  spouse_drivers_license_id                            :bigint
 #  visitor_id                                           :string
@@ -287,6 +288,7 @@
 #  index_intakes_on_email_address                          (email_address)
 #  index_intakes_on_email_domain                           (email_domain)
 #  index_intakes_on_hashed_primary_ssn                     (hashed_primary_ssn)
+#  index_intakes_on_matching_previous_year_intake_id       (matching_previous_year_intake_id)
 #  index_intakes_on_needs_to_flush_searchable_data_set_at  (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_intakes_on_phone_number                           (phone_number)
 #  index_intakes_on_primary_consented_to_service           (primary_consented_to_service)
@@ -301,6 +303,7 @@
 # Foreign Keys
 #
 #  fk_rails_...  (client_id => clients.id)
+#  fk_rails_...  (matching_previous_year_intake_id => intakes.id)
 #  fk_rails_...  (vita_partner_id => vita_partners.id)
 #
 


### PR DESCRIPTION
clients are bucketed into this experiment on the 'chat with us' page if they have any matching previous year intake (by birthdate and full SSN)

add an explicit matching_previous_year_intake_id to the intakes table which is populated as soon as we have SSN

clients in the experiment get set 'ready for review' as soon as they see the Documents::IntroController (which is the intro to all the non-identity document upload pages)