### PR TITLE
Tweaks to deflake screenshot build

### DIFF
--- a/app/jobs/state_file/import_from_direct_file_job.rb
+++ b/app/jobs/state_file/import_from_direct_file_job.rb
@@ -1,11 +1,15 @@
 module StateFile
   class ImportFromDirectFileJob < ApplicationJob
     def perform(token:, intake:)
+      return if intake.raw_direct_file_data
+
       direct_file_xml = IrsApiService.import_federal_data(token)
 
       intake.update(raw_direct_file_data: direct_file_xml)
       intake.direct_file_data.dependents.each do |direct_file_dependent|
-        intake.dependents.create(direct_file_dependent.attributes)
+        dependent = intake.dependents.find_or_initialize_by(ssn: direct_file_dependent.ssn)
+        dependent.assign_attributes(direct_file_dependent.attributes)
+        dependent.save
       end
 
       DfDataTransferJobChannel.broadcast_job_complete(intake)


### PR DESCRIPTION
In some circumstances, the test would see two dependents on the NameOrDobController, indicating that the import job had run twice.

There may be a legit race condition or issue with the DF import getting triggered more than once, considering that it is currently triggered during a GET request.

This fix attempts to make the job more idempotent, so that even if it is triggered more than once, it will refuse to run again if raw_direct_file_data is set, and it will create-or-update dependents by SSN rather than always adding new dependents.