### PR TITLE
Comment out some CTC code from after rejection transition and add filtering for states and state count on /efile_submissions page

### DIFF
--- a/app/controllers/hub/efile_submissions_controller.rb
+++ b/app/controllers/hub/efile_submissions_controller.rb
@@ -30,6 +30,7 @@ module Hub
     end
 
     def failed
+      return if Rails.env.production? || Rails.env.staging?
       # TODO: remove eventually, for testing only
       authorize! :update, @efile_submission
       @efile_submission.transition_to!(:failed, { initiated_by_id: current_user.id })

--- a/app/controllers/hub/state_file/efile_submissions_controller.rb
+++ b/app/controllers/hub/state_file/efile_submissions_controller.rb
@@ -7,7 +7,6 @@ module Hub
       def index
         @efile_submissions = @efile_submissions.includes(:efile_submission_transitions).reorder(created_at: :desc).paginate(page: params[:page], per_page: 30)
         @efile_submissions = @efile_submissions.in_state(params[:status]) if params[:status].present?
-        # @efile_submission_state_counts = state_counts
       end
 
       def show
@@ -36,7 +35,6 @@ module Hub
       end
 
       def state_counts
-        # binding.pry
         @efile_submission_state_counts = EfileSubmission.statefile_state_counts(except: %w[new resubmitted ready_to_resubmit])
         respond_to :js
       end

--- a/app/controllers/hub/state_file/efile_submissions_controller.rb
+++ b/app/controllers/hub/state_file/efile_submissions_controller.rb
@@ -7,6 +7,7 @@ module Hub
       def index
         @efile_submissions = @efile_submissions.includes(:efile_submission_transitions).reorder(created_at: :desc).paginate(page: params[:page], per_page: 30)
         @efile_submissions = @efile_submissions.in_state(params[:status]) if params[:status].present?
+        # @efile_submission_state_counts = state_counts
       end
 
       def show
@@ -15,7 +16,7 @@ module Hub
       end
 
       def show_xml
-        return nil if Rails.env.production?
+        return nil if Rails.env.production? || Rails.env.staging?
 
         submission = EfileSubmission.find(params[:efile_submission_id])
         builder_response = case submission.data_source.state_code
@@ -25,6 +26,19 @@ module Hub
                              SubmissionBuilder::Ty2022::States::Az::IndividualReturn.build(submission)
                            end
         builder_response.errors.present? ? render(plain: builder_response.errors.join("\n") + "\n\n" + builder_response.document.to_xml) : render(xml: builder_response.document)
+      end
+
+      def show_df_xml
+        return nil if Rails.env.production? || Rails.env.staging?
+
+        response = EfileSubmission.find(params[:efile_submission_id]).data_source.raw_direct_file_data
+        render(xml: response)
+      end
+
+      def state_counts
+        # binding.pry
+        @efile_submission_state_counts = EfileSubmission.statefile_state_counts(except: %w[new resubmitted ready_to_resubmit])
+        respond_to :js
       end
 
       private

--- a/app/javascript/lib/fetch_statefile_efile_state_counts.js
+++ b/app/javascript/lib/fetch_statefile_efile_state_counts.js
@@ -1,0 +1,6 @@
+export function fetchStateFileEfileStateCounts() {
+    $.rails.ajax({
+        url: "efile_submissions/state-counts",
+        type: "get",
+    })
+}

--- a/app/javascript/listeners/index.js
+++ b/app/javascript/listeners/index.js
@@ -15,6 +15,7 @@ import { addTargetBlankToLinks } from "../lib/action_text_target_blank";
 import { limitTextMessageLength } from "../lib/text_message_length_limiter";
 import { initServiceComparisonComponent } from "../lib/service_comparison_component";
 import { fetchEfileStateCounts } from "../lib/fetch_efile_state_counts";
+import { fetchStateFileEfileStateCounts } from "../lib/fetch_statefile_efile_state_counts";
 import ClientMenuComponent from "../components/ClientMenuComponent";
 import MixpanelEventTracking from "../lib/mixpanel_event_tracking";
 import IntercomBehavior from "../lib/intercom_behavior";
