### PR TITLE
TeamMember/SiteCoordinator roles can have many sites

### DIFF
--- a/app/controllers/concerns/tax_return_assignable_users.rb
+++ b/app/controllers/concerns/tax_return_assignable_users.rb
@@ -3,16 +3,16 @@ module TaxReturnAssignableUsers
     assignable_users = included_users
     if client.vita_partner.present?
       if client.vita_partner.site?
-        team_members = User.where(role: TeamMemberRole.where(site: client.vita_partner))
-        site_coordinators = User.where(role: SiteCoordinatorRole.where(site: client.vita_partner))
+        team_members = User.where(role: TeamMemberRole.joins(:sites).where(vita_partners: client.vita_partner))
+        site_coordinators = User.where(role: SiteCoordinatorRole.joins(:sites).where(vita_partners: client.vita_partner))
         org_leads = User.where(role: OrganizationLeadRole.where(organization: client.vita_partner.parent_organization))
         assignable_users += team_members.or(site_coordinators).or(org_leads).active.order(name: :asc)
       else
         # client.vita_partner is an organization
         # include all team and site members under the org
         child_sites = VitaPartner.sites.where(parent_organization: client.vita_partner)
-        org_team_members = User.where(role: TeamMemberRole.where(site: child_sites))
-        org_site_coordinators = User.where(role: SiteCoordinatorRole.where(site: child_sites))
+        org_team_members = User.where(role: TeamMemberRole.joins(:sites).where(vita_partners: child_sites))
+        org_site_coordinators = User.where(role: SiteCoordinatorRole.joins(:sites).where(vita_partners: child_sites))
         org_leads = User.where(role: OrganizationLeadRole.where(organization: client.vita_partner))
         assignable_users += org_leads.or(org_team_members).or(org_site_coordinators).active.order(name: :asc)
       end

--- a/app/controllers/hub/users_controller.rb
+++ b/app/controllers/hub/users_controller.rb
@@ -140,13 +140,13 @@ module Hub
         when AdminRole::TYPE
           AdminRole.new
         when SiteCoordinatorRole::TYPE
-          SiteCoordinatorRole.new(sites: [@vita_partners.find(params.require(:site_id))])
+          SiteCoordinatorRole.new(sites: @vita_partners.sites.where(id: JSON.parse(params.require(:sites)).pluck('id')))
         when ClientSuccessRole::TYPE
           ClientSuccessRole.new
         when GreeterRole::TYPE
           GreeterRole.new
         when TeamMemberRole::TYPE
-          TeamMemberRole.new(sites: [@vita_partners.sites.find(params.require(:site_id))])
+          TeamMemberRole.new(sites: @vita_partners.sites.where(id: JSON.parse(params.require(:sites)).pluck('id')))
         end
 
       authorize!(:create, @role)

--- a/app/controllers/hub/users_controller.rb
+++ b/app/controllers/hub/users_controller.rb
@@ -23,8 +23,8 @@ module Hub
                    if vita_partner.is_a?(Organization)
                      @users.where(role: OrganizationLeadRole.where(organization: vita_partner))
                    elsif vita_partner.is_a?(Site)
-                     @users.where(role: SiteCoordinatorRole.where(site: vita_partner))
-                           .or(@users.where(role: TeamMemberRole.where(site: vita_partner)))
+                     @users.where(role: SiteCoordinatorRole.joins(:sites).where(vita_partners: vita_partner))
+                           .or(@users.where(role: TeamMemberRole.joins(:sites).where(vita_partners: vita_partner)))
                    elsif vita_partner.is_a?(Coalition)
                      @users.where(role: CoalitionLeadRole.where(coalition: vita_partner))
                    end

--- a/app/controllers/hub/users_controller.rb
+++ b/app/controllers/hub/users_controller.rb
@@ -140,13 +140,13 @@ module Hub
         when AdminRole::TYPE
           AdminRole.new
         when SiteCoordinatorRole::TYPE
-          SiteCoordinatorRole.new(site: @vita_partners.find(params.require(:site_id)))
+          SiteCoordinatorRole.new(sites: [@vita_partners.find(params.require(:site_id))])
         when ClientSuccessRole::TYPE
           ClientSuccessRole.new
         when GreeterRole::TYPE
           GreeterRole.new
         when TeamMemberRole::TYPE
-          TeamMemberRole.new(site: @vita_partners.sites.find(params.require(:site_id)))
+          TeamMemberRole.new(sites: [@vita_partners.sites.find(params.require(:site_id))])
         end
 
       authorize!(:create, @role)

--- a/app/controllers/hub/users_controller.rb
+++ b/app/controllers/hub/users_controller.rb
@@ -140,13 +140,13 @@ module Hub
         when AdminRole::TYPE
           AdminRole.new
         when SiteCoordinatorRole::TYPE
-          SiteCoordinatorRole.new(sites: @vita_partners.sites.where(id: JSON.parse(params.require(:sites)).pluck('id')))
+          SiteCoordinatorRole.new(sites: @vita_partners.sites.where(id: JSON.parse(params[:sites].presence || '[]').pluck('id')))
         when ClientSuccessRole::TYPE
           ClientSuccessRole.new
         when GreeterRole::TYPE
           GreeterRole.new
         when TeamMemberRole::TYPE
-          TeamMemberRole.new(sites: @vita_partners.sites.where(id: JSON.parse(params.require(:sites)).pluck('id')))
+          TeamMemberRole.new(sites: @vita_partners.sites.where(id: JSON.parse(params[:sites].presence || '[]').pluck('id')))
         end
 
       authorize!(:create, @role)

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -61,23 +61,7 @@ class Users::InvitationsController < Devise::InvitationsController
   end
 
   def load_and_authorize_role
-    @role =
-      case params.dig(:user, :role)
-      when OrganizationLeadRole::TYPE
-        OrganizationLeadRole.new(organization: @vita_partners.find(params.require(:organization_id)))
-      when CoalitionLeadRole::TYPE
-        CoalitionLeadRole.new(coalition: @coalitions.find(params.require(:coalition_id)))
-      when AdminRole::TYPE
-        AdminRole.new
-      when SiteCoordinatorRole::TYPE
-        SiteCoordinatorRole.new(sites: @vita_partners.sites.where(id: JSON.parse(params[:sites].presence || '[]').pluck('id')))
-      when ClientSuccessRole::TYPE
-        ClientSuccessRole.new
-      when GreeterRole::TYPE
-        GreeterRole.new
-      when TeamMemberRole::TYPE
-        TeamMemberRole.new(sites: @vita_partners.sites.where(id: JSON.parse(params[:sites].presence || '[]').pluck('id')))
-      end
+    @role = role_from_params(params.dig(:user, :role), params)
 
     authorize!(:create, @role)
   end

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -70,13 +70,13 @@ class Users::InvitationsController < Devise::InvitationsController
       when AdminRole::TYPE
         AdminRole.new
       when SiteCoordinatorRole::TYPE
-        SiteCoordinatorRole.new(sites: @vita_partners.sites.where(id: JSON.parse(params.require(:sites)).pluck('id')))
+        SiteCoordinatorRole.new(sites: @vita_partners.sites.where(id: JSON.parse(params[:sites].presence || '[]').pluck('id')))
       when ClientSuccessRole::TYPE
         ClientSuccessRole.new
       when GreeterRole::TYPE
         GreeterRole.new
       when TeamMemberRole::TYPE
-        TeamMemberRole.new(sites: @vita_partners.sites.where(id: JSON.parse(params.require(:sites)).pluck('id')))
+        TeamMemberRole.new(sites: @vita_partners.sites.where(id: JSON.parse(params[:sites].presence || '[]').pluck('id')))
       end
 
     authorize!(:create, @role)

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -1,5 +1,6 @@
 class Users::InvitationsController < Devise::InvitationsController
   include AccessControllable
+  include RoleHelper
 
   # Devise::InvitationsController from devise-invitable uses some before_actions to validate
   # data being passed in. We skip those and use our before_action methods to customize

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -70,13 +70,13 @@ class Users::InvitationsController < Devise::InvitationsController
       when AdminRole::TYPE
         AdminRole.new
       when SiteCoordinatorRole::TYPE
-        SiteCoordinatorRole.new(site: @vita_partners.find(params.require(:site_id)))
+        SiteCoordinatorRole.new(sites: [@vita_partners.find(params.require(:site_id))])
       when ClientSuccessRole::TYPE
         ClientSuccessRole.new
       when GreeterRole::TYPE
         GreeterRole.new
       when TeamMemberRole::TYPE
-        TeamMemberRole.new(site: @vita_partners.sites.find(params.require(:site_id)))
+        TeamMemberRole.new(sites: [@vita_partners.sites.find(params.require(:site_id))])
       end
 
     authorize!(:create, @role)

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -70,13 +70,13 @@ class Users::InvitationsController < Devise::InvitationsController
       when AdminRole::TYPE
         AdminRole.new
       when SiteCoordinatorRole::TYPE
-        SiteCoordinatorRole.new(sites: [@vita_partners.find(params.require(:site_id))])
+        SiteCoordinatorRole.new(sites: @vita_partners.sites.where(id: JSON.parse(params.require(:sites)).pluck('id')))
       when ClientSuccessRole::TYPE
         ClientSuccessRole.new
       when GreeterRole::TYPE
         GreeterRole.new
       when TeamMemberRole::TYPE
-        TeamMemberRole.new(sites: [@vita_partners.sites.find(params.require(:site_id))])
+        TeamMemberRole.new(sites: @vita_partners.sites.where(id: JSON.parse(params.require(:sites)).pluck('id')))
       end
 
     authorize!(:create, @role)

--- a/app/helpers/role_helper.rb
+++ b/app/helpers/role_helper.rb
@@ -33,9 +33,11 @@ module RoleHelper
   def role_from_params(role_string, params)
     case role_string
     when OrganizationLeadRole::TYPE
-      OrganizationLeadRole.new(organization: @vita_partners.find(params.require(:organization_id)))
+      role_params = params[:organization_id].present? ? { organization: @vita_partners.find(params[:organization_id]) } : {}
+      OrganizationLeadRole.new(role_params)
     when CoalitionLeadRole::TYPE
-      CoalitionLeadRole.new(coalition: @coalitions.find(params.require(:coalition_id)))
+      role_params = params[:coalition_id].present? ? { coalition: @coalitions.find(params[:coalition_id]) } : {}
+      CoalitionLeadRole.new(role_params)
     when AdminRole::TYPE
       AdminRole.new
     when SiteCoordinatorRole::TYPE

--- a/app/helpers/role_helper.rb
+++ b/app/helpers/role_helper.rb
@@ -57,7 +57,7 @@ module RoleHelper
     elsif user.role_type == CoalitionLeadRole::TYPE
       user.role.coalition.name
     elsif user.role_type == SiteCoordinatorRole::TYPE || user.role_type == TeamMemberRole::TYPE
-      user.role.site.name
+      user.role.sites.map(&:name).join(", ")
     end
   end
 end

--- a/app/helpers/role_helper.rb
+++ b/app/helpers/role_helper.rb
@@ -30,6 +30,25 @@ module RoleHelper
     @_role_names_for_role_type[I18n.locale][role_type] = result
   end
 
+  def role_from_params(role_string, params)
+    case role_string
+    when OrganizationLeadRole::TYPE
+      OrganizationLeadRole.new(organization: @vita_partners.find(params.require(:organization_id)))
+    when CoalitionLeadRole::TYPE
+      CoalitionLeadRole.new(coalition: @coalitions.find(params.require(:coalition_id)))
+    when AdminRole::TYPE
+      AdminRole.new
+    when SiteCoordinatorRole::TYPE
+      SiteCoordinatorRole.new(sites: @vita_partners.sites.where(id: JSON.parse(params[:sites].presence || '[]').pluck('id')))
+    when ClientSuccessRole::TYPE
+      ClientSuccessRole.new
+    when GreeterRole::TYPE
+      GreeterRole.new
+    when TeamMemberRole::TYPE
+      TeamMemberRole.new(sites: @vita_partners.sites.where(id: JSON.parse(params[:sites].presence || '[]').pluck('id')))
+    end
+  end
+
   def role_type_from_role_name(role_name)
     return nil unless role_name.present?
 

