### PR TITLE
Page should not error out if xml element is missing

### DIFF
--- a/app/forms/state_file/federal_info_form.rb
+++ b/app/forms/state_file/federal_info_form.rb
@@ -137,7 +137,9 @@ module StateFile
       super
       attributes_for(:direct_file_data).each do |attribute, value|
         if @intake.direct_file_data.can_override?(attribute)
-          @intake.direct_file_data.send("#{attribute}=", value)
+          if @intake.direct_file_data.send(attribute) != value
+            @intake.direct_file_data.send("#{attribute}=", value)
+          end
         end
       end
     end


### PR DESCRIPTION
We have a case where the XML page simply fails because the XML element `IRS1040Schedule1 UnemploymentCompAmt` is optional and missing. This change adds logic that we only set the value if it has actually changed