### PR TITLE
Fix flow explorer screenshot crash on DIY page

### DIFF
--- a/app/controllers/diy/continue_to_fsa_controller.rb
+++ b/app/controllers/diy/continue_to_fsa_controller.rb
@@ -28,7 +28,7 @@ module Diy
           SendInternalEmailJob.perform_later(internal_email)
         end
       end
-      redirect_to DiySupportExperimentService.taxslayer_link(treatment.to_s, diy_intake.received_1099_yes?), allow_other_host: true
+      redirect_to DiySupportExperimentService.fsa_link(treatment.to_s, diy_intake.received_1099_yes?), allow_other_host: true
     end
 
     private

--- a/app/services/diy_support_experiment_service.rb
+++ b/app/services/diy_support_experiment_service.rb
@@ -1,18 +1,26 @@
 class DiySupportExperimentService
-  def self.taxslayer_link(support_level_treatment, received_1099)
-    return "https://www.taxslayer.com/v.aspx?rdr=/vitafsa&source=TSUSATY2022&sidn=01011934" if support_level_treatment.blank?
+  def self.fsa_domain
+    if Rails.env.test?
+      "https://www.example.com"
+    else
+      "https://www.taxslayer.com"
+    end
+  end
+
+  def self.fsa_link(support_level_treatment, received_1099)
+    return "#{fsa_domain}/v.aspx?rdr=/vitafsa&source=TSUSATY2022&sidn=01011934" if support_level_treatment.blank?
 
     if received_1099
       if support_level_treatment == 'high'
-        "https://www.taxslayer.com/v.aspx?rdr=/vitafsa&source=TSUSATY2022&sidn=23062996"
+        "#{fsa_domain}/v.aspx?rdr=/vitafsa&source=TSUSATY2022&sidn=23062996"
       else
-        "https://www.taxslayer.com/v.aspx?rdr=/vitafsa&source=TSUSATY2022&sidn=34067601"
+        "#{fsa_domain}/v.aspx?rdr=/vitafsa&source=TSUSATY2022&sidn=34067601"
       end
     else
       if support_level_treatment == 'high'
-        "https://www.taxslayer.com/v.aspx?rdr=/vitafsa&source=TSUSATY2022&sidn=23069434"
+        "#{fsa_domain}/v.aspx?rdr=/vitafsa&source=TSUSATY2022&sidn=23069434"
       else
-        "https://www.taxslayer.com/v.aspx?rdr=/vitafsa&source=TSUSATY2022&sidn=21061019"
+        "#{fsa_domain}/v.aspx?rdr=/vitafsa&source=TSUSATY2022&sidn=21061019"
       end
     end
   end

--- a/spec/controllers/diy/continue_to_fsa_controller_spec.rb
+++ b/spec/controllers/diy/continue_to_fsa_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Diy::ContinueToFsaController do
     context "with a diy intake id in the session" do
       context "when they are not part of the experiment" do
         before do
-          allow(DiySupportExperimentService).to receive(:taxslayer_link).with("", false).and_return("https://example.com/redirect_result")
+          allow(DiySupportExperimentService).to receive(:fsa_link).with("", false).and_return("https://example.com/redirect_result")
         end
 
         it "redirects to taxslayer" do
@@ -55,7 +55,7 @@ RSpec.describe Diy::ContinueToFsaController do
             record: diy_intake,
             treatment: support_level_treatment,
           )
-          allow(DiySupportExperimentService).to receive(:taxslayer_link).with(support_level_treatment.to_s, received_1099 == "yes").and_return("https://example.com/redirect_result")
+          allow(DiySupportExperimentService).to receive(:fsa_link).with(support_level_treatment.to_s, received_1099 == "yes").and_return("https://example.com/redirect_result")
         end
 
         let(:received_1099) { false }

--- a/spec/features/diy/new_diy_client_spec.rb
+++ b/spec/features/diy/new_diy_client_spec.rb
@@ -22,7 +22,14 @@ RSpec.feature "Client wants to file on their own" do
     expect(page).to have_selector("h1", text: I18n.t("diy.continue_to_fsa.edit.title"))
     expect(find_link(I18n.t("general.continue"))[:target]).to eq("_blank")
     expect do
