### PR TITLE
Added flag for state_file to admin role and new endpoint

### DIFF
--- a/app/controllers/concerns/access_controllable.rb
+++ b/app/controllers/concerns/access_controllable.rb
@@ -33,7 +33,7 @@ module AccessControllable
 
   def require_state_file
     unless current_user.present? && current_user.admin? && current_user.role.state_file?
-      redirect_to root_path
+      head :forbidden
     end
   end
 end

--- a/app/controllers/concerns/access_controllable.rb
+++ b/app/controllers/concerns/access_controllable.rb
@@ -30,4 +30,10 @@ module AccessControllable
       redirect_to root_path
     end
   end
+
+  def require_state_file
+    unless current_user.present? && current_user.admin? && current_user.role.state_file?
+      redirect_to root_path
+    end
+  end
 end

--- a/app/controllers/hub/admin_tools_controller.rb
+++ b/app/controllers/hub/admin_tools_controller.rb
@@ -15,6 +15,11 @@ module Hub
         [Hub::PortalStatesController.to_path_helper(action: :index), "Portal States"],
         [Hub::FaqCategoriesController.to_path_helper(action: :index), "Frequently Asked Questions"],
       ]
+      if current_user.state_file_admin?
+        @state_file_actions = [
+          [Hub::StateFileController.to_path_helper(action: :index), "State File"]
+        ]
+      end
       @deprecated_actions = [
         [hub_verification_attempts_path, "Client Verification"],
         [hub_fraud_indicators_path, "Fraud Indicators"],

--- a/app/controllers/hub/state_file_controller.rb
+++ b/app/controllers/hub/state_file_controller.rb
@@ -1,0 +1,10 @@
+module Hub
+  class StateFileController < Hub::BaseController
+    #load_and_authorize_resource
+    layout "hub"
+    before_action :require_state_file
+
+    def index
+    end
+  end
+end

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -12,6 +12,13 @@ class Ability
     # Admins can do everything
     if user.admin?
       can :manage, :all
+      unless user.state_file_admin?
+        cannot :manage, StateFileAzIntake
+        cannot :manage, StateFileNyIntake
+        cannot :manage, StateFile1099G
+        cannot :manage, StateFileDependent
+        cannot :manage, StateId
+      end
       return
     end
 
@@ -61,6 +68,11 @@ class Ability
     can :manage, EfileSubmission, tax_return: { client: { vita_partner: accessible_groups } }
 
     cannot :index, EfileSubmission unless user.admin? || user.client_success?
+    cannot :manage, StateFileAzIntake
+    cannot :manage, StateFileNyIntake
+    cannot :manage, StateFile1099G
+    cannot :manage, StateFileDependent
+    cannot :manage, StateId
 
     if user.role_type == CoalitionLeadRole::TYPE
       can :read, Coalition, id: user.role.coalition_id

--- a/app/lib/seeder.rb
+++ b/app/lib/seeder.rb
@@ -120,7 +120,7 @@ class Seeder
         admin_user.update(
           name: admin_names[initials],
           password: Devise.friendly_token[0, 20])
-        admin_user.update(role: AdminRole.create(engineer: true)) if admin_user.role_type != AdminRole::TYPE
+        admin_user.update(role: AdminRole.create(engineer: true, state_file: true)) if admin_user.role_type != AdminRole::TYPE
       end
     end
 
@@ -128,7 +128,7 @@ class Seeder
     admin_user.update(
       name: "Admin Amdapynurian",
       password: "theforcevita")
-    admin_user.update(role: AdminRole.create) if admin_user.role_type != AdminRole::TYPE
+    admin_user.update(role: AdminRole.create(state_file: true)) if admin_user.role_type != AdminRole::TYPE
 
     greeter_user = User.where(email: "greeter@example.com").first_or_initialize
     greeter_user.update(

--- a/app/models/admin_role.rb
+++ b/app/models/admin_role.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  engineer   :boolean
+#  state_file :boolean          default(FALSE), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -237,6 +237,10 @@ class User < ApplicationRecord
     role_type == CoalitionLeadRole::TYPE
   end
 
+  def state_file_admin?
+    role_type == AdminRole::TYPE && role.state_file?
+  end
+
   def suspended?
     suspended_at.present?
   end

--- a/app/views/hub/admin_tools/index.html.erb
+++ b/app/views/hub/admin_tools/index.html.erb
@@ -4,9 +4,14 @@
 <% content_for :card do %>
   <div class="slab">
     <div class="grid">
-      <h1><%= @main_heading %></h1>
+      <h1>Get Your Refund Actions</h1>
 
       <%= render 'tools_table', actions: @actions %>
+
+      <% if @state_file_actions.present? %>
+      <h2>State File Actions</h2>
+      <%= render 'tools_table', actions: @state_file_actions %>
+      <% end %>
 
       <h2>Deprecated Actions</h2>
       <%= render 'tools_table', actions: @deprecated_actions %>

--- a/app/views/hub/state_file/index.html.erb
+++ b/app/views/hub/state_file/index.html.erb
@@ -1,0 +1,1 @@
+<div>TODO: Implement this view</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -214,6 +214,8 @@ Rails.application.routes.draw do
           get '/state-counts', to: 'efile_submissions#state_counts', on: :collection, as: :state_counts
         end
 
+        resources :state_file, only: [:index]
+
         resources :fraud_indicators, path: "fraud-indicators" do
           collection do
             resources :risky_domains, controller: 'fraud_indicators/risky_domains', path: "risky-domains"

--- a/db/migrate/20231214182242_add_state_file_flag_to_admin_role.rb
+++ b/db/migrate/20231214182242_add_state_file_flag_to_admin_role.rb
@@ -1,0 +1,5 @@
+class AddStateFileFlagToAdminRole < ActiveRecord::Migration[7.1]
+  def change
+    add_column :admin_roles, :state_file, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_13_194846) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_14_182242) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -115,6 +115,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_13_194846) do
   create_table "admin_roles", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.boolean "engineer"
