### PR TITLE
Move DependentsController into Questions::DependentsController

### DIFF
--- a/app/controllers/dependents_controller.rb
+++ b/app/controllers/dependents_controller.rb
@@ -3,124 +3,25 @@ class DependentsController < ApplicationController
 
   helper_method :next_path
 
-  def self.show?(intake)
-    intake.had_dependents_yes?
-  end
-
-  def self.navigation_actions
-    [:index, :new]
+  before_action do
+    redirect_to Questions::DependentsController.to_path_helper(action: :index)
   end
 
   def index
-    @dependents = current_intake.dependents
   end
 
   def new
-    @dependent = Dependent.new
   end
 
   def edit
-    @dependent = current_intake.dependents.find(params[:id])
   end
 
   def update
-    @dependent = current_intake.dependents.find(params[:id])
-    if @dependent.update(dependent_params)
-      send_mixpanel_event(event_name: "dependent_updated", data: mixpanel_data(@dependent))
-      redirect_to dependents_path
-    else
-      send_mixpanel_validation_error(@dependent.errors)
-      render :edit
-    end
   end
 
   def create
-    @dependent = Dependent.new(dependent_params.merge(intake: current_intake))
-
-    if @dependent.save
-      send_mixpanel_event(event_name: "dependent_added", data: mixpanel_data(@dependent))
-      redirect_to dependents_path
-    else
-      send_mixpanel_validation_error(@dependent.errors)
-      render :new
-    end
   end
 
   def destroy
-    @dependent = current_intake.dependents.find(params[:id])
-    if @dependent.destroy
-      flash[:notice] = I18n.t("controllers.dependents_controller.removed_dependent", :full_name => @dependent.full_name)
-      send_mixpanel_event(event_name: "dependent_removed")
-    end
-    redirect_to dependents_path
-  end
-
-  def show_progress?
-    true
-  end
-
-  def progress_calculator
-    IntakeProgressCalculator
-  end
-  helper_method :progress_calculator
-
-  def next_path
-    dependent_care_questions_path
-  end
-
-  private
-
-  def mixpanel_data(dependent)
-    {
-      dependent_age_at_end_of_tax_year: dependent.age_during(MultiTenantService.new(:gyr).current_tax_year).to_s,
-      dependent_under_6: dependent.age_during(MultiTenantService.new(:gyr).current_tax_year) < 6 ? "yes" : "no",
-      dependent_months_in_home: dependent.months_in_home.to_s,
-      dependent_was_student: dependent.was_student,
-      dependent_us_citizen: dependent.us_citizen,
-      dependent_north_american_resident: dependent.north_american_resident,
-      dependent_disabled: dependent.disabled,
-      dependent_was_married: dependent.was_married,
-    }
-  end
-
-  def birth_date_param_keys
-    [:birth_date_year, :birth_date_month, :birth_date_day]
-  end
-
-  def dependent_params
-    dependent_attribute_keys = [
-      :first_name,
-      :last_name,
-      :relationship,
-      :months_in_home,
-      :was_student,
-      :us_citizen,
-      :north_american_resident,
-      :disabled,
-      :was_married,
-    ]
-    permitted_params = params.require(:dependent).permit(
-      *dependent_attribute_keys, *birth_date_param_keys
-    )
-    attributes = permitted_params.select { |key, _| dependent_attribute_keys.include?(key.to_sym) }
-    birth_date_params = permitted_params.select { |key, _| birth_date_param_keys.include?(key.to_sym) }
-    attributes.merge(birth_date: parse_birth_date_params(birth_date_params))
-  end
-
-  def parse_birth_date_params(birth_date_params)
-    birth_date_values = birth_date_params.values
-    return nil if birth_date_values.any?(&:blank?)
-    begin
-      parsed_birth_date = Date.new(*birth_date_params.values.map(&:to_i))
-    rescue ArgumentError => error
-      raise error unless error.to_s == "invalid date"
-      return nil
-    end
-
-    if parsed_birth_date.year < 1900 || parsed_birth_date.year > Date.today.year
-      return nil
-    end
-
-    parsed_birth_date
   end
 end

