### PR TITLE
Add .tool-versions for asdf config

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+ruby 3.2.2
+python 3.12.0
+nodejs 18.18.2


### PR DESCRIPTION
This project currently has both nodejs and python dependencies. While rbenv is great for ruby it doesn't handle nodejs or python versioning.

asdf is a tool that is similar to rbenv that can handle versioning for python, nodejs, ruby, and many other things. This .tool-versions file will allow someone to use asdf but should not interrupt any usage of rbenv.