--- a/app/helpers/tagging_helper.rb
+++ b/app/helpers/tagging_helper.rb
@@ -11,6 +11,12 @@ module TaggingHelper
     taggable_vita_partners.to_json.to_s.html_safe
   end
 
+  def taggable_sites(vita_partners)
+    vita_partners.sites.includes(:parent_organization).map do |site|
+      { id: site.id, name: site.name, parentName: site.parent_organization.name, value: site.id }
+    end.to_json.to_s.html_safe
+  end
+
   def taggable_states(state_abbreviations)
     state_abbreviations.map { |abbreviation| { value: abbreviation, name: States.name_for_key(abbreviation)} }.to_json.html_safe
   end

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -88,8 +88,12 @@ class Ability
 
     if user.role_type == SiteCoordinatorRole::TYPE
       # Site coordinators can create site coordinators and team members in their site
-      can :manage, SiteCoordinatorRole, sites: user.role.sites
-      can :manage, TeamMemberRole, sites: user.role.sites
+      can :manage, SiteCoordinatorRole do |role|
+        user.role.sites.map.any? { |site| role.sites.map(&:id).include? site.id }
+      end
+      can :manage, TeamMemberRole do |role|
+        user.role.sites.map.any? { |site| role.sites.map(&:id).include? site.id }
+      end
     end
   end
 end

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -88,8 +88,8 @@ class Ability
 
     if user.role_type == SiteCoordinatorRole::TYPE
       # Site coordinators can create site coordinators and team members in their site
-      can :manage, SiteCoordinatorRole, site: user.role.site
-      can :manage, TeamMemberRole, site: user.role.site
+      can :manage, SiteCoordinatorRole, site: user.role.sites
+      can :manage, TeamMemberRole, site: user.role.sites
     end
   end
 end

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -71,8 +71,8 @@ class Ability
       # Coalition leads can create coalition leads, organization leads, site coordinators, and team members in their coalition
       can :manage, CoalitionLeadRole, coalition: user.role.coalition
       can :manage, OrganizationLeadRole, organization: { coalition_id: user.role.coalition_id }
-      can :manage, SiteCoordinatorRole, site: { parent_organization: { coalition: user.role.coalition } }
-      can :manage, TeamMemberRole, site: { parent_organization: { coalition: user.role.coalition } }
+      can :manage, SiteCoordinatorRole, sites: { parent_organization: { coalition: user.role.coalition } }
+      can :manage, TeamMemberRole, sites: { parent_organization: { coalition: user.role.coalition } }
     end
 
     if user.role_type == OrganizationLeadRole::TYPE
@@ -82,14 +82,14 @@ class Ability
 
       # Organization leads can create organization leads, site coordinators, and team members in their org
       can :manage, OrganizationLeadRole, organization: user.role.organization
-      can :manage, SiteCoordinatorRole, site: { parent_organization: user.role.organization }
-      can :manage, TeamMemberRole, site: { parent_organization: user.role.organization }
+      can :manage, SiteCoordinatorRole, sites: { parent_organization: user.role.organization }
+      can :manage, TeamMemberRole, sites: { parent_organization: user.role.organization }
     end
 
     if user.role_type == SiteCoordinatorRole::TYPE
       # Site coordinators can create site coordinators and team members in their site
-      can :manage, SiteCoordinatorRole, site: user.role.sites
-      can :manage, TeamMemberRole, site: user.role.sites
+      can :manage, SiteCoordinatorRole, sites: user.role.sites
+      can :manage, TeamMemberRole, sites: user.role.sites
     end
   end
 end

--- a/app/lib/seeder.rb
+++ b/app/lib/seeder.rb
@@ -88,14 +88,14 @@ class Seeder
     user.update(
       name: "Cindy Cucumber",
       password: strong_shared_password)
-    user.update(role: SiteCoordinatorRole.create(site: first_site)) if user.role_type != SiteCoordinatorRole::TYPE
+    user.update(role: SiteCoordinatorRole.create(sites: [first_site])) if user.role_type != SiteCoordinatorRole::TYPE
 
     # site team member user
     user = User.where(email: "melon@example.com").first_or_initialize
     user.update(
       name: "Marty Melon",
       password: strong_shared_password)
-    user.update(role: TeamMemberRole.create(site: first_site)) if user.role_type != TeamMemberRole::TYPE
+    user.update(role: TeamMemberRole.create(sites: [first_site])) if user.role_type != TeamMemberRole::TYPE
 
     # coalition lead user
     user = User.where(email: "lemon@example.com").first_or_initialize

--- a/app/models/coalition_lead_role.rb
+++ b/app/models/coalition_lead_role.rb
@@ -20,7 +20,7 @@ class CoalitionLeadRole < ApplicationRecord
 
   belongs_to :coalition
 
-  def served_entity
-    coalition
+  def served_entities
+    [coalition]
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -94,11 +94,11 @@ class Organization < VitaPartner
   end
 
   def site_coordinators
-    User.where(role: SiteCoordinatorRole.where(site: child_sites))
+    User.where(role: SiteCoordinatorRole.joins(:sites).where(vita_partners: child_sites))
   end
 
   def team_members
-    User.where(role: TeamMemberRole.where(site: child_sites))
+    User.where(role: TeamMemberRole.joins(:sites).where(vita_partners: child_sites))
   end
 
   private

--- a/app/models/organization_lead_role.rb
+++ b/app/models/organization_lead_role.rb
@@ -21,8 +21,8 @@ class OrganizationLeadRole < ApplicationRecord
   belongs_to :organization, foreign_key: "vita_partner_id", class_name: "VitaPartner"
   validate :no_sites
 
-  def served_entity
-    organization
+  def served_entities
+    [organization]
   end
 
   private

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -53,11 +53,11 @@ class Site < VitaPartner
   end
 
   def site_coordinators
-    User.where(role: SiteCoordinatorRole.where(site: self))
+    User.where(role: SiteCoordinatorRole.joins(:sites).where(vita_partners: self))
   end
 
   def team_members
-    User.where(role: TeamMemberRole.where(site: self))
+    User.where(role: TeamMemberRole.joins(:sites).where(vita_partners: self))
   end
 
   private

--- a/app/models/site_coordinator_role.rb
+++ b/app/models/site_coordinator_role.rb
@@ -31,8 +31,8 @@ class SiteCoordinatorRole < ApplicationRecord
     end
   end
 
-  def served_entity
-    site
+  def served_entities
+    sites
   end
 
   private

--- a/app/models/site_coordinator_role.rb
+++ b/app/models/site_coordinator_role.rb
@@ -22,6 +22,7 @@ class SiteCoordinatorRole < ApplicationRecord
   has_many :sites, through: :site_coordinator_roles_vita_partners
   has_many :vita_partners, through: :site_coordinator_roles_vita_partners
   validate :has_site
+  validate :all_sites_in_same_org
 
   def sites
     if vita_partner_id
@@ -39,5 +40,11 @@ class SiteCoordinatorRole < ApplicationRecord
 
   def has_site
     errors.add(:sites, "Must be associated to at least one site") if sites.blank?
+  end
+
+  def all_sites_in_same_org
+    if sites.map(&:parent_organization).uniq.length > 1
+      errors.add(:sites, "Must all be part of the same organization")
+    end
   end
 end

--- a/app/models/site_coordinator_role.rb
+++ b/app/models/site_coordinator_role.rb
@@ -5,7 +5,7 @@
 #  id              :bigint           not null, primary key
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  vita_partner_id :bigint           not null
+#  vita_partner_id :bigint
 #
 # Indexes
 #
@@ -18,8 +18,18 @@
 class SiteCoordinatorRole < ApplicationRecord
   TYPE = "SiteCoordinatorRole"
 
-  belongs_to :site, foreign_key: "vita_partner_id", class_name: "VitaPartner"
-  validate :no_organizations
+  has_many :site_coordinator_roles_vita_partners
+  has_many :sites, through: :site_coordinator_roles_vita_partners
+  has_many :vita_partners, through: :site_coordinator_roles_vita_partners
+  validate :has_site
+
+  def sites
+    if vita_partner_id
+      [VitaPartner.find(vita_partner_id)]
+    else
+      super
+    end
+  end
 
   def served_entity
     site
@@ -27,9 +37,7 @@ class SiteCoordinatorRole < ApplicationRecord
 
   private
 
-  def no_organizations
-    if site.present? && site.organization?
-      errors.add(:site, "Site coordinator role cannot contain an organization")
-    end
+  def has_site
+    errors.add(:sites, "Must be associated to at least one site") if sites.blank?
   end
 end

--- a/app/models/site_coordinator_roles_vita_partner.rb
+++ b/app/models/site_coordinator_roles_vita_partner.rb
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: site_coordinator_roles_vita_partners
+#
+#  id                       :bigint           not null, primary key
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  site_coordinator_role_id :bigint           not null
+#  vita_partner_id          :bigint           not null
+#
+# Indexes
+#
+#  index_scr_vita_partners_on_scr_id                              (site_coordinator_role_id)
+#  index_site_coordinator_roles_vita_partners_on_vita_partner_id  (vita_partner_id)
+#
+class SiteCoordinatorRolesVitaPartner < ApplicationRecord
+  belongs_to :vita_partner
+  belongs_to :site, foreign_key: "vita_partner_id", class_name: "Site"
+  belongs_to :site_coordinator_role
+end

--- a/app/models/team_member_role.rb
+++ b/app/models/team_member_role.rb
@@ -22,6 +22,7 @@ class TeamMemberRole < ApplicationRecord
   has_many :vita_partners, through: :team_member_roles_vita_partners
   has_many :sites, through: :team_member_roles_vita_partners
   validate :has_site
+  validate :all_sites_in_same_org
 
   def sites
     if vita_partner_id
@@ -39,5 +40,11 @@ class TeamMemberRole < ApplicationRecord
 
   def has_site
     errors.add(:sites, "Must be associated to at least one site") if sites.blank?
+  end
+
+  def all_sites_in_same_org
+    if sites.map(&:parent_organization).uniq.length > 1
+      errors.add(:sites, "Must all be part of the same organization")
+    end
   end
 end

--- a/app/models/team_member_role.rb
+++ b/app/models/team_member_role.rb
@@ -5,7 +5,7 @@
 #  id              :bigint           not null, primary key
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  vita_partner_id :bigint           not null
+#  vita_partner_id :bigint
 #
 # Indexes
 #
@@ -18,8 +18,18 @@
 class TeamMemberRole < ApplicationRecord
   TYPE = "TeamMemberRole"
 
-  belongs_to :site, foreign_key: "vita_partner_id", class_name: "VitaPartner"
-  validate :no_organizations
+  has_many :team_member_roles_vita_partners
+  has_many :vita_partners, through: :team_member_roles_vita_partners
+  has_many :sites, through: :team_member_roles_vita_partners
+  validate :has_site
+
+  def sites
+    if vita_partner_id
+      [VitaPartner.find(vita_partner_id)]
+    else
+      super
+    end
+  end
 
   def served_entity
     site
@@ -27,8 +37,8 @@ class TeamMemberRole < ApplicationRecord
 
   private
 
-  def no_organizations
-    errors.add(:site, "Cannot contain an organization") if site&.organization?
+  def has_site
+    errors.add(:sites, "Must be associated to at least one site") if sites.blank?
   end
 end
 

--- a/app/models/team_member_role.rb
+++ b/app/models/team_member_role.rb
@@ -31,8 +31,8 @@ class TeamMemberRole < ApplicationRecord
     end
   end
 
-  def served_entity
-    site
+  def served_entities
+    sites
   end
 
   private
@@ -41,4 +41,3 @@ class TeamMemberRole < ApplicationRecord
     errors.add(:sites, "Must be associated to at least one site") if sites.blank?
   end
 end
