### PR TITLE
Use 'selenium-webdriver' directly to find chromedriver instead of using 'webdrivers'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,11 +88,11 @@ commands:
     steps:
       - run: date -I > /tmp/today && cat /tmp/today
       - restore_cache:
-          key: webdrivers-v2-{{ checksum "/tmp/today" }}
-      - run: if [ ! -f ~/.webdrivers/chromedriver ] ; then bundle exec rake webdrivers:chromedriver:update ; fi
+          key: webdrivers-v3-{{ checksum "/tmp/today" }}
+      - run: bin/gyr download_webdriver
       - save_cache:
-          key: webdrivers-v2-{{ checksum "/tmp/today" }}
-          paths: [~/.webdrivers]
+          key: webdrivers-v3-{{ checksum "/tmp/today" }}
+          paths: [~/.cache/selenium]
 jobs:
   i18n_normalize:
     executor: ruby_executor

--- a/Gemfile
+++ b/Gemfile
@@ -96,7 +96,7 @@ group :development, :test do
   gem 'axe-matchers'
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '>= 2.15'
-  gem 'webdrivers', '>= 5.2.0'
+  gem 'selenium-webdriver'
   gem 'rspec-rails'
   gem 'rails-controller-testing'
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
       tzinfo
     byebug (11.1.3)
     cancancan (3.5.0)
-    capybara (3.39.0)
+    capybara (3.39.2)
       addressable
       matrix
       mini_mime (>= 0.1.3)
@@ -581,7 +581,7 @@ GEM
     scenic (1.7.0)
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
-    selenium-webdriver (4.8.6)
+    selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -671,10 +671,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -776,6 +772,7 @@ DEPENDENCIES
   rubyzip
   sass-rails (~> 5.0)
   scenic
+  selenium-webdriver
   sentry-delayed_job
   sentry-rails
   sentry-ruby
@@ -795,7 +792,6 @@ DEPENDENCIES
   valid_email2
   warning
   web-console (>= 3.3.0)
-  webdrivers (>= 5.2.0)
   webmock
   websocket-extensions (>= 0.1.5)
   will_paginate

--- a/cli/gyr_cli.rb
+++ b/cli/gyr_cli.rb
@@ -36,6 +36,15 @@ class GyrCli < Thor
     end
   end
 
+  desc "download_webdriver", "Downloads the latest chromedriver using SeleniumManager from the selenium-webdriver gem"
+  def download_webdriver
+    require 'selenium-webdriver'
+
+    Selenium::WebDriver::SeleniumManager.driver_path(
+      Selenium::WebDriver::Chrome::Options.new(browser_name: "chrome")
+    )
+  end
+
   no_commands do
     def load_rails_env!
       require File.expand_path('../config/environment', File.dirname(__FILE__))

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,7 +6,6 @@ require "spec_helper"
 require "capybara/rails"
 require "capybara/rspec"
 require "selenium/webdriver"
-require "webdrivers"
 require "percy/capybara"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,5 +1,3 @@
 require 'webmock/rspec'
 
-driver_urls = Webdrivers::Common.subclasses.map(&:base_url)
-
-WebMock.disable_net_connect!(allow_localhost: true, allow: driver_urls)
+WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
Currently the webdrivers gem is a little bit confused about chrome 105/chromedriver 104

selenium-webdriver recently introduced its own technology for downloading chromedriver that seems to deal with everything better