### PR TITLE
AZ bug: Incorrect charitable deduction rate

### DIFF
--- a/app/lib/efile/az/az140.rb
+++ b/app/lib/efile/az/az140.rb
@@ -283,7 +283,7 @@ module Efile
       end
 
       def calculate_ccws_line_7c
-        (line_or_zero(:AZ140_CCWS_LINE_6c) * 0.27).round
+        (line_or_zero(:AZ140_CCWS_LINE_6c) * 0.31).round
       end
     end
   end

--- a/app/lib/efile/line_data.yml
+++ b/app/lib/efile/line_data.yml
@@ -91,7 +91,7 @@ AZ140_CCWS_LINE_6c:
   label: '6C Subtract line 5C from line 4C and enter the difference. If less than zero, enter
 “0”'
 AZ140_CCWS_LINE_7c:
-  label: '7C Multiply line 6C by 27% (.27) and enter the result'
+  label: '7C Multiply line 6C by 31% (.31) and enter the result'
 IT201_LINE_1:
   label: '1 Wages, salaries, tips, etc.'
 IT201_LINE_2:

--- a/spec/lib/efile/az/az140_spec.rb
+++ b/spec/lib/efile/az/az140_spec.rb
@@ -209,4 +209,18 @@ describe Efile::Az::Az140 do
       expect(instance.lines[:AZ140_LINE_56].value).to eq(100) # (1 filer + 4 dependents) * 25 = 125 but max is 100
     end
   end
+
+  context 'sets line 7c correctly' do
+    before do
+      intake.charitable_cash = 50
+      intake.charitable_noncash = 50
+      intake.charitable_contributions = 'yes'
+    end
+
+    # 31% of 100 (50+50)
+    it 'sets the credit to the maximum amount' do
+      instance.calculate
+      expect(instance.lines[:AZ140_CCWS_LINE_7c].value).to eq(31)
+    end
+  end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186726356

**Charitable deduction rates by year**
|  2022  | 2023 |
| ------------- | ------------- |
| 27%  | 31%  |

| Before & After | 
| ------------- | 
| ![Screen Shot 2023-12-21 at 5 46 26 PM](https://github.com/codeforamerica/vita-min/assets/2385700/f89e1d87-c023-4f8c-9fa0-9776031e5ab0)  | 
![Screen Shot 2023-12-21 at 5 45 42 PM](https://github.com/codeforamerica/vita-min/assets/2385700/7089db30-8ca8-4f67-9c93-a7b00d448c1e)  |