+    t.boolean "state_file", default: false, null: false
     t.datetime "updated_at", null: false
   end
 

--- a/spec/controllers/hub/state_file_controller_spec.rb
+++ b/spec/controllers/hub/state_file_controller_spec.rb
@@ -23,9 +23,9 @@ describe Hub::StateFileController do
         sign_in user
       end
 
-      it "allows them to see the page" do
+      it "is forbidden" do
         get :index
-        expect(response).not_to be_ok
+        expect(response).to be_forbidden
       end
     end
   end

--- a/spec/controllers/hub/state_file_controller_spec.rb
+++ b/spec/controllers/hub/state_file_controller_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+describe Hub::StateFileController do
+
+  describe "#index" do
+    context "when they are a state file admin" do
+      let(:user) { create(:admin_user, :state_file) }
+
+      before do
+        sign_in user
+      end
+
+      it "allows them to see the page" do
+        get :index
+        expect(response).to be_ok
+      end
+    end
+
+    context "when they are not a state file admin" do
+      let(:user) { create(:admin_user) }
+
+      before do
+        sign_in user
+      end
+
+      it "allows them to see the page" do
+        get :index
+        expect(response).not_to be_ok
+      end
+    end
+  end
+
+end

--- a/spec/factories/admin_roles.rb
+++ b/spec/factories/admin_roles.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  engineer   :boolean
+#  state_file :boolean          default(FALSE), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -113,6 +113,10 @@ FactoryBot.define do
       sequence(:name) { |n| "Admin the #{n}th" }
 
       role { build(:admin_role) }
+
+      trait :state_file do
+        role { create(:admin_role, state_file: true) }
+      end
     end
 
     factory :greeter_user do

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -4,7 +4,8 @@ describe Ability do
   let(:subject) { Ability.new(user) }
 
   context "as an admin" do
-    let(:user) { create(:user, role: create(:admin_role)) }
+    let(:user) { create :admin_user, role: role }
+    let(:role) { create :admin_role, state_file: false }
 
     it "can manage everything" do
       expect(subject.can?(:manage, Document.new)).to eq true
@@ -16,6 +17,28 @@ describe Ability do
       expect(subject.can?(:manage, SystemNote.new)).to eq true
       expect(subject.can?(:manage, User.new)).to eq true
       expect(subject.can?(:manage, VitaPartner.new)).to eq true
