### PR TITLE
Add new NYC Residency Page to flow

### DIFF
--- a/app/controllers/concerns/state_file/state_file_controller_concern.rb
+++ b/app/controllers/concerns/state_file/state_file_controller_concern.rb
@@ -1,0 +1,50 @@
+module StateFile
+  module StateFileControllerConcern
+    extend ActiveSupport::Concern
+
+    included do
+      helper_method :current_tax_year, :state_name, :state_abbr, :ny?, :az?, :state_param, :filer_count
+    end
+
+    private
+
+    def state_name
+      States.name_for_key(state_abbr)
+    end
+
+    def state_abbr
+      state_param&.upcase
+    end
+
+    def state_param
+      params[:us_state]
+    end
+
+    def ny?
+      state_param == "ny"
+    end
+
+    def az?
+      state_param == "az"
+    end
+
+    def service_type
+      case state_param
+      when "az" then :statefile_az
+      when "ny" then :statefile_ny
+      end
+    end
+
+    def tenant_service
+      MultiTenantService.new(service_type)
+    end
+
+    def current_tax_year
+      tenant_service.current_tax_year
+    end
+
+    def filer_count
+      current_intake&.filer_count
+    end
+  end
+end

--- a/app/controllers/state_file/questions/nyc_residency_controller.rb
+++ b/app/controllers/state_file/questions/nyc_residency_controller.rb
@@ -1,0 +1,7 @@
+module StateFile
+  module Questions
+    class NycResidencyController < AuthenticatedQuestionsController
+      include EligibilityOffboardingConcern
+    end
+  end
+end

--- a/app/controllers/state_file/questions/questions_controller.rb
+++ b/app/controllers/state_file/questions/questions_controller.rb
@@ -1,6 +1,8 @@
 module StateFile
   module Questions
     class QuestionsController < ::Questions::QuestionsController
+      include StateFile::StateFileControllerConcern
+
       skip_before_action :redirect_in_offseason
       skip_before_action :redirect_if_completed_intake_present
       helper_method :card_postscript

--- a/app/forms/state_file/nyc_residency_form.rb
+++ b/app/forms/state_file/nyc_residency_form.rb
@@ -1,0 +1,24 @@
+module StateFile
+  class NycResidencyForm < QuestionsForm
+    set_attributes_for :intake,
+                       :nyc_residency,
+                       :nyc_maintained_home
+
+    before_validation :clear_maintained_home_for_residents
+
+    validates :nyc_residency, presence: true
+    validates :nyc_maintained_home, presence: true, if: -> { nyc_residency == "none" }
+
+    def save
+      intake.update(attributes_for(:intake))
+    end
+
+    private
+
+    def clear_maintained_home_for_residents
+      unless nyc_residency == "none"
+        self.nyc_maintained_home = "unfilled"
+      end
+    end
+  end
+end

--- a/app/lib/navigation/state_file_ny_question_navigation.rb
+++ b/app/lib/navigation/state_file_ny_question_navigation.rb
@@ -23,6 +23,7 @@ module Navigation
       StateFile::Questions::FederalInfoController,
       StateFile::Questions::DataTransferOffboardingController,
       StateFile::Questions::NameDobController,
+      StateFile::Questions::NycResidencyController,
       StateFile::Questions::NyPermanentAddressController,
       StateFile::Questions::NyCountyController,
       StateFile::Questions::NySchoolDistrictController,

--- a/app/models/state_file_ny_intake.rb
+++ b/app/models/state_file_ny_intake.rb
@@ -237,6 +237,8 @@ class StateFileNyIntake < StateFileBaseIntake
       eligibility_part_year_nyc_resident: "yes",
       eligibility_withdrew_529: "yes",
       permanent_address_outside_ny: "yes",
+      nyc_residency: "part_year",
+      nyc_maintained_home: "yes"
     }
   end
 

--- a/app/services/multi_tenant_service.rb
+++ b/app/services/multi_tenant_service.rb
@@ -26,12 +26,12 @@ class MultiTenantService
 
   def host
     base =
-      case service_type
+      case service_type_or_parent
       when :ctc
         Rails.configuration.ctc_url
       when :gyr
         Rails.configuration.gyr_url
-      when :statefile, :statefile_az, :statefile_ny
+      when :statefile
         Rails.configuration.statefile_url
       end
     URI(base).hostname
@@ -67,7 +67,7 @@ class MultiTenantService
   end
 
   def email_logo
