### PR TITLE
Replace org/site dropdowns in Hub

### DIFF
--- a/app/controllers/hub/clients/organizations_controller.rb
+++ b/app/controllers/hub/clients/organizations_controller.rb
@@ -3,13 +3,12 @@ module Hub
     class OrganizationsController < ApplicationController
       include AccessControllable
       before_action :require_sign_in
-      before_action :load_vita_partners, only: [:edit, :update]
-      before_action :authorize_vita_partner, only: [:update]
-
-      layout "hub"
       load_and_authorize_resource :client, parent: false
       before_action :redirect_to_client_show_if_archived
       before_action :redirect_if_no_vita_partner_selected, only: [:update]
+      before_action :load_vita_partners, only: [:edit, :update]
+      before_action :authorize_vita_partner, only: [:update]
+      layout "hub"
 
       def edit; end
 
@@ -38,7 +37,7 @@ module Hub
       end
 
       def authorize_vita_partner
-        raise CanCan::AccessDenied unless @vita_partners.find_by(id: parsed_vita_partner_id).present? || parsed_vita_partner_id.present?
+        raise CanCan::AccessDenied unless @vita_partners.find_by(id: parsed_vita_partner_id).present?
       end
 
       def parsed_vita_partner_id
@@ -51,9 +50,9 @@ module Hub
       end
 
       def redirect_if_no_vita_partner_selected
-        return unless parsed_vita_partner_id.nil?
+        return if client_params[:vita_partners].present?
 
-        flash[:error] = "No changes made because no vita partner selected."
+        flash[:alert] = "No changes made because no vita partner selected."
         redirect_to hub_client_path(@client.id)
       end
     end

--- a/app/controllers/hub/clients/organizations_controller.rb
+++ b/app/controllers/hub/clients/organizations_controller.rb
@@ -38,7 +38,7 @@ module Hub
       end
 
       def authorize_vita_partner
-        raise CanCan::AccessDenied unless @vita_partners.find_by(id: parsed_vita_partner_id).present? || parsed_vita_partner_id.nil?
+        raise CanCan::AccessDenied unless @vita_partners.find_by(id: parsed_vita_partner_id).present? || parsed_vita_partner_id.present?
       end
 
       def parsed_vita_partner_id

--- a/app/controllers/hub/clients/organizations_controller.rb
+++ b/app/controllers/hub/clients/organizations_controller.rb
@@ -9,6 +9,7 @@ module Hub
       layout "hub"
       load_and_authorize_resource :client, parent: false
       before_action :redirect_to_client_show_if_archived
+      before_action :redirect_if_no_vita_partner_selected, only: [:update]
 
       def edit; end
 
@@ -16,7 +17,7 @@ module Hub
         begin
           ActiveRecord::Base.transaction do
             UpdateClientVitaPartnerService.new(clients: [@client],
-                                               vita_partner_id: client_params[:vita_partner_id],
+                                               vita_partner_id: parsed_vita_partner_id,
                                                change_initiated_by: current_user).update!
           end
         rescue ActiveRecord::RecordInvalid
@@ -29,7 +30,7 @@ module Hub
       private
 
       def client_params
-        params.require(:client).permit(:vita_partner_id).merge(change_initiated_by: current_user)
+        params.require(:client).permit(:vita_partners).merge(change_initiated_by: current_user)
       end
 
       def load_vita_partners
@@ -37,11 +38,23 @@ module Hub
       end
 
       def authorize_vita_partner
-        raise CanCan::AccessDenied unless @vita_partners.find_by(id: client_params[:vita_partner_id]).present?
+        raise CanCan::AccessDenied unless @vita_partners.find_by(id: parsed_vita_partner_id).present? || parsed_vita_partner_id.nil?
+      end
+
+      def parsed_vita_partner_id
+        return nil unless client_params[:vita_partners].present?
+        JSON.parse(client_params[:vita_partners]).pluck("id")
       end
 
       def redirect_to_client_show_if_archived
         redirect_to hub_client_path(@client.id) unless @client.intake
+      end
+
+      def redirect_if_no_vita_partner_selected
+        return unless parsed_vita_partner_id.nil?
+
+        flash[:error] = "No changes made because no vita partner selected."
+        redirect_to hub_client_path(@client.id)
       end
     end
   end

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -26,6 +26,11 @@ class Users::InvitationsController < Devise::InvitationsController
       redirect_to invitations_path and return
     end
 
+    unless @role.valid?
+      flash[:alert] = "Unable to send invitation. Must select vita partner."
+      redirect_to invitations_path and return
+    end
+
     super
   end
 

--- a/app/helpers/role_helper.rb
+++ b/app/helpers/role_helper.rb
@@ -51,14 +51,16 @@ module RoleHelper
     end
   end
 
-  def taggable_items_from_role_type(role_type)
-    case role_type
-    when CoalitionLeadRole::TYPE
+  def taggable_items_from_role(role)
+    case role.class.name
+    when "CoalitionLeadRole"
       taggable_coalitions(@coalitions)
-    when OrganizationLeadRole::TYPE
+    when "OrganizationLeadRole"
       taggable_organizations(@vita_partners)
-    when SiteCoordinatorRole::TYPE || TeamMemberRole::TYPE
+    when "SiteCoordinatorRole", "TeamMemberRole"
       taggable_sites(@vita_partners)
