### PR TITLE
Heroku review apps: ask for the URL with the command line before posting the comment

### DIFF
--- a/.github/workflows/heroku-pull-request.yml
+++ b/.github/workflows/heroku-pull-request.yml
@@ -106,9 +106,13 @@ jobs:
         if: github.event.action == 'opened' || github.event.action == 'reopened'
         run: heroku ps:scale worker=1 --app=${{ env.HEROKU_APP_NAME }}
 
+      - name: Get heroku generated url
+        if: github.event.action == 'opened' || github.event.action == 'reopened'
+        run: echo "HEROKU_URL=$(heroku apps:info -s --app ${{ env.HEROKU_APP_NAME }} | grep web_url | cut -d= -f2)" >> $GITHUB_ENV
+
       - name: Add comment to PR
         if: github.event.action == 'opened' || github.event.action == 'reopened'
-        run: |
-          gh pr comment ${{ github.event.number }} --body '[Heroku app](https://dashboard.heroku.com/apps/${{ env.HEROKU_APP_NAME }}): https://${{ env.HEROKU_APP_NAME }}.herokuapp.com<br/>View logs: `heroku logs --app ${{ env.HEROKU_APP_NAME }}` (optionally add `--tail`)'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment ${{ github.event.number }} --body '[Heroku app](https://dashboard.heroku.com/apps/${{ env.HEROKU_APP_NAME }}): ${{ env.HEROKU_URL }}<br/>View logs: `heroku logs --app ${{ env.HEROKU_APP_NAME }}` (optionally add `--tail`)'


### PR DESCRIPTION
seems like over the last week Heroku started giving apps urls like 'my-app-1234-abcdefghi' where the last bit is an extra unique identifier. we must respond to this with code!