### PR TITLE
Calculate NYS taxes

### DIFF
--- a/app/lib/efile/ny/it201.rb
+++ b/app/lib/efile/ny/it201.rb
@@ -159,16 +159,27 @@ module Efile
       end
 
       def calculate_line_39
+        # This was implemented based on the official instructions:
+        # https://www.tax.ny.gov/forms/html-instructions/2023/it/it201i-2023.htm#nys-tax-table
         agi = line_or_zero(:IT201_LINE_33)
         taxable_income = line_or_zero(:IT201_LINE_38)
         if agi <= 107_650
-          # use NYS tax rate schedule
+          # Note about tax tables and not using them:
+          #   The instructions point to the use of tax tables if "NYS taxable income is less than $65,000"
+          #   These are the tax tables: https://www.tax.ny.gov/pit/file/tax-tables/it201i-2023.htm
+          #   The tax table values are themselves calculated using the NYS Tax Rate Schedule. After conferring
+          #   with Courtney O'Reilly, it was clear that using the NYS Tax Rate Schedule was the best approach was to
+          #   use the NYS Tax Rate Schedule for all NY AGI under $107,650 regardless of taxable income
+          #
+          # use the NYS tax rate schedule
+          # https://www.tax.ny.gov/forms/html-instructions/2023/it/it201i-2023.htm#nys-tax-rate-schedule
           result = NysTaxRateSchedule.calculate(taxable_income, @filing_status)
         else
           # use NYS tax computation worksheet
+          # https://www.tax.ny.gov/forms/html-instructions/2023/it/it201i-2023.htm#tax-computation
           result = NysTaxComputation.calculate(agi, taxable_income, @filing_status)
         end
-        result.round
+        result.round # rounding to the nearest dollar should be done as a final step, not before.
       end
 
       def calculate_line_40
@@ -470,11 +481,6 @@ module Efile
         else
           table_row.amounts[household_size - 1]
         end
-      end
-
-      def round_to_decimal(val, digits)
-        ten_to_the_digits_power = 10 ** digits
-        (val * ten_to_the_digits_power).round / (ten_to_the_digits_power * 1.0)
       end
     end
   end

--- a/app/lib/efile/ny/it201.rb
+++ b/app/lib/efile/ny/it201.rb
@@ -158,188 +158,16 @@ module Efile
         [result, 0].max
       end
 
-      def nys_tax_from_tables(taxable_income)
-        table =
-          if filing_status_single? || filing_status_mfs?
-            [
-              TaxTableRow.new(-Float::INFINITY, 8_500, 0, 0.0400),
-              TaxTableRow.new(8_500, 11_700, 340, 0.0450),
-              TaxTableRow.new(11_700, 13_900, 484, 0.0525),
-              TaxTableRow.new(13_900, 80_650, 600, 0.0585),
-              TaxTableRow.new(80_650, 215_400, 4_504, 0.0625),
-              TaxTableRow.new(215_400, 1_077_550, 12_926, 0.0685),
-              TaxTableRow.new(1_077_550, 5_000_000, 71_984, 0.0965),
-              TaxTableRow.new(5_000_000, 25_000_000, 450_500, 0.103),
-              TaxTableRow.new(25_000_000, Float::INFINITY, 2_510_500, 0.109)
-            ]
-          elsif filing_status_mfj? || filing_status_qw?
-            [
-              TaxTableRow.new(-Float::INFINITY, 17_150, 0, 0.0400),
-              TaxTableRow.new(17_150, 23_600, 686, 0.0450),
-              TaxTableRow.new(23_600, 27_900, 976, 0.0525),
-              TaxTableRow.new(27_900, 161_550, 1_202, 0.0585),
-              TaxTableRow.new(161_550, 323_200, 9_021, 0.0625),
-              TaxTableRow.new(323_200, 2_155_350, 19_124, 0.0685),
-              TaxTableRow.new(2_155_350, 5_000_000, 144_626, 0.0965),
-              TaxTableRow.new(5_000_000, 25_000_000, 419_135, 0.103),
-              TaxTableRow.new(25_000_000, Float::INFINITY, 2_479_135, 0.109)
-            ]
-          else # head of household
-            [
-              TaxTableRow.new(-Float::INFINITY, 12_800, 0, 0.0400),
-              TaxTableRow.new(12_800, 17_650, 512, 0.0450),
-              TaxTableRow.new(17_650, 20_900, 730, 0.0525),
-              TaxTableRow.new(20_900, 107_650, 901, 0.0585),
-              TaxTableRow.new(107_650, 269_300, 5_976, 0.0625),
-              TaxTableRow.new(269_300, 1_616_450, 16_079, 0.0685),
-              TaxTableRow.new(1_616_450, 5_000_000, 108_359, 0.0965),
-              TaxTableRow.new(5_000_000, 25_000_000, 434_871, 0.103),
-              TaxTableRow.new(25_000_000, Float::INFINITY, 2_494_871, 0.109)
-            ]
-          end
-        table_row = table.reverse.find do |tr|
-          taxable_income > tr.floor && (taxable_income <= tr.ceiling)
-        end
-
-        table_row.compute(taxable_income)
-      end
-
-      def round_to_decimal(val, digits)
-        ten_to_the_digits_power = 10 ** digits
-        (val * ten_to_the_digits_power).round / (ten_to_the_digits_power * 1.0)
-      end
-
       def calculate_line_39
         agi = line_or_zero(:IT201_LINE_33)
         taxable_income = line_or_zero(:IT201_LINE_38)
         if agi <= 107_650