+    else
+      []
     end
   end
 

--- a/app/helpers/role_helper.rb
+++ b/app/helpers/role_helper.rb
@@ -33,10 +33,10 @@ module RoleHelper
   def role_from_params(role_string, params)
     case role_string
     when OrganizationLeadRole::TYPE
-      role_params = params[:organization_id].present? ? { organization: @vita_partners.find(params[:organization_id]) } : {}
+      role_params = params[:organization].present? ? {organization: @vita_partners.find(JSON.parse(params[:organization].presence || '[]').pluck('id').first)} : {}
       OrganizationLeadRole.new(role_params)
     when CoalitionLeadRole::TYPE
-      role_params = params[:coalition_id].present? ? { coalition: @coalitions.find(params[:coalition_id]) } : {}
+      role_params = params[:coalition].present? ? {coalition: @coalitions.find(JSON.parse(params[:coalition].presence || '[]').pluck('id').first)} : {}
       CoalitionLeadRole.new(role_params)
     when AdminRole::TYPE
       AdminRole.new
@@ -48,6 +48,17 @@ module RoleHelper
       GreeterRole.new
     when TeamMemberRole::TYPE
       TeamMemberRole.new(sites: @vita_partners.sites.where(id: JSON.parse(params[:sites].presence || '[]').pluck('id')))
+    end
+  end
+
+  def taggable_items_from_role_type(role_type)
+    case role_type
+    when CoalitionLeadRole::TYPE
+      taggable_coalitions(@coalitions)
+    when OrganizationLeadRole::TYPE
+      taggable_organizations(@vita_partners)
+    when SiteCoordinatorRole::TYPE || TeamMemberRole::TYPE
+      taggable_sites(@vita_partners)
     end
   end
 

--- a/app/helpers/role_helper.rb
+++ b/app/helpers/role_helper.rb
@@ -51,13 +51,13 @@ module RoleHelper
     end
   end
 
-  def taggable_items_from_role(role)
-    case role.class.name
-    when "CoalitionLeadRole"
+  def taggable_items_from_role_type(role_type)
+    case role_type
+    when CoalitionLeadRole::TYPE
       taggable_coalitions(@coalitions)
-    when "OrganizationLeadRole"
+    when OrganizationLeadRole::TYPE
       taggable_organizations(@vita_partners)
-    when "SiteCoordinatorRole", "TeamMemberRole"
+    when SiteCoordinatorRole::TYPE, TeamMemberRole::TYPE
       taggable_sites(@vita_partners)
     else
       []

--- a/app/helpers/tagging_helper.rb
+++ b/app/helpers/tagging_helper.rb
@@ -8,6 +8,9 @@ module TaggingHelper
         taggable_vita_partners << { id: site.id, name: site.name, parentName: organization.name, value: site.id }
       end
     end
+
+    return taggable_sites(vita_partners) if taggable_vita_partners.empty?
+
     taggable_vita_partners.to_json.to_s.html_safe
   end
 

--- a/app/helpers/tagging_helper.rb
+++ b/app/helpers/tagging_helper.rb
@@ -31,4 +31,18 @@ module TaggingHelper
     end
     taggable_orgs.to_json.to_s.html_safe
   end
+
+  def taggable_organizations(vita_partners)
+    taggable_orgs = []
+    Organization.where(id: vita_partners.organizations).each do |vita_partner|
+      taggable_orgs << { id: vita_partner.id, name: vita_partner.name, value: vita_partner.id }
+    end
+    taggable_orgs.to_json.to_s.html_safe
+  end
+
+  def taggable_coalitions(coalitions)
+    coalitions.map do |coalition|
+      { id: coalition.id, name: coalition.name, value: coalition.id }
+    end.to_json.to_s.html_safe
+  end
 end

--- a/app/javascript/lib/tagging/index.js
+++ b/app/javascript/lib/tagging/index.js
@@ -61,6 +61,39 @@ export function initMultiSelectVitaPartner() {
     });
 }
 
