### PR TITLE
Add offseason filing banner to homepage, display after tax deadline until closing

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  helper_method :include_analytics?, :current_intake, :show_progress?, :show_offseason_banner?, :canonical_url, :hreflang_url, :hub?, :wrapping_layout
+  helper_method :include_analytics?, :current_intake, :show_progress?, :canonical_url, :hreflang_url, :hub?, :wrapping_layout
   # This needs to be a class method for the devise controller to have access to it
   # See: http://stackoverflow.com/questions/12550564/how-to-pass-locale-parameter-to-devise
   def self.default_url_options
@@ -304,12 +304,12 @@ class ApplicationController < ActionController::Base
     false
   end
 
-  # Do not show the offseason banner in the hub
-  # Do not show offseason banner if we are open for intake for the session
-  def show_offseason_banner?
+  def show_offseason_filing_banner?
     return false if hub?
-    !open_for_gyr_intake?
+
+    open_for_gyr_intake? && app_time >= Rails.configuration.tax_deadline
   end
+  helper_method :show_offseason_filing_banner?
 
   def open_for_gyr_intake?
     return true if cookies[:used_unique_link] == "yes" &&

--- a/app/views/public_pages/home.html.erb
+++ b/app/views/public_pages/home.html.erb
@@ -12,7 +12,10 @@
       </div>
     </div>
   <% end %>
-  <% if open_for_gyr_intake? %>
+  <% if show_offseason_filing_banner? %>
+    <%= render 'shared/offseason_filing_banner' %>
+  <% end %>
+  <% if open_for_gyr_intake? && !show_offseason_filing_banner? %>
     <%= render 'shared/document_deadline_warning' %>
   <% end %>
 <% end %>

--- a/app/views/questions/welcome/edit.html.erb
+++ b/app/views/questions/welcome/edit.html.erb
@@ -1,7 +1,10 @@
 <% content_for :page_title, t("views.questions.welcome.title") %>
 
 <% content_for :notice do %>
-  <% if open_for_gyr_intake? %>
+  <% if show_offseason_filing_banner? %>
+    <%= render 'shared/offseason_filing_banner' %>
+  <% end %>
+  <% if open_for_gyr_intake? && !show_offseason_filing_banner? %>
     <%= render 'shared/document_deadline_warning' %>
   <% end %>
 <% end %>

--- a/app/views/shared/_offseason_alert.html.erb
+++ b/app/views/shared/_offseason_alert.html.erb
@@ -1,7 +1,0 @@
-<div class="slab slab--flash flash--offseason-warning">
-  <div class="grid">
-    <div class="grid__item">
-      <%= t("views.shared.environment_warning.off_season_html", faq_link: link_to(t("general.faq"), stimulus_path)) %>
-    </div>
-  </div>
-</div>

--- a/app/views/shared/_offseason_filing_banner.html.erb
+++ b/app/views/shared/_offseason_filing_banner.html.erb
@@ -2,12 +2,12 @@
   <div class="grid">
     <div class="grid__item">
       <% end_of_intake = Rails.configuration.end_of_intake %>
-      <% end_of_login = Rails.configuration.end_of_login %>
+      <% end_of_doc_submission = Rails.configuration.end_of_login - 1.week %>
       <%= t("views.shared.environment_warning.off_season_filing",
             end_of_intake_month: I18n.l(end_of_intake, format: "%B", locale: locale),
             end_of_intake_day: locale == :en ? end_of_intake.day.ordinalize : end_of_intake.day,
-            end_of_login_month: I18n.l(end_of_login, format: "%B", locale: locale),
-            end_of_login_day: locale == :en ? end_of_login.day.ordinalize : end_of_login.day,
+            end_of_docs_month: I18n.l(end_of_doc_submission, format: "%B", locale: locale),
+            end_of_docs_day: locale == :en ? end_of_doc_submission.day.ordinalize : end_of_doc_submission.day,
             year: Time.now.year) %>
     </div>
   </div>