@@ -56,6 +57,10 @@ const Listeners =  (function(){
 
                 if(controllerAction == "Hub::EfileSubmissionsController#index") {
                     fetchEfileStateCounts();
+                }
+
+                if(controllerAction == "Hub::StateFile::EfileSubmissionsController#index") {
+                    fetchStateFileEfileStateCounts();
                 }
 
                 if (document.querySelector('.taggable-note')) {

--- a/app/jobs/after_transition_tasks_for_rejected_return_job.rb
+++ b/app/jobs/after_transition_tasks_for_rejected_return_job.rb
@@ -2,7 +2,7 @@ class AfterTransitionTasksForRejectedReturnJob < ApplicationJob
   def perform(submission, transition)
     transition ||= submission.last_transition
 
-    submission.tax_return.transition_to(:file_rejected)
+    # submission.tax_return&.transition_to(:file_rejected) #ctc only
 
     Efile::SubmissionErrorParser.persist_errors(transition)
 
@@ -16,17 +16,17 @@ class AfterTransitionTasksForRejectedReturnJob < ApplicationJob
           submission.transition_to!(:resubmitted, {auto_resubmitted: true})
         end
       end
-      message_class = message_class_for_state(submission.current_state)
-      if message_class
-        ClientMessagingService.send_system_message_to_all_opted_in_contact_methods(
-          client: submission.client,
-          message: message_class,
-          locale: submission.client.intake.locale
-        )
-      end
+      # message_class = message_class_for_state(submission.current_state)
+      # if message_class
+      #   ClientMessagingService.send_system_message_to_all_opted_in_contact_methods(
+      #     client: submission.client,
+      #     message: message_class,
+      #     locale: submission.client.intake.locale
+      #   )
+      # end
     end
 
-    EfileSubmissionStateMachine.send_mixpanel_event(submission, "ctc_efile_return_rejected")
+    EfileSubmissionStateMachine.send_mixpanel_event(submission, "state_file_efile_return_rejected")
   end
 
   def priority

--- a/app/views/hub/state_file/efile_submissions/_state_counts.html.erb
+++ b/app/views/hub/state_file/efile_submissions/_state_counts.html.erb
@@ -1,0 +1,7 @@
+<% efile_submission_state_counts ||= {} %>
+<% (EfileSubmissionStateMachine.states - %w[new resubmitted ready_to_resubmit]).each do |state| %>
+  <div class="metric-box">
+    <div class="status <%= state %>"><%= efile_submission_state_counts[state] || "-" %></div>
+    <div class="status <%= state %>"><%= link_to state, Hub::StateFile::EfileSubmissionsController.to_path_helper(action: :index, status: state), class: 'link--subtle', style: "color: inherit;" %></div>
+  </div>
+<% end %>

--- a/app/views/hub/state_file/efile_submissions/index.html.erb
+++ b/app/views/hub/state_file/efile_submissions/index.html.erb
@@ -32,16 +32,17 @@
         <th scope="col" style="width: 12.5rem" class="index-table__header sortable">
           Status
         </th>
-        <th scope="col" style="width: 10rem" class="index-table__header sortable">IRS Submission ID</th>
-        <th scope="col" style="width: 10rem" class="index-table__header sortable">Federal Submission ID</th>
         <th scope="col" class="index-table__header">
           Errors
         </th>
-        <th scope="col" class="index-table__header">
-          Data Source ID
+        <th scope="col" style="width: 10rem" class="index-table__header sortable">
+          State Submission ID
         </th>
         <th scope="col" class="index-table__header">
-          Data Source type
+          State
+        </th>
+        <th scope="col" class="index-table__header">
+          Email Address
         </th>
       </tr>
       </thead>
@@ -56,12 +57,6 @@
             <%= link_to submission.current_state.humanize(capitalize: false), hub_state_file_efile_submission_path(id: submission.id), class: "underline" %>
           </td>
           <td class="index-table__cell">
-            <%= submission.irs_submission_id.present? ? link_to(submission.irs_submission_id, hub_state_file_efile_submission_path(id: submission.id)) : "" %>
-          </td>
-          <td class="index-table__cell">
-            <%= submission.data_source.federal_submission_id.present? ? link_to(submission.data_source.federal_submission_id, hub_state_file_efile_submission_path(id: submission.id)) : "" %>
-          </td>
-          <td class="index-table__cell">
             <% submission.last_transition&.efile_errors&.each do |error| %>
                 <span class="tooltip max-250 error-<%= error.id %>" data-position="left" title="<%= error.message %>">
                   <%= link_to hub_efile_error_path(id: error.id) do %>
@@ -70,8 +65,11 @@
                 </span>
             <% end %>
           </td>
-          <td class="index-table__cell"><%= submission.data_source_id %></td>
-          <td class="index-table__cell"><%= submission.data_source_type %></td>
+          <td class="index-table__cell">
+            <%= submission.irs_submission_id.present? ? link_to(submission.irs_submission_id, hub_state_file_efile_submission_path(id: submission.id)) : "" %>
+          </td>
+          <td class="index-table__cell"><%= submission.data_source.state_name %></td>
+          <td class="index-table__cell"><%= submission.data_source.email_address %></td>
         </tr>
       <% end %>
       </tbody>

--- a/app/views/hub/state_file/efile_submissions/index.html.erb
+++ b/app/views/hub/state_file/efile_submissions/index.html.erb
@@ -1,5 +1,8 @@
 <% content_for :card do %>
   <div class="spacing-above-25 submissions-index">
+    <div class="efile-state-counts" style="display: flex;">
+      <%= render "state_counts", efile_submission_state_counts: @efile_submission_state_counts %>
+    </div>
     <div class="slab slab--not-padded spacing-above-25">
       <div class="pagination-wrapper">
         <div class="count-wrapper">

--- a/app/views/hub/state_file/efile_submissions/show.html.erb
+++ b/app/views/hub/state_file/efile_submissions/show.html.erb
@@ -25,11 +25,21 @@
       <% end %>
 
       <div style="display: flex;">
-        <% unless Rails.env.production? || Rails.env.staging?  %>
+        <% unless Rails.env.production? || Rails.env.staging? %>
           <%= link_to "Show XML", hub_state_file_efile_submission_show_xml_path(efile_submission_id: @efile_submission.id), class: "button button--small" %>
           <div style="margin-left: 10px;">
             <%= link_to "Show direct-file XML", hub_state_file_efile_submission_show_df_xml_path(efile_submission_id: @efile_submission.id), class: "button button--small" %>
           </div>
+
+          <% if @efile_submission.can_transition_to?(:failed) %>
+            <div style="margin-left: 10px">
+              <%= link_to("Failed",
+                          failed_hub_efile_submission_path(id: @efile_submission.id),
+                          method: :patch,
+                          data: { confirm: "Are you sure you want to mark this tax return submission as 'Failed'?" },
+                          class: "button button--danger button--small") %>
+            </div>
+          <% end %>
         <% end %>
         <% if @efile_submission.can_transition_to?(:resubmitted) %>
           <div style="margin-left: 10px;">
@@ -49,16 +59,6 @@
                         cancel_hub_efile_submission_path(id: @efile_submission.id),
                         method: :patch,
                         data: { confirm: "Are you sure you want to mark this tax return submission as 'Not filing'?" },
-                        class: "button button--danger button--small") %>
-          </div>
-        <% end %>
-
-        <% if @efile_submission.can_transition_to?(:failed) %>
-          <div style="margin-left: 10px">
-            <%= link_to("Failed",
-                        failed_hub_efile_submission_path(id: @efile_submission.id),
-                        method: :patch,
-                        data: { confirm: "Are you sure you want to mark this tax return submission as 'Failed'?" },
                         class: "button button--danger button--small") %>
           </div>
         <% end %>

--- a/app/views/hub/state_file/efile_submissions/show.html.erb
+++ b/app/views/hub/state_file/efile_submissions/show.html.erb
@@ -25,8 +25,11 @@
       <% end %>
 
       <div style="display: flex;">
-        <% unless Rails.env.production? %>
+        <% unless Rails.env.production? || Rails.env.staging?  %>
           <%= link_to "Show XML", hub_state_file_efile_submission_show_xml_path(efile_submission_id: @efile_submission.id), class: "button button--small" %>
+          <div style="margin-left: 10px;">
+            <%= link_to "Show direct-file XML", hub_state_file_efile_submission_show_df_xml_path(efile_submission_id: @efile_submission.id), class: "button button--small" %>
+          </div>
         <% end %>
         <% if @efile_submission.can_transition_to?(:resubmitted) %>
           <div style="margin-left: 10px;">

--- a/app/views/hub/state_file/efile_submissions/state_counts.js.erb
+++ b/app/views/hub/state_file/efile_submissions/state_counts.js.erb
@@ -1,0 +1,2 @@
+$(".efile-state-counts").html("<%= j render 'hub/state_file/efile_submissions/state_counts', efile_submission_state_counts: @efile_submission_state_counts %>");
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -240,6 +240,8 @@ Rails.application.routes.draw do
         namespace :state_file, path: "state-file" do
           resources :efile_submissions, only: [:index, :show]  do
             get "show_xml", to: "efile_submissions#show_xml"
+            get "show_df_xml", to: "efile_submissions#show_df_xml"
+            get "/state-counts", to: 'efile_submissions#state_counts', on: :collection, as: :state_counts
           end
           resources :faq_categories, path: "faq" do
             resources :faq_items

--- a/spec/controllers/hub/state_file/efile_submissions_controller_spec.rb
+++ b/spec/controllers/hub/state_file/efile_submissions_controller_spec.rb
@@ -37,4 +37,20 @@ describe Hub::StateFile::EfileSubmissionsController do
       end
     end
   end
+
+  describe "#state_counts" do
+    context "when authenticated as an admin" do
+      let(:user) { create :state_file_admin_user }
+      let(:state_counts) { { "accepted" => 1, "rejected" => 2 } }
+      before do
+        sign_in user
+        allow(EfileSubmission).to receive(:statefile_state_counts).and_return state_counts
+      end
+
+      it "loads most recent submissions for tax returns" do
+        get :state_counts, format: :js, xhr: true
+        expect(assigns(:efile_submission_state_counts)).to eq state_counts
+      end
+    end
+  end
 end

--- a/spec/features/hub/state_file/efile_submissions_spec.rb
+++ b/spec/features/hub/state_file/efile_submissions_spec.rb
@@ -15,9 +15,8 @@ RSpec.feature "View state-file efile submissions page in hub" do
       expect(page).to have_content(efile_submission.id)
       expect(page).to have_content(efile_submission.current_state.humanize(capitalize: false))
       expect(page).to have_content(efile_submission.irs_submission_id)
-      expect(page).to have_content(efile_submission.data_source.federal_submission_id)
-      expect(page).to have_content(efile_submission.data_source_id)
-      expect(page).to have_content(efile_submission.data_source_type)
+      expect(page).to have_content(efile_submission.data_source.state_name)
+      expect(page).to have_content(efile_submission.data_source.email_address)
     end
 
     context "when before state file launch" do

--- a/spec/jobs/after_transition_tasks_for_rejected_return_job_spec.rb
+++ b/spec/jobs/after_transition_tasks_for_rejected_return_job_spec.rb
@@ -8,20 +8,20 @@ describe AfterTransitionTasksForRejectedReturnJob do
     let(:auto_cancel) { false }
 
     before do
-      allow(ClientMessagingService).to receive(:send_system_message_to_all_opted_in_contact_methods)
+      # allow(ClientMessagingService).to receive(:send_system_message_to_all_opted_in_contact_methods)
       submission.transition_to!(:rejected, error_code: efile_error.code)
     end
 
-    it "updates the tax return status and sends a message" do
-      AfterTransitionTasksForRejectedReturnJob.perform_now(submission, submission.last_transition)
-
-      expect(submission.tax_return.reload.current_state).to eq("file_rejected")
-      expect(ClientMessagingService).to have_received(:send_system_message_to_all_opted_in_contact_methods).with(
-        client: submission.client.reload,
-        message: AutomatedMessage::EfileRejected,
-        locale: submission.client.intake.locale
-      )
-    end
+    # it "updates the tax return status and sends a message" do
+    #   AfterTransitionTasksForRejectedReturnJob.perform_now(submission, submission.last_transition)
+    #
+    #   expect(submission.tax_return.reload.current_state).to eq("file_rejected")
+    #   expect(ClientMessagingService).to have_received(:send_system_message_to_all_opted_in_contact_methods).with(
+    #     client: submission.client.reload,
+    #     message: AutomatedMessage::EfileRejected,
+    #     locale: submission.client.intake.locale
+    #   )
+    # end
 
     context "when the error is auto-wait" do
       let(:auto_wait) { true }
@@ -40,11 +40,11 @@ describe AfterTransitionTasksForRejectedReturnJob do
 
         expect(submission.tax_return.reload.current_state).to eq("file_not_filing")
         expect(submission.current_state).to eq("cancelled")
-        expect(ClientMessagingService).to have_received(:send_system_message_to_all_opted_in_contact_methods).once.with(
-          client: submission.client.reload,
-          message: AutomatedMessage::EfileRejectedAndCancelled,
-          locale: submission.client.intake.locale
-        )
+        # expect(ClientMessagingService).to have_received(:send_system_message_to_all_opted_in_contact_methods).once.with(
+        #   client: submission.client.reload,
+        #   message: AutomatedMessage::EfileRejectedAndCancelled,
+        #   locale: submission.client.intake.locale
+        # )
       end
     end
 


### PR DESCRIPTION
Adds the state (efile submission status) counts and links for filtering on the statefile /efile-submissions page 
<img width="887" alt="Screenshot 2024-02-01 at 11 15 25 AM" src="https://github.com/codeforamerica/vita-min/assets/49880002/408e8e4f-ce4e-4bb2-a5de-19f64f903270">

Adds the "show direct-file XML" button on efile (only for non-prod and non-staging) 
<img width="890" alt="Screenshot 2024-02-01 at 11 15 41 AM" src="https://github.com/codeforamerica/vita-min/assets/49880002/b00b070b-9933-45a9-8368-14535f935377">