-

--- a/app/models/team_member_roles_vita_partner.rb
+++ b/app/models/team_member_roles_vita_partner.rb
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: team_member_roles_vita_partners
+#
+#  id                  :bigint           not null, primary key
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  team_member_role_id :bigint           not null
+#  vita_partner_id     :bigint           not null
+#
+# Indexes
+#
+#  index_team_member_roles_vita_partners_on_team_member_role_id  (team_member_role_id)
+#  index_team_member_roles_vita_partners_on_vita_partner_id      (vita_partner_id)
+#
+class TeamMemberRolesVitaPartner < ApplicationRecord
+  belongs_to :vita_partner
+  belongs_to :site, foreign_key: "vita_partner_id", class_name: "Site"
+  belongs_to :team_member_role
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -81,6 +81,10 @@ class User < ApplicationRecord
   scope :active, -> { where(suspended_at: nil) }
   scope :suspended, -> { where.not(suspended_at: nil) }
 
+  def valid?(*_args)
+    [super, role&.valid?].all?
+  end
+
   def accessible_coalitions
     case role_type
     when AdminRole::TYPE

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -123,7 +123,7 @@ class User < ApplicationRecord
     when OrganizationLeadRole::TYPE
       VitaPartner.organizations.where(id: role.organization).or(VitaPartner.sites.where(parent_organization: role.organization))
     when TeamMemberRole::TYPE, SiteCoordinatorRole::TYPE
-      VitaPartner.sites.where(id: role.site)
+      VitaPartner.sites.where(id: role.sites)
     when CoalitionLeadRole::TYPE
       organizations = VitaPartner.organizations.where(coalition: role.coalition)
       sites = VitaPartner.sites.where(parent_organization: organizations)
@@ -166,9 +166,9 @@ class User < ApplicationRecord
       team_members = User.where(role: TeamMemberRole.where(site: sites))
       organization_leads.or(site_coordinators).or(team_members)
     when SiteCoordinatorRole::TYPE, TeamMemberRole::TYPE
-      organization_leads = User.where(role: OrganizationLeadRole.where(organization: role.site.parent_organization))
-      site_coordinators = User.where(role: SiteCoordinatorRole.where(site: role.site))
-      team_members = User.where(role: TeamMemberRole.where(site: role.site))
+      organization_leads = User.where(role: OrganizationLeadRole.where(organization: role.sites.map(&:parent_organization)))
+      site_coordinators = User.where(role: SiteCoordinatorRole.joins(:sites).where(vita_partners: role.sites))
+      team_members = User.where(role: TeamMemberRole.joins(:sites).where(vita_partners: role.sites))
       organization_leads.or(site_coordinators).or(team_members)
     else
       User.none

--- a/app/services/mixpanel_service.rb
+++ b/app/services/mixpanel_service.rb
@@ -306,7 +306,7 @@ class MixpanelService
         organization = user.role.organization
         coalition = organization.coalition
       when TeamMemberRole::TYPE, SiteCoordinatorRole::TYPE
-        site = user.role.site
+        site = user.role.sites.first
         organization = site.parent_organization
         coalition = organization.coalition
       end

--- a/app/services/tax_return_assignment_service.rb
+++ b/app/services/tax_return_assignment_service.rb
@@ -9,14 +9,20 @@ class TaxReturnAssignmentService
   def assign!
     ActiveRecord::Base.transaction do
       @tax_return.update!(assigned_user: @assigned_user)
-      if @assigned_user.present? &&
-         [TeamMemberRole::TYPE, SiteCoordinatorRole::TYPE, OrganizationLeadRole::TYPE].include?(@assigned_user.role_type) &&
-         @assigned_user.role.vita_partner_id != @client.vita_partner_id
+      if not_already_assigned?
         UpdateClientVitaPartnerService.new(clients: [@client],
                                            vita_partner_id: @assigned_user.role.vita_partner_id,
                                            change_initiated_by: @assigned_user).update!
       end
     end
+  end
+
+  def not_already_assigned?
+    @assigned_user.present? &&
+      (
+        ([OrganizationLeadRole::TYPE].include?(@assigned_user.role_type) && @assigned_user.role.vita_partner_id != @client.vita_partner_id) ||
+        ([TeamMemberRole::TYPE, SiteCoordinatorRole::TYPE].include?(@assigned_user.role_type) && !@assigned_user.role.sites.map(&:id).include?(@client.vita_partner_id))
+      )
   end
 
   def send_notifications

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -4,12 +4,14 @@
   <div class="slab slab--not-padded">
     <%= form_for(resource, as: resource_name, url: invitation_path(resource_name, role: params[:role]), local: true, builder: VitaMinFormBuilder, html: { method: :post }) do |f| %>
       <h1><%= @main_heading %></h1>
-
-      <ul>
-        <% (resource.errors.full_messages + (resource.role&.errors&.full_messages || [])).each do |error_message| %>
-          <li><%= error_message %></li>
-        <% end %>
-      </ul>
+      <% errors = resource.errors.full_messages + (resource.role&.errors&.full_messages || []) %>
+      <% if errors.present? %>
+        <ul>
+          <% errors.each do |error_message| %>
+            <li><%= error_message %></li>
+          <% end %>
+        </ul>
+      <% end %>
       <div class="form-group">
         <%= label_tag(:role, "Which role?", class: "form-question") %>
         <div class="select form-width--long">

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -35,23 +35,20 @@
         </div>
       <% end %>
 
-      <% if params[:role] == SiteCoordinatorRole::TYPE %>
+      <% if (params[:role] == SiteCoordinatorRole::TYPE) || (params[:role] == TeamMemberRole::TYPE) %>
         <div class="form-group">
           <%= label_tag(:site_id, t(".site_label"), class: "form-question") %>
 
           <div class="select form-width--long">
-            <%= select_tag(:site_id, options_for_select(@vita_partners.sites.map { |site| [site.name, site.id] }), class: "select__element") %>
+            <%= hidden_field_tag(:sites, (resource.role&.sites || []).map { |site| { value: site.id, name: site.name }}.to_json.to_s.html_safe, class: "multi-select-vita-partner") %>
           </div>
         </div>
-      <% end %>
 
-      <% if params[:role] == TeamMemberRole::TYPE %>
-        <div class="form-group">
-          <%= label_tag(:site_id, t(".site_label"), class: "form-question") %>
-          <div class="select form-width--long">
-            <%= select_tag(:site_id, options_for_select(@vita_partners.sites.map { |site| [site.name, site.id] }), class: "select__element") %>
-          </div>
-        </div>
+        <% content_for :script do %>
+          <script>
+              window.taggableItems = <%= taggable_sites(@vita_partners) %>;
+          </script>
+        <% end %>
       <% end %>
 
       <%= f.cfa_input_field(:name, t(".name_label"), classes: ['form-width--long']) %>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -6,7 +6,7 @@
       <h1><%= @main_heading %></h1>
 
       <ul>
-        <% resource.errors.full_messages.each do |error_message| %>
+        <% (resource.errors.full_messages + resource.role.errors.full_messages).each do |error_message| %>
           <li><%= error_message %></li>
         <% end %>
       </ul>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -6,7 +6,7 @@
       <h1><%= @main_heading %></h1>
 
       <ul>
-        <% (resource.errors.full_messages + resource.role.errors.full_messages).each do |error_message| %>
+        <% (resource.errors.full_messages + (resource.role&.errors&.full_messages || [])).each do |error_message| %>
           <li><%= error_message %></li>
         <% end %>
       </ul>

--- a/app/views/hub/users/edit_role.html.erb
+++ b/app/views/hub/users/edit_role.html.erb
@@ -44,26 +44,21 @@
         </div>
       <% end %>
 
-      <% if params[:role] == SiteCoordinatorRole::TYPE %>
-        <p><%= role_name_from_role_type(SiteCoordinatorRole::TYPE) %></p>
+      <% if (params[:role] == SiteCoordinatorRole::TYPE) || (params[:role] == TeamMemberRole::TYPE) %>
+        <p><%= role_name_from_role_type(params[:role]) %></p>
 
         <div class="form-group">
           <%= label_tag(:site_id, t("devise.invitations.new.site_label"), class: "form-question") %>
           <div class="select form-width--long">
-            <%= select_tag(:site_id, options_for_select(@vita_partners.sites.map { |site| [site.name, site.id] }), class: "select__element") %>
+            <%= hidden_field_tag(:sites, (@user.role&.respond_to?(:sites) ? @user.role.sites : []).map { |site| { value: site.id, name: site.name }}.to_json.to_s.html_safe, class: "multi-select-vita-partner") %>
           </div>
         </div>
-      <% end %>
 
-      <% if params[:role] == TeamMemberRole::TYPE %>
-        <p><%= role_name_from_role_type(TeamMemberRole::TYPE) %></p>
-
-        <div class="form-group">
-          <%= label_tag(:site_id, t("devise.invitations.new.site_label"), class: "form-question") %>
-          <div class="select form-width--long">
-            <%= select_tag(:site_id, options_for_select(@vita_partners.sites.map { |site| [site.name, site.id] }), class: "select__element") %>
-          </div>
-        </div>
+        <% content_for :script do %>
+          <script>
+              window.taggableItems = <%= taggable_sites(@vita_partners) %>;
+          </script>
+        <% end %>
       <% end %>
 
       <div>

--- a/app/views/hub/users/edit_role.html.erb
+++ b/app/views/hub/users/edit_role.html.erb
@@ -9,22 +9,31 @@
 
     <h2>New role</h2>
 
+    <% errors = @role.errors.full_messages %>
+    <% if errors.present? %>
+      <ul>
+        <% errors.each do |error_message| %>
+          <li><%= error_message %></li>
+        <% end %>
+      </ul>
+    <% end %>
+
     <%= form_for(@user, method: :patch, url: update_role_hub_user_path, local: true, builder: VitaMinFormBuilder) do |f| %>
 
-      <%= f.hidden_field :role, value: params[:role] %>
-      <% if params[:role] == AdminRole::TYPE %>
+      <%= f.hidden_field :role, value: @role.class.name %>
+      <% if @role.is_a?(AdminRole) %>
         <p><%= t("general.admin") %></p>
       <% end %>
 
-      <% if params[:role] == ClientSuccessRole::TYPE %>
+      <% if @role.is_a?(ClientSuccessRole) %>
         <p><%= t("general.client_success") %></p>
       <% end %>
 
-      <% if params[:role] == GreeterRole::TYPE %>
+      <% if @role.is_a?(GreeterRole) %>
         <p><%= t("general.greeter") %></p>
       <% end %>
 
-      <% if params[:role] == CoalitionLeadRole::TYPE %>
+      <% if @role.is_a?(CoalitionLeadRole) %>
         <p><%= role_name_from_role_type(CoalitionLeadRole::TYPE) %></p>
         <div class="form-group">
           <%= label_tag(:coalition_id, t("devise.invitations.new.coalition_label"), class: "form-question") %>
@@ -34,7 +43,7 @@
         </div>
       <% end %>
 
-      <% if params[:role] == OrganizationLeadRole::TYPE %>
+      <% if @role.is_a?(OrganizationLeadRole) %>
         <p><%= role_name_from_role_type(OrganizationLeadRole::TYPE) %></p>
         <div class="form-group">
           <%= label_tag(:organization_id, t("devise.invitations.new.organization_label"), class: "form-question") %>
@@ -44,13 +53,13 @@
         </div>
       <% end %>
 
-      <% if (params[:role] == SiteCoordinatorRole::TYPE) || (params[:role] == TeamMemberRole::TYPE) %>
-        <p><%= role_name_from_role_type(params[:role]) %></p>
+      <% if @role.is_a?(SiteCoordinatorRole) || @role.is_a?(TeamMemberRole) %>
+        <p><%= role_name_from_role_type(@role.class.name) %></p>
 
         <div class="form-group">
           <%= label_tag(:site_id, t("devise.invitations.new.site_label"), class: "form-question") %>
           <div class="select form-width--long">
