### PR TITLE
Add columns for new NYC residency questions

### DIFF
--- a/app/controllers/flows_controller.rb
+++ b/app/controllers/flows_controller.rb
@@ -599,6 +599,8 @@ class FlowsController < ApplicationController
         eligibility_yonkers: "no",
         household_rent_own: "unfilled",
         nursing_home: "unfilled",
+        nyc_residency: "none",
+        nyc_maintained_home: "no",
         nyc_full_year_resident: "no",
         occupied_residence: "unfilled",
         permanent_apartment: "B",

--- a/app/models/state_file_ny_intake.rb
+++ b/app/models/state_file_ny_intake.rb
@@ -44,6 +44,8 @@
 #  ny_mailing_street                  :string
 #  ny_mailing_zip                     :string
 #  nyc_full_year_resident             :integer          default("unfilled"), not null
+#  nyc_maintained_home                :integer          default("unfilled"), not null
+#  nyc_residency                      :integer          default("unfilled"), not null
 #  occupied_residence                 :integer          default("unfilled"), not null
 #  payment_or_deposit_type            :integer          default("unfilled"), not null
 #  permanent_address_outside_ny       :integer          default("unfilled"), not null
@@ -99,6 +101,8 @@
 class StateFileNyIntake < StateFileBaseIntake
   encrypts :account_number, :routing_number, :raw_direct_file_data
 
+  enum nyc_residency: { unfilled: 0, full_year: 1, part_year: 2, none: 3 }, _prefix: :nyc_residency
+  enum nyc_maintained_home: { unfilled: 0, yes: 1, no: 2 }, _prefix: :nyc_maintained_home
   enum nyc_full_year_resident: { unfilled: 0, yes: 1, no: 2 }, _prefix: :nyc_full_year_resident
   enum occupied_residence: { unfilled: 0, yes: 1, no: 2 }, _prefix: :occupied_residence
   enum property_over_limit: { unfilled: 0, yes: 1, no: 2 }, _prefix: :property_over_limit

--- a/db/migrate/20240118201358_add_nyc_residency_columns_to_state_file_ny_intakes.rb
+++ b/db/migrate/20240118201358_add_nyc_residency_columns_to_state_file_ny_intakes.rb
@@ -1,0 +1,6 @@
+class AddNycResidencyColumnsToStateFileNyIntakes < ActiveRecord::Migration[7.1]
+  def change
+    add_column :state_file_ny_intakes, :nyc_residency, :integer, default: 0, null: false
+    add_column :state_file_ny_intakes, :nyc_maintained_home, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_17_020831) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_18_201358) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -1731,6 +1731,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_17_020831) do
     t.string "ny_mailing_street"
     t.string "ny_mailing_zip"
     t.integer "nyc_full_year_resident", default: 0, null: false
+    t.integer "nyc_maintained_home", default: 0, null: false
+    t.integer "nyc_residency", default: 0, null: false
     t.integer "occupied_residence", default: 0, null: false
     t.integer "payment_or_deposit_type", default: 0, null: false
     t.integer "permanent_address_outside_ny", default: 0, null: false

--- a/spec/factories/state_file_ny_intakes.rb
+++ b/spec/factories/state_file_ny_intakes.rb
@@ -44,6 +44,8 @@
 #  ny_mailing_street                  :string
 #  ny_mailing_zip                     :string
 #  nyc_full_year_resident             :integer          default("unfilled"), not null
+#  nyc_maintained_home                :integer          default("unfilled"), not null
+#  nyc_residency                      :integer          default("unfilled"), not null
 #  occupied_residence                 :integer          default("unfilled"), not null
 #  payment_or_deposit_type            :integer          default("unfilled"), not null
 #  permanent_address_outside_ny       :integer          default("unfilled"), not null

--- a/spec/models/state_file_ny_intake_spec.rb
+++ b/spec/models/state_file_ny_intake_spec.rb
@@ -44,6 +44,8 @@
 #  ny_mailing_street                  :string
 #  ny_mailing_zip                     :string
 #  nyc_full_year_resident             :integer          default("unfilled"), not null
+#  nyc_maintained_home                :integer          default("unfilled"), not null
+#  nyc_residency                      :integer          default("unfilled"), not null
 #  occupied_residence                 :integer          default("unfilled"), not null
 #  payment_or_deposit_type            :integer          default("unfilled"), not null
 #  permanent_address_outside_ny       :integer          default("unfilled"), not null


### PR DESCRIPTION
First step for: https://www.pivotaltracker.com/story/show/186865012

Adds two new columns for the new NYC residency questions. These are semi-redundant with some existing columns (`nyc_full_year_resident`, `eligibility_part_year_nyc_resident`), but will store a more accurate residency status than the others. Depending on some possible changes to the UI, we may be able to remove the other columns at a later date.