### PR TITLE
Add job to update a gauge for worker latency

### DIFF
--- a/app/jobs/worker_heartbeat_job.rb
+++ b/app/jobs/worker_heartbeat_job.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class WorkerHeartbeatJob < ApplicationJob
+  self.retry_jitter = 0
+  def perform(time_enqueued_secs)
+    DatadogApi.gauge("worker_heartbeat.latency", Time.current.to_i - time_enqueued_secs)
+  end
+end

--- a/crontab
+++ b/crontab
@@ -5,3 +5,4 @@
 */5 * * * * bundle exec rake client_status_updates:send_completion_surveys
 */20 * * * * bundle exec rake client_status_updates:send_client_in_progress_automated_messages
 15 20 * * * bundle exec rake not_ready_reminders:remind
+*/5 * * * * bundle exec rake worker_heartbeat:perform

--- a/lib/tasks/worker_heartbeat.rake
+++ b/lib/tasks/worker_heartbeat.rake
@@ -1,0 +1,6 @@
+namespace :worker_heartbeat do
+  desc 'Enqueue jobs to track queue delays'
+  task enqueue: :environment do
+    WorkerHeartbeatJob.perform_now(Time.current.to_i)
+  end
+end

--- a/spec/jobs/worker_heartbeat_job_spec.rb
+++ b/spec/jobs/worker_heartbeat_job_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WorkerHeartbeatJob, active_job: true do
+  around do |example|
+    Timecop.freeze do
+      example.run
+    end
+  end
+
+  describe "#perform" do
+    before do
+      allow(DatadogApi).to receive(:gauge)
+    end
+
+    it "updates gauge with delta of enqueue time" do
+      described_class.new.perform(30.seconds.ago.to_i)
+      expect(DatadogApi).to have_received(:gauge).with("worker_heartbeat.latency", 30)
+    end
+  end
+
+end


### PR DESCRIPTION
Lots of inspiration from https://github.com/codeforamerica/gcf-backend/blob/main/app/jobs/worker_heartbeat_job.rb and https://github.com/codeforamerica/gcf-backend/blob/main/lib/tasks/worker_heartbeat.rake.