### PR TITLE
Fix crash when validating primary birthdate on consent or personal info controllers

### DIFF
--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -15,7 +15,7 @@ module DateHelper
     end
 
     if parsed_birth_date.year < 1900 || parsed_birth_date.year > Date.today.year
-      self.errors.add(key, I18n.t('errors.attributes.birth_date.blank'))
+      self.errors.add(:birth_date, I18n.t("helpers.birth_date_helper.valid_birth_date"))
       return false
     end
 

--- a/spec/forms/consent_form_spec.rb
+++ b/spec/forms/consent_form_spec.rb
@@ -64,6 +64,18 @@ RSpec.describe ConsentForm do
           expect(form.errors[:birth_date]).to include "Please select a valid date"
         end
       end
+
+      context "when the date is too old" do
+        let(:params) { valid_params_with_dob.merge(birth_date_year: "1885") }
+
+        it "adds a validation error" do
+          form = ConsentForm.new(intake, params)
+
+          expect(form).not_to be_valid
+          expect(form.errors[:birth_date]).to be_present
+          expect(form.errors[:birth_date]).to include "Please select a valid date"
+        end
+      end
     end
 
     context "not triaged client" do


### PR DESCRIPTION
If the form is posted with a birth year earlier than 1900 or later than the present year, it would crash.

Real users won't enter those values but we still gotta stop them from crashing anyway.