### PR TITLE
More resilient wait page to help deal with Action cable race condition

### DIFF
--- a/app/channels/df_data_transfer_job_channel.rb
+++ b/app/channels/df_data_transfer_job_channel.rb
@@ -1,6 +1,10 @@
 class DfDataTransferJobChannel < ApplicationCable::Channel
   def subscribed
-    stream_for current_state_file_intake
+    intake = current_state_file_intake
+    if intake.raw_direct_file_data
+      broadcast_job_complete(intake)
+    end
+    stream_for intake
   end
 
   def self.broadcast_job_complete(intake)

--- a/app/views/state_file/questions/waiting_to_load_data/edit.html.erb
+++ b/app/views/state_file/questions/waiting_to_load_data/edit.html.erb
@@ -1,5 +1,8 @@
 <% title = t(".title_html") %>
 <% content_for :page_title, title %>
+<% content_for :meta_tags do %>
+  <meta http-equiv="refresh" content="20" />
+<% end %>
 <% content_for :card do %>
   <h1 class="h2" id="main-question"><%= title %></h1>
   <%= link_to "HIDDEN BUTTON", next_path, class: "button button--primary", style: "display: none;", data: { after_data_transfer_button: true } %>


### PR DESCRIPTION
This is a fix for that weird race condition Ben, Gabriel, and I saw the other day. I have taken a 2 pronged approach to dealing with it.

First: I added a broadcast if the event is finished after the subscription happens - this is for the case where the xml finishes parsing after the page controller is called but before action cable has connected.

Second, I added a 20 second refresh into the page meta for the wait page - so at worst a user will wait 20 seconds after loading in the case where action cable failed

**Description of issue:**
Sometimes the system seems to hang on the "waiting for data" page. Opening the chrome debugger, I see the regular websocket traffic except for the event highlighted in the screenshot below:
<img width="877" alt="image" src="https://github.com/codeforamerica/vita-min/assets/17094895/52e5fb55-3b8d-4396-b503-c31dada9f485">

The main way of testing I did was by running the server using `rails s`, then when I got to the delay page, stopping the server and running it using `foreman start`. (So initially the background jobs were not running, but they only started running after I hit the page. Starting it early enough, the job finished after a page refresh and the controller kicked in)