### PR TITLE
Update AZ standard deduction values

### DIFF
--- a/app/lib/efile/az/az140.rb
+++ b/app/lib/efile/az/az140.rb
@@ -120,12 +120,13 @@ module Efile
       end
 
       def calculate_line_43
+        # AZ Standard Deductions for 2023
         if filing_status_single?
-          12950
+          13_850
         elsif filing_status_mfj?
-          25900
+          27_200
         elsif filing_status_hoh?
-          19400
+          20_800
         end
       end
 

--- a/app/lib/efile/ny/it201.rb
+++ b/app/lib/efile/ny/it201.rb
@@ -136,6 +136,7 @@ module Efile
       end
 
       def calculate_line_34
+        # NY Standard Deductions for 2023
         if filing_status_single? && @direct_file_data.claimed_as_dependent?
           3_100
         elsif filing_status_single? || filing_status_mfs?

--- a/spec/lib/efile/az/az140_spec.rb
+++ b/spec/lib/efile/az/az140_spec.rb
@@ -232,8 +232,8 @@ describe Efile::Az::Az140 do
       end
       it 'the tax is 2.5%' do
         instance.calculate
-        expect(instance.lines[:AZ140_LINE_45].value).to eq(4323) # Deductions mean this is taxable
-        expect(instance.lines[:AZ140_LINE_46].value).to eq(108)
+        expect(instance.lines[:AZ140_LINE_45].value).to eq(3423) # Deductions mean this is taxable
+        expect(instance.lines[:AZ140_LINE_46].value).to eq(86)
       end
     end
     context 'when the filer has an income of $150,000' do
@@ -242,8 +242,8 @@ describe Efile::Az::Az140 do
       end
       it 'the tax is 2.5%' do
         instance.calculate
-        expect(instance.lines[:AZ140_LINE_45].value).to eq(129323) # Deductions mean this is taxable
-        expect(instance.lines[:AZ140_LINE_46].value).to eq(3233)
+        expect(instance.lines[:AZ140_LINE_45].value).to eq(128423) # Deductions mean this is taxable
+        expect(instance.lines[:AZ140_LINE_46].value).to eq(3211)
       end
     end
   end


### PR DESCRIPTION
I looked into adding AZ standard deductions to the existing `standard_deductions.yml`, but since that is currently attached only to the model for federal returns, I decided it was out of scope for a minor bug fix. 