### PR TITLE
Claimed as dependent fix

### DIFF
--- a/app/controllers/flows_controller.rb
+++ b/app/controllers/flows_controller.rb
@@ -576,8 +576,6 @@ class FlowsController < ApplicationController
 
     def self.ny_attributes(first_name: 'Testuser', last_name: 'Testuser')
       common_attributes.merge(
-        account_type: "personal_checking",
-        amount_owed_pay_electronically: "unfilled",
         confirmed_permanent_address: "no",
         contact_preference: "text",
         current_step: "/en/questions/confirmation",

--- a/app/controllers/flows_controller.rb
+++ b/app/controllers/flows_controller.rb
@@ -576,7 +576,8 @@ class FlowsController < ApplicationController
 
     def self.ny_attributes(first_name: 'Testuser', last_name: 'Testuser')
       common_attributes.merge(
-        claimed_as_dep: "no",
+        account_type: "personal_checking",
+        amount_owed_pay_electronically: "unfilled",
         confirmed_permanent_address: "no",
         contact_preference: "text",
         current_step: "/en/questions/confirmation",
@@ -622,7 +623,6 @@ class FlowsController < ApplicationController
         charitable_cash: 123,
         charitable_contributions: "yes",
         charitable_noncash: 123,
-        claimed_as_dep: "no",
         contact_preference: "email",
         current_step: "/en/questions/confirmation",
         eligibility_529_for_non_qual_expense: "no",

--- a/app/forms/state_file/federal_info_form.rb
+++ b/app/forms/state_file/federal_info_form.rb
@@ -2,8 +2,7 @@ module StateFile
   class FederalInfoForm < QuestionsForm
     include DateHelper
 
-    set_attributes_for :intake,
-                       :claimed_as_dep
+    set_attributes_for :intake
 
     set_attributes_for :direct_file_data,
                        :tax_return_year,
@@ -20,7 +19,8 @@ module StateFile
                        :fed_taxable_income,
                        :fed_unemployment,
                        :fed_taxable_ssb,
-                       :total_state_tax_withheld
+                       :total_state_tax_withheld,
+                       :total_exempt_primary_spouse
 
     set_attributes_for :form, :skip_schema_validation
 
@@ -152,8 +152,7 @@ module StateFile
     end
 
     def self.existing_attributes(intake)
-      attributes = HashWithIndifferentAccess.new(intake.attributes.merge(intake.direct_file_data.attributes))
-      attributes
+      HashWithIndifferentAccess.new(intake.attributes.merge(intake.direct_file_data.attributes))
     end
 
     class DfDependentDetailForm

--- a/app/lib/efile/az/az140.rb
+++ b/app/lib/efile/az/az140.rb
@@ -3,11 +3,10 @@ module Efile
     class Az140 < ::Efile::TaxCalculator
       attr_reader :lines
 
-      def initialize(year:, filing_status:, claimed_as_dependent:, intake:, dependent_count:, direct_file_data:, include_source: false)
+      def initialize(year:, filing_status:, intake:, dependent_count:, direct_file_data:, include_source: false)
         @year = year
 
         @filing_status = filing_status # single, married_filing_jointly, that's all we support for now
-        @claimed_as_dependent = claimed_as_dependent # true/false
         @intake = intake
         @dependent_count = dependent_count # number
         @direct_file_data = direct_file_data
@@ -233,7 +232,7 @@ module Efile
 
 
       def calculate_line_56
-        if @direct_file_data.primary_ssn.present? && !@claimed_as_dependent && !@intake.sentenced_for_60_days
+        if @direct_file_data.primary_ssn.present? && !@direct_file_data.claimed_as_dependent? && !@intake.sentenced_for_60_days
           # todo question: if they are filing with us does that automatically mean no AZ-140PTC?
           if filing_status_mfj? || filing_status_hoh?
             return 0 unless line_or_zero(:AZ140_LINE_12) <= 25000

--- a/app/lib/efile/ny/it201.rb
+++ b/app/lib/efile/ny/it201.rb
@@ -444,7 +444,7 @@ module Efile
       end
 
       def calculate_line_69a
-        return 0 unless @nyc_full_year_resident && @direct_file_data.claimed_as_dependent? == false
+        return 0 unless @nyc_full_year_resident && !@direct_file_data.claimed_as_dependent?
 
 
         nyc_taxable_income = line_or_zero(:IT201_LINE_47)

--- a/app/lib/efile/ny/it201.rb
+++ b/app/lib/efile/ny/it201.rb
@@ -3,11 +3,10 @@ module Efile
     class It201 < ::Efile::TaxCalculator
       attr_reader :lines
 
-      def initialize(year:, filing_status:, claimed_as_dependent:, intake:, direct_file_data:, nyc_full_year_resident:, dependent_count:, include_source: false)
+      def initialize(year:, filing_status:, intake:, direct_file_data:, nyc_full_year_resident:, dependent_count:, include_source: false)
         @year = year
 
         @filing_status = filing_status # single, married_filing_jointly, that's all we support for now
-        @claimed_as_dependent = claimed_as_dependent # true/false
         @intake = intake
         @direct_file_data = direct_file_data
         @nyc_full_year_resident = nyc_full_year_resident
@@ -27,7 +26,6 @@ module Efile
           lines: @lines,
           direct_file_data: direct_file_data,
           intake: @intake,
-          claimed_as_dependent: claimed_as_dependent,
           nyc_full_year_resident: nyc_full_year_resident
         )
         @it215 = Efile::Ny::It215.new(
@@ -149,7 +147,7 @@ module Efile
 
       def calculate_line_34
         if filing_status_single?
-          if @claimed_as_dependent
+          if @direct_file_data.claimed_as_dependent?
             3100
           else
             8000
@@ -345,7 +343,7 @@ module Efile
       end
 
       def calculate_line_40
-        if @claimed_as_dependent
+        if @direct_file_data.claimed_as_dependent?
           0
         else
           # assumption: we don't support Build America Bonds (special condition code A6)
@@ -397,7 +395,7 @@ module Efile
 
       def calculate_line_48
         # If you are married and filing a joint New York State return and only one of you was a resident of New York City for all of 2022, do not enter an amount here. See the instructions for line 51.
-        if @claimed_as_dependent || !@nyc_full_year_resident
+        if @direct_file_data.claimed_as_dependent? || !@nyc_full_year_resident
           0
         else
           nyc_household_credit(line_or_zero(:IT201_LINE_19A))
@@ -446,7 +444,7 @@ module Efile
       end
 
       def calculate_line_69a
-        return 0 unless @nyc_full_year_resident && @claimed_as_dependent == false
+        return 0 unless @nyc_full_year_resident && @direct_file_data.claimed_as_dependent? == false
 
 
         nyc_taxable_income = line_or_zero(:IT201_LINE_47)

--- a/app/lib/efile/ny/it214.rb
+++ b/app/lib/efile/ny/it214.rb
@@ -23,8 +23,9 @@ module Efile
           offboard
           return
         end
-        set_line(:IT214_LINE_4, -> { @claimed_as_dependent })
-        if @claimed_as_dependent
+        # Dependent on federal return?
+        set_line(:IT214_LINE_4, -> { 2 })
+        if false #if value is 1 then offboard
           offboard
           return
         end

--- a/app/lib/efile/ny/it214.rb
+++ b/app/lib/efile/ny/it214.rb
@@ -3,13 +3,12 @@ module Efile
     class It214 < ::Efile::TaxCalculator
       attr_reader :lines, :value_access_tracker
 
-      def initialize(value_access_tracker:, lines:, direct_file_data:, intake:, nyc_full_year_resident:, claimed_as_dependent:)
+      def initialize(value_access_tracker:, lines:, direct_file_data:, intake:, nyc_full_year_resident:)
         @value_access_tracker = value_access_tracker
         @lines = lines
         @direct_file_data = direct_file_data
         @intake = intake
         @nyc_full_year_resident = nyc_full_year_resident
-        @claimed_as_dependent = claimed_as_dependent
       end
 
       def calculate

--- a/app/lib/efile/ny/it214.rb
+++ b/app/lib/efile/ny/it214.rb
@@ -23,9 +23,9 @@ module Efile
           offboard
           return
         end
-        # Dependent on federal return?
+        # Todo: Dependent on federal return?
         set_line(:IT214_LINE_4, -> { 2 })
-        if false #if value is 1 then offboard
+        if false #todo: if value is 1 then offboard
           offboard
           return
         end

--- a/app/lib/submission_builder/ty2022/states/ny/documents/it201.rb
+++ b/app/lib/submission_builder/ty2022/states/ny/documents/it201.rb
@@ -12,22 +12,18 @@ module SubmissionBuilder
               head_of_household: 4,
               qualifying_widow: 5,
             }.freeze
-            CLAIMED_AS_DEP = {
-              true: 1,
-              false: 2
-            }
             NYC_RES = {
               yes: 1,
               no: 2,
               unfilled: 2 # it was failing on filling out xml.NYC_LVNG_QTR_IND without this, nyc_full_year_resident should always be set? perhaps the calculator calls are resetting it?
-            }
+            }.freeze
 
             def document
               build_xml_doc("IT201") do |xml|
                 xml.PR_DOB_DT claimed: @submission.data_source.primary.birth_date.strftime("%Y-%m-%d")
                 xml.FS_CD claimed: FILING_STATUSES[@submission.data_source.filing_status.to_sym]
                 xml.FED_ITZDED_IND claimed: 2
