### PR TITLE
State file auth flow, without actual auth functionality

### DIFF
--- a/app/controllers/flows_controller.rb
+++ b/app/controllers/flows_controller.rb
@@ -102,14 +102,14 @@ class FlowsController < ApplicationController
       when :state_file_az
         FlowParams.new(
           controller: controller,
-          reference_object: StateFileAzIntake.new,
+          reference_object: controller.current_intake&.is_a?(StateFileAzIntake) ? controller.current_intake : nil,
           controller_list: Navigation::StateFileAzQuestionNavigation::FLOW,
           form: nil
         )
       when :state_file_ny
         FlowParams.new(
           controller: controller,
-          reference_object: StateFileNyIntake.new,
+          reference_object: controller.current_intake&.is_a?(StateFileNyIntake) ? controller.current_intake : nil,
           controller_list: Navigation::StateFileNyQuestionNavigation::FLOW,
           form: nil
         )
@@ -203,9 +203,9 @@ class FlowsController < ApplicationController
           if respond_to?(:resource_name) && resource_name.present?
             url_params[:id] = "fake-#{resource_name}-id"
           end
-          if @reference_object.is_a?(StateFileAzIntake)
+          if @current_controller.params[:id] == 'state_file_az'
             url_params[:us_state] = 'az'
-          elsif @reference_object.is_a?(StateFileNyIntake)
+          elsif @current_controller.params[:id] == 'state_file_ny'
             url_params[:us_state] = 'ny'
           end
           @current_controller.url_for(url_params)

--- a/app/controllers/state_file/questions/code_verified_controller.rb
+++ b/app/controllers/state_file/questions/code_verified_controller.rb
@@ -1,0 +1,11 @@
+module StateFile
+  module Questions
+    class CodeVerifiedController < QuestionsController
+      private
+
+      def form_class
+        NullForm
+      end
+    end
+  end
+end

--- a/app/controllers/state_file/questions/email_address_controller.rb
+++ b/app/controllers/state_file/questions/email_address_controller.rb
@@ -1,0 +1,9 @@
+module StateFile
+  module Questions
+    class EmailAddressController < QuestionsController
+      def self.show?(intake)
+        intake.contact_preference == "email"
+      end
+    end
+  end
+end

--- a/app/controllers/state_file/questions/phone_number_controller.rb
+++ b/app/controllers/state_file/questions/phone_number_controller.rb
@@ -1,0 +1,9 @@
+module StateFile
+  module Questions
+    class PhoneNumberController < QuestionsController
+      def self.show?(intake)
+        intake.contact_preference == "text"
+      end
+    end
+  end
+end

--- a/app/controllers/state_file/questions/verification_code_controller.rb
+++ b/app/controllers/state_file/questions/verification_code_controller.rb
@@ -1,0 +1,16 @@
+module StateFile
+  module Questions
+    class VerificationCodeController < QuestionsController
+      def edit
+        case current_intake.contact_preference
+        when "text"
+          @contact_method = PhoneParser.formatted_phone_number(current_intake.phone_number)
+        when "email"
+          @contact_method = current_intake.email_address
+        end
+
+        super
+      end
+    end
+  end
+end

--- a/app/controllers/state_file/questions/verification_code_controller.rb
+++ b/app/controllers/state_file/questions/verification_code_controller.rb
@@ -4,9 +4,9 @@ module StateFile
       def edit
         case current_intake.contact_preference
         when "text"
-          @contact_method = PhoneParser.formatted_phone_number(current_intake.phone_number)
+          @contact_info = PhoneParser.formatted_phone_number(current_intake.phone_number)
         when "email"
-          @contact_method = current_intake.email_address
+          @contact_info = current_intake.email_address
         end
 
         super

--- a/app/forms/state_file/email_address_form.rb
+++ b/app/forms/state_file/email_address_form.rb
@@ -1,0 +1,11 @@
+module StateFile
+  class EmailAddressForm < QuestionsForm
+    set_attributes_for :intake, :email_address
+
+    validates :email_address, 'valid_email_2/email': true
+
+    def save
+      @intake.update(attributes_for(:intake))
+    end
+  end
+end

