### PR TITLE
Add contact info columns to state file intakes

### DIFF
--- a/app/models/state_file_az_intake.rb
+++ b/app/models/state_file_az_intake.rb
@@ -11,6 +11,8 @@
 #  claimed_as_dep         :integer
 #  contact_preference     :integer          default("unfilled"), not null
 #  current_step           :string
+#  email_address          :citext
+#  phone_number           :string
 #  primary_first_name     :string
 #  primary_last_name      :string
 #  primary_middle_initial :string

--- a/app/models/state_file_ny_intake.rb
+++ b/app/models/state_file_ny_intake.rb
@@ -12,6 +12,7 @@
 #  contact_preference             :integer          default("unfilled"), not null
 #  current_step                   :string
 #  date_electronic_withdrawal     :date
+#  email_address                  :citext
 #  household_cash_assistance      :integer
 #  household_fed_agi              :integer
 #  household_ny_additions         :integer
@@ -37,6 +38,7 @@
 #  permanent_city                 :string
 #  permanent_street               :string
 #  permanent_zip                  :string
+#  phone_number                   :string
 #  primary_email                  :string
 #  primary_first_name             :string
 #  primary_last_name              :string

--- a/db/migrate/20231027154329_add_contact_info_to_state_file_intakes.rb
+++ b/db/migrate/20231027154329_add_contact_info_to_state_file_intakes.rb
@@ -1,0 +1,9 @@
+class AddContactInfoToStateFileIntakes < ActiveRecord::Migration[7.1]
+  def change
+    add_column :state_file_ny_intakes, :email_address, :citext
+    add_column :state_file_ny_intakes, :phone_number, :string
+    
+    add_column :state_file_az_intakes, :email_address, :citext
+    add_column :state_file_az_intakes, :phone_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_26_210020) do
+ActiveRecord::Schema[7.1].define(version: 2023_10_27_154329) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -1561,6 +1561,8 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_26_210020) do
     t.integer "contact_preference", default: 0, null: false
     t.datetime "created_at", null: false
     t.string "current_step"
+    t.citext "email_address"
+    t.string "phone_number"
     t.string "primary_first_name"
     t.string "primary_last_name"
     t.string "primary_middle_initial"
@@ -1599,6 +1601,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_26_210020) do
     t.datetime "created_at", null: false
     t.string "current_step"
     t.date "date_electronic_withdrawal"
+    t.citext "email_address"
     t.integer "household_cash_assistance"
     t.integer "household_fed_agi"
     t.integer "household_ny_additions"
@@ -1624,6 +1627,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_26_210020) do
     t.string "permanent_city"
     t.string "permanent_street"
     t.string "permanent_zip"
+    t.string "phone_number"
     t.string "primary_email"
     t.string "primary_first_name"
     t.string "primary_last_name"

--- a/spec/factories/state_file_az_intakes.rb
+++ b/spec/factories/state_file_az_intakes.rb
@@ -11,6 +11,8 @@
 #  claimed_as_dep         :integer
 #  contact_preference     :integer          default("unfilled"), not null
 #  current_step           :string
+#  email_address          :citext
+#  phone_number           :string
 #  primary_first_name     :string
 #  primary_last_name      :string
 #  primary_middle_initial :string

--- a/spec/factories/state_file_ny_intakes.rb
+++ b/spec/factories/state_file_ny_intakes.rb
@@ -12,6 +12,7 @@
 #  contact_preference             :integer          default("unfilled"), not null
 #  current_step                   :string
 #  date_electronic_withdrawal     :date
+#  email_address                  :citext
 #  household_cash_assistance      :integer
 #  household_fed_agi              :integer
 #  household_ny_additions         :integer
@@ -37,6 +38,7 @@
 #  permanent_city                 :string
 #  permanent_street               :string
 #  permanent_zip                  :string
+#  phone_number                   :string
 #  primary_email                  :string
 #  primary_first_name             :string
 #  primary_last_name              :string


### PR DESCRIPTION
Just adds phone number and email address columns to the tables.
Uses [`citext`](https://www.postgresql.org/docs/current/citext.html) for the `email_address` column

Part of https://www.pivotaltracker.com/story/show/186317243