### PR TITLE
IT-214 bugfix and test coverage #186574910

### DIFF
--- a/app/lib/submission_builder/ty2022/states/ny/documents/it213.rb
+++ b/app/lib/submission_builder/ty2022/states/ny/documents/it213.rb
@@ -9,13 +9,13 @@ module SubmissionBuilder
             def document
               build_xml_doc("IT213") do |xml|
                 if @submission.data_source.eligibility_lived_in_state_yes?
-                  xml.ESC_RSDT_IND claimed: 1
-                  xml.ESC_FED_CR_IND claimed: @submission.data_source.direct_file_data.fed_ctc_claimed ? 1 : 2
-                  xml.ESC_FAGI_LMT_IND claimed: calculated_fields.fetch(:IT213_LINE_3) ? 1 : 2
-                  if @submission.data_source.direct_file_data.fed_ctc_claimed && calculated_fields.fetch(:IT213_LINE_3)
+                  xml.ESC_RSDT_IND claimed: calculated_fields.fetch(:IT213_LINE_1)
+                  xml.ESC_FED_CR_IND claimed: calculated_fields.fetch(:IT213_LINE_2)
+                  xml.ESC_FAGI_LMT_IND claimed: calculated_fields.fetch(:IT213_LINE_3)
+                  if calculated_fields.fetch(:IT213_LINE_2) == 1 || calculated_fields.fetch(:IT213_LINE_3) == 1
                     xml.ESC_FED_CHLD_NMBR claimed: calculated_fields.fetch(:IT213_LINE_4)
                     xml.ESC_SSN_CHLD_NMBR claimed: calculated_fields.fetch(:IT213_LINE_5)
-                    if @submission.data_source.direct_file_data.fed_ctc_claimed
+                    if calculated_fields.fetch(:IT213_LINE_2) == 1
                       xml.ESC_FED_CR_AMT claimed: calculated_fields.fetch(:IT213_LINE_6)
                       xml.ESC_FED_ADDL_AMT claimed: calculated_fields.fetch(:IT213_LINE_7)
                       xml.ESC_FED_TOT_AMT claimed: calculated_fields.fetch(:IT213_LINE_8)

--- a/spec/lib/efile/ny/it201_spec.rb
+++ b/spec/lib/efile/ny/it201_spec.rb
@@ -20,12 +20,12 @@ describe Efile::Ny::It201 do
   describe '#calculate_it213' do
     context "when the client is not eligible because they didn't live in NY state all year" do
       before do
-        intake.eligibility_lived_in_state = 2
+        intake.eligibility_lived_in_state = 2 # no
       end
 
       it "stops calculating IT213 after line 1 and sets IT213_LINE_14 to 0" do
         instance.calculate
-        expect(instance.lines[:IT213_LINE_1].value).to be_falsey
+        expect(instance.lines[:IT213_LINE_1].value).to eq(2)
         expect(instance.lines[:IT213_LINE_2]).to be_nil
         expect(instance.lines[:IT213_LINE_14].value).to eq(0)
       end
@@ -39,9 +39,9 @@ describe Efile::Ny::It201 do
 
       it "stops calculating after line 3 and sets IT213_LINE_14 to 0" do
         instance.calculate
-        expect(instance.lines[:IT213_LINE_1].value).to be_truthy
-        expect(instance.lines[:IT213_LINE_2].value).to be_falsey
-        expect(instance.lines[:IT213_LINE_3].value).to be_falsey
+        expect(instance.lines[:IT213_LINE_1].value).to eq(1)
+        expect(instance.lines[:IT213_LINE_2].value).to eq(2)
+        expect(instance.lines[:IT213_LINE_3].value).to eq(2)
         expect(instance.lines[:IT213_LINE_4]).to be_nil
         expect(instance.lines[:IT213_LINE_14].value).to eq(0)
       end
@@ -51,6 +51,294 @@ describe Efile::Ny::It201 do
       it "populates line 14 with the final credit amount" do
         instance.calculate
         expect(instance.lines[:IT213_LINE_14].value).to eq(330)
