### PR TITLE
Validate verification codes

### DIFF
--- a/app/forms/state_file/verification_code_form.rb
+++ b/app/forms/state_file/verification_code_form.rb
@@ -1,0 +1,33 @@
+module StateFile
+  class VerificationCodeForm < QuestionsForm
+    set_attributes_for :misc, :verification_code
+
+    def valid?
+      # Delegate validation to a phone or email verification form.
+      # If there's no contact preference, use the email form.
+      validation_form_class = is_text_based? ? PhoneVerificationForm : EmailVerificationForm
+      form = validation_form_class.new(intake, attributes_for(:misc))
+      is_valid = form.valid?
+      unless is_valid
+        errors.add(:verification_code, form.errors[:verification_code])
+      end
+
+      is_valid
+    end
+
+    def save
+      intake.touch(:phone_number_verified_at) if is_text_based?
+      intake.touch(:email_address_verified_at) if is_email_based?
+    end
+
+    private
+
+    def is_text_based?
+      intake.contact_preference == "text"
+    end
+
+    def is_email_based?
+      intake.contact_preference == "email"
+    end
+  end
+end

--- a/app/models/state_file_base_intake.rb
+++ b/app/models/state_file_base_intake.rb
@@ -16,6 +16,8 @@ class StateFileBaseIntake < ApplicationRecord
 
   delegate :tax_return_year, to: :direct_file_data
 
+  alias_attribute :sms_phone_number, :phone_number
+
   def direct_file_data
     @direct_file_data ||= DirectFileData.new(raw_direct_file_data)
   end

--- a/spec/controllers/state_file/questions/email_address_controller_spec.rb
+++ b/spec/controllers/state_file/questions/email_address_controller_spec.rb
@@ -16,9 +16,4 @@ RSpec.describe StateFile::Questions::EmailAddressController do
       end
     end
   end
-
-  describe "#update" do
-    xit "enqueues job to send the verification code" do
-    end
-  end
 end

--- a/spec/controllers/state_file/questions/phone_number_controller_spec.rb
+++ b/spec/controllers/state_file/questions/phone_number_controller_spec.rb
@@ -16,9 +16,4 @@ RSpec.describe StateFile::Questions::PhoneNumberController do
       end
     end
   end
-
-  describe "#update" do
-    xit "enqueues job to send the verification code" do
-    end
-  end
 end

--- a/spec/controllers/state_file/questions/verification_code_controller_spec.rb
+++ b/spec/controllers/state_file/questions/verification_code_controller_spec.rb
@@ -50,12 +50,4 @@ RSpec.describe StateFile::Questions::VerificationCodeController do
       end
     end
   end
-
-  describe "#update" do
-    xit "validates the verification code" do
-    end
-
-    xit "authenticates the user" do
-    end
-  end
 end

--- a/spec/forms/state_file/verification_code_form_spec.rb
+++ b/spec/forms/state_file/verification_code_form_spec.rb
@@ -1,0 +1,105 @@
+require 'rails_helper'
+
+RSpec.describe StateFile::VerificationCodeForm do
+  let(:intake) { create :state_file_ny_intake }
+
+  describe "#valid?" do
+    describe "verification_code" do
+      context "without a verification code" do
+        it "returns false and adds an error" do
+          form = described_class.new(intake, { verification_code: "" })
+
+          expect(form).not_to be_valid
+          expect(form.errors).to include(:verification_code)
+        end
+      end
+
+      context "when the magic verification code is enabled" do
+        before do
+          allow(Rails.configuration).to receive(:allow_magic_verification_code).and_return(true)
+        end
+
+        it "will accept the magic verification code as valid" do
+          form = described_class.new(intake, { verification_code: "000000" })
+          expect(form).to be_valid
+        end
+      end
+
+      context "when the intake is using email" do
+        let(:intake) { create :state_file_ny_intake, contact_preference: :email, email_address: "someone@example.com" }
+
+        context "when the verification code with email has a match" do
+          let(:verification_code) do
+            EmailAccessToken.generate!(email_address: intake.email_address).first
+          end
+
+          it "returns true" do
+            form = described_class.new(intake, { verification_code: verification_code })
+            expect(form).to be_valid
+          end
+        end
+
+        context "when there is no matching verification code with the same email" do
+          it "returns false and adds an error" do
+            form = described_class.new(intake, { verification_code: "123456" })
+            expect(form).not_to be_valid
+            expect(form.errors).to include :verification_code
+          end
+        end
+      end
+
+      context "when the intake is using text messaging" do
+        let(:intake) { create :state_file_ny_intake, contact_preference: :text, phone_number: "+14155551212" }
+
+        context "when the verification code with phone number has a match" do
+          let(:verification_code) do
+            TextMessageAccessToken.generate!(sms_phone_number: intake.phone_number).first
+          end
+
+          it "returns true" do
+            form = described_class.new(intake, { verification_code: verification_code })
+            expect(form).to be_valid
+          end
+        end
+
+        context "when there is no matching verification code with the same phone number" do
+          it "returns false and adds an error" do
+            form = described_class.new(intake, { verification_code: "123456" })
+            expect(form).not_to be_valid
+            expect(form.errors).to include :verification_code
+          end
+        end
+      end
+    end
+  end
+
+  describe "#save" do
+    context "when the intake is using email" do
+      let(:intake) { create :state_file_ny_intake, contact_preference: :email, email_address: "someone@example.com" }
+      let(:verification_code) do
+        EmailAccessToken.generate!(email_address: intake.email_address).first
+      end
+
+      it "timestamps the email verification" do
+        form = described_class.new(intake, verification_code: verification_code)
+        expect {
+          form.save
+        }.to change(intake, :email_address_verified_at).from(nil)
+      end
+    end
+
+    context "when the intake is using text message" do
+      let(:intake) { create :state_file_ny_intake, contact_preference: :text, phone_number: "+14155551212" }
+      let(:verification_code) do
+        TextMessageAccessToken.generate!(sms_phone_number: intake.phone_number).first
+      end
+
+      it "timestamps the phone number verification" do
+        form = described_class.new(intake, verification_code: verification_code)
+        expect {
+          form.save
+        }.to change(intake, :phone_number_verified_at).from(nil)
+      end
+    end
+  end
+end

--- a/spec/support/helpers/state_file_intake_helper.rb
+++ b/spec/support/helpers/state_file_intake_helper.rb
@@ -32,8 +32,7 @@ module StateFileIntakeHelper
       code = mail.html_part.body.to_s.match(/\s(\d{6})[.]/)[1]
     end
 
-    # sending the authentication code is currently non-functional
-    # this page is a place holder and does not validate the code
+    fill_in "Enter the 6-digit code", with: code
     click_on "Verify code"
 
     expect(page).to have_text "Code verified!"


### PR DESCRIPTION
Uses the existing GYR phone & email verification forms for validation to maintain consistent shared functionality across services for validating access tokens/verification codes.

[[#186317243]](https://www.pivotaltracker.com/story/show/186317243)