### PR TITLE
Copy updates NY specific questions and uniform taxes owed/tax refund styling 

### DIFF
--- a/app/views/state_file/questions/name_dob/edit.html.erb
+++ b/app/views/state_file/questions/name_dob/edit.html.erb
@@ -54,7 +54,7 @@
     <%= f.fields_for :dependents do |ff| %>
       <div id="dependent-<%= ff.index %>" class="blue-group">
 
-        <p><%= t(".dependent_name_dob", number: number_in_words(ff.index + 1))%></p>
+        <p><%= t(".dependent_name_dob") %></p>
 
         <%= ff.cfa_input_field(:first_name, t("general.first_name"), classes: ["form-width--long"], options: {disabled: true}) %>
         <%= ff.cfa_input_field(:last_name, t("general.last_name"), classes: ["form-width--long"], options: {disabled: true}) %>

--- a/app/views/state_file/questions/ny_primary_state_id/_state_id.html.erb
+++ b/app/views/state_file/questions/ny_primary_state_id/_state_id.html.erb
@@ -19,39 +19,37 @@
     </div>
 
     <div class="question-with-follow-up__follow-up" id="id-details-fields">
-      <div class="blue-group">
-        <div class="form-group-tight">
-          <%= f.cfa_input_field(:id_number, t("state_file.questions.primary_state_id.state_id.id_details.number"), classes: ["form-width--long"]) %>
-          <%= f.cfa_date_select(:issue_date,
-                                t("state_file.questions.primary_state_id.state_id.id_details.issue_month") + " / " + t("state_file.questions.primary_state_id.state_id.id_details.issue_day") + " / " + t("state_file.questions.primary_state_id.state_id.id_details.issue_year"),
+      <div class="blue-group form-group-tight">
+        <%= f.cfa_input_field(:id_number, t("state_file.questions.primary_state_id.state_id.id_details.number"), classes: ["form-width--long"]) %>
+        <%= f.cfa_date_select(:issue_date,
+                              t("state_file.questions.primary_state_id.state_id.id_details.issue_month") + " / " + t("state_file.questions.primary_state_id.state_id.id_details.issue_day") + " / " + t("state_file.questions.primary_state_id.state_id.id_details.issue_year"),
+                              options: {
+                                start_year: Time.now.year,
+                                end_year: 2000,
+                              }
+            ) %>
+        <span id="fields_to_clear">
+          <%= f.cfa_date_select(:expiration_date,
+                                t("state_file.questions.primary_state_id.state_id.id_details.expiration_month") + " / " + t("state_file.questions.primary_state_id.state_id.id_details.expiration_day") + " / " + t("state_file.questions.primary_state_id.state_id.id_details.expiration_year"),
                                 options: {
-                                  start_year: Time.now.year,
-                                  end_year: 2000,
-                                }
-              ) %>
-          <span id="fields_to_clear">
-            <%= f.cfa_date_select(:expiration_date,
-                                  t("state_file.questions.primary_state_id.state_id.id_details.expiration_month") + " / " + t("state_file.questions.primary_state_id.state_id.id_details.expiration_day") + " / " + t("state_file.questions.primary_state_id.state_id.id_details.expiration_year"),
-                                  options: {
-                                    start_year: Time.now.year - 2,
-                                    end_year: Time.now.year + 50,
-                                  }) %>
-          </span>
-          <span id="checkbox">
-            <%= f.cfa_checkbox(:non_expiring, t("state_file.questions.primary_state_id.state_id.id_details.no_expiration_date")) %>
-          </span>
-          <div onchange="$('#first_3_doc_num_container')[event.target.value == 'NY' ? 'show' : 'hide']()">
-            <%= f.cfa_select(:state, t("state_file.questions.primary_state_id.state_id.id_details.issue_state"), States.name_value_pairs, include_blank: true) %>
-          </div>
-          <div id="first_3_doc_num_container"  style="display: <%=options[:include_first_three_doc_num] ? 'block' : 'none'%>">
-            <%= f.cfa_input_field(:first_three_doc_num, t("state_file.questions.primary_state_id.state_id.id_details.first_three_doc_num"), classes: ["form-width--short"]) %>
-          </div>
-          <% if options[:info_link] %>
-            <div class="spacing-above-25">
-              <a class="info-link" href="<%= options[:info_link] %>" target="_blank" rel="nofollow noopener"><%= t('state_file.questions.primary_state_id.state_id.info_link') %></a>
-            </div>
-          <% end %>
+                                  start_year: Time.now.year - 2,
+                                  end_year: Time.now.year + 50,
+                                }) %>
+        </span>
+        <span id="checkbox">
+          <%= f.cfa_checkbox(:non_expiring, t("state_file.questions.primary_state_id.state_id.id_details.no_expiration_date")) %>
+        </span>
+        <div onchange="$('#first_3_doc_num_container')[event.target.value == 'NY' ? 'show' : 'hide']()">
+          <%= f.cfa_select(:state, t("state_file.questions.primary_state_id.state_id.id_details.issue_state"), States.name_value_pairs, include_blank: true) %>
         </div>
