### PR TITLE
Fix regression where we couldn't delete a client with any document_requests attached

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -72,6 +72,8 @@ class Client < ApplicationRecord
   has_one :data_science_click_history, :class_name => 'DataScience::ClickHistory', dependent: :destroy
   has_many :analytics_events, dependent: :destroy
   has_many :documents, dependent: :destroy
+  # We don't create documents_requests anymore but need the `dependent: destroy` if clients with them get deleted
+  has_many :documents_requests, dependent: :destroy
   has_one :intake, inverse_of: :client, dependent: :destroy
   has_one :consent, dependent: :destroy
   has_many :outgoing_text_messages, dependent: :destroy

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -429,6 +429,8 @@ describe Client do
       let!(:outgoing_text_message) { create(:outgoing_text_message, client: client) }
       let!(:bulk_client_sms) { BulkClientMessageOutgoingTextMessage.create(outgoing_text_message: outgoing_text_message) }
       before do
+        doc_request = DocumentsRequest.create(client: client)
+        create :document, client: client, intake: intake, documents_request_id: doc_request.id
         create_list :document, 2, client: client, intake: intake
         create_list :dependent, 2, intake: intake
         tax_return = create :gyr_tax_return, client: client, assigned_user: user, tax_return_selections: [tax_return_selection]


### PR DESCRIPTION
We've eliminated this table in a recent redesign/refactor but old clients still have these records