### PR TITLE
Update duplicate SSN on Robert XML

### DIFF
--- a/spec/fixtures/files/fed_return_robert_mfj_ny.xml
+++ b/spec/fixtures/files/fed_return_robert_mfj_ny.xml
@@ -46,7 +46,7 @@
         <DependentFirstNm>Tina</DependentFirstNm>
         <DependentLastNm>Belcher</DependentLastNm>
         <DependentNameControlTxt>BELC</DependentNameControlTxt>
-        <DependentSSN>300000032</DependentSSN>
+        <DependentSSN>300000031</DependentSSN>
         <DependentRelationshipCd>DAUGHTER</DependentRelationshipCd>
         <EligibleForChildTaxCreditInd>X</EligibleForChildTaxCreditInd>
       </DependentDetail>
@@ -186,7 +186,7 @@
           <PersonFirstNm>Tina</PersonFirstNm>
           <PersonLastNm>Belcher</PersonLastNm>
         </ChildFirstAndLastName>
-        <QualifyingChildSSN>300000032</QualifyingChildSSN>
+        <QualifyingChildSSN>300000031</QualifyingChildSSN>
         <ChildBirthYr>2020</ChildBirthYr>
         <ChildIsAStudentUnder24Ind>false</ChildIsAStudentUnder24Ind>
         <ChildPermanentlyDisabledInd>false</ChildPermanentlyDisabledInd>


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/2650644/stories/186733089/

Both Tina and Gene Belcher had the same SSN which caused one of them to go missing on our flow.  Gabriel has reached out to DF to see if this issue can be prevented on their end.