--- a/app/views/shared/_offseason_filing_banner.html.erb
+++ b/app/views/shared/_offseason_filing_banner.html.erb
@@ -1,0 +1,14 @@
+<div class="slab slab--banner">
+  <div class="grid">
+    <div class="grid__item">
+      <% end_of_intake = Rails.configuration.end_of_intake %>
+      <% end_of_login = Rails.configuration.end_of_login %>
+      <%= t("views.shared.environment_warning.off_season_filing",
+            end_of_intake_month: I18n.l(end_of_intake, format: "%B", locale: locale),
+            end_of_intake_day: locale == :en ? end_of_intake.day.ordinalize : end_of_intake.day,
+            end_of_login_month: I18n.l(end_of_login, format: "%B", locale: locale),
+            end_of_login_day: locale == :en ? end_of_login.day.ordinalize : end_of_login.day,
+            year: Time.now.year) %>
+    </div>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -88,7 +88,7 @@ module VitaMin
     config.start_of_open_intake = Time.find_zone('America/Los_Angeles').parse('2023-01-31 09:59:59')
     config.tax_deadline = Time.find_zone('America/New_York').parse('2023-04-18 23:59:59')
     config.end_of_intake = Time.find_zone('America/New_York').parse('2023-10-01 23:59:59')
-    config.end_of_login = Time.find_zone('America/New_York').parse('2023-10-8 23:59:00')
+    config.end_of_login = Time.find_zone('America/New_York').parse('2023-10-15 23:59:00')
 
     config.ctc_soft_launch = Time.find_zone("America/New_York").parse("2022-05-04 09:00:00")
     config.ctc_full_launch = Time.find_zone("America/New_York").parse("2022-05-11 09:00:00")

--- a/config/application.rb
+++ b/config/application.rb
@@ -86,8 +86,9 @@ module VitaMin
     # These defaults can be overridden per-environment if needed
     config.start_of_unique_links_only_intake = Time.find_zone('America/Los_Angeles').parse('2023-01-24 09:59:59')
     config.start_of_open_intake = Time.find_zone('America/Los_Angeles').parse('2023-01-31 09:59:59')
+    config.tax_deadline = Time.find_zone('America/New_York').parse('2023-04-18 23:59:59')
     config.end_of_intake = Time.find_zone('America/New_York').parse('2023-10-01 23:59:59')
-    config.end_of_login = Time.find_zone('America/New_York').parse('2023-10-15 23:59:00')
+    config.end_of_login = Time.find_zone('America/New_York').parse('2023-10-8 23:59:00')
 
     config.ctc_soft_launch = Time.find_zone("America/New_York").parse("2022-05-04 09:00:00")
     config.ctc_full_launch = Time.find_zone("America/New_York").parse("2022-05-11 09:00:00")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4613,7 +4613,7 @@ en:
         body_html: "<strong>Reminder: You must submit your documents by April 4 in order to meet the federal income tax filing deadline of April 18. You can submit your taxes after the deadline without penalty if you don’t owe.</strong> If you aren’t sure whether or not you will owe, you can complete and mail <a href='https://www.irs.gov/forms-pubs/about-form-4868' target='_blank' rel='noopener noreferrer'>this IRS form</a> requesting an extension."
       environment_warning:
         banner: This site is for example purposes only. If you want help with your taxes, go to
-        off_season_html: GetYourRefund services have not yet opened for this tax season. We look forward to providing our free tax assistance again starting in February. For stimulus questions, visit our %{faq_link}.
+        off_season_filing: Get started with GetYourRefund by %{end_of_intake_month} %{end_of_intake_day} if you want to file with us in %{year}. If your return is in progress, log in and submit your documents by %{end_of_login_month} %{end_of_login_day}.
       footer:
         ctc_service_description_html: GetCTC.org is a non-profit service built by %{link}.
         service_description_html: GetYourRefund.org is a non-profit service built by %{cfa_link} in partnership with the IRS with support from the White House and U.S. Department of Treasury.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4613,7 +4613,7 @@ en:
         body_html: "<strong>Reminder: You must submit your documents by April 4 in order to meet the federal income tax filing deadline of April 18. You can submit your taxes after the deadline without penalty if you don’t owe.</strong> If you aren’t sure whether or not you will owe, you can complete and mail <a href='https://www.irs.gov/forms-pubs/about-form-4868' target='_blank' rel='noopener noreferrer'>this IRS form</a> requesting an extension."
       environment_warning:
         banner: This site is for example purposes only. If you want help with your taxes, go to
