### PR TITLE
Offboarding users when they have an out of state W2

### DIFF
--- a/app/models/direct_file_data.rb
+++ b/app/models/direct_file_data.rb
@@ -50,6 +50,7 @@ class DirectFileData
     fed_mortgage_interest_credit_amount: 'IRS8396 MortgageInterestCreditAmt',
     fed_adoption_credit_amount: 'IRS8839 AdoptionCreditAmt',
     fed_dc_homebuyer_credit_amount: 'IRS8859 DCHmByrCurrentYearCreditAmt',
+    fed_w2_state: 'W2StateLocalTaxGrp W2StateTaxGrp StateAbbreviationCd',
   }.freeze
 
   def initialize(raw_xml)
@@ -487,6 +488,14 @@ class DirectFileData
       end
     end
     value
+  end
+
+  def fed_w2_state
+    df_xml_value(__method__)
+  end
+
+  def fed_w2_state=(value)
+    write_df_xml_value(__method__, value)
   end
 
   def blind_primary_spouse

--- a/app/models/state_file_az_intake.rb
+++ b/app/models/state_file_az_intake.rb
@@ -135,10 +135,13 @@ class StateFileAzIntake < StateFileBaseIntake
   end
 
   def disqualifying_df_data_reason
-    :married_filing_separately if direct_file_data.filing_status == 3
-    direct_file_data.parsed_xml.css('W2StateLocalTaxGrp W2StateTaxGrp StateAbbreviationCd').each do |state|
-      return :has_out_of_state_w2 if state.text != 'AZ'
+    return :married_filing_separately if direct_file_data.filing_status == 3
+
+    w2_states = direct_file_data.parsed_xml.css('W2StateLocalTaxGrp W2StateTaxGrp StateAbbreviationCd')
+    :has_out_of_state_w2 if w2_states.any? do |state|
+      (state.text || '').upcase != 'AZ'
     end
+
   end
 
   def disqualifying_eligibility_rules

--- a/app/models/state_file_az_intake.rb
+++ b/app/models/state_file_az_intake.rb
@@ -136,6 +136,9 @@ class StateFileAzIntake < StateFileBaseIntake
 
   def disqualifying_df_data_reason
     :married_filing_separately if direct_file_data.filing_status == 3
+    direct_file_data.parsed_xml.css('W2StateLocalTaxGrp W2StateTaxGrp StateAbbreviationCd').each do |state|
+      return :has_out_of_state_w2 if state.text != 'AZ'
+    end
   end
 
   def disqualifying_eligibility_rules

--- a/app/models/state_file_az_intake.rb
+++ b/app/models/state_file_az_intake.rb
@@ -141,7 +141,6 @@ class StateFileAzIntake < StateFileBaseIntake
     :has_out_of_state_w2 if w2_states.any? do |state|
       (state.text || '').upcase != 'AZ'
     end
-
   end
 
   def disqualifying_eligibility_rules

--- a/app/models/state_file_ny_intake.rb
+++ b/app/models/state_file_ny_intake.rb
@@ -197,7 +197,7 @@ class StateFileNyIntake < StateFileBaseIntake
   YONKERS_CODES = ['YK', 'YON', 'YNK', 'CITYOFYK', 'CTYOFYKR', 'CITYOF YK', 'CTY OF YK']
   def disqualifying_df_data_reason
     w2_states = direct_file_data.parsed_xml.css('W2StateLocalTaxGrp W2StateTaxGrp StateAbbreviationCd')
-    return :has_out_of_state_w2 if w2_states.any do |state|
+    return :has_out_of_state_w2 if w2_states.any? do |state|
       (state.text || '').upcase != 'NY'
     end
 

--- a/app/models/state_file_ny_intake.rb
+++ b/app/models/state_file_ny_intake.rb
@@ -196,6 +196,10 @@ class StateFileNyIntake < StateFileBaseIntake
   IRC_125_CODES = ['IRC125S', 'IRS125']
   YONKERS_CODES = ['YK', 'YON', 'YNK', 'CITYOFYK', 'CTYOFYKR', 'CITYOF YK', 'CTY OF YK']
   def disqualifying_df_data_reason
+    direct_file_data.parsed_xml.css('W2StateLocalTaxGrp W2StateTaxGrp StateAbbreviationCd').each do |state|
+      return :has_out_of_state_w2 if state.text != 'NY'
+    end
+
     box_14_nodes = direct_file_data.parsed_xml.css('IRSW2 OtherDeductionsBenefitsGrp')
     return :has_irc_125_code if box_14_nodes.any? do |deduction|
       IRC_125_CODES.include?(deduction.at('Desc')&.text)

