### PR TITLE
1099g validation and flow updates #187002000

### DIFF
--- a/app/controllers/state_file/questions/unemployment_controller.rb
+++ b/app/controllers/state_file/questions/unemployment_controller.rb
@@ -10,14 +10,18 @@ module StateFile
       end
 
       def self.navigation_actions
-        [:new, :index]
+        [:index, :new]
       end
 
       def index
         @state_file1099_gs = current_intake.state_file1099_gs
+        unless @state_file1099_gs.present?
+          redirect_to action: :new
+        end
       end
 
       def new
+        # redirect_to action: :index and return if current_intake.state_file1099_gs
         @state_file1099_g = current_intake.state_file1099_gs.build
       end
 

--- a/app/controllers/state_file/questions/unemployment_controller.rb
+++ b/app/controllers/state_file/questions/unemployment_controller.rb
@@ -21,7 +21,6 @@ module StateFile
       end
 
       def new
-        # redirect_to action: :index and return if current_intake.state_file1099_gs
         @state_file1099_g = current_intake.state_file1099_gs.build
       end
 

--- a/app/controllers/state_file/questions/waiting_to_load_data_controller.rb
+++ b/app/controllers/state_file/questions/waiting_to_load_data_controller.rb
@@ -2,6 +2,7 @@ module StateFile
   module Questions
     class WaitingToLoadDataController < QuestionsController
       include EligibilityOffboardingConcern
+      skip_before_action :set_current_step
 
       def edit
         raise ActionController::RoutingError, 'Not Found' unless params[:authorizationCode]

--- a/app/validators/zip_code_validator.rb
+++ b/app/validators/zip_code_validator.rb
@@ -2,7 +2,7 @@ class ZipCodeValidator < ActiveModel::EachValidator
   ZIP_CODE_REGEX = /\A\d{5}\z/
 
   def validate_each(record, attr_name, value)
-    unless value =~ ZIP_CODE_REGEX # && ZipCodes.has_key?(value)
+    unless value =~ ZIP_CODE_REGEX
       record.errors.add(attr_name, I18n.t("validators.zip"))
     end
   end

--- a/app/validators/zip_code_validator.rb
+++ b/app/validators/zip_code_validator.rb
@@ -2,7 +2,7 @@ class ZipCodeValidator < ActiveModel::EachValidator
   ZIP_CODE_REGEX = /\A\d{5}\z/
 
   def validate_each(record, attr_name, value)
-    unless value =~ ZIP_CODE_REGEX && ZipCodes.has_key?(value)
+    unless value =~ ZIP_CODE_REGEX # && ZipCodes.has_key?(value)
       record.errors.add(attr_name, I18n.t("validators.zip"))
     end
   end

--- a/spec/controllers/state_file/questions/unemployment_controller_spec.rb
+++ b/spec/controllers/state_file/questions/unemployment_controller_spec.rb
@@ -36,6 +36,14 @@ RSpec.describe StateFile::Questions::UnemploymentController do
         expect(response.body).to include intake.spouse.full_name
       end
     end
+
+    context "with no existing dependents" do
+      render_views
+      it "redirects to the new view" do
+        get :index, params: { us_state: :ny }
+        expect(response).to redirect_to StateFile::Questions::UnemploymentController.to_path_helper(action: :new, us_state: :ny)
+      end
+    end
   end
 
   describe "#create" do
@@ -235,6 +243,13 @@ RSpec.describe StateFile::Questions::UnemploymentController do
 
       expect(response).to redirect_to StateFile::Questions::UnemploymentController.to_path_helper(us_state: :ny, action: :index)
       expect(flash[:notice]).to eq I18n.t('state_file.questions.unemployment.destroy.removed', name: intake.primary.full_name)
+    end
+  end
+
+  describe "navigation" do
+    it "has index as the default action" do
+      action = StateFile::Questions::UnemploymentController.navigation_actions.first
+      expect(action).to eq :index
     end
   end
 end

--- a/spec/validators/zip_code_validator_spec.rb
+++ b/spec/validators/zip_code_validator_spec.rb
@@ -17,8 +17,13 @@ RSpec.describe ZipCodeValidator do
     assert_invalid("1092")
   end
 
-  specify do
+  # For the moment we have excluded this spec because we not checking against known zip codes
+  xspecify do
     assert_invalid("99999")
+  end
+
+  specify do
+    assert_valid("10752")
   end
 
   specify do

--- a/spec/validators/zip_code_validator_spec.rb
+++ b/spec/validators/zip_code_validator_spec.rb
@@ -17,11 +17,6 @@ RSpec.describe ZipCodeValidator do
     assert_invalid("1092")
   end
 
-  # For the moment we have excluded this spec because we not checking against known zip codes
-  xspecify do
-    assert_invalid("99999")
-  end
-
   specify do
     assert_valid("10752")
   end


### PR DESCRIPTION
Now, when you go to the `unemployment` step, the default action is `index`:
![image](https://github.com/codeforamerica/vita-min/assets/17094895/b77e31f9-99a6-48b7-bcde-c237c1855cf3)

... rather than `new`:
![image](https://github.com/codeforamerica/vita-min/assets/17094895/6f57fdcd-35c9-4d6d-bfdb-e5617fea2e2e)

If there are no 1099G's defined, we redirect into new.

Also, we have loosened the validation on Zip Codes, because our database was missing some (Notably 10572 used in the Javier case). This was causing some weird behavior, as the zip code for the Payee was validated even if it was not specified in the form (Causing saves to fail)
![image](https://github.com/codeforamerica/vita-min/assets/17094895/852766ec-ab77-491a-91c8-7973eae72d8e)
