### PR TITLE
tie off it-214 UI, tax calculations, and pdf generation

### DIFF
--- a/app/lib/efile/ny/it201.rb
+++ b/app/lib/efile/ny/it201.rb
@@ -19,11 +19,12 @@ module Efile
           lines: @lines,
           intake: @intake
         )
-        @it214 = Efile::Ny::It214.new(
-          value_access_tracker: @value_access_tracker,
-          lines: @lines,
-          intake: @intake
-        )
+        # We aren't supporting the real property tax credit so IT-214 is not needed
+        # @it214 = Efile::Ny::It214.new(
+        #   value_access_tracker: @value_access_tracker,
+        #   lines: @lines,
+        #   intake: @intake
+        # )
         @it215 = Efile::Ny::It215.new(
           value_access_tracker: @value_access_tracker,
           lines: @lines,
@@ -78,8 +79,11 @@ module Efile
         set_line(:IT201_LINE_63, -> { @lines[:IT213_LINE_14].value })
         @it215.calculate
         set_line(:IT201_LINE_65, -> { @lines[:IT215_LINE_16].value })
-        @it214.calculate
-        set_line(:IT201_LINE_67, -> { @lines[:IT214_LINE_33].value })
+        # These two lines would be needed to add support for the IT-214 real property tax credit
+        # We currently aren't supporting this, so IT-201 line 67 is always set to 0
+        # @it214.calculate
+        # set_line(:IT201_LINE_67, -> { @lines[:IT214_LINE_33].value })
+        set_line(:IT201_LINE_67, -> { 0 })
         set_line(:IT201_LINE_69, :calculate_line_69)
         set_line(:IT201_LINE_69A, :calculate_line_69a)
         set_line(:IT201_LINE_70, -> { @lines[:IT215_LINE_27] ? @lines[:IT215_LINE_27].value : 0})

--- a/app/lib/navigation/state_file_ny_question_navigation.rb
+++ b/app/lib/navigation/state_file_ny_question_navigation.rb
@@ -26,7 +26,6 @@ module Navigation
       StateFile::Questions::NySalesUseTaxController,
       StateFile::Questions::NyPrimaryStateIdController,
       StateFile::Questions::NySpouseStateIdController,
-      StateFile::Questions::Ny214Controller,
       StateFile::Questions::UnemploymentController,
       StateFile::Questions::NyReviewController,
       StateFile::Questions::TaxesOwedController,

--- a/app/lib/submission_builder/ty2022/states/ny/individual_return.rb
+++ b/app/lib/submission_builder/ty2022/states/ny/individual_return.rb
@@ -126,8 +126,8 @@ module SubmissionBuilder
           def supported_documents
             tax_calculator = @submission.data_source.tax_calculator
             calculated_fields = tax_calculator.calculate
-            receiving_213_credit = calculated_fields[:IT213_LINE_14] > 0
-            receiving_214_credit = calculated_fields[:IT214_LINE_33] > 0
+            receiving_213_credit = calculated_fields[:IT213_LINE_14].present? && calculated_fields[:IT213_LINE_14] > 0
+            receiving_214_credit = calculated_fields[:IT214_LINE_33].present? && calculated_fields[:IT214_LINE_33] > 0
             supported_docs = [
               {
                 xml: SubmissionBuilder::Ty2022::States::Ny::Documents::RtnHeader,

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -87,9 +87,6 @@ RSpec.feature "Completing a state file intake", active_job: true do
       fill_in  I18n.t('state_file.questions.ny_primary_state_id.state_id.id_details.first_three_doc_num'), with: "ABC"
       click_on I18n.t("general.continue")
 
-      expect(page).to have_text "The page with all the info from the IT-214"
-      click_on I18n.t("general.continue")
-
       expect(page).to have_text I18n.t('state_file.questions.unemployment.edit.title')
       choose I18n.t("general.affirmative")
       choose I18n.t('state_file.questions.unemployment.edit.recipient_myself')

--- a/spec/lib/efile/ny/it201_spec.rb
+++ b/spec/lib/efile/ny/it201_spec.rb
@@ -55,291 +55,293 @@ describe Efile::Ny::It201 do
     end
   end
 
-  describe '#calculate_it214' do
-    context "when the client is not eligible because they didn't occupy their residence" do
-      before do
-        intake.occupied_residence = 2 # no
-      end
-
-      it "stops calculating IT214 after line 2 and sets IT214_LINE_33 to 0" do
-        instance.calculate
-        expect(instance.lines[:IT214_LINE_2].value).to eq(2)
-        expect(instance.lines[:IT214_LINE_3]).to be_nil
-        expect(instance.lines[:IT214_LINE_33].value).to eq(0)
-      end
-    end
-
-    context "when the client is not eligible because the property value is over the limit" do
-      before do
-        intake.occupied_residence = 1 # yes
-        intake.property_over_limit = 1 # yes
-      end
-
-      it "stops calculating IT214 after line 3 and sets IT214_LINE_33 to 0" do
-        instance.calculate
-        expect(instance.lines[:IT214_LINE_3].value).to eq(1)
-        expect(instance.lines[:IT214_LINE_4]).to be_nil
-        expect(instance.lines[:IT214_LINE_33].value).to eq(0)
-      end
-    end
-
-    context "when the client is not eligible because they had public housing" do
-      before do
-        intake.occupied_residence = 1 # yes
-        intake.property_over_limit = 2 # no
-        intake.public_housing = 1 # yes
-      end
-
-      it "stops calculating IT214 after line 5 and sets IT214_LINE_33 to 0" do
-        instance.calculate
-        expect(instance.lines[:IT214_LINE_5].value).to eq(1)
-        expect(instance.lines[:IT214_LINE_6]).to be_nil
-        expect(instance.lines[:IT214_LINE_33].value).to eq(0)
-      end
-    end
-
-    context "when the client is not eligible because they were in a nursing home" do
-      before do
-        intake.occupied_residence = 1 # yes
-        intake.property_over_limit = 2 # no
-        intake.public_housing = 2 # no
-        intake.nursing_home = 1 # yes
-      end
-
-      it "stops calculating IT214 after line 6 and sets IT214_LINE_33 to 0" do
-        instance.calculate
-        expect(instance.lines[:IT214_LINE_6].value).to eq(1)
-        expect(instance.lines[:IT214_LINE_7]).to be_nil
-        expect(instance.lines[:IT214_LINE_33].value).to eq(0)
-      end
-    end
-
-    context "when the client is not eligible because they had too much income" do
-      before do
-        intake.occupied_residence = 1 # yes
-        intake.property_over_limit = 2 # no
-        intake.public_housing = 2 # no
-        intake.nursing_home = 2 # no
-        intake.direct_file_data.fed_agi = 100000
-        intake.direct_file_data.fed_wages = 100000
-      end
-
-      it "stops calculating IT214 after line 16 and sets IT214_LINE_33 to 0" do
-        instance.calculate
-        expect(instance.lines[:IT214_LINE_16].value).to be > 18000
-        expect(instance.lines[:IT214_LINE_17]).to be_nil
-        expect(instance.lines[:IT214_LINE_33].value).to eq(0)
-      end
-    end
-
-    context "when the client is a renter and is ineligible because their rent is too high" do
-      before do
-        intake.occupied_residence = 1 # yes
-        intake.property_over_limit = 2 # no
-        intake.public_housing = 2 # no
-        intake.nursing_home = 2 # no
-        intake.household_rent_own = 1 # rent
-        intake.household_rent_amount = 12000 # annual rent @ $1k/month
-        intake.household_rent_adjustments = 6000 # 50% adjustment to $500/month, over the $450 eligibility threshold
-        intake.direct_file_data.fed_agi = 2500
-        intake.direct_file_data.fed_wages = 900
-        intake.direct_file_data.fed_unemployment = 500
-        intake.direct_file_data.fed_taxable_ssb = 400
-      end
-
-      it "stops calculating IT214 after line 21 and sets IT214_LINE_33 to 0" do
-        instance.calculate
-        expect(instance.lines[:IT214_LINE_17].value).to be 0.06
-        expect(instance.lines[:IT214_LINE_18].value).to be 800
-        expect(instance.lines[:IT214_LINE_19].value).to be 12000
-        expect(instance.lines[:IT214_LINE_19].value).to be 12000
-        expect(instance.lines[:IT214_LINE_20].value).to be 6000
-        expect(instance.lines[:IT214_LINE_21].value).to be 500
-        expect(instance.lines[:IT214_LINE_22]).to be_nil
-        expect(instance.lines[:IT214_LINE_33].value).to eq(0)
-      end
-    end
-
-    context "when the client is a renter and is ineligible because their non-subsidized rent is zero" do
-      before do
-        intake.occupied_residence = 1 # yes
-        intake.property_over_limit = 2 # no
-        intake.public_housing = 2 # no
-        intake.nursing_home = 2 # no
-        intake.household_rent_own = 1 # rent
-        intake.household_rent_amount = 0
-        intake.household_rent_adjustments = 0
-        intake.direct_file_data.fed_agi = 2500
-        intake.direct_file_data.fed_wages = 900
-        intake.direct_file_data.fed_unemployment = 500
-        intake.direct_file_data.fed_taxable_ssb = 400
-      end
-
-      it "stops calculating IT214 after line 28 and sets IT214_LINE_33 to 0" do
-        instance.calculate
-        expect(instance.lines[:IT214_LINE_17].value).to be 0.06
-        expect(instance.lines[:IT214_LINE_18].value).to be 800
-        expect(instance.lines[:IT214_LINE_19].value).to be 0
-        expect(instance.lines[:IT214_LINE_20].value).to be 0
-        expect(instance.lines[:IT214_LINE_21].value).to be 0
-        expect(instance.lines[:IT214_LINE_22].value).to be 0
-        expect(instance.lines[:IT214_LINE_28].value).to be 0
-        expect(instance.lines[:IT214_LINE_29]).to be_nil
-        expect(instance.lines[:IT214_LINE_33].value).to eq(0)
-      end
-    end
-
-    context "when the client is a renter and their rent amount is eligible but they are ineligible because their income is too high relative to their rent" do
-      before do
-        intake.occupied_residence = 1 # yes
-        intake.property_over_limit = 2 # no
-        intake.public_housing = 2 # no
-        intake.nursing_home = 2 # no
-        intake.household_rent_own = 1 # rent
-        intake.household_rent_amount = 6000 # annual rent @ $500/month
-        intake.household_rent_adjustments = 3000 # 50% adjustment to $250/month, under the $450 eligibility threshold
-        intake.direct_file_data.fed_agi = 2500
-        intake.direct_file_data.fed_wages = 900
-        intake.direct_file_data.fed_unemployment = 500
-        intake.direct_file_data.fed_taxable_ssb = 400
-      end
-
-      it "stops calculating IT214 after line 29 and sets IT214_LINE_33 to 0" do
-        instance.calculate
-        expect(instance.lines[:IT214_LINE_17].value).to be 0.06
-        expect(instance.lines[:IT214_LINE_18].value).to be 800
-        expect(instance.lines[:IT214_LINE_19].value).to be 6000
-        expect(instance.lines[:IT214_LINE_20].value).to be 3000
-        expect(instance.lines[:IT214_LINE_21].value).to be 250
-        expect(instance.lines[:IT214_LINE_22].value).to be 750
-        expect(instance.lines[:IT214_LINE_28].value).to be 750 # if this is less than line 18 then the client is ineligible
-        expect(instance.lines[:IT214_LINE_29].value).to be 800
-        expect(instance.lines[:IT214_LINE_30]).to be_nil
-        expect(instance.lines[:IT214_LINE_33].value).to eq(0)
-      end
-    end
-
-    context "when the client is a renter and they are eligible for the credit" do
-      before do
-        intake.occupied_residence = 1 # yes
-        intake.property_over_limit = 2 # no
-        intake.public_housing = 2 # no
-        intake.nursing_home = 2 # no
-        intake.household_rent_own = 1 # rent
-        intake.household_rent_amount = 6000 # annual rent @ $500/month
-        intake.household_rent_adjustments = 3000 # 50% adjustment to $250/month, under the $450 eligibility threshold
-        intake.direct_file_data.fed_agi = 1250
-        intake.direct_file_data.fed_wages = 450
-        intake.direct_file_data.fed_unemployment = 250
-        intake.direct_file_data.fed_taxable_ssb = 200
-      end
-
-      it "finishes calculating IT214 and sets IT214_LINE_33 to the final credit value of $34" do
-        instance.calculate
-        expect(instance.lines[:IT214_LINE_17].value).to be 0.06
-        expect(instance.lines[:IT214_LINE_18].value).to be 683
-        expect(instance.lines[:IT214_LINE_19].value).to be 6000
-        expect(instance.lines[:IT214_LINE_20].value).to be 3000
-        expect(instance.lines[:IT214_LINE_21].value).to be 250
-        expect(instance.lines[:IT214_LINE_22].value).to be 750
-        expect(instance.lines[:IT214_LINE_28].value).to be 750 # if this is less than line 18 then the client is ineligible
-        expect(instance.lines[:IT214_LINE_29].value).to be 683
-        expect(instance.lines[:IT214_LINE_30].value).to be 67
-        expect(instance.lines[:IT214_LINE_31].value).to be 34
-        expect(instance.lines[:IT214_LINE_32].value).to be 53
-        expect(instance.lines[:IT214_LINE_33].value).to be 34
-      end
-    end
-
-    context "when the client is a homeowner and is ineligible because their property taxes and assessments were zero" do
-      before do
-        intake.occupied_residence = 1 # yes
-        intake.property_over_limit = 2 # no
-        intake.public_housing = 2 # no
-        intake.nursing_home = 2 # no
-        intake.household_rent_own = 2 # own
-        intake.household_own_propety_tax = 0
-        intake.household_own_assessments = 0
-        intake.direct_file_data.fed_agi = 2500
-        intake.direct_file_data.fed_wages = 900
-        intake.direct_file_data.fed_unemployment = 500
-        intake.direct_file_data.fed_taxable_ssb = 400
-      end
-
-      it "stops calculating IT214 after line 28 and sets IT214_LINE_33 to 0" do
-        instance.calculate
-        expect(instance.lines[:IT214_LINE_17].value).to be 0.06
-        expect(instance.lines[:IT214_LINE_18].value).to be 800
-        expect(instance.lines[:IT214_LINE_23].value).to be 0
-        expect(instance.lines[:IT214_LINE_24].value).to be 0
-        expect(instance.lines[:IT214_LINE_25].value).to be 0
-        expect(instance.lines[:IT214_LINE_27].value).to be 0
-        expect(instance.lines[:IT214_LINE_28].value).to be 0
-        expect(instance.lines[:IT214_LINE_29]).to be_nil
-        expect(instance.lines[:IT214_LINE_33].value).to eq(0)
-      end
-    end
-
-    context "when the client is a homeowner with property tax and assessments but they are ineligible because their income is too high relative to their home costs" do
-      before do
-        intake.occupied_residence = 1 # yes
-        intake.property_over_limit = 2 # no
-        intake.public_housing = 2 # no
-        intake.nursing_home = 2 # no
-        intake.household_rent_own = 2 # own
-        intake.household_own_propety_tax = 500
-        intake.household_own_assessments = 250
-        intake.direct_file_data.fed_agi = 2500
-        intake.direct_file_data.fed_wages = 900
-        intake.direct_file_data.fed_unemployment = 500
-        intake.direct_file_data.fed_taxable_ssb = 400
-      end
-
-      it "stops calculating IT214 after line 28 and sets IT214_LINE_33 to 0" do
-        instance.calculate
-        expect(instance.lines[:IT214_LINE_17].value).to be 0.06
-        expect(instance.lines[:IT214_LINE_18].value).to be 800
-        expect(instance.lines[:IT214_LINE_23].value).to be 500
-        expect(instance.lines[:IT214_LINE_24].value).to be 250
-        expect(instance.lines[:IT214_LINE_25].value).to be 750
-        expect(instance.lines[:IT214_LINE_27].value).to be 750
-        expect(instance.lines[:IT214_LINE_28].value).to be 750 # if this is less than line 18 the client is ineligible
-        expect(instance.lines[:IT214_LINE_29].value).to be 800
-        expect(instance.lines[:IT214_LINE_30]).to be_nil
-        expect(instance.lines[:IT214_LINE_33].value).to eq(0)
-      end
-    end
-
-    context "when the client is a homeowner and they are eligible for the credit" do
-      before do
-        intake.occupied_residence = 1 # yes
-        intake.property_over_limit = 2 # no
-        intake.public_housing = 2 # no
-        intake.nursing_home = 2 # no
-        intake.household_rent_own = 2 # own
-        intake.household_own_propety_tax = 5000
-        intake.household_own_assessments = 2500
-        intake.direct_file_data.fed_agi = 2500
-        intake.direct_file_data.fed_wages = 900
-        intake.direct_file_data.fed_unemployment = 500
-        intake.direct_file_data.fed_taxable_ssb = 400
-      end
-
-      it "finishes calculating IT214 and sets IT214_LINE_33 to the final credit value of $49" do
-        instance.calculate
-        expect(instance.lines[:IT214_LINE_17].value).to be 0.06
-        expect(instance.lines[:IT214_LINE_18].value).to be 800
-        expect(instance.lines[:IT214_LINE_23].value).to be 5000
-        expect(instance.lines[:IT214_LINE_24].value).to be 2500
-        expect(instance.lines[:IT214_LINE_25].value).to be 7500
-        expect(instance.lines[:IT214_LINE_27].value).to be 7500
-        expect(instance.lines[:IT214_LINE_28].value).to be 7500 # if this is less than line 18 the client is ineligible
-        expect(instance.lines[:IT214_LINE_29].value).to be 800
-        expect(instance.lines[:IT214_LINE_30].value).to be 6700
-        expect(instance.lines[:IT214_LINE_31].value).to be 3350
-        expect(instance.lines[:IT214_LINE_32].value).to be 49
-        expect(instance.lines[:IT214_LINE_33].value).to be 49
-      end
-    end
-  end
+  # We aren't supporting IT-214 anymore, so the calculations being tested here aren't running. Restore these tests
+  # if we ever implement this tax credit again.
+  # describe '#calculate_it214' do
+  #   context "when the client is not eligible because they didn't occupy their residence" do
+  #     before do
+  #       intake.occupied_residence = 2 # no
+  #     end
+  #
+  #     it "stops calculating IT214 after line 2 and sets IT214_LINE_33 to 0" do
+  #       instance.calculate
+  #       expect(instance.lines[:IT214_LINE_2].value).to eq(2)
+  #       expect(instance.lines[:IT214_LINE_3]).to be_nil
+  #       expect(instance.lines[:IT214_LINE_33].value).to eq(0)
+  #     end
+  #   end
+  #
+  #   context "when the client is not eligible because the property value is over the limit" do
+  #     before do
+  #       intake.occupied_residence = 1 # yes
+  #       intake.property_over_limit = 1 # yes
+  #     end
+  #
+  #     it "stops calculating IT214 after line 3 and sets IT214_LINE_33 to 0" do
+  #       instance.calculate
+  #       expect(instance.lines[:IT214_LINE_3].value).to eq(1)
+  #       expect(instance.lines[:IT214_LINE_4]).to be_nil
+  #       expect(instance.lines[:IT214_LINE_33].value).to eq(0)
+  #     end
+  #   end
+  #
+  #   context "when the client is not eligible because they had public housing" do
+  #     before do
+  #       intake.occupied_residence = 1 # yes
+  #       intake.property_over_limit = 2 # no
+  #       intake.public_housing = 1 # yes
+  #     end
+  #
+  #     it "stops calculating IT214 after line 5 and sets IT214_LINE_33 to 0" do
+  #       instance.calculate
+  #       expect(instance.lines[:IT214_LINE_5].value).to eq(1)
+  #       expect(instance.lines[:IT214_LINE_6]).to be_nil
+  #       expect(instance.lines[:IT214_LINE_33].value).to eq(0)
+  #     end
+  #   end
+  #
+  #   context "when the client is not eligible because they were in a nursing home" do
+  #     before do
+  #       intake.occupied_residence = 1 # yes
+  #       intake.property_over_limit = 2 # no
+  #       intake.public_housing = 2 # no
+  #       intake.nursing_home = 1 # yes
+  #     end
+  #
+  #     it "stops calculating IT214 after line 6 and sets IT214_LINE_33 to 0" do
+  #       instance.calculate
+  #       expect(instance.lines[:IT214_LINE_6].value).to eq(1)
+  #       expect(instance.lines[:IT214_LINE_7]).to be_nil
+  #       expect(instance.lines[:IT214_LINE_33].value).to eq(0)
+  #     end
+  #   end
+  #
+  #   context "when the client is not eligible because they had too much income" do
+  #     before do
+  #       intake.occupied_residence = 1 # yes
+  #       intake.property_over_limit = 2 # no
+  #       intake.public_housing = 2 # no
+  #       intake.nursing_home = 2 # no
+  #       intake.direct_file_data.fed_agi = 100000
+  #       intake.direct_file_data.fed_wages = 100000
+  #     end
+  #
+  #     it "stops calculating IT214 after line 16 and sets IT214_LINE_33 to 0" do
+  #       instance.calculate
+  #       expect(instance.lines[:IT214_LINE_16].value).to be > 18000
+  #       expect(instance.lines[:IT214_LINE_17]).to be_nil
+  #       expect(instance.lines[:IT214_LINE_33].value).to eq(0)
+  #     end
+  #   end
+  #
+  #   context "when the client is a renter and is ineligible because their rent is too high" do
+  #     before do
+  #       intake.occupied_residence = 1 # yes
+  #       intake.property_over_limit = 2 # no
+  #       intake.public_housing = 2 # no
+  #       intake.nursing_home = 2 # no
+  #       intake.household_rent_own = 1 # rent
+  #       intake.household_rent_amount = 12000 # annual rent @ $1k/month
+  #       intake.household_rent_adjustments = 6000 # 50% adjustment to $500/month, over the $450 eligibility threshold
+  #       intake.direct_file_data.fed_agi = 2500
+  #       intake.direct_file_data.fed_wages = 900
+  #       intake.direct_file_data.fed_unemployment = 500
+  #       intake.direct_file_data.fed_taxable_ssb = 400
+  #     end
+  #
+  #     it "stops calculating IT214 after line 21 and sets IT214_LINE_33 to 0" do
+  #       instance.calculate
+  #       expect(instance.lines[:IT214_LINE_17].value).to be 0.06
+  #       expect(instance.lines[:IT214_LINE_18].value).to be 800
+  #       expect(instance.lines[:IT214_LINE_19].value).to be 12000
+  #       expect(instance.lines[:IT214_LINE_19].value).to be 12000
+  #       expect(instance.lines[:IT214_LINE_20].value).to be 6000
+  #       expect(instance.lines[:IT214_LINE_21].value).to be 500
+  #       expect(instance.lines[:IT214_LINE_22]).to be_nil
+  #       expect(instance.lines[:IT214_LINE_33].value).to eq(0)
+  #     end
+  #   end
+  #
+  #   context "when the client is a renter and is ineligible because their non-subsidized rent is zero" do
+  #     before do
+  #       intake.occupied_residence = 1 # yes
+  #       intake.property_over_limit = 2 # no
+  #       intake.public_housing = 2 # no
+  #       intake.nursing_home = 2 # no
+  #       intake.household_rent_own = 1 # rent
+  #       intake.household_rent_amount = 0
+  #       intake.household_rent_adjustments = 0
+  #       intake.direct_file_data.fed_agi = 2500
+  #       intake.direct_file_data.fed_wages = 900
+  #       intake.direct_file_data.fed_unemployment = 500
+  #       intake.direct_file_data.fed_taxable_ssb = 400
+  #     end
+  #
+  #     it "stops calculating IT214 after line 28 and sets IT214_LINE_33 to 0" do
+  #       instance.calculate
+  #       expect(instance.lines[:IT214_LINE_17].value).to be 0.06
+  #       expect(instance.lines[:IT214_LINE_18].value).to be 800
+  #       expect(instance.lines[:IT214_LINE_19].value).to be 0
+  #       expect(instance.lines[:IT214_LINE_20].value).to be 0
+  #       expect(instance.lines[:IT214_LINE_21].value).to be 0
+  #       expect(instance.lines[:IT214_LINE_22].value).to be 0
+  #       expect(instance.lines[:IT214_LINE_28].value).to be 0
+  #       expect(instance.lines[:IT214_LINE_29]).to be_nil
+  #       expect(instance.lines[:IT214_LINE_33].value).to eq(0)
+  #     end
+  #   end
+  #
+  #   context "when the client is a renter and their rent amount is eligible but they are ineligible because their income is too high relative to their rent" do
+  #     before do
+  #       intake.occupied_residence = 1 # yes
+  #       intake.property_over_limit = 2 # no
+  #       intake.public_housing = 2 # no
+  #       intake.nursing_home = 2 # no
+  #       intake.household_rent_own = 1 # rent
+  #       intake.household_rent_amount = 6000 # annual rent @ $500/month
+  #       intake.household_rent_adjustments = 3000 # 50% adjustment to $250/month, under the $450 eligibility threshold
+  #       intake.direct_file_data.fed_agi = 2500
+  #       intake.direct_file_data.fed_wages = 900
+  #       intake.direct_file_data.fed_unemployment = 500
+  #       intake.direct_file_data.fed_taxable_ssb = 400
+  #     end
+  #
+  #     it "stops calculating IT214 after line 29 and sets IT214_LINE_33 to 0" do
+  #       instance.calculate
+  #       expect(instance.lines[:IT214_LINE_17].value).to be 0.06
+  #       expect(instance.lines[:IT214_LINE_18].value).to be 800
+  #       expect(instance.lines[:IT214_LINE_19].value).to be 6000
+  #       expect(instance.lines[:IT214_LINE_20].value).to be 3000
+  #       expect(instance.lines[:IT214_LINE_21].value).to be 250
+  #       expect(instance.lines[:IT214_LINE_22].value).to be 750
+  #       expect(instance.lines[:IT214_LINE_28].value).to be 750 # if this is less than line 18 then the client is ineligible
+  #       expect(instance.lines[:IT214_LINE_29].value).to be 800
+  #       expect(instance.lines[:IT214_LINE_30]).to be_nil
+  #       expect(instance.lines[:IT214_LINE_33].value).to eq(0)
+  #     end
+  #   end
+  #
+  #   context "when the client is a renter and they are eligible for the credit" do
+  #     before do
+  #       intake.occupied_residence = 1 # yes
+  #       intake.property_over_limit = 2 # no
+  #       intake.public_housing = 2 # no
+  #       intake.nursing_home = 2 # no
+  #       intake.household_rent_own = 1 # rent
+  #       intake.household_rent_amount = 6000 # annual rent @ $500/month
+  #       intake.household_rent_adjustments = 3000 # 50% adjustment to $250/month, under the $450 eligibility threshold
+  #       intake.direct_file_data.fed_agi = 1250
+  #       intake.direct_file_data.fed_wages = 450
+  #       intake.direct_file_data.fed_unemployment = 250
+  #       intake.direct_file_data.fed_taxable_ssb = 200
+  #     end
+  #
+  #     it "finishes calculating IT214 and sets IT214_LINE_33 to the final credit value of $34" do
+  #       instance.calculate
+  #       expect(instance.lines[:IT214_LINE_17].value).to be 0.06
+  #       expect(instance.lines[:IT214_LINE_18].value).to be 683
+  #       expect(instance.lines[:IT214_LINE_19].value).to be 6000
+  #       expect(instance.lines[:IT214_LINE_20].value).to be 3000
+  #       expect(instance.lines[:IT214_LINE_21].value).to be 250
+  #       expect(instance.lines[:IT214_LINE_22].value).to be 750
+  #       expect(instance.lines[:IT214_LINE_28].value).to be 750 # if this is less than line 18 then the client is ineligible
+  #       expect(instance.lines[:IT214_LINE_29].value).to be 683
+  #       expect(instance.lines[:IT214_LINE_30].value).to be 67
+  #       expect(instance.lines[:IT214_LINE_31].value).to be 34
+  #       expect(instance.lines[:IT214_LINE_32].value).to be 53
+  #       expect(instance.lines[:IT214_LINE_33].value).to be 34
+  #     end
+  #   end
+  #
+  #   context "when the client is a homeowner and is ineligible because their property taxes and assessments were zero" do
+  #     before do
+  #       intake.occupied_residence = 1 # yes
+  #       intake.property_over_limit = 2 # no
+  #       intake.public_housing = 2 # no
+  #       intake.nursing_home = 2 # no
+  #       intake.household_rent_own = 2 # own
+  #       intake.household_own_propety_tax = 0
+  #       intake.household_own_assessments = 0
+  #       intake.direct_file_data.fed_agi = 2500
+  #       intake.direct_file_data.fed_wages = 900
+  #       intake.direct_file_data.fed_unemployment = 500
+  #       intake.direct_file_data.fed_taxable_ssb = 400
+  #     end
+  #
+  #     it "stops calculating IT214 after line 28 and sets IT214_LINE_33 to 0" do
+  #       instance.calculate
+  #       expect(instance.lines[:IT214_LINE_17].value).to be 0.06
+  #       expect(instance.lines[:IT214_LINE_18].value).to be 800
+  #       expect(instance.lines[:IT214_LINE_23].value).to be 0
+  #       expect(instance.lines[:IT214_LINE_24].value).to be 0
+  #       expect(instance.lines[:IT214_LINE_25].value).to be 0
+  #       expect(instance.lines[:IT214_LINE_27].value).to be 0
+  #       expect(instance.lines[:IT214_LINE_28].value).to be 0
+  #       expect(instance.lines[:IT214_LINE_29]).to be_nil
+  #       expect(instance.lines[:IT214_LINE_33].value).to eq(0)
+  #     end
+  #   end
+  #
+  #   context "when the client is a homeowner with property tax and assessments but they are ineligible because their income is too high relative to their home costs" do
+  #     before do
+  #       intake.occupied_residence = 1 # yes
+  #       intake.property_over_limit = 2 # no
+  #       intake.public_housing = 2 # no
+  #       intake.nursing_home = 2 # no
+  #       intake.household_rent_own = 2 # own
+  #       intake.household_own_propety_tax = 500
+  #       intake.household_own_assessments = 250
+  #       intake.direct_file_data.fed_agi = 2500
+  #       intake.direct_file_data.fed_wages = 900
+  #       intake.direct_file_data.fed_unemployment = 500
+  #       intake.direct_file_data.fed_taxable_ssb = 400
+  #     end
+  #
+  #     it "stops calculating IT214 after line 28 and sets IT214_LINE_33 to 0" do
+  #       instance.calculate
+  #       expect(instance.lines[:IT214_LINE_17].value).to be 0.06
+  #       expect(instance.lines[:IT214_LINE_18].value).to be 800
+  #       expect(instance.lines[:IT214_LINE_23].value).to be 500
+  #       expect(instance.lines[:IT214_LINE_24].value).to be 250
+  #       expect(instance.lines[:IT214_LINE_25].value).to be 750
+  #       expect(instance.lines[:IT214_LINE_27].value).to be 750
+  #       expect(instance.lines[:IT214_LINE_28].value).to be 750 # if this is less than line 18 the client is ineligible
+  #       expect(instance.lines[:IT214_LINE_29].value).to be 800
+  #       expect(instance.lines[:IT214_LINE_30]).to be_nil
+  #       expect(instance.lines[:IT214_LINE_33].value).to eq(0)
+  #     end
+  #   end
+  #
+  #   context "when the client is a homeowner and they are eligible for the credit" do
+  #     before do
+  #       intake.occupied_residence = 1 # yes
+  #       intake.property_over_limit = 2 # no
+  #       intake.public_housing = 2 # no
+  #       intake.nursing_home = 2 # no
+  #       intake.household_rent_own = 2 # own
+  #       intake.household_own_propety_tax = 5000
+  #       intake.household_own_assessments = 2500
+  #       intake.direct_file_data.fed_agi = 2500
+  #       intake.direct_file_data.fed_wages = 900
+  #       intake.direct_file_data.fed_unemployment = 500
+  #       intake.direct_file_data.fed_taxable_ssb = 400
+  #     end
+  #
+  #     it "finishes calculating IT214 and sets IT214_LINE_33 to the final credit value of $49" do
+  #       instance.calculate
+  #       expect(instance.lines[:IT214_LINE_17].value).to be 0.06
+  #       expect(instance.lines[:IT214_LINE_18].value).to be 800
+  #       expect(instance.lines[:IT214_LINE_23].value).to be 5000
+  #       expect(instance.lines[:IT214_LINE_24].value).to be 2500
+  #       expect(instance.lines[:IT214_LINE_25].value).to be 7500
+  #       expect(instance.lines[:IT214_LINE_27].value).to be 7500
+  #       expect(instance.lines[:IT214_LINE_28].value).to be 7500 # if this is less than line 18 the client is ineligible
+  #       expect(instance.lines[:IT214_LINE_29].value).to be 800
+  #       expect(instance.lines[:IT214_LINE_30].value).to be 6700
+  #       expect(instance.lines[:IT214_LINE_31].value).to be 3350
+  #       expect(instance.lines[:IT214_LINE_32].value).to be 49
+  #       expect(instance.lines[:IT214_LINE_33].value).to be 49
+  #     end
+  #   end
+  # end
 end

--- a/spec/lib/pdf_filler/ny214_pdf_spec.rb
+++ b/spec/lib/pdf_filler/ny214_pdf_spec.rb
@@ -33,32 +33,34 @@ RSpec.describe PdfFiller::Ny214Pdf do
     end
   end
 
-  describe '#hash_for_pdf' do
-    let(:pdf_fields) { filled_in_values(submission.generate_filing_pdf.path) }
-
-    it 'uses field names that exist in the pdf' do
-      missing_fields = pdf.hash_for_pdf.keys.map { |k| k.gsub("'", "&apos;").to_s } - pdf_fields.keys
-      expect(missing_fields).to eq([])
-    end
-
-    context "when the household are homeowners" do
-      it 'calculates the IT214 lines correctly' do
-        expect(pdf_fields['19 dollars14']).to eq ""
-        expect(pdf_fields['27 dollars14']).not_to be_nil
-      end
-    end
-
-    context 'when the household rents' do
-      before do
-        intake.household_rent_own = 'rent'
-        intake.household_rent_amount = 4800
-        intake.household_rent_adjustments = 4800
-      end
-
-      it 'calculates the IT214 lines correctly' do
-        expect(pdf_fields['19 dollars14']).not_to be_nil
-        expect(pdf_fields['27 dollars14']).to eq ""
-      end
-    end
-  end
+  # We aren't supporting IT-214 currently so the generated submission will never contain the values these tests expect
+  # We should reinstate these tests if we ever add IT-214 support back in.
+  # describe '#hash_for_pdf' do
+  #   let(:pdf_fields) { filled_in_values(submission.generate_filing_pdf.path) }
+  #
+  #   it 'uses field names that exist in the pdf' do
+  #     missing_fields = pdf.hash_for_pdf.keys.map { |k| k.gsub("'", "&apos;").to_s } - pdf_fields.keys
+  #     expect(missing_fields).to eq([])
+  #   end
+  #
+  #   context "when the household are homeowners" do
+  #     it 'calculates the IT214 lines correctly' do
+  #       expect(pdf_fields['19 dollars14']).to eq ""
+  #       expect(pdf_fields['27 dollars14']).not_to be_nil
+  #     end
+  #   end
+  #
+  #   context 'when the household rents' do
+  #     before do
+  #       intake.household_rent_own = 'rent'
+  #       intake.household_rent_amount = 4800
+  #       intake.household_rent_adjustments = 4800
+  #     end
+  #
+  #     it 'calculates the IT214 lines correctly' do
+  #       expect(pdf_fields['19 dollars14']).not_to be_nil
+  #       expect(pdf_fields['27 dollars14']).to eq ""
+  #     end
+  #   end
+  # end
 end


### PR DESCRIPTION
- deleted the IT-214 question page from the UI, which was a placeholder anyway
- commented out the tax calculations and pdf generation and related tests rather than deleting, in case there's any chance we'd want to bring support for this back later in the tax season