### PR TITLE
Session Timeout Flow #187040813

### DIFF
--- a/app/controllers/state_file/questions/questions_controller.rb
+++ b/app/controllers/state_file/questions/questions_controller.rb
@@ -24,22 +24,21 @@ module StateFile
       end
 
       def question_navigator
-        case params[:us_state]
-        when 'az'
-          Navigation::StateFileAzQuestionNavigation
-        when 'ny'
-          Navigation::StateFileNyQuestionNavigation
+        @navigator ||= "Navigation::StateFile#{state_code.titleize}QuestionNavigation".constantize
+      end
+
+      def state_code
+        state_code_ = params['us_state']
+        unless StateFileBaseIntake::STATE_CODES.include?(state_code_)
+          raise StandardError state_code_
         end
+        state_code_
       end
 
       def redirect_if_no_intake
         unless current_intake.present?
           flash[:notice] = 'Your session expired. Please sign in again to continue.'
-          if params['us_state'] == 'az'
-            redirect_to az_questions_landing_page_path(us_state: params['us_state'])
-          else
-            redirect_to ny_questions_landing_page_path(us_state: params['us_state'])
-          end
+          redirect_to StateFile::StateFilePagesController.to_path_helper(action: :login_options, us_state: state_code)
         end
       end
 

--- a/app/controllers/state_file/questions/questions_controller.rb
+++ b/app/controllers/state_file/questions/questions_controller.rb
@@ -28,9 +28,9 @@ module StateFile
       end
 
       def state_code
-        state_code_ = params['us_state']
+        state_code_ = params[:us_state].downcase
         unless StateFileBaseIntake::STATE_CODES.include?(state_code_)
-          raise StandardError state_code_
+          raise StandardError, state_code_
         end
         state_code_
       end

--- a/spec/controllers/state_file/questions/data_review_controller_spec.rb
+++ b/spec/controllers/state_file/questions/data_review_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe StateFile::Questions::DataReviewController do
       it 'redirects to the landing page for the correct state' do
         session.destroy
         response = get :edit, params: { us_state: "az" }
-        expect(response).to redirect_to(az_questions_landing_page_path(us_state: 'az'))
+        expect(response).to redirect_to(StateFile::StateFilePagesController.to_path_helper(action: :login_options, us_state: 'az'))
         expect(flash[:notice]).to eq('Your session expired. Please sign in again to continue.')
       end
     end


### PR DESCRIPTION
When your session times out, we redirect to the login page rather than the landing page:
![image](https://github.com/codeforamerica/vita-min/assets/17094895/c0a10c74-3809-44d6-bb12-dbf7801e2cf7)

I also updated code to use `StateFileBaseIntake::StateCodes` rather than enumerating out states individually in each case - so this will lower the bar on adding new States