### PR TITLE
Change date on global carry forward page

### DIFF
--- a/app/views/consent_pages/global_carryforward.html.erb
+++ b/app/views/consent_pages/global_carryforward.html.erb
@@ -4,5 +4,5 @@
 <h1><%= @main_heading %></h1>
 
 <div class="spacing-below-60">
-  <%=  simple_format(t('views.consent_pages.global_carryforward.content_html')) %>
+  <%=  simple_format(t('views.consent_pages.global_carryforward.content_html', product_year: Rails.configuration.product_year)) %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2624,7 +2624,7 @@ en:
           <strong>I authorize the VITA site:</strong>
           Global Carry Forward of data allows TaxSlayer LLC, the provider of the VITA/TCE tax software to make your tax return information available to ANY volunteer site participating in the IRS's VITA/TCE program that you select to prepare a tax return in the next filing season. This means you will be able to visit any volunteer site using TaxSlayer next year and have your tax return populate with your current year data, regardless of where you filed your tax return this year.
 
-          <strong>This consent is valid through November 30, 2023</strong>
+          <strong>This consent is valid through November 30, %{product_year}</strong>
 
           The tax return information that will be disclosed includes, but is not limited to, demographic, financial and other personally identifiable information, about you, your tax return and your sources of income, which was input into the tax preparation software for the purpose of preparing your tax return.
 
@@ -2632,7 +2632,7 @@ en:
 
           You do not need to provide consent for the VITA/TCE partner preparing your tax return this year Carry Forward will assist you only if you visit a different VITA or TCE partner next year.
 
-          <i>Limitation on the Duration of Consent</i>: I/we, the taxpayer, do not wish to limit the duration of the consent-of the disclosure of tax return information to a date earlier than presented above (November 30, 2023). If I/we wish to limit the duration of the consent of the disclosure to an earlier date, I will deny consent.
+          <i>Limitation on the Duration of Consent</i>: I/we, the taxpayer, do not wish to limit the duration of the consent-of the disclosure of tax return information to a date earlier than presented above (November 30, %{product_year}). If I/we wish to limit the duration of the consent of the disclosure to an earlier date, I will deny consent.
 
           <i>Limitation on the Scope of Disclosure</i>: I/we, the taxpayer, do not wish to limit the scope of the disclosure of tax return information further than presented above. If I/we wish to limit the scope of the disclosure of tax return information further than presented above, I/we will deny consent.
 

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1970,7 +1970,7 @@ es:
           <strong>Autorizo al sitio VITA:</strong>
           Global Carry Forward de datos permite a TaxSlayer LLC, el proveedor del software de impuestos VITA/TCE, poner la información de su declaración de impuestos a disposición de CUALQUIER sitio voluntario que participe en el programa VITA/TCE del IRS que usted seleccione para preparar una declaración de impuestos en la próxima temporada de presentación. Esto significa que podrá visitar cualquier sitio voluntario que utilice TaxSlayer el próximo año y que su declaración de impuestos se complete con sus datos del año en curso, independientemente de dónde haya presentado su declaración de impuestos este año.
 
-          <strong>Este consentimiento es válido hasta el 30 de noviembre de 2023</strong>
+          <strong>Este consentimiento es válido hasta el 30 de noviembre de %{product_year}</strong>
 
           La información de la declaración de impuestos que se divulgará incluye, pero no se limita a, información demográfica, financiera y otra información de identificación personal, sobre usted, su declaración de impuestos y sus fuentes de ingresos, que se introdujo en el software de preparación de impuestos con el fin de preparar su declaración de impuestos.
 
@@ -1978,7 +1978,7 @@ es:
 
           No es necesario que dé su consentimiento para que el colaborador de VITA/TCE que le prepare la declaración de impuestos este año. Carry Forward le ayudará sólo si el año que viene acude a otro colaborador de VITA o TCE.
 
-          <i>Limitación de la duración del consentimiento</i>: Yo/nosotros, el contribuyente, no deseamos limitar la duración del consentimiento de la divulgación de la información de la declaración de impuestos a una fecha anterior a la presentada anteriormente (30 de noviembre de 2023). Si deseo/queremos limitar la duración del consentimiento de la divulgación a una fecha anterior, negaré el consentimiento.
+          <i>Limitación de la duración del consentimiento</i>: Yo/nosotros, el contribuyente, no deseamos limitar la duración del consentimiento de la divulgación de la información de la declaración de impuestos a una fecha anterior a la presentada anteriormente (30 de noviembre de %{product_year}). Si deseo/queremos limitar la duración del consentimiento de la divulgación a una fecha anterior, negaré el consentimiento.
 
           <i>Limitación del alcance de la divulgación</i>: Yo/nosotros, el contribuyente, no deseamos limitar el alcance de la divulgación de la información de la declaración de impuestos más allá de lo presentado anteriormente. Si deseo/queremos limitar el alcance de la divulgación de la información de la declaración de impuestos más allá de lo presentado anteriormente, negaré/rechazamos el consentimiento.
 


### PR DESCRIPTION
Changing year reference on global carry forward page
<img width="871" alt="Screenshot 2024-01-19 at 7 42 04 PM" src="https://github.com/codeforamerica/vita-min/assets/49880002/b6b66af9-bb18-48f8-b77d-8e393de500e4">
