### PR TITLE
Filtering incarcerated question from review page #186728319

### DIFF
--- a/app/controllers/state_file/questions/az_incarcerated_controller.rb
+++ b/app/controllers/state_file/questions/az_incarcerated_controller.rb
@@ -4,9 +4,7 @@ module StateFile
       include ReturnToReviewConcern
 
       def self.show?(intake)
-        has_valid_ssn = intake.primary.ssn.present? && !intake.primary.has_itin?
-        has_valid_agi = intake.direct_file_data.fed_agi <= (intake.filing_status_mfj? || intake.filing_status_hoh? ? 25_000 : 12_500)
-        has_valid_ssn && has_valid_agi
+        intake.ask_whether_incarcerated?
       end
     end
   end

--- a/app/models/state_file_az_intake.rb
+++ b/app/models/state_file_az_intake.rb
@@ -151,4 +151,10 @@ class StateFileAzIntake < StateFileBaseIntake
       eligibility_529_for_non_qual_expense: "yes",
     }
   end
+
+  def ask_whether_incarcerated?
+    has_valid_ssn = primary.ssn.present? && !primary.has_itin?
+    has_valid_agi = direct_file_data.fed_agi <= (filing_status_mfj? || filing_status_hoh? ? 25_000 : 12_500)
+    has_valid_ssn && has_valid_agi
+  end
 end

--- a/app/views/state_file/questions/az_review/edit.html.erb
+++ b/app/views/state_file/questions/az_review/edit.html.erb
@@ -42,13 +42,15 @@
     </div>
   </div>
 
-  <div id="incarcerated" class="blue-group">
-    <div class="spacing-below-5">
-      <p class="text--bold spacing-below-5"><%=t(".incarcerated") %></p>
-      <p><%=current_intake.was_incarcerated_yes? ? t("general.affirmative") : t("general.negative") %></p>
-      <%= link_to t("general.edit"), StateFile::Questions::AzIncarceratedController.to_path_helper(us_state: "az", return_to_review: "y"), class: "button--small" %>
+  <% if current_intake.ask_whether_incarcerated? %>
+    <div id="incarcerated" class="blue-group">
+      <div class="spacing-below-5">
+        <p class="text--bold spacing-below-5"><%=t(".incarcerated") %></p>
+        <p><%=current_intake.was_incarcerated_yes? ? t("general.affirmative") : t("general.negative") %></p>
+        <%= link_to t("general.edit"), StateFile::Questions::AzIncarceratedController.to_path_helper(us_state: "az", return_to_review: "y"), class: "button--small" %>
+      </div>
     </div>
-  </div>
+  <% end %>
 
   <%= render "state_file/questions/shared/review_footer" %>
 <% end %>

--- a/spec/controllers/state_file/questions/az_review_controller_spec.rb
+++ b/spec/controllers/state_file/questions/az_review_controller_spec.rb
@@ -35,5 +35,29 @@ RSpec.describe StateFile::Questions::AzReviewController do
         expect(refund_or_owed_label).to eq I18n.t("state_file.questions.shared.review_header.your_refund")
       end
     end
+
+    context "ask about incarceration" do
+      render_views
+      let(:intake) { create :state_file_az_refund_intake }
+      before do
+        session[:state_file_intake] = intake.to_global_id
+        sign_in intake
+      end
+
+      it "shows the incarcerated question" do
+        session[:state_file_intake] = intake.to_global_id
+
+        get :edit, params: { us_state: "az" }
+        expect(response.body).to include I18n.t("state_file.questions.az_review.edit.incarcerated")
+      end
+
+      it "does not show the incarcerated question" do
+        intake.update(raw_direct_file_data: intake.raw_direct_file_data.gsub!("10000", "20000"))
+        session[:state_file_intake] = intake.to_global_id
+
+        get :edit, params: { us_state: "az" }
+        expect(response.body).not_to include I18n.t("state_file.questions.az_review.edit.incarcerated")
+      end
+    end
   end
 end

--- a/spec/models/state_file_az_intake_spec.rb
+++ b/spec/models/state_file_az_intake_spec.rb
@@ -219,4 +219,22 @@ describe StateFileAzIntake do
       expect(intake.qualifying_parents_and_grandparents).to eq(1)
     end
   end
+
+  describe 'ask_whether_incarcerated' do
+    let(:intake) { create :state_file_az_intake }
+
+    context "when should ask" do
+      it 'asks whether incarcerated' do
+        intake.direct_file_data.fed_agi = 10000
+        expect(intake.ask_whether_incarcerated?).to eq true
+      end
+    end
+
+    context "when should not ask" do
+      it 'does not ask whether incarcerated' do
+        intake.direct_file_data.fed_agi = 20000
+        expect(intake.ask_whether_incarcerated?).to eq false
+      end
+    end
+  end
 end


### PR DESCRIPTION
Using the existing rules (Moved to model from controller) to determine whether to show / hide the incarcerated section in review (Shown below hidden):
![image](https://github.com/codeforamerica/vita-min/assets/17094895/127d83eb-d11e-4e07-8b63-97af0e80ad39)