--- a/app/controllers/questions/dependents_controller.rb
+++ b/app/controllers/questions/dependents_controller.rb
@@ -1,0 +1,132 @@
+module Questions
+  class DependentsController < ApplicationController
+    include AuthenticatedClientConcern
+
+    helper_method :next_path
+
+    def self.show?(intake)
+      intake.had_dependents_yes?
+    end
+
+    def self.i18n_base_path
+      "views.dependents"
+    end
+
+    def self.navigation_actions
+      [:index, :new]
+    end
+
+    def index
+      @dependents = current_intake.dependents
+    end
+
+    def new
+      @dependent = Dependent.new
+    end
+
+    def edit
+      @dependent = current_intake.dependents.find(params[:id])
+    end
+
+    def update
+      @dependent = current_intake.dependents.find(params[:id])
+      if @dependent.update(dependent_params)
+        send_mixpanel_event(event_name: "dependent_updated", data: mixpanel_data(@dependent))
+        redirect_to action: :index
+      else
+        send_mixpanel_validation_error(@dependent.errors)
+        render :edit
+      end
+    end
+
+    def create
+      @dependent = Dependent.new(dependent_params.merge(intake: current_intake))
+
+      if @dependent.save
+        send_mixpanel_event(event_name: "dependent_added", data: mixpanel_data(@dependent))
+        redirect_to action: :index
+      else
+        send_mixpanel_validation_error(@dependent.errors)
+        render :new
+      end
+    end
+
+    def destroy
+      @dependent = current_intake.dependents.find(params[:id])
+      if @dependent.destroy
+        flash[:notice] = I18n.t("controllers.dependents_controller.removed_dependent", :full_name => @dependent.full_name)
+        send_mixpanel_event(event_name: "dependent_removed")
+      end
+      redirect_to action: :index
+    end
+
+    def show_progress?
+      true
+    end
+
+    def progress_calculator
+      IntakeProgressCalculator
+    end
+    helper_method :progress_calculator
+
+    def next_path
+      dependent_care_questions_path
+    end
+
+    private
+
+    def mixpanel_data(dependent)
+      {
+        dependent_age_at_end_of_tax_year: dependent.age_during(MultiTenantService.new(:gyr).current_tax_year).to_s,
+        dependent_under_6: dependent.age_during(MultiTenantService.new(:gyr).current_tax_year) < 6 ? "yes" : "no",
+        dependent_months_in_home: dependent.months_in_home.to_s,
+        dependent_was_student: dependent.was_student,
+        dependent_us_citizen: dependent.us_citizen,
+        dependent_north_american_resident: dependent.north_american_resident,
+        dependent_disabled: dependent.disabled,
+        dependent_was_married: dependent.was_married,
+      }
+    end
+
+    def birth_date_param_keys
+      [:birth_date_year, :birth_date_month, :birth_date_day]
+    end
+
+    def dependent_params
+      dependent_attribute_keys = [
+        :first_name,
+        :last_name,
+        :relationship,
+        :months_in_home,
+        :was_student,
+        :us_citizen,
+        :north_american_resident,
+        :disabled,
+        :was_married,
+      ]
+      permitted_params = params.require(:dependent).permit(
+        *dependent_attribute_keys, *birth_date_param_keys
+      )
+      attributes = permitted_params.select { |key, _| dependent_attribute_keys.include?(key.to_sym) }
+      birth_date_params = permitted_params.select { |key, _| birth_date_param_keys.include?(key.to_sym) }
+      attributes.merge(birth_date: parse_birth_date_params(birth_date_params))
+    end
+
+    def parse_birth_date_params(birth_date_params)
+      birth_date_values = birth_date_params.values
+      return nil if birth_date_values.any?(&:blank?)
+      begin
+        parsed_birth_date = Date.new(*birth_date_params.values.map(&:to_i))
+      rescue ArgumentError => error
+        raise error unless error.to_s == "invalid date"
+        return nil
+      end
+
+      if parsed_birth_date.year < 1900 || parsed_birth_date.year > Date.today.year
+        return nil
+      end
+
+      parsed_birth_date
+    end
+  end
+end

--- a/app/lib/navigation/gyr_question_navigation.rb
+++ b/app/lib/navigation/gyr_question_navigation.rb
@@ -76,7 +76,7 @@ module Navigation
       # Dependents
       Questions::HadDependentsController,
 
-      DependentsController,
+      Questions::DependentsController,
 
       # Dependent related questions
       Questions::DependentCareController,

--- a/app/views/dependents/edit.html.erb
+++ b/app/views/dependents/edit.html.erb
@@ -1,2 +1,0 @@
-<% @allow_deletion = true %>
-<%= render "dependents/form" %>

