### PR TITLE
Style updates for the taxes-owed page

### DIFF
--- a/app/views/state_file/questions/taxes_owed/edit.html.erb
+++ b/app/views/state_file/questions/taxes_owed/edit.html.erb
@@ -9,20 +9,23 @@
   <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder, html: {class: 'form-card form-card--long'} do |f| %>
     <div class="question-with-follow-up">
       <div class="question-with-follow-up__question">
-        <%= f.cfa_radio_set(
-          :payment_or_deposit_type,
-          collection: [
-            { value: :mail, label: t(".pay_mail_online_html",
-                                               pay_mail_online_link: pay_mail_online_link,
-                                               pay_mail_online_text: pay_mail_online_text,
-                                               ) },
-            { value: :direct_deposit, label: t(".pay_bank"), input_html: { "data-follow-up": "#pay-from-bank" } },
-          ]
-        ) %>
+        <div class="blue-group">
+          <%= f.cfa_radio_set(
+            :payment_or_deposit_type,
+            collection: [
+              { value: :mail, label: t(".pay_mail_online_html",
+                                                 pay_mail_online_link: pay_mail_online_link,
+                                                 pay_mail_online_text: pay_mail_online_text,
+                                                 ) },
+              { value: :direct_deposit, label: t(".pay_bank"), input_html: { "data-follow-up": "#pay-from-bank" } },
+            ]
+          ) %>
+        </div>
       </div>
       <div class="question-with-follow-up__follow-up" id="pay-from-bank">
         <div class="question-with-follow-up">
           <div class="question-with-follow-up__question">
+            <div class="blue-group">
               <div class="form-card__content">
                 <h1 class="h2">
                   <%= t(".bank_title") %>
@@ -64,6 +67,7 @@
                 <%= f.cfa_input_field(:account_number_confirmation, t(".confirm_account_number"), classes: ["form-width--long", "disablepaste", "disablecopy"]) %>
                 <p class="spacing-above-25"><strong><%= t(".double_check") %></strong></p>
               </div>
+            </div>
           </div>
         </div>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2230,7 +2230,7 @@ en:
           checking: Checking
           confirm_account_number: Confirm Account Number
           confirm_routing_number: Confirm Routing Number
-          date_withdraw_text: 'The date you would like funds withdrawn from your account (must be on or before April 15, 2024):'
+          date_withdraw_text: 'When would you like the funds withdrawn from your account? (Must be on or before April 15, 2024):'
           double_check: Check to make sure your bank information is correct. You won’t be able to correct this after you submit your return.
           pay_bank: Pay directly from your checking or savings account (direct debit)
           pay_mail_online_html: Pay by mail or online at <a target="_blank" rel="noopener nofollow" href="%{pay_mail_online_link}">%{pay_mail_online_text}</a>


### PR DESCRIPTION
Making the view look like the mocks in figma - we now have a blue background. (Also there was a copy update)
![image](https://github.com/codeforamerica/vita-min/assets/17094895/74e36088-860a-4a84-8b13-5d8a123a3b78)
