### PR TITLE
Transmit Federal SubmissionId

### DIFF
--- a/app/controllers/flows_controller.rb
+++ b/app/controllers/flows_controller.rb
@@ -577,7 +577,7 @@ class FlowsController < ApplicationController
         current_step: "/en/questions/confirmation",
         eligibility_lived_in_state: "yes",
         eligibility_out_of_state_income: "no",
-        federal_submission_id: "000000000",
+        federal_submission_id: "12345202201011234570",
         federal_return_status: "accepted",
         consented_to_terms_and_conditions: "yes",
         current_sign_in_at: nil,

--- a/app/controllers/flows_controller.rb
+++ b/app/controllers/flows_controller.rb
@@ -577,6 +577,8 @@ class FlowsController < ApplicationController
         current_step: "/en/questions/confirmation",
         eligibility_lived_in_state: "yes",
         eligibility_out_of_state_income: "no",
+        federal_submission_id: "000000000",
+        federal_return_status: "accepted",
         consented_to_terms_and_conditions: "yes",
         current_sign_in_at: nil,
         current_sign_in_ip: nil,

--- a/app/jobs/state_file/import_from_direct_file_job.rb
+++ b/app/jobs/state_file/import_from_direct_file_job.rb
@@ -3,9 +3,13 @@ module StateFile
     def perform(authorization_code:, intake:)
       return if intake.raw_direct_file_data
 
-      direct_file_xml = IrsApiService.import_federal_data(authorization_code, intake.state_code)
+      direct_file_json = IrsApiService.import_federal_data(authorization_code, intake.state_code)
 
-      intake.update(raw_direct_file_data: direct_file_xml)
+      intake.update(
+        raw_direct_file_data: direct_file_json['xml'],
+        federal_submission_id: direct_file_json['submissionId'],
+        federal_return_status: direct_file_json['status']
+      )
       intake.synchronize_df_dependents_to_database
 
       DfDataTransferJobChannel.broadcast_job_complete(intake)

--- a/app/lib/submission_builder/state_manifest.rb
+++ b/app/lib/submission_builder/state_manifest.rb
@@ -18,7 +18,7 @@ module SubmissionBuilder
         xml.SubmissionCategoryCd "IND"
         xml.PrimarySSN data_source.primary.ssn
         xml.PrimaryNameControlTxt name_control_type(data_source.primary.last_name)
-        # xml.IRSSubmissionId "abcdefg"
+        xml.IRSSubmissionId data_source.federal_submission_id
       end
     end
   end

--- a/app/models/state_file_az_intake.rb
+++ b/app/models/state_file_az_intake.rb
@@ -24,6 +24,7 @@
 #  email_address                         :citext
 #  email_address_verified_at             :datetime
 #  failed_attempts                       :integer          default(0), not null
+#  federal_return_status                 :string
 #  has_prior_last_names                  :integer          default("unfilled"), not null
 #  last_sign_in_at                       :datetime
 #  last_sign_in_ip                       :inet
@@ -53,6 +54,7 @@
 #  withdraw_amount                       :integer
 #  created_at                            :datetime         not null
 #  updated_at                            :datetime         not null
+#  federal_submission_id                 :string
 #  primary_state_id_id                   :bigint
 #  spouse_state_id_id                    :bigint
 #  visitor_id                            :string

--- a/app/models/state_file_ny_intake.rb
+++ b/app/models/state_file_ny_intake.rb
@@ -21,6 +21,7 @@
 #  email_address                      :citext
 #  email_address_verified_at          :datetime
 #  failed_attempts                    :integer          default(0), not null
+#  federal_return_status              :string
 #  household_cash_assistance          :integer
 #  household_fed_agi                  :integer
 #  household_ny_additions             :integer
@@ -81,6 +82,7 @@
 #  withdraw_amount                    :integer
 #  created_at                         :datetime         not null
 #  updated_at                         :datetime         not null
+#  federal_submission_id              :string
 #  primary_state_id_id                :bigint
 #  spouse_state_id_id                 :bigint
 #  visitor_id                         :string

--- a/app/services/irs_api_service.rb
+++ b/app/services/irs_api_service.rb
@@ -11,7 +11,11 @@ class IrsApiService
 
   def self.import_federal_data(authorization_code, state_code)
     if authorization_code == "abcdefg"
-      return df_return_sample
+      return {
+        'xml' => df_return_sample,
+        'submissionId' => "00000000000000",
+        'status' => "accepted"
+      }
     end
 
     account_id = EnvironmentCredentials.dig('statefile', state_code, "account_id")
@@ -95,7 +99,10 @@ class IrsApiService
     # puts "Response Code: #{response.code}"
     # puts "Response Body: #{plain}"
 
