### PR TITLE
Fix crash with VITA providers map

### DIFF
--- a/app/controllers/vita_providers_controller.rb
+++ b/app/controllers/vita_providers_controller.rb
@@ -47,7 +47,7 @@ class VitaProvidersController < ApplicationController
   end
 
   def map
-    @provider = VitaProvider.find(params[:id])
+    @provider = VitaProvider.find_by_id(params[:id])
     track_provider_page_map_click
 
     redirect_to @provider.google_maps_url, allow_other_host: true

--- a/spec/controllers/vita_providers_controller_spec.rb
+++ b/spec/controllers/vita_providers_controller_spec.rb
@@ -265,5 +265,18 @@ RSpec.describe VitaProvidersController do
       }
       expect(subject).to have_received(:send_mixpanel_event).with(event_name: "provider_page_map_click", data: expected_data)
     end
+
+    it "fails to look up multiple providers at once" do
+      other_provider = create(:vita_provider, :with_coordinates)
+      get :map, params: { id: [provider.id, other_provider.id] }
+      ap response
+      expect(response).to have_http_status(:ok)
+
+      expected_data = {
+        provider_id: provider.id.to_s,
+        provider_name: "Public Library of the Test Suite",
+      }
+      expect(subject).to have_received(:send_mixpanel_event).with(event_name: "provider_page_map_click", data: expected_data)
+    end
   end
 end


### PR DESCRIPTION
- Add failing test case of multiple params
- Patch and confirm that we use 'find_by_id' for maps
