### PR TITLE
Add mobile desktop menu #186639306

### DIFF
--- a/app/assets/stylesheets/_state-file.scss
+++ b/app/assets/stylesheets/_state-file.scss
@@ -5,13 +5,7 @@
 
 .state-file-html-bg--az {
   background-color: $color-az-grey;
-}
 
-.state-file-html-bg--ny {
-  background-color: $color-ny-blue;
-}
-
-.state-file.us-state--az{
   .main-header {
     background-color: $color-az-grey;
   }
@@ -23,7 +17,9 @@
   }
 }
 
-.state-file.us-state--ny{
+.state-file-html-bg--ny {
+  background-color: $color-ny-blue;
+
   .main-header {
     background-color: $color-ny-blue;
   }
@@ -41,7 +37,11 @@
 
   .main-header {
     .toolbar__item {
-      font-size: 1.5rem
+      font-size: 1.5rem;
+    }
+
+    .toolbar__right {
+      margin-top: 0;
     }
   }
 

--- a/app/assets/stylesheets/_state-file.scss
+++ b/app/assets/stylesheets/_state-file.scss
@@ -3,31 +3,24 @@
   background-color: $color-az-grey; // set default background color on <html> so the footer doesn't look weird on shared pages
 }
 
+// Color overrides for AZ (Only for html element as Az is the default for the rest)
 .state-file-html-bg--az {
   background-color: $color-az-grey;
-
-  .main-header {
-    background-color: $color-az-grey;
-  }
-  .client-menu-closer {
-    background-color: $color-az-grey;
-  }
-  .client-menu {
-    background-color: $color-az-grey;
-  }
 }
 
+// Color overrides for NY
 .state-file-html-bg--ny {
   background-color: $color-ny-blue;
-
-  .main-header {
-    background-color: $color-ny-blue;
-  }
-  .client-menu-closer {
-    background-color: $color-ny-blue;
-  }
-  .client-menu {
-    background-color: $color-ny-blue;
+  .state-file {
+    .main-header {
+      background-color: $color-ny-blue;
+    }
+    .client-menu-closer {
+      background-color: $color-ny-blue;
+    }
+    .client-menu {
+      background-color: $color-ny-blue;
+    }
   }
 }
 
@@ -36,6 +29,8 @@
   font-size: 1.6rem;
 
   .main-header {
+    background-color: $color-az-grey;
+
     .toolbar__item {
       font-size: 1.5rem;
     }
@@ -46,6 +41,7 @@
   }
 
   .client-menu-closer {
+    background-color: $color-az-grey;
     color: white;
     width: 5.4rem;
     height: 5.4rem;
@@ -56,6 +52,7 @@
   }
 
   .client-menu {
+    background-color: $color-az-grey;
     top: 5.7rem;
     color: white;
 

--- a/app/assets/stylesheets/_state-file.scss
+++ b/app/assets/stylesheets/_state-file.scss
@@ -11,13 +11,62 @@
   background-color: $color-ny-blue;
 }
 
+.state-file.us-state--az{
+  .main-header {
+    background-color: $color-az-grey;
+  }
+  .client-menu-closer {
+    background-color: $color-az-grey;
+  }
+  .client-menu {
+    background-color: $color-az-grey;
+  }
+}
+
+.state-file.us-state--ny{
+  .main-header {
+    background-color: $color-ny-blue;
+  }
+  .client-menu-closer {
+    background-color: $color-ny-blue;
+  }
+  .client-menu {
+    background-color: $color-ny-blue;
+  }
+}
+
 .state-file {
-  background-color: $color-state-file-bg;
   font-family: $font-state-file;
   font-size: 1.6rem;
 
   .main-header {
-    background-color: $color-state-file-black;
+    .toolbar__item {
+      font-size: 1.5rem
+    }
+  }
+
+  .client-menu-closer {
+    color: white;
+    width: 5.4rem;
+    height: 5.4rem;
+
+    img {
+      filter: invert(1);
+    }
+  }
+
+  .client-menu {
+    top: 5.7rem;
+    color: white;
+
+    .client-menu-item {
+      border-bottom: none;
+      a {
+        color: white;
+        text-decoration: underline;
+        font-size: 2.2rem;
+      }
+    }
   }
 
   .footer {

--- a/app/assets/stylesheets/_state-file.scss
+++ b/app/assets/stylesheets/_state-file.scss
@@ -55,6 +55,11 @@
     background-color: $color-az-grey;
     top: 5.7rem;
     color: white;
+    width: 100%;
+
+    .container {
+      width: 100%;
+    }
 
     .client-menu-item {
       border-bottom: none;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -61,7 +61,9 @@
   <body <% if content_for :body_class %>class="<%= yield :body_class %>"<% elsif state_file? %>class="state-file"<% end %>>
     <div class="page-wrapper">
       <div data-component="ClientMenuOverlay" class="menu-overlay"></div>
-      <% unless hub? %>
+      <% if state_file? %>
+        <%= render 'state_file/state_file_pages/client_menu' %>
+      <% elsif !hub? %>
         <%= render "shared/client_menu" %>
       <% end %>
       <div class="page-content">

--- a/app/views/state_file/state_file_pages/_client_menu.html.erb
+++ b/app/views/state_file/state_file_pages/_client_menu.html.erb
@@ -1,0 +1,28 @@
+<div data-component="ClientMenuComponent" class="client-menu" data-target="toggle">
+  <div class="container">
+    <div>
+      <div class="client-menu-item">
+        <%= link_to "About", new_portal_client_login_path %>
+      </div>
+      <div class="client-menu-item">
+        <%= link_to t("general.faq"), faq_path %>
+      </div>
+      <div class="client-menu-item">
+        <%= link_to "Help", faq_path %>
+      </div>
+
+      <% if I18n.locale != :en %>
+        <div class="client-menu-item">
+          <%= link_to_english %>
+        </div>
+      <% end %>
+
+      <% if I18n.locale != :es %>
+        <div class="client-menu-item">
+          <%= link_to_spanish %>
+        </div>
+      <% end %>
+
+    </div>
+  </div>
+</div>

--- a/app/views/state_file/state_file_pages/_client_menu.html.erb
+++ b/app/views/state_file/state_file_pages/_client_menu.html.erb
@@ -2,13 +2,10 @@
   <div class="container">
     <div>
       <div class="client-menu-item">
-        <%= link_to "About", new_portal_client_login_path %>
+        <%= link_to t("general.about"), about_us_path %>
       </div>
       <div class="client-menu-item">
         <%= link_to t("general.faq"), faq_path %>
-      </div>
-      <div class="client-menu-item">
-        <%= link_to "Help", faq_path %>
       </div>
 
       <% if I18n.locale != :en %>

--- a/app/views/state_file/state_file_pages/_header.html.erb
+++ b/app/views/state_file/state_file_pages/_header.html.erb
@@ -8,6 +8,8 @@
       </div>
     </div>
     <div class="toolbar__right is-mobile-hidden">
+      <%= link_to t("general.about"), about_us_path, class: "toolbar__item text--small" %>
+      <%= link_to t("general.faq"), faq_path, class: "toolbar__item text--small" %>
       <% if I18n.locale != :en %>
         <%= link_to_english(class: "toolbar__item text--small") %>
       <% end %>

--- a/app/views/state_file/state_file_pages/_header.html.erb
+++ b/app/views/state_file/state_file_pages/_header.html.erb
@@ -7,5 +7,17 @@
         <% end %>
       </div>
     </div>
+    <div class="toolbar__right is-mobile-hidden">
+      <% if I18n.locale != :en %>
+        <%= link_to_english(class: "toolbar__item text--small") %>
+      <% end %>
+      <% if I18n.locale != :es %>
+        <%= link_to_spanish(class: "toolbar__item text--small") %>
+      <% end %>
+    </div>
+    <a data-component="ClientMenuTrigger" class="client-menu-trigger is-desktop-hidden toolbar__item text--small">Menu</a>
+    <a class="is-desktop-hidden client-menu-closer" data-component="ClientMenuCloser">
+      <%= image_tag "icons/close.svg"%>
+    </a>
   </div>
 </header>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -248,6 +248,7 @@ en:
         withdrawal_date_deadline: Please enter a date on or before April 15, %{year}
   general:
     NA: N/A
+    about: About
     access_denied: You are not authorized to take this action.
     activate_all: Activate All
     active: active

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -249,6 +249,7 @@ es:
         withdrawal_date_deadline: Ingrese una fecha anterior al 15 de abril de %{year}
   general:
     NA: N/A
+    about: Acerca de
     access_denied: Usted no está autorizado a tomar esta acción.
     activate_all: Activar todo
     active: activos


### PR DESCRIPTION
A whole bunch of CSS changes / fixes went in here. The menu links are not fully right yet, but match the mocks in figma.
The mobile menu for state file now has a button:
![image](https://github.com/codeforamerica/vita-min/assets/17094895/7efc6257-4123-4047-9bb2-a0ea451b2ef0)
Menu Items are vertically centered in state file (They were 4px off due to different toolbar sizes for gyr):
![image](https://github.com/codeforamerica/vita-min/assets/17094895/b460debb-b93b-47b1-be79-f75c8b31a164)
There is a mobile menu with colors that match figma for both AZ and NY. It is now positioned as in the mock - also, the X is the correct color and does not overhang the menu:
![image](https://github.com/codeforamerica/vita-min/assets/17094895/b081c5e8-3a3c-4b5f-b4db-298e2ba72161)

