### PR TITLE
Removing Daytime phone from fed info page

### DIFF
--- a/app/forms/state_file/federal_info_form.rb
+++ b/app/forms/state_file/federal_info_form.rb
@@ -8,8 +8,6 @@ module StateFile
     set_attributes_for :direct_file_data,
                        :tax_return_year,
                        :filing_status,
-                       :phone_daytime,
-                       :phone_daytime_area_code,
                        :primary_ssn,
                        :primary_occupation,
                        :spouse_ssn,

--- a/app/lib/submission_builder/ty2022/states/return_header.rb
+++ b/app/lib/submission_builder/ty2022/states/return_header.rb
@@ -44,7 +44,6 @@ module SubmissionBuilder
                 xml.StateAbbreviationCd @submission.bundle_class.state_abbreviation
                 xml.ZIPCd @submission.data_source.direct_file_data.mailing_zip
               end
-              # xml.USPhone [@submission.data_source.direct_file_data.phone_daytime_area_code, @submission.data_source.direct_file_data.phone_daytime].join(' ')
             end
           end
         end

--- a/app/models/direct_file_data.rb
+++ b/app/models/direct_file_data.rb
@@ -10,6 +10,7 @@ class DirectFileData
     mailing_street: 'ReturnHeader Filer USAddress AddressLine1Txt',
     mailing_state: 'ReturnHeader Filer USAddress StateAbbreviationCd',
     mailing_zip: 'ReturnHeader Filer USAddress ZIPCd',
+    cell_phone_number: 'ReturnHeader AdditionalFilerInformation AtSubmissionFilingGrp CellPhoneNum',
     fed_tax: 'IRS1040 TotalTaxBeforeCrAndOthTaxesAmt',
     fed_agi: 'IRS1040 AdjustedGrossIncomeAmt',
     fed_wages: 'IRS1040 WagesAmt',
@@ -45,12 +46,8 @@ class DirectFileData
     write_df_xml_value(__method__, value)
   end
 
-  def phone_daytime
-    # TODO
-  end
-
-  def phone_daytime_area_code
-    # TODO
+  def cell_phone_number
+    df_xml_value(__method__)
   end
 
   def primary_ssn
@@ -332,8 +329,6 @@ class DirectFileData
     [
       :tax_return_year,
       :filing_status,
-      :phone_daytime,
-      :phone_daytime_area_code,
       :primary_ssn,
       :primary_occupation,
       :spouse_ssn,
@@ -342,6 +337,7 @@ class DirectFileData
       :mailing_street,
       :mailing_apartment,
       :mailing_zip,
+      :cell_phone_number,
       :fed_wages,
       :fed_taxable_income,
       :fed_unemployment,

--- a/app/views/state_file/questions/federal_info/edit.html.erb
+++ b/app/views/state_file/questions/federal_info/edit.html.erb
@@ -37,9 +37,6 @@
 
       <%= f.cfa_checkbox(:claimed_as_dep, "claimed as dependent?", options: { checked_value: "yes", unchecked_value: "no" }) %>
 
-      <%= f.state_file_qa_input_field :phone_daytime, "daytime phone number" %>
-      <%= f.state_file_qa_input_field :phone_daytime_area_code, "daytime phone area code" %>
-
       <%= f.state_file_qa_input_field :total_fed_adjustments_identify, "Total Federal Adjustments (description)" %>
       <%= f.state_file_qa_input_field :total_fed_adjustments, "Total Federal Adjustments (amount)" %>
 


### PR DESCRIPTION
- adds cell_phone_number for getting phone from 1040
- does NOT yet fill any XML or PDF with the phone number. Not clear yet if that is needed and where it would go