### PR TITLE
WIP: Database fields for state file login

### DIFF
--- a/app/models/state_file_az_intake.rb
+++ b/app/models/state_file_az_intake.rb
@@ -18,6 +18,8 @@
 #  primary_middle_initial :string
 #  prior_last_names       :string
 #  raw_direct_file_data   :text
+#  referrer               :string
+#  source                 :string
 #  spouse_first_name      :string
 #  spouse_last_name       :string
 #  spouse_middle_initial  :string

--- a/app/models/state_file_az_intake.rb
+++ b/app/models/state_file_az_intake.rb
@@ -8,7 +8,7 @@
 #  bank_routing_number    :string
 #  charitable_cash        :integer          default(0)
 #  charitable_noncash     :integer          default(0)
-#  claimed_as_dep         :integer
+#  claimed_as_dep         :integer          default("unfilled")
 #  contact_preference     :integer          default("unfilled"), not null
 #  current_step           :string
 #  email_address          :citext

--- a/app/models/state_file_base_intake.rb
+++ b/app/models/state_file_base_intake.rb
@@ -1,7 +1,7 @@
 class StateFileBaseIntake < ApplicationRecord
   self.abstract_class = true
 
-  enum claimed_as_dep: { yes: 1, no: 2 }, _prefix: :claimed_as_dep
+  enum claimed_as_dep: { unfilled: 0, yes: 1, no: 2 }, _prefix: :claimed_as_dep
   enum contact_preference: { unfilled: 0, email: 1, text: 2 }, _prefix: :contact_preference
   has_one_attached :submission_pdf
 

--- a/app/models/state_file_ny_intake.rb
+++ b/app/models/state_file_ny_intake.rb
@@ -7,7 +7,7 @@
 #  account_type                   :integer          default("unfilled"), not null
 #  amount_electronic_withdrawal   :integer
 #  amount_owed_pay_electronically :integer          default("unfilled"), not null
-#  claimed_as_dep                 :integer          not null
+#  claimed_as_dep                 :integer          default("unfilled"), not null
 #  confirmed_permanent_address    :integer          default("unfilled"), not null
 #  contact_preference             :integer          default("unfilled"), not null
 #  current_step                   :string

--- a/app/models/state_file_ny_intake.rb
+++ b/app/models/state_file_ny_intake.rb
@@ -48,12 +48,14 @@
 #  property_over_limit            :integer          default("unfilled"), not null
 #  public_housing                 :integer          default("unfilled"), not null
 #  raw_direct_file_data           :text
+#  referrer                       :string
 #  refund_choice                  :integer          default("unfilled"), not null
 #  residence_county               :string
 #  routing_number                 :string
 #  sales_use_tax                  :integer
 #  school_district                :string
 #  school_district_number         :integer
+#  source                         :string
 #  spouse_birth_date              :date
 #  spouse_first_name              :string
 #  spouse_last_name               :string

--- a/db/migrate/20231027203055_state_intake_default_to_claimed_as_dep_unfilled.rb
+++ b/db/migrate/20231027203055_state_intake_default_to_claimed_as_dep_unfilled.rb
@@ -1,0 +1,6 @@
+class StateIntakeDefaultToClaimedAsDepUnfilled < ActiveRecord::Migration[7.1]
+  def change
+    change_column_default :state_file_az_intakes, :claimed_as_dep, from: nil, to: 0
+    change_column_default :state_file_ny_intakes, :claimed_as_dep, from: nil, to: 0
+  end
+end

--- a/db/migrate/20231027221327_add_source_referrer_to_state_intakes.rb
+++ b/db/migrate/20231027221327_add_source_referrer_to_state_intakes.rb
@@ -1,0 +1,8 @@
+class AddSourceReferrerToStateIntakes < ActiveRecord::Migration[7.1]
+  def change
+    add_column :state_file_az_intakes, :source, :string
+    add_column :state_file_az_intakes, :referrer, :string
+    add_column :state_file_ny_intakes, :source, :string
+    add_column :state_file_ny_intakes, :referrer, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_27_154329) do
+ActiveRecord::Schema[7.1].define(version: 2023_10_27_203055) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -1557,7 +1557,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_27_154329) do
     t.string "bank_routing_number"
     t.integer "charitable_cash", default: 0
     t.integer "charitable_noncash", default: 0
