### PR TITLE
Reverse ordering on date picker for license expiration

### DIFF
--- a/app/views/state_file/questions/ny_primary_state_id/_state_id.html.erb
+++ b/app/views/state_file/questions/ny_primary_state_id/_state_id.html.erb
@@ -32,8 +32,8 @@
           <%= f.cfa_date_select(:expiration_date,
                                 t("state_file.questions.primary_state_id.state_id.id_details.expiration_month") + " / " + t("state_file.questions.primary_state_id.state_id.id_details.expiration_day") + " / " + t("state_file.questions.primary_state_id.state_id.id_details.expiration_year"),
                                 options: {
-                                  start_year: Time.now.year + 50,
-                                  end_year: Time.now.year - 2,
+                                  start_year: Time.now.year - 2,
+                                  end_year: Time.now.year + 50,
                                 }) %>
           <%= f.cfa_checkbox(:non_expiring, t("state_file.questions.primary_state_id.state_id.id_details.no_expiration_date")) %>
           <%= f.cfa_select(:state, t("state_file.questions.primary_state_id.state_id.id_details.issue_state"), States.name_value_pairs, include_blank: true, classes: ["form-width--short, spacing-above-0"]) %>


### PR DESCRIPTION
So the first options people see are close to now, rather than 2073
![image](https://github.com/codeforamerica/vita-min/assets/17094895/af7d215b-0d53-4f65-91d5-905c97086b95)