-    case service_type
+    case service_type_or_parent
     when :ctc then File.read(Rails.root.join('app/assets/images/get-ctc-logo.png'))
     when :gyr then File.read(Rails.root.join('app/assets/images/logo.png'))
     when :statefile then File.read(Rails.root.join('app/assets/images/logo.png')) # TODO(state-file): email logo for state file
@@ -75,11 +75,11 @@ class MultiTenantService
   end
 
   def default_email
-    Rails.configuration.email_from[:default][service_type]
+    Rails.configuration.email_from[:default][service_type_or_parent]
   end
 
   def noreply_email
-    Rails.configuration.email_from[:noreply][service_type]
+    Rails.configuration.email_from[:noreply][service_type_or_parent]
   end
 
   def delivery_method_options
@@ -94,7 +94,7 @@ class MultiTenantService
   end
 
   def current_tax_year
-    case service_type
+    case service_type_or_parent
     when :ctc then Rails.configuration.ctc_current_tax_year
     when :gyr then Rails.configuration.gyr_current_tax_year
     when :statefile then Rails.configuration.statefile_current_tax_year
@@ -110,7 +110,7 @@ class MultiTenantService
   end
 
   def filing_years
-    if service_type == :ctc || service_type == :state_file
+    if service_type_or_parent == :ctc || service_type_or_parent == :state_file
       [current_tax_year]
     else
       ((current_tax_year - 3)..current_tax_year).to_a.reverse.freeze

--- a/app/views/state_file/questions/nyc_residency/edit.html.erb
+++ b/app/views/state_file/questions/nyc_residency/edit.html.erb
@@ -1,0 +1,37 @@
+<% title = t(".title", year: current_tax_year) %>
+<% content_for :page_title, title %>
+
+<% content_for :card do %>
+  <h1 class="h2"><%= title %></h1>
+
+  <p><%= t(".nyc_includes") %></p>
+
+  <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
+    <div class="question-with-follow-up">
+      <div class="question-with-follow-up__question">
+        <div class="blue-group">
+          <%= f.cfa_radio_set(:nyc_residency, label_text: title, collection: [
+            { value: :full_year, label: t(".full_year", count: current_intake.filer_count, year: current_tax_year) },
+            { value: :none, label: t(".none", count: current_intake.filer_count, year: current_tax_year),  input_html: { "data-follow-up": "#nyc-maintained-home" } },
+            { value: :part_year, label: t(".part_year", count: current_intake.filer_count, year: current_tax_year) },
+          ], legend_class: "sr-only") %>
+        </div>
+      </div>
+
+      <div class="question-with-follow-up__follow-up" id="nyc-maintained-home">
+        <div class="blue-group">
+          <%= f.cfa_radio_set(
+                :nyc_maintained_home,
+                label_text: t(".maintained_home", count: current_intake.filer_count, year: current_tax_year),
+                collection: [
+                  { value: :yes, label: t("general.affirmative") },
+                  { value: :no, label: t("general.negative") },
+                ]
+              ) %>
+        </div>
+      </div>
+    </div>
+
+    <%= f.continue %>
+  <% end %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2036,6 +2036,8 @@ en:
             eligibility_part_year_nyc_resident: were a part-time New York City resident in 2023
             eligibility_withdrew_529: withdrew money from a 529 college savings account in 2023
             eligibility_yonkers: lived or earned income in Yonkers in 2023
+            nyc_maintained_home: you lived in or maintained a home in New York City for some of the year.
+            nyc_residency: you lived in or maintained a home in New York City for some of the year.
             permanent_address_outside_ny: you did not live in New York for all of 2023
           title: Unfortunately, you can't use this tool this year. Don't worry, there are other filing options.
       eligibility_out_of_state_income:
@@ -2239,6 +2241,22 @@ en:
           helper_heading: How do I find my school district?
           school_district_name: School District Name
           title: Select the school district where you lived on December 31, %{filing_year}
+      nyc_residency:
+        edit:
+          full_year:
+            one: I lived in New York City all year in %{year}
+            other: My spouse and I lived in New York City all year in %{year}
+          maintained_home:
+            one: Did you maintain a home in New York City at any time during %{year}?
+            other: Did you or your spouse maintain a home in New York City at any time during %{year}?
+          none:
+            one: I did not live in New York City at all in %{year}
+            other: My spouse and I did not live in New York City at all in %{year}
+          nyc_includes: New York City includes the Bronx, Brooklyn, Manhattan, Queens, and Staten Island.
+          part_year:
+            one: I lived in New York City for some of the year
+            other: My spouse and I lived in New York City for some of the year, or we lived in New York City for different amounts of time.
+          title: 'Select your New York City residency status during %{year}:'
       other_filing_options:
         edit:
           faq_link: Visit our FAQ

