### PR TITLE
Calculate NYC EIC

### DIFF
--- a/app/lib/efile/line_data.yml
+++ b/app/lib/efile/line_data.yml
@@ -92,6 +92,18 @@ AZ140_CCWS_LINE_6c:
 “0”'
 AZ140_CCWS_LINE_7c:
   label: '7C Multiply line 6C by 31% (.31) and enter the result'
+NYC_EIC_RATE_WK_LINE_1:
+  label: 'Enter the amount from Form IT-201, line 33, New York adjusted gross income.'
+NYC_EIC_RATE_WK_LINE_2:
+  label: 'Enter the appropriate dollar amount from the NYC EIC rate table for your New York adjusted gross income (NYAGI), if applicable.'
+NYC_EIC_RATE_WK_LINE_3:
+  label: 'Subtract line 2 from line 1.'
+NYC_EIC_RATE_WK_LINE_4:
+  label: 'Multiply line 3 by .00002 (round the result to four decimal places).'
+NYC_EIC_RATE_WK_LINE_5:
+  label: 'Enter the decimal from the NYC EIC rate table.'
+NYC_EIC_RATE_WK_LINE_6:
+  label: 'Subtract line 4 from line 5 or enter the decimal from the NYC EIC rate table. Also enter on Worksheet C, line 2.'
 IT201_LINE_1:
   label: '1 Wages, salaries, tips, etc.'
 IT201_LINE_2:

--- a/app/lib/efile/ny/it201.rb
+++ b/app/lib/efile/ny/it201.rb
@@ -83,7 +83,7 @@ module Efile
         set_line(:IT201_LINE_67, -> { 0 })
         set_line(:IT201_LINE_69, :calculate_line_69)
         set_line(:IT201_LINE_69A, :calculate_line_69a)
-        set_line(:IT201_LINE_70, -> { @lines[:IT215_LINE_27] ? @lines[:IT215_LINE_27].value : 0})
+        set_line(:IT201_LINE_70, -> { line_or_zero(:IT215_LINE_27) })
         set_line(:IT201_LINE_72, :calculate_line_72)
         set_line(:IT201_LINE_73, :calculate_line_73)
         set_line(:IT201_LINE_76, :calculate_line_76)

--- a/app/lib/efile/ny/it215.rb
+++ b/app/lib/efile/ny/it215.rb
@@ -10,6 +10,11 @@ module Efile
         @lines = lines
         @direct_file_data = intake.direct_file_data
         @intake = intake
+
+        @nyc_eic_rate_worksheet = Efile::Ny::NycEicRateWorksheet.new(
+          value_access_tracker: @value_access_tracker,
+          lines: @lines,
+        )
       end
 
       def calculate
@@ -37,14 +42,17 @@ module Efile
         set_line(:IT215_LINE_14, -> { @lines[:IT201_LINE_40].value })
         set_line(:IT215_LINE_15, :calculate_line_15)
         set_line(:IT215_LINE_16, :calculate_line_16)
-        if @intake.nyc_full_year_resident_yes? # non full-year residents are out of scope
-          # https://www.tax.ny.gov/forms/current-forms/it/it215i.htm#worksheet-c
-          set_line(:IT215_WK_C_LINE_1, -> { @lines[:IT215_LINE_10].value })
-          set_line(:IT215_WK_C_LINE_2, :calculate_wk_c_line_2)
-          set_line(:IT215_WK_C_LINE_3, :calculate_wk_c_line_3)
-          set_line(:IT215_WK_C_LINE_4, :calculate_wk_c_line_4)
-          set_line(:IT215_LINE_27, -> {@lines[:IT215_WK_C_LINE_3].value})
-        end
+
+        # lines 17-26 are out of scope
+
+        # https://www.tax.ny.gov/forms/current-forms/it/it215i.htm#worksheet-c
+        set_line(:IT215_WK_C_LINE_1, -> { @lines[:IT215_LINE_10].value })
+        @nyc_eic_rate_worksheet.calculate
+        set_line(:IT215_WK_C_LINE_2, -> { @lines[:NYC_EIC_RATE_WK_LINE_6].value })
+        set_line(:IT215_WK_C_LINE_3, :calculate_wk_c_line_3)
+        # worksheet c line 4 is out of scope
+
+        set_line(:IT215_LINE_27, -> {@lines[:IT215_WK_C_LINE_3].value})
       end
 
       def calculate_line_3