-        off_season_filing: Get started with GetYourRefund by %{end_of_intake_month} %{end_of_intake_day} if you want to file with us in %{year}. If your return is in progress, log in and submit your documents by %{end_of_login_month} %{end_of_login_day}.
+        off_season_filing: Get started with GetYourRefund by %{end_of_intake_month} %{end_of_intake_day} if you want to file with us in %{year}. If your return is in progress, log in and submit your documents by %{end_of_docs_month} %{end_of_docs_day}.
       footer:
         ctc_service_description_html: GetCTC.org is a non-profit service built by %{link}.
         service_description_html: GetYourRefund.org is a non-profit service built by %{cfa_link} in partnership with the IRS with support from the White House and U.S. Department of Treasury.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4659,7 +4659,7 @@ es:
         body_html: "<strong>Recordatorio: debe presentar sus documentos antes del 4 de abril para cumplir con la fecha límite de presentación de impuestos federales sobre la renta del 18 de abril. Puede presentar sus impuestos después de la fecha límite sin penalización si no debe.</strong> Si no está seguro de si o no deberá, puede completar y enviar por correo  <a href='https://www.irs.gov/es/forms-pubs/about-form-4868' target='_blank' rel='noopener noreferrer'>este formulario del IRS</a> solicitando una prórroga."
       environment_warning:
         banner: 'Este sitio es sólo para fines de ejemplo. Si necesitas ayuda con sus impuestos, visite  '
-        off_season_filing: Comience con GetYourRefund antes del %{end_of_intake_day} de %{end_of_intake_month} si desea presentar su declaración con nosotros en %{year}. Si su declaración está en curso, inicie sesión y envíe sus documentos antes del %{end_of_login_day} de %{end_of_login_month}.
+        off_season_filing: Comience con GetYourRefund antes del %{end_of_intake_day} de %{end_of_intake_month} si desea presentar su declaración con nosotros en %{year}. Si su declaración está en curso, inicie sesión y envíe sus documentos antes del %{end_of_docs_day} de %{end_of_docs_month}.
       footer:
         ctc_service_description_html: GetCTC.org es un servicio sin fines de lucro creado por %{link}.
         service_description_html: GetYourRefund.org es un servicio sin fines de lucro ofrecido por %{cfa_link}, realizado en colaboración con el IRS, con el apoyo de la Casa Blanca y el Departamento del Tesoro de EE. UU.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4659,7 +4659,7 @@ es:
         body_html: "<strong>Recordatorio: debe presentar sus documentos antes del 4 de abril para cumplir con la fecha límite de presentación de impuestos federales sobre la renta del 18 de abril. Puede presentar sus impuestos después de la fecha límite sin penalización si no debe.</strong> Si no está seguro de si o no deberá, puede completar y enviar por correo  <a href='https://www.irs.gov/es/forms-pubs/about-form-4868' target='_blank' rel='noopener noreferrer'>este formulario del IRS</a> solicitando una prórroga."
       environment_warning:
         banner: 'Este sitio es sólo para fines de ejemplo. Si necesitas ayuda con sus impuestos, visite  '
-        off_season_html: Los servicios Get Your Refund aún no se han abierto para esta temporada de impuestos. Esperamos volver poder ofrecerle nuestra asistencia gratuita a partir de febrero. Para preguntas de estímulo, visite nuestro %{faq_link}
+        off_season_filing: Comience con GetYourRefund antes del %{end_of_intake_day} de %{end_of_intake_month} si desea presentar su declaración con nosotros en %{year}. Si su declaración está en curso, inicie sesión y envíe sus documentos antes del %{end_of_login_day} de %{end_of_login_month}.
       footer:
         ctc_service_description_html: GetCTC.org es un servicio sin fines de lucro creado por %{link}.
         service_description_html: GetYourRefund.org es un servicio sin fines de lucro ofrecido por %{cfa_link}, realizado en colaboración con el IRS, con el apoyo de la Casa Blanca y el Departamento del Tesoro de EE. UU.

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1183,14 +1183,44 @@ RSpec.describe ApplicationController do
     end
   end
 
-  describe '#show_offseason_banner?' do
-    context "when open for intake" do
+  describe '#show_offseason_filing_banner?' do
+    around do |example|
+      freeze_time do
+        example.run
+      end
+    end
+    let(:past) { 1.minute.ago }
+    let(:future) { Time.now + 1.minute }
+
+    context "when between intake opening and tax deadline" do
       before do
         allow(subject).to receive(:open_for_gyr_intake?).and_return true