-    Nokogiri::XML(JSON.parse(plain)['xml']).to_xml
+    decrypted_json = JSON.parse(plain)
+    decrypted_json['xml'] = Nokogiri::XML(decrypted_json['xml']).to_xml
+
+    decrypted_json
   end
 
   private

--- a/app/services/irs_api_service.rb
+++ b/app/services/irs_api_service.rb
@@ -13,7 +13,7 @@ class IrsApiService
     if authorization_code == "abcdefg"
       return {
         'xml' => df_return_sample,
-        'submissionId' => "00000000000000",
+        'submissionId' => "12345202201011234570",
         'status' => "accepted"
       }
     end

--- a/bin/test
+++ b/bin/test
@@ -24,6 +24,7 @@ if [[ -n "$1" ]] && [[ $1 == "state_file" ]]; then
       spec/lib/pdf_filler/ny213_pdf_spec.rb \
       spec/lib/pdf_filler/ny214_pdf_spec.rb \
       spec/lib/pdf_filler/ny215_pdf_spec.rb \
+      spec/lib/submission_bundle_spec.rb \
       spec/lib/submission_builder/ty2022 \
       spec/lib/submission_builder/shared/return_header1040_spec.rb \
       spec/lib/submission_builder/federal_manifest_spec.rb \

--- a/db/migrate/20231208221742_add_federal_submission_id_to_state_intakes.rb
+++ b/db/migrate/20231208221742_add_federal_submission_id_to_state_intakes.rb
@@ -1,0 +1,8 @@
+class AddFederalSubmissionIdToStateIntakes < ActiveRecord::Migration[7.1]
+  def change
+    add_column :state_file_az_intakes, :federal_submission_id, :string
+    add_column :state_file_az_intakes, :federal_return_status, :string
+    add_column :state_file_ny_intakes, :federal_submission_id, :string
+    add_column :state_file_ny_intakes, :federal_return_status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_07_081909) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_08_221742) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -1597,6 +1597,8 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_07_081909) do
     t.citext "email_address"
     t.datetime "email_address_verified_at"
     t.integer "failed_attempts", default: 0, null: false
+    t.string "federal_return_status"
+    t.string "federal_submission_id"
     t.integer "has_prior_last_names", default: 0, null: false
     t.datetime "last_sign_in_at"
     t.inet "last_sign_in_ip"
@@ -1684,6 +1686,8 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_07_081909) do
     t.citext "email_address"
     t.datetime "email_address_verified_at"
     t.integer "failed_attempts", default: 0, null: false
+    t.string "federal_return_status"
+    t.string "federal_submission_id"
     t.integer "household_cash_assistance"
     t.integer "household_fed_agi"
     t.integer "household_ny_additions"

--- a/spec/factories/state_file_az_intakes.rb
+++ b/spec/factories/state_file_az_intakes.rb
@@ -24,6 +24,7 @@
 #  email_address                         :citext
 #  email_address_verified_at             :datetime
 #  failed_attempts                       :integer          default(0), not null
+#  federal_return_status                 :string
 #  has_prior_last_names                  :integer          default("unfilled"), not null
 #  last_sign_in_at                       :datetime
 #  last_sign_in_ip                       :inet
@@ -53,6 +54,7 @@
 #  withdraw_amount                       :integer
 #  created_at                            :datetime         not null
 #  updated_at                            :datetime         not null
+#  federal_submission_id                 :string
 #  primary_state_id_id                   :bigint
 #  spouse_state_id_id                    :bigint
 #  visitor_id                            :string

--- a/spec/factories/state_file_ny_intakes.rb
+++ b/spec/factories/state_file_ny_intakes.rb
@@ -21,6 +21,7 @@
 #  email_address                      :citext
 #  email_address_verified_at          :datetime
 #  failed_attempts                    :integer          default(0), not null
+#  federal_return_status              :string
 #  household_cash_assistance          :integer
 #  household_fed_agi                  :integer
 #  household_ny_additions             :integer
@@ -81,6 +82,7 @@
 #  withdraw_amount                    :integer
 #  created_at                         :datetime         not null
 #  updated_at                         :datetime         not null
+#  federal_submission_id              :string
 #  primary_state_id_id                :bigint
 #  spouse_state_id_id                 :bigint
 #  visitor_id                         :string