--- a/app/models/state_file_ny_intake.rb
+++ b/app/models/state_file_ny_intake.rb
@@ -196,8 +196,9 @@ class StateFileNyIntake < StateFileBaseIntake
   IRC_125_CODES = ['IRC125S', 'IRS125']
   YONKERS_CODES = ['YK', 'YON', 'YNK', 'CITYOFYK', 'CTYOFYKR', 'CITYOF YK', 'CTY OF YK']
   def disqualifying_df_data_reason
-    direct_file_data.parsed_xml.css('W2StateLocalTaxGrp W2StateTaxGrp StateAbbreviationCd').each do |state|
-      return :has_out_of_state_w2 if state.text != 'NY'
+    w2_states = direct_file_data.parsed_xml.css('W2StateLocalTaxGrp W2StateTaxGrp StateAbbreviationCd')
+    return :has_out_of_state_w2 if w2_states.any do |state|
+      (state.text || '').upcase != 'NY'
     end
 
     box_14_nodes = direct_file_data.parsed_xml.css('IRSW2 OtherDeductionsBenefitsGrp')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1968,9 +1968,9 @@ en:
           get_started_with_vita: Get started with VITA now
           ineligible_reason:
             has_irc_125_code: your W2 lists IRC 125 benefit plan amounts.
+            has_out_of_state_w2: You have a W2 from outside the state.
             has_yonkers_income: you lived or earned income in Yonkers in 2023.
             married_filing_separately: you are filing “married filing separately”.
-            has_out_of_state_w2: You have a W2 from outside the state.
           learn_more_content_how: IRS-certified VITA volunteers will use this information to prepare and e-file your state return. This entire process can take 2-3 weeks to complete.
           learn_more_content_link_html: Learn more <a href="%{link}">here</a>.
           learn_more_content_what: If you choose this option, you’ll be connected with a Volunteer Income Tax Assistance (VITA) partner in Arizona. You will receive a quick intake call in the next few days. You will have to answer a few more questions about your tax situation and securely upload your tax documents.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1970,6 +1970,7 @@ en:
             has_irc_125_code: your W2 lists IRC 125 benefit plan amounts.
             has_yonkers_income: you lived or earned income in Yonkers in 2023.
             married_filing_separately: you are filing “married filing separately”.
+            has_out_of_state_w2: You have a W2 from outside the state.
           learn_more_content_how: IRS-certified VITA volunteers will use this information to prepare and e-file your state return. This entire process can take 2-3 weeks to complete.
           learn_more_content_link_html: Learn more <a href="%{link}">here</a>.
           learn_more_content_what: If you choose this option, you’ll be connected with a Volunteer Income Tax Assistance (VITA) partner in Arizona. You will receive a quick intake call in the next few days. You will have to answer a few more questions about your tax situation and securely upload your tax documents.

--- a/spec/factories/state_file_az_intakes.rb
+++ b/spec/factories/state_file_az_intakes.rb
@@ -88,6 +88,7 @@ FactoryBot.define do
       }[evaluator.filing_status.to_sym] || evaluator.filing_status
       intake.direct_file_data.filing_status = numeric_status
       intake.direct_file_data.fed_agi = 120000
+      intake.direct_file_data.fed_w2_state = "AZ"
       intake.raw_direct_file_data = intake.direct_file_data.to_s
     end
 

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -25,6 +25,10 @@ RSpec.feature "Completing a state file intake", active_job: true do
 
       step_through_df_data_transfer
 
+      puts "TRACE:101"
+      puts page.body
+      puts "TRACE:102"
+
       click_on "visit_federal_info_controller"
 
       expect(page).to have_field("tax return year", with: "2023")
@@ -166,6 +170,10 @@ RSpec.feature "Completing a state file intake", active_job: true do
       click_on I18n.t("state_file.questions.terms_and_conditions.edit.accept")
 
       step_through_df_data_transfer
+
+      puts "TRACE:201"
+      puts page.body
+      puts "TRACE:202"
 
       click_on "visit_federal_info_controller"
       click_on "New Dependent Detail"

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -168,8 +168,10 @@ RSpec.feature "Completing a state file intake", active_job: true do
       step_through_df_data_transfer
 
       puts "TRACE:201"