--- a/spec/controllers/state_file/questions/nyc_residency_controller_spec.rb
+++ b/spec/controllers/state_file/questions/nyc_residency_controller_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe StateFile::Questions::NycResidencyController do
+  let(:intake) { create :state_file_ny_intake }
+  before do
+    session[:state_file_intake] = intake.to_global_id
+    sign_in intake
+  end
+
+  describe "#update" do
+    describe "#next_path" do
+      context "with a disqualifying answer" do
+        it "redirects to the offboarding page with offboarded_from" do
+          post :update, params: {
+            us_state: "ny",
+            state_file_nyc_residency_form: {
+              nyc_residency: "none",
+              nyc_maintained_home: "yes"
+            }
+          }
+
+          expected_path = StateFile::Questions::EligibilityOffboardingController.to_path_helper(
+            us_state: "ny")
+          expect(response).to redirect_to expected_path
+          expect(session[:offboarded_from]).to eq described_class.to_path_helper(us_state: "ny")
+        end
+      end
+    end
+  end
+end

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -52,6 +52,17 @@ RSpec.feature "Completing a state file intake", active_job: true do
       end
       click_on I18n.t("general.continue")
 
+      expect(page).to have_text I18n.t("state_file.questions.nyc_residency.edit.title", year: 2023)
+      choose I18n.t("state_file.questions.nyc_residency.edit.none", count: 2, year: 2023)
+      choose I18n.t("general.affirmative")
+      click_on I18n.t("general.continue")
+
+      expect(page).to have_text I18n.t("state_file.questions.eligibility_offboarding.edit.ineligible_reason.nyc_maintained_home")
+      click_on "Go back"
+      expect(page).to have_text I18n.t("state_file.questions.nyc_residency.edit.title", year: 2023)
+      choose I18n.t("state_file.questions.nyc_residency.edit.full_year", count: 2, year: 2023)
+      click_on I18n.t("general.continue")
+
       expect(page).to have_text I18n.t("state_file.questions.ny_permanent_address.edit.title")
       choose I18n.t("general.affirmative")
       click_on I18n.t("general.continue")

--- a/spec/forms/state_file/nyc_residency_form_spec.rb
+++ b/spec/forms/state_file/nyc_residency_form_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+RSpec.describe StateFile::NycResidencyForm do
+  let(:intake) { create(:state_file_ny_intake, nyc_residency: "unfilled", nyc_maintained_home: "unfilled") }
+
+  describe "#valid?" do
+    it "requires an answer for nyc_residency" do
+      form = described_class.new(intake, {})
+      expect(form).not_to be_valid
+      expect(form.errors).to include :nyc_residency
+      expect(form.errors).not_to include :nyc_maintained_home
+
+      params = { nyc_residency: "", nyc_maintained_home: "" }
+      form = described_class.new(intake, params)
+      expect(form).not_to be_valid
+      expect(form.errors).to include :nyc_residency
+      expect(form.errors).not_to include :nyc_maintained_home
+    end
+
+    context "when nyc_residency = 'none'" do
+      it "requires an answer for nyc_maintained_home" do
+        params = { nyc_residency: "none" }
+        form = described_class.new(intake, params)
+        expect(form).not_to be_valid
+        expect(form.errors).to include :nyc_maintained_home
+
+        params = { nyc_residency: "none", nyc_maintained_home: "" }
+        form = described_class.new(intake, params)
+        expect(form).not_to be_valid
+        expect(form.errors).to include :nyc_maintained_home
+      end
+    end
+
+    context "when nyc_residency is full_year or part_year" do
+      it "is valid and does not require an answer for nyc_maintained_home" do
+        params = { nyc_residency: "full_year" }
+        form = described_class.new(intake, params)
+        expect(form).to be_valid
+        expect(form.errors).not_to include :nyc_maintained_home
+
+        params = { nyc_residency: "part_year" }
+        form = described_class.new(intake, params)
+        expect(form).to be_valid
+        expect(form.errors).not_to include :nyc_maintained_home
+      end
+
+      it "clears any answer for nyc_maintained_home" do
+        params = { nyc_residency: "full_year", nyc_maintained_home: "yes" }
+        form = described_class.new(intake, params)
+        expect(form).to be_valid
+        expect(form.errors).not_to include :nyc_maintained_home
+        expect(form.nyc_maintained_home).to eq "unfilled"
+      end
+    end
+  end
+
+  describe "#save" do
+    it "saves the data to the intake" do
+      params = { nyc_residency: "none", nyc_maintained_home: "yes" }
+      form = described_class.new(intake, params)
+      form.save
+      intake.reload
+
+      expect(intake.nyc_residency).to eq "none"
+      expect(intake.nyc_maintained_home).to eq "yes"
+    end
+
+    context "when nyc_residency is full_year or part_year" do
+      it "saves nyc_maintained_home as unfilled" do
+        params = { nyc_residency: "part_year", nyc_maintained_home: "yes" }
+        form = described_class.new(intake, params)
+        expect(form).to be_valid # validation should clear nyc_maintained_home
+        form.save
+        intake.reload
+
+        expect(intake.nyc_residency).to eq "part_year"
+        expect(intake.nyc_maintained_home).to eq "unfilled"
+      end
+    end
+  end
+end

