### PR TITLE
Add cache control to hub

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -480,6 +480,13 @@ class ApplicationController < ActionController::Base
     "application"
   end
 
+  def set_cache_headers
+    # prevents browser caching on pages set with before action
+    response.headers["Cache-Control"] = "no-cache, no-store"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "Mon, 01 Jan 1990 00:00:00 GMT"
+  end
+
   rescue_from CanCan::AccessDenied do |exception|
     respond_to do |format|
       format.html do

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -480,7 +480,7 @@ class ApplicationController < ActionController::Base
     "application"
   end
 
-  def set_cache_headers
+  def set_no_cache_headers
     # prevents browser caching on pages set with before action
     response.headers["Cache-Control"] = "no-cache, no-store"
     response.headers["Pragma"] = "no-cache"

--- a/app/controllers/hub/admin/experiment_participants_controller.rb
+++ b/app/controllers/hub/admin/experiment_participants_controller.rb
@@ -1,8 +1,6 @@
 module Hub
   module Admin
-    class ExperimentParticipantsController < ApplicationController
-      include AccessControllable
-      before_action :require_sign_in
+    class ExperimentParticipantsController < Hub::BaseController
       load_and_authorize_resource
       layout "hub"
       before_action :redirect_on_prod, only: [:update]

--- a/app/controllers/hub/admin/experiments_controller.rb
+++ b/app/controllers/hub/admin/experiments_controller.rb
@@ -1,8 +1,6 @@
 module Hub
   module Admin
-    class ExperimentsController < ApplicationController
-      include AccessControllable
-      before_action :require_sign_in
+    class ExperimentsController < Hub::BaseController
       before_action :load_vita_partners, only: [:edit]
       load_and_authorize_resource
       layout "hub"

--- a/app/controllers/hub/admin_toggles_controller.rb
+++ b/app/controllers/hub/admin_toggles_controller.rb
@@ -1,7 +1,5 @@
 module Hub
-  class AdminTogglesController < ApplicationController
-    include AccessControllable
-    before_action :require_sign_in
+  class AdminTogglesController < Hub::BaseController
     layout "hub"
     load_and_authorize_resource
 

--- a/app/controllers/hub/admin_tools_controller.rb
+++ b/app/controllers/hub/admin_tools_controller.rb
@@ -1,7 +1,5 @@
 module Hub
-  class AdminToolsController < ApplicationController
-    include AccessControllable
-    before_action :require_sign_in
+  class AdminToolsController < Hub::BaseController
     layout "hub"
     load_and_authorize_resource class: false
 

--- a/app/controllers/hub/analytics_controller.rb
+++ b/app/controllers/hub/analytics_controller.rb
@@ -1,7 +1,5 @@
 module Hub
-  class AnalyticsController < ApplicationController
-    include AccessControllable
-    before_action :require_sign_in
+  class AnalyticsController < Hub::BaseController
     before_action :require_admin
     load_and_authorize_resource :client
     load_and_authorize_resource :user, parent: false, only: [:index]

--- a/app/controllers/hub/assigned_clients_controller.rb
+++ b/app/controllers/hub/assigned_clients_controller.rb
@@ -1,10 +1,7 @@
 module Hub
-  class AssignedClientsController < ApplicationController
+  class AssignedClientsController < Hub::BaseController
     FILTER_COOKIE_NAME = "assigned_clients_filters".freeze
-    include AccessControllable
     include ClientSortable
-
-    before_action :require_sign_in
     before_action :ensure_always_current_user_assigned, :load_vita_partners, :load_users, only: [:index]
     load_and_authorize_resource :client, parent: false
     before_action :setup_sortable_client, only: [:index]

--- a/app/controllers/hub/automated_messages_controller.rb
+++ b/app/controllers/hub/automated_messages_controller.rb
@@ -1,7 +1,5 @@
 module Hub
-  class AutomatedMessagesController < ApplicationController
-    include AccessControllable
-    before_action :require_sign_in
+  class AutomatedMessagesController < Hub::BaseController
     before_action :require_admin
     layout "hub"
 

--- a/app/controllers/hub/base_controller.rb
+++ b/app/controllers/hub/base_controller.rb
@@ -1,0 +1,7 @@
+module Hub
+  class BaseController < ApplicationController
+    include AccessControllable
+    before_action :set_cache_headers, :require_sign_in
+
+  end
+end