+        <div id="first_3_doc_num_container"  style="display: <%=options[:include_first_three_doc_num] ? 'block' : 'none'%>">
+          <%= f.cfa_input_field(:first_three_doc_num, t("state_file.questions.primary_state_id.state_id.id_details.first_three_doc_num_html"), classes: ["form-width--short"]) %>
+        </div>
+        <% if options[:info_link] %>
+          <div class="spacing-above-25">
+            <a class="info-link" href="<%= options[:info_link] %>" target="_blank" rel="nofollow noopener"><%= t('state_file.questions.primary_state_id.state_id.info_link') %></a>
+          </div>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/state_file/questions/tax_refund/_bank_details.html.erb
+++ b/app/views/state_file/questions/tax_refund/_bank_details.html.erb
@@ -1,0 +1,36 @@
+<div class="blue-group">
+  <p class="spacing-below-0"><%= t(".bank_title") %></p>
+  <p class="text--small"><%= t(".foreign_accounts") %></p>
+  <div class="form-group-tight">
+    <% if owe_taxes %>
+      <%= form.cfa_input_field(:withdraw_amount, t('.withdraw_amount', owed_amount: taxes_owed), classes: ["form-width--long"]) %>
+      <div class="date-select">
+        <% year = MultiTenantService.new(:statefile).current_tax_year + 1 %>
+        <%= form.cfa_date_select(
+              :date_electronic_withdrawal,
+              t(".date_withdraw_text"),
+              options: {
+                start_year: year,
+                end_year: year,
+              }
+            ) %>
+      </div>
+    <% end %>
+
+    <%= form.cfa_input_field(:bank_name, t("views.questions.bank_details.bank_name"), classes: ["form-width--long"]) %>
+    <%= form.cfa_radio_set(
+          :account_type,
+          label_text: t("views.questions.bank_details.account_type.label"),
+          collection: [
+            { value: :checking, label: t("views.questions.bank_details.account_type.checking") },
+            { value: :savings, label: t("views.questions.bank_details.account_type.savings") },
+          ]
+        )
+    %>
+    <%= form.cfa_input_field(:routing_number, t(".routing_number"), classes: ["form-width--long", "disablecopy"]) %>
+    <%= form.cfa_input_field(:routing_number_confirmation, t(".confirm_routing_number"), classes: ["form-width--long", "disablepaste", "disablecopy"]) %>
+    <%= form.cfa_input_field(:account_number, t(".account_number"), classes: ["form-width--long", "disablecopy"]) %>
+    <%= form.cfa_input_field(:account_number_confirmation, t(".confirm_account_number"), classes: ["form-width--long", "disablepaste", "disablecopy"]) %>
+  </div>
+  <p><strong><%= t(".disclaimer") %></strong></p>
+</div>

--- a/app/views/state_file/questions/tax_refund/edit.html.erb
+++ b/app/views/state_file/questions/tax_refund/edit.html.erb
@@ -1,8 +1,6 @@
-<% title = t(".title",
+<% title = t(".title_html",
              state_name: States.name_for_key(params[:us_state].upcase),
-             refund_amount: refund_amount
-             ) %>
-<% bank_title = t(".bank_title") %>
+             refund_amount: refund_amount) %>
 
 <% content_for :page_title, title %>
 <% content_for :card do %>
@@ -27,27 +25,7 @@
       <div class="question-with-follow-up__follow-up" id="deposit-to-bank">
         <div class="question-with-follow-up">
           <div class="question-with-follow-up__question">