-                xml.DEP_CLAIM_IND claimed: CLAIMED_AS_DEP[@submission.data_source.direct_file_data.claimed_as_dependent?.to_sym]
+                xml.DEP_CLAIM_IND claimed: @submission.data_source.direct_file_data.claimed_as_dependent? ? 1 : 2
                 xml.NYC_LVNG_QTR_IND claimed: NYC_RES[@submission.data_source.nyc_full_year_resident.to_sym]
                 # TODO: DAYS_NYC_NMBR are we only taking full-year nyc residents?
                 xml.WG_AMT claimed: calculated_fields.fetch(:IT201_LINE_1)

--- a/app/lib/submission_builder/ty2022/states/ny/documents/it201.rb
+++ b/app/lib/submission_builder/ty2022/states/ny/documents/it201.rb
@@ -13,8 +13,8 @@ module SubmissionBuilder
               qualifying_widow: 5,
             }.freeze
             CLAIMED_AS_DEP = {
-              yes: 1,
-              no: 2
+              true: 1,
+              false: 2
             }
             NYC_RES = {
               yes: 1,
@@ -27,7 +27,7 @@ module SubmissionBuilder
                 xml.PR_DOB_DT claimed: @submission.data_source.primary.birth_date.strftime("%Y-%m-%d")
                 xml.FS_CD claimed: FILING_STATUSES[@submission.data_source.filing_status.to_sym]
                 xml.FED_ITZDED_IND claimed: 2
-                xml.DEP_CLAIM_IND claimed: CLAIMED_AS_DEP[@submission.data_source.claimed_as_dep.to_sym]
+                xml.DEP_CLAIM_IND claimed: CLAIMED_AS_DEP[@submission.data_source.direct_file_data.claimed_as_dependent?.to_sym]
                 xml.NYC_LVNG_QTR_IND claimed: NYC_RES[@submission.data_source.nyc_full_year_resident.to_sym]
                 # TODO: DAYS_NYC_NMBR are we only taking full-year nyc residents?
                 xml.WG_AMT claimed: calculated_fields.fetch(:IT201_LINE_1)

--- a/app/models/direct_file_data.rb
+++ b/app/models/direct_file_data.rb
@@ -25,6 +25,7 @@ class DirectFileData
     fed_taxable_ssb: 'IRS1040 TaxableSocSecAmt',
     fed_ssb: 'IRS1040 SocSecBnftAmt',
     fed_eic: 'IRS1040 EarnedIncomeCreditAmt',
+    total_exempt_primary_spouse: 'IRS1040 TotalExemptPrimaryAndSpouseCnt'
   }.freeze
 
   def initialize(raw_xml)
