### PR TITLE
Finish deprecating nyc_full_year_resident

### DIFF
--- a/app/controllers/flows_controller.rb
+++ b/app/controllers/flows_controller.rb
@@ -601,7 +601,6 @@ class FlowsController < ApplicationController
         nursing_home: "unfilled",
         nyc_residency: "none",
         nyc_maintained_home: "no",
-        nyc_full_year_resident: "no",
         occupied_residence: "unfilled",
         permanent_apartment: "B",
         permanent_city: "New York",

--- a/app/lib/pdf_filler/ny201_pdf.rb
+++ b/app/lib/pdf_filler/ny201_pdf.rb
@@ -54,7 +54,7 @@ module PdfFiller
         Foreign_account: xml_value_to_pdf_checkbox('Foreign_account', 'FORGN_ACCT_IND'),
         yonkers_freeze_credit: xml_value_to_pdf_checkbox('yonkers_freeze_credit', 'YNK_LVNG_QTR_IND'),
         D4: 'no',
-        E1: claimed_attr_value('NYC_LVNG_QTR_IND') == '2' ? 'no' : 'Off',
+        E1: claimed_attr_value('NYC_LVNG_QTR_IND') == '2' ? 'no' : 'Off', # should never be "yes"
         E2: claimed_attr_value('DAYS_NYC_NMBR'),
         F1_NYC: claimed_attr_value('PR_NYC_MNTH_NMBR'),
         F2_NYC: claimed_attr_value('SP_NYC_MNTH_NMBR'),

--- a/app/models/state_file_ny_intake.rb
+++ b/app/models/state_file_ny_intake.rb
@@ -43,7 +43,6 @@
 #  ny_mailing_city                    :string
 #  ny_mailing_street                  :string
 #  ny_mailing_zip                     :string
-#  nyc_full_year_resident             :integer          default("unfilled"), not null
 #  nyc_maintained_home                :integer          default("unfilled"), not null
 #  nyc_residency                      :integer          default("unfilled"), not null
 #  occupied_residence                 :integer          default("unfilled"), not null
@@ -101,9 +100,9 @@
 class StateFileNyIntake < StateFileBaseIntake
   encrypts :account_number, :routing_number, :raw_direct_file_data
 
+  self.ignored_columns = ["nyc_full_year_resident"] # needed to safely drop this column in an upcoming commit
   enum nyc_residency: { unfilled: 0, full_year: 1, part_year: 2, none: 3 }, _prefix: :nyc_residency
   enum nyc_maintained_home: { unfilled: 0, yes: 1, no: 2 }, _prefix: :nyc_maintained_home
-  enum nyc_full_year_resident: { unfilled: 0, yes: 1, no: 2 }, _prefix: :nyc_full_year_resident
   enum occupied_residence: { unfilled: 0, yes: 1, no: 2 }, _prefix: :occupied_residence
   enum property_over_limit: { unfilled: 0, yes: 1, no: 2 }, _prefix: :property_over_limit
   enum public_housing: { unfilled: 0, yes: 1, no: 2 }, _prefix: :public_housing

--- a/spec/factories/state_file_ny_intakes.rb
+++ b/spec/factories/state_file_ny_intakes.rb
@@ -43,7 +43,6 @@
 #  ny_mailing_city                    :string
 #  ny_mailing_street                  :string
 #  ny_mailing_zip                     :string
-#  nyc_full_year_resident             :integer          default("unfilled"), not null
 #  nyc_maintained_home                :integer          default("unfilled"), not null
 #  nyc_residency                      :integer          default("unfilled"), not null
 #  occupied_residence                 :integer          default("unfilled"), not null

--- a/spec/models/state_file_ny_intake_spec.rb
+++ b/spec/models/state_file_ny_intake_spec.rb
@@ -43,7 +43,6 @@
 #  ny_mailing_city                    :string
 #  ny_mailing_street                  :string
 #  ny_mailing_zip                     :string
-#  nyc_full_year_resident             :integer          default("unfilled"), not null
 #  nyc_maintained_home                :integer          default("unfilled"), not null
 #  nyc_residency                      :integer          default("unfilled"), not null
 #  occupied_residence                 :integer          default("unfilled"), not null


### PR DESCRIPTION
Followup to https://www.pivotaltracker.com/story/show/186865012

Fully deprecates the use of nyc_full_year_resident, and prepares for database removal

I tried to add a migration to remove the `nyc_full_year_resident` column, but got this message from strong_migrations:
```
=== Dangerous operation detected #strong_migrations ===

Active Record caches attributes, which causes problems
when removing columns. Be sure to ignore the column:

class StateFileNyIntake < ApplicationRecord
  self.ignored_columns = ["nyc_full_year_resident"]
end

Deploy the code, then wrap this step in a safety_assured { ... } block.

class RemoveNycFullYearResidentFromStateFileNyIntakes < ActiveRecord::Migration[7.1]
  def change
    safety_assured { remove_column :state_file_ny_intakes, :nyc_full_year_resident, :integer, default: 0, null: false }
  end
end
```