-          return nys_tax_from_tables(taxable_income).round
+          # use NYS tax rate schedule
+          result = NysTaxRateSchedule.calculate(taxable_income, @filing_status)
+        else
+          # use NYS tax computation worksheet
+          result = NysTaxComputation.calculate(agi, taxable_income, @filing_status)
         end
-        result = case @filing_status
-                 when :married_filing_jointly, :qualifying_widow
-                   if agi > 107_650 && agi <= 25_000_000 && taxable_income <= 161_550
-                     if agi >= 157_650
-                       taxable_income * 0.0585
-                     else
-                       step_3_flat_tax = (taxable_income * 0.0585).round
-                       step_4_usual_tax = nys_tax_from_tables(taxable_income)
-                       step_5_flat_tax_extra_amount = step_3_flat_tax - step_4_usual_tax
-                       step_6_marginal_taxable_amount = agi - 107_650
-                       step_7 = round_to_decimal(step_6_marginal_taxable_amount / 50_000, 4)
-                       step_8 = (step_5_flat_tax_extra_amount * step_7).round
-                       step_4_usual_tax + step_8
-                     end
-                   elsif agi > 161_550 && agi <= 25_000_000 && taxable_income > 161_550 && taxable_income <= 323_200
-                     step_3_usual_tax = nys_tax_from_tables(taxable_income)
-                     step_6_marginal_taxable_amount = agi - 161_550
-                     step_7 = [step_6_marginal_taxable_amount, 50_000].min
-                     step_8 = round_to_decimal(step_7 / 50_000, 4)
-                     step_9 = (646 * step_8).round
-                     step_3_usual_tax + 430 + step_9
-                   elsif agi > 323_200 && agi <= 25_000_000 && taxable_income > 323_200 && taxable_income <= 2_155_350
-                     step_3_usual_tax = nys_tax_from_tables(taxable_income)
-                     step_6_marginal_taxable_amount = agi - 323_200
-                     step_7 = [step_6_marginal_taxable_amount, 50_000].min
-                     step_8 = round_to_decimal(step_7 / 50_000, 4)
-                     step_9 = (1_940 * step_8).round
-                     step_3_usual_tax + 1_076 + step_9
-                   elsif agi > 2155350 && agi <= 25000000 && taxable_income > 2155350 && taxable_income <= 5000000
-                     step_3_usual_tax = nys_tax_from_tables(taxable_income)
-                     step_6_marginal_taxable_amount = agi - 2_155_350
-                     step_7 = [step_6_marginal_taxable_amount, 50_000].min
-                     step_8 = round_to_decimal(step_7 / 50_000, 4)
-                     step_9 = (60_349 * step_8).round
-                     step_3_usual_tax + 3_016 + step_9
-                   elsif agi > 5_000_000 && agi <= 25_000_000 && taxable_income > 5_000_000
-                     step_3_usual_tax = nys_tax_from_tables(taxable_income)
-                     step_6_marginal_taxable_amount = agi - 5_000_000
-                     step_7 = [step_6_marginal_taxable_amount, 50_000].min
-                     step_8 = round_to_decimal(step_7 / 50_000, 4)
-                     step_9 = (63_365 * step_8).round
-                     step_3_usual_tax + 32_500 + step_9
-                   elsif agi > 25_050_000
-                     taxable_income * 0.109
-                   else
-                     # if 25_000_000 < agi < 25_050_000 TODO
-                     raise NotImplementedError, "Unsure how to handle AGI in this range"
-                   end
-                 when :single, :married_filing_separately
-                   if agi > 107_650 && agi <= 25_000_000 && taxable_income <= 215_400
-                     if agi >= 157_650
-                       taxable_income * 0.0625
-                     else
-                       step_3_flat_tax = (taxable_income * 0.0625).round
-                       step_4_usual_tax = nys_tax_from_tables(taxable_income)
-                       step_5_flat_tax_extra_amount = step_3_flat_tax - step_4_usual_tax
-                       step_6_marginal_taxable_amount = agi - 107_650
-                       step_7 = round_to_decimal(step_6_marginal_taxable_amount / 50_000, 4)
-                       step_8 = (step_5_flat_tax_extra_amount * step_7).round
-                       step_4_usual_tax + step_8
-                     end
-                   elsif agi > 215_400 && agi <= 25_000_000 && taxable_income > 215_400 && taxable_income <= 1_077_550
-                     step_3_usual_tax = nys_tax_from_tables(taxable_income)
-                     step_6_marginal_taxable_amount = agi - 215_400
-                     step_7 = [step_6_marginal_taxable_amount, 50_000].min
-                     step_8 = round_to_decimal(step_7 / 50_000, 4)
-                     step_9 = (1_293 * step_8).round
-                     step_3_usual_tax + 536 + step_9
-                   elsif agi > 1_077_550 && agi <= 25_000_000 && taxable_income > 1_077_550 && taxable_income <= 5_000_000
-                     step_3_usual_tax = nys_tax_from_tables(taxable_income)
-                     step_6_marginal_taxable_amount = agi - 1_077_550
-                     step_7 = [step_6_marginal_taxable_amount, 50_000].min
-                     step_8 = round_to_decimal(step_7 / 50_000, 4)
-                     step_9 = (30_171 * step_8).round
-                     step_3_usual_tax + 1_829 + step_9
-                   elsif agi > 5_000_000 && agi <= 25_000_000 && taxable_income > 5_000_000
-                     step_3_usual_tax = nys_tax_from_tables(taxable_income)
-                     step_6_marginal_taxable_amount = agi - 5_000_000
-                     step_7 = [step_6_marginal_taxable_amount, 50_000].min
-                     step_8 = round_to_decimal(step_7 / 50_000, 4)
-                     step_9 = (32_500 * step_8).round
-                     step_3_usual_tax + 32_000 + step_9
-                   else
-                     taxable_income * 0.109
-                   end
-                 when :head_of_household
-                   if agi > 107_650 && agi <= 25_000_000 && taxable_income <= 269_300
-                     if agi >= 157_650
-                       taxable_income * 0.0625
-                     else
-                       step_3_flat_tax = (taxable_income * 0.0625).round
-                       step_4_usual_tax = nys_tax_from_tables(taxable_income)
-                       step_5_flat_tax_extra_amount = step_3_flat_tax - step_4_usual_tax
-                       step_6_marginal_taxable_amount = agi - 107_650
-                       step_7 = round_to_decimal(step_6_marginal_taxable_amount / 50_000, 4)
-                       step_8 = (step_5_flat_tax_extra_amount * step_7).round
-                       step_4_usual_tax + step_8
-                     end
-                   elsif agi > 269_300 && agi <= 25_000_000 && taxable_income > 269_300 && taxable_income <= 1_616_450
-                     step_3_usual_tax = nys_tax_from_tables(taxable_income)
-                     step_6_marginal_taxable_amount = agi - 269_300
-                     step_7 = [step_6_marginal_taxable_amount, 50_000].min
-                     step_8 = round_to_decimal(step_7 / 50_000, 4)
-                     step_9 = (1_616 * step_8).round
-                     step_3_usual_tax + 752 + step_9
-                   elsif agi > 1_616_450 && agi <= 25_000_000 && taxable_income > 1_616_450 && taxable_income <= 5_000_000
-                     step_3_usual_tax = nys_tax_from_tables(taxable_income)
-                     step_6_marginal_taxable_amount = agi - 1_616_450
-                     step_7 = [step_6_marginal_taxable_amount, 50_000].min
-                     step_8 = round_to_decimal(step_7 / 50_000, 4)
-                     step_9 = (45_261 * step_8).round
-                     step_3_usual_tax + 2_368 + step_9
-                   elsif agi > 5_000_000 && agi <= 25_000_000 && taxable_income > 5_000_000
-                     step_3_usual_tax = nys_tax_from_tables(taxable_income)
-                     step_6_marginal_taxable_amount = agi - 5_000_000
-                     step_7 = [step_6_marginal_taxable_amount, 50_000].min
-                     step_8 = round_to_decimal(step_7 / 50_000, 4)
-                     step_9 = (32_500 * step_8).round
-                     step_3_usual_tax + 47_629 + step_9
-                   elsif agi > 25_000_000
-                     taxable_income * 0.109
-                   end
-                 else
-                   raise "Unknown filing status!"
-                 end
         result.round
       end
 