--- a/spec/jobs/state_file/import_from_direct_file_job_spec.rb
+++ b/spec/jobs/state_file/import_from_direct_file_job_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe StateFile::ImportFromDirectFileJob, type: :job do
+  describe '#perform' do
+    let(:intake) { create :minimal_state_file_az_intake, raw_direct_file_data: nil }
+
+    let(:xml_result) do
+      File.read(Rails.root.join("spec/fixtures/files/fed_return_five_dependents.xml"))
+    end
+
+    let(:json_result) do
+      {
+        "xml" => xml_result,
+        "submissionId" => "91873649812736",
+        "status" => "accepted"
+      }
+    end
+
+    before do
+      allow(IrsApiService).to receive(:import_federal_data).and_return(json_result)
+      allow(DfDataTransferJobChannel).to receive(:broadcast_job_complete)
+    end
+
+    context "with a successful direct file response" do
+      it "calls the DF api, updates the intake and broadcasts to the ActionCable channel" do
+        auth_code = "8700210c-781c-4db6-8e25-8db4e1082312"
+        described_class.perform_now(authorization_code: auth_code, intake: intake)
+
+        expect(IrsApiService).to have_received(:import_federal_data).with(auth_code, "az")
+        expect(intake.federal_submission_id).to eq "91873649812736"
+        expect(intake.federal_return_status).to eq "accepted"
+        expect(intake.raw_direct_file_data).to eq xml_result
+        # it looks like there is a bug related to parsing dependents in the xml
+        # expect(intake.dependents.count).to eq(5)
+        expect(DfDataTransferJobChannel).to have_received(:broadcast_job_complete)
+      end
+    end
+  end
+end

--- a/spec/jobs/state_file/import_from_direct_file_job_spec.rb
+++ b/spec/jobs/state_file/import_from_direct_file_job_spec.rb
@@ -30,8 +30,7 @@ RSpec.describe StateFile::ImportFromDirectFileJob, type: :job do
         expect(intake.federal_submission_id).to eq "91873649812736"
         expect(intake.federal_return_status).to eq "accepted"
         expect(intake.raw_direct_file_data).to eq xml_result
-        # it looks like there is a bug related to parsing dependents in the xml
-        # expect(intake.dependents.count).to eq(5)
+        expect(intake.dependents.count).to eq(5)
         expect(DfDataTransferJobChannel).to have_received(:broadcast_job_complete)
       end
     end

--- a/spec/lib/submission_bundle_spec.rb
+++ b/spec/lib/submission_bundle_spec.rb
@@ -71,9 +71,11 @@ describe SubmissionBundle do
   end
 
   describe "state filing" do
+    let(:fed_return_submission_id) { "12345202201011234570" }
+    let(:state_return_submission_id) { "44445202201011234577" }
     context "NY state" do
       let(:submission) {
-        create(:efile_submission, data_source: create(:state_file_ny_intake, :with_efile_device_infos), irs_submission_id: "12345202201011234570")
+        create(:efile_submission, data_source: create(:state_file_ny_intake, :with_efile_device_infos, federal_submission_id: fed_return_submission_id), irs_submission_id: state_return_submission_id)
       }
       it "can bundle a minimal NY return" do
         expect(described_class.new(submission).build.errors).to eq([])
@@ -82,7 +84,7 @@ describe SubmissionBundle do
 
     context "AZ state" do
       let(:submission) {
-        create(:efile_submission, data_source: create(:state_file_az_intake, :with_efile_device_infos), irs_submission_id: "12345202201011234570")
+        create(:efile_submission, data_source: create(:state_file_az_intake, :with_efile_device_infos, federal_submission_id: fed_return_submission_id), irs_submission_id: state_return_submission_id)
       }
 
       it "can bundle a minimal AZ return" do

--- a/spec/models/state_file_az_intake_spec.rb
+++ b/spec/models/state_file_az_intake_spec.rb
@@ -24,6 +24,7 @@
 #  email_address                         :citext
 #  email_address_verified_at             :datetime
 #  failed_attempts                       :integer          default(0), not null
+#  federal_return_status                 :string
 #  has_prior_last_names                  :integer          default("unfilled"), not null
 #  last_sign_in_at                       :datetime
 #  last_sign_in_ip                       :inet
@@ -53,6 +54,7 @@
 #  withdraw_amount                       :integer
 #  created_at                            :datetime         not null
 #  updated_at                            :datetime         not null
+#  federal_submission_id                 :string
 #  primary_state_id_id                   :bigint
 #  spouse_state_id_id                    :bigint
 #  visitor_id                            :string

--- a/spec/models/state_file_ny_intake_spec.rb
+++ b/spec/models/state_file_ny_intake_spec.rb
@@ -21,6 +21,7 @@
 #  email_address                      :citext
 #  email_address_verified_at          :datetime
 #  failed_attempts                    :integer          default(0), not null
+#  federal_return_status              :string
 #  household_cash_assistance          :integer
 #  household_fed_agi                  :integer
 #  household_ny_additions             :integer
@@ -81,6 +82,7 @@
 #  withdraw_amount                    :integer
 #  created_at                         :datetime         not null
 #  updated_at                         :datetime         not null
+#  federal_submission_id              :string
 #  primary_state_id_id                :bigint
 #  spouse_state_id_id                 :bigint
 #  visitor_id                         :string


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186641460

- Add columns for fed SubmissionId & status
- update irs_api_service to return the full json of data, including the federal submission Id
- save the submission id to the state intake
- add the submission id to the state manifest XML