### PR TITLE
Add dev link to download full xml bundle

### DIFF
--- a/app/views/state_file/questions/submission_confirmation/edit.html.erb
+++ b/app/views/state_file/questions/submission_confirmation/edit.html.erb
@@ -15,8 +15,14 @@
   <% end %>
 
   <%= link_to t(".download_state_return_pdf"), StateFile::Questions::SubmissionPdfsController.to_path_helper(us_state: params[:us_state], action: :show, id: EfileSubmission.where(data_source: current_intake).first), class: "button button--primary" %>
-  <p>
-    <%= link_to "Show XML", StateFile::Questions::ConfirmationController.to_path_helper(us_state: params[:us_state], action: :show_xml), class: 'dev-button' %>
-    <%= link_to "Explain Calculations", StateFile::Questions::ConfirmationController.to_path_helper(us_state: params[:us_state], action: :explain_calculations), class: 'dev-button' %>
-  </p>
+  <% if Rails.env != "production" %>
+    <p>
+      <% xml_bundle = EfileSubmission.where(data_source: current_intake).last&.submission_bundle %>
+      <%= link_to "Main XML Doc", StateFile::Questions::ConfirmationController.to_path_helper(us_state: params[:us_state], action: :show_xml), class: 'dev-button' %>
+      <% if xml_bundle.present? %>
+        <%= link_to "Full XML Bundle", rails_blob_path(xml_bundle, disposition: "attachment"), class: 'dev-button' %>
+      <% end %>
+      <%= link_to "Explain Calculations", StateFile::Questions::ConfirmationController.to_path_helper(us_state: params[:us_state], action: :explain_calculations), class: 'dev-button' %>
+    </p>
+  <% end %>
 <% end %>

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -136,7 +136,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
 
       expect(page).to have_text I18n.t("state_file.questions.submission_confirmation.edit.title", state_name: "New York")
       expect(page).to have_link I18n.t("state_file.questions.submission_confirmation.edit.download_state_return_pdf")
-      click_on "Show XML"
+      click_on "Main XML Doc"
       expect(page.body).to include('ReturnState')
       expect(page.body).to include('<FirstName>Titus</FirstName>')
 
@@ -273,7 +273,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
 
       expect(page).to have_text I18n.t("state_file.questions.submission_confirmation.edit.title", state_name: "Arizona")
       expect(page).to have_link I18n.t("state_file.questions.submission_confirmation.edit.download_state_return_pdf")
-      click_on "Show XML"
+      click_on "Main XML Doc"
 
       expect(page.body).to include('efile:ReturnState')
       expect(page.body).to include('<FirstName>Titus</FirstName>')


### PR DESCRIPTION
Allows us to download the full XML bundle (zip file named using submission id, the manifest, and the main xml document)

<img width="652" alt="Screenshot 2024-01-17 at 4 45 01 PM" src="https://github.com/codeforamerica/vita-min/assets/451510/d3401f9a-002b-401b-942e-ec61377f4d1d">

<img width="634" alt="Screenshot 2024-01-17 at 4 45 32 PM" src="https://github.com/codeforamerica/vita-min/assets/451510/a03b08a3-881d-4ce8-a73a-c67a7a38a13f">