@@ -643,29 +471,10 @@ module Efile
           table_row.amounts[household_size - 1]
         end
       end
-    end
 
-    class TaxTableRow
-      attr_reader :floor, :ceiling, :cumulative, :rate
-
-      def initialize(floor, ceiling, cumulative, rate)
-        @floor = floor
-        @ceiling = ceiling
-        @cumulative = cumulative
-        @rate = rate
-      end
-
-      def compute(amount)
-        if amount < 0
-          raise "Negative income input"
-        end
-        amount_for_rate =
-          if @floor == -Float::INFINITY
-            amount
-          else
-            amount - @floor
-          end
-        @cumulative + (amount_for_rate * @rate)
+      def round_to_decimal(val, digits)
+        ten_to_the_digits_power = 10 ** digits
+        (val * ten_to_the_digits_power).round / (ten_to_the_digits_power * 1.0)
       end
     end
   end

--- a/app/lib/efile/ny/nys_tax_computation.rb
+++ b/app/lib/efile/ny/nys_tax_computation.rb
@@ -1,13 +1,19 @@
 module Efile
   module Ny
     class NysTaxComputation
-      AGI_TOP_BRACKET_THRESHOLD = 25_000_000
-      # for use with NY AGI over $107,650
+      # Implements the NYS Tax Computation, for use with NY AGI over $107,650, as documented in the IT-201 instructions
+      # https://www.tax.ny.gov/forms/html-instructions/2023/it/it201i-2023.htm#tax-computation
+      # Worksheet numbers in the comments correspond to worksheets in the instructions
+
+      AGI_TOP_BRACKET_THRESHOLD = 25_000_000 # used as the upper AGI limit for all mid and bottom bracket worksheets
+
       class << self
         def calculate(agi, taxable_income, filing_status)