--- a/app/controllers/hub/base_controller.rb
+++ b/app/controllers/hub/base_controller.rb
@@ -1,7 +1,7 @@
 module Hub
   class BaseController < ApplicationController
     include AccessControllable
-    before_action :set_cache_headers, :require_sign_in
+    before_action :set_no_cache_headers, :require_sign_in
 
   end
 end

--- a/app/controllers/hub/bulk_actions/base_bulk_actions_controller.rb
+++ b/app/controllers/hub/bulk_actions/base_bulk_actions_controller.rb
@@ -1,14 +1,10 @@
 module Hub
   module BulkActions
-    class BaseBulkActionsController < ApplicationController
-      include AccessControllable
-
-      layout "hub"
-
-      before_action :require_sign_in
+    class BaseBulkActionsController < Hub::BaseController
       load_and_authorize_resource :tax_return_selection
       before_action :load_clients, :load_template_variables
       before_action :load_edit_form, only: :edit
+      layout "hub"
 
       def edit; end
 

--- a/app/controllers/hub/bulk_client_messages_controller.rb
+++ b/app/controllers/hub/bulk_client_messages_controller.rb
@@ -1,11 +1,8 @@
 module Hub
-  class BulkClientMessagesController < ApplicationController
-    include AccessControllable
-
-    layout "hub"
-
-    before_action :require_sign_in, :load_vita_partners, :load_users
+  class BulkClientMessagesController < Hub::BaseController
+    before_action :load_vita_partners, :load_users
     before_action :load_bulk_message, :load_selection, :load_clients, only: [:show]
+    layout "hub"
 
     def show
       @hide_filters = true

--- a/app/controllers/hub/bulk_message_csvs_controller.rb
+++ b/app/controllers/hub/bulk_message_csvs_controller.rb
@@ -1,7 +1,5 @@
 module Hub
-  class BulkMessageCsvsController < ApplicationController
-    include AccessControllable
-    before_action :require_sign_in
+  class BulkMessageCsvsController < Hub::BaseController
     load_and_authorize_resource
     before_action :load_bulk_message_csvs
 

--- a/app/controllers/hub/bulk_signup_messages_controller.rb
+++ b/app/controllers/hub/bulk_signup_messages_controller.rb
@@ -1,9 +1,7 @@
 require 'csv'
 
 module Hub
-  class BulkSignupMessagesController < ApplicationController
-    include AccessControllable
-    before_action :require_sign_in
+  class BulkSignupMessagesController < Hub::BaseController
     load_and_authorize_resource
 
     layout "hub"

--- a/app/controllers/hub/clients/bank_accounts_controller.rb
+++ b/app/controllers/hub/clients/bank_accounts_controller.rb
@@ -1,8 +1,6 @@
 module Hub
   module Clients
-    class BankAccountsController < ApplicationController
-      include AccessControllable
-      before_action :require_sign_in
+    class BankAccountsController < Hub::BaseController
       load_and_authorize_resource :client, parent: false
 
       def show

--- a/app/controllers/hub/clients/organizations_controller.rb
+++ b/app/controllers/hub/clients/organizations_controller.rb
@@ -1,8 +1,6 @@
 module Hub
   module Clients
-    class OrganizationsController < ApplicationController
-      include AccessControllable
-      before_action :require_sign_in
+    class OrganizationsController < Hub::BaseController
       load_and_authorize_resource :client, parent: false
       before_action :redirect_to_client_show_if_archived
       before_action :redirect_if_no_vita_partner_selected, only: [:update]

--- a/app/controllers/hub/clients/secrets_controller.rb
+++ b/app/controllers/hub/clients/secrets_controller.rb
@@ -1,8 +1,6 @@
 module Hub
   module Clients
-    class SecretsController < ApplicationController
-      include AccessControllable
-      before_action :require_sign_in
+    class SecretsController < Hub::BaseController
       load_and_authorize_resource :client, parent: false
       respond_to :js
 

--- a/app/controllers/hub/clients_controller.rb
+++ b/app/controllers/hub/clients_controller.rb
@@ -1,10 +1,8 @@
 module Hub
-  class ClientsController < ApplicationController
+  class ClientsController < Hub::BaseController
     FILTER_COOKIE_NAME = "all_clients_filters".freeze
-    include AccessControllable
     include ClientSortable
 
