### PR TITLE
Revert "Add an acme challenge route so that letsencrypt will sign our…

### DIFF
--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -93,20 +93,6 @@ class PublicPagesController < ApplicationController
     end
   end
 
-  def acme_challenge
-    website_text =
-      if Routes::StateFileDomain.new.matches?(request) && params[:id] == "nAiwr5D4js5JKPcdlY7oN2Dxim4UUq-N6kNOvHew18o"
-        # AZ demo.fileyourstatetaxes.org cert challenge
-        "nAiwr5D4js5JKPcdlY7oN2Dxim4UUq-N6kNOvHew18o.cwZpB_0Yw5Z-XZHRGYZPtCj4fUivbvN1yK4zBuNBVBk"
-      else
-        "Unknown ACME challenge."
-      end
-    respond_to do |format|
-      format.text { render plain: website_text  }
-      format.any { head 404 }
-    end
-  end
-
   private
 
   def markdown_content_from_file(file_name)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -562,8 +562,6 @@ Rails.application.routes.draw do
         post "/clear_session", to: 'state_file_pages#clear_session'
       end
     end
-
-    get '/.well-known/acme-challenge/:id', to: 'public_pages#acme_challenge'
   end
 
   get '*unmatched_route', to: 'public_pages#page_not_found', constraints: lambda { |req|


### PR DESCRIPTION
… AZ demo.fileyourstatetaxes.org cert (#3762)"

It was not an effective way to respond to an ACME challenge, since Aptible overrode the path and redirected to their s3 bucket of challenge responses

This reverts commit 577970df220f002bfe6358abcf5e2de5006cb60a.