+        allow(Rails.application.config).to receive(:tax_deadline).and_return(future)
       end
 
       it "is false" do
-        expect(subject.show_offseason_banner?).to be false
+        expect(subject.show_offseason_filing_banner?).to be false
+      end
+    end
+
+    context "when between tax deadline and intake closing" do
+      before do
+        allow(subject).to receive(:open_for_gyr_intake?).and_return true
+        allow(Rails.application.config).to receive(:tax_deadline).and_return(past)
+      end
+
+      it "is true" do
+        expect(subject.show_offseason_filing_banner?).to be true
+      end
+    end
+
+    context "when between intake closing and intake opening" do
+      before do
+        allow(subject).to receive(:open_for_gyr_intake?).and_return false
+      end
+
+      it "is false" do
+        expect(subject.show_offseason_filing_banner?).to be false
       end
     end
 
@@ -1198,18 +1228,9 @@ RSpec.describe ApplicationController do
       controller(Hub::UsersController) do
         def hub_path; end
       end
+
       it "is false" do
-        expect(subject.show_offseason_banner?).to be false
-      end
-    end
-
-    context "when not open for intake and not a hub path" do
-      before do
-        allow(subject).to receive(:open_for_gyr_intake?).and_return false
-      end
-
-      it "is true" do
-        expect(subject.show_offseason_banner?).to be true
+        expect(subject.show_offseason_filing_banner?).to be false
       end
     end
   end

--- a/spec/features/visit_home_page_spec.rb
+++ b/spec/features/visit_home_page_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature "Visit home page" do
     context "when open for filing and before the tax deadline" do
       let(:current_time) { DateTime.new(2023, 4, 1) }
 
-      scenario "shows the document deadline banner?" do
+      scenario "shows the document deadline banner" do
         visit "/"
 
         expect(page).to have_text "Reminder: You must submit your documents by April 4 in order to meet the federal income tax filing deadline of April 18. You can submit your taxes after the deadline without penalty if you don’t owe. If you aren’t sure whether or not you will owe, you can complete and mail this IRS form requesting an extension."

--- a/spec/features/visit_home_page_spec.rb
+++ b/spec/features/visit_home_page_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature "Visit home page" do
       allow(Rails.configuration).to receive(:end_of_login).and_return(DateTime.new(2023, 10, 15))
     end
 
-    context "when closed for filing" do
+    context "when closed for new intakes" do
       let(:current_time) { DateTime.new(2023, 10, 2) }
 
       scenario "shows the closed banner" do

--- a/spec/features/visit_home_page_spec.rb
+++ b/spec/features/visit_home_page_spec.rb
@@ -21,32 +21,51 @@ RSpec.feature "Visit home page" do
   end
 
   context "shows the correct date-dependent banners" do
-    xcontext "when closed for filing" do
-      scenario "shows the closed banner" do; end
+    let(:current_time) { nil }
+
+    around do |example|
+      Timecop.freeze(current_time)
+      example.run
+      Timecop.return
     end
 
-    xcontext "when open for filing and before the tax deadline" do
-      scenario "shows the document deadline banner?" do; end
+    before do
+      allow(Rails.configuration).to receive(:start_of_open_intake).and_return(DateTime.new(2023, 1, 31))
+      allow(Rails.configuration).to receive(:tax_deadline).and_return(DateTime.new(2023, 4, 18))
+      allow(Rails.configuration).to receive(:end_of_intake).and_return(DateTime.new(2023, 10, 1))
+      allow(Rails.configuration).to receive(:end_of_login).and_return(DateTime.new(2023, 10, 15))
+    end
+
+    context "when closed for filing" do
+      let(:current_time) { DateTime.new(2023, 10, 2) }
+
+      scenario "shows the closed banner" do
+        visit "/"
+
+        expect(page).to have_text "GetYourRefund will reopen January 31."
+        expect(page.all(:css, '.slab--banner').length).to eq 1
+      end
+    end
+
+    context "when open for filing and before the tax deadline" do
+      let(:current_time) { DateTime.new(2023, 4, 1) }
+
+      scenario "shows the document deadline banner?" do
+        visit "/"
+
+        expect(page).to have_text "Reminder: You must submit your documents by April 4 in order to meet the federal income tax filing deadline of April 18. You can submit your taxes after the deadline without penalty if you don’t owe. If you aren’t sure whether or not you will owe, you can complete and mail this IRS form requesting an extension."
+        expect(page.all(:css, '.slab--banner').length).to eq 1
+      end
     end
 
     context "when open for filing and after the deadline" do
