### PR TITLE
Add Retry Logic for Intercom

### DIFF
--- a/app/services/intercom_service.rb
+++ b/app/services/intercom_service.rb
@@ -134,7 +134,14 @@ class IntercomService
       Rails.logger.debug("Calling Intercom: #{collection}.#{verb}(#{params})")
     end
 
-    result = intercom.send(collection).send(verb, params)
+    retry_counts = 0
+
+    begin
+      result = intercom.send(collection).send(verb, params)
+    rescue
+      retry_counts += 1
+      retry if retry_counts < 3
+    end
 
     if Rails.env.development?
       Rails.logger.debug("Intercom provided response: #{result.inspect}")

--- a/app/services/intercom_service.rb
+++ b/app/services/intercom_service.rb
@@ -141,8 +141,9 @@ class IntercomService
     begin
       result = intercom.send(collection).send(verb, params)
     rescue
-      retry_counts += 1
-      retry if retry_counts < MAX_RETRY_COUNT
+      Intercom::AuthenticationError => e
+        retry_counts += 1
+        retry if retry_counts <= MAX_RETRY_COUNT
     end
 
     if Rails.env.development?

--- a/app/services/intercom_service.rb
+++ b/app/services/intercom_service.rb
@@ -133,7 +133,9 @@ class IntercomService
     if Rails.env.development?
       Rails.logger.debug("Calling Intercom: #{collection}.#{verb}(#{params})")
     end
+
     result = intercom.send(collection).send(verb, params)
+
     if Rails.env.development?
       Rails.logger.debug("Intercom provided response: #{result.inspect}")
     end

--- a/app/services/intercom_service.rb
+++ b/app/services/intercom_service.rb
@@ -143,11 +143,13 @@ class IntercomService
     rescue
       Intercom::AuthenticationError => e
         retry_counts += 1
+        DatadogApi.increment("intercom.api.authentication_failure_retry")
         retry if retry_counts <= MAX_RETRY_COUNT
+        raise e, "Failed #{MAX_RETRY_COUNT} times to authenticate with Intercom"
     end
 
     if Rails.env.development?
-      Rails.logger.debug("Intercom provided response: #{result.inspect}")
+      Rails.logger.debug("Intercom provided response for call: #{result.inspect}")
     end
     result
   end

--- a/app/services/intercom_service.rb
+++ b/app/services/intercom_service.rb
@@ -129,6 +129,8 @@ class IntercomService
     @intercom ||= Intercom::Client.new(token: EnvironmentCredentials.dig(:intercom, :intercom_access_token))
   end
 
+  MAX_RETRY_COUNT = 3
+
   def self.intercom_api(collection, verb, params)
     if Rails.env.development?
       Rails.logger.debug("Calling Intercom: #{collection}.#{verb}(#{params})")
@@ -140,7 +142,7 @@ class IntercomService
       result = intercom.send(collection).send(verb, params)
     rescue
       retry_counts += 1
-      retry if retry_counts < 3
+      retry if retry_counts < MAX_RETRY_COUNT
     end
 
     if Rails.env.development?

--- a/app/validators/e164_phone_validator.rb
+++ b/app/validators/e164_phone_validator.rb
@@ -3,7 +3,7 @@ class E164PhoneValidator < ActiveModel::EachValidator
   # This may occur in a form, or in a before_validation hook, etc.
   def validate_each(record, attr_name, value)
     return if value&.valid_encoding? && value =~ /\A\+1\d{10}\z/ && Phony.plausible?(value)
-
+    Rails.logger.warn("Bade number jlkjflkasdjfl")
     record.errors.add(attr_name, I18n.t("errors.attributes.phone_number.invalid"))
   end
 end

--- a/app/validators/e164_phone_validator.rb
+++ b/app/validators/e164_phone_validator.rb
@@ -3,7 +3,7 @@ class E164PhoneValidator < ActiveModel::EachValidator
   # This may occur in a form, or in a before_validation hook, etc.
   def validate_each(record, attr_name, value)
     return if value&.valid_encoding? && value =~ /\A\+1\d{10}\z/ && Phony.plausible?(value)
-    Rails.logger.warn("Bade number jlkjflkasdjfl")
+
     record.errors.add(attr_name, I18n.t("errors.attributes.phone_number.invalid"))
   end
 end

--- a/spec/services/intercom_service_spec.rb
+++ b/spec/services/intercom_service_spec.rb
@@ -249,7 +249,7 @@ RSpec.describe IntercomService do
       before do
         allow(fake_intercom.messages).to receive(:create).with(params) {
           raise Intercom::AuthenticationError.new("fake error")
-        }.exactly(3).times
+        }.exactly(4).times
       end
 
       it "retries to send the last message" do

--- a/spec/services/intercom_service_spec.rb
+++ b/spec/services/intercom_service_spec.rb
@@ -249,13 +249,13 @@ RSpec.describe IntercomService do
       before do
         allow(fake_intercom.messages).to receive(:create).with(params) {
           raise Intercom::AuthenticationError.new("fake error")
-        }
+        }.exactly(3).times
       end
 
       it "retries to send the last message" do
         expect {
           described_class.intercom_api(:messages, :create, params)
-        }.not_to raise_exception(Intercom::AuthenticationError)
+        }.not_to raise_exception
       end
     end
   end


### PR DESCRIPTION
A naive approach of doing some retries against Intercom in the event of an authentication failure.