### PR TITLE
Timestamp contact verification for state intakes

### DIFF
--- a/app/models/state_file_az_intake.rb
+++ b/app/models/state_file_az_intake.rb
@@ -2,31 +2,33 @@
 #
 # Table name: state_file_az_intakes
 #
-#  id                     :bigint           not null, primary key
-#  bank_account_number    :string
-#  bank_account_type      :integer
-#  bank_routing_number    :string
-#  charitable_cash        :integer          default(0)
-#  charitable_noncash     :integer          default(0)
-#  claimed_as_dep         :integer          default("unfilled")
-#  contact_preference     :integer          default("unfilled"), not null
-#  current_step           :string
-#  email_address          :citext
-#  has_prior_last_names   :integer          default("unfilled"), not null
-#  phone_number           :string
-#  primary_first_name     :string
-#  primary_last_name      :string
-#  primary_middle_initial :string
-#  prior_last_names       :string
-#  raw_direct_file_data   :text
-#  referrer               :string
-#  source                 :string
-#  spouse_first_name      :string
-#  spouse_last_name       :string
-#  spouse_middle_initial  :string
-#  created_at             :datetime         not null
-#  updated_at             :datetime         not null
-#  visitor_id             :string
+#  id                        :bigint           not null, primary key
+#  bank_account_number       :string
+#  bank_account_type         :integer
+#  bank_routing_number       :string
+#  charitable_cash           :integer          default(0)
+#  charitable_noncash        :integer          default(0)
+#  claimed_as_dep            :integer          default("unfilled")
+#  contact_preference        :integer          default("unfilled"), not null
+#  current_step              :string
+#  email_address             :citext
+#  email_address_verified_at :datetime
+#  has_prior_last_names      :integer          default("unfilled"), not null
+#  phone_number              :string
+#  phone_number_verified_at  :datetime
+#  primary_first_name        :string
+#  primary_last_name         :string
+#  primary_middle_initial    :string
+#  prior_last_names          :string
+#  raw_direct_file_data      :text
+#  referrer                  :string
+#  source                    :string
+#  spouse_first_name         :string
+#  spouse_last_name          :string
+#  spouse_middle_initial     :string
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  visitor_id                :string
 #
 class StateFileAzIntake < StateFileBaseIntake
   encrypts :bank_account_number, :bank_routing_number, :raw_direct_file_data

--- a/app/models/state_file_ny_intake.rb
+++ b/app/models/state_file_ny_intake.rb
@@ -13,6 +13,7 @@
 #  current_step                     :string
 #  date_electronic_withdrawal       :date
 #  email_address                    :citext
+#  email_address_verified_at        :datetime
 #  household_cash_assistance        :integer
 #  household_fed_agi                :integer
 #  household_ny_additions           :integer
@@ -39,6 +40,7 @@
 #  permanent_street                 :string
 #  permanent_zip                    :string
 #  phone_number                     :string
+#  phone_number_verified_at         :datetime
 #  primary_birth_date               :date
 #  primary_email                    :string
 #  primary_first_name               :string

--- a/db/migrate/20231103162002_add_contact_verification_to_state_intakes.rb
+++ b/db/migrate/20231103162002_add_contact_verification_to_state_intakes.rb
@@ -1,0 +1,8 @@
+class AddContactVerificationToStateIntakes < ActiveRecord::Migration[7.1]
+  def change
+    add_column :state_file_az_intakes, :email_address_verified_at, :datetime
+    add_column :state_file_az_intakes, :phone_number_verified_at, :datetime
+    add_column :state_file_ny_intakes, :email_address_verified_at, :datetime
+    add_column :state_file_ny_intakes, :phone_number_verified_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_02_062958) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_03_162002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -1562,8 +1562,10 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_02_062958) do
     t.datetime "created_at", null: false
     t.string "current_step"
     t.citext "email_address"
+    t.datetime "email_address_verified_at"
     t.integer "has_prior_last_names", default: 0, null: false
     t.string "phone_number"
+    t.datetime "phone_number_verified_at"
     t.string "primary_first_name"
     t.string "primary_last_name"
     t.string "primary_middle_initial"
@@ -1608,6 +1610,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_02_062958) do
     t.string "current_step"
     t.date "date_electronic_withdrawal"
     t.citext "email_address"
+    t.datetime "email_address_verified_at"
     t.integer "household_cash_assistance"
     t.integer "household_fed_agi"
     t.integer "household_ny_additions"
@@ -1634,6 +1637,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_02_062958) do
     t.string "permanent_street"
     t.string "permanent_zip"
     t.string "phone_number"
+    t.datetime "phone_number_verified_at"
     t.date "primary_birth_date"
     t.string "primary_email"
     t.string "primary_first_name"

--- a/spec/factories/state_file_az_intakes.rb
+++ b/spec/factories/state_file_az_intakes.rb
@@ -2,31 +2,33 @@
 #
 # Table name: state_file_az_intakes
 #