-            <%= hidden_field_tag(:sites, (@user.role&.respond_to?(:sites) ? @user.role.sites : []).map { |site| { value: site.id, name: site.name }}.to_json.to_s.html_safe, class: "multi-select-vita-partner") %>
+            <%= hidden_field_tag(:sites, (@role&.respond_to?(:sites) ? @role.sites : []).map { |site| { value: site.id, name: site.name }}.to_json.to_s.html_safe, class: "multi-select-vita-partner") %>
           </div>
         </div>
 

--- a/db/migrate/20230606174612_create_team_member_roles_vita_partners.rb
+++ b/db/migrate/20230606174612_create_team_member_roles_vita_partners.rb
@@ -1,0 +1,10 @@
+class CreateTeamMemberRolesVitaPartners < ActiveRecord::Migration[7.0]
+  def change
+    create_table :team_member_roles_vita_partners do |t|
+      t.references :vita_partner, null: false, index: true
+      t.references :team_member_role, null: false, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230606175533_create_site_coordinator_roles_vita_partners.rb
+++ b/db/migrate/20230606175533_create_site_coordinator_roles_vita_partners.rb
@@ -1,0 +1,10 @@
+class CreateSiteCoordinatorRolesVitaPartners < ActiveRecord::Migration[7.0]
+  def change
+    create_table :site_coordinator_roles_vita_partners do |t|
+      t.references :vita_partner, null: false, index: true
+      t.references :site_coordinator_role, null: false, index: { name: "index_scr_vita_partners_on_scr_id" }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230606180600_remove_vita_partner_null_constraint_from_team_member_roles_and_site_coordinator_roles.rb
+++ b/db/migrate/20230606180600_remove_vita_partner_null_constraint_from_team_member_roles_and_site_coordinator_roles.rb
@@ -1,0 +1,6 @@
+class RemoveVitaPartnerNullConstraintFromTeamMemberRolesAndSiteCoordinatorRoles < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null(:team_member_roles, :vita_partner_id, true)
+    change_column_null(:site_coordinator_roles, :vita_partner_id, true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_30_183601) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_06_180600) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -1493,8 +1493,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_30_183601) do
   create_table "site_coordinator_roles", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "vita_partner_id", null: false
+    t.bigint "vita_partner_id"
     t.index ["vita_partner_id"], name: "index_site_coordinator_roles_on_vita_partner_id"
+  end
+
+  create_table "site_coordinator_roles_vita_partners", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "site_coordinator_role_id", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "vita_partner_id", null: false
+    t.index ["site_coordinator_role_id"], name: "index_scr_vita_partners_on_scr_id"
+    t.index ["vita_partner_id"], name: "index_site_coordinator_roles_vita_partners_on_vita_partner_id"
   end
 
   create_table "source_parameters", force: :cascade do |t|
@@ -1605,8 +1614,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_30_183601) do
   create_table "team_member_roles", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "vita_partner_id", null: false
+    t.bigint "vita_partner_id"
     t.index ["vita_partner_id"], name: "index_team_member_roles_on_vita_partner_id"
+  end
+
+  create_table "team_member_roles_vita_partners", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "team_member_role_id", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "vita_partner_id", null: false
+    t.index ["team_member_role_id"], name: "index_team_member_roles_vita_partners_on_team_member_role_id"
+    t.index ["vita_partner_id"], name: "index_team_member_roles_vita_partners_on_vita_partner_id"
   end
 
   create_table "text_message_access_tokens", force: :cascade do |t|

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -545,8 +545,8 @@ RSpec.describe ApplicationController do
     context "user is logged in" do
       let(:user_coalition) { build(:coalition, name: "Tax Universe") }
       let(:user_organization) { build(:organization, name: "Tax Collective", coalition: user_coalition) }
-      let(:user_site) { build(:site, name: "Tax Partners", parent_organization: user_organization) }
-      let(:user) { create(:team_member_user, site: user_site, current_sign_in_at: 5.minutes.ago) }
+      let(:user_site) { create(:site, name: "Tax Partners", parent_organization: user_organization) }
+      let(:user) { create(:team_member_user, sites: [user_site], current_sign_in_at: 5.minutes.ago) }
 
       before do
         sign_in user

--- a/spec/controllers/concerns/tax_return_assignable_users_spec.rb
+++ b/spec/controllers/concerns/tax_return_assignable_users_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe TaxReturnAssignableUsers, type: :controller do
     let(:organization) { create :organization }
     let!(:tax_return) { create :gyr_tax_return, client: client, assigned_user: assigned_user }
 
-    let!(:assigned_user) { create :user, role: create(:team_member_role, site: site) }
-    let!(:team_member) { create :user, role: create(:team_member_role, site: site) }
-    let!(:another_team_member) { create :user, role: create(:team_member_role, site: second_site) }
-    let!(:site_coordinator) { create :user, role: create(:site_coordinator_role, site: site) }
+    let!(:assigned_user) { create :user, role: create(:team_member_role, sites: [site]) }
+    let!(:team_member) { create :user, role: create(:team_member_role, sites: [site]) }
+    let!(:another_team_member) { create :user, role: create(:team_member_role, sites: [second_site]) }
+    let!(:site_coordinator) { create :user, role: create(:site_coordinator_role, sites: [site]) }
     let!(:org_lead) { create :user, role: create(:organization_lead_role, organization: organization) }
     let!(:another_org_lead) { create :user, role: create(:organization_lead_role, organization: organization) }
     let!(:inaccessible_user) { create :user }

--- a/spec/controllers/hub/bulk_actions/change_assignee_and_status_controller_spec.rb
+++ b/spec/controllers/hub/bulk_actions/change_assignee_and_status_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Hub::BulkActions::ChangeAssigneeAndStatusController do
     end
 
     context "an unauthorized user" do
-      let(:unauthorized_team_member) { create :user, role: create(:team_member_role, sites: [create(:site])) }
+      let(:unauthorized_team_member) { create :user, role: create(:team_member_role, sites: [create(:site)]) }
 
       before do
         sign_in unauthorized_team_member
@@ -119,7 +119,7 @@ RSpec.describe Hub::BulkActions::ChangeAssigneeAndStatusController do
       end
 
       context "an unauthorized user" do
-        let(:unauthorized_team_member) { create :user, role: create(:team_member_role, sites: [create(:site])) }
+        let(:unauthorized_team_member) { create :user, role: create(:team_member_role, sites: [create(:site)]) }
 
         before do
           sign_in unauthorized_team_member

--- a/spec/controllers/hub/bulk_actions/change_assignee_and_status_controller_spec.rb
+++ b/spec/controllers/hub/bulk_actions/change_assignee_and_status_controller_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Hub::BulkActions::ChangeAssigneeAndStatusController do
   let(:site) { create :site }
   let(:organization) { create :organization }
 
-  let!(:team_member) { create :user, role: create(:team_member_role, site: site) }
-  let!(:site_coordinator) { create :user, role: create(:site_coordinator_role, site: site) }
+  let!(:team_member) { create :user, role: create(:team_member_role, sites: [site]) }
+  let!(:site_coordinator) { create :user, role: create(:site_coordinator_role, sites: [site]) }
   let!(:inaccessible_user) { create :user }
 
   let(:tax_return_1) { create :gyr_tax_return, :file_ready_to_file, assigned_user: team_member, client: client }
@@ -39,7 +39,7 @@ RSpec.describe Hub::BulkActions::ChangeAssigneeAndStatusController do
     end
 
     context "an unauthorized user" do
-      let(:unauthorized_team_member) { create :user, role: create(:team_member_role, site: create(:site)) }
+      let(:unauthorized_team_member) { create :user, role: create(:team_member_role, sites: [create(:site])) }
 
       before do
         sign_in unauthorized_team_member
@@ -119,7 +119,7 @@ RSpec.describe Hub::BulkActions::ChangeAssigneeAndStatusController do
       end
 
       context "an unauthorized user" do
-        let(:unauthorized_team_member) { create :user, role: create(:team_member_role, site: create(:site)) }
+        let(:unauthorized_team_member) { create :user, role: create(:team_member_role, sites: [create(:site])) }
 
         before do
           sign_in unauthorized_team_member

--- a/spec/controllers/hub/clients_controller_spec.rb
+++ b/spec/controllers/hub/clients_controller_spec.rb
@@ -161,7 +161,8 @@ RSpec.describe Hub::ClientsController do
     end
 
     context "as a team member user" do
-      let(:user) { create(:user, role: create(:team_member_role, site: create(:site))) }
+      let(:vita_partner_id) { user.role.sites.first.id }
+      let(:user) { create(:user, role: create(:team_member_role, sites: [create(:site)])) }
       before { sign_in user }
 
       context "with valid params" do
@@ -169,7 +170,7 @@ RSpec.describe Hub::ClientsController do
           expect do
             post :create, params: params
           end.to change(Client, :count).by 1
-          expect(Client.last.vita_partner).to eq(user.role.site)
+          expect(Client.last.vita_partner).to eq(user.role.sites.first)
         end
       end
     end
@@ -1330,7 +1331,7 @@ RSpec.describe Hub::ClientsController do
       let!(:site) { create :site }
       let!(:client_outside_of_site) { create(:client) }
       before {
-        sign_in create(:site_coordinator_user, site: site)
+        sign_in create(:site_coordinator_user, sites: [site])
         client.update(vita_partner: site)
       }
 

--- a/spec/controllers/hub/efile_submissions_controller_spec.rb
+++ b/spec/controllers/hub/efile_submissions_controller_spec.rb
@@ -63,7 +63,7 @@ describe Hub::EfileSubmissionsController, requires_default_vita_partners: true d
     end
 
     context "as a member of GetCTC.org (Site)" do
-      let(:user) { create :team_member_user, site: VitaPartner.ctc_site }
+      let(:user) { create :team_member_user, sites: [VitaPartner.ctc_site] }
       before { sign_in user }
 
       it "loads the tax return by id and latest submission as instance variables" do
@@ -121,7 +121,7 @@ describe Hub::EfileSubmissionsController, requires_default_vita_partners: true d
     end
 
     context "as a member of GetCTC.org (Site)" do
-      let(:user) { create :team_member_user, site: VitaPartner.ctc_site }
+      let(:user) { create :team_member_user, sites: [VitaPartner.ctc_site] }
       before do
         allow_any_instance_of(EfileSubmission).to receive(:transition_to!)
       end
@@ -179,7 +179,7 @@ describe Hub::EfileSubmissionsController, requires_default_vita_partners: true d
     end
 
     context "with a GetCTC.org role (team member at site)" do
-      let(:user) { create :team_member_user, site: VitaPartner.ctc_site }
+      let(:user) { create :team_member_user, sites: [VitaPartner.ctc_site] }
 
       it "transitions the submission to waiting and records the initiator" do
         patch :wait, params: params
@@ -233,7 +233,7 @@ describe Hub::EfileSubmissionsController, requires_default_vita_partners: true d
     end
 
     context "as a user of GetCTC.org (Site)" do
-      let(:user) { create :team_member_user, site: VitaPartner.ctc_site }
+      let(:user) { create :team_member_user, sites: [VitaPartner.ctc_site] }
 
       it "transitions the efile submission to cancelled and records the initiator" do
         patch :cancel, params: params
@@ -285,7 +285,7 @@ describe Hub::EfileSubmissionsController, requires_default_vita_partners: true d
     end
 
     context "as an authenticated user of GetCTC.org (Site)" do
-      let(:user) { create :team_member_user, site: VitaPartner.ctc_site }
+      let(:user) { create :team_member_user, sites: [VitaPartner.ctc_site] }
 
       it "transitions the efile submission to investigate and records the initiator" do
         patch :investigate, params: params

--- a/spec/controllers/hub/notes_controller_spec.rb
+++ b/spec/controllers/hub/notes_controller_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Hub::NotesController, type: :controller do
 
     describe "#taggable_users" do
       let(:admin_user) { create :admin_user, name: "Penelope Persimmon" }