+      end
+    end
+  end
+
+  describe '#calculate_it214' do
+    context "when the client is not eligible because they didn't occupy their residence" do
+      before do
+        intake.occupied_residence = 2 # no
+      end
+
+      it "stops calculating IT214 after line 2 and sets IT214_LINE_33 to 0" do
+        instance.calculate
+        expect(instance.lines[:IT214_LINE_2].value).to eq(2)
+        expect(instance.lines[:IT214_LINE_3]).to be_nil
+        expect(instance.lines[:IT214_LINE_33].value).to eq(0)
+      end
+    end
+
+    context "when the client is not eligible because the property value is over the limit" do
+      before do
+        intake.occupied_residence = 1 # yes
+        intake.property_over_limit = 1 # yes
+      end
+
+      it "stops calculating IT214 after line 3 and sets IT214_LINE_33 to 0" do
+        instance.calculate
+        expect(instance.lines[:IT214_LINE_3].value).to eq(1)
+        expect(instance.lines[:IT214_LINE_4]).to be_nil
+        expect(instance.lines[:IT214_LINE_33].value).to eq(0)
+      end
+    end
+
+    context "when the client is not eligible because they had public housing" do
+      before do
+        intake.occupied_residence = 1 # yes
+        intake.property_over_limit = 2 # no
+        intake.public_housing = 1 # yes
+      end
+
+      it "stops calculating IT214 after line 5 and sets IT214_LINE_33 to 0" do
+        instance.calculate
+        expect(instance.lines[:IT214_LINE_5].value).to eq(1)
+        expect(instance.lines[:IT214_LINE_6]).to be_nil
+        expect(instance.lines[:IT214_LINE_33].value).to eq(0)
+      end
+    end
+
+    context "when the client is not eligible because they were in a nursing home" do
+      before do
+        intake.occupied_residence = 1 # yes
+        intake.property_over_limit = 2 # no
+        intake.public_housing = 2 # no
+        intake.nursing_home = 1 # yes
+      end
+
+      it "stops calculating IT214 after line 6 and sets IT214_LINE_33 to 0" do
+        instance.calculate
+        expect(instance.lines[:IT214_LINE_6].value).to eq(1)
+        expect(instance.lines[:IT214_LINE_7]).to be_nil
+        expect(instance.lines[:IT214_LINE_33].value).to eq(0)
+      end
+    end
+
+    context "when the client is not eligible because they had too much income" do
+      before do
+        intake.occupied_residence = 1 # yes
+        intake.property_over_limit = 2 # no
+        intake.public_housing = 2 # no
+        intake.nursing_home = 2 # no
+        intake.direct_file_data.fed_agi = 100000
+        intake.direct_file_data.fed_wages = 100000
+      end
+
+      it "stops calculating IT214 after line 16 and sets IT214_LINE_33 to 0" do
+        instance.calculate
+        expect(instance.lines[:IT214_LINE_16].value).to be > 18000
+        expect(instance.lines[:IT214_LINE_17]).to be_nil
+        expect(instance.lines[:IT214_LINE_33].value).to eq(0)
+      end
+    end
+
+    context "when the client is a renter and is ineligible because their rent is too high" do
+      before do
+        intake.occupied_residence = 1 # yes
+        intake.property_over_limit = 2 # no
+        intake.public_housing = 2 # no
+        intake.nursing_home = 2 # no
+        intake.household_rent_own = 1 # rent
+        intake.household_rent_amount = 12000 # annual rent @ $1k/month
+        intake.household_rent_adjustments = 6000 # 50% adjustment to $500/month, over the $450 eligibility threshold
+        intake.direct_file_data.fed_agi = 2500
+        intake.direct_file_data.fed_wages = 900
+        intake.direct_file_data.fed_unemployment = 500
+        intake.direct_file_data.fed_taxable_ssb = 400
+      end
+
+      it "stops calculating IT214 after line 21 and sets IT214_LINE_33 to 0" do
+        instance.calculate
+        expect(instance.lines[:IT214_LINE_17].value).to be 0.06
+        expect(instance.lines[:IT214_LINE_18].value).to be 800
+        expect(instance.lines[:IT214_LINE_19].value).to be 12000
+        expect(instance.lines[:IT214_LINE_19].value).to be 12000
+        expect(instance.lines[:IT214_LINE_20].value).to be 6000
+        expect(instance.lines[:IT214_LINE_21].value).to be 500
+        expect(instance.lines[:IT214_LINE_22]).to be_nil
+        expect(instance.lines[:IT214_LINE_33].value).to eq(0)
+      end
+    end
+
+    context "when the client is a renter and is ineligible because their non-subsidized rent is zero" do
+      before do
+        intake.occupied_residence = 1 # yes
+        intake.property_over_limit = 2 # no
+        intake.public_housing = 2 # no
+        intake.nursing_home = 2 # no
+        intake.household_rent_own = 1 # rent
+        intake.household_rent_amount = 0
+        intake.household_rent_adjustments = 0
+        intake.direct_file_data.fed_agi = 2500
+        intake.direct_file_data.fed_wages = 900
+        intake.direct_file_data.fed_unemployment = 500
+        intake.direct_file_data.fed_taxable_ssb = 400
+      end
+
+      it "stops calculating IT214 after line 28 and sets IT214_LINE_33 to 0" do
+        instance.calculate
+        expect(instance.lines[:IT214_LINE_17].value).to be 0.06
+        expect(instance.lines[:IT214_LINE_18].value).to be 800
+        expect(instance.lines[:IT214_LINE_19].value).to be 0
+        expect(instance.lines[:IT214_LINE_20].value).to be 0
+        expect(instance.lines[:IT214_LINE_21].value).to be 0
+        expect(instance.lines[:IT214_LINE_22].value).to be 0
+        expect(instance.lines[:IT214_LINE_28].value).to be 0
+        expect(instance.lines[:IT214_LINE_29]).to be_nil
+        expect(instance.lines[:IT214_LINE_33].value).to eq(0)
+      end
+    end
+
+    context "when the client is a renter and their rent amount is eligible but they are ineligible because their income is too high relative to their rent" do
+      before do
+        intake.occupied_residence = 1 # yes
+        intake.property_over_limit = 2 # no
+        intake.public_housing = 2 # no
+        intake.nursing_home = 2 # no
+        intake.household_rent_own = 1 # rent
+        intake.household_rent_amount = 6000 # annual rent @ $500/month
+        intake.household_rent_adjustments = 3000 # 50% adjustment to $250/month, under the $450 eligibility threshold
+        intake.direct_file_data.fed_agi = 2500
+        intake.direct_file_data.fed_wages = 900
+        intake.direct_file_data.fed_unemployment = 500
+        intake.direct_file_data.fed_taxable_ssb = 400
+      end
+
+      it "stops calculating IT214 after line 29 and sets IT214_LINE_33 to 0" do
+        instance.calculate
+        expect(instance.lines[:IT214_LINE_17].value).to be 0.06
+        expect(instance.lines[:IT214_LINE_18].value).to be 800
+        expect(instance.lines[:IT214_LINE_19].value).to be 6000
+        expect(instance.lines[:IT214_LINE_20].value).to be 3000
+        expect(instance.lines[:IT214_LINE_21].value).to be 250
+        expect(instance.lines[:IT214_LINE_22].value).to be 750
+        expect(instance.lines[:IT214_LINE_28].value).to be 750 # if this is less than line 18 then the client is ineligible
+        expect(instance.lines[:IT214_LINE_29].value).to be 800
+        expect(instance.lines[:IT214_LINE_30]).to be_nil
+        expect(instance.lines[:IT214_LINE_33].value).to eq(0)
+      end
+    end
+
+    context "when the client is a renter and they are eligible for the credit" do
+      before do
+        intake.occupied_residence = 1 # yes
+        intake.property_over_limit = 2 # no
+        intake.public_housing = 2 # no
+        intake.nursing_home = 2 # no
+        intake.household_rent_own = 1 # rent
+        intake.household_rent_amount = 6000 # annual rent @ $500/month
+        intake.household_rent_adjustments = 3000 # 50% adjustment to $250/month, under the $450 eligibility threshold
+        intake.direct_file_data.fed_agi = 1250
+        intake.direct_file_data.fed_wages = 450
+        intake.direct_file_data.fed_unemployment = 250
+        intake.direct_file_data.fed_taxable_ssb = 200
+      end
+
+      it "finishes calculating IT214 and sets IT214_LINE_33 to the final credit value of $34" do
+        instance.calculate
+        expect(instance.lines[:IT214_LINE_17].value).to be 0.06
+        expect(instance.lines[:IT214_LINE_18].value).to be 683
+        expect(instance.lines[:IT214_LINE_19].value).to be 6000
+        expect(instance.lines[:IT214_LINE_20].value).to be 3000
+        expect(instance.lines[:IT214_LINE_21].value).to be 250
+        expect(instance.lines[:IT214_LINE_22].value).to be 750
+        expect(instance.lines[:IT214_LINE_28].value).to be 750 # if this is less than line 18 then the client is ineligible
+        expect(instance.lines[:IT214_LINE_29].value).to be 683
+        expect(instance.lines[:IT214_LINE_30].value).to be 67
+        expect(instance.lines[:IT214_LINE_31].value).to be 34
+        expect(instance.lines[:IT214_LINE_32].value).to be 53
+        expect(instance.lines[:IT214_LINE_33].value).to be 34
+      end
+    end
+
+    context "when the client is a homeowner and is ineligible because their property taxes and assessments were zero" do
+      before do
+        intake.occupied_residence = 1 # yes
+        intake.property_over_limit = 2 # no
+        intake.public_housing = 2 # no
+        intake.nursing_home = 2 # no
+        intake.household_rent_own = 2 # own
+        intake.household_own_propety_tax = 0
+        intake.household_own_assessments = 0
+        intake.direct_file_data.fed_agi = 2500
+        intake.direct_file_data.fed_wages = 900
+        intake.direct_file_data.fed_unemployment = 500
+        intake.direct_file_data.fed_taxable_ssb = 400
+      end
+
+      it "stops calculating IT214 after line 28 and sets IT214_LINE_33 to 0" do
+        instance.calculate
+        expect(instance.lines[:IT214_LINE_17].value).to be 0.06
+        expect(instance.lines[:IT214_LINE_18].value).to be 800
+        expect(instance.lines[:IT214_LINE_23].value).to be 0
+        expect(instance.lines[:IT214_LINE_24].value).to be 0
+        expect(instance.lines[:IT214_LINE_25].value).to be 0
+        expect(instance.lines[:IT214_LINE_27].value).to be 0
+        expect(instance.lines[:IT214_LINE_28].value).to be 0
+        expect(instance.lines[:IT214_LINE_29]).to be_nil
+        expect(instance.lines[:IT214_LINE_33].value).to eq(0)
+      end
+    end
+
+    context "when the client is a homeowner with property tax and assessments but they are ineligible because their income is too high relative to their home costs" do
+      before do
+        intake.occupied_residence = 1 # yes
+        intake.property_over_limit = 2 # no
+        intake.public_housing = 2 # no
+        intake.nursing_home = 2 # no
+        intake.household_rent_own = 2 # own
+        intake.household_own_propety_tax = 500
+        intake.household_own_assessments = 250
+        intake.direct_file_data.fed_agi = 2500
+        intake.direct_file_data.fed_wages = 900
+        intake.direct_file_data.fed_unemployment = 500
+        intake.direct_file_data.fed_taxable_ssb = 400
+      end
+
+      it "stops calculating IT214 after line 28 and sets IT214_LINE_33 to 0" do
+        instance.calculate
+        expect(instance.lines[:IT214_LINE_17].value).to be 0.06
+        expect(instance.lines[:IT214_LINE_18].value).to be 800
+        expect(instance.lines[:IT214_LINE_23].value).to be 500
+        expect(instance.lines[:IT214_LINE_24].value).to be 250
+        expect(instance.lines[:IT214_LINE_25].value).to be 750
+        expect(instance.lines[:IT214_LINE_27].value).to be 750
+        expect(instance.lines[:IT214_LINE_28].value).to be 750 # if this is less than line 18 the client is ineligible
+        expect(instance.lines[:IT214_LINE_29].value).to be 800
+        expect(instance.lines[:IT214_LINE_30]).to be_nil
+        expect(instance.lines[:IT214_LINE_33].value).to eq(0)
+      end
+    end
+
+    context "when the client is a homeowner and they are eligible for the credit" do
+      before do
+        intake.occupied_residence = 1 # yes
+        intake.property_over_limit = 2 # no
+        intake.public_housing = 2 # no
+        intake.nursing_home = 2 # no
+        intake.household_rent_own = 2 # own
+        intake.household_own_propety_tax = 5000
+        intake.household_own_assessments = 2500
+        intake.direct_file_data.fed_agi = 2500
+        intake.direct_file_data.fed_wages = 900
+        intake.direct_file_data.fed_unemployment = 500
+        intake.direct_file_data.fed_taxable_ssb = 400
+      end
+
+      it "finishes calculating IT214 and sets IT214_LINE_33 to the final credit value of $49" do
+        instance.calculate
+        expect(instance.lines[:IT214_LINE_17].value).to be 0.06
+        expect(instance.lines[:IT214_LINE_18].value).to be 800
+        expect(instance.lines[:IT214_LINE_23].value).to be 5000
+        expect(instance.lines[:IT214_LINE_24].value).to be 2500
+        expect(instance.lines[:IT214_LINE_25].value).to be 7500
+        expect(instance.lines[:IT214_LINE_27].value).to be 7500
+        expect(instance.lines[:IT214_LINE_28].value).to be 7500 # if this is less than line 18 the client is ineligible
+        expect(instance.lines[:IT214_LINE_29].value).to be 800
+        expect(instance.lines[:IT214_LINE_30].value).to be 6700
+        expect(instance.lines[:IT214_LINE_31].value).to be 3350
+        expect(instance.lines[:IT214_LINE_32].value).to be 49
+        expect(instance.lines[:IT214_LINE_33].value).to be 49
       end
     end
   end


### PR DESCRIPTION
- fix some logic errors in IT-214 due to checking for enum string values vs integers
- updated IT-213 calculations to also use integers for enums rather than booleans to be consistent with IT-214 and with the XML spec
- added full test coverage on all the logic branches for IT-214