-          # find correct worksheet
+          # Get the set of worksheets for the filing status
           worksheets = worksheets_for_filing_status(filing_status)
+          # Find the correct worksheet based on AGI and taxable income
           worksheet = worksheets.find { |w| w.valid_for(agi, taxable_income) }
+          # use the worksheet to compute the NYS tax amount
           worksheet.compute(agi, taxable_income, filing_status)
         end
 
@@ -23,57 +29,59 @@ module Efile
 
         def joint_filer_worksheets
           [
-            WorksheetBottomBracket.new( 107_650,           161_550, 0.055), # worksheet_1
-            WorksheetMidBracket.new(    161_550,           323_200,    333,    807), # worksheet_2
-            WorksheetMidBracket.new(    323_200,         2_155_350,  1_140,  2_747), # worksheet_3
-            WorksheetMidBracket.new(    2_155_350,       5_000_000,  3_887, 60_350), # worksheet_4
-            WorksheetMidBracket.new(    5_000_000, Float::INFINITY, 64_237, 32_500), # worksheet_5
-            WorksheetTopBracket.new # worksheet_6
+            WorksheetBottomBracket.new( 107_650,           161_550, 0.055), # worksheet 1
+            WorksheetMidBracket.new(    161_550,           323_200,    333,    807), # worksheet 2
+            WorksheetMidBracket.new(    323_200,         2_155_350,  1_140,  2_747), # worksheet 3
+            WorksheetMidBracket.new(    2_155_350,       5_000_000,  3_887, 60_350), # worksheet 4
+            WorksheetMidBracket.new(    5_000_000, Float::INFINITY, 64_237, 32_500), # worksheet 5
+            WorksheetTopBracket.new # worksheet 6
           ]
         end
 
         def single_filer_worksheets
           [
-             WorksheetBottomBracket.new(   107_650,        215_400, 0.06), # worksheet_7
-             WorksheetMidBracket.new(      215_400,      1_077_550,    568,  1_831), # worksheet_8
-             WorksheetMidBracket.new(    1_077_550,      5_000_000,  2_399, 30_172), # worksheet_9
-             WorksheetMidBracket.new(   5_000_000, Float::INFINITY, 32_571, 32_500), # worksheet_10
-             WorksheetTopBracket.new # worksheet_11
+             WorksheetBottomBracket.new(   107_650,        215_400, 0.06), # worksheet 7
+             WorksheetMidBracket.new(      215_400,      1_077_550,    568,  1_831), # worksheet 8
+             WorksheetMidBracket.new(    1_077_550,      5_000_000,  2_399, 30_172), # worksheet 9
+             WorksheetMidBracket.new(   5_000_000, Float::INFINITY, 32_571, 32_500), # worksheet 10
+             WorksheetTopBracket.new # worksheet 11
           ]
         end
 
         def head_of_household_worksheets
           [
-            WorksheetBottomBracket.new(  107_650,         269_300, 0.06), # worksheet_12
-            WorksheetMidBracket.new(     269_300,       1_616_450,    787,  2_289), # worksheet_13
-            WorksheetMidBracket.new(   1_616_450,       5_000_000,  3_076, 45_261), # worksheet_14
-            WorksheetMidBracket.new(   5_000_000, Float::INFINITY, 48_337, 32_500), # worksheet_15
-            WorksheetTopBracket.new # worksheet_16
+            WorksheetBottomBracket.new(  107_650,         269_300, 0.06), # worksheet 12
+            WorksheetMidBracket.new(     269_300,       1_616_450,    787,  2_289), # worksheet 13
+            WorksheetMidBracket.new(   1_616_450,       5_000_000,  3_076, 45_261), # worksheet 14
+            WorksheetMidBracket.new(   5_000_000, Float::INFINITY, 48_337, 32_500), # worksheet 15
+            WorksheetTopBracket.new # worksheet 16
           ]
         end
       end
 
 
       class Worksheet
