### PR TITLE
Updates to Links for #186581695

### DIFF
--- a/app/views/state_file/questions/eligible/edit.html.erb
+++ b/app/views/state_file/questions/eligible/edit.html.erb
@@ -11,7 +11,7 @@
           <li><%= t(".increased_deduction") %></li>
           <li><a href="https://azdor.gov/individuals/income-tax-filing-assistance/deductions-and-exemptions" target="_blank" rel="noopener nofollow"><%= t(".dependent_credit") %></a></li>
           <li><a href="https://azdor.gov/individuals/income-tax-filing-assistance/tax-credits" target="_blank" rel="noopener nofollow"><%= t(".family_income_credit") %></a></li>
-          <li><a href="https://www.google.com/url?q=https://azdor.gov/forms/tax-credits-forms/credit-increased-excise-taxes&sa=D&source=docs&ust=1702498005392291&usg=AOvVaw27BYuJkG6FJtRuvyRPR_W5" target="_blank" rel="noopener nofollow"><%= t(".increased_excise_credit") %></a></li>
+          <li><a href="https://azdor.gov/forms/tax-credits-forms/credit-increased-excise-taxes" target="_blank" rel="noopener nofollow"><%= t(".increased_excise_credit") %></a></li>
         </ul>
       <% else %>
         <ul class="list--bulleted">

--- a/app/views/state_file/questions/submission_confirmation/edit.html.erb
+++ b/app/views/state_file/questions/submission_confirmation/edit.html.erb
@@ -8,7 +8,7 @@
 
   <p><%= t(".email_text_update") %></p>
 
-  <p><%= link_to t(".register_to_vote"), "" %></p>
+  <p><%= link_to t(".register_to_vote"), "https://vote.gov/" %></p>
 
   <% if params[:us_state] == "ny" %>
     <p><%= t(".ny_notifications_signup_html") %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2061,14 +2061,14 @@ en:
           public_school_tax_credit_provide_info_html: Provide school information, including the <a href="https://azdor.gov/sites/default/files/2023-03/PUBLICATION_ADESchoolListing.pdf" target="_blank" rel="noopener nofollow">CTDS code</a>
         edit:
           dependent_credit: Dependent Credit
-          empire_state_ctc: Empire State Child Credit
+          empire_state_ctc: Empire State Child Tax Credit
           family_income_credit: Family Income Credit
           increased_deduction: An increased deduction for charitable contributions
           increased_excise_credit: Increased Excise Credit
           not_supported: What credits and deductions does this tool not support this year?
           nyc_school_tax_credit: NYC School Tax Credit
-          nys_eic: NYS/NYC Earned Income Credit
-          nys_hh_credit: NYS/NYC Household Credit
+          nys_eic: NYS Earned Income Credit
+          nys_hh_credit: NYS Household Credit
           title1: Good news, you can use this tool this year to file your state taxes.
           title2: Here are the credits and deductions you may be able to claim with this tool to maximize your refund.
           want_to_claim_heading: Want to claim these credits or deductions?
@@ -2238,7 +2238,7 @@ en:
           help_friend_html: 'Help a friend or family member file their taxes for free. <a target="_blank" rel="noopener nofollow" href="">Tell them about IRS Direct File.</a>
 
             '
-          register_to_vote_html: '<a target="_blank" rel="noopener nofollow" href="">Register to vote.</a>
+          register_to_vote_html: '<a target="_blank" rel="noopener nofollow" href="https://vote.gov/">Register to vote.</a>
 
             '
           title: Your 2023 %{state_name} state tax return is accepted


### PR DESCRIPTION
1. Vita link is set to get your refund (gyr_url) . The link in this ticket is incorrect (TBD?)
2. Currently takes to links like http://statefile.localhost:3000/en/state_file/questions/other_filing_options?us_state=ny
3. Seems to already be complete.
4. Seems to be already complete
5. Fixed Increased Excise Credit link. The others already seem to be correct.
6. Links were correct, but terminology needed update
7. Register to vote link fixed