+    end
+
+    context "state_file true" do
+      let(:role) { create :admin_role, state_file: true }
+
+      it "can manage state file intakes" do
+        expect(subject.can?(:manage, StateFileAzIntake.new)).to eq true
+        expect(subject.can?(:manage, StateFileNyIntake.new)).to eq true
+        expect(subject.can?(:manage, StateFile1099G.new)).to eq true
+        expect(subject.can?(:manage, StateFileDependent.new)).to eq true
+        expect(subject.can?(:manage, StateId.new)).to eq true
+      end
+    end
+
+    context "state_file false" do
+      it "cannot manage state file intakes" do
+        expect(subject.can?(:manage, StateFileAzIntake.new)).to eq false
+        expect(subject.can?(:manage, StateFileNyIntake.new)).to eq false
+        expect(subject.can?(:manage, StateFile1099G.new)).to eq false
+        expect(subject.can?(:manage, StateFileDependent.new)).to eq false
+        expect(subject.can?(:manage, StateId.new)).to eq false
+      end
     end
 
     context "with a client data unrelated to the user" do
@@ -49,6 +72,14 @@ describe Ability do
       expect(subject.can?(:manage, GreeterRole)).to eq false
       expect(subject.can?(:manage, CoalitionLeadRole)).to eq false
       expect(subject.can?(:manage, OrganizationLeadRole)).to eq false
+    end
+
+    it "cannot manage state file intakes" do
+      expect(subject.can?(:manage, StateFileAzIntake.new)).to eq false
+      expect(subject.can?(:manage, StateFileNyIntake.new)).to eq false
+      expect(subject.can?(:manage, StateFile1099G.new)).to eq false
+      expect(subject.can?(:manage, StateFileDependent.new)).to eq false
+      expect(subject.can?(:manage, StateId.new)).to eq false
     end
   end
 
@@ -572,6 +603,20 @@ describe Ability do
           it "cannot manage" do
             expect(subject.can?(:manage, target_role)).to eq false
           end
+        end
+      end
+    end
+
+    context "Permissions regarding StateFile objects" do
+      let(:user) { create :team_member_user }
+
+      context "managing StateFile intakes" do
+        it "cannot manage state file intakes" do
+          expect(subject.can?(:manage, StateFileAzIntake.new)).to eq false
+          expect(subject.can?(:manage, StateFileNyIntake.new)).to eq false
+          expect(subject.can?(:manage, StateFile1099G.new)).to eq false
+          expect(subject.can?(:manage, StateFileDependent.new)).to eq false
+          expect(subject.can?(:manage, StateId.new)).to eq false
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -570,6 +570,32 @@ RSpec.describe User, type: :model, requires_default_vita_partners: true do
     end
   end
 
+
+  describe "#state_file_admin?" do
+    context "when the user has AdminRole type and state_file is true" do
+      let(:user) { create :admin_user, role: role }
+      let(:role) { create :admin_role, state_file: true }
+      it "returns true" do
+        expect(user.state_file_admin?).to be true
+      end
+    end
+
+    context "when the user does not have AdminRole type" do
+      let(:user) { create :greeter_user }
+      it "returns false" do
+        expect(user.state_file_admin?).to be false
+      end
+    end
+
+    context "when the user does have AdminRole type and state_file is false" do
+      let(:user) { create :admin_user, role: role }
+      let(:role) { create :admin_role, state_file: false }
+      it "returns false" do
+        expect(user.state_file_admin?).to be false
+      end
+    end
+  end
+
   describe ".active" do
     let!(:user) { create :user }
     let!(:suspended_user) { create :user, suspended_at: DateTime.now }


### PR DESCRIPTION
At Em's convincing, we introduced a new flag on the admin role rather than a full new role for this. I think it makes sense given that some users will need both `admin` and `state_admin` privileges.

The hub/admin/tools view has a State File section if the flag is present
<img width="631" alt="image" src="https://github.com/codeforamerica/vita-min/assets/17094895/b9c4d6d7-3d14-49c3-9146-b034295675ba">

Currently there is nothing in this view, but it is protected by the new flag:
<img width="639" alt="image" src="https://github.com/codeforamerica/vita-min/assets/17094895/c3e8a144-160b-4fa7-bd03-fd7dfa7edd3f">

Specs and Seeds were updated with this new flag.

Co-authored-by: Em Barnard-Shao <ebarnard@codeforamerica.org>