-        attr_reader :floor, :inc_ceiling
+        attr_reader :floor, :taxable_income_ceiling
 
-        def initialize(floor, inc_ceiling)
+        def initialize(floor, taxable_income_ceiling)
+          # floor is used as the bottom limit for both NY AGI & taxable income
           @floor = floor
-          @inc_ceiling = inc_ceiling
+          @taxable_income_ceiling = taxable_income_ceiling
         end
 
         def valid_for(agi, taxable_income)
-          agi > floor && agi <= AGI_TOP_BRACKET_THRESHOLD \
-            && taxable_income > floor && taxable_income <= inc_ceiling
+          agi_within_bracket = (floor < agi) && (agi <= AGI_TOP_BRACKET_THRESHOLD)
+          taxable_income_within_bracket = (floor < taxable_income) && (taxable_income <= taxable_income_ceiling)
+          agi_within_bracket && taxable_income_within_bracket
         end
       end
 
       class WorksheetBottomBracket < Worksheet
         attr_reader :rate
 
-        def initialize(floor, inc_ceiling, rate)
+        def initialize(floor, taxable_income_ceiling, rate)
           @rate = rate
-          super(floor, inc_ceiling)
+          super(floor, taxable_income_ceiling)
         end
 
         def compute(agi, taxable_income, filing_status)
@@ -83,7 +91,7 @@ module Efile
           step_4 = NysTaxRateSchedule.calculate(taxable_income, filing_status)
           step_5 = step_3 - step_4
           step_6 = agi - floor
-          step_7 = (step_6 / 50_000.0).round(4)
+          step_7 = (step_6 / 50_000.to_f).round(4) # ensure division by float, then round to 4th decimal place
           step_8 = step_5 * step_7
           step_4 + step_8
         end
@@ -92,17 +100,17 @@ module Efile
       class WorksheetMidBracket < Worksheet
         attr_reader :recapture_base_amt, :incremental_benefit_amt
 
-        def initialize(floor, inc_ceiling, recapture_base_amt, incremental_benefit_amt)
+        def initialize(floor, taxable_income_ceiling, recapture_base_amt, incremental_benefit_amt)
           @recapture_base_amt = recapture_base_amt
           @incremental_benefit_amt = incremental_benefit_amt
-          super(floor, inc_ceiling)
+          super(floor, taxable_income_ceiling)
         end
 
         def compute(agi, taxable_income, filing_status)
           step_3 = NysTaxRateSchedule.calculate(taxable_income, filing_status)
           step_6 = agi - floor
           step_7 = [step_6, 50_000].min
-          step_8 = (step_7 / 50_000.to_f).round(4)
+          step_8 = (step_7 / 50_000.to_f).round(4) # ensure division by float, then round to 4th decimal place
           step_9 = incremental_benefit_amt * step_8
           step_3 + recapture_base_amt + step_9
         end
@@ -116,7 +124,7 @@ module Efile
         end
 
         def valid_for(agi, _taxable_income)
-          agi > AGI_TOP_BRACKET_THRESHOLD
+          AGI_TOP_BRACKET_THRESHOLD < agi
         end
 
         def compute(_agi, taxable_income, _filing_status)

