### PR TITLE
Ensure that bulk tax return assignment is to an authorized assignee

### DIFF
--- a/app/forms/hub/bulk_action_form.rb
+++ b/app/forms/hub/bulk_action_form.rb
@@ -25,7 +25,7 @@ module Hub
     end
 
     def assigned_user
-      return if assigned_user_id.nil? || assigned_user_id.to_i.zero?
+      return if assigned_user_id.nil? || [BulkTaxReturnUpdate::KEEP, BulkTaxReturnUpdate::REMOVE].include?(assigned_user_id)
 
       @assigned_user ||= User.find_by_id(assigned_user_id)
     end

--- a/spec/controllers/hub/bulk_actions/change_assignee_and_status_controller_spec.rb
+++ b/spec/controllers/hub/bulk_actions/change_assignee_and_status_controller_spec.rb
@@ -107,6 +107,17 @@ RSpec.describe Hub::BulkActions::ChangeAssigneeAndStatusController do
         end
       end
 
+      context "when new assignee is a non-assignable user" do
+        let(:new_assigned_user_id) { create(:team_member_user, name: "The Unassignable User").id }
+
+        it "does not persist the tax return, renders new and flashes an error" do
+          expect do
+            put :update, params: params
+          end.not_to change { team_member.notifications.count }
+          expect(response).to be_forbidden
+        end
+      end
+
       context "an unauthorized user" do
         let(:unauthorized_team_member) { create :user, role: create(:team_member_role, site: create(:site)) }
 


### PR DESCRIPTION
We only list authorized assignees in the dropdown and this also checks that a different ID wasn't manually changed in the html