### PR TITLE
Forms xsd audit

### DIFF
--- a/app/lib/submission_builder/ty2022/states/az/documents/state1099_g.rb
+++ b/app/lib/submission_builder/ty2022/states/az/documents/state1099_g.rb
@@ -30,7 +30,7 @@ module SubmissionBuilder
                 xml.RecipientSSN recipient.ssn
                 xml.RecipientName recipient.full_name
                 xml.RecipientUSAddress do
-                  xml.AddressLine1Txt form1099g.recipient_street_address
+                  xml.AddressLine1Txt form1099g.form1099g.recipient_address_line1
                   xml.CityNm form1099g.recipient_city
                   xml.StateAbbreviationCd "AZ"
                   xml.ZIPCd form1099g.recipient_zip

--- a/app/lib/submission_builder/ty2022/states/az/documents/state1099_g.rb
+++ b/app/lib/submission_builder/ty2022/states/az/documents/state1099_g.rb
@@ -30,7 +30,7 @@ module SubmissionBuilder
                 xml.RecipientSSN recipient.ssn
                 xml.RecipientName recipient.full_name
                 xml.RecipientUSAddress do
-                  xml.AddressLine1Txt form1099g.form1099g.recipient_address_line1
+                  xml.AddressLine1Txt form1099g.recipient_address_line1
                   xml.CityNm form1099g.recipient_city
                   xml.StateAbbreviationCd "AZ"
                   xml.ZIPCd form1099g.recipient_zip

--- a/app/lib/submission_builder/ty2022/states/ny/documents/state1099_g.rb
+++ b/app/lib/submission_builder/ty2022/states/ny/documents/state1099_g.rb
@@ -30,7 +30,7 @@ module SubmissionBuilder
                 xml.RecipientSSN recipient.ssn
                 xml.RecipientName recipient.full_name
                 xml.RecipientUSAddress do
-                  xml.AddressLine1Txt form1099g.recipient_street_address
+                  xml.AddressLine1Txt form1099g.recipient_address_line1
                   xml.CityNm form1099g.recipient_city
                   xml.StateAbbreviationCd "NY"
                   xml.ZIPCd form1099g.recipient_zip

--- a/app/models/state_file1099_g.rb
+++ b/app/models/state_file1099_g.rb
@@ -30,7 +30,7 @@
 #
 class StateFile1099G < ApplicationRecord
   belongs_to :intake, polymorphic: true
-  before_save :update_conditional_attributes
+  before_validation :update_conditional_attributes
 
   enum address_confirmation: { unfilled: 0, yes: 1, no: 2 }, _prefix: :address_confirmation
   enum had_box_11: { unfilled: 0, yes: 1, no: 2 }, _prefix: :had_box_11

--- a/app/models/state_file1099_g.rb
+++ b/app/models/state_file1099_g.rb
@@ -43,6 +43,9 @@ class StateFile1099G < ApplicationRecord
   validates_presence_of :payer_zip, :message => I18n.t("errors.attributes.address.zip.blank")
   validates :payer_tin, format: { :with => /\d{9}/, :message => I18n.t("errors.attributes.payer_tin.blank")}
   validates_presence_of :state_identification_number, :message => I18n.t("errors.attributes.state_id_number.empty")
+  validates_presence_of :recipient_city
+  validates_presence_of :recipient_street_address
+  validates_presence_of :recipient_zip
 
   def update_conditional_attributes
     if address_confirmation_yes?

--- a/app/models/state_file1099_g.rb
+++ b/app/models/state_file1099_g.rb
@@ -66,4 +66,8 @@ class StateFile1099G < ApplicationRecord
       intake.spouse.full_name
     end
   end
+
+  def recipient_address_line1
+    "#{recipient_street_address_apartment} #{recipient_street_address}".strip
+  end
 end

--- a/spec/factories/state_file1099_gs.rb
+++ b/spec/factories/state_file1099_gs.rb
@@ -40,5 +40,8 @@ FactoryBot.define do
     unemployment_compensation { '1' }
     federal_income_tax_withheld { '0' }
     state_income_tax_withheld { '0' }
+    recipient_city {'New York'}
+    recipient_street_address {'123 Recipient St'}
+    recipient_zip {'11102'}
   end
 end

--- a/spec/models/state_file1099_g_spec.rb
+++ b/spec/models/state_file1099_g_spec.rb
@@ -95,5 +95,9 @@ RSpec.describe StateFile1099G do
       state_file_1099.state_income_tax_withheld = '-1'
       expect(state_file_1099.save).to eq false
     end
+
+    it "yields a valid recipient address line 1" do
+      expect(state_file_1099.recipient_address_line_1).to eq "123 Main St"
+    end
   end
 end

--- a/spec/models/state_file1099_g_spec.rb
+++ b/spec/models/state_file1099_g_spec.rb
@@ -97,6 +97,8 @@ RSpec.describe StateFile1099G do
     end
 
     it "yields a valid recipient address line 1" do
+      expect(state_file_1099.recipient_address_line1).to eq "Apt E 123 Main St"
+      state_file_1099.recipient_street_address_apartment = nil
       expect(state_file_1099.recipient_address_line1).to eq "123 Main St"
     end
   end

--- a/spec/models/state_file1099_g_spec.rb
+++ b/spec/models/state_file1099_g_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe StateFile1099G do
     end
 
     it "yields a valid recipient address line 1" do
-      expect(state_file_1099.recipient_address_line_1).to eq "123 Main St"
+      expect(state_file_1099.recipient_address_line1).to eq "123 Main St"
     end
   end
 end


### PR DESCRIPTION
I moved the action that copies the address from the intake from `before_save` to `before_validation` - this means that the address will always be present and can be validated. I added validations for the address