-#  id                     :bigint           not null, primary key
-#  bank_account_number    :string
-#  bank_account_type      :integer
-#  bank_routing_number    :string
-#  charitable_cash        :integer          default(0)
-#  charitable_noncash     :integer          default(0)
-#  claimed_as_dep         :integer          default("unfilled")
-#  contact_preference     :integer          default("unfilled"), not null
-#  current_step           :string
-#  email_address          :citext
-#  has_prior_last_names   :integer          default("unfilled"), not null
-#  phone_number           :string
-#  primary_first_name     :string
-#  primary_last_name      :string
-#  primary_middle_initial :string
-#  prior_last_names       :string
-#  raw_direct_file_data   :text
-#  referrer               :string
-#  source                 :string
-#  spouse_first_name      :string
-#  spouse_last_name       :string
-#  spouse_middle_initial  :string
-#  created_at             :datetime         not null
-#  updated_at             :datetime         not null
-#  visitor_id             :string
+#  id                        :bigint           not null, primary key
+#  bank_account_number       :string
+#  bank_account_type         :integer
+#  bank_routing_number       :string
+#  charitable_cash           :integer          default(0)
+#  charitable_noncash        :integer          default(0)
+#  claimed_as_dep            :integer          default("unfilled")
+#  contact_preference        :integer          default("unfilled"), not null
+#  current_step              :string
+#  email_address             :citext
+#  email_address_verified_at :datetime
+#  has_prior_last_names      :integer          default("unfilled"), not null
+#  phone_number              :string
+#  phone_number_verified_at  :datetime
+#  primary_first_name        :string
+#  primary_last_name         :string
+#  primary_middle_initial    :string
+#  prior_last_names          :string
+#  raw_direct_file_data      :text
+#  referrer                  :string
+#  source                    :string
+#  spouse_first_name         :string
+#  spouse_last_name          :string
+#  spouse_middle_initial     :string
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  visitor_id                :string
 #
 FactoryBot.define do
   factory :state_file_az_intake do

--- a/spec/factories/state_file_ny_intakes.rb
+++ b/spec/factories/state_file_ny_intakes.rb
@@ -13,6 +13,7 @@
 #  current_step                     :string
 #  date_electronic_withdrawal       :date
 #  email_address                    :citext
+#  email_address_verified_at        :datetime
 #  household_cash_assistance        :integer
 #  household_fed_agi                :integer
 #  household_ny_additions           :integer
@@ -39,6 +40,7 @@
 #  permanent_street                 :string
 #  permanent_zip                    :string
 #  phone_number                     :string
+#  phone_number_verified_at         :datetime
 #  primary_birth_date               :date
 #  primary_email                    :string
 #  primary_first_name               :string

--- a/spec/models/state_file_az_intake_spec.rb
+++ b/spec/models/state_file_az_intake_spec.rb
@@ -2,31 +2,33 @@
 #
 # Table name: state_file_az_intakes
 #
-#  id                     :bigint           not null, primary key
-#  bank_account_number    :string
-#  bank_account_type      :integer
-#  bank_routing_number    :string
-#  charitable_cash        :integer          default(0)
-#  charitable_noncash     :integer          default(0)
-#  claimed_as_dep         :integer          default("unfilled")
-#  contact_preference     :integer          default("unfilled"), not null
-#  current_step           :string
-#  email_address          :citext
-#  has_prior_last_names   :integer          default("unfilled"), not null
-#  phone_number           :string
-#  primary_first_name     :string
-#  primary_last_name      :string
-#  primary_middle_initial :string
-#  prior_last_names       :string
-#  raw_direct_file_data   :text
-#  referrer               :string
-#  source                 :string
-#  spouse_first_name      :string
-#  spouse_last_name       :string
-#  spouse_middle_initial  :string
-#  created_at             :datetime         not null
-#  updated_at             :datetime         not null
-#  visitor_id             :string
+#  id                        :bigint           not null, primary key
+#  bank_account_number       :string
+#  bank_account_type         :integer
+#  bank_routing_number       :string
+#  charitable_cash           :integer          default(0)
+#  charitable_noncash        :integer          default(0)
+#  claimed_as_dep            :integer          default("unfilled")
+#  contact_preference        :integer          default("unfilled"), not null
+#  current_step              :string
+#  email_address             :citext
+#  email_address_verified_at :datetime
+#  has_prior_last_names      :integer          default("unfilled"), not null
+#  phone_number              :string
+#  phone_number_verified_at  :datetime
+#  primary_first_name        :string
+#  primary_last_name         :string
+#  primary_middle_initial    :string
+#  prior_last_names          :string
+#  raw_direct_file_data      :text
+#  referrer                  :string
+#  source                    :string
+#  spouse_first_name         :string
+#  spouse_last_name          :string
+#  spouse_middle_initial     :string
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  visitor_id                :string
 #
 require "rails_helper"
 

--- a/spec/models/state_file_ny_intake_spec.rb
+++ b/spec/models/state_file_ny_intake_spec.rb
@@ -13,6 +13,7 @@
 #  current_step                     :string
 #  date_electronic_withdrawal       :date
 #  email_address                    :citext
+#  email_address_verified_at        :datetime
 #  household_cash_assistance        :integer
 #  household_fed_agi                :integer
 #  household_ny_additions           :integer
@@ -39,6 +40,7 @@
 #  permanent_street                 :string
 #  permanent_zip                    :string
 #  phone_number                     :string
+#  phone_number_verified_at         :datetime
 #  primary_birth_date               :date
 #  primary_email                    :string
 #  primary_first_name               :string
@@ -66,6 +68,7 @@
 #  created_at                       :datetime         not null
 #  updated_at                       :datetime         not null
 #  visitor_id                       :string
+#
 
 require "rails_helper"
 


### PR DESCRIPTION
This adds two timestamp fields for state intakes that are used for verifying contact info as part of the authentication process
- `email_address_verified_at`
- `phone_number_verified_at`


[[#186317243]](https://www.pivotaltracker.com/story/show/186317243)