-      click_on I18n.t("general.continue")
+      if Capybara.current_driver == Capybara.javascript_driver
+        taxslayer_window = window_opened_by do
+          click_on I18n.t("general.continue")
+        end
+        taxslayer_window.close
+      else
+        click_on I18n.t("general.continue")
+      end
     end.to have_enqueued_job(SendInternalEmailJob)
 
     perform_enqueued_jobs

--- a/spec/services/diy_support_experiment_service_spec.rb
+++ b/spec/services/diy_support_experiment_service_spec.rb
@@ -1,13 +1,16 @@
 require 'rails_helper'
 
 describe DiySupportExperimentService do
-  describe ".taxslayer_link" do
+
+  describe ".fsa_link" do
+    fsa_domain = described_class.fsa_domain
+
     scenarios = [
-      { received_1099: :ignored_because_treatment_nil, support_level_treatment: '', link: "https://www.taxslayer.com/v.aspx?rdr=/vitafsa&source=TSUSATY2022&sidn=01011934"},
-      { received_1099: true, support_level_treatment: "high", link: "https://www.taxslayer.com/v.aspx?rdr=/vitafsa&source=TSUSATY2022&sidn=23062996"},
-      { received_1099: true, support_level_treatment: "not-high", link: "https://www.taxslayer.com/v.aspx?rdr=/vitafsa&source=TSUSATY2022&sidn=34067601"},
-      { received_1099: false, support_level_treatment: "high", link: "https://www.taxslayer.com/v.aspx?rdr=/vitafsa&source=TSUSATY2022&sidn=23069434"},
-      { received_1099: false, support_level_treatment: "not-high", link: "https://www.taxslayer.com/v.aspx?rdr=/vitafsa&source=TSUSATY2022&sidn=21061019"},
+      { received_1099: :ignored_because_treatment_nil, support_level_treatment: '', link: "#{fsa_domain}/v.aspx?rdr=/vitafsa&source=TSUSATY2022&sidn=01011934"},
+      { received_1099: true, support_level_treatment: "high", link: "#{fsa_domain}/v.aspx?rdr=/vitafsa&source=TSUSATY2022&sidn=23062996"},
+      { received_1099: true, support_level_treatment: "not-high", link: "#{fsa_domain}/v.aspx?rdr=/vitafsa&source=TSUSATY2022&sidn=34067601"},
+      { received_1099: false, support_level_treatment: "high", link: "#{fsa_domain}/v.aspx?rdr=/vitafsa&source=TSUSATY2022&sidn=23069434"},
+      { received_1099: false, support_level_treatment: "not-high", link: "#{fsa_domain}/v.aspx?rdr=/vitafsa&source=TSUSATY2022&sidn=21061019"},
     ]
 
     scenarios.each do |scenario|
@@ -16,7 +19,7 @@ describe DiySupportExperimentService do
       expected_link = scenario[:link]
       context "Given received_1099=#{received_1099} and support_level_treatment=#{support_level_treatment}" do
         it "returns the expected link" do
-          expect(described_class.taxslayer_link(support_level_treatment, received_1099)).to eq(expected_link)
+          expect(described_class.fsa_link(support_level_treatment, received_1099)).to eq(expected_link)
         end
       end
     end

--- a/spec/support/locale_helper.rb
+++ b/spec/support/locale_helper.rb
@@ -6,6 +6,10 @@ end
 
 class ActionDispatch::Routing::RouteSet
   def default_url_options(_options = {})
-    { locale: I18n.default_locale, host: "test.host" }
+    if Capybara.current_driver == Capybara.javascript_driver
+      { locale: I18n.default_locale, host: "#{Capybara.server_host}:#{Capybara.server_port}" }
+    else
+      { locale: I18n.default_locale, host: "test.host" }
+    end
   end
 end


### PR DESCRIPTION
needed to wait for the window to open before running enqueued jobs, and make sure the host on a link was set correctly

make the fsa_link `example.com` in test so we aren't visiting a third-party website every testrun