### PR TITLE
Data transfer errors out on first attempt

### DIFF
--- a/app/controllers/questions/questions_controller.rb
+++ b/app/controllers/questions/questions_controller.rb
@@ -101,12 +101,6 @@ module Questions
     end
 
     def redirect_if_no_intake
-      # session.delete(:state_file_intake)
-      # current_intake.timedout?(14.minutes.ago)
-      # session[:state_file_intake]
-      # current_intake
-      # binding.pry
-
       if current_intake.present?
         # Assign the global id of the state_file_intake of the session to be that of the current_intake
         # This attempts to prevent the weird timeout issues we have been experiencing in the flow.

--- a/app/controllers/questions/questions_controller.rb
+++ b/app/controllers/questions/questions_controller.rb
@@ -2,7 +2,6 @@ module Questions
   class QuestionsController < ApplicationController
     before_action :redirect_in_offseason
     before_action :redirect_if_completed_intake_present
-    before_action :redirect_if_no_intake
     before_action :set_current_step, :set_in_intake_flow
     delegate :form_name, to: :class
     delegate :form_class, to: :class
@@ -97,26 +96,6 @@ module Questions
     def redirect_if_completed_intake_present
       if current_intake && current_intake.completed_at.present?
         redirect_to portal_root_path
-      end
-    end
-
-    def redirect_if_no_intake
-      if current_intake.present?
-        # Assign the global id of the state_file_intake of the session to be that of the current_intake
-        # This attempts to prevent the weird timeout issues we have been experiencing in the flow.
-        # Where the session's intake does match the true current one and ends up timing out erroneously.
-        session[:state_file_intake] = "gid://vita-min/#{current_intake.class}/#{current_intake.id}"
-        # Sign out from previous intake if they differ from current_intake
-        # TODO
-      else
-        begin
-          visitor_id = cookies['visitor_id']
-          raise "The session for visitor with id:#{visitor_id} has expired"
-        rescue => e
-          Sentry.capture_exception(e)
-        end
-        flash[:notice] = 'Your session expired. Please sign in again to continue.'
-        redirect_to root_path
       end
     end
 

--- a/app/controllers/questions/questions_controller.rb
+++ b/app/controllers/questions/questions_controller.rb
@@ -101,7 +101,17 @@ module Questions
     end
 
     def redirect_if_no_intake
-      unless current_intake.present?
+      # session.delete(:state_file_intake)
+      # current_intake.timedout?(14.minutes.ago)
+      # session[:state_file_intake]
+      # current_intake
+      # binding.pry
+
+      if current_intake.present?
+        # Assign the global id of the state_file_intake of the session to be that of the current_intake
+        # This attempts to prevent the weird timeout issues we have been experiencing in the flow.
+        session[:state_file_intake] = "gid://vita-min/#{current_intake.class}/#{current_intake.id}"
+      else
         begin
           visitor_id = question_navigator.intake_class.last.visitor_id
           raise "The session for visitor with id:#{visitor_id} has expired"

--- a/app/controllers/questions/questions_controller.rb
+++ b/app/controllers/questions/questions_controller.rb
@@ -106,6 +106,8 @@ module Questions
         # This attempts to prevent the weird timeout issues we have been experiencing in the flow.
         # Where the session's intake does match the true current one and ends up timing out erroneously.
         session[:state_file_intake] = "gid://vita-min/#{current_intake.class}/#{current_intake.id}"
+        # Sign out from previous intake if they differ from current_intake
+        # TODO
       else
         begin
           visitor_id = question_navigator.intake_class.last.visitor_id

--- a/app/controllers/questions/questions_controller.rb
+++ b/app/controllers/questions/questions_controller.rb
@@ -110,7 +110,7 @@ module Questions
         # TODO
       else
         begin
-          visitor_id = question_navigator.intake_class.last.visitor_id
+          visitor_id = cookies['visitor_id']
           raise "The session for visitor with id:#{visitor_id} has expired"
         rescue => e
           Sentry.capture_exception(e)

--- a/app/controllers/questions/questions_controller.rb
+++ b/app/controllers/questions/questions_controller.rb
@@ -104,6 +104,7 @@ module Questions
       if current_intake.present?
         # Assign the global id of the state_file_intake of the session to be that of the current_intake
         # This attempts to prevent the weird timeout issues we have been experiencing in the flow.
+        # Where the session's intake does match the true current one and ends up timing out erroneously.
         session[:state_file_intake] = "gid://vita-min/#{current_intake.class}/#{current_intake.id}"
       else
         begin

--- a/app/controllers/state_file/questions/landing_page_controller.rb
+++ b/app/controllers/state_file/questions/landing_page_controller.rb
@@ -2,6 +2,11 @@ module StateFile
   module Questions
     class LandingPageController < QuestionsController
       include StartIntakeConcern
