### PR TITLE
Flow Explorer: update with generators for state file az/ny

### DIFF
--- a/app/controllers/state_file/questions/federal_info_controller.rb
+++ b/app/controllers/state_file/questions/federal_info_controller.rb
@@ -3,68 +3,10 @@ module StateFile
     class FederalInfoController < QuestionsController
       layout "state_file/question"
 
-      def update_with_sample_data
-        update_intake_with_sample_data
-        redirect_to action: :edit, us_state: params[:us_state]
-      end
-
       private
 
       def illustration_path
         nil
-      end
-
-      def update_intake_with_sample_data
-        case params[:us_state]
-        when "ny"
-          current_intake.update(
-            claimed_as_dep: "no",
-            primary_email: "whatever@example.com",
-            date_electronic_withdrawal: Date.today,
-            residence_county: "COUN",
-            school_district: "Pizza District",
-            school_district_number: 234,
-            nyc_full_year_resident: "yes",
-            ny_414h_retirement: 567,
-            ny_other_additions: 123,
-            amount_owed_pay_electronically: "yes",
-            refund_choice: "paper",
-            account_type: "personal_checking",
-            routing_number: "013456789",
-            account_number: "456789008765",
-            amount_electronic_withdrawal: 768,
-            primary_signature: "beep boop",
-            spouse_signature: "hup",
-            **it214_fields
-          )
-        when "az"
-          intake = current_intake.update(claimed_as_dep: "no")
-        else
-          raise "No state specified"
-        end
-      end
-
-      def it214_fields
-        {
-          ny_mailing_street: "123 Homeowner way",
-          ny_mailing_apartment: "B",
-          ny_mailing_city: "Brooklyn",
-          ny_mailing_zip: "10113",
-          occupied_residence: "yes",
-          property_over_limit: "no",
-          public_housing: "no",
-          nursing_home: "no",
-          household_fed_agi: 1234,
-          household_ny_additions: 1234,
-          household_ssi: 1234,
-          household_cash_assistance: 1234,
-          household_other_income: 1234,
-          household_rent_own: "own",
-          household_rent_amount: 0,
-          household_rent_adjustments: 123,
-          household_own_propety_tax: 123,
-          household_own_assessments: 123,
-        }
       end
     end
   end

--- a/app/forms/state_file/ny214_form.rb
+++ b/app/forms/state_file/ny214_form.rb
@@ -21,6 +21,11 @@ module StateFile
                        :household_own_assessments
 
     def save
+      self.household_rent_own ||= 'unfilled'
+      self.nursing_home ||= 'unfilled'
+      self.occupied_residence ||= 'unfilled'
+      self.property_over_limit ||= 'unfilled'
+      self.public_housing ||= 'unfilled'
       @intake.update(attributes_for(:intake))
     end
   end

--- a/app/views/state_file/questions/federal_info/edit.html.erb
+++ b/app/views/state_file/questions/federal_info/edit.html.erb
@@ -5,8 +5,6 @@
   <h1 class="h2"><%= title %></h1>
   <h3>This page represents data that was imported from Direct File and does not exist in the real flow.</h3>
 
-  <%= link_to "Populate with sample data", state_file_questions_update_with_sample_data_path(us_state: params[:us_state]), class: "button button--small" %>
-
   <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: StateFileQaFormBuilder, html: { class: "form-card form-card--long" } do |f| %>
     <%= f.state_file_qa_input_field :tax_return_year, "tax return year" %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -533,7 +533,6 @@ Rails.application.routes.draw do
     scope '(:locale)', locale: /#{I18n.available_locales.join('|')}/ do
       namespace :state_file do
         namespace :questions do
-          get "update_with_sample_data", to: "federal_info#update_with_sample_data"
           get "show_xml", to: "confirmation#show_xml"
           get "explain_calculations", to: "confirmation#explain_calculations"
         end

--- a/spec/controllers/flows_controller_spec.rb
+++ b/spec/controllers/flows_controller_spec.rb
@@ -103,6 +103,47 @@ RSpec.describe FlowsController do
         expect(controller.current_intake.email_address).to be_nil
       end
     end
