### PR TITLE
Drop Intake#vita_partner_name

### DIFF
--- a/db/migrate/20230530183039_drop_vita_partner_name_from_intakes.rb
+++ b/db/migrate/20230530183039_drop_vita_partner_name_from_intakes.rb
@@ -1,0 +1,5 @@
+class DropVitaPartnerNameFromIntakes < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured { remove_column :intakes, :vita_partner_name, :string }
+  end
+end

--- a/db/migrate/20230530183601_create_data_migrations.rb
+++ b/db/migrate/20230530183601_create_data_migrations.rb
@@ -1,0 +1,7 @@
+class CreateDataMigrations < ActiveRecord::Migration[7.0]
+  def change
+    unless table_exists?(:data_migrations)
+      create_table :data_migrations, primary_key: 'version', id: :string
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_25_230120) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_30_183601) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -1319,7 +1319,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_25_230120) do
     t.boolean "viewed_at_capacity", default: false
     t.string "visitor_id"
     t.bigint "vita_partner_id"
-    t.string "vita_partner_name"
     t.integer "wants_to_itemize", default: 0, null: false
     t.integer "was_blind", default: 0, null: false
     t.integer "was_full_time_student", default: 0, null: false


### PR DESCRIPTION
it is not used, we use Client#vita_partner_id

also make a migration to create the data_migrations table if it doesn't exist so the schema will thrash less