-      puts page.body
+      puts current_url
       puts "TRACE:202"
+      puts page.body
+      puts "TRACE:203"
 
       click_on "visit_federal_info_controller"
       click_on "New Dependent Detail"

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -25,10 +25,6 @@ RSpec.feature "Completing a state file intake", active_job: true do
 
       step_through_df_data_transfer
 
-      puts "TRACE:101"
-      puts page.body
-      puts "TRACE:102"
-
       click_on "visit_federal_info_controller"
 
       expect(page).to have_field("tax return year", with: "2023")

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -166,6 +166,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
       click_on I18n.t("state_file.questions.terms_and_conditions.edit.accept")
 
       step_through_df_data_transfer
+      #
 
       click_on "visit_federal_info_controller"
       click_on "New Dependent Detail"

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -166,7 +166,6 @@ RSpec.feature "Completing a state file intake", active_job: true do
       click_on I18n.t("state_file.questions.terms_and_conditions.edit.accept")
 
       step_through_df_data_transfer
-      #
 
       click_on "visit_federal_info_controller"
       click_on "New Dependent Detail"

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -165,7 +165,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
       expect(page).to have_text I18n.t('state_file.questions.terms_and_conditions.edit.title')
       click_on I18n.t("state_file.questions.terms_and_conditions.edit.accept")
 
-      step_through_df_data_transfer
+      step_through_df_data_transfer("Transfer AZ Old sample")
 
       click_on "visit_federal_info_controller"
       click_on "New Dependent Detail"

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -167,12 +167,6 @@ RSpec.feature "Completing a state file intake", active_job: true do
 
       step_through_df_data_transfer
 
-      puts "TRACE:201"
-      puts current_url
-      puts "TRACE:202"
-      puts page.body
-      puts "TRACE:203"
-
       click_on "visit_federal_info_controller"
       click_on "New Dependent Detail"
       within page.all('.df-dependent-detail-form')[1] do

