### PR TITLE
Translate dependent relationships 

### DIFF
--- a/app/helpers/pdf_helper.rb
+++ b/app/helpers/pdf_helper.rb
@@ -1,5 +1,4 @@
 module PdfHelper
-
   def yes_no_unfilled_to_checkbox(value)
     value == "yes" ? "1" : nil
   end

--- a/app/lib/pdf_filler/az140_pdf.rb
+++ b/app/lib/pdf_filler/az140_pdf.rb
@@ -42,18 +42,17 @@ module PdfFiller
       end
 
       answers["10a_10b check box"] = 'Yes' if @xml_document.css('DependentsDetail').length > 3
-
-      @xml_document.css('DependentDetails').each_with_index do |dependents_node, index|
+      @submission.data_source.dependents.reject(&:is_qualifying_parent_or_grandparent?).each_with_index do |dependent, index|
         # PDF fields seem to be named consistently (10c ... 10p) whether they are on Page 1 or Page 4
         prefix = "10#{('c'..'p').to_a[index]}"
         answers.merge!(
-          "#{prefix} First" => dependents_node.at("FirstName")&.text,
-          "#{prefix} Last" => dependents_node.at("LastName")&.text,
-          "#{prefix} SSN" => dependents_node.at("DependentSSN")&.text,
-          "#{prefix} Relationship" => dependents_node.at("RelationShip")&.text,
-          "#{prefix} Mo in Home" => dependents_node.at("NumMonthsLived")&.text,
-          "#{prefix}_10a check box" => dependents_node.at("DepUnder17")&.text,
-          "#{prefix}_10b check box" => dependents_node.at("Dep17AndOlder")&.text,
+          "#{prefix} First" => dependent.first_name,
+          "#{prefix} Last" => dependent.last_name,
+          "#{prefix} SSN" => dependent.ssn.delete('-'),
+          "#{prefix} Relationship" => dependent.relationship_label,
+          "#{prefix} Mo in Home" => dependent.months_in_home,
+          "#{prefix}_10a check box" => dependent.under_17? ? "X" : nil,
+          "#{prefix}_10b check box" => dependent.under_17? ? nil : "X",
         )
       end
 
@@ -64,17 +63,17 @@ module PdfFiller
 
       answers["11a check box"] = 'Yes' if @xml_document.css('QualParentsAncestors').length > 2
 
-      @xml_document.css('QualParentsAncestors').each_with_index do |qualifying_relative_node, index|
+      @submission.data_source.dependents.select(&:is_qualifying_parent_or_grandparent?).each_with_index do |dependent, index|
         # PDF fields seem to be named consistently (11b ... 11i) whether they are on Page 1 or Page 4
         prefix = "11#{('b'..'i').to_a[index]}"
         answers.merge!(
-          "#{prefix} First" => qualifying_relative_node.at("FirstName")&.text,
-          "#{prefix} Last" => qualifying_relative_node.at("LastName")&.text,
-          "#{prefix} SSN" => qualifying_relative_node.at("DependentSSN")&.text,
-          "#{prefix} Relationship" => qualifying_relative_node.at("RelationShip")&.text,
-          "#{prefix} Mo in Home" => qualifying_relative_node.at("NumMonthsLived")&.text,
-          "#{prefix} over 65" => qualifying_relative_node.at("IsOverSixtyFive")&.text,
-          "#{prefix} died" => qualifying_relative_node.at("DiedInTaxYear")&.text,
+          "#{prefix} First" => dependent.first_name,
+          "#{prefix} Last" => dependent.last_name,
+          "#{prefix} SSN" => dependent.ssn.delete('-'),
+          "#{prefix} Relationship" => dependent.relationship_label,
+          "#{prefix} Mo in Home" => dependent.months_in_home,
+          "#{prefix} over 65" => dependent.over65? ? "X" : nil,
+          "#{prefix} died" => dependent.passed_away_yes? ? "X" : nil,
         )
       end
 