-            <div class="blue-group">
-              <p class="form-question spacing-below-25"><%= bank_title %></p>
-              <div class="form-group-tight">
-                <%= f.cfa_input_field(:bank_name, t("views.questions.bank_details.bank_name"), classes: ["form-width--long"]) %>
-                <%= f.cfa_radio_set(
-                      :account_type,
-                      label_text: t("views.questions.bank_details.account_type.label"),
-                      collection: [
-                        { value: :checking, label: t("views.questions.bank_details.account_type.checking") },
-                        { value: :savings, label: t("views.questions.bank_details.account_type.savings") },
-                      ]
-                    )
-                %>
-                <%= f.cfa_input_field(:routing_number, t(".routing_number"), classes: ["form-width--long", "disablecopy"]) %>
-                <%= f.cfa_input_field(:routing_number_confirmation, t(".confirm_routing_number"), classes: ["form-width--long", "disablepaste", "disablecopy"]) %>
-                <%= f.cfa_input_field(:account_number, t(".account_number"), classes: ["form-width--long", "disablecopy"]) %>
-                <%= f.cfa_input_field(:account_number_confirmation, t(".confirm_account_number"), classes: ["form-width--long", "disablepaste", "disablecopy"]) %>
-              </div>
-              <%= t(".disclaimer_html") %>
-              <br/>
-            </div>
+            <%= render 'state_file/questions/tax_refund/bank_details', form: f, owe_taxes: false %>
           </div>
         </div>
       </div>

--- a/app/views/state_file/questions/taxes_owed/edit.html.erb
+++ b/app/views/state_file/questions/taxes_owed/edit.html.erb
@@ -1,73 +1,27 @@
-<% title = t(".title", owed_amount: taxes_owed) %>
-
-<% content_for :page_title, title %>
+<% content_for :page_title, t(".page_title", owed_amount: taxes_owed, state_name: States.name_for_key(params[:us_state].upcase)) %>
 <% content_for :card do %>
   <h1 class="h2">
-    <%= title %>
+    <%= t(".title_html", owed_amount: taxes_owed, state_name: States.name_for_key(params[:us_state].upcase)) %>
   </h1>
 
-  <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder, html: {class: 'form-card form-card--long'} do |f| %>
+  <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
     <div class="question-with-follow-up">
-      <div class="question-with-follow-up__question">
-        <div class="blue-group">
-          <%= f.cfa_radio_set(
-            :payment_or_deposit_type,
-            collection: [
-              { value: :mail, label: t(".pay_mail_online_html",
-                                                 pay_mail_online_link: pay_mail_online_link,
-                                                 pay_mail_online_text: pay_mail_online_text,
-                                                 ) },
-              { value: :direct_deposit, label: t(".pay_bank"), input_html: { "data-follow-up": "#pay-from-bank" } },
-            ]
-          ) %>
-        </div>
+      <div class="question-with-follow-up__question blue-group">
+        <%= f.cfa_radio_set(
+          :payment_or_deposit_type,
+          collection: [
+            { value: :mail, label: t(".pay_mail_online_html",
+                                               pay_mail_online_link: pay_mail_online_link,
+                                               pay_mail_online_text: pay_mail_online_text,
+                                               ) },
+            { value: :direct_deposit, label: t(".pay_bank"), input_html: { "data-follow-up": "#pay-from-bank" } },
+          ]
+        ) %>
       </div>
       <div class="question-with-follow-up__follow-up" id="pay-from-bank">
         <div class="question-with-follow-up">
           <div class="question-with-follow-up__question">