-      around do |example|
-        Timecop.freeze(DateTime.new(2023, 4, 20))
-        example.run
-        Timecop.return
-      end
-
-      before do
-        allow(Rails.configuration).to receive(:start_of_open_intake).and_return(DateTime.new(2023, 1, 31))
-        allow(Rails.configuration).to receive(:tax_deadline).and_return(DateTime.new(2023, 4, 18))
-        allow(Rails.configuration).to receive(:end_of_intake).and_return(DateTime.new(2023, 10, 1))
-        allow(Rails.configuration).to receive(:end_of_login).and_return(DateTime.new(2023, 10, 15))
-      end
+      let(:current_time) { DateTime.new(2023, 4, 20) }
 
       scenario "shows the banner with closing date and document submission deadline" do
         visit "/"
 
         expect(page).to have_text "Get started with GetYourRefund by October 1st if you want to file with us in 2023. If your return is in progress, log in and submit your documents by October 8th."
+        expect(page.all(:css, '.slab--banner').length).to eq 1
       end
 
       scenario "shows the banner with closing date and document submission deadline with correctly formatted spanish dates" do

--- a/spec/features/visit_home_page_spec.rb
+++ b/spec/features/visit_home_page_spec.rb
@@ -20,6 +20,43 @@ RSpec.feature "Visit home page" do
     expect(page).to have_text I18n.t('views.questions.welcome.title')
   end
 
+  context "shows the correct date-dependent banners" do
+    xcontext "when closed for filing" do
+      scenario "shows the closed banner" do; end
+    end
+
+    xcontext "when open for filing and before the tax deadline" do
+      scenario "shows the document deadline banner?" do; end
+    end
+
+    context "when open for filing and after the deadline" do
+      around do |example|
+        Timecop.freeze(DateTime.new(2023, 4, 20))
+        example.run
+        Timecop.return
+      end
+
+      before do
+        allow(Rails.configuration).to receive(:start_of_open_intake).and_return(DateTime.new(2023, 1, 31))
+        allow(Rails.configuration).to receive(:tax_deadline).and_return(DateTime.new(2023, 4, 18))
+        allow(Rails.configuration).to receive(:end_of_intake).and_return(DateTime.new(2023, 10, 1))
+        allow(Rails.configuration).to receive(:end_of_login).and_return(DateTime.new(2023, 10, 15))
+      end
+
+      scenario "shows the banner with closing date and document submission deadline" do
+        visit "/"
+
+        expect(page).to have_text "Get started with GetYourRefund by October 1st if you want to file with us in 2023. If your return is in progress, log in and submit your documents by October 8th."
+      end
+
+      scenario "shows the banner with closing date and document submission deadline with correctly formatted spanish dates" do
+        visit "/es"
+
+        expect(page).to have_text "Comience con GetYourRefund antes del 1 de octubre si desea presentar su declaración con nosotros en 2023. Si su declaración está en curso, inicie sesión y envíe sus documentos antes del 8 de octubre."
+      end
+    end
+  end
+
   scenario "it has the correct SEO link tags in English" do
     visit "/en?source=test"
     # We are currently viewing the English homepage so the canonical URL is the English version.


### PR DESCRIPTION
2 things I would like checked:
1. did the language-dependent date stuff actually work and do we like it
2. did i correctly understand the dates that each banner should be shown and did it therefore make sense to change the end_of_login date per the [story](https://www.pivotaltracker.com/story/show/184967876)

1 thing i would like an opinion on:
1. should we add a feature spec? the part that feels uncovered is the logic for the document deadline banner and just the fact that we invoke any logic in the view at all (as far as i can tell there are no feature specs that look for these banners), but it is pretty simple so idk if worth it

a note: i repurposed the previous off season partial and controller method because they weren't used anywhere (offseason here meant "closed" so i changed the names to include "offseason filing")

english:
<img width="1310" alt="image" src="https://user-images.githubusercontent.com/43800769/232886564-27e0e180-7ae5-4024-a107-fa2d25904b90.png">

spanish:
<img width="1308" alt="image" src="https://user-images.githubusercontent.com/43800769/232886661-f6cbf535-0f21-44c6-a838-e52272597212.png">
