### PR TITLE
Ignore Intake#vita_partner_name (to be dropped later)

### DIFF
--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -253,7 +253,6 @@
 #  usps_address_late_verification_attempts              :integer          default(0)
 #  usps_address_verified_at                             :datetime
 #  viewed_at_capacity                                   :boolean          default(FALSE)
-#  vita_partner_name                                    :string
 #  wants_to_itemize                                     :integer          default(0), not null
 #  was_blind                                            :integer          default(0), not null
 #  was_full_time_student                                :integer          default(0), not null
@@ -642,5 +641,5 @@ class Intake < ApplicationRecord
   delegate *archived_columns, to: :intake_archive, allow_nil: true
   has_one :intake_archive, foreign_key: :id, dependent: :destroy
 
-  self.ignored_columns = ["primary_consented_to_service_at"] + archived_columns
+  self.ignored_columns = ["primary_consented_to_service_at", "vita_partner_name"] + archived_columns
 end

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -253,7 +253,6 @@
 #  usps_address_late_verification_attempts              :integer          default(0)
 #  usps_address_verified_at                             :datetime
 #  viewed_at_capacity                                   :boolean          default(FALSE)
-#  vita_partner_name                                    :string
 #  wants_to_itemize                                     :integer          default(0), not null
 #  was_blind                                            :integer          default("unfilled"), not null
 #  was_full_time_student                                :integer          default(0), not null

--- a/app/models/intake/gyr_intake.rb
+++ b/app/models/intake/gyr_intake.rb
@@ -253,7 +253,6 @@
 #  usps_address_late_verification_attempts              :integer          default(0)
 #  usps_address_verified_at                             :datetime
 #  viewed_at_capacity                                   :boolean          default(FALSE)
-#  vita_partner_name                                    :string
 #  wants_to_itemize                                     :integer          default("unfilled"), not null
 #  was_blind                                            :integer          default("unfilled"), not null
 #  was_full_time_student                                :integer          default("unfilled"), not null

--- a/spec/factories/intakes.rb
+++ b/spec/factories/intakes.rb
@@ -222,7 +222,6 @@ FactoryBot.define do
     city { "San Francisco" }
     state { "CA" }
     state_of_residence { state }
-    vita_partner_name { vita_partner.name }
     routing_value { "az" }
     routing_criteria { "state" }
     job_count { [1, 2, 3].sample }

--- a/spec/models/intake/gyr_intake_spec.rb
+++ b/spec/models/intake/gyr_intake_spec.rb
@@ -253,7 +253,6 @@
 #  usps_address_late_verification_attempts              :integer          default(0)
 #  usps_address_verified_at                             :datetime
 #  viewed_at_capacity                                   :boolean          default(FALSE)
-#  vita_partner_name                                    :string
 #  wants_to_itemize                                     :integer          default("unfilled"), not null
 #  was_blind                                            :integer          default("unfilled"), not null
 #  was_full_time_student                                :integer          default("unfilled"), not null

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -253,7 +253,6 @@
 #  usps_address_late_verification_attempts              :integer          default(0)
 #  usps_address_verified_at                             :datetime
 #  viewed_at_capacity                                   :boolean          default(FALSE)
-#  vita_partner_name                                    :string
 #  wants_to_itemize                                     :integer          default(0), not null
 #  was_blind                                            :integer          default(0), not null
 #  was_full_time_student                                :integer          default(0), not null


### PR DESCRIPTION
This is nil on every single intake in our database, archived and not.

In real life the name is retrievable through the `vita_partner` association (which is actually on `client`)