### PR TITLE
Fix can't assign org to coalition when previously saved state routing targets exist

### DIFF
--- a/app/forms/hub/organization_form.rb
+++ b/app/forms/hub/organization_form.rb
@@ -25,13 +25,13 @@ module Hub
         @states = nil
       end
       organization.assign_attributes(attributes_for(:organization))
+      UpdateStateRoutingTargetsService.update(organization, (@states || "").split(","))
 
       unless valid? & organization.valid?
         organization.errors.each { |error| self.errors.add(error.attribute, error.message) }
         return false
       end
 
-      UpdateStateRoutingTargetsService.update(organization, (@states || "").split(","))
       organization.save
     end
 

--- a/spec/forms/hub/organization_form_spec.rb
+++ b/spec/forms/hub/organization_form_spec.rb
@@ -208,8 +208,9 @@ RSpec.describe Hub::OrganizationForm do
     end
 
     context "when is_independent is no" do
-      context "when a coalition is submitted" do
+      context "when a coalition is submitted and there are existing state routing targets" do
         let(:extra_params) { { is_independent: "no", states: "OH,CA", coalition_id: create(:coalition, name: "Koala Koalition").id } }
+        let!(:srt) { create(:state_routing_target, state_abbreviation: "AL", target: organization) }
 
         it "updates the organization's coalition" do
           subject.save


### PR DESCRIPTION
This was failing before because it was failing on the organization model validation ("no_state_routing_targets_if_in_coalition") and return false before removing state routing targets in the form save method. I just moved the removal of the SRTs before the validation check