@@ -234,6 +235,18 @@ class DirectFileData
     parsed_xml.at('IRS1040ScheduleEIC QualifyingChildInformation') != nil
   end
 
+  def total_exempt_primary_spouse
+    df_xml_value(__method__).to_i
+  end
+
+  def total_exempt_primary_spouse=(value)
+    write_df_xml_value(__method__, value.to_i)
+  end
+
+  def claimed_as_dependent?
+    total_exempt_primary_spouse.zero?
+  end
+
   def fed_65_primary_spouse
     elements_to_check = ['Primary65OrOlderInd', 'Spouse65OrOlderInd']
     value = 0
@@ -391,7 +404,8 @@ class DirectFileData
       :fed_taxable_ssb,
       :fed_adjustments_claimed,
       :fed_total_adjustments,
-      :total_state_tax_withheld
+      :total_state_tax_withheld,
+      :total_exempt_primary_spouse
     ].each_with_object({}) do |field, hsh|
       hsh[field] = send(field)
     end

--- a/app/models/direct_file_data.rb
+++ b/app/models/direct_file_data.rb
@@ -404,7 +404,6 @@ class DirectFileData
       :fed_taxable_ssb,
       :fed_adjustments_claimed,
       :fed_total_adjustments,
-      :total_state_tax_withheld,
       :total_exempt_primary_spouse
     ].each_with_object({}) do |field, hsh|
       hsh[field] = send(field)

--- a/app/models/state_file_az_intake.rb
+++ b/app/models/state_file_az_intake.rb
@@ -84,7 +84,6 @@ class StateFileAzIntake < StateFileBaseIntake
     Efile::Az::Az140.new(
       year: 2022,
       filing_status: filing_status.to_sym,
-      claimed_as_dependent: claimed_as_dep_yes?,
       intake: self,
       dependent_count: dependents.length,
       direct_file_data: direct_file_data,
@@ -140,4 +139,6 @@ class StateFileAzIntake < StateFileBaseIntake
       eligibility_529_for_non_qual_expense: "yes",
     }
   end
