### PR TITLE
Make ApplicationRecord.enum_with_validation the default behavior for enum

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -4,8 +4,8 @@ class ApplicationRecord < ActiveRecord::Base
   # Allow counting up to a max number; see https://alexcastano.com/the-hidden-cost-of-the-invisible-queries-in-rails/#how-far-do-you-plan-to-count
   scope :count_greater_than?, ->(n) { limit(n + 1).count > n }
 
-  def self.enum_with_validation(**enums)
-    enum **enums
+  def self.enum(**enums)
+    super
 
     enums.each do |enum_name, _|
       mapping = defined_enums[enum_name.to_s]
@@ -15,7 +15,7 @@ class ApplicationRecord < ActiveRecord::Base
         EnumTypeWithoutValidValueAssertion.new(enum_name, mapping, subtype)
       end
 
-      validates_inclusion_of enum_name, { in: mapping.keys + mapping.values }
+      validates_inclusion_of enum_name, { in: mapping.keys + mapping.values, allow_blank: true }
     end
   end
 end

--- a/app/models/faq_survey.rb
+++ b/app/models/faq_survey.rb
@@ -14,5 +14,5 @@
 #  index_faq_surveys_on_visitor_id_and_question_key  (visitor_id,question_key)
 #
 class FaqSurvey < ApplicationRecord
-  enum_with_validation answer: { unfilled: 0, positive: 1, neutral: 2, negative: 3 }, _prefix: :answer
+  enum answer: { unfilled: 0, positive: 1, neutral: 2, negative: 3 }, _prefix: :answer
 end

--- a/spec/forms/ctc/filed_prior_tax_year_form_spec.rb
+++ b/spec/forms/ctc/filed_prior_tax_year_form_spec.rb
@@ -25,10 +25,10 @@ describe Ctc::FiledPriorTaxYearForm do
 
     context "when filed_2019 is not in the set" do
       let(:filed_prior_tax_year) { "on_the_moon" }
-      it "is not valid" do
-        expect {
-          described_class.new(intake, params).save
-        }.to raise_error ArgumentError
+
+      it "is not saved" do
+        form = described_class.new(intake, params)
+        expect { form.save }.not_to change { intake.reload.filed_prior_tax_year }
       end
     end
   end

--- a/spec/forms/ctc/spouse_filed_prior_tax_year_form_spec.rb
+++ b/spec/forms/ctc/spouse_filed_prior_tax_year_form_spec.rb
@@ -25,10 +25,10 @@ describe Ctc::SpouseFiledPriorTaxYearForm do
 
     context "when spouse_filed_prior_tax_year is not part of the expected value set" do
       let(:filed_prior_year) { "on_the_moon" }
-      it "is not valid" do
-        expect {
-          described_class.new(intake, params).save
-        }.to raise_error ArgumentError
+
+      it "is not saved" do
+        form = described_class.new(intake, params)
+        expect { form.save }.not_to change { intake.reload.spouse_filed_prior_tax_year }
       end
     end
   end

--- a/spec/models/application_record_spec.rb
+++ b/spec/models/application_record_spec.rb
@@ -7,11 +7,11 @@ describe ApplicationRecord do
                  # Using arbitrary table and column name from the real schema
                  def self.table_name; "intakes"; end
 
-                 enum_with_validation paid_self_employment_expenses: { unfilled: 0, yes: 1, no: 2 }, _prefix: :paid_self_employment_expenses
+                 enum paid_self_employment_expenses: { unfilled: 0, yes: 1, no: 2 }, _prefix: :paid_self_employment_expenses
                end)
   end
 
-  describe '#enum_with_validation' do
+  describe '.enum' do
     context "when setting a valid value" do
       it "is valid and has the value" do
         record = ValidatingEnumRecord.new(paid_self_employment_expenses: 1)


### PR DESCRIPTION
By default in Rails if you assign an arbitrary string to an enum you will get an 'ArgumentError', which is annoying because security scanners can post all sorts of nonsense that create Sentry items for us to deal with.

Previously we piloted `enum_with_validation` for this, but we may as well just push that behavior into the default `enum` so we don't have to think about it.