### PR TITLE
Remove pre-population for `months-in-home` from the direct file data

### DIFF
--- a/app/models/direct_file_data.rb
+++ b/app/models/direct_file_data.rb
@@ -560,7 +560,6 @@ class DirectFileData
         dependent.eic_qualifying = true
         dependent.eic_student = node.at('ChildIsAStudentUnder24Ind')&.text
         dependent.eic_disability = node.at('ChildPermanentlyDisabledInd')&.text
-        dependent.months_in_home = node.at('MonthsChildLivedWithYouCnt')&.text
       else
         dependents << Dependent.new(
           first_name: node.at('ChildFirstAndLastName PersonFirstNm')&.text,
@@ -570,7 +569,6 @@ class DirectFileData
           eic_qualifying: true,
           eic_student: node.at('ChildIsAStudentUnder24Ind')&.text,
           eic_disability: node.at('ChildPermanentlyDisabledInd')&.text,
-          months_in_home: node.at('MonthsChildLivedWithYouCnt')&.text,
         )
       end
     end
@@ -584,11 +582,10 @@ class DirectFileData
                   :relationship,
                   :eic_student,
                   :eic_disability,
-                  :months_in_home,
                   :eic_qualifying
 
     def initialize(first_name:, last_name:, ssn:, relationship:,
-                   eic_student: nil, eic_disability: nil, months_in_home: nil, eic_qualifying: nil)
+                   eic_student: nil, eic_disability: nil, eic_qualifying: nil)
 
       @first_name = first_name
       @last_name = last_name
@@ -596,7 +593,6 @@ class DirectFileData
       @relationship = relationship
       @eic_student = eic_student
       @eic_disability = eic_disability
-      @months_in_home = months_in_home
       @eic_qualifying = eic_qualifying
     end
 
@@ -608,7 +604,6 @@ class DirectFileData
         relationship: @relationship,
         eic_student: @eic_student,
         eic_disability: @eic_disability,
-        months_in_home: @months_in_home,
         eic_qualifying: @eic_qualifying,
       }
     end

--- a/app/models/state_file_dependent.rb
+++ b/app/models/state_file_dependent.rb
@@ -34,6 +34,7 @@ class StateFileDependent < ApplicationRecord
   # Create birth_date_* accessor methods for Honeycrisp's cfa_date_select
   delegate :month, :day, :year, to: :dob, prefix: :dob, allow_nil: true
   validates_presence_of :first_name, :last_name, :dob, on: :dob_form
+  validates_presence_of :months_in_home, on: :dob_form, if: -> { self.intake_type == 'StateFileAzIntake' }
   validates :passed_away, :needed_assistance, inclusion: { in: %w[yes no], message: I18n.t("errors.messages.blank") }, on: :az_senior_form
 
   scope :az_qualifying_senior, -> do

--- a/app/views/state_file/questions/name_dob/edit.html.erb
+++ b/app/views/state_file/questions/name_dob/edit.html.erb
@@ -70,7 +70,8 @@
           <%= ff.cfa_select(
                 :months_in_home,
                 t('.dependent_months_lived_label', year: MultiTenantService.statefile.current_tax_year),
-                (0..12).map { |i| [i.to_s, i] }.reverse
+                (0..12).map { |i| [i.to_s, i] }.reverse,
+                prompt: t('general.select_prompt')
               ) %>
         <% end %>
       </div>


### PR DESCRIPTION
See [story](https://www.pivotaltracker.com/story/show/186714730) for a discussion on why we are not using the direct file data and instead asking users to enter this data. 

TL;DR - direct file changes the months the user enter and AZ needs the actual value for other reasons other than EIC