### PR TITLE
Efile submission transitions logs reformatting in hub

### DIFF
--- a/app/views/hub/state_file/efile_submissions/_log.html.erb
+++ b/app/views/hub/state_file/efile_submissions/_log.html.erb
@@ -38,9 +38,9 @@
                   <% xml = Nokogiri::XML(t.metadata["receipt"]) %>
                   <tr>
                     <td>
-                      <%= xml.css("SubmissionReceivedTs").text.strip %>
+                      <%= DateTime.parse(xml.css("SubmissionReceivedTs").text.strip).strftime("%Y-%m-%d %H:%M") %>
                     </td>
-                    <td>Submission received time</td>
+                    <td>Submission received</td>
                   </tr>
                 <% end %>
               <% end %>

--- a/app/views/hub/state_file/efile_submissions/_log.html.erb
+++ b/app/views/hub/state_file/efile_submissions/_log.html.erb
@@ -1,29 +1,73 @@
-<li role="listitem">
-  <div class="timestamp"><%= timestamp transition.created_at %></div>
-  <div class="status <%= transition.to_state %>"><%= transition.to_state.humanize %></div>
-  <div class="details">
-    <% if transition.initiated_by.present? %>
-      <div>Initiated by: <%= transition.initiated_by.name_with_role %></div>
-    <% end %>
-    <% transition.efile_errors.each do |error| %>
-        <div>
-          <strong><%= "#{error.code}" if error.code.present? %></strong>
-          <%= error.message %>
+<% transmitted_transitions = transitions.select { |t| t.to_state == "transmitted" } %>
+<% if transitions.present? %>
+  <% transitions.each do |transition| %>
+    <% unless transmitted_transitions.include?(transition) && transition != transmitted_transitions.first %>
+      <li role="listitem">
+        <div class="timestamp"><%= timestamp transition.created_at %></div>
+        <div class="status <%= transition.to_state %>"><%= transition.to_state.humanize %></div>
+        <div class="details">
+          <% if transition.initiated_by.present? %>
+            <div>Initiated by: <%= transition.initiated_by.name_with_role %></div>
+          <% end %>
+
+          <% transition.efile_errors.each do |error| %>
+            <div>
+              <strong><%= "#{error.code}" if error.code.present? %></strong>
+              <%= error.message %>
+            </div>
+          <% end %>
+
+          <% if transition.to_state == "transmitted" %>
+            <table>
+              <tr>
+                <th>date</th>
+                <th>submission status</th>
+              </tr>
+              <% transmitted_transitions.each do |t| %>
+                <% if t.metadata["raw_response"].present? %>
+                  <% xml = Nokogiri::XML(t.metadata["raw_response"]) %>
+                  <tr>
+                    <td>
+                      <%= xml.css("SubmsnStatusAcknowledgementDt").text.strip %>
+                    </td>
+                    <td>
+                      <%= xml.css("SubmissionStatusTxt").text.strip %>
+                    </td>
+                  </tr>
+                <% elsif t.metadata["receipt"] %>
+                  <% xml = Nokogiri::XML(t.metadata["receipt"]) %>
+                  <tr>
+                    <td>
+                      <%= xml.css("SubmissionReceivedTs").text.strip %>
+                    </td>
+                    <td>Submission received time</td>
+                  </tr>
+                <% end %>
+              <% end %>
+            </table>
+          <% end %>
+
+          <% if transition.metadata.present? %>
+            <div class="accordion spacing-above-10">
+              <a href="#" class="accordion__button" aria-expanded="true" aria-controls="a2">
+                <h3>Details</h3>
+              </a>
+              <div class="accordion__content" id="a2">
+              <pre>
+                <code>
+                  <% metadata = transition.to_state == "transmitted" ? transmitted_transitions.pluck(:metadata) : transition.metadata %>
+                  <% metadata.each do |m| %>
+                    <%= m %>
+                  <% end %>
+                </code>
+              </pre>
+              </div>
+            </div>
+          <% end %>
         </div>
+      </li>
     <% end %>
-    <% if transition.metadata.present? %>
-      <div class="accordion spacing-above-10">
-        <a href="#" class="accordion__button" aria-expanded="true" aria-controls="a2">
-          <h3>Details</h3>
-        </a>
-        <div class="accordion__content" id="a2">
-          <pre>
-            <code>
-              <%= transition.metadata %>
-            </code>
-          </pre>
-        </div>
-      </div>
-    <% end %>
-  </div>
-</li>
+  <% end %>
+<% else %>
+  <p>No logs yet</p>
+<% end %>

--- a/app/views/hub/state_file/efile_submissions/show.html.erb
+++ b/app/views/hub/state_file/efile_submissions/show.html.erb
@@ -60,7 +60,7 @@
       <div class="log-wrapper">
         <h4 class="spacing-below-10">Status Logs</h4>
         <ul role="list" class="logs">
-          <%= render(partial: "log", collection: @efile_submission.efile_submission_transitions, as: :transition) || "No logs yet" %>
+          <%= render("log", transitions: @efile_submission.efile_submission_transitions) %>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
Consolidating the display of the transmitted states so that its easier to read in the hub
<img width="1126" alt="Screenshot 2024-01-09 at 12 38 05 PM" src="https://github.com/codeforamerica/vita-min/assets/49880002/e603fdb5-add0-4d49-93b0-34db938de4a5">
