### PR TITLE
Deprecate nyc_full_year_resident

### DIFF
--- a/app/controllers/concerns/state_file/eligibility_offboarding_concern.rb
+++ b/app/controllers/concerns/state_file/eligibility_offboarding_concern.rb
@@ -12,11 +12,17 @@ module StateFile
 
     def next_path
       if current_intake.has_disqualifying_eligibility_answer?
-        session[:offboarded_from] = self.class.to_path_helper(us_state: params[:us_state])
+        session[:offboarded_from] = self.class.to_path_helper(from_path_params)
         return offboarding_path
       end
 
       super
+    end
+
+    def from_path_params
+      [:us_state, :return_to_review].each_with_object({}) do |key, path_params|
+        path_params[key] = params[key] if params[key].present?
+      end
     end
   end
 end

--- a/app/controllers/concerns/state_file/state_file_controller_concern.rb
+++ b/app/controllers/concerns/state_file/state_file_controller_concern.rb
@@ -3,7 +3,9 @@ module StateFile
     extend ActiveSupport::Concern
 
     included do
-      helper_method :current_tax_year, :state_name, :state_abbr, :ny?, :az?, :state_param, :filer_count
+      helper_method(
+        :current_tax_year, :filer_count, :state_name, :state_abbr, :ny?, :az?, :state_param
+      )
     end
 
     private

--- a/app/controllers/state_file/questions/nyc_residency_controller.rb
+++ b/app/controllers/state_file/questions/nyc_residency_controller.rb
@@ -1,6 +1,11 @@
 module StateFile
   module Questions
     class NycResidencyController < AuthenticatedQuestionsController
+      # the order of these two concerns is important.
+      # they both overwrite next_path and defer to super.
+      # offboarding should be last because its next_path method should take precedence and should be called first.
+      # returning to review should be first because we should only return to review if the answer is not disqualifying
+      include ReturnToReviewConcern
       include EligibilityOffboardingConcern
     end
   end

--- a/app/forms/state_file/ny_county_form.rb
+++ b/app/forms/state_file/ny_county_form.rb
@@ -1,11 +1,9 @@
 module StateFile
   class NyCountyForm < QuestionsForm
     set_attributes_for :intake,
-                       :residence_county,
-                       :nyc_full_year_resident
+                       :residence_county
 
     validates :residence_county, presence: true
-    validate :set_nyc_full_year_resident
 
     def save
       if @intake.residence_county != self.residence_county
@@ -13,15 +11,6 @@ module StateFile
       end
       @intake.assign_attributes(attributes_for(:intake))
       @intake.save
-    end
-
-    def set_nyc_full_year_resident
-      nyc_counties = ['New York (Manhattan)', 'Manhattan (see New York)', 'Kings (Brooklyn)', 'Richmond (Staten Island)', 'Queens', 'Bronx']
-      if nyc_counties.include?(residence_county) && @intake.eligibility_lived_in_state_yes?
-        self.nyc_full_year_resident = 'yes'
-      else
-        self.nyc_full_year_resident = 'no'
-      end
     end
   end
 end

--- a/app/lib/efile/ny/it201.rb
+++ b/app/lib/efile/ny/it201.rb
@@ -216,7 +216,7 @@ module Efile
       end
 
       def calculate_line_47
-        if @intake.nyc_full_year_resident_yes?
+        if @intake.nyc_residency_full_year?
           line_or_zero(:IT201_LINE_38)
         else
           0
@@ -224,7 +224,7 @@ module Efile
       end
 
       def calculate_line_47a
-        if @intake.nyc_full_year_resident_yes?
+        if @intake.nyc_residency_full_year?
           nyc_tax_from_tables(@lines[:IT201_LINE_47].value)
         else
           0
@@ -233,7 +233,7 @@ module Efile
 
       def calculate_line_48
         # If you are married and filing a joint New York State return and only one of you was a resident of New York City for all of 2022, do not enter an amount here. See the instructions for line 51.
-        if @direct_file_data.claimed_as_dependent? || @intake.nyc_full_year_resident_no?
+        if @direct_file_data.claimed_as_dependent? || @intake.nyc_residency_none?
           0
         else
           nyc_household_credit(line_or_zero(:IT201_LINE_19))
@@ -287,13 +287,13 @@ module Efile
         # account and an individual retirement annuity, from Form IT-201, line 9, if they were included in your federal
         # adjusted gross income.
         income_eligible = (line_or_zero(:IT201_LINE_19) - line_or_zero(:IT201_LINE_9)) < 250_000
