### PR TITLE
Save months in home to EIC dependents

### DIFF
--- a/app/models/direct_file_data.rb
+++ b/app/models/direct_file_data.rb
@@ -604,6 +604,7 @@ class DirectFileData
       eitc_dependent_node = eitc_eligible_dependents[ssn]
       if eitc_dependent_node.present?
         dependent.eic_qualifying = true
+        dependent.months_in_home = eitc_dependent_node.at('MonthsChildLivedWithYouCnt').text.to_i
         dependent.eic_student = eitc_dependent_node.at('ChildIsAStudentUnder24Ind').text == "true"
         dependent.eic_disability = eitc_dependent_node.at('ChildPermanentlyDisabledInd').text == "true"
       else
@@ -846,11 +847,12 @@ class DirectFileData
                   :eic_student,
                   :eic_disability,
                   :eic_qualifying,
-                  :ctc_qualifying
+                  :ctc_qualifying,
+                  :months_in_home
 
     def initialize(first_name:, last_name:, ssn:, relationship:,
                    eic_student: nil, eic_disability: nil, eic_qualifying: nil,
-                   ctc_qualifying: nil)
+                   ctc_qualifying: nil, months_in_home: nil)
 
       @first_name = first_name
       @last_name = last_name
@@ -860,6 +862,7 @@ class DirectFileData
       @eic_disability = eic_disability
       @eic_qualifying = eic_qualifying
       @ctc_qualifying = ctc_qualifying
+      @months_in_home = months_in_home
     end
 
     def attributes
@@ -871,7 +874,8 @@ class DirectFileData
         eic_student: @eic_student,
         eic_disability: @eic_disability,
         eic_qualifying: @eic_qualifying,
-        ctc_qualifying: @ctc_qualifying
+        ctc_qualifying: @ctc_qualifying,
+        months_in_home: @months_in_home
       }
     end
   end

--- a/spec/models/direct_file_data_spec.rb
+++ b/spec/models/direct_file_data_spec.rb
@@ -313,8 +313,10 @@ describe DirectFileData do
     context "when there are EIC dependents in the xml" do
       let(:xml) { File.read(Rails.root.join('spec/fixtures/files/fed_return_zeus_8_deps_ny.xml')) }
       it 'sets eic_qualifying on those dependents' do
-        expect(described_class.new(xml).dependents.select{ |d| d.eic_qualifying }.length).to eq(3)
-        expect(described_class.new(xml).dependents.select{ |d| d.eic_qualifying == false }.length).to eq(5)
+        dependents = described_class.new(xml).dependents
+        expect(dependents.select{ |d| d.eic_qualifying }.length).to eq(3)
+        expect(dependents.select{ |d| d.eic_qualifying == false }.length).to eq(5)
+        expect(dependents.select { |d| d.months_in_home == 7}.length).to eq(3)
 
         expect(described_class.new(xml).dependents.length).to eq(8)
       end


### PR DESCRIPTION
Addresses [a bug](https://www.pivotaltracker.com/story/show/186733283/comments/239871533) where we weren't saving the months in home for EIC-qualifying dependents.

Months in home appears to be listed in the federal XML under `IRS1040ScheduleEIC QualifyingChildInformation  MonthsChildLivedWithYouCnt`. I don't see a value for `MonthsChildLivedWithYouCnt` under other dependents in the XML, only for EIC qualifying dependents. See [the Zeus XML](https://github.com/codeforamerica/vita-min/blob/d6512101be55184a2222a5e2ae3cbf6640a28baf/spec/fixtures/files/fed_return_zeus_8_deps_ny.xml#L4) for an example.