--- a/app/lib/efile/ny/nys_tax_computation.rb
+++ b/app/lib/efile/ny/nys_tax_computation.rb
@@ -1,0 +1,128 @@
+module Efile
+  module Ny
+    class NysTaxComputation
+      AGI_TOP_BRACKET_THRESHOLD = 25_000_000
+      # for use with NY AGI over $107,650
+      class << self
+        def calculate(agi, taxable_income, filing_status)
+          # find correct worksheet
+          worksheets = worksheets_for_filing_status(filing_status)
+          worksheet = worksheets.find { |w| w.valid_for(agi, taxable_income) }
+          worksheet.compute(agi, taxable_income, filing_status)
+        end
+
+        private
+
+        def worksheets_for_filing_status(filing_status)
+          case filing_status
+          when :married_filing_jointly, :qualifying_widow then joint_filer_worksheets
+          when :single, :married_filing_separately then single_filer_worksheets
+          when :head_of_household then head_of_household_worksheets
+          end
+        end
+
+        def joint_filer_worksheets
+          [
+            WorksheetBottomBracket.new( 107_650,           161_550, 0.055), # worksheet_1
+            WorksheetMidBracket.new(    161_550,           323_200,    333,    807), # worksheet_2
+            WorksheetMidBracket.new(    323_200,         2_155_350,  1_140,  2_747), # worksheet_3
+            WorksheetMidBracket.new(    2_155_350,       5_000_000,  3_887, 60_350), # worksheet_4
+            WorksheetMidBracket.new(    5_000_000, Float::INFINITY, 64_237, 32_500), # worksheet_5
+            WorksheetTopBracket.new # worksheet_6
+          ]
+        end
+
+        def single_filer_worksheets
+          [
+             WorksheetBottomBracket.new(   107_650,        215_400, 0.06), # worksheet_7
+             WorksheetMidBracket.new(      215_400,      1_077_550,    568,  1_831), # worksheet_8
+             WorksheetMidBracket.new(    1_077_550,      5_000_000,  2_399, 30_172), # worksheet_9
+             WorksheetMidBracket.new(   5_000_000, Float::INFINITY, 32_571, 32_500), # worksheet_10
+             WorksheetTopBracket.new # worksheet_11
+          ]
+        end
+
+        def head_of_household_worksheets
+          [
+            WorksheetBottomBracket.new(  107_650,         269_300, 0.06), # worksheet_12
+            WorksheetMidBracket.new(     269_300,       1_616_450,    787,  2_289), # worksheet_13
+            WorksheetMidBracket.new(   1_616_450,       5_000_000,  3_076, 45_261), # worksheet_14
+            WorksheetMidBracket.new(   5_000_000, Float::INFINITY, 48_337, 32_500), # worksheet_15
+            WorksheetTopBracket.new # worksheet_16
+          ]
+        end
+      end
+
+
+      class Worksheet
+        attr_reader :floor, :inc_ceiling
+
+        def initialize(floor, inc_ceiling)
+          @floor = floor
+          @inc_ceiling = inc_ceiling
+        end
+
+        def valid_for(agi, taxable_income)
+          agi > floor && agi <= AGI_TOP_BRACKET_THRESHOLD \
+            && taxable_income > floor && taxable_income <= inc_ceiling
+        end
+      end
+
+      class WorksheetBottomBracket < Worksheet
+        attr_reader :rate
+
+        def initialize(floor, inc_ceiling, rate)
+          @rate = rate
+          super(floor, inc_ceiling)
+        end
+
+        def compute(agi, taxable_income, filing_status)
+          step_3 = taxable_income * @rate
+          return step_3 if agi >= 157_650
+
+          step_4 = NysTaxRateSchedule.calculate(taxable_income, filing_status)
+          step_5 = step_3 - step_4
+          step_6 = agi - floor
+          step_7 = (step_6 / 50_000.0).round(4)
+          step_8 = step_5 * step_7
+          step_4 + step_8
+        end
+      end
+
+      class WorksheetMidBracket < Worksheet
+        attr_reader :recapture_base_amt, :incremental_benefit_amt
+
+        def initialize(floor, inc_ceiling, recapture_base_amt, incremental_benefit_amt)
+          @recapture_base_amt = recapture_base_amt
+          @incremental_benefit_amt = incremental_benefit_amt
+          super(floor, inc_ceiling)
+        end
+
+        def compute(agi, taxable_income, filing_status)
+          step_3 = NysTaxRateSchedule.calculate(taxable_income, filing_status)
+          step_6 = agi - floor
+          step_7 = [step_6, 50_000].min
+          step_8 = (step_7 / 50_000.to_f).round(4)
+          step_9 = incremental_benefit_amt * step_8
+          step_3 + recapture_base_amt + step_9
+        end
+      end
+
+      class WorksheetTopBracket
+        attr_reader :rate
+
+        def initialize
+          @rate = 0.109
+        end
+
+        def valid_for(agi, _taxable_income)
+          agi > AGI_TOP_BRACKET_THRESHOLD
+        end
+
+        def compute(_agi, taxable_income, _filing_status)
+          taxable_income * rate
+        end
+      end
+    end
+  end
+end

--- a/app/lib/efile/ny/nys_tax_rate_schedule.rb
+++ b/app/lib/efile/ny/nys_tax_rate_schedule.rb
@@ -1,6 +1,8 @@
 module Efile
   module Ny
     class NysTaxRateSchedule
+      # Implements the NYS Tax Rate Schedule, as documented in the IT-201 instructions
+      # https://www.tax.ny.gov/forms/html-instructions/2023/it/it201i-2023.htm#nys-tax-rate-schedule
       class << self
         def calculate(taxable_income, filing_status)
           rows = case filing_status