--- a/app/lib/pdf_filler/az140_pdf.rb
+++ b/app/lib/pdf_filler/az140_pdf.rb
@@ -72,7 +72,7 @@ module PdfFiller
           "#{prefix} SSN" => dependent.ssn.delete('-'),
           "#{prefix} Relationship" => dependent.relationship_label,
           "#{prefix} Mo in Home" => dependent.months_in_home,
-          "#{prefix} over 65" => dependent.over65? ? "X" : nil,
+          "#{prefix} over 65" => "X", # all of these dependents are 65 or older
           "#{prefix} died" => dependent.passed_away_yes? ? "X" : nil,
         )
       end

--- a/app/lib/pdf_filler/ny201_pdf.rb
+++ b/app/lib/pdf_filler/ny201_pdf.rb
@@ -183,7 +183,7 @@ module PdfFiller
         answers["H_first#{index}"] = dependent.first_name
         answers["H_middle#{index}"] = dependent.middle_initial
         answers["H_last#{index}"] = dependent.last_name
-        answers["H_relationship#{index}"] = dependent.relationship
+        answers["H_relationship#{index}"] = dependent.relationship_label
         answers["H_dependent_ssn#{index}"] = dependent.ssn
         answers["H_dependent_dob#{index}"] = dependent.dob.strftime("%m%d%Y")
       end

--- a/app/lib/pdf_filler/ny215_pdf.rb
+++ b/app/lib/pdf_filler/ny215_pdf.rb
@@ -53,7 +53,7 @@ module PdfFiller
                          "ln3mi#{index}" => dependent.middle_initial,
                          "ln34ln#{index}" => dependent.last_name,
                          "ln34suf#{index}" => dependent.suffix,
-                         "ln34real#{index}" => dependent.relationship,
+                         "ln34real#{index}" => dependent.relationship_label,
                          "month#{index}" => nil,
                          "ln34disability#{index}" =>  dependent.eic_disability,
                          "ln34student#{index}" =>  dependent.eic_student ? "Yes" : "Off",

--- a/app/lib/submission_builder/ty2022/states/az/dependent_relationship_table.rb
+++ b/app/lib/submission_builder/ty2022/states/az/dependent_relationship_table.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+module SubmissionBuilder
+  module Ty2022
+    module States
+      module Az
+        module DependentRelationshipTable
+          # "direct file relationship" => "AZ XML relationship"
+          DF_TO_AZ_XML_RELATIONSHIPS = {
+            "DAUGHTER" => "CHILD",
+            "STEPCHILD" => "CHILD",
+            "FOSTER CHILD" => "FOSTERCHILD",
+            "GRANDCHILD" => "GRANDCHILD",
+            "SISTER" => "SIBLING",
+            "NEPHEW" => "NIECENEPHEW",
+            "HALF" => "SISTER	HALFSIBLING",
+            "STEPBROTHER" => "STEPSIBLING",
+            "GRANDPARENT" => "GRANDPARENT",
+            "PARENT" => "PARENT",
+            "NONE" => "OTHER"
+          }.freeze
+
+          # returns the corresponding AZ XML relationship string for the
+          # input Direct File relationship key
+          def relationship_key(direct_file_relationship)
+            DF_TO_AZ_XML_RELATIONSHIPS[direct_file_relationship]
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/submission_builder/ty2022/states/az/dependent_relationship_table.rb
+++ b/app/lib/submission_builder/ty2022/states/az/dependent_relationship_table.rb
@@ -12,7 +12,7 @@ module SubmissionBuilder
             "GRANDCHILD" => "GRANDCHILD",
             "SISTER" => "SIBLING",
             "NEPHEW" => "NIECENEPHEW",
-            "HALF" => "SISTER	HALFSIBLING",
+            "HALF SISTER" => "HALFSIBLING",
             "STEPBROTHER" => "STEPSIBLING",
             "GRANDPARENT" => "GRANDPARENT",
             "PARENT" => "PARENT",

