### PR TITLE
DIY flow: hide preferred name and filing status if we think the person came from triage

### DIFF
--- a/app/controllers/diy/file_yourself_controller.rb
+++ b/app/controllers/diy/file_yourself_controller.rb
@@ -28,6 +28,9 @@ module Diy
 
     def create_params
       form_params = params.fetch(:file_yourself_form, {}).permit(FileYourselfForm.attribute_names)
+      if DiyIntake.should_carry_over_params_from?(current_intake)
+        form_params.merge!(preferred_first_name: current_intake.preferred_name, filing_frequency: current_intake.triage_filing_frequency)
+      end
       if session[:diy_intake_id]
         existing_diy_intake = DiyIntake.find(session[:diy_intake_id])
         form_params.merge(

--- a/app/models/diy_intake.rb
+++ b/app/models/diy_intake.rb
@@ -22,4 +22,8 @@ class DiyIntake < ApplicationRecord
   enum filing_frequency: { unfilled: 0, every_year: 1, some_years: 2, not_filed: 3 }, _prefix: :filing_frequency
 
   validates :email_address, presence: true, 'valid_email_2/email': { mx: true }, confirmation: true
+  
+  def self.should_carry_over_params_from?(intake)
+    intake && intake.updated_at > 30.minutes.ago && intake.preferred_name.present? && intake.triage_filing_frequency.present?
+  end
 end

--- a/app/views/diy/file_yourself/edit.html.erb
+++ b/app/views/diy/file_yourself/edit.html.erb
@@ -17,7 +17,9 @@
 
         <%= form_with model: @form, url: diy_file_yourself_path, local: true, method: "put", builder: VitaMinFormBuilder, html: { class: "form-card form-card--long" } do |f| %>
           <div class="form-card__content">
-            <%= f.cfa_input_field(:preferred_first_name, t("views.questions.personal_info.preferred_name"), classes: ["form-width--long"]) %>
+            <% unless DiyIntake.should_carry_over_params_from?(current_intake) %>
+              <%= f.cfa_input_field(:preferred_first_name, t("views.questions.personal_info.preferred_name"), classes: ["form-width--long"]) %>
+            <% end %>
             <%= f.cfa_input_field(:email_address, t("general.email"), classes: ["form-width--long"]) %>
             <%= f.cfa_select(
                   :received_1099,
@@ -29,16 +31,18 @@
                   help_text: t(".received_1099.help_text"),
                   include_blank: true,
                 ) %>
-            <%= f.cfa_select(
-                  :filing_frequency,
-                  t("questions.triage_income_level.edit.filing_frequency.label_html"),
-                  [
-                    [t("questions.triage_income_level.edit.filing_frequency.options.every_year"), :every_year],
-                    [t("questions.triage_income_level.edit.filing_frequency.options.some_years"), :some_years],
-                    [t("questions.triage_income_level.edit.filing_frequency.options.not_filed"), :not_filed],
-                  ],
-                  include_blank: true,
-                ) %>
+            <% unless DiyIntake.should_carry_over_params_from?(current_intake) %>
+              <%= f.cfa_select(
+                    :filing_frequency,
+                    t("questions.triage_income_level.edit.filing_frequency.label_html"),
+                    [
+                      [t("questions.triage_income_level.edit.filing_frequency.options.every_year"), :every_year],
+                      [t("questions.triage_income_level.edit.filing_frequency.options.some_years"), :some_years],
+                      [t("questions.triage_income_level.edit.filing_frequency.options.not_filed"), :not_filed],
+                    ],
+                    include_blank: true,
+                  ) %>
+              <% end %>
           </div>
 
           <%= f.continue %>

--- a/spec/features/diy/new_diy_client_spec.rb
+++ b/spec/features/diy/new_diy_client_spec.rb
@@ -1,10 +1,12 @@
 require "rails_helper"
 
 RSpec.feature "Client wants to file on their own" do
-  scenario "a new client files through TaxSlayer", :flow_explorer_screenshot do
+  before do
     ExperimentService.ensure_experiments_exist_in_database
     Experiment.update_all(enabled: true)
+  end
 
+  scenario "a new client files through TaxSlayer", :flow_explorer_screenshot do
     allow(MixpanelService).to receive(:send_event)
     # TODO(diy-cleanup): Once /diy redirect goes away, visit /diy/file_yourself directly
     visit "/diy"
@@ -22,5 +24,24 @@ RSpec.feature "Client wants to file on their own" do
     experiment = Experiment.find_by(key: ExperimentService::DIY_SUPPORT_LEVEL_EXPERIMENT)
     experiment_particpant = ExperimentParticipant.find_by(record: DiyIntake.last, experiment: experiment)
     expect(experiment_particpant.treatment.to_sym).to be_in(experiment.treatment_weights.keys)
+  end
+
+  scenario "a new client who goes through DIY after going through triage doesn't have to re-answer preferred name and filing frequency" do
+    answer_gyr_triage_questions(choices: :defaults)
+    click_on I18n.t("questions.triage.diy_tile.choose_diy")
+
+    expect(page).to have_selector("h1", text: I18n.t("diy.file_yourself.edit.title"))
+    expect(page).not_to have_field("Preferred first name")
+    expect(page).not_to have_select("In the last 4 years, how often have you filed?")
+
+    fill_in "Email", with: "example@example.com"
+    select "Yes", from: I18n.t("diy.file_yourself.edit.received_1099.label")
+    click_on I18n.t('general.continue')
+
+    expect(page).to have_selector("h1", text: I18n.t("diy.continue_to_fsa.edit.title"))
+
+    diy_intake = DiyIntake.last
+    expect(diy_intake.preferred_first_name).to eq('Gary')
+    expect(diy_intake.filing_frequency).to eq('not_filed')
   end
 end


### PR DESCRIPTION
we are making the somewhat arbitrary decision to only carry over info from the current_intake if it has been updated in the last 30 minutes (to deal with scenarios where current_intake still returns a record but it was something edited a long time ago on a shared computer)