+
+  #todo do a rollback on claimed_as_dep field
 end

--- a/app/models/state_file_az_intake.rb
+++ b/app/models/state_file_az_intake.rb
@@ -11,7 +11,6 @@
 #  charitable_cash                       :integer          default(0)
 #  charitable_contributions              :integer          default("unfilled"), not null
 #  charitable_noncash                    :integer          default(0)
-#  claimed_as_dep                        :integer          default("unfilled")
 #  contact_preference                    :integer          default("unfilled"), not null
 #  current_step                          :string
 #  date_electronic_withdrawal            :date

--- a/app/models/state_file_az_intake.rb
+++ b/app/models/state_file_az_intake.rb
@@ -48,29 +48,12 @@
 #  visitor_id                            :string
 #
 class StateFileAzIntake < StateFileBaseIntake
-  encrypts :bank_account_number, :bank_routing_number, :raw_direct_file_data
-
-  enum account_type: { unfilled: 0, checking: 1, savings: 2 }, _prefix: :account_type
   enum has_prior_last_names: { unfilled: 0, yes: 1, no: 2 }, _prefix: :has_prior_last_names
   enum tribal_member: { unfilled: 0, yes: 1, no: 2 }, _prefix: :tribal_member
   enum armed_forces_member: { unfilled: 0, yes: 1, no: 2 }, _prefix: :armed_forces_member
   enum charitable_contributions: { unfilled: 0, yes: 1, no: 2 }, _prefix: :charitable_contributions
   enum eligibility_married_filing_separately: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_married_filing_separately
   enum eligibility_529_for_non_qual_expense: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_529_for_non_qual_expense
-  enum payment_or_deposit_type: { unfilled: 0, direct_deposit: 1, mail: 2 }, _prefix: :payment_or_deposit_type
-  enum primary_esigned: { unfilled: 0, yes: 1, no: 2 }, _prefix: :primary_esigned
-  enum spouse_esigned: { unfilled: 0, yes: 1, no: 2 }, _prefix: :spouse_esigned
-
-  before_save do
-    if payment_or_deposit_type_changed?(to: "mail") || payment_or_deposit_type_changed?(to: "unfilled")
-      self.account_type = "unfilled"
-      self.bank_name = nil
-      self.routing_number = nil
-      self.account_number = nil
-      self.withdraw_amount = nil
-      self.date_electronic_withdrawal = nil
-    end
-  end
 
   def state_code
     'az'
@@ -139,6 +122,4 @@ class StateFileAzIntake < StateFileBaseIntake
       eligibility_529_for_non_qual_expense: "yes",
     }
   end
-
-  #todo do a rollback on claimed_as_dep field
 end

--- a/app/models/state_file_az_intake.rb
+++ b/app/models/state_file_az_intake.rb
@@ -56,12 +56,10 @@ class StateFileAzIntake < StateFileBaseIntake
   enum charitable_contributions: { unfilled: 0, yes: 1, no: 2 }, _prefix: :charitable_contributions
   enum eligibility_married_filing_separately: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_married_filing_separately
   enum eligibility_529_for_non_qual_expense: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_529_for_non_qual_expense
-  enum primary_esigned: { unfilled: 0, yes: 1, no: 2 }, _prefix: :primary_esigned
-  enum spouse_esigned: { unfilled: 0, yes: 1, no: 2 }, _prefix: :spouse_esigned
-  enum account_type: { unfilled: 0, checking: 1, savings: 2}, _prefix: :account_type
-  enum payment_or_deposit_type: { unfilled: 0, direct_deposit: 1, mail: 2 }, _prefix: :payment_or_deposit_type
 
   before_save do
+    save_nil_enums_with_unfilled
+
     if payment_or_deposit_type_changed?(to: "mail") || payment_or_deposit_type_changed?(to: "unfilled")
       self.account_type = "unfilled"
       self.bank_name = nil

--- a/app/models/state_file_az_intake.rb
+++ b/app/models/state_file_az_intake.rb
@@ -48,12 +48,25 @@
 #  visitor_id                            :string
 #
 class StateFileAzIntake < StateFileBaseIntake
+  encrypts :account_number, :routing_number, :raw_direct_file_data
+
   enum has_prior_last_names: { unfilled: 0, yes: 1, no: 2 }, _prefix: :has_prior_last_names
   enum tribal_member: { unfilled: 0, yes: 1, no: 2 }, _prefix: :tribal_member
   enum armed_forces_member: { unfilled: 0, yes: 1, no: 2 }, _prefix: :armed_forces_member
   enum charitable_contributions: { unfilled: 0, yes: 1, no: 2 }, _prefix: :charitable_contributions
   enum eligibility_married_filing_separately: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_married_filing_separately
   enum eligibility_529_for_non_qual_expense: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_529_for_non_qual_expense