+      before_action :before_update, only: :update
+
+      def before_update
+        sign_out current_intake if current_intake
+      end
     end
   end
 end

--- a/app/controllers/state_file/questions/questions_controller.rb
+++ b/app/controllers/state_file/questions/questions_controller.rb
@@ -50,7 +50,7 @@ module StateFile
             Sentry.capture_exception(e)
           end
           flash[:notice] = 'Your session expired. Please sign in again to continue.'
-          redirect_to root_path
+          redirect_to question_navigator.first.controller_path
         end
       end
 

--- a/app/controllers/state_file/questions/questions_controller.rb
+++ b/app/controllers/state_file/questions/questions_controller.rb
@@ -36,14 +36,12 @@ module StateFile
 
       def redirect_if_no_intake
         unless current_intake.present?
-          begin
-            visitor_id = cookies['visitor_id']
-            raise "The session for visitor with id:#{visitor_id} has expired"
-          rescue => e
-            Sentry.capture_exception(e)
-          end
           flash[:notice] = 'Your session expired. Please sign in again to continue.'
-          redirect_to  '/'+I18n.locale.to_s.concat('/', request.url.split('/')[4], '/',question_navigator.first.controller_path.gsub('_page', '-page').split('/')[1..2].join('/'))
+          if params['us_state'] == 'az'
+            redirect_to az_questions_landing_page_path(us_state: params['us_state'])
+          else
+            redirect_to ny_questions_landing_page_path(us_state: params['us_state'])
+          end
         end
       end
 

--- a/app/controllers/state_file/questions/questions_controller.rb
+++ b/app/controllers/state_file/questions/questions_controller.rb
@@ -35,14 +35,7 @@ module StateFile
       end
 
       def redirect_if_no_intake
-        if current_intake.present?
-          # Assign the global id of the state_file_intake of the session to be that of the current_intake
-          # This attempts to prevent the weird timeout issues we have been experiencing in the flow.
-          # Where the session's intake does match the true current one and ends up timing out erroneously.
-          session[:state_file_intake] = "gid://vita-min/#{current_intake.class}/#{current_intake.id}"
-          # Sign out from previous intake if they differ from current_intake
-          # TODO
-        else
+        unless current_intake.present?
           begin
             visitor_id = cookies['visitor_id']
             raise "The session for visitor with id:#{visitor_id} has expired"
@@ -50,7 +43,7 @@ module StateFile
             Sentry.capture_exception(e)
           end
           flash[:notice] = 'Your session expired. Please sign in again to continue.'
-          redirect_to question_navigator.first.controller_path
+          redirect_to  '/'+I18n.locale.to_s.concat('/', request.url.split('/')[4], '/',question_navigator.first.controller_path.gsub('_page', '-page').split('/')[1..2].join('/'))
         end
       end
 

--- a/spec/controllers/state_file/questions/data_review_controller_spec.rb
+++ b/spec/controllers/state_file/questions/data_review_controller_spec.rb
@@ -30,6 +30,17 @@ RSpec.describe StateFile::Questions::DataReviewController do
         expect(response).to redirect_to(StateFile::Questions::DataTransferOffboardingController.to_path_helper(us_state: "az"))
       end
     end
+
+    context 'when the session times out/ is destroyed' do
+      it "redirects to the home page" do
+        allow(Sentry).to receive(:capture_exception)
+        session.destroy
+        response = get :edit, params: { us_state: "az" }
+        expect(response).to redirect_to(root_path)
+        expect(flash[:notice]).to eq('Your session expired. Please sign in again to continue.')
+        expect(Sentry).to have_received(:capture_exception)
+      end
+    end
   end
 
   describe "#update" do

--- a/spec/controllers/state_file/questions/data_review_controller_spec.rb
+++ b/spec/controllers/state_file/questions/data_review_controller_spec.rb
@@ -32,13 +32,11 @@ RSpec.describe StateFile::Questions::DataReviewController do
     end
 
     context 'when the session times out/ is destroyed' do
-      it "redirects to the home page" do
-        allow(Sentry).to receive(:capture_exception)
+      it 'redirects to the landing page for the correct state' do
         session.destroy
         response = get :edit, params: { us_state: "az" }
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(az_questions_landing_page_path(us_state: 'az'))
         expect(flash[:notice]).to eq('Your session expired. Please sign in again to continue.')
-        expect(Sentry).to have_received(:capture_exception)
       end
     end
   end


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/2650644/stories/186828012

<img width="453" alt="Screen Shot 2024-01-12 at 11 34 49 AM" src="https://github.com/codeforamerica/vita-min/assets/2385700/3ff9a7b5-ab75-4357-8cfd-ec30041bc365">

### Description
This code fix prevents intakes from previous sessions to time out the devise's timeoutable feature though warden.  However, it will still error if you two simultaneous sessions from either state running along side each other.

Thanks @bengolder & @tofarr for your input!