--- a/app/forms/state_file/phone_number_form.rb
+++ b/app/forms/state_file/phone_number_form.rb
@@ -1,0 +1,17 @@
+module StateFile
+  class PhoneNumberForm < QuestionsForm
+    set_attributes_for :intake, :phone_number
+
+    before_validation :normalize_phone_number
+
+    validates :phone_number, e164_phone: true
+
+    def normalize_phone_number
+      self.phone_number = PhoneParser.normalize(phone_number) if phone_number.present?
+    end
+
+    def save
+      @intake.update(attributes_for(:intake))
+    end
+  end
+end

--- a/app/lib/navigation/state_file_az_question_navigation.rb
+++ b/app/lib/navigation/state_file_az_question_navigation.rb
@@ -5,6 +5,10 @@ module Navigation
     FLOW = [
       StateFile::Questions::LandingPageController,
       StateFile::Questions::ContactPreferenceController, # creates state_intake (StartIntakeConcern)
+      StateFile::Questions::PhoneNumberController,
+      StateFile::Questions::EmailAddressController,
+      StateFile::Questions::VerificationCodeController,
+      StateFile::Questions::CodeVerifiedController,
       StateFile::Questions::FederalInfoController,
       StateFile::Questions::FederalDependentsController,
       StateFile::Questions::DobController,

--- a/app/lib/navigation/state_file_ny_question_navigation.rb
+++ b/app/lib/navigation/state_file_ny_question_navigation.rb
@@ -5,6 +5,10 @@ module Navigation
     FLOW = [
       StateFile::Questions::LandingPageController,
       StateFile::Questions::ContactPreferenceController, # creates state_intake (StartIntakeConcern)
+      StateFile::Questions::PhoneNumberController,
+      StateFile::Questions::EmailAddressController,
+      StateFile::Questions::VerificationCodeController,
+      StateFile::Questions::CodeVerifiedController,
       StateFile::Questions::FederalInfoController,
       StateFile::Questions::FederalDependentsController,
       StateFile::Questions::DobController,

--- a/app/views/state_file/questions/code_verified/edit.html.erb
+++ b/app/views/state_file/questions/code_verified/edit.html.erb
@@ -1,0 +1,15 @@
+<% title = t(".title") %>
+<% content_for :page_title, title %>
+<% content_for :card do %>
+  <h1 class="h2" id="main-question"><%= title %></h1>
+
+    <% if current_intake.contact_preference == "email" %>
+      <p><%= t(".subtitle_email") %></p>
+    <% elsif current_intake.contact_preference == "text" %>
+      <p><%= t(".subtitle_text") %></p>
+    <% end %>
+
+    <%= link_to next_path, class: "button button--primary", id: "firstCta" do %>
+      <%= t("general.continue") %>
+    <% end %>
+<% end %>

--- a/app/views/state_file/questions/email_address/edit.html.erb
+++ b/app/views/state_file/questions/email_address/edit.html.erb
@@ -1,0 +1,11 @@
+<% title = t(".title") %>
+<% content_for :page_title, title %>
+<% content_for :card do %>
+  <h1 class="h2" id="main-question"><%= title %></h1>
+
+  <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
+    <%= f.cfa_input_field(:email_address, t(".email_address_label"), classes: ["form-width--long"]) %>
+
+    <%= f.submit t(".action") %>
+  <% end %>
+<% end %>

--- a/app/views/state_file/questions/phone_number/edit.html.erb
+++ b/app/views/state_file/questions/phone_number/edit.html.erb
@@ -1,0 +1,11 @@
+<% title = t(".title") %>
+<% content_for :page_title, title %>
+<% content_for :card do %>
+  <h1 class="h2" id="main-question"><%= title %></h1>
+
+  <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
+    <%= f.cfa_input_field(:phone_number, t(".phone_number_label"), classes: ["form-width--long"]) %>
+
+    <%= f.submit t(".action") %>
+  <% end %>
+<% end %>

--- a/app/views/state_file/questions/verification_code/edit.html.erb
+++ b/app/views/state_file/questions/verification_code/edit.html.erb
@@ -3,7 +3,7 @@
 <% content_for :card do %>
   <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
     <h1 class="h2" id="main-question"><%= title %></h1>
-    <p><%= t(".subtitle_html", contact_method: @contact_method) %></p>
+    <p><%= t(".subtitle_html", contact_info: @contact_info) %></p>
     <%= f.cfa_input_field(:verification_code, t(".verification_code_label"), classes: ["form-width--long"]) %>
 
     <%= f.submit t(".action") %>

--- a/app/views/state_file/questions/verification_code/edit.html.erb
+++ b/app/views/state_file/questions/verification_code/edit.html.erb
@@ -1,0 +1,11 @@
+<% title = t(".title") %>
+<% content_for :page_title, title %>
+<% content_for :card do %>
+  <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
+    <h1 class="h2" id="main-question"><%= title %></h1>
+    <p><%= t(".subtitle_html", contact_method: @contact_method) %></p>
+    <%= f.cfa_input_field(:verification_code, t(".verification_code_label"), classes: ["form-width--long"]) %>
+
+    <%= f.submit t(".action") %>
+  <% end %>
+<% end %>

--- a/bin/test
+++ b/bin/test
@@ -32,7 +32,8 @@ if [[ -n "$1" ]] && [[ $1 == "state_file" ]]; then
       spec/models/efile_security_information_spec.rb \
       spec/models/efile_submission_spec.rb \
       spec/models/efile_submission_dependent_spec.rb \
-      spec/models/efile_submission_transition_spec.rb
+      spec/models/efile_submission_transition_spec.rb \
+      spec/controllers/flows_controller_spec.rb
 else
   # Full test suite
   EAGER_LOAD=1 RAILS_CACHE_CLASSES=1 bundle exec turbo_tests || { echo "Not running JS tests due to rspec failure." ; exit 1; }

--- a/bin/test
+++ b/bin/test
@@ -33,7 +33,8 @@ if [[ -n "$1" ]] && [[ $1 == "state_file" ]]; then
       spec/models/efile_submission_spec.rb \
       spec/models/efile_submission_dependent_spec.rb \
       spec/models/efile_submission_transition_spec.rb \
-      spec/controllers/flows_controller_spec.rb
+      spec/controllers/flows_controller_spec.rb \
+      spec/i18n_spec.rb
 else
   # Full test suite
   EAGER_LOAD=1 RAILS_CACHE_CLASSES=1 bundle exec turbo_tests || { echo "Not running JS tests due to rspec failure." ; exit 1; }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1817,6 +1817,11 @@ en:
       subheader: Please sign up here to receive a notification when we open in January.
   state_file:
     questions:
+      code_verified:
+        edit:
+          subtitle_email: You’ll now receive email updates when your state tax return is accepted.
+          subtitle_text: You’ll now receive text updates when your state tax return is accepted.
+          title: Code verified!
       contact_preference:
         edit:
           email_option: Email me a code
@@ -1833,25 +1838,20 @@ en:
           your_dob: Your date of birth
       email_address:
         edit:
-          title: "Enter your email address"
-          email_address_label: "Your email address (avoid using a temporary email)"
-          action: "Send code"
+          action: Send code
+          email_address_label: Your email address (avoid using a temporary email)
+          title: Enter your email address
       phone_number:
         edit:
-          title: "Enter your phone number"
-          phone_number_label: "Your phone number"
-          action: "Send code"
+          action: Send code
+          phone_number_label: Your phone number
+          title: Enter your phone number
       verification_code:
         edit:
-          title: "Verify the code to continue"
-          subtitle_html: "A message with your code has been sent to <strong>%{contact_method}</strong>."
-          verification_code_label: "Enter the 6-digit code"
-          action: "Verify code"
-      code_verified:
-        edit:
-          title: "Code verified!"
-          subtitle_email: "You’ll now receive email updates when your state tax return is accepted."
-          subtitle_text: "You’ll now receive text updates when your state tax return is accepted."
+          action: Verify code
+          subtitle_html: A message with your code has been sent to <strong>%{contact_info}</strong>.
+          title: Verify the code to continue
+          verification_code_label: Enter the 6-digit code
   validators:
     account_number: This account number is not valid for direct deposit transactions. Please review your account number or switch to check payments.
     alpha: Only letters A-Z and a-z are accepted.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1831,6 +1831,27 @@ en:
           title2_family: First, please provide more information about the people in your family.
           title2_you_and_household: First, please enter the date of birth for you and everyone in your household.
           your_dob: Your date of birth
+      email_address:
+        edit:
+          title: "Enter your email address"
+          email_address_label: "Your email address (avoid using a temporary email)"
+          action: "Send code"
+      phone_number:
+        edit:
+          title: "Enter your phone number"
+          phone_number_label: "Your phone number"
+          action: "Send code"
+      verification_code:
+        edit:
+          title: "Verify the code to continue"
+          subtitle_html: "A message with your code has been sent to <strong>%{contact_method}</strong>."
+          verification_code_label: "Enter the 6-digit code"
+          action: "Verify code"
+      code_verified:
+        edit:
+          title: "Code verified!"
+          subtitle_email: "You’ll now receive email updates when your state tax return is accepted."
+          subtitle_text: "You’ll now receive text updates when your state tax return is accepted."
   validators:
     account_number: This account number is not valid for direct deposit transactions. Please review your account number or switch to check payments.
     alpha: Only letters A-Z and a-z are accepted.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1798,6 +1798,11 @@ es:
         03_message_freq: La frecuencia de los mensajes varía. Se aplican las tarifas estándar de los mensajes. Envíe HELP al 11111 para obtener ayuda. Envíe STOP al 11111 para cancelarlo. Los operadores (por ejemplo, AT&T, Verizon, etc.) no son responsables de los mensajes no entregados o retrasados.
         04_detail_links_html: Favor de consultar nuestras <a href="%{terms_link}" target="_blank" rel="noopener noreferrer">Condiciones generales</a> y <a href="%{privacy_link}" target="_blank" rel="noopener noreferrer">Política de privacidad.</a>
       subheader: Regístrese aquí para recibir una notificación cuando abramos en enero.
+  state_file:
+    questions:
+      verification_code:
+        edit:
+          subtitle_html: "{contact_info}"
   validators:
     account_number: Este número de cuenta no es válido para transacciones de depósito directo. Revise su número de cuenta o cambie a pagos con cheque.
     alpha: Sólo se aceptan las letras A-Z y a-z.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1802,7 +1802,7 @@ es:
     questions:
       verification_code:
         edit:
-          subtitle_html: "{contact_info}"
+          subtitle_html: "%{contact_info}"
   validators:
     account_number: Este número de cuenta no es válido para transacciones de depósito directo. Revise su número de cuenta o cambie a pagos con cheque.
     alpha: Sólo se aceptan las letras A-Z y a-z.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1802,7 +1802,7 @@ es:
     questions:
       verification_code:
         edit:
-          subtitle_html: "%{contact_info}"
+          subtitle_html: "<strong>%{contact_info}</strong>"
   validators:
     account_number: Este número de cuenta no es válido para transacciones de depósito directo. Revise su número de cuenta o cambie a pagos con cheque.
     alpha: Sólo se aceptan las letras A-Z y a-z.

--- a/spec/controllers/state_file/questions/email_address_controller_spec.rb
+++ b/spec/controllers/state_file/questions/email_address_controller_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe StateFile::Questions::EmailAddressController do
+  describe ".show?" do
+    context "when contact preference is email" do
+      it "returns true" do
+        intake = create(:state_file_az_intake, contact_preference: "email")
+        expect(described_class.show?(intake)).to eq true
+      end
+    end
+
+    context "when contact preference is not email" do
+      it "returns false" do
+        intake = create(:state_file_az_intake)
+        expect(described_class.show?(intake)).to eq false
+      end
+    end
+  end
+
+  describe "#update" do
+    xit "enqueues job to send the verification code" do
+    end
+  end
+end

--- a/spec/controllers/state_file/questions/phone_number_controller_spec.rb
+++ b/spec/controllers/state_file/questions/phone_number_controller_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe StateFile::Questions::PhoneNumberController do
+  describe ".show?" do
+    context "when contact preference is text message" do
+      it "returns true" do
+        intake = create(:state_file_az_intake, contact_preference: "text")
+        expect(described_class.show?(intake)).to eq true
+      end
+    end
+
+    context "when contact preference is not text message" do
+      it "returns false" do
+        intake = create(:state_file_az_intake)
+        expect(described_class.show?(intake)).to eq false
+      end
+    end
+  end
+
+  describe "#update" do
+    xit "enqueues job to send the verification code" do
+    end
+  end
+end

--- a/spec/controllers/state_file/questions/verification_code_controller_spec.rb
+++ b/spec/controllers/state_file/questions/verification_code_controller_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe StateFile::Questions::VerificationCodeController do
+  describe "#edit" do
+    before do
+      session[:state_file_intake] = intake.to_global_id
+    end
+
+    context "with an intake that prefers text message" do
+      let(:intake) { create(:state_file_az_intake, contact_preference: "text", phone_number: "+14153334444") }
+
+      it "sets @contact_method to a pretty phone number" do
+        get :edit, params: { us_state: "az" }
+
+        expect(assigns(:contact_method)).to eq "(415) 333-4444"
+      end
+    end
+    context "with an intake that prefers email" do
+      let(:intake) { create(:state_file_az_intake, contact_preference: "email", email_address: "someone@example.com") }
+
+      it "sets @contact_method to an email address" do
+        get :edit, params: { us_state: "az" }
+
+        expect(assigns(:contact_method)).to eq "someone@example.com"
+      end
+    end
+  end
+  describe "#update" do
+    xit "validates the verification code" do
+    end
+
+    xit "authenticates the user" do
+    end
+  end
+end

--- a/spec/controllers/state_file/questions/verification_code_controller_spec.rb
+++ b/spec/controllers/state_file/questions/verification_code_controller_spec.rb
@@ -12,19 +12,21 @@ RSpec.describe StateFile::Questions::VerificationCodeController do
       it "sets @contact_method to a pretty phone number" do
         get :edit, params: { us_state: "az" }
 
-        expect(assigns(:contact_method)).to eq "(415) 333-4444"
+        expect(assigns(:contact_info)).to eq "(415) 333-4444"
       end
     end
+
     context "with an intake that prefers email" do
       let(:intake) { create(:state_file_az_intake, contact_preference: "email", email_address: "someone@example.com") }
 
       it "sets @contact_method to an email address" do
         get :edit, params: { us_state: "az" }
 
-        expect(assigns(:contact_method)).to eq "someone@example.com"
+        expect(assigns(:contact_info)).to eq "someone@example.com"
       end
     end
   end
+
   describe "#update" do
     xit "validates the verification code" do
     end

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.feature "Completing a state file intake" do
+  include StateFileIntakeHelper
+
   let(:fake_xml) { "<haha>Your xml here</haha>" }
   before do
     allow_any_instance_of(Routes::StateFileDomain).to receive(:matches?).and_return(true)
@@ -14,8 +16,7 @@ RSpec.feature "Completing a state file intake" do
       expect(page).to have_text "File your New York state taxes for free"
       click_on "Get Started", id: "firstCta"
 
-      expect(page).to have_text "Next, set up your account with a quick code"
-      click_on "Text me a code"
+      step_through_initial_authentication(contact_preference: :text_message)
 
       expect(page).to have_text "The page with all the info from the 1040"
 
@@ -85,8 +86,7 @@ RSpec.feature "Completing a state file intake" do
       expect(page).to have_text "File your Arizona state taxes for free"
       click_on "Get Started", id: "firstCta"
 
-      expect(page).to have_text "Next, set up your account with a quick code"
-      click_on "Text me a code"
+      step_through_initial_authentication(contact_preference: :text_message)
 
       click_on "Fetch 1040 data from IRS"
       click_on "Continue"

--- a/spec/forms/state_file/email_address_form_spec.rb
+++ b/spec/forms/state_file/email_address_form_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe StateFile::EmailAddressForm do
+  let(:intake) { create :state_file_ny_intake }
+  let(:valid_params) do
+    { email_address: "someone@example.com" }
+  end
+
+  describe "validations" do
+    context "with an invalid email" do
+      let(:invalid_params) do
+        { email_address: "someone@example" }
+      end
+      it "is not valid" do
+        form = described_class.new(intake, invalid_params)
+        expect(form).not_to be_valid
+      end
+    end
+
+    context "with a valid email" do
+      it "is valid" do
+        form = described_class.new(intake, valid_params)
+        expect(form).to be_valid
+      end
+    end
+  end
+
+  describe "#save" do
+    it "saves the contact preference to the intake" do
+      form = described_class.new(intake, valid_params)
+      expect do
+        form.save
+      end.to change(intake, :email_address).to("someone@example.com")
+    end
+  end
+  let(:intake) { create :intake }
+
+
+end

--- a/spec/forms/state_file/email_address_form_spec.rb
+++ b/spec/forms/state_file/email_address_form_spec.rb
@@ -26,14 +26,11 @@ RSpec.describe StateFile::EmailAddressForm do
   end
 
   describe "#save" do
-    it "saves the contact preference to the intake" do
+    it "saves the email to the intake" do
       form = described_class.new(intake, valid_params)
       expect do
         form.save
       end.to change(intake, :email_address).to("someone@example.com")
     end
   end
-  let(:intake) { create :intake }
-
-
 end

--- a/spec/forms/state_file/phone_number_form_spec.rb
+++ b/spec/forms/state_file/phone_number_form_spec.rb
@@ -2,16 +2,40 @@ require 'rails_helper'
 
 RSpec.describe StateFile::PhoneNumberForm do
   let(:intake) { create :state_file_ny_intake }
-  describe "#save" do
-    let(:valid_params) do
-      { email_address: "someone@example.com" }
+  let(:valid_params) do
+    { phone_number: "4153334444" }
+  end
+
+  describe "#normalize_phone_number" do
+    it "normalizes the phone number to e164 format" do
+      form = described_class.new(intake, { phone_number: "4153334444" })
+      form.normalize_phone_number
+      expect(form.phone_number).to eq "+14153334444"
+    end
+  end
+
+  describe "validations" do
+    context "with an invalid phone number" do
+      it "is not valid" do
+        form = described_class.new(intake, { phone_number: "55555" })
+        expect(form).not_to be_valid
+      end
     end
 
-    it "saves the contact preference to the intake" do
+    context "with a valid phone number" do
+      it "is valid" do
+        form = described_class.new(intake, valid_params)
+        expect(form).to be_valid
+      end
+    end
+  end
+
+  describe "#save" do
+    it "saves the phone number to the intake" do
       form = described_class.new(intake, valid_params)
-      expect do
-        form.save
-      end.to change { intake.reload.email_address }.from(nil).to("someone@example.com")
+      form.valid?
+      form.save
+      expect(intake.reload.phone_number).to eq "+14153334444"
     end
   end
 end

--- a/spec/forms/state_file/phone_number_form_spec.rb
+++ b/spec/forms/state_file/phone_number_form_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe StateFile::PhoneNumberForm do
+  let(:intake) { create :state_file_ny_intake }
+  describe "#save" do
+    let(:valid_params) do
+      { email_address: "someone@example.com" }
+    end
+
+    it "saves the contact preference to the intake" do
+      form = described_class.new(intake, valid_params)
+      expect do
+        form.save
+      end.to change { intake.reload.email_address }.from(nil).to("someone@example.com")
+    end
+  end
+end

--- a/spec/support/helpers/state_file_intake_helper.rb
+++ b/spec/support/helpers/state_file_intake_helper.rb
@@ -1,0 +1,34 @@
+module StateFileIntakeHelper
+  def step_through_initial_authentication(contact_preference: :text_message)
+    expect(page).to have_text "Next, set up your account with a quick code"
+
+    case contact_preference
+    when :text_message
+      click_on "Text me a code"
+
+      expect(page).to have_text "Enter your phone number"
+      fill_in "Your phone number", with: "4153334444"
+      click_on "Send code"
+
+
+      expect(page).to have_text "Verify the code to continue"
+      expect(page).to have_text "A message with your code has been sent to (415) 333-4444."
+    when :email
+      click_on "Email me a code"
+
+      expect(page).to have_text "Enter your email address"
+      fill_in "Your email address (avoid using a temporary email)", with: "someone@example.com"
+      click_on "Send code"
+
+      expect(page).to have_text "Verify the code to continue"
+      expect(page).to have_text "A message with your code has been sent to someone@example.com."
+    end
+
+    # sending the authentication code is currently non-functional
+    # this page is a place holder and does not validate the code
+    click_on "Verify code"
+
+    expect(page).to have_text "Code verified!"
+    click_on "Continue"
+  end
+end


### PR DESCRIPTION
This creates the remaining pages in the [state file authentication flow](https://www.pivotaltracker.com/story/show/186317243), but it does not yet implement the verification codes or sign in process.

[Figma Mocks:
![Screenshot 2023-10-31 at 2 28 32 PM](https://github.com/codeforamerica/vita-min/assets/451510/d8409b81-21fa-441e-bf46-7aa3def86da4)](https://www.figma.com/file/0bD4TA3HEZs5nwrPQ2GH5t/State-File-UX-Designs?type=design&node-id=75-816&mode=design&t=TaCxGrYGd7KReEKU-0)
