### PR TITLE
Handle ArgumentError 'string contains null byte' uniformly across the app by responding 400

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -494,4 +494,16 @@ class ApplicationController < ActionController::Base
       format.any { head 400 }
     end
   end
+
+  rescue_from 'ArgumentError' do |error|
+    respond_to do |format|
+      format.any do
+        if error.message == "string contains null byte"
+          head 400
+        else
+          raise
+        end
+      end
+    end
+  end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -41,16 +41,4 @@ class Users::SessionsController < Devise::SessionsController
       redirect_to new_user_session_path
     end
   end
-
-  rescue_from 'ArgumentError' do |error|
-    respond_to do |format|
-      format.any do
-        if error.message == "string contains null byte"
-          head 400
-        else
-          raise
-        end
-      end
-    end
-  end
 end


### PR DESCRIPTION
these are always from security scans / manipulated requests, we should be able to ignore them safely