### PR TITLE
Small fixes for NYC EIC

### DIFF
--- a/app/lib/efile/ny/it215.rb
+++ b/app/lib/efile/ny/it215.rb
@@ -45,14 +45,8 @@ module Efile
 
         # lines 17-26 are out of scope
 
-        # https://www.tax.ny.gov/forms/current-forms/it/it215i.htm#worksheet-c
-        set_line(:IT215_WK_C_LINE_1, -> { @lines[:IT215_LINE_10].value })
-        @nyc_eic_rate_worksheet.calculate
-        set_line(:IT215_WK_C_LINE_2, -> { @lines[:NYC_EIC_RATE_WK_LINE_6].value })
-        set_line(:IT215_WK_C_LINE_3, :calculate_wk_c_line_3)
-        # worksheet c line 4 is out of scope
-
-        set_line(:IT215_LINE_27, -> {@lines[:IT215_WK_C_LINE_3].value})
+        # NYC EIC
+        set_line(:IT215_LINE_27, :calculate_line_27)
       end
 
       def calculate_line_3
@@ -81,6 +75,21 @@ module Efile
 
       def calculate_line_16
         @lines[:IT215_LINE_12].value - @lines[:IT215_LINE_15].value
+      end
+
+      def calculate_line_27
+        # NYC EIC
+        if @intake.nyc_full_year_resident_yes?
+          # https://www.tax.ny.gov/forms/current-forms/it/it215i.htm#worksheet-c
+          set_line(:IT215_WK_C_LINE_1, -> { @lines[:IT215_LINE_10].value })
+          @nyc_eic_rate_worksheet.calculate
+          set_line(:IT215_WK_C_LINE_2, -> { @lines[:NYC_EIC_RATE_WK_LINE_6].value })
+          set_line(:IT215_WK_C_LINE_3, :calculate_wk_c_line_3)
+          # worksheet c line 4 is out of scope
+          @lines[:IT215_WK_C_LINE_3].value
+        else
+          0
+        end
       end
 
       def calculate_wk_c_line_3

--- a/app/lib/submission_builder/ty2022/states/ny/documents/it215.rb
+++ b/app/lib/submission_builder/ty2022/states/ny/documents/it215.rb
@@ -25,9 +25,7 @@ module SubmissionBuilder
                 xml.E_HH_CR_AMT claimed: calculated_fields.fetch("IT215_LINE_14")
                 xml.E_EITC_LMT_AMT claimed: calculated_fields.fetch("IT215_LINE_15")
                 xml.E_EITC_CR_AMT claimed: calculated_fields.fetch("IT215_LINE_16")
-                if calculated_fields["IT215_LINE_27"]
-                  xml.E_NYC_EITC_CR_AMT claimed: calculated_fields.fetch("IT215_LINE_27")
-                end
+                xml.E_NYC_EITC_CR_AMT claimed: calculated_fields.fetch("IT215_LINE_27")
                 xml.E_TX_AMT claimed: calculated_fields.fetch("IT215_WK_B_LINE_1")
                 xml.E_RSDT_CR_AMT claimed: calculated_fields.fetch("IT215_WK_B_LINE_2")
                 xml.E_ACM_DIST_AMT claimed: calculated_fields.fetch("IT215_WK_B_LINE_3")

--- a/app/views/state_file/questions/confirmation/explain_calculations.html.erb
+++ b/app/views/state_file/questions/confirmation/explain_calculations.html.erb
@@ -18,7 +18,7 @@
         </td>
         <td style="vertical-align: top;"><%= line.value %></td>
         <td style="vertical-align: top; white-space: nowrap;">
-          <% line.inputs.each do |line_id| %>
+          <% line.inputs&.each do |line_id| %>
             <div>
               <a href="#<%= line_id %>"><%= line_id %></a>: <%= @calculator.lines[line_id]&.value %>
             </div>

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -123,7 +123,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
       expect(page).to have_text I18n.t("state_file.questions.shared.review_header.title")
       click_on I18n.t("general.continue")
 
-      expect(page).to have_text I18n.t("state_file.questions.tax_refund.edit.title", refund_amount: 1_981, state_name: "New York")
+      expect(page).to have_text I18n.t("state_file.questions.tax_refund.edit.title", refund_amount: 1_715, state_name: "New York")
       expect(page).to_not have_text "Your responses are saved. If you need a break, you can come back and log in to your account at fileyourstatetaxes.org."
       choose I18n.t("state_file.questions.tax_refund.edit.mail")
       click_on I18n.t("general.continue")


### PR DESCRIPTION
Finishing touches for https://www.pivotaltracker.com/story/show/186814386
- Ensures that NYC EIC is only calculated for NYC full-year residents
- Moves NYC EIC calculation into method so that the calculator can extract an explanation of how line 27 was calculated.
- Removes the conditional on the XML, allowing the value of zero to be passed through.