-      let(:team_member) { create :team_member_user, name: "Mel Melon", site: (create :site, name: "Some Site") }
+      let(:team_member) { create :team_member_user, name: "Mel Melon", sites: [(create :site, name: "Some Site")] }
 
       before do
         allow(User).to receive(:taggable_for).and_return([team_member, admin_user])

--- a/spec/controllers/hub/organizations_controller_spec.rb
+++ b/spec/controllers/hub/organizations_controller_spec.rb
@@ -291,9 +291,9 @@ RSpec.describe Hub::OrganizationsController, type: :controller do
   describe "#suspend_all" do
     let(:organization) { create :organization }
     let(:site) { create :site, parent_organization: organization }
-    let!(:team_member_1) { create :user, role: (create :team_member_role, site: site) }
-    let!(:team_member_2) { create :user, role: (create :team_member_role, site: site) }
-    let!(:team_member_3) { create :user, role: (create :team_member_role, site: site) }
+    let!(:team_member_1) { create :user, role: (create :team_member_role, sites: [site]) }
+    let!(:team_member_2) { create :user, role: (create :team_member_role, sites: [site]) }
+    let!(:team_member_3) { create :user, role: (create :team_member_role, sites: [site]) }
     let(:params) do
       {
         role_type: TeamMemberRole::TYPE,
@@ -321,9 +321,9 @@ RSpec.describe Hub::OrganizationsController, type: :controller do
   describe "#activate_all" do
     let(:organization) { create :organization }
     let(:site) { create :site, parent_organization: organization }
-    let!(:team_member_1) { create :user, role: (create :team_member_role, site: site), suspended_at: DateTime.now }
-    let!(:team_member_2) { create :user, role: (create :team_member_role, site: site), suspended_at: DateTime.now }
-    let!(:team_member_3) { create :user, role: (create :team_member_role, site: site), suspended_at: DateTime.now }
+    let!(:team_member_1) { create :user, role: (create :team_member_role, sites: [site]), suspended_at: DateTime.now }
+    let!(:team_member_2) { create :user, role: (create :team_member_role, sites: [site]), suspended_at: DateTime.now }
+    let!(:team_member_3) { create :user, role: (create :team_member_role, sites: [site]), suspended_at: DateTime.now }
     let(:params) do
       {
         role_type: TeamMemberRole::TYPE,

--- a/spec/controllers/hub/tax_return_selections_controller_spec.rb
+++ b/spec/controllers/hub/tax_return_selections_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Hub::TaxReturnSelectionsController do
         let(:site) { create :site, parent_organization: organization }
         let(:clients_for_org) { create_list :client_with_intake_and_return, 3, vita_partner: organization, tax_return_state: "file_efiled" }
         let(:clients_for_site) { create_list :client_with_intake_and_return, 2, vita_partner: site, tax_return_state: "file_efiled" }
-        let(:user) { create :site_coordinator_user, site: site }
+        let(:user) { create :site_coordinator_user, sites: [site] }
         let(:clients) { clients_for_org + clients_for_site }
 
         it "only shows the allowed clients" do

--- a/spec/controllers/hub/tax_returns_controller_spec.rb
+++ b/spec/controllers/hub/tax_returns_controller_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Hub::TaxReturnsController, type: :controller do
   let(:site) { create :site, parent_organization: organization }
 
   let!(:organization_lead) { create :organization_lead_user, organization: organization }
-  let!(:site_coordinator) { create :site_coordinator_user, site: site, name: "Barbara" }
-  let!(:team_member) { create :team_member_user, site: site, name: "Aaron" }
+  let!(:site_coordinator) { create :site_coordinator_user, sites: [site], name: "Barbara" }
+  let!(:team_member) { create :team_member_user, sites: [site], name: "Aaron" }
   let!(:unauthorized_team_member) { create :team_member_user }
 
   let(:currently_assigned_coalition_lead) { create :coalition_lead_user, coalition: coalition }

--- a/spec/controllers/hub/users_controller_spec.rb
+++ b/spec/controllers/hub/users_controller_spec.rb
@@ -128,8 +128,8 @@ RSpec.describe Hub::UsersController do
 
       context "with a team member user" do
         let!(:team_member) { create :team_member_user }
-        let!(:other_team_member) { create :team_member_user, site: team_member.role.site }
-        let!(:site_coordinator) { create :site_coordinator_user, site: team_member.role.site }
+        let!(:other_team_member) { create :team_member_user, sites: team_member.role.sites }
+        let!(:site_coordinator) { create :site_coordinator_user, sites: team_member.role.sites }
 
         before { sign_in team_member }
 
@@ -167,7 +167,7 @@ RSpec.describe Hub::UsersController do
           let!(:site) { create(:site, parent_organization: organization) }
           let!(:first_match) { create :organization_lead_user, email: "someone@example.com", organization: organization }
           let!(:nonmatch) { create :organization_lead_user, email: "someone@example.org" }
-          let!(:nonmatch_user_at_child_site) { create :site_coordinator_user, email: "someone@example.net", site: site }
+          let!(:nonmatch_user_at_child_site) { create :site_coordinator_user, email: "someone@example.net", sites: [site] }
 
           it "returns the users within that org" do
             get :index, params: params
@@ -181,7 +181,7 @@ RSpec.describe Hub::UsersController do
           end
           let!(:organization) { create(:organization, name: "Oregano Org") }
           let!(:site) { create(:site, parent_organization: organization, name: "Library Site") }
-          let!(:user_at_child_site) { create :site_coordinator_user, email: "someone@example.net", site: site }
+          let!(:user_at_child_site) { create :site_coordinator_user, email: "someone@example.net", sites: [site] }
           let!(:nonmatch_parent_org_user) { create :organization_lead_user, email: "someone@example.com", organization: organization }
           let!(:nonmatch) { create :organization_lead_user, email: "someone@example.org" }
 

--- a/spec/controllers/hub/users_controller_spec.rb
+++ b/spec/controllers/hub/users_controller_spec.rb
@@ -280,7 +280,7 @@ RSpec.describe Hub::UsersController do
   describe "#edit_role" do
     let!(:user) { create :user, name: "Anne", role: create(:organization_lead_role, organization: create(:organization)) }
 
-    let(:params) { { id: user.id, user: { role: "AdminRole" } } }
+    let(:params) { { id: user.id, role: "AdminRole" } }
     it_behaves_like :a_get_action_for_admins_only, action: :edit
 
     context "as an admin user" do

--- a/spec/controllers/users/invitations_controller_spec.rb
+++ b/spec/controllers/users/invitations_controller_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Users::InvitationsController do
               email: "cherry@example.com",
               role: SiteCoordinatorRole::TYPE,
             },
-            site_id: site.id
+            sites: [{id: site.id}].to_json
           }
         end
 
@@ -256,7 +256,7 @@ RSpec.describe Users::InvitationsController do
               email: "cherry@example.com",
               role: TeamMemberRole::TYPE,
             },
-            site_id: site.id
+            sites: [{ id: site.id}].to_json
           }
         end
 

--- a/spec/controllers/users/invitations_controller_spec.rb
+++ b/spec/controllers/users/invitations_controller_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Users::InvitationsController do
           end.to (change(User, :count).by 1).and(change(SiteCoordinatorRole, :count).by(1))
 
           site_coordinator_role = SiteCoordinatorRole.last
-          expect(site_coordinator_role.site).to eq site
+          expect(site_coordinator_role.sites).to include site
 
           invited_user = User.last
           expect(invited_user.role).to eq site_coordinator_role
@@ -266,7 +266,7 @@ RSpec.describe Users::InvitationsController do
           end.to (change(User, :count).by 1).and(change(TeamMemberRole, :count).by(1))
 
           role = TeamMemberRole.last
-          expect(role.site).to eq site
+          expect(role.sites).to include site
 
           invited_user = User.last
           expect(invited_user.role).to eq role

--- a/spec/factories/site_coordinator_roles.rb
+++ b/spec/factories/site_coordinator_roles.rb
@@ -5,7 +5,7 @@
 #  id              :bigint           not null, primary key
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  vita_partner_id :bigint           not null
+#  vita_partner_id :bigint
 #
 # Indexes
 #
@@ -17,6 +17,6 @@
 #
 FactoryBot.define do
   factory :site_coordinator_role do
-    site { create(:site) }
+    sites { [create(:site)] }
   end
 end

--- a/spec/factories/team_member_roles.rb
+++ b/spec/factories/team_member_roles.rb
@@ -5,7 +5,7 @@
 #  id              :bigint           not null, primary key
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  vita_partner_id :bigint           not null
+#  vita_partner_id :bigint
 #
 # Indexes
 #
@@ -17,6 +17,6 @@
 #
 FactoryBot.define do
   factory :team_member_role do
-    site { create :site }
+    sites { [create(:site)] }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -89,10 +89,10 @@ FactoryBot.define do
       sequence(:name) { |n| "Site Coordinator the #{n}th" }
 
       transient do
-        site { nil }
+        sites { nil }
       end
 
-      role { build(:site_coordinator_role, site: site || build(:site)) }
+      role { build(:site_coordinator_role, sites: sites || [build(:site)]) }
     end
 
     factory :team_member_user do
@@ -101,10 +101,10 @@ FactoryBot.define do
       sequence(:name) { |n| "Team Member the #{n}th" }
 
       transient do
-        site { nil }
+        sites { nil }
       end
 
-      role { build(:team_member_role, site: site || build(:site)) }
+      role { build(:team_member_role, sites: sites || [build(:site)]) }
     end
 
     factory :admin_user do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -92,7 +92,7 @@ FactoryBot.define do
         sites { nil }
       end
 
-      role { build(:site_coordinator_role, sites: sites || [build(:site)]) }
+      role { build(:site_coordinator_role, sites: sites || [create(:site)]) }
     end
 
     factory :team_member_user do
@@ -104,7 +104,7 @@ FactoryBot.define do
         sites { nil }
       end
 
-      role { build(:team_member_role, sites: sites || [build(:site)]) }
+      role { build(:team_member_role, sites: sites || [create(:site)]) }
     end
 
     factory :admin_user do

--- a/spec/features/hub/edit_organization_spec.rb
+++ b/spec/features/hub/edit_organization_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe "a user editing an organization", :js do
       let(:organization) { create :organization, capacity_limit: 100, allows_greeters: false, state_routing_targets: [build(:state_routing_target, state_abbreviation: "CA")] }
       let!(:org_lead) { create :organization_lead_user, organization: organization }
       let!(:site) { create :site, parent_organization: organization, name: "Child Site" }
-      let!(:site_coordinator) { create :site_coordinator_user, site: site, suspended_at: DateTime.now }
-      let!(:team_member) { create :team_member_user, site: site, suspended_at: DateTime.now }
-      let!(:team_member2) { create :team_member_user, site: site }
+      let!(:site_coordinator) { create :site_coordinator_user, sites: [site], suspended_at: DateTime.now }
+      let!(:team_member) { create :team_member_user, sites: [site], suspended_at: DateTime.now }
+      let!(:team_member2) { create :team_member_user, sites: [site] }
 
       before { login_as current_user }
 

--- a/spec/features/hub/edit_user_spec.rb
+++ b/spec/features/hub/edit_user_spec.rb
@@ -133,17 +133,16 @@ RSpec.describe "a user editing a user" do
           end
         end
 
-        scenario "assigning a site coordinator role" do
+        scenario "assigning a site coordinator role", js: true do
           user_to_edit = create(:admin_user)
           create :site, name: "Suite Site"
           create :site, name: "Sour Site"
 
           visit edit_hub_user_path(id: user_to_edit)
+          click_on "Reassign"
           click_on "Site Coordinator"
 
-          expect(page).to have_text("Sour Site")
-
-          select "Suite Site"
+          fill_in_tagify '.multi-select-vita-partner', "Suite Site"
 
           click_on "Submit"
 
@@ -152,17 +151,16 @@ RSpec.describe "a user editing a user" do
           end
         end
 