+export function initSelectVitaPartner() {
+    const input = document.querySelector('.select-vita-partner');
+
+    new Tagify(input, {
+        tagTextProp: 'name',  // <-- defines which attr is used as the tag display value
+        // Array for initial interpolation, which allows only these tags to be used
+        whitelist: window.taggableItems,
+        enforceWhitelist: true,
+        mode : "select",
+        dropdown : {
+            classname: "multi-select-dropdown",
+            enabled: 0,
+            mapValueTo: 'name', // <-- defines which attr is used to display dropdown items
+            searchKeys: ['name'], // <-- defines the attr used to search for in dropdown
+            highlightFirst: true,  // <-- automatically highlights first suggestion item in the dropdown
+            closeOnSelect: true, // <-- close dropdown open after selection
+            maxItems: window.taggableItems.length, // <-- render all available items for the dropdown
+            position: 'input', // <-- render the suggestions list under the input element
+        },
+        templates: {
+            dropdownItem: function(item){
+                return `<div ${this.getAttributes(item)}
+                    class='${this.settings.classNames.dropdownItem}'
+                    tabindex="0"
+                    role="option">
+                        <div class='${item.parentName ? "parent" : ""}'>${item.parentName || ''}</div>
+                        <div class='${item.parentName ? "site" : "org"}'>${item.value}</div>
+                    </div>`
+            },
+        }
+    });
+}
+
 export function initMultiSelectState() {
     const input = document.querySelector('.multi-select-state');
     new Tagify(input, {

--- a/app/javascript/listeners/index.js
+++ b/app/javascript/listeners/index.js
@@ -7,7 +7,7 @@ import { initMetricsTableSortAndFilter } from "../lib/metrics_table_sort";
 import { documentSubmittingIndicator } from "../lib/document_submitting_indicator";
 import { initStateRoutingsListeners } from "../lib/state_routings";
 import tooltip from "../components/tooltip";
-import { initTaggableNote, initMultiSelectVitaPartner, initMultiSelectState } from '../lib/tagging';
+import { initTaggableNote, initMultiSelectVitaPartner, initMultiSelectState, initSelectVitaPartner } from '../lib/tagging';
 import { initBulkAction } from "../lib/bulk_action";
 import { getEfileSecurityInformation } from "../lib/efile_security_information";
 import { initTINTypeSelector } from "../lib/tin_type_selector";
@@ -63,6 +63,9 @@ const Listeners =  (function(){
                 }
                 if (document.querySelector('.multi-select-vita-partner')) {
                     initMultiSelectVitaPartner();
+                }
+                if (document.querySelector('.select-vita-partner')) {
+                    initSelectVitaPartner();
                 }
                 if (document.querySelector('.multi-select-state')) {
                     initMultiSelectState();

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -21,18 +21,18 @@
 
       <% if params[:role] == OrganizationLeadRole::TYPE %>
         <div class="form-group">
-          <%= label_tag(:organization_id, t(".organization_label"), class: "form-question") %>
-          <div class="select form-width--long">
-            <%= select_tag :organization_id, options_for_select(@vita_partners.organizations.map { |org| [org.name, org.id] }), class: "select__element" %>
+          <%= label_tag(:organization, t(".organization_label"), class: "form-question") %>
+          <div class="form-width--long">
+            <%= hidden_field_tag(:organization, [], class: "select-vita-partner select__element") %>
           </div>
         </div>
       <% end %>
 
       <% if params[:role] == CoalitionLeadRole::TYPE %>
         <div class="form-group">
-          <%= label_tag(:coalition_id, t(".coalition_label"), class: "form-question") %>
-          <div class="select form-width--long">
-            <%= select_tag(:coalition_id, options_for_select(@coalitions.all.map { |coalition| [coalition.name, coalition.id] }), class: "select__element") %>
+          <%= label_tag(:coalition, t(".coalition_label"), class: "form-question") %>
+          <div class="form-width--long">
+            <%= hidden_field_tag(:coalition, [], class: "select-vita-partner select__element") %>
           </div>
         </div>
       <% end %>
@@ -42,15 +42,9 @@
           <%= label_tag(:site_id, t(".site_label"), class: "form-question") %>
 
           <div class="select form-width--long">
-            <%= hidden_field_tag(:sites, (resource.role&.sites || []).map { |site| { value: site.id, name: site.name }}.to_json.to_s.html_safe, class: "multi-select-vita-partner") %>
+            <%= hidden_field_tag(:sites, (resource.role&.sites || []).map { |site| { value: site.id, name: site.name } }.to_json.to_s.html_safe, class: "multi-select-vita-partner") %>
           </div>
         </div>
-
-        <% content_for :script do %>
-          <script>
-              window.taggableItems = <%= taggable_sites(@vita_partners) %>;
-          </script>
-        <% end %>
       <% end %>
 
       <%= f.cfa_input_field(:name, t(".name_label"), classes: ['form-width--long']) %>
@@ -65,4 +59,10 @@
       </div>
     <% end %>
   </div>
+<% end %>
+
+<% content_for :script do %>
+  <script>
+      window.taggableItems = <%= taggable_items_from_role_type(params[:role]) %>;
+  </script>
 <% end %>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -39,7 +39,7 @@
 
       <% if (params[:role] == SiteCoordinatorRole::TYPE) || (params[:role] == TeamMemberRole::TYPE) %>
         <div class="form-group">
-          <%= label_tag(:site_id, t(".site_label"), class: "form-question") %>
+          <%= label_tag(:sites, t(".site_label"), class: "form-question") %>
 
           <div class="select form-width--long">
             <%= hidden_field_tag(:sites, (resource.role&.sites || []).map { |site| { value: site.id, name: site.name } }.to_json.to_s.html_safe, class: "multi-select-vita-partner") %>
@@ -63,6 +63,6 @@
 
 <% content_for :script do %>
   <script>
-      window.taggableItems = <%= taggable_items_from_role(@role) %>;
+      window.taggableItems = <%= taggable_items_from_role_type(params[:role]) %>;
   </script>
 <% end %>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -63,6 +63,6 @@
 
 <% content_for :script do %>
   <script>
-      window.taggableItems = <%= taggable_items_from_role_type(params[:role]) %>;
+      window.taggableItems = <%= taggable_items_from_role(@role) %>;
   </script>
 <% end %>

--- a/app/views/hub/clients/organizations/edit.html.erb
+++ b/app/views/hub/clients/organizations/edit.html.erb
@@ -2,32 +2,30 @@
 
 <% content_for :card do %>
   <div class="slab">
-    <div class="grid">
-      <div class="grid--item width-one-half">
-        <h2>
-          Edit Organization for <%= @client.preferred_name %>
-        </h2>
-        <p class="text--help text--bold"><%= t(".warning_text_1") %></p>
-        <p class="text--help text--bold spacing-below-25"><%= t(".warning_text_2") %></p>
-        <%= form_with model: @client, url: organization_hub_client_path(id: @client.id), local: true, method: :patch, builder: VitaMinFormBuilder do |f| %>
+    <h2>
+      Edit Organization for <%= @client.preferred_name %>
+    </h2>
+    <p class="text--help text--bold"><%= t(".warning_text_1") %></p>
+    <p class="text--help text--bold spacing-below-25"><%= t(".warning_text_2") %></p>
+    <%= form_with model: @client, url: organization_hub_client_path(id: @client.id), local: true, method: :patch, builder: VitaMinFormBuilder do |f| %>
 
-          <div class="field-display spacing-below-60">
-            <label class="form-question"><%= t("general.organization") %></label>
-            <%= f.hidden_field(:vita_partners, class: "select-vita-partner") %>
-          </div>
-
-          <div>
-            <%= f.submit t("general.save"), class: "button button--primary" %>
-          </div>
-        <% end %>
-
-        <% content_for :script do %>
-          <script>
-              window.taggableItems = <%= taggable_vita_partners(@vita_partners) %>;
-          </script>
-        <% end %>
+      <div class="form-group spacing-below-60">
+        <%= label_tag(:vita_partners, t("general.organization"), class: "form-question") %>
+        <div class="form-width--long">
+          <%= f.hidden_field(:vita_partners, class: "select-vita-partner select__element") %>
+        </div>
       </div>
-    </div>
+
+      <div>
+        <%= f.submit t("general.save"), class: "button button--primary" %>
+      </div>
+    <% end %>
   </div>
+<% end %>
+
+<% content_for :script do %>
+  <script>
+      window.taggableItems = <%= taggable_vita_partners(@vita_partners) %>;
+  </script>
 <% end %>
 

--- a/app/views/hub/clients/organizations/edit.html.erb
+++ b/app/views/hub/clients/organizations/edit.html.erb
@@ -2,18 +2,32 @@
 
 <% content_for :card do %>
   <div class="slab">
-    <h2>
-      Edit Organization for <%= @client.preferred_name %>
-    </h2>
-    <p class="text--help text--bold"><%= t(".warning_text_1") %></p>
-    <p class="text--help text--bold spacing-below-25"><%= t(".warning_text_2") %></p>
-    <%= form_with model: @client, url: organization_hub_client_path(id: @client.id), local: true, method: :patch, builder: VitaMinFormBuilder do |f|%>
+    <div class="grid">
+      <div class="grid--item width-one-half">
+        <h2>
+          Edit Organization for <%= @client.preferred_name %>
+        </h2>
+        <p class="text--help text--bold"><%= t(".warning_text_1") %></p>
+        <p class="text--help text--bold spacing-below-25"><%= t(".warning_text_2") %></p>
+        <%= form_with model: @client, url: organization_hub_client_path(id: @client.id), local: true, method: :patch, builder: VitaMinFormBuilder do |f| %>
 
-      <%= f.cfa_select(:vita_partner_id, t("general.organization"), grouped_vita_partner_options) %>
-      <div>
-        <%= f.submit t("general.save"), class: "button button--primary" %>
+          <div class="field-display spacing-below-60">
+            <label class="form-question"><%= t("general.organization") %></label>
+            <%= f.hidden_field(:vita_partners, class: "select-vita-partner") %>
+          </div>
+
+          <div>
+            <%= f.submit t("general.save"), class: "button button--primary" %>
+          </div>
+        <% end %>
+
+        <% content_for :script do %>
+          <script>
+              window.taggableItems = <%= taggable_vita_partners(@vita_partners) %>;
+          </script>
+        <% end %>
       </div>
-    <% end %>
+    </div>
   </div>
 <% end %>
 

--- a/app/views/hub/users/edit_role.html.erb
+++ b/app/views/hub/users/edit_role.html.erb
@@ -37,8 +37,8 @@
         <p><%= role_name_from_role_type(CoalitionLeadRole::TYPE) %></p>
         <div class="form-group">
           <%= label_tag(:coalition_id, t("devise.invitations.new.coalition_label"), class: "form-question") %>
-          <div class="select form-width--long">
-            <%= select_tag(:coalition_id, options_for_select(@coalitions.all.map { |coalition| [coalition.name, coalition.id] }), class: "select__element") %>
+          <div class="form-width--long">
+            <%= hidden_field_tag(:coalition, [], class: "select-vita-partner select__element") %>
           </div>
         </div>
       <% end %>
@@ -46,9 +46,9 @@
       <% if @role.is_a?(OrganizationLeadRole) %>
         <p><%= role_name_from_role_type(OrganizationLeadRole::TYPE) %></p>
         <div class="form-group">
-          <%= label_tag(:organization_id, t("devise.invitations.new.organization_label"), class: "form-question") %>
-          <div class="select form-width--long">
-            <%= select_tag :organization_id, options_for_select(@vita_partners.organizations.map { |org| [org.name, org.id] }), class: "select__element" %>
+          <%= label_tag(:organization, t("devise.invitations.new.organization_label"), class: "form-question") %>
+          <div class="form-width--long">
+            <%= hidden_field_tag(:organization, [], class: "select-vita-partner select__element") %>
           </div>
         </div>
       <% end %>
@@ -62,12 +62,6 @@
             <%= hidden_field_tag(:sites, (@role&.respond_to?(:sites) ? @role.sites : []).map { |site| { value: site.id, name: site.name }}.to_json.to_s.html_safe, class: "multi-select-vita-partner") %>
           </div>
         </div>
-
-        <% content_for :script do %>
-          <script>
-              window.taggableItems = <%= taggable_sites(@vita_partners) %>;
-          </script>
-        <% end %>
       <% end %>
 
       <div>
@@ -77,4 +71,10 @@
       </div>
     <% end %>
   </div>
+<% end %>
+
+<% content_for :script do %>
+  <script>
+      window.taggableItems = <%= taggable_items_from_role_type(params[:role]) %>;
+  </script>
 <% end %>

--- a/app/views/hub/users/edit_role.html.erb
+++ b/app/views/hub/users/edit_role.html.erb
@@ -38,7 +38,8 @@
         <div class="form-group">
           <%= label_tag(:coalition_id, t("devise.invitations.new.coalition_label"), class: "form-question") %>
           <div class="form-width--long">
-            <%= hidden_field_tag(:coalition, [], class: "select-vita-partner select__element") %>
+            <% coalition_value = @user.role.is_a?(CoalitionLeadRole) && @user.role&.coalition&.present? ? [{ value: @user.role.coalition.id, name: @user.role.coalition.name }].to_json.to_s.html_safe : [] %>
+            <%= hidden_field_tag(:coalition, coalition_value, class: "select-vita-partner select__element") %>
           </div>
         </div>
       <% end %>
@@ -48,7 +49,8 @@
         <div class="form-group">
           <%= label_tag(:organization, t("devise.invitations.new.organization_label"), class: "form-question") %>
           <div class="form-width--long">
-            <%= hidden_field_tag(:organization, [], class: "select-vita-partner select__element") %>
+            <% org_value = @user.role.is_a?(OrganizationLeadRole) && @user.role&.organization&.present? ? [{ value: @user.role.organization.id, name: @user.role.organization.name }].to_json.to_s.html_safe : [] %>
+            <%= hidden_field_tag(:organization, org_value, class: "select-vita-partner select__element") %>
           </div>
         </div>
       <% end %>
@@ -57,9 +59,9 @@
         <p><%= role_name_from_role_type(@role.class.name) %></p>
 
         <div class="form-group">
-          <%= label_tag(:site_id, t("devise.invitations.new.site_label"), class: "form-question") %>
+          <%= label_tag(:sites, t("devise.invitations.new.site_label"), class: "form-question") %>
           <div class="select form-width--long">
-            <%= hidden_field_tag(:sites, (@role&.respond_to?(:sites) ? @role.sites : []).map { |site| { value: site.id, name: site.name }}.to_json.to_s.html_safe, class: "multi-select-vita-partner") %>
+            <%= hidden_field_tag(:sites, (@role&.respond_to?(:sites) ? @role.sites : []).map { |site| { value: site.id, name: site.name }}.to_json.to_s.html_safe, class: "multi-select-vita-partner select__element") %>
           </div>
         </div>
       <% end %>
@@ -75,6 +77,6 @@
 
 <% content_for :script do %>
   <script>
-      window.taggableItems = <%= taggable_items_from_role_type(params[:role]) %>;
+      window.taggableItems = <%= taggable_items_from_role(@role) %>;
   </script>
 <% end %>

--- a/app/views/hub/users/edit_role.html.erb
+++ b/app/views/hub/users/edit_role.html.erb
@@ -38,7 +38,7 @@
         <div class="form-group">
           <%= label_tag(:coalition_id, t("devise.invitations.new.coalition_label"), class: "form-question") %>
           <div class="form-width--long">
-            <% coalition_value = @user.role.is_a?(CoalitionLeadRole) && @user.role&.coalition&.present? ? [{ value: @user.role.coalition.id, name: @user.role.coalition.name }].to_json.to_s.html_safe : [] %>
+            <% coalition_value = @user.role.is_a?(CoalitionLeadRole) && @user.role.coalition.present? ? [{ value: @user.role.coalition.id, name: @user.role.coalition.name }].to_json.to_s.html_safe : [] %>
             <%= hidden_field_tag(:coalition, coalition_value, class: "select-vita-partner select__element") %>
           </div>
         </div>
@@ -49,7 +49,7 @@
         <div class="form-group">
           <%= label_tag(:organization, t("devise.invitations.new.organization_label"), class: "form-question") %>
           <div class="form-width--long">
-            <% org_value = @user.role.is_a?(OrganizationLeadRole) && @user.role&.organization&.present? ? [{ value: @user.role.organization.id, name: @user.role.organization.name }].to_json.to_s.html_safe : [] %>
+            <% org_value = @user.role.is_a?(OrganizationLeadRole) && @user.role.organization.present? ? [{ value: @user.role.organization.id, name: @user.role.organization.name }].to_json.to_s.html_safe : [] %>
             <%= hidden_field_tag(:organization, org_value, class: "select-vita-partner select__element") %>
           </div>
         </div>
@@ -77,6 +77,6 @@
 
 <% content_for :script do %>
   <script>
-      window.taggableItems = <%= taggable_items_from_role(@role) %>;
+      window.taggableItems = <%= taggable_items_from_role_type(params[:role]) %>;
   </script>
 <% end %>

--- a/spec/controllers/hub/clients/organizations_controller_spec.rb
+++ b/spec/controllers/hub/clients/organizations_controller_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Hub::Clients::OrganizationsController, type: :controller do
         end
       end
 
-      context "when no new vita partner is selected" do
+      context "when no vita partner selected" do
         let(:vita_partners) { "" }
 
         it "redirects to client profile and does not change the org" do

--- a/spec/controllers/users/invitations_controller_spec.rb
+++ b/spec/controllers/users/invitations_controller_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe Users::InvitationsController do
       before { sign_in user }
 
       context "inviting an org lead user" do
+        let(:org_params) { JSON.generate([{ id: vita_partner.id, name: vita_partner.name, value: vita_partner.id }]) }
         let(:params) do
           {
             user: {
@@ -55,7 +56,7 @@ RSpec.describe Users::InvitationsController do
               email: "cherry@example.com",
               role: OrganizationLeadRole::TYPE,
             },
-            organization_id: vita_partner.id
+            organization: org_params
           }
         end
 
@@ -77,6 +78,17 @@ RSpec.describe Users::InvitationsController do
           expect(response).to redirect_to invitations_path
         end
 
+        context "does not create an invitation and when no organization is selected" do
+          let(:org_params) { '' }
+
+          it "redirects to invitations page" do
+            expect do
+              post :create, params: params
+            end.to not_change(User, :count).and not_change(OrganizationLeadRole, :count)
+            expect(response).to redirect_to invitations_path
+          end
+        end
+
         context "if the invited user already exists and is an admin" do
           let!(:invited_user) { create :admin_user, email: "cherry@example.com" }
 
@@ -89,6 +101,7 @@ RSpec.describe Users::InvitationsController do
 
       context "inviting a coalition lead user" do
         let(:coalition) { create :coalition }
+        let(:coalition_params) { JSON.generate([{ id: coalition.id, name: coalition.name, value: coalition.id }]) }
         let(:params) do
           {
             user: {
@@ -96,7 +109,7 @@ RSpec.describe Users::InvitationsController do
               email: "cherry@example.com",
               role: CoalitionLeadRole::TYPE,
             },
-            coalition_id: coalition.id
+            coalition: coalition_params
           }
         end
 
@@ -117,10 +130,22 @@ RSpec.describe Users::InvitationsController do
           expect(invited_user.invited_by).to eq user
           expect(response).to redirect_to invitations_path
         end
+
+        context "when no coalition is selected" do
+          let(:coalition_params) { '' }
+
+          it "does not create an invitation and redirects to invitations page" do
+            expect do
+              post :create, params: params
+            end.to not_change(User, :count).and not_change(CoalitionLeadRole, :count)
+            expect(response).to redirect_to invitations_path
+          end
+        end
       end
 
       context "inviting a site coordinator user" do
         let(:site) { create :site }
+        let(:site_params) { [{id: site.id}].to_json }
         let(:params) do
           {
             user: {
@@ -128,7 +153,7 @@ RSpec.describe Users::InvitationsController do
               email: "cherry@example.com",
               role: SiteCoordinatorRole::TYPE,
             },
-            sites: [{id: site.id}].to_json
+            sites: site_params
           }
         end
 
@@ -148,6 +173,17 @@ RSpec.describe Users::InvitationsController do
           expect(invited_user.invitation_token).to be_present
           expect(invited_user.invited_by).to eq user
           expect(response).to redirect_to invitations_path
+        end
+
+        context "when no site is selected" do
+          let(:site_params) { '' }
+
+          it "does not create an invitation and redirects to invitations page" do
+            expect do
+              post :create, params: params
+            end.to not_change(User, :count).and not_change(SiteCoordinatorRole, :count)
+            expect(response).to redirect_to invitations_path
+          end
         end
       end
 
@@ -249,6 +285,7 @@ RSpec.describe Users::InvitationsController do
 
       context "inviting a team member user" do
         let(:site) { create(:site) }
+        let(:site_params) { [{ id: site.id}].to_json }
         let(:params) do
           {
             user: {
@@ -256,7 +293,7 @@ RSpec.describe Users::InvitationsController do
               email: "cherry@example.com",
               role: TeamMemberRole::TYPE,
             },
-            sites: [{ id: site.id}].to_json
+            sites: site_params
           }
         end
 
@@ -276,6 +313,17 @@ RSpec.describe Users::InvitationsController do
           expect(invited_user.invitation_token).to be_present
           expect(invited_user.invited_by).to eq user
           expect(response).to redirect_to invitations_path
+        end
+
+        context "when no site is selected" do
+          let(:site_params) { '' }
+
+          it "does not create an invitation and redirects to invitations page" do
+            expect do
+              post :create, params: params
+            end.to not_change(User, :count).and not_change(SiteCoordinatorRole, :count)
+            expect(response).to redirect_to invitations_path
+          end
         end
       end
     end

--- a/spec/features/hub/client/show_client_spec.rb
+++ b/spec/features/hub/client/show_client_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "a user viewing a client" do
       login_as user
     end
 
-    scenario "can view and update client organization" do
+    scenario "can view and update client organization", js: true do
       visit hub_client_path(id: client.id)
       within ".client-header" do
         expect(page).to have_text client.vita_partner.name
@@ -20,10 +20,17 @@ RSpec.describe "a user viewing a client" do
       end
       expect(page.current_path).to eq edit_organization_hub_client_path(id: client.id)
       expect(page).to have_text "Edit Organization for #{client.preferred_name}"
-      select other_vita_partner.name, from: "Organization"
+      expect(page).to have_text "Organization"
+      fill_in_tagify '.select-vita-partner', other_vita_partner.name
       click_on "Save"
       within ".client-header" do
         expect(page).to have_text other_vita_partner.name
+      end
+    end
+
+    scenario "can toggle client flag" do
+      visit hub_client_path(id: client.id)
+      within ".client-header" do
         check "Flag"
         expect(page).to have_field("toggle-flag", checked: true)
         uncheck "Flag"
@@ -142,7 +149,7 @@ RSpec.describe "a user viewing a client" do
       end
     end
 
-    scenario "can view and update client organization" do
+    scenario "can view and update client organization", js: true do
       visit hub_client_path(id: client.id)
       within ".client-header" do
         expect(page).to have_text client.vita_partner.name
@@ -150,7 +157,8 @@ RSpec.describe "a user viewing a client" do
       end
       expect(page.current_path).to eq edit_organization_hub_client_path(id: client.id)
       expect(page).to have_text "Edit Organization for #{client.preferred_name}"
-      select second_org.name, from: "Organization"
+      expect(page).to have_text "Organization"
+      fill_in_tagify '.select-vita-partner', second_org.name
       click_on "Save"
       within ".client-header" do
         expect(page).to have_text second_org.name

--- a/spec/features/hub/edit_client_spec.rb
+++ b/spec/features/hub/edit_client_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "a user editing a clients intake fields" do
     }
     before { login_as user }
 
-    scenario "if I update a clients' organization that an assigned tax return user cannot access, they are unassigned" do
+    scenario "if I update a clients' organization that an assigned tax return user cannot access, they are unassigned", js: true do
       visit hub_client_path(id: client.id)
 
       within '.tax-return-list__assignment' do
@@ -46,7 +46,8 @@ RSpec.describe "a user editing a clients intake fields" do
 
       expect(page).to have_text "Edit Organization for #{client.preferred_name}"
       expect(page).to have_text I18n.t("hub.clients.organizations.edit.warning_text_1")
-      select "Other Site", from: "Organization"
+      expect(page).to have_text "Organization"
+      fill_in_tagify '.select-vita-partner', "Other Site"
       click_on "Save"
 
       within '.tax-return-list__assignment' do

--- a/spec/features/hub/edit_user_spec.rb
+++ b/spec/features/hub/edit_user_spec.rb
@@ -209,20 +209,20 @@ RSpec.describe "a user editing a user" do
             end
           end
 
-          scenario "assigning a organization lead role on a different org" do
-            create :organization, name: "Orange Organization", coalition: coalition
+          scenario "assigning a organization lead role on a different org", js: true do
+            create :organization, name: "Acercola Organization", coalition: coalition
 
             visit edit_hub_user_path(id: user_to_edit)
+            click_on "Reassign"
             click_on "Organization Lead"
 
-            expect(page).to have_text("Apples Associated")
-
-            select "Orange Organization"
+            expect(page.find('.select-vita-partner').text).to eq("Apples Associated")
+            fill_in_tagify '.select-vita-partner', "Acercola Organization"
 
             click_on "Submit"
 
             within "#current-role" do
-              expect(page).to have_text "Organization Lead, Orange Organization"
+              expect(page).to have_text "Organization Lead, Acercola Organization"
             end
           end
 
@@ -290,13 +290,13 @@ RSpec.describe "a user editing a user" do
         end
 
         context "editing user roles" do
-          scenario "assigning a organization lead role" do
+          scenario "assigning a organization lead role", js: true do
             visit edit_hub_user_path(id: user_to_edit)
+            click_on "Reassign"
             click_on "Organization Lead"
 
-            expect(page).to have_text("Apples Associated")
-
-            select "Apples Associated"
+            expect(page.find('.select-vita-partner').text).to eq("")
+            fill_in_tagify '.select-vita-partner', "Apples Associated"
 
             click_on "Submit"
 

--- a/spec/features/hub/edit_user_spec.rb
+++ b/spec/features/hub/edit_user_spec.rb
@@ -96,17 +96,16 @@ RSpec.describe "a user editing a user" do
           end
         end
 
-        scenario "assigning a coalition lead role" do
+        scenario "assigning a coalition lead role", js: true do
           user_to_edit = create(:admin_user)
           create :coalition, name: "Koala Koalition"
-          create :coalition, name: "Coal Coalition"
 
           visit edit_hub_user_path(id: user_to_edit)
+          click_on "Reassign"
           click_on "Coalition Lead"
 
-          expect(page).to have_text("Coal Coalition")
-
-          select "Koala Koalition"
+          expect(page.find('.select-vita-partner').text).to eq("")
+          fill_in_tagify '.select-vita-partner', "Koala Koalition"
 
           click_on "Submit"
 
@@ -115,16 +114,15 @@ RSpec.describe "a user editing a user" do
           end
         end
 
-        scenario "assigning a organization lead role" do
+        scenario "assigning a organization lead role", js: true do
           create :organization, name: "Orange Organization"
-          create :organization, name: "Odious Organization"
 
           visit edit_hub_user_path(id: user_to_edit)
+          click_on "Reassign"
           click_on "Organization Lead"
 
-          expect(page).to have_text("Odious Organization")
-
-          select "Orange Organization"
+          expect(page.find('.select-vita-partner').text).to eq("")
+          fill_in_tagify '.select-vita-partner', "Orange Organization"
 
           click_on "Submit"
 
@@ -136,7 +134,6 @@ RSpec.describe "a user editing a user" do
         scenario "assigning a site coordinator role", js: true do
           user_to_edit = create(:admin_user)
           create :site, name: "Suite Site"
-          create :site, name: "Sour Site"
 
           visit edit_hub_user_path(id: user_to_edit)
           click_on "Reassign"
@@ -155,7 +152,6 @@ RSpec.describe "a user editing a user" do
         scenario "assigning a team member role", js: true do
           user_to_edit = create(:admin_user)
           create :site, name: "Suite Site"
-          create :site, name: "Sour Site"
 
           visit edit_hub_user_path(id: user_to_edit)
           click_on "Reassign"
@@ -198,13 +194,13 @@ RSpec.describe "a user editing a user" do
         end
 
         context "editing user roles" do
-          scenario "assigning a coalition lead role" do
+          scenario "assigning a coalition lead role", js: true do
             visit edit_hub_user_path(id: user_to_edit)
+            click_on "Reassign"
             click_on "Coalition Lead"
 
-            expect(page).to have_text("Koala Coalition")
-
-            select "Koala Coalition"
+            expect(page.find('.select-vita-partner').text).to eq("")
+            fill_in_tagify '.select-vita-partner', "Koala Coalition"
 
             click_on "Submit"
 

--- a/spec/features/hub/invitations/coalition_lead_spec.rb
+++ b/spec/features/hub/invitations/coalition_lead_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Inviting coalition leads" do
       login_as user
     end
 
-    scenario "Inviting, re-sending invites, and accepting invites" do
+    scenario "Inviting, re-sending invites, and accepting invites", js: true do
       visit hub_tools_path
       click_on "Invitations"
 
@@ -21,7 +21,8 @@ RSpec.feature "Inviting coalition leads" do
       expect(page).to have_text "Send a new invitation"
       fill_in "What is their name?", with: "Colleen Cauliflower"
       fill_in "What is their email?", with: "colleague@cauliflower.org"
-      select "Kohlrabi Koalition", from: "Which coalition?"
+      expect(page).to have_text "Which coalition?"
+      fill_in_tagify '.select-vita-partner', "Kohlrabi Koalition"
       click_on "Send invitation email"
 
       # back on the invitations page

--- a/spec/features/hub/invitations/org_lead_spec.rb
+++ b/spec/features/hub/invitations/org_lead_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Inviting organization leads" do
       login_as user
     end
 
-    scenario "Inviting, re-sending invites, and accepting invites" do
+    scenario "Inviting, re-sending invites, and accepting invites", js: true do
       visit hub_tools_path
       click_on "Invitations"
 
@@ -21,7 +21,8 @@ RSpec.feature "Inviting organization leads" do
       expect(page).to have_text "Send a new invitation"
       fill_in "What is their name?", with: "Colleen Cauliflower"
       fill_in "What is their email?", with: "colleague@cauliflower.org"
-      select "Brassica Asset Builders", from: "Which organization?"
+      expect(page).to have_text "Which organization?"
+      fill_in_tagify '.select-vita-partner', "Brassica Asset Builders"
       click_on "Send invitation email"
 
       # back on the invitations page

--- a/spec/features/hub/roles/org_lead_spec.rb
+++ b/spec/features/hub/roles/org_lead_spec.rb
@@ -9,14 +9,15 @@ describe "Org Lead" do
 
   before { login_as user }
 
-  it "allows me to assign a client to a site within my organization" do
+  it "allows me to assign a client to a site within my organization", js: true do
     visit hub_client_path(id: client.id)
 
     within(".client-header__organization") do
       click_on "Edit"
     end
 
-    select site.name, from: "Organization"
+    expect(page).to have_text "Organization"
+    fill_in_tagify '.select-vita-partner', site.name
 
     click_on "Save"
 


### PR DESCRIPTION
This PR adds single type-to-select drop-downs for the following pages:

**1. Edit client organization page**
![Screen Shot 2023-08-08 at 11 59 19 AM](https://github.com/codeforamerica/vita-min/assets/49880002/5c63e239-ce7f-4c37-b6a8-7ac6c8efa3ce)

**2. User edit role page for org and coalition leads**
![Screen Shot 2023-08-08 at 11 59 00 AM](https://github.com/codeforamerica/vita-min/assets/49880002/7e99f5d6-ccea-4639-be96-cd2cdb84b1fe)

**3. Send user invitation page for org and coalition leads**
![Screen Shot 2023-08-08 at 11 58 18 AM](https://github.com/codeforamerica/vita-min/assets/49880002/fa2249e0-5e20-4989-82fb-ab08e9f6af0a)

It is similar to the multi-select tool that is used for team members but the user can only select one value. 