-        return 0 unless income_eligible && @intake.nyc_full_year_resident_yes? && !@direct_file_data.claimed_as_dependent?
+        return 0 unless income_eligible && @intake.nyc_residency_full_year? && !@direct_file_data.claimed_as_dependent?
 
         @filing_status.in?([:single, :married_filing_separately, :head_of_household]) ? 63 : 125
       end
 
       def calculate_line_69a
-        return 0 unless @intake.nyc_full_year_resident_yes? && !@direct_file_data.claimed_as_dependent?
+        return 0 unless @intake.nyc_residency_full_year? && !@direct_file_data.claimed_as_dependent?
 
         nyc_taxable_income = line_or_zero(:IT201_LINE_47)
         result = case @filing_status

--- a/app/lib/efile/ny/it215.rb
+++ b/app/lib/efile/ny/it215.rb
@@ -79,7 +79,7 @@ module Efile
 
       def calculate_line_27
         # NYC EIC
-        if @intake.nyc_full_year_resident_yes?
+        if @intake.nyc_residency_full_year?
           # https://www.tax.ny.gov/forms/current-forms/it/it215i.htm#worksheet-c
           set_line(:IT215_WK_C_LINE_1, -> { @lines[:IT215_LINE_10].value })
           @nyc_eic_rate_worksheet.calculate

--- a/app/lib/pdf_filler/ny201_pdf.rb
+++ b/app/lib/pdf_filler/ny201_pdf.rb
@@ -54,7 +54,8 @@ module PdfFiller
         Foreign_account: xml_value_to_pdf_checkbox('Foreign_account', 'FORGN_ACCT_IND'),
         yonkers_freeze_credit: xml_value_to_pdf_checkbox('yonkers_freeze_credit', 'YNK_LVNG_QTR_IND'),
         D4: 'no',
-        E1: xml_value_to_pdf_checkbox('E1', 'NYC_LVNG_QTR_IND'),
+        E1: claimed_attr_value('NYC_LVNG_QTR_IND') == '2' ? 'no' : 'Off',
+        E2: claimed_attr_value('DAYS_NYC_NMBR'),
         F1_NYC: claimed_attr_value('PR_NYC_MNTH_NMBR'),
         F2_NYC: claimed_attr_value('SP_NYC_MNTH_NMBR'),
       }

--- a/app/views/state_file/questions/ny_review/edit.html.erb
+++ b/app/views/state_file/questions/ny_review/edit.html.erb
@@ -5,8 +5,8 @@
   <div id="full-year-resident" class="blue-group">
     <div class="spacing-below-5">
       <p class="text--bold spacing-below-5"><%=t(".nyc_full_year_resident") %></p>
-      <p><%=current_intake.nyc_full_year_resident_yes? ? t("general.affirmative") : t("general.negative") %></p>
-      <%= link_to t("general.edit"), StateFile::Questions::NyCountyController.to_path_helper(us_state: "ny", return_to_review: "y"), class: "button--small" %>
+      <p><%=current_intake.nyc_residency_full_year? ? t("general.affirmative") : t("general.negative") %></p>
+      <%= link_to t("general.edit"), StateFile::Questions::NycResidencyController.to_path_helper(us_state: "ny", return_to_review: "y"), class: "button--small" %>
     </div>
   </div>
 

--- a/spec/controllers/state_file/questions/nyc_residency_controller_spec.rb
+++ b/spec/controllers/state_file/questions/nyc_residency_controller_spec.rb
@@ -25,6 +25,37 @@ RSpec.describe StateFile::Questions::NycResidencyController do
           expect(session[:offboarded_from]).to eq described_class.to_path_helper(us_state: "ny")
         end
       end
+
+      context "when accessed from the review page" do
+        it "redirects to the review page" do
+          post :update, params: {
+            us_state: "ny",
+            return_to_review: "y",
+            state_file_nyc_residency_form: {
+              nyc_residency: "full_year"
+            }
+          }
+
+          expect(response).to redirect_to(controller: "ny_review", action: :edit, us_state: "ny")
+        end
+      end
+
+      context "with both a disqualifying answer and a return to review param" do
+        it "redirects to offboarding but retains the return to review param in the path to return to" do
+          post :update, params: {
+            us_state: "ny",
+            return_to_review: "y",
+            state_file_nyc_residency_form: {
+              nyc_residency: "part_year"
+            }
+          }
+
+          expected_path = StateFile::Questions::EligibilityOffboardingController.to_path_helper(
+            us_state: "ny")
+          expect(response).to redirect_to expected_path
+          expect(session[:offboarded_from]).to eq described_class.to_path_helper(us_state: "ny", return_to_review: "y")
+        end
+      end
     end
   end
 end