-        scenario "assigning a team member role" do
+        scenario "assigning a team member role", js: true do
           user_to_edit = create(:admin_user)
           create :site, name: "Suite Site"
           create :site, name: "Sour Site"
 
           visit edit_hub_user_path(id: user_to_edit)
+          click_on "Reassign"
           click_on "Team Member"
 
-          expect(page).to have_text("Sour Site")
-
-          select "Suite Site"
+          fill_in_tagify '.multi-select-vita-partner', "Suite Site"
 
           click_on "Submit"
 

--- a/spec/features/hub/edit_user_spec.rb
+++ b/spec/features/hub/edit_user_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe "a user editing a user" do
 
       context "editing a user in my organization" do
         let(:site) { create :site, parent_organization: organization, name: "Sweet Site" }
-        let(:user_to_edit) { create :site_coordinator_user, site: site }
+        let(:user_to_edit) { create :site_coordinator_user, sites: [site] }
         before { login_as current_user }
 
         scenario "update all fields" do

--- a/spec/features/hub/edit_user_spec.rb
+++ b/spec/features/hub/edit_user_spec.rb
@@ -142,6 +142,7 @@ RSpec.describe "a user editing a user" do
           click_on "Reassign"
           click_on "Site Coordinator"
 
+          expect(page.find('.multi-select-vita-partner').text).to eq("")
           fill_in_tagify '.multi-select-vita-partner', "Suite Site"
 
           click_on "Submit"
@@ -160,6 +161,7 @@ RSpec.describe "a user editing a user" do
           click_on "Reassign"
           click_on "Team Member"
 
+          expect(page.find('.multi-select-vita-partner').text).to eq("")
           fill_in_tagify '.multi-select-vita-partner', "Suite Site"
 
           click_on "Submit"
@@ -228,16 +230,16 @@ RSpec.describe "a user editing a user" do
             end
           end
 
-          scenario "assigning a site coordinator role" do
+          scenario "assigning a site coordinator role", js: true do
             create :site, name: "Sweet Site", parent_organization: organization
             create :site, name: "Sour Site", parent_organization: organization
 
             visit edit_hub_user_path(id: user_to_edit)
+            click_on "Reassign"
             click_on "Site Coordinator"
 
-            expect(page).to have_text("Sour Site")
-
-            select "Sweet Site"
+            expect(page.find('.multi-select-vita-partner').text).to eq("")
+            fill_in_tagify '.multi-select-vita-partner', "Sweet Site"
 
             click_on "Submit"
 
@@ -246,16 +248,16 @@ RSpec.describe "a user editing a user" do
             end
           end
 
-          scenario "assigning a team member role" do
+          scenario "assigning a team member role", js: true do
             create :site, name: "Sweet Site", parent_organization: organization
             create :site, name: "Sour Site", parent_organization: organization
 
             visit edit_hub_user_path(id: user_to_edit)
+            click_on "Reassign"
             click_on "Team Member"
 
-            expect(page).to have_text("Sour Site")
-
-            select "Sweet Site"
+            expect(page.find('.multi-select-vita-partner').text).to eq("")
+            fill_in_tagify '.multi-select-vita-partner', "Sweet Site"
 
             click_on "Submit"
 
@@ -307,15 +309,15 @@ RSpec.describe "a user editing a user" do
             end
           end
 
-          scenario "assigning a site coordinator role on a different site" do
+          scenario "assigning a site coordinator role on a different site", js: true do
             create :site, name: "Sour Site", parent_organization: organization
 
             visit edit_hub_user_path(id: user_to_edit)
+            click_on "Reassign"
             click_on "Site Coordinator"
 
-            expect(page).to have_text("Sweet Site")
-
-            select "Sour Site"
+            expect(page.find('.multi-select-vita-partner').text).to eq("Sweet Site")
+            fill_in_tagify '.multi-select-vita-partner', "Sour Site"
 
             click_on "Submit"
 
@@ -324,15 +326,15 @@ RSpec.describe "a user editing a user" do
             end
           end
 
-          scenario "assigning a team member role" do
+          scenario "assigning a team member role", js: true do
             create :site, name: "Sour Site", parent_organization: organization
 
             visit edit_hub_user_path(id: user_to_edit)
+            click_on "Reassign"
             click_on "Team Member"
 
-            expect(page).to have_text("Sour Site")
-
-            select "Sweet Site"
+            expect(page.find('.multi-select-vita-partner').text).to eq("Sweet Site")
+            fill_in_tagify '.multi-select-vita-partner', "Sweet Site"
 
             click_on "Submit"
 

--- a/spec/features/hub/invitations/site_coordinator_spec.rb
+++ b/spec/features/hub/invitations/site_coordinator_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Inviting site coordinator" do
       login_as user
     end
 
-    scenario "Inviting, re-sending invites, and accepting invites" do
+    scenario "Inviting, re-sending invites, and accepting invites", js: true do
       visit hub_tools_path
       click_on "Invitations"
 
@@ -21,7 +21,7 @@ RSpec.feature "Inviting site coordinator" do
       expect(page).to have_text "Send a new invitation"
       fill_in "What is their name?", with: "Colleen Cauliflower"
       fill_in "What is their email?", with: "colleague@cauliflower.org"
-      select  "Spring Onion Site", from: "Which site?"
+      fill_in_tagify '.multi-select-vita-partner', "Spring Onion Site"
       click_on "Send invitation email"
 
       # back on the invitations page

--- a/spec/features/hub/invitations/team_member_spec.rb
+++ b/spec/features/hub/invitations/team_member_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Inviting team members" do
       login_as user
     end
 
-    scenario "Inviting, re-sending invites, and accepting invites" do
+    scenario "Inviting, re-sending invites, and accepting invites", js: true do
       visit hub_tools_path
       click_on "Invitations"
 
@@ -24,7 +24,8 @@ RSpec.feature "Inviting team members" do
       fill_in "What is their name?", with: "Tammy Tomato"
       fill_in "What is their email?", with: "colleague@tomato.org"
       expect(page).to have_text "Which site?"
-      select "Squash Site"
+      fill_in_tagify '.multi-select-vita-partner', "Squash Site"
+
       click_on "Send invitation email"
 
       # back on the invitations page

--- a/spec/features/hub/roles/site_coordinator_spec.rb
+++ b/spec/features/hub/roles/site_coordinator_spec.rb
@@ -2,11 +2,11 @@ require "rails_helper"
 
 describe "Site Coordinator" do
   let(:site) { create :site }
-  let(:user) { create :site_coordinator_user, site: site }
+  let(:user) { create :site_coordinator_user, sites: [site] }
   let(:client) { create :client, vita_partner: site}
   let!(:intake) { create :intake, client: client }
   let!(:tax_return) { create :gyr_tax_return, client: client, assigned_user: nil }
-  let!(:team_member) { create :team_member_user, site: site }
+  let!(:team_member) { create :team_member_user, sites: [site] }
 
   before { login_as user }
 

--- a/spec/features/hub/roles/team_member_spec.rb
+++ b/spec/features/hub/roles/team_member_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.feature "Team member role" do
   context "A logged in team member" do
     let!(:vita_partner) { create :site, name: "Squash Site" }
-    let(:user) { create :team_member_user, role: create(:team_member_role, site: vita_partner) }
+    let(:user) { create :team_member_user, role: create(:team_member_role, sites: [vita_partner]) }
     # TODO: create a factory for users that will show up on the client list (consented, etc)
     # TODO: also, there should be an easier way to create a client that will not fail the edit form validations (currently this looks like create(:intake, :with_contact_info, :filled_out, state_of_residence: "CA"))
     let!(:hester_intake) { build(:intake, :filled_out, :with_contact_info, preferred_name: "Hester Horseradish", primary_consented_to_service: "yes", state_of_residence: "CA") }

--- a/spec/helpers/role_helper_spec.rb
+++ b/spec/helpers/role_helper_spec.rb
@@ -86,7 +86,7 @@ describe RoleHelper do
 
     context "for a site coordinator user" do
       let(:site) { create :site, name: "Soda Site" }
-      let(:user) { create :site_coordinator_user, site: site }
+      let(:user) { create :site_coordinator_user, sites: [site] }
 
       it "returns the name of the site that they are a coordinator for" do
         expect(helper.user_group(user)).to eq("Soda Site")
@@ -94,7 +94,7 @@ describe RoleHelper do
     end
 
     context "for a team member user" do
-      let(:user) { create :team_member_user, site: create(:site, name: "Soda Site") }
+      let(:user) { create :team_member_user, sites: [create(:site, name: "Soda Site")] }
 
       it "returns the name of their group" do
         expect(helper.user_group(user)).to eq("Soda Site")

--- a/spec/helpers/vita_partner_helper_spec.rb
+++ b/spec/helpers/vita_partner_helper_spec.rb
@@ -13,8 +13,8 @@ describe VitaPartnerHelper, requires_default_vita_partners: true do
         @vita_partners = team_member.accessible_vita_partners
         expected = [
           [
-            team_member.role.site.parent_organization.name,
-            [[team_member.role.site.name, team_member.role.site.id]]
+            team_member.role.sites.first.parent_organization.name,
+            [[team_member.role.sites.first.name, team_member.role.sites.first.id]]
           ]
         ]
 
@@ -33,8 +33,8 @@ describe VitaPartnerHelper, requires_default_vita_partners: true do
         @vita_partners = VitaPartner.accessible_by(Ability.new(site_coordinator))
         expected = [
           [
-            site_coordinator.role.site.parent_organization.name,
-            [[site_coordinator.role.site.name, site_coordinator.role.site.id]]
+            site_coordinator.role.sites.first.parent_organization.name,
+            [[site_coordinator.role.sites.first.name, site_coordinator.role.sites.first.id]]
           ]
         ]
 

--- a/spec/jobs/bulk_action_job_spec.rb
+++ b/spec/jobs/bulk_action_job_spec.rb
@@ -295,7 +295,7 @@ describe BulkActionJob do
 
       context "when users are assigned to the returns and don't have access through the new partner" do
         let(:old_site) { create :site, parent_organization: organization }
-        let(:assigned_user_at_old_site) { create :site_coordinator_user, site: old_site }
+        let(:assigned_user_at_old_site) { create :site_coordinator_user, sites: [old_site] }
         let(:assigned_user_who_retains_access) { create :organization_lead_user, organization: organization }
         let(:selected_client) { create :client, intake: (build :intake), vita_partner: old_site }
         let!(:still_assigned_return) { create :tax_return, client: selected_client, assigned_user: assigned_user_who_retains_access, year: 2018, tax_return_selections: [tax_return_selection] }

--- a/spec/jobs/bulk_action_job_spec.rb
+++ b/spec/jobs/bulk_action_job_spec.rb
@@ -331,8 +331,8 @@ describe BulkActionJob do
       let(:client) { create :client, vita_partner: site, intake: build(:intake) }
       let(:site) { create :site }
 
-      let!(:team_member) { create :user, role: create(:team_member_role, site: site) }
-      let!(:site_coordinator) { create :user, role: create(:site_coordinator_role, site: site) }
+      let!(:team_member) { create :user, role: create(:team_member_role, sites: [site]) }
+      let!(:site_coordinator) { create :user, role: create(:site_coordinator_role, sites: [site]) }
       let!(:inaccessible_user) { create :user }
 
       let(:params) do

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -249,7 +249,7 @@ describe Ability do
         shared_examples :user_cannot_manage_other_users_in_their_site do
           let(:target_user) { create :site_coordinator_user }
           before do
-            allow(user).to receive(:accessible_vita_partners).and_return(VitaPartner.where(id: target_user.role.site))
+            allow(user).to receive(:accessible_vita_partners).and_return(VitaPartner.where(id: target_user.role.sites))
           end
 
           it "cannot manage other users in a site they have access to" do

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -451,7 +451,7 @@ describe Ability do
         let(:another_organization) { create :organization, coalition: coalition }
         let(:site) { create(:site, parent_organization: organization) }
         let(:another_site) { create(:site, parent_organization: organization) }
