### PR TITLE
incorrect/old style syntax for keyword variable arguments in db migration

### DIFF
--- a/db/migrate/20221207160354_add_previous_years_to_intakes.rb
+++ b/db/migrate/20221207160354_add_previous_years_to_intakes.rb
@@ -1,8 +1,8 @@
 class AddPreviousYearsToIntakes < ActiveRecord::Migration[7.0]
   def change
-    add_column :intakes, :needs_help_previous_year_3, :integer, { default: 0, null: false }
-    add_column :intakes, :needs_help_previous_year_2, :integer, { default: 0, null: false }
-    add_column :intakes, :needs_help_previous_year_1, :integer, { default: 0, null: false }
-    add_column :intakes, :needs_help_current_year, :integer, { default: 0, null: false }
+    add_column :intakes, :needs_help_previous_year_3, :integer, default: 0, null: false
+    add_column :intakes, :needs_help_previous_year_2, :integer, default: 0, null: false
+    add_column :intakes, :needs_help_previous_year_1, :integer, default: 0, null: false
+    add_column :intakes, :needs_help_current_year, :integer, default: 0, null: false
   end
 end


### PR DESCRIPTION
Fix for a syntax error in this migration class