+
+  before_save do
+    if payment_or_deposit_type_changed?(to: "mail") || payment_or_deposit_type_changed?(to: "unfilled")
+      self.account_type = "unfilled"
+      self.bank_name = nil
+      self.routing_number = nil
+      self.account_number = nil
+      self.withdraw_amount = nil
+      self.date_electronic_withdrawal = nil
+    end
+  end
 
   def state_code
     'az'

--- a/app/models/state_file_az_intake.rb
+++ b/app/models/state_file_az_intake.rb
@@ -56,6 +56,10 @@ class StateFileAzIntake < StateFileBaseIntake
   enum charitable_contributions: { unfilled: 0, yes: 1, no: 2 }, _prefix: :charitable_contributions
   enum eligibility_married_filing_separately: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_married_filing_separately
   enum eligibility_529_for_non_qual_expense: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_529_for_non_qual_expense
+  enum primary_esigned: { unfilled: 0, yes: 1, no: 2 }, _prefix: :primary_esigned
+  enum spouse_esigned: { unfilled: 0, yes: 1, no: 2 }, _prefix: :spouse_esigned
+  enum account_type: { unfilled: 0, checking: 1, savings: 2}, _prefix: :account_type
+  enum payment_or_deposit_type: { unfilled: 0, direct_deposit: 1, mail: 2 }, _prefix: :payment_or_deposit_type
 
   before_save do
     if payment_or_deposit_type_changed?(to: "mail") || payment_or_deposit_type_changed?(to: "unfilled")

--- a/app/models/state_file_base_intake.rb
+++ b/app/models/state_file_base_intake.rb
@@ -4,10 +4,6 @@ class StateFileBaseIntake < ApplicationRecord
   enum contact_preference: { unfilled: 0, email: 1, text: 2 }, _prefix: :contact_preference
   enum eligibility_lived_in_state: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_lived_in_state
   enum eligibility_out_of_state_income: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_out_of_state_income
-  enum primary_esigned: { unfilled: 0, yes: 1, no: 2 }, _prefix: :primary_esigned
-  enum spouse_esigned: { unfilled: 0, yes: 1, no: 2 }, _prefix: :spouse_esigned
-  enum account_type: { unfilled: 0, checking: 1, savings: 2}, _prefix: :account_type
-  enum payment_or_deposit_type: { unfilled: 0, direct_deposit: 1, mail: 2 }, _prefix: :payment_or_deposit_type
 
   has_one_attached :submission_pdf
 

--- a/app/models/state_file_base_intake.rb
+++ b/app/models/state_file_base_intake.rb
@@ -1,6 +1,5 @@
 class StateFileBaseIntake < ApplicationRecord
   self.abstract_class = true
-  encrypts :account_number, :routing_number, :raw_direct_file_data
 
   enum contact_preference: { unfilled: 0, email: 1, text: 2 }, _prefix: :contact_preference
   enum eligibility_lived_in_state: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_lived_in_state
@@ -24,17 +23,6 @@ class StateFileBaseIntake < ApplicationRecord
   delegate :tax_return_year, to: :direct_file_data
 
   alias_attribute :sms_phone_number, :phone_number
-
-  before_save do
-    if payment_or_deposit_type_changed?(to: "mail") || payment_or_deposit_type_changed?(to: "unfilled")
-      self.account_type = "unfilled"
-      self.bank_name = nil
-      self.routing_number = nil
-      self.account_number = nil
-      self.withdraw_amount = nil
-      self.date_electronic_withdrawal = nil
-    end
-  end
 
   def direct_file_data
     @direct_file_data ||= DirectFileData.new(raw_direct_file_data)

--- a/app/models/state_file_base_intake.rb
+++ b/app/models/state_file_base_intake.rb
@@ -1,10 +1,14 @@
 class StateFileBaseIntake < ApplicationRecord
   self.abstract_class = true
+  encrypts :account_number, :routing_number, :raw_direct_file_data
 
-  enum claimed_as_dep: { unfilled: 0, yes: 1, no: 2 }, _prefix: :claimed_as_dep
   enum contact_preference: { unfilled: 0, email: 1, text: 2 }, _prefix: :contact_preference
   enum eligibility_lived_in_state: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_lived_in_state
   enum eligibility_out_of_state_income: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_out_of_state_income
+  enum primary_esigned: { unfilled: 0, yes: 1, no: 2 }, _prefix: :primary_esigned
+  enum spouse_esigned: { unfilled: 0, yes: 1, no: 2 }, _prefix: :spouse_esigned
+  enum account_type: { unfilled: 0, checking: 1, savings: 2}, _prefix: :account_type
+  enum payment_or_deposit_type: { unfilled: 0, direct_deposit: 1, mail: 2 }, _prefix: :payment_or_deposit_type
 
   has_one_attached :submission_pdf
 