--- a/app/views/dependents/new.html.erb
+++ b/app/views/dependents/new.html.erb
@@ -1,1 +1,0 @@
-<%= render "dependents/form" %>

--- a/app/views/questions/dependents/_form.html.erb
+++ b/app/views/questions/dependents/_form.html.erb
@@ -12,7 +12,8 @@
       <%= yield :notices %>
       <%= render "shared/progress_bar" %>
       <main role="main">
-        <%= form_with model: @dependent, local: true, builder: VitaMinFormBuilder, html: {class: 'form-card form-card--long'} do |f| %>
+        <% form_action = @dependent.persisted? ? :update : :create %>
+        <%= form_with url: { action: form_action }, model: @dependent, local: true, builder: VitaMinFormBuilder, html: { class: 'form-card form-card--long'} do |f| %>
           <h1 class="form-question">
             <%= @main_heading %>
           </h1>
@@ -50,7 +51,7 @@
 
           <% if @allow_deletion %>
             <%= link_to(
-                    dependent_path(@dependent),
+                    { action: :destroy },
                     method: :delete,
                     class: "button button--danger button--wide button--icon",
                     data: {confirm: t("views.dependents.form.delete_confirmation", :name => "#{@dependent.full_name}")}

--- a/app/views/questions/dependents/edit.html.erb
+++ b/app/views/questions/dependents/edit.html.erb
@@ -1,0 +1,2 @@
+<% @allow_deletion = true %>
+<%= render "questions/dependents/form" %>

--- a/app/views/questions/dependents/index.html.erb
+++ b/app/views/questions/dependents/index.html.erb
@@ -19,7 +19,7 @@
                 <h3 class="dependent__label">
                   <%= dependent.full_name %> <%= default_date_format(dependent.birth_date) %>
                 </h3>
-                <%= link_to t("general.edit"), edit_dependent_path(dependent), class: "button button--inline-action" %>
+                <%= link_to t("general.edit"), Questions::DependentsController.to_path_helper(action: :edit, id: dependent.id), class: "button button--inline-action" %>
               </div>
             </li>
             <% end %>
@@ -29,7 +29,7 @@
           <h1 class="h2"><%=t("views.dependents.index.title") %></h1>
           <p><%=t("views.dependents.index.info") %></p>
 
-          <%= link_to(new_dependent_path, class: "button button--wide button--icon") do %>
+          <%= link_to(Questions::DependentsController.to_path_helper(action: :new), class: "button button--wide button--icon") do %>
             <%= image_tag("add-person.svg", alt: "") %>
             <%=t("views.dependents.index.add_person") %>
           <% end %>

--- a/app/views/questions/dependents/new.html.erb
+++ b/app/views/questions/dependents/new.html.erb
@@ -1,0 +1,1 @@
+<%= render "questions/dependents/form" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,9 +68,15 @@ Rails.application.routes.draw do
       resources :vita_providers, only: [:index, :show]
       get "/vita_provider/map", to: "vita_providers#map"
 
+      namespace :questions do
+        resources :dependents, only: [:index, :new, :create, :edit, :update, :destroy]
+      end
+
       resources :questions, controller: :questions do
         collection do
           Navigation::GyrQuestionNavigation.controllers.uniq.each do |controller_class|
+            next if controller_class.navigation_actions != [:edit]
+
             { get: :edit, put: :update }.each do |method, action|
               match "/#{controller_class.to_param}",
                     action: action,
@@ -100,6 +106,7 @@ Rails.application.routes.draw do
         post '/request-doc-help', to: 'documents_help#request_doc_help', as: :request_doc_help
       end
 
+      # DEPRECATED: exists just to redirect to proper Questions::DependentsController version
       resources :dependents, only: [:index, :new, :create, :edit, :update, :destroy]
 
       resources :signups, only: [:new, :create], path: "sign-up", path_names: { new: '' } do

--- a/spec/controllers/dependents_controller_spec.rb
+++ b/spec/controllers/dependents_controller_spec.rb
@@ -2,335 +2,48 @@ require "rails_helper"
 
 RSpec.describe DependentsController do
   let(:intake) { create :intake }
-  before { allow(MixpanelService).to receive(:send_event).and_call_original }
 
-  describe "#next_path" do
-    before { sign_in intake.client }
-
-    it "returns a link to dependent care questions" do
-      expect(subject.next_path).to include dependent_care_questions_path
-    end
-  end
+  before { sign_in intake.client }
 
   describe "#index" do
-    let(:birth_year) { MultiTenantService.new(:gyr).current_tax_year - 9 }
-
-    it_behaves_like :a_get_action_for_authenticated_clients_only, action: :index
-    it_behaves_like :a_get_action_redirects_for_show_still_needs_help_clients, action: :index
-
-    context "with an authenticated client" do
-      before { sign_in intake.client }
-
-      context "with existing dependents" do
-        render_views
-        let!(:dependent_one) { create :dependent, first_name: "Kylie", last_name: "Kiwi", birth_date: Date.new(birth_year, 4, 21), intake: intake}
-        let!(:dependent_two) { create :dependent, first_name: "Kelly", last_name: "Kiwi", birth_date: Date.new(birth_year, 4, 21), intake: intake}
-
-        it "renders information about each dependent" do
-          get :index
-
-          expect(response.body).to include "Kylie Kiwi 4/21/#{birth_year}"
-          expect(response.body).to include "Kelly Kiwi 4/21/#{birth_year}"
-        end
-      end
+    it "redirects to Questions::DependentsController" do
+      get :index
+      expect(response).to redirect_to(Questions::DependentsController.to_path_helper(action: :index))
     end
   end
 
   describe "#create" do
-    let(:birth_year) { MultiTenantService.new(:gyr).current_tax_year - 5 }
-
-    let(:params) do
-      {
-        dependent: {
-          first_name: "Kylie",
-          last_name: "Kiwi",
-          birth_date_month: "6",
-          birth_date_day: "15",
-          birth_date_year: birth_year,
-          relationship: "Nibling",
-          months_in_home: "12",
-          was_student: "no",
-          us_citizen: "no",
-          north_american_resident: "yes",
-          disabled: "no",
-          was_married: "no"
-        }
-      }
-    end
-
-    it_behaves_like :a_post_action_for_authenticated_clients_only, action: :create
-
-    context "with an authenticated client" do
-      before { sign_in intake.client }
-
-      it "creates a new dependent linked to the current intake and redirects to the index" do
-        expect do
-          post :create, params: params
-        end.to change(Dependent, :count).by 1
-
-        expect(response).to redirect_to(dependents_path)
-
-        dependent = Dependent.last
-        expect(dependent.intake).to eq intake
-        expect(dependent.first_name).to eq "Kylie"
-        expect(dependent.last_name).to eq "Kiwi"
-        expect(dependent.birth_date).to eq Date.new(birth_year, 6, 15)
-        expect(dependent.relationship).to eq "Nibling"
-        expect(dependent.months_in_home).to eq 12
-        expect(dependent.was_student).to eq "no"
-        expect(dependent.us_citizen).to eq "no"
-        expect(dependent.north_american_resident).to eq "yes"
-        expect(dependent.disabled).to eq "no"
-        expect(dependent.was_married).to eq "no"
-      end
-
-      it "sends analytics to mixpanel" do
-        post :create, params: params
-
-        expect(MixpanelService).to have_received(:send_event).with(hash_including(
-          event_name: "dependent_added",
-          data: {
-            dependent_age_at_end_of_tax_year: "5",
-            dependent_under_6: "yes",
-            dependent_months_in_home: "12",
-            dependent_was_student: "no",
-            dependent_us_citizen: "no",
-            dependent_north_american_resident: "yes",
-            dependent_disabled: "no",
-            dependent_was_married: "no",
-          }
-        ))
-      end
-
-      context "with invalid params" do
-        render_views
-
-        let(:params) do
-          {
-            dependent: {
-              first_name: "Kylie",
-              birth_date_month: "12",
-              birth_date_day: "2",
-              birth_date_year: "96",
-              relationship: "Nibling",
-              months_in_home: "12",
-              was_student: "no",
-              was_not_citizen: "no",
-              north_american_resident: "yes",
-              disabled: "no",
-              was_married: "no"
-            }
-          }
-        end
-
-        it "renders new with validation errors" do
-          expect do
-            post :create, params: params
-          end.not_to change(Dependent, :count)
-
-          expect(response).to render_template(:new)
-
-          expect(response.body).to include "Please enter a valid date."
-          expect(response.body).to include "Please enter a last name."
-        end
-
-        it "sends validation errors to mixpanel" do
-          post :create, params: params
-
-          expect(MixpanelService).to have_received(:send_event).with(hash_including(
-            event_name: "validation_error",
-            data: {
-              invalid_birth_date: true,
-              invalid_last_name: true,
-            }
-          ))
-        end
-      end
-    end
-  end
-
-  describe "#edit" do
-    let(:client) { intake.client }
-    let!(:dependent) do
-      create :dependent,
-             first_name: "Mary",
-             last_name: "Mango",
-             birth_date: Date.new(2017, 4, 21),
-             relationship: "Kid",
-             intake: intake
-    end
-    let(:params) { { id: dependent.id } }
-
-    it_behaves_like :a_get_action_for_authenticated_clients_only, action: :edit
-    it_behaves_like :a_get_action_redirects_for_show_still_needs_help_clients, action: :edit
-
-    context "with an authenticated client" do
-      render_views
-
-      before { sign_in client }
-
-      it "renders information about the existing dependent and renders a delete button" do
-        get :edit, params: params
-
-        expect(response.body).to include("Mary")
-        expect(response.body).to include("Mango")
-        expect(response.body).to include("Kid")
-        expect(response.body).to include("Remove this person")
-      end
+    it "redirects to Questions::DependentsController" do
+      post :create
+      expect(response).to redirect_to(Questions::DependentsController.to_path_helper(action: :index))
     end
   end
 
   describe "#update" do
-    let(:birth_year) { MultiTenantService.new(:gyr).current_tax_year - 5 }
-    let!(:dependent) do
-      create :dependent,
-             first_name: "Mary",
-             last_name: "Mango",
-             birth_date: Date.new(2017, 4, 21),
-             relationship: "Kid",
-             intake: intake
+    it "redirects to Questions::DependentsController" do
+      put :update, params: { id: 123 }
+      expect(response).to redirect_to(Questions::DependentsController.to_path_helper(action: :index))
     end
-    let(:params) do
-      {
-        id: dependent.id,
-        dependent: {
-          first_name: "Kylie",
-          last_name: "Kiwi",
-          birth_date_month: "6",
-          birth_date_day: "15",
-          birth_date_year: birth_year,
-          relationship: "Nibling",
-          months_in_home: "12",
-          was_student: "no",
-          us_citizen: "no",
-          north_american_resident: "yes",
-          disabled: "no",
-          was_married: "no"
-        }
-      }
+  end
+
+  describe "#new" do
+    it "redirects to Questions::DependentsController" do
+      get :new
+      expect(response).to redirect_to(Questions::DependentsController.to_path_helper(action: :index))
     end
+  end
 
-    it_behaves_like :a_post_action_for_authenticated_clients_only, action: :update
-
-
-    context "with an authenticated client" do
-      before { sign_in intake.client }
-
-      it "updates the dependent and redirects to the index" do
-        post :update, params: params
-
-        expect(response).to redirect_to(dependents_path)
-
-        dependent.reload
-        expect(dependent.first_name).to eq "Kylie"
-        expect(dependent.last_name).to eq "Kiwi"
-        expect(dependent.birth_date).to eq Date.new(birth_year, 6, 15)
-        expect(dependent.relationship).to eq "Nibling"
-        expect(dependent.months_in_home).to eq 12
-        expect(dependent.was_student).to eq "no"
-        expect(dependent.us_citizen).to eq "no"
-        expect(dependent.north_american_resident).to eq "yes"
-        expect(dependent.disabled).to eq "no"
-        expect(dependent.was_married).to eq "no"
-      end
-
-      it "sends analytics to mixpanel" do
-        post :update, params: params
-
-        expect(MixpanelService).to have_received(:send_event).with(hash_including(
-          event_name: "dependent_updated",
-          data: {
-            dependent_age_at_end_of_tax_year: "5",
-            dependent_under_6: "yes",
-            dependent_months_in_home: "12",
-            dependent_was_student: "no",
-            dependent_us_citizen: "no",
-            dependent_north_american_resident: "yes",
-            dependent_disabled: "no",
-            dependent_was_married: "no",
-          }
-        ))
-      end
-
-      context "with invalid params" do
-        render_views
-
-        let(:params) do
-          {
-            id: dependent.id,
-            dependent: {
-              first_name: "Kylie",
-              last_name: "",
-              birth_date_month: "16",
-              birth_date_day: "2",
-              birth_date_year: "2015",
-              relationship: "Nibling",
-              months_in_home: "12",
-              was_student: "no",
-              was_not_citizen: "no",
-              north_american_resident: "yes",
-              disabled: "no",
-              was_married: "no"
-            }
-          }
-        end
-
-        it "renders edit with validation errors" do
-          expect do
-            post :update, params: params
-          end.not_to change(Dependent, :count)
-
-          expect(response).to render_template(:edit)
-
-          expect(response.body).to include "Please enter a valid date."
-          expect(response.body).to include "Please enter a last name."
-        end
-
-        it "sends validation errors to mixpanel" do
-          post :create, params: params
-
-          expect(MixpanelService).to have_received(:send_event).with(hash_including(
-            event_name: "validation_error",
-            data: {
-              invalid_birth_date: true,
-              invalid_last_name: true,
-            }
-          ))
-        end
-      end
+  describe "#edit" do
+    it "redirects to Questions::DependentsController" do
+      get :edit, params: { id: 123 }
+      expect(response).to redirect_to(Questions::DependentsController.to_path_helper(action: :index))
     end
   end
 
   describe "#destroy" do
-    let!(:dependent) do
-      create :dependent,
-             first_name: "Mary",
-             last_name: "Mango",
-             birth_date: Date.new(2017, 4, 21),
-             relationship: "Kid",
-             intake: intake
-    end
-    let(:params) { { id: dependent.id } }
-
-    it_behaves_like :a_post_action_for_authenticated_clients_only, action: :destroy
-
-    context "with an authenticated client" do
-      before { sign_in intake.client }
-
-      it "deletes the dependent and adds a flash message and redirects to dependents path" do
-        expect do
-          delete :destroy, params: params
-        end.to change(Dependent, :count).by(-1)
-
-        expect(response).to redirect_to dependents_path
-        expect(flash[:notice]).to eq "Removed Mary Mango."
-      end
-
-      it "sends analytics to mixpanel" do
-        delete :destroy, params: params
-
-        expect(MixpanelService).to have_received(:send_event).with(hash_including(event_name: "dependent_removed"))
-      end
+    it "redirects to Questions::DependentsController" do
+      delete :destroy, params: { id: 123 }
+      expect(response).to redirect_to(Questions::DependentsController.to_path_helper(action: :index))
     end
   end
 end

--- a/spec/controllers/questions/dependents_controller_spec.rb
+++ b/spec/controllers/questions/dependents_controller_spec.rb
@@ -1,0 +1,336 @@
+require "rails_helper"
+
+RSpec.describe Questions::DependentsController do
+  let(:intake) { create :intake }
+  before { allow(MixpanelService).to receive(:send_event).and_call_original }
+
+  describe "#next_path" do
+    before { sign_in intake.client }
+
+    it "returns a link to dependent care questions" do
+      expect(subject.next_path).to include dependent_care_questions_path
+    end
+  end
+
+  describe "#index" do
+    let(:birth_year) { MultiTenantService.new(:gyr).current_tax_year - 9 }
+
+    it_behaves_like :a_get_action_for_authenticated_clients_only, action: :index
+    it_behaves_like :a_get_action_redirects_for_show_still_needs_help_clients, action: :index
+
+    context "with an authenticated client" do
+      before { sign_in intake.client }
+
+      context "with existing dependents" do
+        render_views
+        let!(:dependent_one) { create :dependent, first_name: "Kylie", last_name: "Kiwi", birth_date: Date.new(birth_year, 4, 21), intake: intake}
+        let!(:dependent_two) { create :dependent, first_name: "Kelly", last_name: "Kiwi", birth_date: Date.new(birth_year, 4, 21), intake: intake}
+
+        it "renders information about each dependent" do
+          get :index
+
+          expect(response.body).to include "Kylie Kiwi 4/21/#{birth_year}"
+          expect(response.body).to include "Kelly Kiwi 4/21/#{birth_year}"
+        end
+      end
+    end
+  end
+
+  describe "#create" do
+    let(:birth_year) { MultiTenantService.new(:gyr).current_tax_year - 5 }
+
+    let(:params) do
+      {
+        dependent: {
+          first_name: "Kylie",
+          last_name: "Kiwi",
+          birth_date_month: "6",
+          birth_date_day: "15",
+          birth_date_year: birth_year,
+          relationship: "Nibling",
+          months_in_home: "12",
+          was_student: "no",
+          us_citizen: "no",
+          north_american_resident: "yes",
+          disabled: "no",
+          was_married: "no"
+        }
+      }
+    end
+
+    it_behaves_like :a_post_action_for_authenticated_clients_only, action: :create
+
+    context "with an authenticated client" do
+      before { sign_in intake.client }
+
+      it "creates a new dependent linked to the current intake and redirects to the index" do
+        expect do
+          post :create, params: params
+        end.to change(Dependent, :count).by 1
+
+        expect(response).to redirect_to(Questions::DependentsController.to_path_helper(action: :index))
+
+        dependent = Dependent.last
+        expect(dependent.intake).to eq intake
+        expect(dependent.first_name).to eq "Kylie"
+        expect(dependent.last_name).to eq "Kiwi"
+        expect(dependent.birth_date).to eq Date.new(birth_year, 6, 15)
+        expect(dependent.relationship).to eq "Nibling"
+        expect(dependent.months_in_home).to eq 12
+        expect(dependent.was_student).to eq "no"
+        expect(dependent.us_citizen).to eq "no"
+        expect(dependent.north_american_resident).to eq "yes"
+        expect(dependent.disabled).to eq "no"
+        expect(dependent.was_married).to eq "no"
+      end
+
+      it "sends analytics to mixpanel" do
+        post :create, params: params
+
+        expect(MixpanelService).to have_received(:send_event).with(hash_including(
+          event_name: "dependent_added",
+          data: {
+            dependent_age_at_end_of_tax_year: "5",
+            dependent_under_6: "yes",
+            dependent_months_in_home: "12",
+            dependent_was_student: "no",
+            dependent_us_citizen: "no",
+            dependent_north_american_resident: "yes",
+            dependent_disabled: "no",
+            dependent_was_married: "no",
+          }
+        ))
+      end
+
+      context "with invalid params" do
+        render_views
+
+        let(:params) do
+          {
+            dependent: {
+              first_name: "Kylie",
+              birth_date_month: "12",
+              birth_date_day: "2",
+              birth_date_year: "96",
+              relationship: "Nibling",
+              months_in_home: "12",
+              was_student: "no",
+              was_not_citizen: "no",
+              north_american_resident: "yes",
+              disabled: "no",
+              was_married: "no"
+            }
+          }
+        end
+
+        it "renders new with validation errors" do
+          expect do
+            post :create, params: params
+          end.not_to change(Dependent, :count)
+
+          expect(response).to render_template(:new)
+
+          expect(response.body).to include "Please enter a valid date."
+          expect(response.body).to include "Please enter a last name."
+        end
+
+        it "sends validation errors to mixpanel" do
+          post :create, params: params
+
+          expect(MixpanelService).to have_received(:send_event).with(hash_including(
+            event_name: "validation_error",
+            data: {
+              invalid_birth_date: true,
+              invalid_last_name: true,
+            }
+          ))
+        end
+      end
+    end
+  end
+
+  describe "#edit" do
+    let(:client) { intake.client }
+    let!(:dependent) do
+      create :dependent,
+             first_name: "Mary",
+             last_name: "Mango",
+             birth_date: Date.new(2017, 4, 21),
+             relationship: "Kid",
+             intake: intake
+    end
+    let(:params) { { id: dependent.id } }
+
+    it_behaves_like :a_get_action_for_authenticated_clients_only, action: :edit
+    it_behaves_like :a_get_action_redirects_for_show_still_needs_help_clients, action: :edit
+
+    context "with an authenticated client" do
+      render_views
+
+      before { sign_in client }
+
+      it "renders information about the existing dependent and renders a delete button" do
+        get :edit, params: params
+
+        expect(response.body).to include("Mary")
+        expect(response.body).to include("Mango")
+        expect(response.body).to include("Kid")
+        expect(response.body).to include("Remove this person")
+      end
+    end
+  end
+
+  describe "#update" do
+    let(:birth_year) { MultiTenantService.new(:gyr).current_tax_year - 5 }
+    let!(:dependent) do
+      create :dependent,
+             first_name: "Mary",
+             last_name: "Mango",
+             birth_date: Date.new(2017, 4, 21),
+             relationship: "Kid",
+             intake: intake
+    end
+    let(:params) do
+      {
+        id: dependent.id,
+        dependent: {
+          first_name: "Kylie",
+          last_name: "Kiwi",
+          birth_date_month: "6",
+          birth_date_day: "15",
+          birth_date_year: birth_year,
+          relationship: "Nibling",
+          months_in_home: "12",
+          was_student: "no",
+          us_citizen: "no",
+          north_american_resident: "yes",
+          disabled: "no",
+          was_married: "no"
+        }
+      }
+    end
+
+    it_behaves_like :a_post_action_for_authenticated_clients_only, action: :update
+
+
+    context "with an authenticated client" do
+      before { sign_in intake.client }
+
+      it "updates the dependent and redirects to the index" do
+        post :update, params: params
+
+        expect(response).to redirect_to(Questions::DependentsController.to_path_helper(action: :index))
+
+        dependent.reload
+        expect(dependent.first_name).to eq "Kylie"
+        expect(dependent.last_name).to eq "Kiwi"
+        expect(dependent.birth_date).to eq Date.new(birth_year, 6, 15)
+        expect(dependent.relationship).to eq "Nibling"
+        expect(dependent.months_in_home).to eq 12
+        expect(dependent.was_student).to eq "no"
+        expect(dependent.us_citizen).to eq "no"
+        expect(dependent.north_american_resident).to eq "yes"
+        expect(dependent.disabled).to eq "no"
+        expect(dependent.was_married).to eq "no"
+      end
+
+      it "sends analytics to mixpanel" do
+        post :update, params: params
+
+        expect(MixpanelService).to have_received(:send_event).with(hash_including(
+          event_name: "dependent_updated",
+          data: {
+            dependent_age_at_end_of_tax_year: "5",
+            dependent_under_6: "yes",
+            dependent_months_in_home: "12",
+            dependent_was_student: "no",
+            dependent_us_citizen: "no",
+            dependent_north_american_resident: "yes",
+            dependent_disabled: "no",
+            dependent_was_married: "no",
+          }
+        ))
+      end
+
+      context "with invalid params" do
+        render_views
+
+        let(:params) do
+          {
+            id: dependent.id,
+            dependent: {
+              first_name: "Kylie",
+              last_name: "",
+              birth_date_month: "16",
+              birth_date_day: "2",
+              birth_date_year: "2015",
+              relationship: "Nibling",
+              months_in_home: "12",
+              was_student: "no",
+              was_not_citizen: "no",
+              north_american_resident: "yes",
+              disabled: "no",
+              was_married: "no"
+            }
+          }
+        end
+
+        it "renders edit with validation errors" do
+          expect do
+            post :update, params: params
+          end.not_to change(Dependent, :count)
+
+          expect(response).to render_template(:edit)
+
+          expect(response.body).to include "Please enter a valid date."
+          expect(response.body).to include "Please enter a last name."
+        end
+
+        it "sends validation errors to mixpanel" do
+          post :create, params: params
+
+          expect(MixpanelService).to have_received(:send_event).with(hash_including(
+            event_name: "validation_error",
+            data: {
+              invalid_birth_date: true,
+              invalid_last_name: true,
+            }
+          ))
+        end
+      end
+    end
+  end
+
+  describe "#destroy" do
+    let!(:dependent) do
+      create :dependent,
+             first_name: "Mary",
+             last_name: "Mango",
+             birth_date: Date.new(2017, 4, 21),
+             relationship: "Kid",
+             intake: intake
+    end
+    let(:params) { { id: dependent.id } }
+
+    it_behaves_like :a_post_action_for_authenticated_clients_only, action: :destroy
+
+    context "with an authenticated client" do
+      before { sign_in intake.client }
+
+      it "deletes the dependent and adds a flash message and redirects to dependents path" do
+        expect do
+          delete :destroy, params: params
+        end.to change(Dependent, :count).by(-1)
+
+        expect(response).to redirect_to Questions::DependentsController.to_path_helper(action: :index)
+        expect(flash[:notice]).to eq "Removed Mary Mango."
+      end
+
+      it "sends analytics to mixpanel" do
+        delete :destroy, params: params
+
+        expect(MixpanelService).to have_received(:send_event).with(hash_including(event_name: "dependent_removed"))
+      end
+    end
+  end
+end

--- a/spec/controllers/questions/had_dependents_controller_spec.rb
+++ b/spec/controllers/questions/had_dependents_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Questions::HadDependentsController do
       let(:had_dependents) { "yes" }
 
       it "returns the dependents path" do
-        expect(subject.next_path).to eq dependents_path
+        expect(subject.next_path).to eq Questions::DependentsController.to_path_helper(action: :index)
       end
     end
 
@@ -23,4 +23,3 @@ RSpec.describe Questions::HadDependentsController do
     end
   end
 end
-


### PR DESCRIPTION
it should be with its other GYR intake friends

DependentsController itself sticks around as a pure redirect to the Questions:: version

keeping the translation ymls in the same place for now; I don't think there's any relative references we need to move to fix, maybe the tests will tell me