--- a/spec/fixtures/files/fed_return_old_sample_az.xml
+++ b/spec/fixtures/files/fed_return_old_sample_az.xml
@@ -1,0 +1,254 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Return xmlns="http://www.irs.gov/efile" xmlns:efile="http://www.irs.gov/efile" returnVersion="2023v3.0">
+  <ReturnHeader binaryAttachmentCnt="0">
+    <ReturnTs>2023-09-12T16:47:43-04:00</ReturnTs>
+    <TaxYr>2023</TaxYr>
+    <TaxPeriodBeginDt>2023-01-01</TaxPeriodBeginDt>
+    <TaxPeriodEndDt>2023-12-31</TaxPeriodEndDt>
+    <SoftwareId>11111111</SoftwareId>
+    <SoftwareVersionNum>2022.2.100</SoftwareVersionNum>
+    <OriginatorGrp>
+      <EFIN>111111</EFIN>
+      <OriginatorTypeCd>ERO</OriginatorTypeCd>
+    </OriginatorGrp>
+    <SelfSelectPINGrp>
+      <PrimaryBirthDt>1958-01-01</PrimaryBirthDt>
+      <PrimaryPriorYearAGIAmt>0</PrimaryPriorYearAGIAmt>
+    </SelfSelectPINGrp>
+    <PINTypeCd>Self-Select On-Line</PINTypeCd>
+    <JuratDisclosureCd>Online Self Select PIN</JuratDisclosureCd>
+    <PrimaryPINEnteredByCd>Taxpayer</PrimaryPINEnteredByCd>
+    <PrimarySignaturePIN>12345</PrimarySignaturePIN>
+    <PrimarySignatureDt>2015-11-12</PrimarySignatureDt>
+    <ReturnTypeCd>1040</ReturnTypeCd>
+    <Filer>
+      <PrimarySSN>555002222</PrimarySSN>
+      <NameLine1Txt>TESTY T&lt;TESTERSON</NameLine1Txt>
+      <PrimaryNameControlTxt>TEST</PrimaryNameControlTxt>
+      <USAddress>
+        <AddressLine1Txt>123 Sesame St</AddressLine1Txt>
+        <CityNm>New York</CityNm>
+        <StateAbbreviationCd>AZ</StateAbbreviationCd>
+        <ZIPCd>10128</ZIPCd>
+      </USAddress>
+    </Filer>
+    <AdditionalFilerInformation>
+      <AtSubmissionFilingGrp>
+        <RefundProductElectionInd>false</RefundProductElectionInd>
+        <RefundDisbursementGrp>
+          <RefundDisbursementCd>3</RefundDisbursementCd>
+        </RefundDisbursementGrp>
+        <CellPhoneNum>8885551212</CellPhoneNum>
+        <EmailAddressTxt>testerson@example.com</EmailAddressTxt>
+      </AtSubmissionFilingGrp>
+      <TrustedCustomerGrp>
+        <TrustedCustomerCd>0</TrustedCustomerCd>
+      </TrustedCustomerGrp>
+    </AdditionalFilerInformation>
+    <FilingSecurityInformation>
+      <AtSubmissionCreationGrp>
+        <IPAddress>
+          <IPv4AddressTxt>76.122.220.120</IPv4AddressTxt>
+        </IPAddress>
+        <IPPortNum>58362</IPPortNum>
+        <DeviceId>0123456789AAAAAAAAAABBBBBBBBBBCCCCCCCCCC</DeviceId>
+        <DeviceTypeCd>0</DeviceTypeCd>
+      </AtSubmissionCreationGrp>
+      <AtSubmissionFilingGrp>
+        <IPAddress>
+          <IPv4AddressTxt>76.122.220.120</IPv4AddressTxt>
+        </IPAddress>
+        <DeviceId>0123456789AAAAAAAAAABBBBBBBBBBCCCCCCCCCC</DeviceId>
+        <DeviceTypeCd>0</DeviceTypeCd>
+      </AtSubmissionFilingGrp>
+      <FilingLicenseTypeCd>P</FilingLicenseTypeCd>
+      <TotalPreparationSubmissionTs>0</TotalPreparationSubmissionTs>
+      <TotActiveTimePrepSubmissionTs>0</TotActiveTimePrepSubmissionTs>
+      <AuthenticationReviewCd>0</AuthenticationReviewCd>
+      <VendorControlNum>IRSDIRTAXFPRD001</VendorControlNum>
+      <AuthenticationReviewTxt>58362#2023-03-11T02:13:50-06:00#2023-03-11T02:14:31-06:00</AuthenticationReviewTxt>
+    </FilingSecurityInformation>
+  </ReturnHeader>
+  <ReturnData documentCnt="8">
+    <IRS1040 documentId="IRS10400001">
+      <IndividualReturnFilingStatusCd>4</IndividualReturnFilingStatusCd>
+      <VirtualCurAcquiredDurTYInd>false</VirtualCurAcquiredDurTYInd>
+      <Primary65OrOlderInd>X</Primary65OrOlderInd>
+      <TotalExemptPrimaryAndSpouseCnt>1</TotalExemptPrimaryAndSpouseCnt>
+      <DependentDetail>
+        <DependentFirstNm>TESSA</DependentFirstNm>
+        <DependentLastNm>TESTERSON</DependentLastNm>
+        <DependentNameControlTxt>TEST</DependentNameControlTxt>
+        <DependentSSN>555004444</DependentSSN>
+        <DependentRelationshipCd>DAUGHTER</DependentRelationshipCd>
+        <EligibleForChildTaxCreditInd>X</EligibleForChildTaxCreditInd>
+      </DependentDetail>
+      <ChldWhoLivedWithYouCnt>1</ChldWhoLivedWithYouCnt>
+      <OtherDependentsListedCnt>0</OtherDependentsListedCnt>
+      <TotalExemptionsCnt>1</TotalExemptionsCnt>
+      <WagesAmt>21000</WagesAmt>
+      <HouseholdEmployeeWagesAmt>0</HouseholdEmployeeWagesAmt>
+      <TipIncomeAmt>0</TipIncomeAmt>
+      <MedicaidWaiverPymtNotRptW2Amt>0</MedicaidWaiverPymtNotRptW2Amt>
+      <TaxableBenefitsAmt>0</TaxableBenefitsAmt>
+      <TaxableBenefitsForm8839Amt>0</TaxableBenefitsForm8839Amt>
+      <TotalWagesWithNoWithholdingAmt>0</TotalWagesWithNoWithholdingAmt>
+      <NontxCombatPayElectionAmt>0</NontxCombatPayElectionAmt>
+      <WagesSalariesAndTipsAmt>21000</WagesSalariesAndTipsAmt>
+      <TaxableInterestAmt>24</TaxableInterestAmt>
+      <TotalTaxablePensionsAmt>0</TotalTaxablePensionsAmt>
+      <SocSecBnftAmt>12203</SocSecBnftAmt>
+      <TaxableSocSecAmt>5627</TaxableSocSecAmt>
+      <CapitalGainLossAmt>0</CapitalGainLossAmt>
+      <TotalAdditionalIncomeAmt>8500</TotalAdditionalIncomeAmt>
+      <TotalIncomeAmt>35151</TotalIncomeAmt>
+      <TotalAdjustmentsAmt>2800</TotalAdjustmentsAmt>
+      <AdjustedGrossIncomeAmt>32351</AdjustedGrossIncomeAmt>
+      <TotalItemizedOrStandardDedAmt>21150</TotalItemizedOrStandardDedAmt>
+      <TotalDeductionsAmt>21150</TotalDeductionsAmt>
+      <TaxableIncomeAmt>11201</TaxableIncomeAmt>
+      <TaxAmt>1123</TaxAmt>
+      <AdditionalTaxAmt>0</AdditionalTaxAmt>
+      <TotalTaxBeforeCrAndOthTaxesAmt>1123</TotalTaxBeforeCrAndOthTaxesAmt>
+      <TotalNonrefundableCreditsAmt>0</TotalNonrefundableCreditsAmt>
+      <TotalCreditsAmt>1123</TotalCreditsAmt>
+      <TaxLessCreditsAmt>0</TaxLessCreditsAmt>
+      <TotalOtherTaxesAmt>0</TotalOtherTaxesAmt>
+      <TotalTaxAmt>0</TotalTaxAmt>
+      <FormW2WithheldTaxAmt>1302</FormW2WithheldTaxAmt>
+      <Form1099WithheldTaxAmt>0</Form1099WithheldTaxAmt>
+      <TaxWithheldOtherAmt>0</TaxWithheldOtherAmt>
+      <WithholdingTaxAmt>1302</WithholdingTaxAmt>
+      <EstimatedTaxPaymentsAmt>0</EstimatedTaxPaymentsAmt>
+      <EarnedIncomeCreditAmt>1776</EarnedIncomeCreditAmt>
+      <AdditionalChildTaxCreditAmt>877</AdditionalChildTaxCreditAmt>
+      <TotalOtherPaymentsRfdblCrAmt>0</TotalOtherPaymentsRfdblCrAmt>
+      <RefundableCreditsAmt>2653</RefundableCreditsAmt>
+      <TotalPaymentsAmt>3955</TotalPaymentsAmt>
+      <OverpaidAmt>3955</OverpaidAmt>
+      <RefundAmt>3955</RefundAmt>
+      <OwedAmt>0</OwedAmt>
+      <EsPenaltyAmt>0</EsPenaltyAmt>
+      <ThirdPartyDesigneeInd>false</ThirdPartyDesigneeInd>
+      <PrimaryOccupationTxt>Teacher</PrimaryOccupationTxt>
+      <RefundProductCd>NO FINANCIAL PRODUCT</RefundProductCd>
+    </IRS1040>
+    <IRS1040Schedule1 documentId="Schedule10001">
+      <UnemploymentCompAmt>8500</UnemploymentCompAmt>
+      <TotalAdditionalIncomeAmt>8500</TotalAdditionalIncomeAmt>
+      <EducatorExpensesAmt>300</EducatorExpensesAmt>
+      <StudentLoanInterestDedAmt>2500</StudentLoanInterestDedAmt>
+      <TotalAdjustmentsAmt>2800</TotalAdjustmentsAmt>
+    </IRS1040Schedule1>
+    <IRS1040Schedule8812 documentId="Schedule88120001">
+      <AdjustedGrossIncomeAmt>32351</AdjustedGrossIncomeAmt>
+      <ModifiedAGIAmt>32351</ModifiedAGIAmt>
+      <QlfyChildUnderAgeSSNCnt>1</QlfyChildUnderAgeSSNCnt>
+      <QlfyChildUnderAgeSSNLimtAmt>2000</QlfyChildUnderAgeSSNLimtAmt>
+      <InitialCTCODCAmt>2000</InitialCTCODCAmt>
+      <FilingStatusThresholdCd>200000</FilingStatusThresholdCd>
+      <CTCODCOverAGILimitInd>true</CTCODCOverAGILimitInd>
+      <CTCODCAfterAGILimitAmt>2000</CTCODCAfterAGILimitAmt>
+      <ACTCTaxLiabiltyLimitAmt>1123</ACTCTaxLiabiltyLimitAmt>
+      <CTCODCAmt>1123</CTCODCAmt>
+      <ClaimACTCAllFilersGrp>
+        <ACTCBeforeLimitAmt>877</ACTCBeforeLimitAmt>
+        <QlfyChildUnderAgeSSNCnt>1</QlfyChildUnderAgeSSNCnt>
+        <QlfyChildUnderAgeSSNLimtAmt>1500</QlfyChildUnderAgeSSNLimtAmt>
+        <ACTCAfterLimitAmt>877</ACTCAfterLimitAmt>
+        <TotalEarnedIncomeAmt>21000</TotalEarnedIncomeAmt>
+        <EarnedIncmMoreThanSpecifiedInd>true</EarnedIncmMoreThanSpecifiedInd>
+        <NetTotalEarnedIncomeAmt>18500</NetTotalEarnedIncomeAmt>
+        <NetEarnedIncomeCalculatedAmt>2775</NetEarnedIncomeCalculatedAmt>
+        <ThreeOrMoreQlfyChildrenInd>false</ThreeOrMoreQlfyChildrenInd>
+      </ClaimACTCAllFilersGrp>
+      <AdditionalChildTaxCreditAmt>877</AdditionalChildTaxCreditAmt>
+    </IRS1040Schedule8812>
+    <IRS1040ScheduleEIC documentId="ScheduleEIC0001">
+      <QualifyingChildInformation>
+        <QualifyingChildNameControlTxt>TEST</QualifyingChildNameControlTxt>
+        <ChildFirstAndLastName>
+          <PersonFirstNm>Tessa</PersonFirstNm>
+          <PersonLastNm>Testerson</PersonLastNm>
+        </ChildFirstAndLastName>
+        <QualifyingChildSSN>555004444</QualifyingChildSSN>
+        <ChildBirthYr>2017</ChildBirthYr>
+        <ChildRelationshipCd>DAUGHTER</ChildRelationshipCd>
+        <MonthsChildLivedWithYouCnt>12</MonthsChildLivedWithYouCnt>
+      </QualifyingChildInformation>
+    </IRS1040ScheduleEIC>
+    <IRS1040ScheduleLEP documentId="ScheduleLEP0001">
+      <PersonNm>Testy T Testerson</PersonNm>
+      <SSN>555002222</SSN>
+      <LanguagePreferenceCd>001</LanguagePreferenceCd>
+    </IRS1040ScheduleLEP>
+    <IRS8862 documentId="88620001">
+      <TaxYr>2023</TaxYr>
+      <EICClaimedInd>X</EICClaimedInd>
+      <CTCACTCODCClaimedInd>X</CTCACTCODCClaimedInd>
+      <EICEligClmIncmIncorrectRptInd>false</EICEligClmIncmIncorrectRptInd>
+      <EICEligClmQlfyChldOfOtherInd>false</EICEligClmQlfyChldOfOtherInd>
+      <QualifyingChildInd>true</QualifyingChildInd>
+      <FilerWithQualifyingChildGrp>
+        <ChildFirstAndLastName>
+          <PersonFirstNm>Tessa</PersonFirstNm>
+          <PersonLastNm>Testerson</PersonLastNm>
+        </ChildFirstAndLastName>
+        <LiveInUSDayCnt>365</LiveInUSDayCnt>
+      </FilerWithQualifyingChildGrp>
+      <CTCACTCChildInformationGrp>
+        <ChildFirstAndLastName>
+          <PersonFirstNm>Tessa</PersonFirstNm>
+          <PersonLastNm>Testerson</PersonLastNm>
+        </ChildFirstAndLastName>
+        <LiveWithChildOverHalfYearInd>true</LiveWithChildOverHalfYearInd>
+        <QualifyingChildInd>true</QualifyingChildInd>
+        <DependentInd>true</DependentInd>
+        <USCitizenOrNationalInd>true</USCitizenOrNationalInd>
+      </CTCACTCChildInformationGrp>
+    </IRS8862>
+    <IRS9000 documentId="90000001">
+      <PersonNm>Testy T Testerson</PersonNm>
+      <SSN>555002222</SSN>
+      <AlternativeMediaCd>01</AlternativeMediaCd>
+    </IRS9000>
+    <IRSW2 documentId="W20001">
+      <EmployeeSSN>555002222</EmployeeSSN>
+      <EmployerEIN>121234567</EmployerEIN>
+      <EmployerNameControlTxt>APPL</EmployerNameControlTxt>
+      <EmployerName>
+        <BusinessNameLine1Txt>Apple Tree School</BusinessNameLine1Txt>
+      </EmployerName>
+      <EmployerUSAddress>
+        <AddressLine1Txt>273 Spencer Avenue</AddressLine1Txt>
+        <CityNm>New York</CityNm>
+        <StateAbbreviationCd>AZ</StateAbbreviationCd>
+        <ZIPCd>10128</ZIPCd>
+      </EmployerUSAddress>
+      <EmployeeNm>Testy T Testerson</EmployeeNm>
+      <EmployeeUSAddress>
+        <AddressLine1Txt>123 Sesame St</AddressLine1Txt>
+        <CityNm>New York</CityNm>
+        <StateAbbreviationCd>AZ</StateAbbreviationCd>
+        <ZIPCd>10128</ZIPCd>
+      </EmployeeUSAddress>
+      <WagesAmt>21000</WagesAmt>
+      <WithholdingAmt>1302</WithholdingAmt>
+      <SocialSecurityWagesAmt>21000</SocialSecurityWagesAmt>
+      <SocialSecurityTaxAmt>1302</SocialSecurityTaxAmt>
+      <MedicareWagesAndTipsAmt>21000</MedicareWagesAndTipsAmt>
+      <MedicareTaxWithheldAmt>305</MedicareTaxWithheldAmt>
+      <SocialSecurityTipsAmt>0</SocialSecurityTipsAmt>
+      <AllocatedTipsAmt>0</AllocatedTipsAmt>
+      <W2StateLocalTaxGrp>
+        <W2StateTaxGrp>
+          <StateAbbreviationCd>AZ</StateAbbreviationCd>
+          <EmployerStateIdNum>911123456</EmployerStateIdNum>
+          <StateWagesAmt>21000</StateWagesAmt>
+          <StateIncomeTaxAmt>450</StateIncomeTaxAmt>
+        </W2StateTaxGrp>
+      </W2StateLocalTaxGrp>
+      <StandardOrNonStandardCd>S</StandardOrNonStandardCd>
+    </IRSW2>
+  </ReturnData>
+</Return>

