### PR TITLE
Remove column: nyc_full_year_resident

### DIFF
--- a/app/models/state_file_ny_intake.rb
+++ b/app/models/state_file_ny_intake.rb
@@ -99,8 +99,7 @@
 #
 class StateFileNyIntake < StateFileBaseIntake
   encrypts :account_number, :routing_number, :raw_direct_file_data
-
-  self.ignored_columns = ["nyc_full_year_resident"] # needed to safely drop this column in an upcoming commit
+  
   enum nyc_residency: { unfilled: 0, full_year: 1, part_year: 2, none: 3 }, _prefix: :nyc_residency
   enum nyc_maintained_home: { unfilled: 0, yes: 1, no: 2 }, _prefix: :nyc_maintained_home
   enum occupied_residence: { unfilled: 0, yes: 1, no: 2 }, _prefix: :occupied_residence

--- a/db/migrate/20240120021530_remove_nyc_full_year_resident_from_state_file_ny_intakes.rb
+++ b/db/migrate/20240120021530_remove_nyc_full_year_resident_from_state_file_ny_intakes.rb
@@ -1,0 +1,5 @@
+class RemoveNycFullYearResidentFromStateFileNyIntakes < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured { remove_column :state_file_ny_intakes, :nyc_full_year_resident, :integer, default: 0, null: false }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_18_201358) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_20_021530) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -1730,7 +1730,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_18_201358) do
     t.string "ny_mailing_city"
     t.string "ny_mailing_street"
     t.string "ny_mailing_zip"
-    t.integer "nyc_full_year_resident", default: 0, null: false
     t.integer "nyc_maintained_home", default: 0, null: false
     t.integer "nyc_residency", default: 0, null: false
     t.integer "occupied_residence", default: 0, null: false


### PR DESCRIPTION
Final follow up to https://www.pivotaltracker.com/story/show/186865012

Deletes the `nyc_full_year_resident` column from `state_file_ny_intakes`