-    before_action :require_sign_in
     before_action :load_vita_partners, only: [:new, :create, :index]
     before_action :load_users, only: [:index]
     load_and_authorize_resource except: [:new, :create, :resource_to_client_redirect]

--- a/app/controllers/hub/coalitions_controller.rb
+++ b/app/controllers/hub/coalitions_controller.rb
@@ -1,7 +1,5 @@
 module Hub
-  class CoalitionsController < ApplicationController
-    include AccessControllable
-    before_action :require_sign_in
+  class CoalitionsController < Hub::BaseController
     load_and_authorize_resource :coalition, parent: false
 
     layout "hub"

--- a/app/controllers/hub/ctc_clients_controller.rb
+++ b/app/controllers/hub/ctc_clients_controller.rb
@@ -1,8 +1,5 @@
 module Hub
-  class CtcClientsController < ApplicationController
-    include AccessControllable
-
-    before_action :require_sign_in
+  class CtcClientsController < Hub::BaseController
     load_and_authorize_resource :client, parent: false
     layout "hub"
 

--- a/app/controllers/hub/data_migrations_controller.rb
+++ b/app/controllers/hub/data_migrations_controller.rb
@@ -1,6 +1,5 @@
 module Hub
-  class DataMigrationsController < ApplicationController
-    include AccessControllable
+  class DataMigrationsController < Hub::BaseController
     before_action :require_engineer
     layout "hub"
 

--- a/app/controllers/hub/documents_controller.rb
+++ b/app/controllers/hub/documents_controller.rb
@@ -1,9 +1,6 @@
 module Hub
-  class DocumentsController < ApplicationController
-    include AccessControllable
+  class DocumentsController < Hub::BaseController
     include FilesConcern
-
-    before_action :require_sign_in
     load_and_authorize_resource :client
     load_and_authorize_resource through: :client
     before_action :load_document_type_options

--- a/app/controllers/hub/efile_errors_controller.rb
+++ b/app/controllers/hub/efile_errors_controller.rb
@@ -1,7 +1,5 @@
 module Hub
-  class EfileErrorsController < ApplicationController
-    include AccessControllable
-    before_action :require_sign_in
+  class EfileErrorsController < Hub::BaseController
     load_and_authorize_resource
     layout "hub"
 

--- a/app/controllers/hub/efile_submissions_controller.rb
+++ b/app/controllers/hub/efile_submissions_controller.rb
@@ -1,9 +1,6 @@
 module Hub
-  class EfileSubmissionsController < ApplicationController
-    include AccessControllable
+  class EfileSubmissionsController < Hub::BaseController
     include FilesConcern
-
-    before_action :require_sign_in
     authorize_resource
     load_resource except: [:index, :show]
     layout "hub"

--- a/app/controllers/hub/faq_categories_controller.rb
+++ b/app/controllers/hub/faq_categories_controller.rb
@@ -1,7 +1,5 @@
 module Hub
-  class FaqCategoriesController < ApplicationController
-    include AccessControllable
-    before_action :require_sign_in
+  class FaqCategoriesController < Hub::BaseController
     before_action :require_admin
     before_action :set_paper_trail_whodunnit
     load_and_authorize_resource

--- a/app/controllers/hub/faq_items_controller.rb
+++ b/app/controllers/hub/faq_items_controller.rb
@@ -1,7 +1,5 @@
 module Hub
-  class FaqItemsController < ApplicationController
-    include AccessControllable
-    before_action :require_sign_in
+  class FaqItemsController < Hub::BaseController
     before_action :require_admin
     before_action :set_paper_trail_whodunnit
     before_action :load_faq_category

--- a/app/controllers/hub/fraud_indicators/base_controller.rb
+++ b/app/controllers/hub/fraud_indicators/base_controller.rb
@@ -1,8 +1,6 @@
 module Hub
   module FraudIndicators
-    class BaseController < ApplicationController
-      include AccessControllable
-      before_action :require_sign_in
+    class BaseController < Hub::BaseController
       helper_method :page_title, :form_attributes, :resource_name, :resource_class
       layout "hub"
 

--- a/app/controllers/hub/fraud_indicators_controller.rb
+++ b/app/controllers/hub/fraud_indicators_controller.rb
@@ -1,10 +1,7 @@
 module Hub
