### PR TITLE
NY Section I Audit: IT-201 lines 34-38

### DIFF
--- a/spec/lib/efile/ny/it201_spec.rb
+++ b/spec/lib/efile/ny/it201_spec.rb
@@ -16,6 +16,44 @@ describe Efile::Ny::It201 do
     end
   end
 
+  describe 'Lines 34-38 New York State tax from tables' do
+    context 'when the filing status is single AND primary_claim_as_dependent' do
+      before do
+        intake.direct_file_data.filing_status = 1 # single
+        intake.direct_file_data.primary_claim_as_dependent = 'X'
+      end
+
+      it 'sets the correct tax amount' do
+        instance.calculate
+        expect(instance.lines[:IT201_LINE_34].value).to eq(3_100) # taxable income
+      end
+    end
+
+    context 'when the filing status is single' do
+      before do
+        intake.direct_file_data.filing_status = 1 # single
+      end
+
+      it 'sets the correct tax amount' do
+        instance.calculate
+        expect(instance.lines[:IT201_LINE_34].value).to eq(8_000) # taxable income
+      end
+    end
+
+    context 'when the filing status is married_filing_separately' do
+      before do
+        intake.direct_file_data.filing_status = 3 # married_filing_separately
+      end
+
+      it 'sets the correct tax amount' do
+        instance.calculate
+        expect(instance.lines[:IT201_LINE_34].value).to eq(8_000) # taxable income
+      end
+    end
+
+  end
+
+
   describe 'Line 39 New York State tax from tables' do
     context 'when the filing status is single' do
       before do

--- a/spec/lib/efile/ny/it201_spec.rb
+++ b/spec/lib/efile/ny/it201_spec.rb
@@ -126,7 +126,6 @@ describe Efile::Ny::It201 do
     end
 
     context 'IT201_LINE_36' do
-      # let(:intake) { create(:state_file_zeus_intake) } # Has 8 dependents
       it 'adds the correct dependent exemptions' do
         instance.calculate
         expect(intake.dependents.count).to eq(1)

--- a/spec/lib/efile/ny/it201_spec.rb
+++ b/spec/lib/efile/ny/it201_spec.rb
@@ -120,7 +120,7 @@ describe Efile::Ny::It201 do
           instance.calculate
           expect(instance.lines[:IT201_LINE_33].value).to eq(7000)
           expect(instance.lines[:IT201_LINE_34].value).to eq(8000)
-          expect(instance.lines[:IT201_LINE_35].value).to eq(0)
+          expect(instance.lines[:IT201_LINE_35].value).to eq(0) # (if line 34 is more than line 33, leave blank)
         end
       end
     end

--- a/spec/lib/efile/ny/it201_spec.rb
+++ b/spec/lib/efile/ny/it201_spec.rb
@@ -132,6 +132,20 @@ describe Efile::Ny::It201 do
         expect(instance.lines[:IT201_LINE_36].value).to eq(1) # (The form adds a '000.00' to it == 1000.00)
       end
     end
+
+    context 'IT201_LINE_37' do
+      it 'adds the correct taxable income' do
+        instance.calculate
+        expect(instance.lines[:IT201_LINE_35].value).to eq(18_724)
+        expect(instance.lines[:IT201_LINE_36].value).to eq(1)
+        expect(instance.lines[:IT201_LINE_37].value).to eq(17_724) # Taxable income (subtract line 36*1000 from line 35) .
+      end
+    end
+
+    context 'IT201_LINE_38' do
+      # TODO
+    end
+
   end
 
   describe 'Line 39 New York State tax from tables' do

--- a/spec/lib/efile/ny/it201_spec.rb
+++ b/spec/lib/efile/ny/it201_spec.rb
@@ -17,8 +17,8 @@ describe Efile::Ny::It201 do
   end
 
   describe 'Line 33 New York State tax from tables' do
-    context 'when the New York adjusted gross income is 50k' do
-      it 'populates the correct value from IRS1040 AdjustedGrossIncomeAmt' do
+    context 'when there are NY additions (lines 20-24) and subtractions (lines 25-31)' do
+      it 'populates the correct value for the New York adjusted gross income' do
         instance.calculate
         expect(instance.lines[:IT201_LINE_24].value).to eq(32_351)
         expect(instance.lines[:IT201_LINE_32].value).to eq(5_627)