--- a/app/lib/submission_builder/ty2022/states/ny/documents/it201.rb
+++ b/app/lib/submission_builder/ty2022/states/ny/documents/it201.rb
@@ -96,7 +96,7 @@ module SubmissionBuilder
                       xml.DEP_CHLD_FRST_NAME claimed: dependent.first_name
                       xml.DEP_CHLD_MI_NAME claimed: dependent.middle_initial
                       xml.DEP_CHLD_LAST_NAME claimed: dependent.last_name
-                      xml.DEP_RELATION_DESC claimed: dependent.relationship
+                      xml.DEP_RELATION_DESC claimed: dependent.relationship.delete(" ") # no spaces
                       xml.DEP_SSN_NMBR claimed: dependent.ssn
                       xml.DOB_DT claimed: dependent.dob.strftime("%Y-%m-%d")
                     end

--- a/app/lib/submission_builder/ty2022/states/ny/individual_return.rb
+++ b/app/lib/submission_builder/ty2022/states/ny/individual_return.rb
@@ -87,7 +87,7 @@ module SubmissionBuilder
                   xml.DEP_SEQ_NMBR index+1
                   xml.DEP_DISAB_IND dependent.eic_disability == true ? 1 : 2
                   xml.DEP_FORM_ID 348 # 348 is the code for the IT-213 form
-                  xml.DEP_RELATION_DESC dependent.relationship
+                  xml.DEP_RELATION_DESC dependent.relationship.delete(" ") # no spaces
                   xml.DEP_STUDENT_IND dependent.eic_student == true ? 1 : 2
                   xml.DEP_CHLD_LAST_NAME dependent.last_name
                   xml.DEP_CHLD_FRST_NAME dependent.first_name
@@ -104,7 +104,7 @@ module SubmissionBuilder
                   xml.DEP_SEQ_NMBR index+1
                   xml.DEP_DISAB_IND dependent.eic_disability == true ? 1 : 2
                   xml.DEP_FORM_ID 215
-                  xml.DEP_RELATION_DESC dependent.relationship
+                  xml.DEP_RELATION_DESC dependent.relationship.delete(" ") # no spaces
                   xml.DEP_STUDENT_IND dependent.eic_student == true ? 1 : 2
                   xml.DEP_CHLD_LAST_NAME dependent.last_name
                   xml.DEP_CHLD_FRST_NAME dependent.first_name

--- a/app/models/state_file_dependent.rb
+++ b/app/models/state_file_dependent.rb
@@ -27,6 +27,20 @@
 #  index_state_file_dependents_on_intake  (intake_type,intake_id)
 #
 class StateFileDependent < ApplicationRecord
+  RELATIONSHIP_LABELS = {
+    "DAUGHTER" => "Child",
+    "STEPCHILD" => "Child",
+    "FOSTER CHILD" => "Foster Child",
+    "GRANDCHILD" => "Grandchild",
+    "SISTER" => "Sibling",
+    "HALF SISTER" => "Half-Sibling",
+    "NEPHEW" => "Niece/Nephew",
+    "STEPBROTHER" => "Step-Sibling",
+    "PARENT" => "Parent",
+    "GRANDPARENT" => "Grandparent",
+    "NONE" => "Other",
+  }.freeze
+
   belongs_to :intake, polymorphic: true
   encrypts :ssn
   enum needed_assistance: { unfilled: 0, yes: 1, no: 2 }, _prefix: :needed_assistance
@@ -58,7 +72,19 @@ class StateFileDependent < ApplicationRecord
     MultiTenantService.statefile.end_of_current_tax_year.years_ago(65)
   end
 
+  def under_17?
+    age < 17
+  end
+
+  def over_65?
+    age > 65
+  end
+
   def age
     ((MultiTenantService.statefile.end_of_current_tax_year.to_time - dob.to_time) / 1.year.seconds).floor
+  end
+
+  def relationship_label
+    RELATIONSHIP_LABELS[relationship]
   end
 end

