### PR TITLE
State file: only include 1099gs on ny if the payer name is default

### DIFF
--- a/app/lib/submission_builder/ty2022/states/ny/individual_return.rb
+++ b/app/lib/submission_builder/ty2022/states/ny/individual_return.rb
@@ -141,7 +141,7 @@ module SubmissionBuilder
               supported_docs << {
                 xml: SubmissionBuilder::Ty2022::States::Ny::Documents::State1099G,
                 pdf: nil,
-                include: true,
+                include: form1099g.payer_name_is_default_yes?,
                 kwargs: { form1099g: form1099g }
               }
             end


### PR DESCRIPTION
non-default payer names are going to be offboarded