@@ -20,6 +24,17 @@ class StateFileBaseIntake < ApplicationRecord
   delegate :tax_return_year, to: :direct_file_data
 
   alias_attribute :sms_phone_number, :phone_number
+
+  before_save do
+    if payment_or_deposit_type_changed?(to: "mail") || payment_or_deposit_type_changed?(to: "unfilled")
+      self.account_type = "unfilled"
+      self.bank_name = nil
+      self.routing_number = nil
+      self.account_number = nil
+      self.withdraw_amount = nil
+      self.date_electronic_withdrawal = nil
+    end
+  end
 
   def direct_file_data
     @direct_file_data ||= DirectFileData.new(raw_direct_file_data)

--- a/app/models/state_file_ny_intake.rb
+++ b/app/models/state_file_ny_intake.rb
@@ -6,7 +6,6 @@
 #  account_number                     :string
 #  account_type                       :integer          default("unfilled"), not null
 #  bank_name                          :string
-#  claimed_as_dep                     :integer          default("unfilled"), not null
 #  confirmed_permanent_address        :integer          default("unfilled"), not null
 #  contact_preference                 :integer          default("unfilled"), not null
 #  current_step                       :string

--- a/app/models/state_file_ny_intake.rb
+++ b/app/models/state_file_ny_intake.rb
@@ -102,6 +102,10 @@ class StateFileNyIntake < StateFileBaseIntake
   enum eligibility_yonkers: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_yonkers
   enum eligibility_part_year_nyc_resident: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_part_year_nyc_resident
   enum eligibility_withdrew_529: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_withdrew_529
+  enum primary_esigned: { unfilled: 0, yes: 1, no: 2 }, _prefix: :primary_esigned
+  enum spouse_esigned: { unfilled: 0, yes: 1, no: 2 }, _prefix: :spouse_esigned
+  enum account_type: { unfilled: 0, checking: 1, savings: 2}, _prefix: :account_type
+  enum payment_or_deposit_type: { unfilled: 0, direct_deposit: 1, mail: 2 }, _prefix: :payment_or_deposit_type
 
   before_save do
     if untaxed_out_of_state_purchases_changed?(to: "no") || untaxed_out_of_state_purchases_changed?(to: "unfilled")

--- a/app/models/state_file_ny_intake.rb
+++ b/app/models/state_file_ny_intake.rb
@@ -85,6 +85,7 @@
 #  index_state_file_ny_intakes_on_spouse_state_id_id   (spouse_state_id_id)
 #
 class StateFileNyIntake < StateFileBaseIntake
+  encrypts :account_number, :routing_number, :raw_direct_file_data
   belongs_to :primary_state_id, class_name: "StateId", optional: true
   belongs_to :spouse_state_id, class_name: "StateId", optional: true
   accepts_nested_attributes_for :primary_state_id, :spouse_state_id
@@ -103,8 +104,6 @@ class StateFileNyIntake < StateFileBaseIntake
   enum eligibility_withdrew_529: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_withdrew_529
 
   before_save do
-    super
-
     if untaxed_out_of_state_purchases_changed?(to: "no") || untaxed_out_of_state_purchases_changed?(to: "unfilled")
       self.sales_use_tax_calculation_method = "unfilled"
       self.sales_use_tax = nil
@@ -112,6 +111,15 @@ class StateFileNyIntake < StateFileBaseIntake
 
     if sales_use_tax_calculation_method_changed?(to: "automated")
       self.sales_use_tax = calculate_sales_use_tax
+    end
+
+    if payment_or_deposit_type_changed?(to: "mail") || payment_or_deposit_type_changed?(to: "unfilled")
+      self.account_type = "unfilled"
+      self.bank_name = nil
+      self.routing_number = nil
+      self.account_number = nil
+      self.withdraw_amount = nil
+      self.date_electronic_withdrawal = nil
     end
   end
 

--- a/app/models/state_file_ny_intake.rb
+++ b/app/models/state_file_ny_intake.rb
@@ -102,12 +102,10 @@ class StateFileNyIntake < StateFileBaseIntake
   enum eligibility_yonkers: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_yonkers
   enum eligibility_part_year_nyc_resident: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_part_year_nyc_resident
   enum eligibility_withdrew_529: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_withdrew_529
-  enum primary_esigned: { unfilled: 0, yes: 1, no: 2 }, _prefix: :primary_esigned
-  enum spouse_esigned: { unfilled: 0, yes: 1, no: 2 }, _prefix: :spouse_esigned
-  enum account_type: { unfilled: 0, checking: 1, savings: 2}, _prefix: :account_type
-  enum payment_or_deposit_type: { unfilled: 0, direct_deposit: 1, mail: 2 }, _prefix: :payment_or_deposit_type
 
   before_save do