@@ -75,38 +83,8 @@ module Efile
         @lines[:IT215_LINE_12].value - @lines[:IT215_LINE_15].value
       end
 
-      def calculate_wk_c_line_2
-        rates = [
-          [-99999999999999, 5000, nil, nil, 0.30],
-          [5000, 7500, 4999, 0.30, nil],
-          [7500, 15000, nil, nil, 0.25],
-          [15000, 17500, 14999, 0.25, nil],
-          [17500, 20000, nil, nil, 0.20],
-          [20000, 22500, 19999, 0.20, nil],
-          [22500, 40000, nil, nil, 0.15],
-          [40000, 42500, 39999, 0.15, nil],
-          [42500, 99999999999999, nil, nil, 0.10]
-        ]
-
-        ln_3_hardval = 0.00002
-        ny_agi = @lines[:IT201_LINE_33].value
-        rates_line = rates.find { |line| ny_agi >= line[0] && ny_agi < line[1] }
-        return rates_line[4] if rates_line[4].present?
-
-        ln_2_val = rates_line[2]
-        ln_3_val = ny_agi - ln_2_val
-        ln_4_val = ((ln_3_val * ln_3_hardval) * 10000).round / 10000.0
-        ln_5_val = rates_line[3]
-
-        ((ln_5_val - ln_4_val) * 10000).round / 10000.0
-      end
-
       def calculate_wk_c_line_3
         (line_or_zero(:IT215_WK_C_LINE_1) * @lines[:IT215_WK_C_LINE_2].value).round
-      end
-
-      def calculate_wk_c_line_4
-        # TODO with intake on asking client how they would like to split line 3 credits
       end
     end
   end

--- a/app/lib/efile/ny/nyc_eic_rate_table.rb
+++ b/app/lib/efile/ny/nyc_eic_rate_table.rb
@@ -1,0 +1,31 @@
+module Efile
+  module Ny
+    class NycEicRateTable
+      # https://www.tax.ny.gov/forms/current-forms/it/it215i.htm#nyc-eic-table
+
+      class << self
+        def find_row(ny_agi)
+          ROWS.find do |r|
+            r.agi_floor <= ny_agi && ny_agi < r.agi_ceiling
+          end
+        end
+      end
+
+      private
+
+      EicRateTableRow = Struct.new(:agi_floor, :agi_ceiling, :line_2_amt, :line_5_amt, :line_6_amt)
+
+      ROWS = [
+        EicRateTableRow.new(-Float::INFINITY,           5_000,    nil,  nil, 0.30),
+        EicRateTableRow.new(           5_000,           7_500,  4_999, 0.30,  nil),
+        EicRateTableRow.new(           7_500,          15_000,    nil,  nil, 0.25),
+        EicRateTableRow.new(          15_000,          17_500, 14_999, 0.25,  nil),
+        EicRateTableRow.new(          17_500,          20_000,    nil,  nil, 0.20),
+        EicRateTableRow.new(          20_000,          22_500, 19_999, 0.20,  nil),
+        EicRateTableRow.new(          22_500,          40_000,    nil,  nil, 0.15),
+        EicRateTableRow.new(          40_000,          42_500, 39_999, 0.15,  nil),
+        EicRateTableRow.new(          42_500, Float::INFINITY,    nil,  nil, 0.10),
+      ]
+    end
+  end
+end

