### PR TITLE
Hide reject code and description on /return-status page if not present

### DIFF
--- a/app/views/state_file/questions/return_status/_rejected.html.erb
+++ b/app/views/state_file/questions/return_status/_rejected.html.erb
@@ -8,15 +8,19 @@
   <%= @title %>
 </h1>
 
-<section class="spacing-below-15">
-  <strong><%= t('.reject_code') %></strong>
-  <%= @reject_code %>
-</section>
+<% if @reject_code.present? %>
+  <section class="spacing-below-15">
+    <strong><%= t('.reject_code') %></strong>
+    <%= @reject_code %>
+  </section>
+<% end %>
 
-<section class="spacing-below-15">
-  <strong><%= t('.reject_desc') %></strong>
-  <%= @reject_description %>
-</section>
+<% if @reject_description.present? %>
+  <section class="spacing-below-15">
+    <strong><%= t('.reject_desc') %></strong>
+    <%= @reject_description %>
+  </section>
+<% end %>
 
 <section class="spacing-below-15">
   <p class="spacing-below-5"><strong><%= t('.whats_next') %></strong></p>


### PR DESCRIPTION
hiding "reject code:" and "reject description:" unless present
<img width="817" alt="Screenshot 2024-01-30 at 3 01 22 PM" src="https://github.com/codeforamerica/vita-min/assets/49880002/25dac567-04ee-480e-bcbd-23f6ba94a684">