--- a/app/views/state_file/questions/ny_permanent_address/edit.html.erb
+++ b/app/views/state_file/questions/ny_permanent_address/edit.html.erb
@@ -15,7 +15,7 @@
           <div class="form-question spacing-below-15">
             <div class="text--bold"><%=t(".address_header") %></div>
             <div><%= current_intake.direct_file_data.mailing_street %></div>
-            <div><%= current_intake.direct_file_data.mailing_city %>,<%= current_intake.direct_file_data.mailing_state %> <%= current_intake.direct_file_data.mailing_zip %></div>
+            <div><%= current_intake.direct_file_data.mailing_city %>, <%= current_intake.direct_file_data.mailing_state %> <%= current_intake.direct_file_data.mailing_zip %></div>
           </div>
           <div>
             <%=

--- a/spec/lib/submission_builder/ty2022/states/az/individual_return_spec.rb
+++ b/spec/lib/submission_builder/ty2022/states/az/individual_return_spec.rb
@@ -20,7 +20,12 @@ describe SubmissionBuilder::Ty2022::States::Az::IndividualReturn do
       let(:dob) { 12.years.ago }
 
       before do
-        intake.dependents.create(dob: dob)
+        create(:state_file_dependent, intake: intake, dob: dob, relationship: "DAUGHTER")
+      end
+
+      it "translates the relationship to the appropriate AZ XML relationship key" do
+        xml = Nokogiri::XML::Document.parse(described_class.build(submission).document.to_xml)
+        expect(xml.at("DependentDetails RelationShip").text).to eq "CHILD"
       end
 
       context "when a dependent is under 17" do

--- a/spec/models/state_file/state_file_dependent_spec.rb
+++ b/spec/models/state_file/state_file_dependent_spec.rb
@@ -49,7 +49,7 @@ describe StateFileDependent do
     end
   end
 
-  describe "asking additional AZ senior questions" do
+  describe "#ask_senior_questions?" do
     it "asks more questions when a dependent is 65+ by the end of the tax year + grandparent + 12 months in home" do
       dependent = build(
         :state_file_dependent,
@@ -106,7 +106,7 @@ describe StateFileDependent do
     end
   end
 
-  describe "detecting qualified parents or grandparents for dependents that are 65+" do
+  describe "#is_qualifying_parent_or_grandparent?" do
     it "only returns dependents that are 65+ by end of tax year, a grandparent or parent, spent 12 months in home, and needed assistance" do
       qualifying_grandparent = create(
         :state_file_dependent,

--- a/spec/models/state_file/state_file_dependent_spec.rb
+++ b/spec/models/state_file/state_file_dependent_spec.rb
@@ -159,7 +159,7 @@ describe StateFileDependent do
     end
   end
 
-  describe "age calculates correctly" do
+  describe "#age" do
     it "when the birthday is the last day of the tax year" do
       dependent = build(
         :state_file_dependent,
@@ -173,6 +173,13 @@ describe StateFileDependent do
         dob: (MultiTenantService.statefile.end_of_current_tax_year + 1.days - 10.years).strftime("%Y-%m-%d")
       )
       expect(dependent.age).to be 9
+    end
+  end
+
+  describe "#relationship_label" do
+    it "provides a correct gender neutral relationship label" do
+      dependent = build(:state_file_dependent, relationship: "STEPBROTHER")
+      expect(dependent.relationship_label).to eq "Step-Sibling"
     end
   end
 end


### PR DESCRIPTION
- use a standard gender neutral label for all pdf filling
- for NY XML, use the direct file key without spaces
- for AZ XML, use a specific lookup table to translate
- Lookup table: https://docs.google.com/spreadsheets/d/1UsqhxMo5vHsXgoaYunzsAkGw0u9I41kqB73eCRG9fBI/edit?usp=sharing
- Pivotal Tracker Story: https://www.pivotaltracker.com/story/show/186770060