--- a/spec/factories/state_file_ny_intakes.rb
+++ b/spec/factories/state_file_ny_intakes.rb
@@ -116,7 +116,7 @@ FactoryBot.define do
     permanent_street { direct_file_data.mailing_street }
     permanent_city { direct_file_data.mailing_city }
     permanent_zip { direct_file_data.mailing_zip }
-    nyc_full_year_resident { 'yes' }
+    nyc_residency { 'full_year' }
 
     after(:build) do |intake, evaluator|
       numeric_status = {
@@ -150,7 +150,7 @@ FactoryBot.define do
     end
 
     factory :state_file_ny_owed_intake do
-      nyc_full_year_resident { 'no' }
+      nyc_residency { 'none' }
       after(:build) do |intake, evaluator|
         intake.direct_file_data.fed_unemployment = 45000
         intake.raw_direct_file_data = intake.direct_file_data.to_s

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -134,7 +134,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
       expect(page).to have_text I18n.t("state_file.questions.shared.review_header.title")
       click_on I18n.t("general.continue")
 
-      expect(page).to have_text I18n.t("state_file.questions.tax_refund.edit.title", refund_amount: 1_715, state_name: "New York")
+      expect(page).to have_text I18n.t("state_file.questions.tax_refund.edit.title", refund_amount: 1_825, state_name: "New York")
       expect(page).to_not have_text "Your responses are saved. If you need a break, you can come back and log in to your account at fileyourstatetaxes.org."
       choose I18n.t("state_file.questions.tax_refund.edit.mail")
       click_on I18n.t("general.continue")

--- a/spec/forms/state_file/ny_county_form_spec.rb
+++ b/spec/forms/state_file/ny_county_form_spec.rb
@@ -25,38 +25,17 @@ RSpec.describe StateFile::NyCountyForm do
   end
 
   describe ".save" do
-    context "with a non-NYC county" do
-      let(:form) { described_class.new(intake, valid_params) }
-      let(:valid_params) do
-        {
-          residence_county: "Albany",
-        }
-      end
-
-      it "saves attributes and updates residency" do
-        expect(form.valid?).to eq true
-        form.save
-
-        expect(intake.residence_county).to eq "Albany"
-        expect(intake.nyc_full_year_resident).to eq "no"
-      end
+    let(:form) { described_class.new(intake, valid_params) }
+    let(:valid_params) do
+      {
+        residence_county: "Albany",
+      }
     end
+    it "saves attributes" do
+      expect(form.valid?).to eq true
+      form.save
 
-    context "with an NYC county" do
-      let(:form) { described_class.new(intake, valid_params) }
-      let(:valid_params) do
-        {
-          residence_county: "Bronx",
-        }
-      end
-
-      it "saves the county and updates residency" do
-        expect(form.valid?).to eq true
-        form.save
-
-        expect(intake.residence_county).to eq "Bronx"
-        expect(intake.nyc_full_year_resident).to eq "yes"
-      end
+      expect(intake.residence_county).to eq "Albany"
     end
   end
 end

--- a/spec/forms/state_file/taxes_owed_form_spec.rb
+++ b/spec/forms/state_file/taxes_owed_form_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe StateFile::TaxesOwedForm do
-  let!(:withdraw_amount) { 139 }
+  let!(:withdraw_amount) { 118 }
   let!(:intake) {
     create :state_file_ny_intake,
            payment_or_deposit_type: "unfilled",

--- a/spec/lib/efile/ny/it201_spec.rb
+++ b/spec/lib/efile/ny/it201_spec.rb
@@ -356,7 +356,7 @@ describe Efile::Ny::It201 do
         intake.direct_file_data.fed_taxable_income = 2_000
         intake.direct_file_data.fed_taxable_ssb = 0
         intake.direct_file_data.fed_unemployment = 0
-        intake.nyc_full_year_resident = 1 # yes
+        intake.nyc_residency = "full_year" # yes
       end
 
       it 'sets the credit to 0 because the filer is ineligible' do
@@ -367,7 +367,7 @@ describe Efile::Ny::It201 do
 
     context 'when the filer was not a full year NYC resident' do
       before do
-        intake.nyc_full_year_resident = 2 # no
+        intake.nyc_residency = "none"
       end
 
       it 'sets the credit to 0 because the filer is ineligible' do
@@ -448,7 +448,7 @@ describe Efile::Ny::It201 do
     context 'when the filer has been claimed as a dependent' do
       before do
         intake.direct_file_data.primary_claim_as_dependent = "X"
-        intake.nyc_full_year_resident = 1 # yes
+        intake.nyc_residency = "full_year" # yes
         intake.direct_file_data.fed_wages = 2_000
         intake.direct_file_data.fed_taxable_income = 2_000
         intake.direct_file_data.fed_taxable_ssb = 0
@@ -463,7 +463,7 @@ describe Efile::Ny::It201 do
 
     context 'when the filer was not a full year NYC resident' do
       before do
-        intake.nyc_full_year_resident = 2 # no
+        intake.nyc_residency = "none" # no
         intake.direct_file_data.fed_wages = 2_000
         intake.direct_file_data.fed_taxable_income = 2_000
         intake.direct_file_data.fed_taxable_ssb = 0
@@ -478,7 +478,7 @@ describe Efile::Ny::It201 do
 
     context 'when the filer had more than $250,000 in income' do
       before do
-        intake.nyc_full_year_resident = 1 # yes
+        intake.nyc_residency = "full_year" # yes
         intake.direct_file_data.fed_wages = 200_000
         intake.direct_file_data.fed_taxable_income = 200_000
         intake.direct_file_data.fed_taxable_ssb = 0
@@ -494,7 +494,7 @@ describe Efile::Ny::It201 do
     context 'when the filer is eligible and filing status is single' do
       before do
         intake.direct_file_data.filing_status = 1 # single
-        intake.nyc_full_year_resident = 1 # yes
+        intake.nyc_residency = "full_year" # yes
         intake.direct_file_data.fed_wages = 2_000
         intake.direct_file_data.fed_taxable_income = 2_000
         intake.direct_file_data.fed_taxable_ssb = 0
@@ -510,7 +510,7 @@ describe Efile::Ny::It201 do
     context 'when the filer is eligible and filing status is mfj' do
       before do
         intake.direct_file_data.filing_status = 2 # mfj
-        intake.nyc_full_year_resident = 1 # yes
+        intake.nyc_residency = "full_year" # yes
         intake.direct_file_data.fed_wages = 2_000
         intake.direct_file_data.fed_taxable_income = 2_000
         intake.direct_file_data.fed_taxable_ssb = 0
@@ -526,7 +526,7 @@ describe Efile::Ny::It201 do
     context 'when the filer is eligible and filing status is mfs' do
       before do
         intake.direct_file_data.filing_status = 3 # mfs
-        intake.nyc_full_year_resident = 1 # yes
+        intake.nyc_residency = "full_year" # yes
         intake.direct_file_data.fed_wages = 2_000
         intake.direct_file_data.fed_taxable_income = 2_000
         intake.direct_file_data.fed_taxable_ssb = 0
@@ -542,7 +542,7 @@ describe Efile::Ny::It201 do
     context 'when the filer is eligible and filing status is hoh' do
       before do
         intake.direct_file_data.filing_status = 4 # hoh
-        intake.nyc_full_year_resident = 1 # yes
+        intake.nyc_residency = "full_year" # yes
         intake.direct_file_data.fed_wages = 2_000
         intake.direct_file_data.fed_taxable_income = 2_000
         intake.direct_file_data.fed_taxable_ssb = 0
@@ -558,7 +558,7 @@ describe Efile::Ny::It201 do
     context 'when the filer is eligible and filing status is qualifying_widow' do
       before do
         intake.direct_file_data.filing_status = 5 # qualifying_widow
-        intake.nyc_full_year_resident = 1 # yes
+        intake.nyc_residency = "full_year" # yes
         intake.direct_file_data.fed_wages = 2_000
         intake.direct_file_data.fed_taxable_income = 2_000
         intake.direct_file_data.fed_taxable_ssb = 0


### PR DESCRIPTION
The penultimate PR for https://www.pivotaltracker.com/story/show/186865012
The only remaining step after this PR is to remove the deprecated database column

- updates all code that depended on the now-deprecated `nyc_full_year_resident` column to instead use the newer `nyc_residency` column
- stops the NY County page from setting `nyc_full_year_resident` or any other NYC residency data
- updates the NY review page section about NYC residency to link to NycResidency instead of NyCounty
- updates the NycResidencyController so that it could appropriately handle going back to the review page or redirecting to offboarding depending on whether the answer was disqualifying or the page was accessed from the review page.
- ensures that values relating to nyc residency are set appropriately in the XML and PDF
- includes a minor readability refactor in `submission_builder/ty2022/states/ny/documents/it201.rb` to replace all the calls to `@submission.data_source` with calls to an `intake` method.