### PR TITLE
Only Displaying Months in Home if Present #186728244

### DIFF
--- a/app/views/state_file/questions/shared/_review_header.html.erb
+++ b/app/views/state_file/questions/shared/_review_header.html.erb
@@ -43,10 +43,12 @@
         <p class="text--bold spacing-below-5"><%=t(".dependent_dob") %></p>
         <p><%=dependent.dob %></p>
       </div>
-      <div class="spacing-below-5">
-        <p class="text--bold spacing-below-5"><%=t(".dependent_months_in_home") %></p>
-        <p><%=dependent.months_in_home %></p>
-      </div>
+      <% if dependent.months_in_home.present? %>
+        <div class="spacing-below-5">
+          <p class="text--bold spacing-below-5"><%=t(".dependent_months_in_home") %></p>
+          <p><%=dependent.months_in_home %></p>
+        </div>
+      <% end %>
     <% end %>
     <div class="spacing-below-5">
       <%= link_to t("general.edit"), StateFile::Questions::NameDobController.to_path_helper(us_state: us_state, return_to_review: "y"), class: "button--small" %>

--- a/spec/controllers/state_file/questions/ny_review_controller_spec.rb
+++ b/spec/controllers/state_file/questions/ny_review_controller_spec.rb
@@ -29,5 +29,18 @@ RSpec.describe StateFile::Questions::NyReviewController do
         expect(refund_or_owed_label).to eq I18n.t("state_file.questions.shared.review_header.your_refund")
       end
     end
+
+    context "when a dependent is present" do
+      render_views
+      let(:intake) { create :state_file_ny_refund_intake }
+      let!(:dependent) { intake.dependents.create(dob: 7.years.ago, first_name: "Bobby", last_name: "Tables", relationship: "Son") }
+
+      it "displayed dependent details" do
+        get :edit, params: { us_state: "ny" }
+        expect(response.body).to include I18n.t("state_file.questions.shared.review_header.dependent_dob")
+        expect(response.body).to include "Bobby Tables"
+        expect(response.body).not_to include I18n.t("state_file.questions.shared.review_header.dependent_months_in_home")
+      end
+    end
   end
 end


### PR DESCRIPTION
Months in home is now only displayed in the review page if it is present in the record (Shown filtered below). This view is shared between AZ and NY, and checking for presence means we don't need to change that:
![image](https://github.com/codeforamerica/vita-min/assets/17094895/fe50a24e-ef6f-45d6-8c4b-167774de3539)
