### PR TITLE
Skip before action

### DIFF
--- a/app/controllers/state_file/questions/waiting_to_load_data_controller.rb
+++ b/app/controllers/state_file/questions/waiting_to_load_data_controller.rb
@@ -2,6 +2,7 @@ module StateFile
   module Questions
     class WaitingToLoadDataController < QuestionsController
       include EligibilityOffboardingConcern
+      skip_before_action :set_current_step
 
       def edit
         raise ActionController::RoutingError, 'Not Found' unless params[:authorizationCode]


### PR DESCRIPTION
Follow on from this morning: We cannot restore the waiting-to-load-data step because we don't save the authorization code. If this fails, we should try restarting the transfer.