-        let(:target_role) { create :site_coordinator_role, site: site }
+        let(:target_role) { create :site_coordinator_role, sites: [site] }
 
         context "current user is coalition lead in the site's coalition" do
           let(:user) { create :coalition_lead_user, coalition: coalition }
@@ -516,7 +516,7 @@ describe Ability do
         let(:another_organization) { create :organization, coalition: coalition }
         let(:site) { create(:site, parent_organization: organization) }
         let(:another_site) { create(:site, parent_organization: organization) }
-        let(:target_role) { create :team_member_role, site: site }
+        let(:target_role) { create :team_member_role, sites: [site] }
 
         context "current user is coalition lead in the site's coalition" do
           let(:user) { create :coalition_lead_user, coalition: coalition }

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -272,7 +272,7 @@ describe Ability do
             context "users in their coalition" do
               let!(:target_user) do
                 create :site_coordinator_user,
-                       site: create(:site, parent_organization: create(:organization, coalition: user.role.coalition))
+                       sites: [create(:site, parent_organization: create(:organization, coalition: user.role.coalition))]
               end
 
               it "can manage users in their coalition" do
@@ -297,7 +297,7 @@ describe Ability do
             context "users in their org" do
               let!(:target_user) do
                 create :site_coordinator_user,
-                       site: create(:site, parent_organization: user.role.organization)
+                       sites: [create(:site, parent_organization: user.role.organization)]
               end
 
               it "can manage users in their org" do
@@ -437,7 +437,7 @@ describe Ability do
         end
 
         context "anyone else" do
-          let(:user) { create :site_coordinator_user, site: create(:site, parent_organization: organization) }
+          let(:user) { create :site_coordinator_user, sites: [create(:site, parent_organization: organization)] }
 
           it "cannot manage" do
             expect(subject.can?(:manage, target_role)).to eq false
@@ -486,7 +486,7 @@ describe Ability do
         end
 
         context "current user is site coordinator in the same site" do
-          let(:user) { create :site_coordinator_user, site: site }
+          let(:user) { create :site_coordinator_user, sites: [site] }
 
           it "can manage" do
             expect(subject.can?(:manage, target_role)).to eq true
@@ -494,7 +494,7 @@ describe Ability do
         end
 
         context "current user is site coordinator in another site" do
-          let(:user) { create :site_coordinator_user, site: another_site }
+          let(:user) { create :site_coordinator_user, sites: [another_site] }
 
           it "cannot manage" do
             expect(subject.can?(:manage, target_role)).to eq false
@@ -502,7 +502,7 @@ describe Ability do
         end
 
         context "anyone else" do
-          let(:user) { create :team_member_user, site: site }
+          let(:user) { create :team_member_user, sites: [site] }
 
           it "cannot manage" do
             expect(subject.can?(:manage, target_role)).to eq false
@@ -551,7 +551,7 @@ describe Ability do
         end
 
         context "current user is site coordinator in the same site" do
-          let(:user) { create :site_coordinator_user, site: site }
+          let(:user) { create :site_coordinator_user, sites: [site] }
 
           it "can manage" do
             expect(subject.can?(:manage, target_role)).to eq true
@@ -559,7 +559,7 @@ describe Ability do
         end
 
         context "current user is site coordinator in another site" do
-          let(:user) { create :site_coordinator_user, site: another_site }
+          let(:user) { create :site_coordinator_user, sites: [another_site] }
 
           it "cannot manage" do
             expect(subject.can?(:manage, target_role)).to eq false
@@ -567,7 +567,7 @@ describe Ability do
         end
 
         context "anyone else" do
-          let(:user) { create :team_member_user, site: site }
+          let(:user) { create :team_member_user, sites: [site] }
 
           it "cannot manage" do
             expect(subject.can?(:manage, target_role)).to eq false

--- a/spec/lib/client_sorter_spec.rb
+++ b/spec/lib/client_sorter_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe ClientSorter do
   let(:clients_query_double) { double }
   let(:intakes_query_double) { double }
-  let(:user_role) { build :team_member_role, site: build(:site) }
+  let(:user_role) { build :team_member_role, sites: [build(:site)] }
   let(:user) { create :user, role: user_role }
   let(:subject) { described_class.new(clients_query_double, user, params, {}) }
 

--- a/spec/lib/client_sorter_spec.rb
+++ b/spec/lib/client_sorter_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe ClientSorter do
   let(:clients_query_double) { double }
   let(:intakes_query_double) { double }
-  let(:user_role) { build :team_member_role, sites: [build(:site)] }
+  let(:user_role) { build :team_member_role, sites: [create(:site)] }
   let(:user) { create :user, role: user_role }
   let(:subject) { described_class.new(clients_query_double, user, params, {}) }
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -36,7 +36,7 @@ describe Organization do
     let(:site) { create :site, parent_organization: organization }
     let!(:lead) { create :organization_lead_user, organization: organization }
     let!(:outside_lead) { create :organization_lead_user }
-    let!(:team_member) { create :team_member_user, site: site }
+    let!(:team_member) { create :team_member_user, sites: [site] }
 
     it "returns users who are organization leads for the provided vita_partner" do
       expect(organization.organization_leads).to eq [lead]
@@ -52,9 +52,9 @@ describe Organization do
 
     let!(:lead) { create :organization_lead_user, organization: organization }
     let!(:outside_lead) { create :organization_lead_user }
-    let!(:site1_coordinator) { create :site_coordinator_user, site: site1 }
-    let!(:site2_coordinator) { create :site_coordinator_user, site: site2 }
-    let!(:team_member) { create :team_member_user, site: site1 }
+    let!(:site1_coordinator) { create :site_coordinator_user, sites: [site1] }
+    let!(:site2_coordinator) { create :site_coordinator_user, sites: [site2] }
+    let!(:team_member) { create :team_member_user, sites: [site1] }
 
     it "includes site coordinators from all child sites" do
       expect(organization.site_coordinators).to match_array([site1_coordinator, site2_coordinator])
@@ -67,8 +67,8 @@ describe Organization do
     let(:site2) { create :site, parent_organization: organization }
     let!(:lead) { create :organization_lead_user, organization: organization }
     let!(:outside_lead) { create :organization_lead_user }
-    let!(:site1_team_member) { create :team_member_user, site: site1 }
-    let!(:site2_team_member) { create :team_member_user, site: site2 }
+    let!(:site1_team_member) { create :team_member_user, sites: [site1] }
+    let!(:site2_team_member) { create :team_member_user, sites: [site2] }
 
     it "includes site coordinators from all child sites" do
       expect(organization.team_members).to match_array([site1_team_member, site2_team_member])

--- a/spec/models/site_coordinator_role_spec.rb
+++ b/spec/models/site_coordinator_role_spec.rb
@@ -26,11 +26,17 @@ RSpec.describe SiteCoordinatorRole, type: :model do
     end
   end
 
-  describe "required fields" do
+  describe "validations" do
     context "with a site" do
       it "is valid" do
         site = create(:site)
         expect(described_class.new(sites: [site])).to be_valid
+      end
+    end
+
+    context "with sites from multiple parent organizations" do
+      it "is not valid" do
+        expect(described_class.new(sites: [create(:site), create(:site)])).not_to be_valid
       end
     end
 

--- a/spec/models/site_coordinator_role_spec.rb
+++ b/spec/models/site_coordinator_role_spec.rb
@@ -5,7 +5,7 @@
 #  id              :bigint           not null, primary key
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  vita_partner_id :bigint           not null
+#  vita_partner_id :bigint
 #
 # Indexes
 #
@@ -18,11 +18,19 @@
 require 'rails_helper'
 
 RSpec.describe SiteCoordinatorRole, type: :model do
+  describe '#sites' do
+    it "returns the old associated site if this record hasn't been migrated to join table land" do
+      site = create(:site)
+      role = described_class.new(vita_partner_id: site.id)
+      expect(role.sites).to eq([site])
+    end
+  end
+
   describe "required fields" do
     context "with a site" do
       it "is valid" do
         site = create(:site)
-        expect(described_class.new(site: site)).to be_valid
+        expect(described_class.new(sites: [site])).to be_valid
       end
     end
 
@@ -35,7 +43,7 @@ RSpec.describe SiteCoordinatorRole, type: :model do
     context "with an organization" do
       it "is not valid" do
         organization = create(:organization)
-        expect(described_class.new(site: organization)).not_to be_valid
+        expect { described_class.new(sites: [organization]) }.to raise_error(ActiveRecord::AssociationTypeMismatch)
       end
     end
   end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -38,9 +38,9 @@ describe Site do
 
     let!(:lead) { create :organization_lead_user, organization: organization }
     let!(:outside_lead) { create :organization_lead_user }
-    let!(:site1_coordinator) { create :site_coordinator_user, site: site1 }
-    let!(:site2_coordinator) { create :site_coordinator_user, site: site2 }
-    let!(:team_member) { create :team_member_user, site: site1 }
+    let!(:site1_coordinator) { create :site_coordinator_user, sites: [site1] }
+    let!(:site2_coordinator) { create :site_coordinator_user, sites: [site2] }
+    let!(:team_member) { create :team_member_user, sites: [site1] }
 
     it "only includes site coordinators from that site" do
       expect(site1.site_coordinators).to eq [site1_coordinator]
@@ -53,8 +53,8 @@ describe Site do
     let(:site2) { create :site, parent_organization: organization }
     let!(:lead) { create :organization_lead_user, organization: organization }
     let!(:outside_lead) { create :organization_lead_user }
-    let!(:site1_team_member) { create :team_member_user, site: site1 }
-    let!(:site2_team_member) { create :team_member_user, site: site2 }
+    let!(:site1_team_member) { create :team_member_user, sites: [site1] }
+    let!(:site2_team_member) { create :team_member_user, sites: [site2] }
 
     it "only includes team members from that site" do
       expect(site1.team_members).to eq [site1_team_member]

--- a/spec/models/system_note/tax_return_created_spec.rb
+++ b/spec/models/system_note/tax_return_created_spec.rb
@@ -41,7 +41,7 @@ describe SystemNote::TaxReturnCreated do
     end
 
     context "a team member" do
-      let(:user) { create :team_member_user, name: "Team User", site: (create :site, name: "Some Site") }
+      let(:user) { create :team_member_user, name: "Team User", sites: [create(:site, name: "Some Site")] }
 
       it "creates the appropriate system note" do
         note = described_class.generate!(tax_return: tax_return, initiated_by: user)

--- a/spec/models/team_member_role_spec.rb
+++ b/spec/models/team_member_role_spec.rb
@@ -26,10 +26,16 @@ RSpec.describe TeamMemberRole, type: :model do
     end
   end
 
-  describe "required fields" do
+  describe "validations" do
     context "with a site" do
       it "is valid" do
         expect(described_class.new(sites: [create(:site)])).to be_valid
+      end
+    end
+
+    context "with sites from multiple parent organizations" do
+      it "is not valid" do
+        expect(described_class.new(sites: [create(:site), create(:site)])).not_to be_valid
       end
     end
 

--- a/spec/models/team_member_role_spec.rb
+++ b/spec/models/team_member_role_spec.rb
@@ -5,7 +5,7 @@
 #  id              :bigint           not null, primary key
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  vita_partner_id :bigint           not null
+#  vita_partner_id :bigint
 #
 # Indexes
 #
@@ -18,10 +18,18 @@
 require 'rails_helper'
 
 RSpec.describe TeamMemberRole, type: :model do
+  describe '#sites' do
+    it "returns the old associated site if this record hasn't been migrated to join table land" do
+      site = create(:site)
+      role = described_class.new(vita_partner_id: site.id)
+      expect(role.sites).to eq([site])
+    end
+  end
+
   describe "required fields" do
     context "with a site" do
       it "is valid" do
-        expect(described_class.new(site: create(:site))).to be_valid
+        expect(described_class.new(sites: [create(:site)])).to be_valid
       end
     end
 
@@ -32,8 +40,8 @@ RSpec.describe TeamMemberRole, type: :model do
     end
 
     context "with a organization" do
