### PR TITLE
Update Metrics page logic to include clients who never messaged us in the SLA breach counts

### DIFF
--- a/app/services/sla_breach_service.rb
+++ b/app/services/sla_breach_service.rb
@@ -14,7 +14,7 @@ class SLABreachService
   end
 
   def last_outgoing_communication_breaches
-    count_by_vita_partner(Client.where("last_outgoing_communication_at < ?", breach_threshold_date))
+    count_by_vita_partner(Client.sla_tracked.where("last_outgoing_communication_at < ?", breach_threshold_date))
   end
 
   def self.generate_report

--- a/app/services/sla_breach_service.rb
+++ b/app/services/sla_breach_service.rb
@@ -13,14 +13,13 @@ class SLABreachService
     count_by_vita_partner(Client.sla_tracked)
   end
 
-  # clients who messaged us and have not been responded to _with a message, call or email_ within the breach threshold
-  def first_unanswered_incoming_interaction_communication_breaches
-    count_by_vita_partner(Client.first_unanswered_incoming_interaction_between(...breach_threshold_date))
+  def last_outgoing_communication_breaches
+    count_by_vita_partner(Client.where("last_outgoing_communication_at < ?", breach_threshold_date))
   end
 
   def self.generate_report
     report = SLABreachService.new
-    communication_breaches = report.first_unanswered_incoming_interaction_communication_breaches
+    communication_breaches = report.last_outgoing_communication_breaches
     active_sla_clients = report.active_sla_clients_count
     {
         breached_at: report.breach_threshold_date,

--- a/spec/services/sla_breach_service_spec.rb
+++ b/spec/services/sla_breach_service_spec.rb
@@ -100,6 +100,7 @@ describe SLABreachService do
       before do
         # breaches at vita_partner_1
         _client1 = create(:client, last_outgoing_communication_at: 1.day.ago, intake: (create :intake), vita_partner_id: vita_partner_1.id, tax_returns: [create(:gyr_tax_return, :prep_ready_for_prep)]) # within SLA
+        _client1 = create(:client, last_outgoing_communication_at: 10.day.ago, intake: (create :intake), vita_partner_id: vita_partner_1.id, tax_returns: [create(:gyr_tax_return, :file_accepted)]) # excluded from SLA due to tax return state
 
         # breaches at vita_partner_2
         _client2 = create(:client, last_outgoing_communication_at: 1.day.ago, intake: (create :intake), vita_partner_id: vita_partner_2.id, tax_returns: [create(:gyr_tax_return, :prep_ready_for_prep)]) # within SLA

--- a/spec/services/sla_breach_service_spec.rb
+++ b/spec/services/sla_breach_service_spec.rb
@@ -99,23 +99,12 @@ describe SLABreachService do
       let(:vita_partner_2) { create :organization }
       before do
         # breaches at vita_partner_1
-        client1 = create(:client, intake: (create :intake) ,vita_partner_id: vita_partner_1.id, tax_returns:  [create(:gyr_tax_return, :prep_ready_for_prep)]) # breach
-        Timecop.freeze(8.days.ago) { client1.flag! }
-        Timecop.freeze(7.days.ago) { InteractionTrackingService.update_last_outgoing_communication_at(client1) }
+        _client1 = create(:client, last_outgoing_communication_at: 1.day.ago, intake: (create :intake), vita_partner_id: vita_partner_1.id, tax_returns: [create(:gyr_tax_return, :prep_ready_for_prep)]) # within SLA
 
         # breaches at vita_partner_2
-        client2 = create(:client, intake: (create :intake), vita_partner_id: vita_partner_2.id, tax_returns: [create(:gyr_tax_return, :prep_ready_for_prep)]) # breach
-        Timecop.freeze(9.days.ago) { client2.flag! }
-
-        client3 = create(:client, intake: (create :intake), vita_partner_id: vita_partner_2.id, tax_returns: [create(:gyr_tax_return, :prep_ready_for_prep)]) # breach
-        Timecop.freeze(10.days.ago) { client3.flag! }
-
-        client4 = create(:client, intake: (create :intake), vita_partner_id: vita_partner_2.id, tax_returns: [create(:gyr_tax_return, :prep_ready_for_prep)]) # not in breach t1, in breach t2
-        Timecop.freeze(10.days.ago) {
-          InteractionTrackingService.record_incoming_interaction(client4)
-          client4.flag!
-        }
-        Timecop.freeze(t.prev_occurring(:sunday)) { InteractionTrackingService.record_internal_interaction(client4) }
+        _client2 = create(:client, last_outgoing_communication_at: 1.day.ago, intake: (create :intake), vita_partner_id: vita_partner_2.id, tax_returns: [create(:gyr_tax_return, :prep_ready_for_prep)]) # within SLA
+        _client3 = create(:client, last_outgoing_communication_at: 1.day.ago, intake: (create :intake), vita_partner_id: vita_partner_2.id, tax_returns: [create(:gyr_tax_return, :prep_ready_for_prep)]) # within SLA
+        _client4 = create(:client, last_outgoing_communication_at: 10.day.ago, intake: (create :intake), vita_partner_id: vita_partner_2.id, tax_returns: [create(:gyr_tax_return, :prep_ready_for_prep)]) # breached SLA
       end
 
       it "returns an accurate hash of attributes for the report" do


### PR DESCRIPTION
The SLA breach counts are just based on whether we've waited too long to message them, not on whether they've messaged us.