-  class FraudIndicatorsController < ApplicationController
-    include AccessControllable
-
-    before_action :require_sign_in
-    layout "hub"
+  class FraudIndicatorsController < Hub::BaseController
     load_and_authorize_resource class: Fraud::Indicator
+    layout "hub"
 
     def index
       @fraud_indicators = Fraud::Indicator.unscoped

--- a/app/controllers/hub/intentional_log_controller.rb
+++ b/app/controllers/hub/intentional_log_controller.rb
@@ -1,6 +1,5 @@
 module Hub
-  class IntentionalLogController < ApplicationController
-    include AccessControllable
+  class IntentionalLogController < Hub::BaseController
     before_action :require_engineer
     layout "hub"
 

--- a/app/controllers/hub/messages_controller.rb
+++ b/app/controllers/hub/messages_controller.rb
@@ -1,8 +1,5 @@
 module Hub
-  class MessagesController < ApplicationController
-    include AccessControllable
-
-    before_action :require_sign_in
+  class MessagesController < Hub::BaseController
     load_and_authorize_resource :client
     layout "hub"
 

--- a/app/controllers/hub/metrics_controller.rb
+++ b/app/controllers/hub/metrics_controller.rb
@@ -1,10 +1,8 @@
 module Hub
-  class MetricsController < ApplicationController
-    include AccessControllable
-    before_action :require_sign_in
-    layout "hub"
+  class MetricsController < Hub::BaseController
     load_and_authorize_resource :vita_partner, parent: false
     load_and_authorize_resource :organization, parent: false
+    layout "hub"
 
     def index
       generated_in_last_10_minutes = Report.arel_table[:generated_at].gteq(10.minutes.ago)

--- a/app/controllers/hub/notes_controller.rb
+++ b/app/controllers/hub/notes_controller.rb
@@ -1,7 +1,5 @@
 module Hub
-  class NotesController < ApplicationController
-    include AccessControllable
-    before_action :require_sign_in
+  class NotesController < Hub::BaseController
     load_and_authorize_resource :client
     load_and_authorize_resource through: :client, only: [:create]
     load_and_authorize_resource :user, parent: false, only: [:index]

--- a/app/controllers/hub/organizations_controller.rb
+++ b/app/controllers/hub/organizations_controller.rb
@@ -1,8 +1,5 @@
 module Hub
-  class OrganizationsController < ApplicationController
-    include AccessControllable
-    before_action :require_sign_in
-
+  class OrganizationsController < Hub::BaseController
     before_action :load_coalitions
     load_and_authorize_resource
 

--- a/app/controllers/hub/outbound_calls_controller.rb
+++ b/app/controllers/hub/outbound_calls_controller.rb
@@ -1,7 +1,5 @@
 module Hub
-  class OutboundCallsController < ApplicationController
-    include AccessControllable
-    before_action :require_sign_in
+  class OutboundCallsController < Hub::BaseController
     load_and_authorize_resource :client
     before_action :redirect_unless_editable
 

--- a/app/controllers/hub/outgoing_emails_controller.rb
+++ b/app/controllers/hub/outgoing_emails_controller.rb
@@ -1,8 +1,5 @@
 module Hub
-  class OutgoingEmailsController < ApplicationController
-    include AccessControllable
-
-    before_action :require_sign_in
+  class OutgoingEmailsController < Hub::BaseController
     load_and_authorize_resource :client
 
     def create

--- a/app/controllers/hub/outgoing_text_messages_controller.rb
+++ b/app/controllers/hub/outgoing_text_messages_controller.rb
@@ -1,8 +1,5 @@
 module Hub
-  class OutgoingTextMessagesController < ApplicationController
-    include AccessControllable
-
-    before_action :require_sign_in
+  class OutgoingTextMessagesController < Hub::BaseController
     load_and_authorize_resource :client
 
     def create

--- a/app/controllers/hub/portal_states_controller.rb
+++ b/app/controllers/hub/portal_states_controller.rb
@@ -1,11 +1,6 @@
 module Hub
-  class PortalStatesController < ApplicationController
-    include AccessControllable
-
-    layout "hub"
+  class PortalStatesController < Hub::BaseController
     load_and_authorize_resource class: false
-
-    before_action :require_sign_in
 
     def index
       @tax_returns = (TaxReturnStateMachine.states - ['intake_before_consent']).map do |state|

