### PR TITLE
GYR invitations: don't require admins to set a password

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -28,6 +28,27 @@ class Users::InvitationsController < Devise::InvitationsController
     super
   end
 
+  def update
+    if User.google_login_domain?(resource.email)
+      raw_invitation_token = update_resource_params[:invitation_token]
+      self.resource = accept_resource
+      invitation_accepted = resource.errors.empty?
+
+      if invitation_accepted
+        flash[:notice] = [
+          I18n.t('devise.invitations.updated'),
+          I18n.t("controllers.users.sessions_controller.must_use_admin_sign_in")
+        ].join("\n")
+        redirect_to new_user_session_path
+      else
+        resource.invitation_token = raw_invitation_token
+        render :edit
+      end
+    else
+      super
+    end
+  end
+
   private
 
   def user_already_exists?

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -62,7 +62,7 @@ class Users::InvitationsController < Devise::InvitationsController
 
   def load_and_authorize_role
     @role =
-      case params.dig(:user, :role)
+      case params.require(:user).permit(:role)[:role]
       when OrganizationLeadRole::TYPE
         OrganizationLeadRole.new(organization: @vita_partners.find(params.require(:organization_id)))
       when CoalitionLeadRole::TYPE

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -62,7 +62,7 @@ class Users::InvitationsController < Devise::InvitationsController
 
   def load_and_authorize_role
     @role =
-      case params.require(:user).permit(:role)[:role]
+      case params.dig(:user, :role)
       when OrganizationLeadRole::TYPE
         OrganizationLeadRole.new(organization: @vita_partners.find(params.require(:organization_id)))
       when CoalitionLeadRole::TYPE

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -13,8 +13,10 @@
       <%= f.hidden_field :invitation_token, readonly: true %>
       <%= f.cfa_input_field(:name, t(".name_label")) %>
       <%= f.cfa_select(:timezone, t("general.timezone"), timezone_select_options) %>
-      <%= f.cfa_input_field(:password, t(".password_label"), type: "password", help_text: t("views.passwords.password_help_text_html")) %>
-      <%= f.cfa_input_field(:password_confirmation, t(".password_confirmation_label"), type: "password") %>
+      <% unless User.google_login_domain?(resource.email) %>
+        <%= f.cfa_input_field(:password, t(".password_label"), type: "password", help_text: t("views.passwords.password_help_text_html")) %>
+        <%= f.cfa_input_field(:password_confirmation, t(".password_confirmation_label"), type: "password") %>
+      <% end %>
 
       <div>
         <%= f.submit t(".submit"), class: "button button--primary" %>

--- a/spec/features/hub/authenticate_spec.rb
+++ b/spec/features/hub/authenticate_spec.rb
@@ -121,16 +121,15 @@ RSpec.feature "Logging in and out to the volunteer portal" do
   end
 
   context "when signing in with Google" do
-    before do
-      create(:admin_user, email: "example@codeforamerica.org")
+    let!(:admin) { create(:admin_user, email: "example@codeforamerica.org") }
+
+    around do |example|
       OmniAuth.config.test_mode = true
       OmniAuth.config.add_mock(
         :google_oauth2,
         { uid: '12345', info: { email: "example@codeforamerica.org" }, extra: { id_info: { hd: "codeforamerica.org" } } }
       )
-    end
-
-    after do
+      example.run
       OmniAuth.config.test_mode = false
       OmniAuth.config.mock_auth[:google_oauth2] = nil
     end

--- a/spec/features/hub/authenticate_spec.rb
+++ b/spec/features/hub/authenticate_spec.rb
@@ -124,7 +124,6 @@ RSpec.feature "Logging in and out to the volunteer portal" do
     let!(:admin) { create(:admin_user, email: "example@codeforamerica.org") }
 
     around do |example|
-      OmniAuth.config.test_mode = true
       OmniAuth.config.add_mock(
         :google_oauth2,
         { uid: '12345', info: { email: "example@codeforamerica.org" }, extra: { id_info: { hd: "codeforamerica.org" } } }

--- a/spec/features/hub/invitations/admin_spec.rb
+++ b/spec/features/hub/invitations/admin_spec.rb
@@ -10,13 +10,11 @@ RSpec.feature "Inviting admin users" do
     end
 
     around do |example|
-      OmniAuth.config.test_mode = true
       OmniAuth.config.add_mock(
         :google_oauth2,
         { uid: oauth_uid, info: { email: "aileen@codeforamerica.org" }, extra: { id_info: { hd: "codeforamerica.org" } } }
       )
       example.run
-      OmniAuth.config.test_mode = false
       OmniAuth.config.mock_auth[:google_oauth2] = nil
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -137,7 +137,7 @@ RSpec.configure do |config|
     allow(fake_dns).to receive(:open) { raise StandardError, "Cannot use DNS from test suite" }
     allow(fake_dns).to receive(:close)
     allow(Resolv::DNS).to receive(:new).and_return(fake_dns)
-
+    OmniAuth.config.test_mode = true
   end
 
   if config.filter.rules[:flow_explorer_screenshot]


### PR DESCRIPTION
after accepting the invitation, admins are required to click 'sign in as admin' to auth with google