+    save_nil_enums_with_unfilled
+
     if untaxed_out_of_state_purchases_changed?(to: "no") || untaxed_out_of_state_purchases_changed?(to: "unfilled")
       self.sales_use_tax_calculation_method = "unfilled"
       self.sales_use_tax = nil

--- a/app/views/state_file/questions/federal_info/edit.html.erb
+++ b/app/views/state_file/questions/federal_info/edit.html.erb
@@ -76,9 +76,6 @@
 
     <div style="background: #eaacea; padding: 15px; margin-bottom: 15px;">
       <h3>TODO ZONE: where do these things go?</h3>
-
-      <%= f.state_file_qa_input_field :phone_daytime, "daytime phone number" %>
-      <%= f.state_file_qa_input_field :phone_daytime_area_code, "daytime phone area code" %>
       <%= f.state_file_qa_input_field :total_state_tax_withheld, "Total state tax withheld" %>
     </div>
 

--- a/app/views/state_file/questions/federal_info/edit.html.erb
+++ b/app/views/state_file/questions/federal_info/edit.html.erb
@@ -39,6 +39,7 @@
     <%= f.state_file_qa_input_field :fed_taxable_income, "Taxable interest" %>
     <%= f.state_file_qa_input_field :fed_unemployment, "Unemployment compensation" %>
     <%= f.state_file_qa_input_field :fed_taxable_ssb, "Taxable SS Income" %>
+    <%= f.state_file_qa_input_field :total_exempt_primary_spouse, "Total exempt primary and spouse count" %>
 
     <div class="federal-info-controller-subform-section with-padding-med">
       <div class="federal-info-controller-subform-section-title">Dependent Detail Zone</div>
@@ -76,7 +77,8 @@
     <div style="background: #eaacea; padding: 15px; margin-bottom: 15px;">
       <h3>TODO ZONE: where do these things go?</h3>
 
-      <%= f.cfa_checkbox(:claimed_as_dep, "claimed as dependent?", options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <%= f.state_file_qa_input_field :phone_daytime, "daytime phone number" %>
+      <%= f.state_file_qa_input_field :phone_daytime_area_code, "daytime phone area code" %>
 
       <%= f.state_file_qa_input_field :total_state_tax_withheld, "Total state tax withheld" %>
     </div>

--- a/app/views/state_file/questions/federal_info/edit.html.erb
+++ b/app/views/state_file/questions/federal_info/edit.html.erb
@@ -79,7 +79,6 @@
 
       <%= f.state_file_qa_input_field :phone_daytime, "daytime phone number" %>
       <%= f.state_file_qa_input_field :phone_daytime_area_code, "daytime phone area code" %>
-
       <%= f.state_file_qa_input_field :total_state_tax_withheld, "Total state tax withheld" %>
     </div>
 

--- a/db/migrate/20231120213825_remove_claimed_as_dep.rb
+++ b/db/migrate/20231120213825_remove_claimed_as_dep.rb
@@ -1,0 +1,8 @@
+class RemoveClaimedAsDep < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      remove_column :state_file_ny_intakes, :claimed_as_dep
+      remove_column :state_file_az_intakes, :claimed_as_dep
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_15_183759) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_20_213825) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -1580,7 +1580,6 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_15_183759) do
     t.integer "charitable_cash", default: 0
     t.integer "charitable_contributions", default: 0, null: false
     t.integer "charitable_noncash", default: 0
-    t.integer "claimed_as_dep", default: 0
     t.integer "contact_preference", default: 0, null: false
     t.datetime "created_at", null: false
     t.string "current_step"
@@ -1642,7 +1641,6 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_15_183759) do
     t.string "account_number"
     t.integer "account_type", default: 0, null: false
     t.string "bank_name"
-    t.integer "claimed_as_dep", default: 0, null: false
     t.integer "confirmed_permanent_address", default: 0, null: false
     t.integer "contact_preference", default: 0, null: false
     t.datetime "created_at", null: false

--- a/spec/factories/state_file_az_intakes.rb
+++ b/spec/factories/state_file_az_intakes.rb
@@ -11,7 +11,6 @@
 #  charitable_cash                       :integer          default(0)
 #  charitable_contributions              :integer          default("unfilled"), not null
 #  charitable_noncash                    :integer          default(0)
-#  claimed_as_dep                        :integer          default("unfilled")
 #  contact_preference                    :integer          default("unfilled"), not null
 #  current_step                          :string
 #  date_electronic_withdrawal            :date