--- a/app/controllers/hub/portal_states_controller.rb
+++ b/app/controllers/hub/portal_states_controller.rb
@@ -1,6 +1,7 @@
 module Hub
   class PortalStatesController < Hub::BaseController
     load_and_authorize_resource class: false
+    layout "hub"
 
     def index
       @tax_returns = (TaxReturnStateMachine.states - ['intake_before_consent']).map do |state|

--- a/app/controllers/hub/security_controller.rb
+++ b/app/controllers/hub/security_controller.rb
@@ -1,7 +1,5 @@
 module Hub
-  class SecurityController < ApplicationController
-    include AccessControllable
-    before_action :require_sign_in
+  class SecurityController < Hub::BaseController
     load_and_authorize_resource :client, parent: false
     layout "hub"
 

--- a/app/controllers/hub/signup_selections_controller.rb
+++ b/app/controllers/hub/signup_selections_controller.rb
@@ -1,9 +1,7 @@
 require 'csv'
 
 module Hub
-  class SignupSelectionsController < ApplicationController
-    include AccessControllable
-    before_action :require_sign_in
+  class SignupSelectionsController < Hub::BaseController
     before_action :set_main_heading, only: [:index, :create]
     load_and_authorize_resource
 

--- a/app/controllers/hub/sites_controller.rb
+++ b/app/controllers/hub/sites_controller.rb
@@ -1,9 +1,6 @@
 module Hub
-  class SitesController < ApplicationController
-    include AccessControllable
-    before_action :require_sign_in
+  class SitesController < Hub::BaseController
     before_action :load_organizations, only: [:new, :create, :edit, :update]
-
     load_and_authorize_resource :site, parent: false
 
     layout "hub"

--- a/app/controllers/hub/source_params_controller.rb
+++ b/app/controllers/hub/source_params_controller.rb
@@ -1,7 +1,5 @@
 module Hub
-  class SourceParamsController < ApplicationController
-    include AccessControllable
-    before_action :require_sign_in
+  class SourceParamsController < Hub::BaseController
     authorize_resource :vita_partner, parent: false, only: :create
 
     def create

--- a/app/controllers/hub/state_routings_controller.rb
+++ b/app/controllers/hub/state_routings_controller.rb
@@ -1,7 +1,5 @@
 module Hub
-  class StateRoutingsController < ApplicationController
-    include AccessControllable
-    before_action :require_sign_in
+  class StateRoutingsController < Hub::BaseController
     before_action :load_state_and_routing_targets, :load_independent_organizations, only: [:edit, :update, :add_organizations]
     authorize_resource :state_routing_target
     layout "hub"

--- a/app/controllers/hub/tax_return_selections_controller.rb
+++ b/app/controllers/hub/tax_return_selections_controller.rb
@@ -1,12 +1,9 @@
 module Hub
-  class TaxReturnSelectionsController < ApplicationController
-    include AccessControllable
+  class TaxReturnSelectionsController < Hub::BaseController
     include ClientSortable
-
-    layout "hub"
-
-    before_action :require_sign_in, :load_vita_partners, :load_users
+    before_action :load_vita_partners, :load_users
     before_action :load_selection, only: [:show]
+    layout "hub"
 
     ALLOWED_ACTION_TYPES = ["change-organization", "send-a-message", "change-assignee-and-status"]
 

--- a/app/controllers/hub/tax_returns/certifications_controller.rb
+++ b/app/controllers/hub/tax_returns/certifications_controller.rb
@@ -1,8 +1,6 @@
 module Hub
   module TaxReturns
-    class CertificationsController < ApplicationController
-      include AccessControllable
-      before_action :require_sign_in
+    class CertificationsController < Hub::BaseController
       load_and_authorize_resource :tax_return, parent: false
 
       def update

--- a/app/controllers/hub/tax_returns_controller.rb
+++ b/app/controllers/hub/tax_returns_controller.rb
@@ -1,9 +1,6 @@
 module Hub
-  class TaxReturnsController < ApplicationController
-    include AccessControllable
+  class TaxReturnsController < Hub::BaseController
     include TaxReturnAssignableUsers
-
-    before_action :require_sign_in
     load_and_authorize_resource except: [:new, :create]
     # on new/create, authorize through client but initialize tax return object
     before_action :load_client, only: [:new, :create]

--- a/app/controllers/hub/tools_controller.rb
+++ b/app/controllers/hub/tools_controller.rb
@@ -1,9 +1,6 @@
 module Hub