-            <div class="blue-group">
-              <div class="form-card__content">
-                <h1 class="h2">
-                  <%= t(".bank_title") %>
-                </h1>
-                <%= f.cfa_input_field(:withdraw_amount, t('.withdraw_amount', owed_amount: taxes_owed), classes: ["form-width--long"]) %>
-                <p>
-                  <%= image_tag("icons/exclamation.svg", alt: "") %>
-                  <strong>
-                    <%= t(".payment_notice", owed_amount: taxes_owed, pay_url: pay_mail_online_link) %>
-                  </strong>
-                </p>
-
-                <div class="date-select">
-                  <% year = MultiTenantService.new(:statefile).current_tax_year + 1 %>
-                  <%= f.cfa_date_select(
-                        :date_electronic_withdrawal,
-                        t(".date_withdraw_text"),
-                        options: {
-                          start_year: year,
-                          end_year: year,
-                        }
-                      ) %>
-                </div>
-
-                <%= f.cfa_input_field(:bank_name, t('.bank_name'), classes: ["form-width--long"]) %>
-
-                <%= f.cfa_radio_set(
-                      :account_type,
-                      label_text: t('.account_type_description'),
-                      collection: [
-                        { value: :checking, label: t(".checking")},
-                        { value: :savings, label: t(".savings")},
-                      ]
-                    ) %>
-
-                <%= f.cfa_input_field(:routing_number, t(".routing_number"), classes: ["form-width--long", "disablecopy"]) %>
-                <%= f.cfa_input_field(:routing_number_confirmation, t(".confirm_routing_number"), classes: ["form-width--long", "disablepaste", "disablecopy"]) %>
-                <%= f.cfa_input_field(:account_number, t(".account_number"), classes: ["form-width--long", "disablecopy"]) %>
-                <%= f.cfa_input_field(:account_number_confirmation, t(".confirm_account_number"), classes: ["form-width--long", "disablepaste", "disablecopy"]) %>
-                <p class="spacing-above-25"><strong><%= t(".double_check") %></strong></p>
-              </div>
-            </div>
+            <%= render 'state_file/questions/tax_refund/bank_details', form: f, owe_taxes: true %>
           </div>
         </div>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2284,7 +2284,7 @@ en:
             expiration_day: Day
             expiration_month: Expiration month
             expiration_year: Year
-            first_three_doc_num_html: <strong>For New York IDs&#58;</strong> First three characters of the document number (located on the back of your ID)
+            first_three_doc_num_html: "<strong>For New York IDs&#58;</strong> First three characters of the document number (located on the back of your ID)"
             issue_day: Day
             issue_month: Issue month
             issue_state: Issue State
@@ -2364,29 +2364,26 @@ en:
           register_to_vote: Register to vote
           title: Your 2023 %{state_name} state tax return is now submitted!
       tax_refund:
+        bank_details:
+          account_number: Account Number
+          bank_title: 'Please provide your bank details:'
+          confirm_account_number: Confirm Account Number
+          confirm_routing_number: Confirm Routing Number
+          date_withdraw_text: 'When would you like the funds withdrawn from your account? (Must be on or before April 15, 2024):'
+          disclaimer: Check to make sure your bank information is correct. You won’t be able to correct this after you submit your return.
+          foreign_accounts: "(Foreign accounts are not accepted)"
+          routing_number: Routing Number
+          withdraw_amount: How much do you authorize to be withdrawn from your account? (Your total amount due is&#58; $%{owed_amount}.)
         edit:
           direct_deposit: Direct deposit (fastest)
           mail: Mail my payment (slower)
           title_html: Good news, you're getting a %{state_name} state tax refund of <strong>$%{refund_amount}.</strong> How would you like to receive your refund?
-        bank_details:
-          bank_title: 'Please provide your bank details:'
-          account_number: Account Number
-          disclaimer: Check to make sure your bank information is correct. You won’t be able to correct this after you submit your return.
-          foreign_accounts: (Foreign accounts are not accepted)
-          confirm_account_number: Confirm Account Number
-          confirm_routing_number: Confirm Routing Number
-          routing_number: Routing Number
-          withdraw_amount: How much do you authorize to be withdrawn from your account? (Your total amount due is&#58; $%{owed_amount}.)
-          date_withdraw_text: 'When would you like the funds withdrawn from your account? (Must be on or before April 15, 2024):'
-          checking: Checking
-          savings: Savings
-          account_type_description: What type of account is this?
       taxes_owed:
         edit:
-          pay_mail_online_html: Pay by mail or online at <a target="_blank" rel="noopener nofollow" href="%{pay_mail_online_link}">%{pay_mail_online_text}</a>
           page_title: You owe $%{owed_amount} in %{state_name} state taxes. How would you like to pay?
-          title_html: You owe <strong>$%{owed_amount}</strong> in %{state_name} state taxes. How would you like to pay?
           pay_bank: Pay directly from your checking or savings account (direct debit)
+          pay_mail_online_html: Pay by mail or online at <a target="_blank" rel="noopener nofollow" href="%{pay_mail_online_link}">%{pay_mail_online_text}</a>
+          title_html: You owe <strong>$%{owed_amount}</strong> in %{state_name} state taxes. How would you like to pay?
       terms_and_conditions:
         edit:
           accept: Accept

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2284,7 +2284,7 @@ en:
             expiration_day: Day
             expiration_month: Expiration month
             expiration_year: Year
-            first_three_doc_num_html: "<strong>For New York IDs&#58;</strong> First three characters of the document number (located on the back of your ID)"
+            first_three_doc_num_html: "<strong>For New York IDs:</strong> First three characters of the document number (located on the back of your ID)"
             issue_day: Day
             issue_month: Issue month
             issue_state: Issue State

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2161,7 +2161,7 @@ en:
       name_dob:
         edit:
           dependent_months_lived_label: Number of months they lived with you in %{year}
-          dependent_name_dob: Your %{number} dependent's name and date of birth
+          dependent_name_dob: Please tell us your dependent’s date of birth
           months_helper_born_died: Select 12 months if the dependent was born or died during 2023.
           months_helper_description: Count any months the dependent lived in your home, as well as any months the dependent was temporarily absent due to being away at school, in a hospital or medical facility, or away on business or vacation.
           months_helper_heading: Which months should I count?
@@ -2233,8 +2233,8 @@ en:
           title:
             one: Did you make any out-of-state purchases in %{year} that went untaxed?
             other: Did you or your spouse make any out-of-state purchases in %{year} without paying sales or use tax?
-          use_tax_method_automated: All of your purchases were less than $1,000 each. We’ll calculate the amount of use tax.
-          use_tax_method_manual_html: I will calculate my use tax manually. <a href="https://www.tax.ny.gov/pdf/current_forms/st/st140.pdf" target="_blank" rel="noopener noreferrer">(Learn more)</a>
+          use_tax_method_automated: All of your purchases were less than $1,000 each. Calculate the amount of use tax for me.
+          use_tax_method_manual_html: I had an untaxed purchase over $1,000, or I would prefer to calculate my use tax manually. (<a href="https://www.tax.ny.gov/pdf/current_forms/st/st140.pdf" target="_blank" rel="noopener noreferrer">Learn more</a> and search ‘exact calculation method’)
       ny_school_district:
         edit:
           helper_description_html: You can try searching for your school district <a href="https://www.greatschools.org/school-district-boundaries-map/" target="_blank" rel="noopener nofollow">here</a>. If you’re still unsure, you may need to contact your nearest public school to ask for the school district name.
@@ -2281,20 +2281,20 @@ en:
           title: Please share some details from your state-issued ID
         state_id:
           id_details:
-            expiration_day: Expiration Day
-            expiration_month: Expiration Month
-            expiration_year: Expiration Year
-            first_three_doc_num: 'For New York IDs: First three characters of the document number (located on the back of your ID)'
-            issue_day: Issue Day
-            issue_month: Issue Month
+            expiration_day: Day
+            expiration_month: Expiration month
+            expiration_year: Year
+            first_three_doc_num_html: <strong>For New York IDs&#58;</strong> First three characters of the document number (located on the back of your ID)
+            issue_day: Day
+            issue_month: Issue month
             issue_state: Issue State
-            issue_year: Issue Year
+            issue_year: Year
             no_expiration_date: No expiration date
             number: ID Number
           id_type_question:
             dmv: DMV/BMV State ID
             drivers_license: Driver’s license
-            label: Your ID Type
+            label: ID Type
             no_id: No driver’s license or state ID
           info_link: View where to find this information
       return_status:
@@ -2344,12 +2344,14 @@ en:
           nth_dependent_name: Your %{ordinal} dependent's name
           spouse_name: Your spouse's name
           taxes_owed_html: |
-            <strong>Your estimated refund or taxes owed</strong> $0. <br/>
-            You broke even on your state tax return. This means that you <strong>will not</strong>
-            receive a state refund and you <strong>do not</strong> owe state taxes.
+            <p>
+              <strong>Your refund or taxes owed</strong> <br/>
+              $0
+            </p>
+            Your refund is $0. This means that you <strong>will not</strong> receive a state refund and you <strong>do not</strong> owe state taxes. You should finish filing your return, since you may be required to file even though you won’t get or receive any money.
           title: You're done! Review your state tax return before you submit.
           your_name: Your name
-          your_refund: Your refund
+          your_refund: Your refund amount
           your_tax_owed: Your taxes owed
       spouse_state_id:
         edit:
@@ -2363,36 +2365,28 @@ en:
           title: Your 2023 %{state_name} state tax return is now submitted!
       tax_refund:
         edit:
+          direct_deposit: Direct deposit (fastest)
+          mail: Mail my payment (slower)
+          title_html: Good news, you're getting a %{state_name} state tax refund of <strong>$%{refund_amount}.</strong> How would you like to receive your refund?
+        bank_details:
+          bank_title: 'Please provide your bank details:'
           account_number: Account Number
-          bank_title: 'Please provide your bank details: '
+          disclaimer: Check to make sure your bank information is correct. You won’t be able to correct this after you submit your return.
+          foreign_accounts: (Foreign accounts are not accepted)
           confirm_account_number: Confirm Account Number
           confirm_routing_number: Confirm Routing Number
-          direct_deposit: Direct deposit (fastest)
-          disclaimer_html: |
-            <strong>
-            Check to make sure your bank information is correct. You won't be able to correct this after you submit your return.
-            </strong><br/>
-          mail: Mail my payment (slower)
           routing_number: Routing Number
-          title: Good news, you're getting a %{state_name} state tax refund of $%{refund_amount}. How would you like to receive your refund?
+          withdraw_amount: How much do you authorize to be withdrawn from your account? (Your total amount due is&#58; $%{owed_amount}.)
+          date_withdraw_text: 'When would you like the funds withdrawn from your account? (Must be on or before April 15, 2024):'
+          checking: Checking
+          savings: Savings
+          account_type_description: What type of account is this?
       taxes_owed:
         edit:
-          account_number: Account Number
-          account_type_description: What type of account is this?
-          bank_name: Bank Name
-          bank_title: Please provide your bank details
-          checking: Checking
-          confirm_account_number: Confirm Account Number
-          confirm_routing_number: Confirm Routing Number
-          date_withdraw_text: 'When would you like the funds withdrawn from your account? (Must be on or before April 15, 2024):'
-          double_check: Check to make sure your bank information is correct. You won’t be able to correct this after you submit your return.
-          pay_bank: Pay directly from your checking or savings account (direct debit)
           pay_mail_online_html: Pay by mail or online at <a target="_blank" rel="noopener nofollow" href="%{pay_mail_online_link}">%{pay_mail_online_text}</a>
-          payment_notice: Your total amount due is $%{owed_amount}. If you want less than this amount to be withdrawn from your account, you'll need to pay the rest at %{pay_url} on or before April 15, 2024.
-          routing_number: Routing Number
-          savings: Savings
-          title: You owe $%{owed_amount}. How would you like to pay your taxes owed?
-          withdraw_amount: How much do you authorize to be withdrawn from your account? (Your total amount due is&#58; $%{owed_amount}.)
+          page_title: You owe $%{owed_amount} in %{state_name} state taxes. How would you like to pay?
+          title_html: You owe <strong>$%{owed_amount}</strong> in %{state_name} state taxes. How would you like to pay?
+          pay_bank: Pay directly from your checking or savings account (direct debit)
       terms_and_conditions:
         edit:
           accept: Accept
@@ -2433,7 +2427,7 @@ en:
           apartment: Apartment/Unit Number
           box_10b_html: "<strong>Box 10b</strong>, State identification number"
           city: City
-          confirm_address_html: Please confirm <strong>your mailing address</strong> listed on Form 1099-G. Note&#58; this may be different than your current address. Please edit the address to match what’s on your form.
+          confirm_address_html: Please confirm <strong>the mailing address</strong> listed on Form 1099-G. Note&#58; this may be different than your current address. Please edit to match what’s on your form.
           confirm_address_no: No, I need to edit
           confirm_address_yes: Yes, that's the address
           federal_income_tax_withheld_html: "<strong>Box 4</strong>, Federal income tax withheld"
@@ -2442,10 +2436,10 @@ en:
             Find the 1099-G you used to enter your unemployment income on your federal tax return. If you have multiple 1099-Gs, you can add multiple forms. <br><br>
             Next, find the requested information in the following locations: </br>
             <ol class="list--numbered">
-              <li><b>Who does this form belong to?</b> The left side of the form will say if this form belongs to you or your spouse, if applicable. Look for “recipient’s name.”</li>
-              <li><b>Your mailing address</b> is listed under “recipient’s name” on the left side of the form. Make sure the address matches what you enter here.</li>
-              <li><b>Payer’s information,</b> or the government agency that issued the form, is listed in the top left corner of the page. Enter the name, address, and TIN as shown on the form.</li>
-              <li><b>Boxes 1, 4, 10b, and 11</b> are all labeled with the same numbers on the right side of the form. Enter the information exactly as it appears in those boxes.</li>
+              <li><strong>Who does this form belong to?</strong> The left side of the form will say if this form belongs to you or your spouse, if applicable. Look for “recipient’s name.”</li>
+              <li><strong>Your mailing address</strong> is listed under "recipient's name" on the left side of the form. Make sure the address on the form matches what you enter here.</li>
+              <li><strong>Payer’s information,</strong> or the government agency that issued the form, is listed in the top left corner of the page. Enter the name, address, and TIN as shown on the form.</li>
+              <li><strong>Boxes 1, 4, 10b, and 11</strong> are all labeled with the same numbers on the right side of the form. Enter the information exactly as it appears in those boxes.</li>
             </ol>
           information_html: "<strong>How do I find this information?</strong>"
           money_boxes_label: Please complete the following boxes based on what’s reported on Form 1099-G.
@@ -2453,8 +2447,8 @@ en:
           other_tax_filing_options_html: <strong>Reminder:</strong> In 2024, this tool does not support filing unemployment income received from another state. To file income received from another state, check out <a target="_blank" rel="noopener nofollow" href="%{link}">other tax filing options.</a>
           payer_address: Payer's Street Address
           payer_name: Payer's Name
-          payer_question_html: Enter the payer’s information <strong>located in the top left corner</strong> of the form&#58;
-          payer_tin: Payer’s TIN (XXXXXXXXX)
+          payer_question_html: Please enter the <strong>payer's information located in the top left corner</strong> of the form&#58;
+          payer_tin: Payer’s TIN (XX-XXXXXXX)
           recipient_my_spouse: My spouse
           recipient_myself: Myself
           recipient_question: Who is this form for?

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -100,7 +100,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
       select_cfa_date "state_file_ny_spouse_state_id_form_issue_date", Time.now - 4.year
       select_cfa_date "state_file_ny_spouse_state_id_form_expiration_date", Time.now + 4.year
       select("New York", from: I18n.t('state_file.questions.primary_state_id.state_id.id_details.issue_state'))
-      fill_in I18n.t('state_file.questions.primary_state_id.state_id.id_details.first_three_doc_num'), with: "ABC"
+      fill_in "For New York IDs: First three characters of the document number (located on the back of your ID)", with: "ABC"
       click_on I18n.t("general.continue")
 
       expect(page).to have_text I18n.t('state_file.questions.unemployment.edit.title.other', year: MultiTenantService.statefile.current_tax_year)
@@ -134,7 +134,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
       expect(page).to have_text I18n.t("state_file.questions.shared.review_header.title")
       click_on I18n.t("general.continue")
 
-      expect(page).to have_text I18n.t("state_file.questions.tax_refund.edit.title", refund_amount: 1_825, state_name: "New York")
+      expect(page).to have_text "Good news, you're getting a New York state tax refund of $1825. How would you like to receive your refund?"
       expect(page).to_not have_text "Your responses are saved. If you need a break, you can come back and log in to your account at fileyourstatetaxes.org."
       choose I18n.t("state_file.questions.tax_refund.edit.mail")
       click_on I18n.t("general.continue")
@@ -271,7 +271,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
       expect(page).to have_text I18n.t("state_file.questions.shared.review_header.title")
       click_on I18n.t("general.continue")
 
-      expect(page).to have_text I18n.t("state_file.questions.tax_refund.edit.title", refund_amount: 1239, state_name: "Arizona")
+      expect(page).to have_text "Good news, you're getting a Arizona state tax refund of $1239. How would you like to receive your refund?"
       expect(page).to_not have_text "Your responses are saved. If you need a break, you can come back and log in to your account at fileyourstatetaxes.org."
 
       choose I18n.t("state_file.questions.tax_refund.edit.mail")


### PR DESCRIPTION
Some copy updates and fixed some styling on taxes owed/tax refund so that it matches the mocks more and both pages use the same partial with different conditionals 
Before:
<img width="312" alt="Screenshot 2024-01-19 at 1 44 59 PM" src="https://github.com/codeforamerica/vita-min/assets/49880002/b1c3f975-a2b9-4cc1-808a-78c0f30a95e7">

After:
<img width="336" alt="Screenshot 2024-01-19 at 12 03 37 PM" src="https://github.com/codeforamerica/vita-min/assets/49880002/0ec86134-64d1-4216-9605-73e0ac405047">