-      it "is not valid" do
-        expect(described_class.new(site: create(:organization))).not_to be_valid
+      it "is not allowed" do
+        expect { described_class.new(sites: [create(:organization)]) }.to raise_error(ActiveRecord::AssociationTypeMismatch)
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -440,8 +440,8 @@ RSpec.describe User, type: :model, requires_default_vita_partners: true do
 
     let(:coalition_lead_user) { create :coalition_lead_user, coalition: client_coalition }
     let(:organization_lead_user) { create :organization_lead_user, organization: client_organization }
-    let(:site_coordinator_user) { create :site_coordinator_user, site: client_site }
-    let(:team_member_user) { create :team_member_user, site: client_site }
+    let(:site_coordinator_user) { create :site_coordinator_user, sites: [client_site] }
+    let(:team_member_user) { create :team_member_user, sites: [client_site] }
 
     context "with a client assigned to an organization" do
 
@@ -579,33 +579,33 @@ RSpec.describe User, type: :model, requires_default_vita_partners: true do
     end
   end
 
-  describe "#served_entity" do
+  describe "#served_entities" do
     context "an admin user" do
       let(:user) { create :admin_user }
       it "returns nil" do
-        expect(user.served_entity).to eq nil
+        expect(user.served_entities).to eq nil
       end
     end
 
     context "a client success user" do
       let(:user) { create :client_success_user }
       it "returns nil" do
-        expect(user.served_entity).to eq nil
+        expect(user.served_entities).to eq nil
       end
     end
 
     context "a greeter user" do
       let(:user) { create :greeter_user }
       it "returns nil" do
-        expect(user.served_entity).to eq nil
+        expect(user.served_entities).to eq nil
       end
     end
 
     context "a team member user" do
       let(:site) { create :site }
-      let(:user) { create :team_member_user, site: site }
+      let(:user) { create :team_member_user, sites: [site] }
       it "returns their site" do
-        expect(user.served_entity).to eq site
+        expect(user.served_entities).to eq [site]
       end
     end
 
@@ -613,7 +613,7 @@ RSpec.describe User, type: :model, requires_default_vita_partners: true do
       let(:coalition) { create :coalition }
       let(:user) { create :coalition_lead_user, coalition: coalition }
       it "returns their coalition" do
-        expect(user.served_entity).to eq coalition
+        expect(user.served_entities).to eq [coalition]
       end
     end
 
@@ -621,15 +621,15 @@ RSpec.describe User, type: :model, requires_default_vita_partners: true do
       let(:organization) { create :organization }
       let(:user) { create :organization_lead_user, organization: organization }
       it "returns their organization" do
-        expect(user.served_entity).to eq organization
+        expect(user.served_entities).to eq [organization]
       end
     end
 
     context "a site coordinator user" do
       let(:site) { create :site }
-      let(:user) { create :site_coordinator_user, site: site }
+      let(:user) { create :site_coordinator_user, sites: [site] }
       it "returns their organization" do
-        expect(user.served_entity).to eq site
+        expect(user.served_entities).to eq [site]
       end
     end
   end
@@ -680,14 +680,22 @@ RSpec.describe User, type: :model, requires_default_vita_partners: true do
     end
 
     context "a team member" do
-      let(:user) { create :team_member_user, name: "Marty Melon", site: (create :site, name: "New Site") }
+      let(:user) { create :team_member_user, name: "Marty Melon", sites: [create(:site, name: "New Site")] }
       it "is Admin" do
         expect(user.name_with_role_and_entity).to eq "Marty Melon (Team Member) - New Site"
+      end
+
+      context "a team member with multiple sites" do
+        it "returns the first site name and the number of additional sites" do
+          user.role.sites << create(:site, name: "New Site2")
+          user.role.sites << create(:site, name: "New Site3")
+          expect(user.name_with_role_and_entity).to eq "Marty Melon (Team Member) - New Site (and 2 more)"
+        end
       end
     end
 
     context "site coordinator" do
-      let(:user) { create :site_coordinator_user, name: "Luna Lemon", site: (create :site, name: "New Site") }
+      let(:user) { create :site_coordinator_user, name: "Luna Lemon", sites: [create(:site, name: "New Site")] }
       it "is Site Coordinator" do
         expect(user.name_with_role_and_entity).to eq "Luna Lemon (Site Coordinator) - New Site"
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe User, type: :model, requires_default_vita_partners: true do
     let!(:other_coalition) { create(:coalition) }
 
     context "team member user" do
-      let(:user) { create(:team_member_user, site: site) }
+      let(:user) { create(:team_member_user, sites: [site]) }
 
       it "does not include coalition" do
         expect(user.accessible_coalitions).to be_empty
@@ -203,7 +203,7 @@ RSpec.describe User, type: :model, requires_default_vita_partners: true do
     end
 
     context "site coordinator user" do
-      let(:user) { create(:site_coordinator_user, site: site) }
+      let(:user) { create(:site_coordinator_user, sites: [site]) }
 
       it "does not include coalition" do
         expect(user.accessible_coalitions).to be_empty
@@ -250,7 +250,7 @@ RSpec.describe User, type: :model, requires_default_vita_partners: true do
 
       it "should return a user's site" do
         accessible_group_ids = user.accessible_vita_partners.pluck(:id)
-        expect(accessible_group_ids).to include(user.role.site.id)
+        expect(accessible_group_ids).to match_array(user.role.sites.map(&:id))
         expect(accessible_group_ids).not_to include(not_accessible_partner.id)
       end
     end
@@ -261,7 +261,7 @@ RSpec.describe User, type: :model, requires_default_vita_partners: true do
 
       it "should return the user's site" do
         accessible_group_ids = user.accessible_vita_partners.pluck(:id)
-        expect(accessible_group_ids).to include(user.role.site.id)
+        expect(accessible_group_ids).to match_array(user.role.sites.map(&:id))
         expect(accessible_group_ids).not_to include(unaccessible_site.id)
       end
     end
@@ -362,13 +362,13 @@ RSpec.describe User, type: :model, requires_default_vita_partners: true do
     let!(:cousin_organization_lead) { create :organization_lead_user, organization: sibling_organization }
 
     let!(:site) { create :site, parent_organization: organization }
-    let!(:site_coordinator) { create :site_coordinator_user, site: site }
-    let!(:sibling_site_coordinator) { create :site_coordinator_user, site: site }
-    let!(:team_member) { create :team_member_user, site: site }
-    let!(:sibling_team_member) { create :team_member_user, site: site }
+    let!(:site_coordinator) { create :site_coordinator_user, sites: [site] }
+    let!(:sibling_site_coordinator) { create :site_coordinator_user, sites: [site] }
+    let!(:team_member) { create :team_member_user, sites: [site] }
+    let!(:sibling_team_member) { create :team_member_user, sites: [site] }
 
     let!(:sibling_site) { create :site, parent_organization: organization }
-    let!(:cousin_site_coordinator) { create :site_coordinator_user, site: sibling_site }
+    let!(:cousin_site_coordinator) { create :site_coordinator_user, sites: [sibling_site] }
 
     let(:admin) { create :admin_user }
 

--- a/spec/services/mixpanel_service_spec.rb
+++ b/spec/services/mixpanel_service_spec.rb
@@ -172,7 +172,7 @@ describe MixpanelService do
       let(:organization) { create :organization, name: "Parent Org", coalition: coalition }
       let(:site) { create :site, name: "Child Site", parent_organization: organization }
       let(:client) { create :client, intake: (build :intake, visitor_id: "fake_visitor_id"), vita_partner: site }
-      let(:user) { create :team_member_user, site: site }
+      let(:user) { create :team_member_user, sites: [site] }
 
       context "when the event is triggered by a user" do
         let!(:tax_return) { create :gyr_tax_return, :intake_before_consent, certification_level: "basic", client: client, metadata: { initiated_by_user_id: user.id } }
@@ -240,7 +240,7 @@ describe MixpanelService do
       let(:organization) { create :organization, name: "Parent Org", coalition: coalition }
       let(:site) { create :site, name: "Child Site", parent_organization: organization }
       let(:client) { create :client, intake: (build :intake, visitor_id: "fake_visitor_id"), vita_partner: site }
-      let(:user) { create :team_member_user, site: site }
+      let(:user) { create :team_member_user, sites: [site] }
 
       context "when the event is triggered by a user" do
         let!(:tax_return) { create :gyr_tax_return, :review_reviewing, metadata: { initiated_by_user_id: user.id }, certification_level: "basic", client: client }
@@ -284,7 +284,7 @@ describe MixpanelService do
         let(:organization) { create :organization, name: "Parent Org", coalition: coalition }
         let(:site) { create :site, name: "Child Site", parent_organization: organization }
         let(:client) { create :client, intake: (build :intake, visitor_id: "fake_visitor_id"), vita_partner: site }
-        let(:user) { create :team_member_user, site: site }
+        let(:user) { create :team_member_user, sites: [site] }
 
         context "when the event is triggered by a user" do
           let(:tax_return) { create :gyr_tax_return, :prep_ready_for_prep, metadata: { initiated_by_user_id: user.id }, certification_level: "basic", client: client }
@@ -389,7 +389,7 @@ describe MixpanelService do
         let(:organization) { create :organization, name: "Parent Org", coalition: coalition }
         let(:site) { create :site, name: "Child Site", parent_organization: organization }
         let(:client) { create :client, intake: (build :intake, visitor_id: "fake_visitor_id"), vita_partner: site }
-        let(:user) { create :team_member_user, site: site }
+        let(:user) { create :team_member_user, sites: [site] }
 
         context "when the event is triggered by a user" do
           let(:tax_return) { create :gyr_tax_return, :prep_ready_for_prep, certification_level: "basic", client: client, metadata: { initiated_by_user_id: user.id } }
@@ -712,7 +712,7 @@ describe MixpanelService do
           let(:coalition) { create :coalition }
           let(:organization) { create :organization, coalition: coalition }
           let(:site) { create :site, parent_organization: organization }
-          let(:user) { create :site_coordinator_user, site: site }
+          let(:user) { create :site_coordinator_user, sites: [site] }
 
           it 'returns all user fields' do
             expected = {
@@ -734,7 +734,7 @@ describe MixpanelService do
           let(:coalition) { create :coalition }
           let(:organization) { create :organization, coalition: coalition }
           let(:site) { create :site, parent_organization: organization }
-          let(:user) { create :team_member_user, site: site }
+          let(:user) { create :team_member_user, sites: [site] }
 
           it 'returns all user fields' do
             expected = {

--- a/spec/services/tax_return_assignment_service_spec.rb
+++ b/spec/services/tax_return_assignment_service_spec.rb
@@ -27,7 +27,7 @@ describe TaxReturnAssignmentService do
 
       context "when assigned user has a different vita partner than the clients" do
         let(:tax_return) { create :gyr_tax_return, assigned_user: (create :user), client: create(:client, vita_partner: old_site) }
-        let(:assigned_user) { create :user, role: create(:team_member_role, site: new_site) }
+        let(:assigned_user) { create :user, role: create(:team_member_role, sites: [new_site]) }
         let(:new_site) { create :site }
         let(:old_site) { create :site }
 

--- a/spec/services/update_client_vita_partner_service_spec.rb
+++ b/spec/services/update_client_vita_partner_service_spec.rb
@@ -12,7 +12,7 @@ describe UpdateClientVitaPartnerService do
     let(:other_site) { create :site, parent_organization: current_site.parent_organization }
     let(:client) { create :client, vita_partner: current_site, tax_returns: [tax_return], intake: build(:intake) }
     let(:tax_return) { build :tax_return, year: 2019, assigned_user: assigned_user }
-    let(:assigned_user) { create :team_member_user, site: current_site }
+    let(:assigned_user) { create :team_member_user, sites: [current_site] }
 
     context "when a client was previously routed to no one because we were at capacity" do
       let(:fake_service) { instance_double(InitialTaxReturnsService) }


### PR DESCRIPTION
keep around the `vita_partner_id` for those roles until we migrate everything to join tables