-  class ToolsController < ApplicationController
-    include AccessControllable
-    before_action :require_sign_in
+  class ToolsController < Hub::BaseController
     layout "hub"
-
     def index; end
   end
 end

--- a/app/controllers/hub/user_notifications_controller.rb
+++ b/app/controllers/hub/user_notifications_controller.rb
@@ -1,9 +1,6 @@
 module Hub
-  class UserNotificationsController < ApplicationController
-    include AccessControllable
-    before_action :require_sign_in
+  class UserNotificationsController < Hub::BaseController
     layout "hub"
-
     after_action :flush_memoized_data, only: [:index]
 
     def index

--- a/app/controllers/hub/users/strong_passwords_controller.rb
+++ b/app/controllers/hub/users/strong_passwords_controller.rb
@@ -2,7 +2,7 @@ module Hub
   module Users
     class StrongPasswordsController < ApplicationController
       before_action :redirect_away_if_needed
-      before_action :set_cache_headers
+      before_action :set_no_cache_headers
 
       layout "hub"
 

--- a/app/controllers/hub/users/strong_passwords_controller.rb
+++ b/app/controllers/hub/users/strong_passwords_controller.rb
@@ -2,6 +2,7 @@ module Hub
   module Users
     class StrongPasswordsController < ApplicationController
       before_action :redirect_away_if_needed
+      before_action :set_cache_headers
 
       layout "hub"
 

--- a/app/controllers/hub/users_controller.rb
+++ b/app/controllers/hub/users_controller.rb
@@ -1,9 +1,6 @@
 module Hub
-  class UsersController < ApplicationController
-    include AccessControllable
+  class UsersController < Hub::BaseController
     include RoleHelper
-
-    before_action :require_sign_in
     before_action :load_groups, only: [:edit_role, :update_role]
     before_action :load_and_authorize_role, only: [:update_role]
     load_and_authorize_resource

--- a/app/controllers/hub/verification_attempts_controller.rb
+++ b/app/controllers/hub/verification_attempts_controller.rb
@@ -1,8 +1,6 @@
 module Hub
-  class VerificationAttemptsController < ApplicationController
+  class VerificationAttemptsController < Hub::BaseController
     include FilesConcern
-    include AccessControllable
-    before_action :require_sign_in
     helper_method :transient_storage_url
     load_and_authorize_resource
 

--- a/app/controllers/hub/zip_codes_controller.rb
+++ b/app/controllers/hub/zip_codes_controller.rb
@@ -1,7 +1,5 @@
 module Hub
-  class ZipCodesController < ApplicationController
-    include AccessControllable
-    before_action :require_sign_in
+  class ZipCodesController < Hub::BaseController
     authorize_resource :vita_partner_zip_code
     authorize_resource :vita_partner, parent: false, only: :create
 

--- a/spec/features/hub/cache_control_spec.rb
+++ b/spec/features/hub/cache_control_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe "Cache control" do
+  let(:user) { create :admin_user }
+
+  before do
+    login_as user
+  end
+
+  context "user on profile page, logs out and clicks back button", js: true do
+    it "cache is cleared and redirects to the login page" do
+      visit hub_user_profile_path
+      click_on 'Sign out'
+      page.evaluate_script('window.history.back()')
+      expect(page).to have_text "Sign in"
+    end
+  end
+
+  context "user on client page, logs out and clicks back button", js: true do
+    it "cache is cleared and redirects to the login page" do
+      visit hub_clients_path
+      click_on 'Sign out'
+      page.evaluate_script('window.history.back()')
+      expect(page).to have_text "Sign in"
+    end
+  end
+end


### PR DESCRIPTION
This work comes out of [this BugCrowd ticket](https://tracker.bugcrowd.com/code-for-america-mbb/submissions/7b1c21b0-c571-4582-afe5-d3741735687f?duplicate[]=false&sort[]=severity-asc&substate[]=unresolved). Basically in the hub, a user could logout and then click the back button and return to the page that they were previously on. Adding this `set_cache_headers` on the hub basecontroller should clear the cache and prevent this from happening. 

References to this work came from [Arin's PR in GCF](https://github.com/codeforamerica/gcf-backend/pull/8866) and this [stackoverflow post ](https://stackoverflow.com/questions/711418/how-to-prevent-browser-page-caching-in-rails/748646#748646).