### PR TITLE
Style updates as requested

### DIFF
--- a/app/assets/stylesheets/_state-file.scss
+++ b/app/assets/stylesheets/_state-file.scss
@@ -365,6 +365,68 @@
     font-size: 2.5rem;
     font-weight: normal;
   }
+
+  .text-input,
+  a,
+  .button,
+  .radio-button,
+  .radio-button input[type='radio'],
+  .select__element,
+  .checkbox,
+  .checkbox input[type='checkbox'] {
+    box-shadow: 0 0 0 5px rgba(33, 200, 52, 0);
+    transition: box-shadow 0.2s ease;
+  }
+
+  .text-input:focus,
+  a:focus,
+  .button:focus,
+  .button:hover,
+  .radio-button input[type='radio']:focus,
+  .select__element:focus,
+  .checkbox input[type='checkbox']:focus {
+    box-shadow: 0 0 0 5px rgba(33, 200, 52, 1), inset 0px 2px 0px rgba(0, 0, 0, 0.15);
+  }
+
+  input[type='radio'] {
+    accent-color: #000;
+  }
+
+  // Hack to make radio buttons black instead of green
+  input[type='radio']:checked:after {
+    width: 15px;
+    height: 15px;
+    border-radius: 15px;
+    top: -2.5px;
+    left: 0.5px;
+    position: relative;
+    background-color: #000;
+    content: '';
+    display: inline-block;
+    visibility: visible;
+    border: 2px solid white;
+  }
+
+  // Hack to make checkboxes black instead of green
+  input[type='checkbox']:checked:after {
+    content: " ";
+    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj48cGF0aCBmaWxsPSIjMDAwIiBkPSJNMTczLjg5OCA0MzkuNDA0bC0xNjYuNC0xNjYuNGMtOS45OTctOS45OTctOS45OTctMjYuMjA2IDAtMzYuMjA0bDM2LjIwMy0zNi4yMDRjOS45OTctOS45OTggMjYuMjA3LTkuOTk4IDM2LjIwNCAwTDE5MiAzMTIuNjkgNDMyLjA5NSA3Mi41OTZjOS45OTctOS45OTcgMjYuMjA3LTkuOTk3IDM2LjIwNCAwbDM2LjIwMyAzNi4yMDRjOS45OTcgOS45OTcgOS45OTcgMjYuMjA2IDAgMzYuMjA0bC0yOTQuNCAyOTQuNDAxYy05Ljk5OCA5Ljk5Ny0yNi4yMDcgOS45OTctMzYuMjA0LS4wMDF6Ii8+PC9zdmc+);
+    background-repeat: no-repeat;
+    background-size: 18px 18px;
+    background-position: center center;
+    position: absolute;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-left: 0px;
+    left: -2px;
+    top: -2.5px;
+    text-align: center;
+    background-color: transparent;
+    font-size: 10px;
+    height: 20px;
+    width: 20px;
+  }
 }
 
 $state-colors: (

--- a/app/assets/stylesheets/_state-file.scss
+++ b/app/assets/stylesheets/_state-file.scss
@@ -374,7 +374,7 @@
   .select__element,
   .checkbox,
   .checkbox input[type='checkbox'] {
-    box-shadow: 0 0 0 5px rgba(33, 200, 52, 0);
+    box-shadow: 0 0 0 5px rgba($color-state-file-primary, 0);
     transition: box-shadow 0.2s ease;
   }
 
@@ -385,7 +385,7 @@
   .radio-button input[type='radio']:focus,
   .select__element:focus,
   .checkbox input[type='checkbox']:focus {
-    box-shadow: 0 0 0 5px rgba(33, 200, 52, 1), inset 0px 2px 0px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 0 0 5px $color-state-file-primary, inset 0px 2px 0px rgba(0, 0, 0, 0.15);
   }
 
   input[type='radio'] {

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 // Fonts
 $font-gyr: "Helvetica Neue", -apple-system, BlinkMacSystemFont, "Segoe UI",
   "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans",
@@ -43,6 +45,7 @@ $color-state-file-bg: #FBFCF7;
 $color-state-file-blue-box: #E7F6F8;
 $color-state-file-blue-box-border: #52DAF2;
 $color-state-file-input-border: #1B1B1B;
+$color-state-file-primary: #21C834;
 
 // Size
 $intake-max-width: 570px;

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -1,5 +1,3 @@
-@use 'sass:color';
-
 // Fonts
 $font-gyr: "Helvetica Neue", -apple-system, BlinkMacSystemFont, "Segoe UI",
   "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans",


### PR DESCRIPTION
- Focus color is now green (Rather than yellow - this also applies to links)
- Checkbox checked is now black (And thicker)
- Radio checked is now black
- Buttons now have hover style mimicing focus style
- Slight transition on focus state
<img width="618" alt="image" src="https://github.com/codeforamerica/vita-min/assets/17094895/2de7d15e-670c-40ff-b8f1-8e8a53dbf02d">
<img width="642" alt="image" src="https://github.com/codeforamerica/vita-min/assets/17094895/3abe49f8-e756-4a22-8e96-5e83344fa2db">
<img width="475" alt="image" src="https://github.com/codeforamerica/vita-min/assets/17094895/6d13a386-e150-4ffe-97dc-a8d220d2c133">
<img width="623" alt="image" src="https://github.com/codeforamerica/vita-min/assets/17094895/b39fa9b1-5b8e-4bdb-be2b-4f618fec5e12">
<img width="434" alt="image" src="https://github.com/codeforamerica/vita-min/assets/17094895/2aaf873b-dde0-4b89-ba38-6098a8ef059c">

