### PR TITLE
State file style: add blue box styles

### DIFF
--- a/app/assets/stylesheets/_state-file.scss
+++ b/app/assets/stylesheets/_state-file.scss
@@ -26,8 +26,8 @@
   .blue-group {
     padding: 1.9rem;
     margin-bottom: 2.5rem;
-    background: #E7F6F8;
-    border: 2px solid #52DAF2;
+    background: $color-state-file-blue-box;
+    border: 2px solid $color-state-file-blue-box-border;
     border-radius: 6px;
   }
 

--- a/app/assets/stylesheets/_state-file.scss
+++ b/app/assets/stylesheets/_state-file.scss
@@ -23,6 +23,14 @@
     }
   }
 
+  .blue-group {
+    padding: 1.9rem;
+    margin-bottom: 2.5rem;
+    background: #E7F6F8;
+    border: 2px solid #52DAF2;
+    border-radius: 6px;
+  }
+
   .button {
     border-radius: 0.4rem;
     font-size: 2.2rem;
@@ -58,6 +66,12 @@
 
   .form-card {
     background-color: transparent;
+
+    .blue-group {
+      .form-group:last-child {
+        margin-bottom: 0;
+      }
+    }
   }
 
   .h1 {

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -39,6 +39,8 @@ $color-focused-link: #000000;
 $color-az-grey: #3C3A3A;
 $color-ny-blue: #184A72;
 $color-state-file-bg: #FBFCF7;
+$color-state-file-blue-box: #E7F6F8;
+$color-state-file-blue-box-border: #52DAF2;
 
 // Size
 $intake-max-width: 570px;

--- a/app/views/state_file/questions/az_charitable_contributions/edit.html.erb
+++ b/app/views/state_file/questions/az_charitable_contributions/edit.html.erb
@@ -5,7 +5,7 @@
   <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
     <div class="question-with-follow-up">
       <div class="question-with-follow-up__question">
-        <div class="highlight-box highlight-box--blue spacing-below-15">
+        <div class="blue-group spacing-below-15">
           <div class="spacing-below-5">
             <%= f.cfa_radio_set(:charitable_contributions, collection: [
               { value: "yes", label: t("general.affirmative"), input_html: { "data-follow-up": "#charitable_contributions" } },
@@ -15,7 +15,7 @@
         </div>
       </div>
       <div class="question-with-follow-up__follow-up" id="charitable_contributions">
-        <div class="highlight-box highlight-box--blue spacing-below-15">
+        <div class="blue-group spacing-below-15">
           <div class="spacing-below-25">
             <%= f.cfa_input_field(:charitable_cash, t(".charitable_cash"), classes: ["form-width--long"]) %>
           </div>

--- a/app/views/state_file/questions/az_prior_last_names/edit.html.erb
+++ b/app/views/state_file/questions/az_prior_last_names/edit.html.erb
@@ -8,7 +8,7 @@
 
     <div class="question-with-follow-up">
       <div class="question-with-follow-up__question">
-        <div class="highlight-box highlight-box--blue spacing-below-15">
+        <div class="blue-group spacing-below-15">
           <div class="spacing-below-5">
             <%= f.cfa_radio_set(:has_prior_last_names, collection: [
               { value: "yes", label: t("general.affirmative"), input_html: { "data-follow-up": "#prior-last-names" } },
@@ -18,7 +18,7 @@
         </div>
       </div>
       <div class="question-with-follow-up__follow-up" id="prior-last-names">
-        <div class="highlight-box highlight-box--blue spacing-below-15">
+        <div class="blue-group spacing-below-15">
           <div class="spacing-below-5">
             <%= f.cfa_input_field(:prior_last_names, t(".prior_last_names_label"), classes: ["form-width--long"]) %>
           </div>

--- a/app/views/state_file/questions/az_review/edit.html.erb
+++ b/app/views/state_file/questions/az_review/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :card do %>
   <%= render "state_file/questions/shared/review_header", us_state: 'az' %>
 
-  <div id="prior-last-names" class="highlight-box highlight-box--blue spacing-below-15">
+  <div id="prior-last-names" class="blue-group spacing-below-15">
     <div class="spacing-below-5">
       <p class="text--bold spacing-below-5"><%=t(".last_names") %></p>
       <p><%=current_intake.prior_last_names || t("general.none") %></p>
@@ -10,7 +10,7 @@
     </div>
   </div>
 
-  <div id="state-credits" class="highlight-box highlight-box--blue spacing-below-15">
+  <div id="state-credits" class="blue-group spacing-below-15">
     <div class="spacing-below-5">
       <p class="text--bold spacing-below-5"><%=t(".tribal_member") %></p>
       <p><%=current_intake.tribal_member_yes? ? t("general.affirmative") : t("general.negative") %></p>
@@ -28,7 +28,7 @@
     </div>
   </div>
 
-  <div id="charitable-contributions" class="highlight-box highlight-box--blue spacing-below-25">
+  <div id="charitable-contributions" class="blue-group spacing-below-25">
     <div class="spacing-below-5">
       <p class="text--bold spacing-below-5"><%=t(".charitable_contributions") %></p>
       <p><%=current_intake.charitable_contributions_yes? ? t("general.affirmative") : t("general.negative") %></p>

--- a/app/views/state_file/questions/az_senior_dependents/edit.html.erb
+++ b/app/views/state_file/questions/az_senior_dependents/edit.html.erb
@@ -5,7 +5,7 @@
 
   <%= form_with model: @form, url: { action: :update }, method: :put, local: true, builder: VitaMinFormBuilder, class: 'form-card' do |f| %>
     <%= f.fields_for :dependents do |ff| %>
-        <div class="highlight-box highlight-box--blue spacing-below-15">
+        <div class="blue-group spacing-below-15">
           <div class="spacing-below-5">
             <%= ff.cfa_radio_set(
                   :needed_assistance,
@@ -17,7 +17,7 @@
                 ) %>
           </div>
         </div>
-        <div class="highlight-box highlight-box--blue spacing-below-15">
+        <div class="blue-group spacing-below-15">
           <div class="spacing-below-5">
             <%= ff.cfa_radio_set(
                   :passed_away,

--- a/app/views/state_file/questions/az_state_credits/edit.html.erb
+++ b/app/views/state_file/questions/az_state_credits/edit.html.erb
@@ -6,7 +6,7 @@
   <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
     <div class="question-with-follow-up spacing-below-15">
       <div class="question-with-follow-up__question">
-        <div class="highlight-box highlight-box--blue spacing-below-15">
+        <div class="blue-group spacing-below-15">
           <div class="spacing-below-5">
             <%= f.cfa_checkbox(:tribal_member, t(".tribal_member_label_html"),
                                options: { checked_value: "yes", unchecked_value: "no", "data-follow-up": "#tribal-wages" })
@@ -15,7 +15,7 @@
         </div>
       </div>
       <div class="question-with-follow-up__follow-up" id="tribal-wages">
-        <div class="highlight-box highlight-box--blue spacing-below-15">
+        <div class="blue-group spacing-below-15">
           <div class="spacing-below-25">
             <%=t(".tribal_wages_label_html",
                     wages: number_to_currency(f.object&.intake&.direct_file_data&.fed_wages)) %>
@@ -34,7 +34,7 @@
 
     <div class="question-with-follow-up spacing-below-15">
       <div class="question-with-follow-up__question">
-        <div class="highlight-box highlight-box--blue spacing-below-15">
+        <div class="blue-group spacing-below-15">
           <div class="spacing-below-5">
             <%= f.cfa_checkbox(:armed_forces_member, t(".armed_forces_member_label"),
                                options: { checked_value: "yes", unchecked_value: "no", "data-follow-up": "#armed-forces-wages" })
@@ -43,7 +43,7 @@
         </div>
       </div>
       <div class="question-with-follow-up__follow-up" id="armed-forces-wages">
-        <div class="highlight-box highlight-box--blue spacing-below-15">
+        <div class="blue-group spacing-below-15">
           <div class="spacing-below-25">
             <%=t(".armed_forces_wages_label_html",
                  wages: number_to_currency(f.object&.intake&.direct_file_data&.fed_wages)) %>

--- a/app/views/state_file/questions/name_dob/edit.html.erb
+++ b/app/views/state_file/questions/name_dob/edit.html.erb
@@ -5,7 +5,7 @@
   <p><%= t('.title2') %></p>
 
   <%= form_with model: @form, url: { action: :update }, method: :put, local: true, builder: VitaMinFormBuilder, class: 'form-card' do |f| %>
-    <div class="highlight-box highlight-box--blue spacing-below-15">
+    <div class="blue-group spacing-below-15">
       <p><%= t(".primary_name") %></p>
       <%= f.cfa_input_field(:primary_first_name, t("general.first_name"), classes: ["form-width--long"]) %>
       <%= f.cfa_input_field(:primary_last_name, t("general.last_name"), classes: ["form-width--long"]) %>
@@ -21,7 +21,7 @@
       <% end %>
     </div>
     <% if f.object.ask_spouse_name?  %>
-      <div class="highlight-box highlight-box--blue spacing-below-15">
+      <div class="blue-group spacing-below-15">
         <p><%= t(".spouse_name") %></p>
         <%= f.cfa_input_field(:spouse_first_name, t("general.first_name"), classes: ["form-width--long"]) %>
         <%= f.cfa_input_field(:spouse_last_name, t("general.last_name"), classes: ["form-width--long"]) %>
@@ -39,7 +39,7 @@
     <% end %>
 
     <%= f.fields_for :dependents do |ff| %>
-      <div id="dependent-<%= ff.index %>" class="highlight-box highlight-box--blue spacing-below-15">
+      <div id="dependent-<%= ff.index %>" class="blue-group spacing-below-15">
 
         <p><%= t(".dependent_name_dob", number: number_in_words(ff.index + 1))%></p>
 

--- a/app/views/state_file/questions/ny_primary_state_id/_state_id.html.erb
+++ b/app/views/state_file/questions/ny_primary_state_id/_state_id.html.erb
@@ -1,6 +1,6 @@
 <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
   <div class="question-with-follow-up spacing-below-25">
-    <div class="question-with-follow-up__question highlight-box highlight-box--blue spacing-below-15">
+    <div class="question-with-follow-up__question blue-group spacing-below-15">
       <%=
         f.cfa_radio_set(
           :id_type,
@@ -14,7 +14,7 @@
       %>
     </div>
     <div class="question-with-follow-up__follow-up" id="id-details-fields">
-      <div class="highlight-box highlight-box--blue spacing-below-15">
+      <div class="blue-group spacing-below-15">
         <%= f.cfa_input_field(:id_number, t("state_file.questions.primary_state_id.state_id.id_details.number"), classes: ["form-width--long, spacing-below-15"]) %>
         <%= f.cfa_date_select(:issue_date,
                               t("state_file.questions.primary_state_id.state_id.id_details.issue_month") + " / " + t("state_file.questions.primary_state_id.state_id.id_details.issue_day") + " / " + t("state_file.questions.primary_state_id.state_id.id_details.issue_year"),

--- a/app/views/state_file/questions/ny_review/edit.html.erb
+++ b/app/views/state_file/questions/ny_review/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :card do %>
   <%= render "state_file/questions/shared/review_header", us_state: 'ny' %>
 
-  <div id="full-year-resident" class="highlight-box highlight-box--blue spacing-below-25 padding-20">
+  <div id="full-year-resident" class="blue-group spacing-below-25 padding-20">
     <div class="spacing-below-5">
       <p class="text--bold spacing-below-5"><%=t(".nyc_full_year_resident") %></p>
       <p><%=current_intake.nyc_full_year_resident_yes? ? t("general.affirmative") : t("general.negative") %></p>
@@ -10,7 +10,7 @@
     </div>
   </div>
 
-  <div id="county" class="highlight-box highlight-box--blue spacing-below-25 padding-20">
+  <div id="county" class="blue-group spacing-below-25 padding-20">
     <div class="spacing-below-5">
       <p class="text--bold spacing-below-5"><%=t(".residence_county") %></p>
       <p><%=current_intake.residence_county %></p>
@@ -18,7 +18,7 @@
     </div>
   </div>
 
-  <div id="school-district" class="highlight-box highlight-box--blue spacing-below-25 padding-20">
+  <div id="school-district" class="blue-group spacing-below-25 padding-20">
     <div class="spacing-below-5">
       <p class="text--bold spacing-below-5"><%=t(".school_district") %></p>
       <p><%=current_intake.school_district %></p>
@@ -26,7 +26,7 @@
     </div>
   </div>
 
-  <div id="use-tax" class="highlight-box highlight-box--blue spacing-below-25 padding-20">
+  <div id="use-tax" class="blue-group spacing-below-25 padding-20">
     <div class="spacing-below-5">
       <p class="text--bold spacing-below-5"><%=t(".out_of_state_purchases") %></p>
       <p><%=current_intake.untaxed_out_of_state_purchases_yes? ? t("general.affirmative") : t("general.negative") %>&nbsp;<%=number_to_currency(current_intake.sales_use_tax) %></p>

--- a/app/views/state_file/questions/ny_sales_use_tax/edit.html.erb
+++ b/app/views/state_file/questions/ny_sales_use_tax/edit.html.erb
@@ -18,7 +18,7 @@
         %>
       </div>
       <div class="question-with-follow-up__follow-up" id="sut-method-field">
-        <div class="question-with-follow-up highlight-box highlight-box--blue">
+        <div class="question-with-follow-up blue-group">
           <div class="question-with-follow-up__question">
             <%=
               f.cfa_radio_set(

--- a/app/views/state_file/questions/shared/_review_header.html.erb
+++ b/app/views/state_file/questions/shared/_review_header.html.erb
@@ -2,13 +2,13 @@
 
 <div class="review-header">
   <% if @refund_or_owed_amount == 0 %>
-    <div class="highlight-box highlight-box--blue spacing-below-15 padding-20">
+    <div class="blue-group spacing-below-15 padding-20">
       <div class="spacing-below-5">
         <%= t(".taxes_owed_html") %>
       </div>
     </div>
   <% else %>
-    <div class="highlight-box highlight-box--blue spacing-below-15 padding-20">
+    <div class="blue-group spacing-below-15 padding-20">
       <div class="spacing-below-5">
         <p class="text--bold spacing-below-5"><%=@refund_or_owed_label %></p>
         <p class="spacing-below-0"><%=number_to_currency(@refund_or_owed_amount.abs) %></p>
@@ -16,7 +16,7 @@
     </div>
   <% end %>
 
-  <div id="household-info" class="highlight-box highlight-box--blue spacing-below-25 padding-20">
+  <div id="household-info" class="blue-group spacing-below-25 padding-20">
     <div class="spacing-below-25">
       <p class="text--bold spacing-below-5"><%=t(".household_info") %></p>
     </div>


### PR DESCRIPTION
looked at most of the pages where this changed. obviously there are other style tweaks to be made on some of them but overall not a huge difference between the random class we were using and this box. it probably also needs to be dropped into some other places but didn't want to spend extra time as it's been deprioritized since i picked it up

<img width="805" alt="image" src="https://github.com/codeforamerica/vita-min/assets/43800769/dd4c26e0-bb27-40ba-84d4-642c322c8535">

<img width="763" alt="image" src="https://github.com/codeforamerica/vita-min/assets/43800769/a001621d-2226-4f71-bfb1-8060dafd783d">

<img width="863" alt="image" src="https://github.com/codeforamerica/vita-min/assets/43800769/c6ca7b57-726f-4765-8a50-772a1529039d">

<img width="850" alt="image" src="https://github.com/codeforamerica/vita-min/assets/43800769/f9aa1c53-d117-4c1c-8727-eadeebddd9ce">

<img width="855" alt="image" src="https://github.com/codeforamerica/vita-min/assets/43800769/8fdd465d-e8d4-497f-a606-6595344e91c2">

<img width="851" alt="image" src="https://github.com/codeforamerica/vita-min/assets/43800769/baf9bba3-567a-4bce-903e-875ec76070ad">

<img width="827" alt="image" src="https://github.com/codeforamerica/vita-min/assets/43800769/895de630-e684-409e-9c8e-61df41d933cd">