+
+    context 'for a state file az intake' do
+      let(:default_params) do
+        {
+          type: :state_file_az,
+          flows_controller_sample_intake_form: {
+            first_name: 'Testuser',
+            last_name: 'Testuser',
+            email_address: 'testuser@example.com',
+          },
+        }
+      end
+
+      it 'can generate a single intake' do
+        expect do
+          post :generate, params: default_params.merge({ submit_single: 'Head Of Household ✨' })
+        end.to change(StateFileAzIntake, :count).by(1)
+        expect(controller.current_intake.filing_status).to eq(:head_of_household)
+      end
+    end
+
+    context 'for a state file ny intake' do
+      let(:default_params) do
+        {
+          type: :state_file_ny,
+          flows_controller_sample_intake_form: {
+            first_name: 'Testuser',
+            last_name: 'Testuser',
+            email_address: 'testuser@example.com',
+          },
+        }
+      end
+
+      it 'can generate a single intake' do
+        expect do
+          post :generate, params: default_params.merge({ submit_single: 'Head Of Household ✨' })
+        end.to change(StateFileNyIntake, :count).by(1)
+        expect(controller.current_intake).to be_a(StateFileNyIntake)
+        expect(controller.current_intake.filing_status).to eq(:head_of_household)
+      end
+    end
   end
 
   describe '#show' do

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -26,7 +26,6 @@ RSpec.feature "Completing a state file intake", active_job: true do
       expect(page).to have_text "Direct File Data Overrides"
 
       expect(page).to have_field("tax return year", with: "2023")
-      click_on "Populate with sample data"
       select "married filing jointly", from: "state_file_federal_info_form[filing_status]"
       click_on "Continue"
 
@@ -121,8 +120,9 @@ RSpec.feature "Completing a state file intake", active_job: true do
       expect(page).to have_link "Download your state return"
       click_on "Show XML"
       expect(page.body).to include('efile:ReturnState')
-      expect(page.body).to include('<ABA_NMBR claimed="013456789"/>')
-      expect(page.body).to include('<BANK_ACCT_NMBR claimed="456789008765"/>')
+      expect(page.body).to include('<FirstName>Titus</FirstName>')
+
+      assert_flow_explorer_sample_params_includes_everything('ny')
 
       perform_enqueued_jobs
       submission = EfileSubmission.last
@@ -149,7 +149,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
       step_through_df_data_transfer
       click_on "Continue"
 
-      click_on "Populate with sample data"
+      expect(page).to have_text "Direct File Data Overrides"
       click_on "Continue"
 
       expect(page).to have_text "The page that shows your dependents"
@@ -234,6 +234,8 @@ RSpec.feature "Completing a state file intake", active_job: true do
       expect(page.body).to include('<QualParentsAncestors>')
       expect(page.body).to include('<WageAmIndian>100</WageAmIndian>')
       expect(page.body).to include('<CompNtnlGrdArmdFrcs>100</CompNtnlGrdArmdFrcs>')
+
+      assert_flow_explorer_sample_params_includes_everything('az')
 
       perform_enqueued_jobs
       submission = EfileSubmission.last

--- a/spec/support/helpers/state_file_intake_helper.rb
+++ b/spec/support/helpers/state_file_intake_helper.rb
@@ -84,4 +84,30 @@ module StateFileIntakeHelper
       find_link("HIDDEN BUTTON", visible: :any).click
     end
   end
+
+  def assert_flow_explorer_sample_params_includes_everything(us_state)
+    # Enforce that the attributes used to generate state file intakes in the Flow Explorer
+    # include at least every property that a state file intake would have at the end of
+    # one of our feature tests
+    #
+    # e.g. if we introduced a new 'received_railroad_benefits' enum, and the feature test
+    # fills it out, it should be included in the params used by SampleStateFileIntakeGenerator
+
+    intake = {}
+    flow_explorer_params = {}
+
+    case us_state
+    when 'az'
+      intake = StateFileAzIntake.last
+      flow_explorer_params = FlowsController::SampleStateFileIntakeGenerator.az_attributes
+    when 'ny'
+      intake = StateFileNyIntake.last
+      flow_explorer_params = FlowsController::SampleStateFileIntakeGenerator.ny_attributes
+    end
+
+    intake_attribute_keys = intake.attributes.select { |_k, v| v }.keys
+    flow_explorer_generated_intake_keys = flow_explorer_params.keys.map(&:to_s)
+    missing_keys = intake_attribute_keys - flow_explorer_generated_intake_keys - %w[id primary_state_id_id]
+    expect(missing_keys).to eq([])
+  end
 end


### PR DESCRIPTION
Remove "populate with sample data" button from the normal state file flow. If you want sample data, use the flow explorer.

Add an assertion to the end of the complete az/ny intake tests ensuring that the flow explorer sample params are reasonably comprehensive (every attribute set during the feature test is included in the flow explorer generated state file intakes)