--- a/spec/factories/state_file_az_intakes.rb
+++ b/spec/factories/state_file_az_intakes.rb
@@ -53,7 +53,6 @@ FactoryBot.define do
     end
 
     raw_direct_file_data { File.read(Rails.root.join('app', 'controllers', 'state_file', 'questions', 'df_return_sample.xml')) }
-    claimed_as_dep { 'no' }
     primary_first_name { "Ariz" }
     primary_last_name { "Onian" }
 

--- a/spec/factories/state_file_ny_intakes.rb
+++ b/spec/factories/state_file_ny_intakes.rb
@@ -90,7 +90,6 @@ FactoryBot.define do
     end
 
     raw_direct_file_data { File.read(Rails.root.join('app', 'controllers', 'state_file', 'questions', 'df_return_sample.xml')) }
-    claimed_as_dep { 'no' }
     primary_first_name { "New" }
     primary_last_name { "Yorker" }
     primary_birth_date{ Date.parse("May 1, 1979") }

--- a/spec/factories/state_file_ny_intakes.rb
+++ b/spec/factories/state_file_ny_intakes.rb
@@ -6,7 +6,6 @@
 #  account_number                     :string
 #  account_type                       :integer          default("unfilled"), not null
 #  bank_name                          :string
-#  claimed_as_dep                     :integer          default("unfilled"), not null
 #  confirmed_permanent_address        :integer          default("unfilled"), not null
 #  contact_preference                 :integer          default("unfilled"), not null
 #  current_step                       :string

--- a/spec/lib/efile/ny/it201_spec.rb
+++ b/spec/lib/efile/ny/it201_spec.rb
@@ -8,7 +8,6 @@ describe Efile::Ny::It201 do
     described_class.new(
       year: 2022,
       filing_status: filing_status,
-      claimed_as_dependent: false,
       intake: intake,
       direct_file_data: intake.direct_file_data,
       nyc_full_year_resident: true,

--- a/spec/models/state_file_az_intake_spec.rb
+++ b/spec/models/state_file_az_intake_spec.rb
@@ -11,7 +11,6 @@
 #  charitable_cash                       :integer          default(0)
 #  charitable_contributions              :integer          default("unfilled"), not null
 #  charitable_noncash                    :integer          default(0)
-#  claimed_as_dep                        :integer          default("unfilled")
 #  contact_preference                    :integer          default("unfilled"), not null
 #  current_step                          :string
 #  date_electronic_withdrawal            :date

--- a/spec/models/state_file_az_intake_spec.rb
+++ b/spec/models/state_file_az_intake_spec.rb
@@ -75,6 +75,17 @@ describe StateFileAzIntake do
          .and change(intake.reload, :date_electronic_withdrawal).to(nil)
       end
     end
+
+    context "when enum that has unfilled type is set to nil" do
+      let(:intake) { create :state_file_az_intake, armed_forces_member: "yes", account_type: "checking", spouse_esigned_at: DateTime.now }
+      it "saves as unfilled" do
+        expect {
+          intake.update(armed_forces_member: nil, account_type: nil, spouse_esigned_at: nil)
+        }.to change(intake, :armed_forces_member).to("unfilled")
+        .and change(intake, :account_type).to("unfilled")
+        .and change(intake, :spouse_esigned_at).to(nil)
+      end
+    end
   end
 
   describe "#ask_spouse_name?" do

--- a/spec/models/state_file_ny_intake_spec.rb
+++ b/spec/models/state_file_ny_intake_spec.rb
@@ -133,6 +133,15 @@ describe StateFileNyIntake do
       end
     end
 
+    context "when enum that has unfilled type is set to nil" do
+      let(:intake) { create :state_file_ny_intake, eligibility_yonkers: "yes", account_type: "checking" }
+      it "saves as unfilled" do
+        expect {
+          intake.update(eligibility_yonkers: nil, account_type: nil)
+        }.to change(intake.reload, :eligibility_yonkers).to("unfilled")
+        .and change(intake.reload, :account_type).to("unfilled")
+      end
+    end
   end
 
   describe "#calculate_sales_use_tax" do

--- a/spec/models/state_file_ny_intake_spec.rb
+++ b/spec/models/state_file_ny_intake_spec.rb
@@ -6,7 +6,6 @@
 #  account_number                     :string
 #  account_type                       :integer          default("unfilled"), not null
 #  bank_name                          :string
-#  claimed_as_dep                     :integer          default("unfilled"), not null
 #  confirmed_permanent_address        :integer          default("unfilled"), not null
 #  contact_preference                 :integer          default("unfilled"), not null
 #  current_step                       :string


### PR DESCRIPTION
Previously we had the `claimed_as_dep` field as a placeholder but now we are replacing it with the `TotalExemptPrimaryAndSpouseCnt` value that we are grabbing from the DF XML. Where if they are claimed as a dependent this value should be `0`