### PR TITLE
Patch will_paginate's `page` method to sanitize page param

### DIFF
--- a/app/controllers/hub/users_controller.rb
+++ b/app/controllers/hub/users_controller.rb
@@ -33,7 +33,7 @@ module Hub
                  end
       end
 
-      @users = @users.page(!params[:page].to_i.zero? ? params[:page] : 1)
+      @users = @users.page(params[:page])
     end
 
     def edit; end

--- a/config/initializers/pagination.rb
+++ b/config/initializers/pagination.rb
@@ -1,0 +1,13 @@
+module PaginationPatch
+  # defend against params[:page] being something other than a number
+  def page(page_number)
+    super(page_number.to_i.zero? ? 1 : page_number.to_i)
+  end
+end
+
+Rails.application.reloader.to_prepare do
+  klasses = [ActiveRecord::Relation, ActiveRecord::Associations::CollectionProxy]
+
+  # support pagination on associations and scopes
+  klasses.each { |klass| klass.send(:include, PaginationPatch) }
+end

--- a/spec/controllers/vita_providers_controller_spec.rb
+++ b/spec/controllers/vita_providers_controller_spec.rb
@@ -66,10 +66,7 @@ RSpec.describe VitaProvidersController do
         it "returns the first page of providers, not including archived records" do
           get :index, params: params
 
-          expect(assigns(:providers).size).to eq 5
-          local_providers.each do |provider|
-            expect(assigns(:providers)).to include provider
-          end
+          expect(assigns(:providers)).to match_array(local_providers)
         end
 
         it "sends provider_search event to mixpanel" do
@@ -117,10 +114,7 @@ RSpec.describe VitaProvidersController do
         it "returns the second page of providers" do
           get :index, params: params
 
-          expect(assigns(:providers).size).to eq 5
-          next_closest_providers.each do |provider|
-            expect(assigns(:providers)).to include provider
-          end
+          expect(assigns(:providers)).to match_array(next_closest_providers)
         end
 
         it "sends provider_search event to mixpanel with page number" do
@@ -148,6 +142,19 @@ RSpec.describe VitaProvidersController do
           get :index, params: params
 
           expect(assigns(:providers)).to eq([])
+        end
+      end
+
+      context "with more invalid page number" do
+        let!(:local_providers) { create_list :vita_provider, 5, :with_coordinates, lat_lon: [37.834519, -122.263273] }
+        let(:params) do
+          { zip: "94609", page: "1nvalid" }
+        end
+
+        it "shows first page of search results" do
+          get :index, params: params
+
+          expect(assigns(:providers)).to match_array(local_providers)
         end
       end
 


### PR DESCRIPTION
Now people who put `page=1nvalid` in the URL won't be able to cause a sentry error