--- a/spec/lib/efile/ny/it201_spec.rb
+++ b/spec/lib/efile/ny/it201_spec.rb
@@ -138,14 +138,19 @@ describe Efile::Ny::It201 do
         instance.calculate
         expect(instance.lines[:IT201_LINE_35].value).to eq(18_724)
         expect(instance.lines[:IT201_LINE_36].value).to eq(1)
-        expect(instance.lines[:IT201_LINE_37].value).to eq(17_724) # Taxable income (subtract line 36*1000 from line 35) .
+        # Taxable income (subtract line 36*1000 from line 35)
+        # 18_724 - 1000
+        expect(instance.lines[:IT201_LINE_37].value).to eq(17_724)
       end
     end
 
     context 'IT201_LINE_38' do
-      # TODO
+      it 'sets the correct taxable income' do
+        instance.calculate
+        expect(instance.lines[:IT201_LINE_37].value).to eq(17_724)
+        expect(instance.lines[:IT201_LINE_38].value).to eq(17_724) # Taxable income (from line 37 on page 2)
+      end
     end
-
   end
 
   describe 'Line 39 New York State tax from tables' do

--- a/spec/lib/efile/ny/it201_spec.rb
+++ b/spec/lib/efile/ny/it201_spec.rb
@@ -58,7 +58,7 @@ describe Efile::Ny::It201 do
 
       context 'when the filing status is married_filing_separately' do
         before do
-          intake.direct_file_data.filing_status = 3
+          intake.direct_file_data.filing_status = 3 # married_filing_separately
         end
 
         it 'sets the correct deduction amount' do
@@ -69,7 +69,7 @@ describe Efile::Ny::It201 do
 
       context 'when the filing status is married_filing_jointly' do
         before do
-          intake.direct_file_data.filing_status = 2
+          intake.direct_file_data.filing_status = 2 # married_filing_jointly
         end
 
         it 'sets the correct deduction amount' do
@@ -80,7 +80,7 @@ describe Efile::Ny::It201 do
 
       context 'when the filing status is qualifying_widow' do
         before do
-          intake.direct_file_data.filing_status = 5
+          intake.direct_file_data.filing_status = 5 # qualifying_widow
         end
 
         it 'sets the correct deduction amount' do
@@ -91,7 +91,7 @@ describe Efile::Ny::It201 do
 
       context 'when the filing status is head_of_household' do
         before do
-          intake.direct_file_data.filing_status = 4
+          intake.direct_file_data.filing_status = 4 # head_of_household
         end
 
         it 'sets the correct deduction amount' do
@@ -122,6 +122,15 @@ describe Efile::Ny::It201 do
           expect(instance.lines[:IT201_LINE_34].value).to eq(8000)
           expect(instance.lines[:IT201_LINE_35].value).to eq(0)
         end
+      end
+    end
+
+    context 'IT201_LINE_36' do
+      # let(:intake) { create(:state_file_zeus_intake) } # Has 8 dependents
+      it 'adds the correct dependent exemptions' do
+        instance.calculate
+        expect(intake.dependents.count).to eq(1)
+        expect(instance.lines[:IT201_LINE_36].value).to eq(1) # (The form adds a '000.00' to it == 1000.00)
       end
     end
   end

--- a/spec/lib/efile/ny/it201_spec.rb
+++ b/spec/lib/efile/ny/it201_spec.rb
@@ -18,10 +18,6 @@ describe Efile::Ny::It201 do
 
   describe 'Line 33 New York State tax from tables' do
     context 'when the New York adjusted gross income is 50k' do
-      before do
-        intake.direct_file_data.fed_agi = 50_000
-      end
-
       it 'populates the correct value from IRS1040 AdjustedGrossIncomeAmt' do
         instance.calculate
         expect(instance.lines[:IT201_LINE_24].value).to eq(32_351)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186692291

NY Section I Audit: IT-201 lines 34-38 | (Standard deduction, dependent exemptions, taxable income)

The one open question around line 36 and its' downstream implications have been verified with the specs in my PR. We add the number of dependents on line 36, but the form has 000.00 appended; which is technically adding the $1000.00 of exemption dollars for each dependent. The downstream code is correct in using the number of dependents times a thousand.

![Screen Shot 2024-01-11 at 11 11 45 AM](https://github.com/codeforamerica/vita-min/assets/2385700/388d6213-10f2-44d6-9df2-d3e29a2e545e)

------------

<img width="940" alt="Screen Shot 2024-01-10 at 1 30 17 PM" src="https://github.com/codeforamerica/vita-min/assets/2385700/35cfdd94-4930-42ad-9b50-334d4c819f1d">