--- a/spec/models/state_file_ny_intake_spec.rb
+++ b/spec/models/state_file_ny_intake_spec.rb
@@ -340,5 +340,13 @@ describe StateFileNyIntake do
     it "returns nil when direct file data has no disqualifying fields" do
       expect(intake.disqualifying_df_data_reason).to be_nil
     end
+
+    it "returns has_out_of_state_w2 when direct file data has an out of state W2" do
+      w2 = intake.direct_file_data.w2_nodes.first
+      state_abbreviation_cd = w2.at("W2StateLocalTaxGrp W2StateTaxGrp StateAbbreviationCd")
+      state_abbreviation_cd.inner_html = "UT"
+
+      expect(intake.disqualifying_df_data_reason).to eq :has_out_of_state_w2
+    end
   end
 end

--- a/spec/support/helpers/state_file_intake_helper.rb
+++ b/spec/support/helpers/state_file_intake_helper.rb
@@ -67,12 +67,12 @@ module StateFileIntakeHelper
     click_on "Continue"
   end
 
-  def step_through_df_data_transfer
+  def step_through_df_data_transfer(sample_name = "Transfer my 2023 federal tax return to FileYourStateTaxes")
     expect(page).to have_text I18n.t('state_file.questions.initiate_data_transfer.edit.title')
     click_on I18n.t('state_file.questions.initiate_data_transfer.edit.button')
 
     expect(page).to have_text "Your 2023 federal tax return is ready to transfer to your state tax return."
-    click_on "Transfer my 2023 federal tax return to FileYourStateTaxes"
+    click_on sample_name
 
     expect(page).to have_text "Just a moment, we’re transferring your federal tax return to pre-fill parts of your state return."
     if Capybara.current_driver == Capybara.javascript_driver


### PR DESCRIPTION
When a user has a W2 from outside the current state in their direct file data, they get the following page:
![image](https://github.com/codeforamerica/vita-min/assets/17094895/1e47a09d-e7ab-4bb0-8e6e-dcc9f5e0f548)

To get tests working again after adding this additional constraint, I had to add a new test dataset that mimics an existing one, but has the state as AZ instead of NY
