### PR TITLE
Remove redundant abs #186692275

### DIFF
--- a/app/lib/efile/ny/it201.rb
+++ b/app/lib/efile/ny/it201.rb
@@ -44,7 +44,7 @@ module Efile
         set_line(:IT201_LINE_15, @direct_file_data, :fed_taxable_ssb)
         set_line(:IT201_LINE_17, :calculate_line_17)
         set_line(:IT201_LINE_18, @direct_file_data, :fed_total_adjustments)
-        set_line(:IT201_LINE_19, @direct_file_data, :fed_agi)
+        set_line(:IT201_LINE_19, :calculate_line_19)
         set_line(:IT201_LINE_21, @direct_file_data, :ny_public_employee_retirement_contributions)
         set_line(:IT201_LINE_24, :calculate_line_24)
         set_line(:IT201_LINE_25, -> { @lines[:IT201_LINE_4]&.value })
@@ -109,6 +109,10 @@ module Efile
         end
 
         result
+      end
+
+      def calculate_line_19
+        line_or_zero(:IT201_LINE_17) - line_or_zero(:IT201_LINE_18)
       end
 
       def calculate_line_24

--- a/app/lib/efile/ny/it201.rb
+++ b/app/lib/efile/ny/it201.rb
@@ -44,7 +44,7 @@ module Efile
         set_line(:IT201_LINE_15, @direct_file_data, :fed_taxable_ssb)
         set_line(:IT201_LINE_17, :calculate_line_17)
         set_line(:IT201_LINE_18, @direct_file_data, :fed_total_adjustments)
-        set_line(:IT201_LINE_19, :calculate_line_19)
+        set_line(:IT201_LINE_19, @direct_file_data, :fed_agi)
         set_line(:IT201_LINE_21, @direct_file_data, :ny_public_employee_retirement_contributions)
         set_line(:IT201_LINE_24, :calculate_line_24)
         set_line(:IT201_LINE_25, -> { @lines[:IT201_LINE_4]&.value })
@@ -109,10 +109,6 @@ module Efile
         end
 
         result
-      end
-
-      def calculate_line_19
-        line_or_zero(:IT201_LINE_17) - line_or_zero(:IT201_LINE_18)
       end
 
       def calculate_line_24

--- a/app/lib/efile/ny/it201.rb
+++ b/app/lib/efile/ny/it201.rb
@@ -112,7 +112,7 @@ module Efile
       end
 
       def calculate_line_19
-        line_or_zero(:IT201_LINE_17) - line_or_zero(:IT201_LINE_18).abs
+        line_or_zero(:IT201_LINE_17) - line_or_zero(:IT201_LINE_18)
       end
 
       def calculate_line_24


### PR DESCRIPTION
We derive Line18 from direct_file_data.fed_total_adjustments, which is really just
taken from the XML: `IRS1040Schedule1 TotalAdjustmentsAmt`

Looking at the IRS1040Schedule1.xsd for this:
```
<xsd:element name="TotalAdjustmentsAmt" minOccurs="0">
	<xsd:annotation>
		<xsd:documentation>
			<Description>Total Adjustments Amount</Description>
			<LineNumber>22</LineNumber>
		</xsd:documentation>
	</xsd:annotation>
	<xsd:complexType>
		<xsd:simpleContent>
			<xsd:extension base="USAmountNNType">
				<xsd:attribute name="referenceDocumentId" type="IdListType"/>
				<xsd:attribute name="referenceDocumentName" type="StringType" fixed="OtherAdjustmentsStatement"/>
			</xsd:extension>
		</xsd:simpleContent>
	</xsd:complexType>
</xsd:element>
```

It indicates that it is Line 22 of the 1040:
`Subtract line 21 from line 18. If zero or less, enter -0-`

And the XML type is USAmountNNType - a non negative integer:
```
	<xsd:simpleType name="USAmountNNType">
		<xsd:annotation>
			<xsd:documentation>Type for a U.S. non-negative integer amount field</xsd:documentation>
		</xsd:annotation>
		<xsd:restriction base="xsd:nonNegativeInteger">
			<xsd:totalDigits value="15"/>
		</xsd:restriction>
	</xsd:simpleType>
```

I guess there is no way this value should ever be less than 0, so the abs seems redundant. Given that the code was written by Travis Grathwell, I don't have any way to confirm this.

I double checked in aptible that there are not any test intakes where this value is < 0:
```
StateFileNyIntake.all.select do
  begin
    i.direct_file_data.fed_total_adjustments != 0
  rescue
    false
  end
end

=> []
```