-    t.integer "claimed_as_dep"
+    t.integer "claimed_as_dep", default: 0
     t.integer "contact_preference", default: 0, null: false
     t.datetime "created_at", null: false
     t.string "current_step"
@@ -1596,7 +1596,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_27_154329) do
     t.integer "account_type", default: 0, null: false
     t.integer "amount_electronic_withdrawal"
     t.integer "amount_owed_pay_electronically", default: 0, null: false
-    t.integer "claimed_as_dep", null: false
+    t.integer "claimed_as_dep", default: 0, null: false
     t.integer "confirmed_permanent_address", default: 0, null: false
     t.integer "contact_preference", default: 0, null: false
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_27_203055) do
+ActiveRecord::Schema[7.1].define(version: 2023_10_27_221327) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -1568,6 +1568,8 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_27_203055) do
     t.string "primary_middle_initial"
     t.string "prior_last_names"
     t.text "raw_direct_file_data"
+    t.string "referrer"
+    t.string "source"
     t.string "spouse_first_name"
     t.string "spouse_last_name"
     t.string "spouse_middle_initial"
@@ -1638,13 +1640,14 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_27_203055) do
     t.integer "property_over_limit", default: 0, null: false
     t.integer "public_housing", default: 0, null: false
     t.text "raw_direct_file_data"
+    t.string "referrer"
     t.integer "refund_choice", default: 0, null: false
     t.string "residence_county"
     t.string "routing_number"
     t.integer "sales_use_tax"
     t.string "school_district"
     t.integer "school_district_number"
-    t.date "spouse_birth_date"
+    t.string "source"
     t.string "spouse_first_name"
     t.string "spouse_last_name"
     t.string "spouse_middle_initial"

--- a/spec/factories/state_file_az_intakes.rb
+++ b/spec/factories/state_file_az_intakes.rb
@@ -18,6 +18,8 @@
 #  primary_middle_initial :string
 #  prior_last_names       :string
 #  raw_direct_file_data   :text
+#  referrer               :string
+#  source                 :string
 #  spouse_first_name      :string
 #  spouse_last_name       :string
 #  spouse_middle_initial  :string

--- a/spec/factories/state_file_az_intakes.rb
+++ b/spec/factories/state_file_az_intakes.rb
@@ -8,7 +8,7 @@
 #  bank_routing_number    :string
 #  charitable_cash        :integer          default(0)
 #  charitable_noncash     :integer          default(0)
-#  claimed_as_dep         :integer
+#  claimed_as_dep         :integer          default("unfilled")
 #  contact_preference     :integer          default("unfilled"), not null
 #  current_step           :string
 #  email_address          :citext

--- a/spec/factories/state_file_ny_intakes.rb
+++ b/spec/factories/state_file_ny_intakes.rb
@@ -7,7 +7,7 @@
 #  account_type                   :integer          default("unfilled"), not null
 #  amount_electronic_withdrawal   :integer
 #  amount_owed_pay_electronically :integer          default("unfilled"), not null
-#  claimed_as_dep                 :integer          not null
+#  claimed_as_dep                 :integer          default("unfilled"), not null
 #  confirmed_permanent_address    :integer          default("unfilled"), not null
 #  contact_preference             :integer          default("unfilled"), not null
 #  current_step                   :string

--- a/spec/factories/state_file_ny_intakes.rb
+++ b/spec/factories/state_file_ny_intakes.rb
@@ -48,12 +48,14 @@
 #  property_over_limit            :integer          default("unfilled"), not null
 #  public_housing                 :integer          default("unfilled"), not null
 #  raw_direct_file_data           :text
+#  referrer                       :string
 #  refund_choice                  :integer          default("unfilled"), not null
 #  residence_county               :string
 #  routing_number                 :string
 #  sales_use_tax                  :integer
 #  school_district                :string
 #  school_district_number         :integer
+#  source                         :string
 #  spouse_birth_date              :date
 #  spouse_first_name              :string
 #  spouse_last_name               :string


### PR DESCRIPTION
This adds updates the state file schema
- adds source & referrer columns (for tracking how people arrive at state file). This is data we want to save on the first page where we create an intake
- updates claimed_as_dep to have a default so we can create state intakes before we have an answer