--- a/app/lib/efile/ny/nys_tax_rate_schedule.rb
+++ b/app/lib/efile/ny/nys_tax_rate_schedule.rb
@@ -1,0 +1,85 @@
+module Efile
+  module Ny
+    class NysTaxRateSchedule
+      class << self
+        def calculate(taxable_income, filing_status)
+          rows = case filing_status
+                 when :single, :married_filing_separately then single_filer_rows
+                 when :married_filing_jointly, :qualifying_widow then joint_filer_rows
+                 when :head_of_household then head_of_household_rows
+                 end
+          schedule_row = rows.reverse.find do |row|
+            taxable_income > row.floor && (taxable_income <= row.ceiling)
+          end
+          schedule_row.compute(taxable_income)
+        end
+
+        def single_filer_rows
+          [
+            TaxRateScheduleRow.new(-Float::INFINITY, 8_500, 0, 0.04),
+            TaxRateScheduleRow.new(8_500, 11_700, 340, 0.045),
+            TaxRateScheduleRow.new(11_700, 13_900, 484, 0.0525),
+            TaxRateScheduleRow.new(13_900, 80_650, 600, 0.055),
+            TaxRateScheduleRow.new(80_650, 215_400, 4_271, 0.06),
+            TaxRateScheduleRow.new(215_400, 1_077_550, 12_356, 0.0685),
+            TaxRateScheduleRow.new(1_077_550, 5_000_000, 71_413, 0.0965),
+            TaxRateScheduleRow.new(5_000_000, 25_000_000, 449_929, 0.103),
+            TaxRateScheduleRow.new(25_000_000, Float::INFINITY, 2_509_929, 0.109)
+          ]
+        end
+
+        def joint_filer_rows
+          [
+            TaxRateScheduleRow.new(-Float::INFINITY, 17_150, 0, 0.04),
+            TaxRateScheduleRow.new(17_150, 23_600, 686, 0.045),
+            TaxRateScheduleRow.new(23_600, 27_900, 976, 0.0525),
+            TaxRateScheduleRow.new(27_900, 161_550, 1_202, 0.055),
+            TaxRateScheduleRow.new(161_550, 323_200, 8_553, 0.06),
+            TaxRateScheduleRow.new(323_200, 2_155_350, 18_252, 0.0685),
+            TaxRateScheduleRow.new(2_155_350, 5_000_000, 143_754, 0.0965),
+            TaxRateScheduleRow.new(5_000_000, 25_000_000, 418_263, 0.103),
+            TaxRateScheduleRow.new(25_000_000, Float::INFINITY, 2_478_263, 0.109)
+          ]
+        end
+
+        def head_of_household_rows
+          [
+            TaxRateScheduleRow.new(-Float::INFINITY, 12_800, 0, 0.04),
+            TaxRateScheduleRow.new(12_800, 17_650, 512, 0.045),
+            TaxRateScheduleRow.new(17_650, 20_900, 730, 0.0525),
+            TaxRateScheduleRow.new(20_900, 107_650, 901, 0.055),
+            TaxRateScheduleRow.new(107_650, 269_300, 5_672, 0.06),
+            TaxRateScheduleRow.new(269_300, 1_616_450, 15_371, 0.0685),
+            TaxRateScheduleRow.new(1_616_450, 5_000_000, 107_651, 0.0965),
+            TaxRateScheduleRow.new(5_000_000, 25_000_000, 434_163, 0.103),
+            TaxRateScheduleRow.new(25_000_000, Float::INFINITY, 2_494_163, 0.109)
+          ]
+        end
+      end
+
+      class TaxRateScheduleRow
+        attr_reader :floor, :ceiling, :cumulative, :rate
+
+        def initialize(floor, ceiling, cumulative, rate)
+          @floor = floor
+          @ceiling = ceiling
+          @cumulative = cumulative
+          @rate = rate
+        end
+
+        def compute(amount)
+          if amount < 0
+            raise "Negative income input"
+          end
+          amount_for_rate =
+            if @floor == -Float::INFINITY
+              amount
+            else
+              amount - @floor
+            end
+          @cumulative + (amount_for_rate * @rate)
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/state_file/taxes_owed_form_spec.rb
+++ b/spec/forms/state_file/taxes_owed_form_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe StateFile::TaxesOwedForm do
-  let!(:withdraw_amount) { 150 }
+  let!(:withdraw_amount) { 139 }
   let!(:intake) {
     create :state_file_ny_intake,
            payment_or_deposit_type: "unfilled",

--- a/spec/lib/efile/ny/it201_spec.rb
+++ b/spec/lib/efile/ny/it201_spec.rb
@@ -149,84 +149,74 @@ describe Efile::Ny::It201 do
     end
   end
 
-  describe 'Line 39 New York State tax from tables' do
-    context 'when the filing status is single' do
+  describe '#calculate_line_39' do
+    context 'when single with 58k agi' do
       before do
         intake.direct_file_data.filing_status = 1 # single
-        intake.direct_file_data.fed_wages = 20_000
-        intake.direct_file_data.fed_taxable_income = 20_000
-        intake.direct_file_data.fed_taxable_ssb = 0
-        intake.direct_file_data.fed_unemployment = 0
+        allow(instance).to receive(:line_or_zero).and_call_original
+        allow(instance).to receive(:line_or_zero).with(:IT201_LINE_33).and_return(58_000)
+        allow(instance).to receive(:line_or_zero).with(:IT201_LINE_38).and_return(50_000)
       end
 
       it 'sets the correct tax amount' do
         instance.calculate
-        expect(instance.lines[:IT201_LINE_38].value).to eq(28_200) # taxable income
-        expect(instance.lines[:IT201_LINE_39].value).to eq(1_437)
+        expect(instance.lines[:IT201_LINE_39].value).to eq(2_586)
       end
     end
 
-    context 'when the filing status is mfj' do
+    context 'when mfj with 136,050 agi' do
       before do
         intake.direct_file_data.filing_status = 2 # mfj
-        intake.direct_file_data.fed_wages = 20_000
-        intake.direct_file_data.fed_taxable_income = 20_000
-        intake.direct_file_data.fed_taxable_ssb = 0
-        intake.direct_file_data.fed_unemployment = 0
+        allow(instance).to receive(:line_or_zero).and_call_original
+        allow(instance).to receive(:line_or_zero).with(:IT201_LINE_33).and_return(136_050)
+        allow(instance).to receive(:line_or_zero).with(:IT201_LINE_38).and_return(120_000)
       end
 
       it 'sets the correct tax amount' do
         instance.calculate
-        expect(instance.lines[:IT201_LINE_38].value).to eq(20_150) # taxable income
-        expect(instance.lines[:IT201_LINE_39].value).to eq(821)
+        expect(instance.lines[:IT201_LINE_39].value).to eq(6_456)
       end
     end
 
-    context 'when the filing status is mfs' do
+    context 'when mfs with 168k agi' do
       before do
         intake.direct_file_data.filing_status = 3 # mfs
-        intake.direct_file_data.fed_wages = 20_000
-        intake.direct_file_data.fed_taxable_income = 20_000
-        intake.direct_file_data.fed_taxable_ssb = 0
-        intake.direct_file_data.fed_unemployment = 0
+        allow(instance).to receive(:line_or_zero).and_call_original
+        allow(instance).to receive(:line_or_zero).with(:IT201_LINE_33).and_return(168_000)
+        allow(instance).to receive(:line_or_zero).with(:IT201_LINE_38).and_return(160_000)
       end
 
       it 'sets the correct tax amount' do
         instance.calculate
-        expect(instance.lines[:IT201_LINE_38].value).to eq(28_200) # taxable income
-        expect(instance.lines[:IT201_LINE_39].value).to eq(1_437)
+        expect(instance.lines[:IT201_LINE_39].value).to eq(9_600)
       end
     end
 
-    context 'when the filing status is hoh' do
+    context 'when hoh with 24.2k agi' do
       before do
         intake.direct_file_data.filing_status = 4 # hoh
-        intake.direct_file_data.fed_wages = 20_000
-        intake.direct_file_data.fed_taxable_income = 20_000
-        intake.direct_file_data.fed_taxable_ssb = 0
-        intake.direct_file_data.fed_unemployment = 0
+        allow(instance).to receive(:line_or_zero).and_call_original
+        allow(instance).to receive(:line_or_zero).with(:IT201_LINE_33).and_return(24_200)
+        allow(instance).to receive(:line_or_zero).with(:IT201_LINE_38).and_return(11_000)
       end
 
       it 'sets the correct tax amount' do
         instance.calculate
-        expect(instance.lines[:IT201_LINE_38].value).to eq(25_000) # taxable income
-        expect(instance.lines[:IT201_LINE_39].value).to eq(1_141)
+        expect(instance.lines[:IT201_LINE_39].value).to eq(440)
       end
     end
 
-    context 'when the filing status is qw' do
+    context 'when qss with 44,950 agi' do
       before do
-        intake.direct_file_data.filing_status = 5 # qw
-        intake.direct_file_data.fed_wages = 20_000
-        intake.direct_file_data.fed_taxable_income = 20_000
-        intake.direct_file_data.fed_taxable_ssb = 0
-        intake.direct_file_data.fed_unemployment = 0
+        intake.direct_file_data.filing_status = 5 # qss
+        allow(instance).to receive(:line_or_zero).and_call_original
+        allow(instance).to receive(:line_or_zero).with(:IT201_LINE_33).and_return(44_950)
+        allow(instance).to receive(:line_or_zero).with(:IT201_LINE_38).and_return(27_900)
       end
 
       it 'sets the correct tax amount' do
         instance.calculate
-        expect(instance.lines[:IT201_LINE_38].value).to eq(20_150) # taxable income
-        expect(instance.lines[:IT201_LINE_39].value).to eq(821)
+        expect(instance.lines[:IT201_LINE_39].value).to eq(1_202)
       end
     end
   end


### PR DESCRIPTION
Addresses Section J: https://www.pivotaltracker.com/story/show/186692297
Implements https://www.tax.ny.gov/forms/html-instructions/2023/it/it201i-2023.htm#nys-tax-table

The existing calculations had several bugs. I refactored the code to be more easily unit-tested if we want more tests.
The new unit tests I added were given by Courtney.