--- a/app/lib/efile/ny/nyc_eic_rate_worksheet.rb
+++ b/app/lib/efile/ny/nyc_eic_rate_worksheet.rb
@@ -1,0 +1,42 @@
+module Efile
+  module Ny
+    class NycEicRateWorksheet < ::Efile::TaxCalculator
+      # https://www.tax.ny.gov/forms/current-forms/it/it215i.htm#nyc-eic-worksheet
+
+      attr_accessor :lines, :value_access_tracker
+
+      def initialize(value_access_tracker:, lines:)
+        @value_access_tracker = value_access_tracker
+        @lines = lines
+      end
+
+      def calculate
+        set_line(:NYC_EIC_RATE_WK_LINE_1, -> { @lines[:IT201_LINE_33].value })
+        @rate_table_row = NycEicRateTable.find_row(@lines[:NYC_EIC_RATE_WK_LINE_1].value)
+        if @rate_table_row.line_2_amt.present?
+          set_line(:NYC_EIC_RATE_WK_LINE_2, -> { @rate_table_row.line_2_amt })
+          set_line(:NYC_EIC_RATE_WK_LINE_3, :calculate_line_3)
+          set_line(:NYC_EIC_RATE_WK_LINE_4, :calculate_line_4)
+          set_line(:NYC_EIC_RATE_WK_LINE_5, -> { @rate_table_row.line_5_amt })
+          set_line(:NYC_EIC_RATE_WK_LINE_6, :calculate_line_6)
+        else
+          set_line(:NYC_EIC_RATE_WK_LINE_6, -> { @rate_table_row.line_6_amt })
+        end
+      end
+
+      private
+
+      def calculate_line_3
+        @lines[:NYC_EIC_RATE_WK_LINE_1].value - @lines[:NYC_EIC_RATE_WK_LINE_2].value
+      end
+
+      def calculate_line_4
+        (@lines[:NYC_EIC_RATE_WK_LINE_3].value * 0.00002).round(4)
+      end
+
+      def calculate_line_6
+        @lines[:NYC_EIC_RATE_WK_LINE_5].value - @lines[:NYC_EIC_RATE_WK_LINE_4].value
+      end
+    end
+  end
+end

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -123,7 +123,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
       expect(page).to have_text I18n.t("state_file.questions.shared.review_header.title")
       click_on I18n.t("general.continue")
 
-      expect(page).to have_text I18n.t("state_file.questions.tax_refund.edit.title", refund_amount: 1715, state_name: "New York")
+      expect(page).to have_text I18n.t("state_file.questions.tax_refund.edit.title", refund_amount: 1_981, state_name: "New York")
       expect(page).to_not have_text "Your responses are saved. If you need a break, you can come back and log in to your account at fileyourstatetaxes.org."
       choose I18n.t("state_file.questions.tax_refund.edit.mail")
       click_on I18n.t("general.continue")

--- a/spec/lib/efile/ny/nyc_eic_rate_table_spec.rb
+++ b/spec/lib/efile/ny/nyc_eic_rate_table_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe Efile::Ny::NycEicRateTable do
+  describe ".find_row" do
+    it "returns the correct row" do
+      result = described_class.find_row(2_333)
+      expect(result.line_2_amt).to be_nil
+      expect(result.line_5_amt).to be_nil
+      expect(result.line_6_amt).to eq(0.30)
+
+      result = described_class.find_row(15_000)
+      expect(result.line_2_amt).to eq(14_999)
+      expect(result.line_5_amt).to eq(0.25)
+      expect(result.line_6_amt).to be_nil
+
+      result = described_class.find_row(43_333)
+      expect(result.line_2_amt).to be_nil
+      expect(result.line_5_amt).to be_nil
+      expect(result.line_6_amt).to eq(0.10)
+    end
+  end
+end


### PR DESCRIPTION
Part of https://www.pivotaltracker.com/story/show/186814386

- I implemented the NYC EIC Rate Worksheet using a new TaxCalculator subclass, because I wanted us to be able to pull explanations of the calculations.
- I added the NYC EIC Rate Table as a separate class, so I could test it independently
- This only updates calculations. I still need to confirm if the XML and PDF are filled correctly. 