--- a/spec/models/state_file_ny_intake_spec.rb
+++ b/spec/models/state_file_ny_intake_spec.rb
@@ -259,6 +259,16 @@ describe StateFileNyIntake do
       intake = build(:state_file_ny_intake, eligibility_withdrew_529: "yes")
       expect(intake.disqualifying_eligibility_answer).to eq :eligibility_withdrew_529
     end
+
+    it "returns :nyc_residency when they were a part year resident" do
+      intake = build(:state_file_ny_intake, nyc_residency: "part_year")
+      expect(intake.disqualifying_eligibility_answer).to eq :nyc_residency
+    end
+
+    it "returns :nyc_maintained_home when they maintained a home in nyc" do
+      intake = build(:state_file_ny_intake, nyc_maintained_home: "yes")
+      expect(intake.disqualifying_eligibility_answer).to eq :nyc_maintained_home
+    end
   end
 
   describe "#has_disqualifying_eligibility_answer?" do
@@ -289,6 +299,16 @@ describe StateFileNyIntake do
 
     it "returns true when they withdrew from a 529 account" do
       intake = build(:state_file_ny_intake, eligibility_withdrew_529: "yes")
+      expect(intake.has_disqualifying_eligibility_answer?).to eq true
+    end
+
+    it "returns true when they were a part year resident" do
+      intake = build(:state_file_ny_intake, nyc_residency: "part_year")
+      expect(intake.has_disqualifying_eligibility_answer?).to eq true
+    end
+
+    it "returns true when they maintained a home in nyc" do
+      intake = build(:state_file_ny_intake, nyc_maintained_home: "yes")
       expect(intake.has_disqualifying_eligibility_answer?).to eq true
     end
   end


### PR DESCRIPTION
- implements most of https://www.pivotaltracker.com/story/show/186865012
  - does not yet remove residency updates from NY County form
  - does not add residency information to XML, PDF, or calculations
- Adds a controller, form, and view for the NYC residency questions
- Adds additional offboarding criteria if they are a part-year NYC resident or weren't residents but maintained a home in NYC
- a few small refactors to multi_tenant_service to prevent errors
- adds a controller concern for oft-useful helper methods (which US state, current tax year, etc.)
<kbd><img width="433" alt="Screenshot 2024-01-19 at 10 28 11 AM" src="https://github.com/codeforamerica/vita-min/assets/451510/3b64bfcd-6e8a-4bcd-b17f-c2ba7154b1e6"></kbd>

<kbd><img width="439" alt="Screenshot 2024-01-19 at 10 28 30 AM" src="https://github.com/codeforamerica/vita-min/assets/451510/f5531692-1979-4d8e-af50-ae47a431cee3"></kbd>
<kbd><img width="446" alt="Screenshot 2024-01-19 at 10 28 41 AM" src="https://github.com/codeforamerica/vita-min/assets/451510/e7e76d4c-5830-4a90-b953-60633a04e4fd"></kbd>
<kbd><img width="471" alt="Screenshot 2024-01-19 at 10 32 56 AM" src="https://github.com/codeforamerica/vita-min/assets/451510/2360b885-5994-4cb4-9bf1-0afd4f843880"></kbd>
