### PR TITLE
Add some submission ids for NY sample returns

### DIFF
--- a/app/services/state_file/xml_return_sample_service.rb
+++ b/app/services/state_file/xml_return_sample_service.rb
@@ -4,7 +4,11 @@ module StateFile
       @_samples = []
       @_sample_lookup = {}
       @_submission_id_lookup = {
-        rudy_v2_ny: '1016422024027ate001k'
+        rudy_v2_ny: '1016422024027ate001k',
+        javier_ny: '1016422024018atw000x',
+        matthew_v2_ny: '1016422024026atw001u',
+        khaled_ny: '1016422024009at0000z',
+        ivy_414h_ny: '1016422024025atw000h'
       }
     end
 


### PR DESCRIPTION
Steps using starting point "matthew_v2_ny - NY 782" as an example:
1. Look up intake by id & state provided, confirm name matches (or is nil - this is acceptable):
   * Login to aptible cli
   * `aptible ssh --app vita-min-demo`
   * `rails c`
   * `StateFileNyIntake.find(782).primary_first_name`
   * `=> "MATTHEW"`
2. Get federal_submission_id
   * `StateFileNyIntake.find(782).federal_submission_id`
   * `=> "1016422024026atw001u"`
3. Add lookup to `xml_return_sample_service.rb` using the key provided
   * `matthew_v2_ny: '1016422024026atw001u'`
