### PR TITLE
Less deprecation warnings during test runs

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -7,6 +7,12 @@ Devise.setup do |config|
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default.
 
+  # Silence unhelpful deprecation warnings:
+  # https://github.com/heartcombo/devise/issues/5644
+  # Can be removed once we are using a new devise release that
+  # incorporates https://github.com/heartcombo/devise/pull/5645
+  config.secret_key = Rails.application.secret_key_base
+
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.
   config.parent_controller = 'BaseDeviseController'


### PR DESCRIPTION
Gets rid of this stuff that we keep seeing during test runs:
```
DEPRECATION WARNING: `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2. (called from <top (required)> at /Users/bgolder/Developer/vita-min/config/environment.rb:5)
DEPRECATION WARNING: `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2. (called from <top (required)> at /Users/bgolder/Developer/vita-min/config/environment.rb:5)
DEPRECATION WARNING: `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2. (called from <top (required)> at /Users/bgolder/Developer/vita-min/config/environment.rb:5)
DEPRECATION WARNING: `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2. (called from <top (required)> at /Users/bgolder/Developer/vita-min/config/environment.rb:5)
DEPRECATION WARNING: `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2. (called from <top (required)> at /Users/bgolder/Developer/vita-min/config/environment.rb:5)
DEPRECATION WARNING: `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2. (called from <top (required)> at /Users/bgolder/Developer/vita-min/config/environment.rb:5)
DEPRECATION WARNING: `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2. (called from <top (required)> at /Users/bgolder/Developer/vita-min/config/environment.rb:5)
DEPRECATION WARNING: `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2. (called from <top (required)> at /Users/bgolder/Developer/vita-min/config/environment.rb:5)
```