### PR TITLE
Log In Messages #187042699

### DIFF
--- a/app/controllers/state_file/intake_logins_controller.rb
+++ b/app/controllers/state_file/intake_logins_controller.rb
@@ -1,7 +1,6 @@
 module StateFile
   class IntakeLoginsController < Portal::ClientLoginsController
     helper_method :prev_path, :illustration_path
-    before_action :redirect_to_data_review_if_intake_authenticated
     layout "state_file/question"
 
     def new
@@ -93,19 +92,6 @@ module StateFile
       when "az" then :statefile_az
       when "ny" then :statefile_ny
       when "us" then :statefile
-      end
-    end
-
-    def redirect_to_data_review_if_intake_authenticated
-      intake = current_state_file_az_intake || current_state_file_ny_intake
-      if intake.present?
-        # Redirect to last step
-        controller = intake.controller_for_current_step
-        to_path = controller.to_path_helper(
-          action: controller.navigation_actions.first,
-          us_state: intake.state_code
-        )
-        redirect_to to_path
       end
     end
 

--- a/app/controllers/state_file/intake_logins_controller.rb
+++ b/app/controllers/state_file/intake_logins_controller.rb
@@ -14,6 +14,13 @@ module StateFile
 
     def create
       @contact_method = params[:contact_method] unless @contact_method.present?
+      value = params[:state_file_request_intake_login_form][@contact_method]
+      @records = client_login_service.intake_classes.map { |intake_class| intake_class.where({@contact_method => value}) }.flatten
+      if @records.blank?
+        flash[:alert] = I18n.t("state_file.intake_logins.new.#{@contact_method}.not_found")
+        redirect_to action: :new, contact_method: @contact_method
+        return
+      end
       super
     end
 

--- a/app/controllers/state_file/intake_logins_controller.rb
+++ b/app/controllers/state_file/intake_logins_controller.rb
@@ -1,6 +1,7 @@
 module StateFile
   class IntakeLoginsController < Portal::ClientLoginsController
     helper_method :prev_path, :illustration_path
+    before_action :redirect_to_data_review_if_intake_authenticated
     layout "state_file/question"
 
     def new
@@ -85,6 +86,19 @@ module StateFile
 
     def request_client_login_params
       params.require(:state_file_request_intake_login_form).permit(:email_address, :sms_phone_number)
+    end
+
+    def redirect_to_data_review_if_intake_authenticated
+      intake = current_state_file_az_intake || current_state_file_ny_intake
+      if intake.present?
+        # Redirect to last step
+        controller = intake.controller_for_current_step
+        to_path = controller.to_path_helper(
+          action: controller.navigation_actions.first,
+          us_state: intake.state_code
+        )
+        redirect_to to_path
+      end
     end
 
     def service_type

--- a/app/controllers/state_file/intake_logins_controller.rb
+++ b/app/controllers/state_file/intake_logins_controller.rb
@@ -14,12 +14,14 @@ module StateFile
 
     def create
       @contact_method = params[:contact_method] unless @contact_method.present?
-      value = params[:state_file_request_intake_login_form][@contact_method]
-      @records = client_login_service.intake_classes.map { |intake_class| intake_class.where({@contact_method => value}) }.flatten
-      if @records.blank?
-        flash[:alert] = I18n.t("state_file.intake_logins.new.#{@contact_method}.not_found")
-        redirect_to action: :new, contact_method: @contact_method
-        return
+      @form = request_login_form_class.new(request_client_login_params)
+      if @form.valid?
+        intake_classes = client_login_service.intake_classes
+        @records = intake_classes.map { |intake_class| @form.filter_records(intake_class) }.flatten
+        if @records.blank?
+          flash[:alert] = I18n.t("state_file.intake_logins.new.#{@contact_method}.not_found")
+          render :new and return
+        end
       end
       super
     end

--- a/app/controllers/state_file/intake_logins_controller.rb
+++ b/app/controllers/state_file/intake_logins_controller.rb
@@ -88,6 +88,14 @@ module StateFile
       params.require(:state_file_request_intake_login_form).permit(:email_address, :sms_phone_number)
     end
 
+    def service_type
+      case params[:us_state]
+      when "az" then :statefile_az
+      when "ny" then :statefile_ny
+      when "us" then :statefile
+      end
+    end
+
     def redirect_to_data_review_if_intake_authenticated
       intake = current_state_file_az_intake || current_state_file_ny_intake
       if intake.present?
@@ -98,14 +106,6 @@ module StateFile
           us_state: intake.state_code
         )
         redirect_to to_path
-      end
-    end
-
-    def service_type
-      case params[:us_state]
-      when "az" then :statefile_az
-      when "ny" then :statefile_ny
-      when "us" then :statefile
       end
     end
 

--- a/app/forms/state_file/request_intake_login_form.rb
+++ b/app/forms/state_file/request_intake_login_form.rb
@@ -1,5 +1,14 @@
 module StateFile
   class RequestIntakeLoginForm < Portal::RequestClientLoginForm
+
+    def filter_records(intake_class)
+      if email_address.present?
+        intake_class.where(email_address: email_address)
+      else
+        intake_class.where(phone_number: sms_phone_number)
+      end
+    end
+
     private
 
     def phone_number_or_email_address

--- a/app/views/state_file/questions/landing_page/edit.html.erb
+++ b/app/views/state_file/questions/landing_page/edit.html.erb
@@ -23,5 +23,10 @@
     <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
       <%= f.submit t("general.get_started"), class: "button button--primary button--wide", id: "firstCta" %>
     <% end %>
+
+    <h2 class="h2">
+      <%= t(".already_started_html", sign_in_url: StateFile::StateFilePagesController.to_path_helper(action: :login_options, us_state: params[:us_state])) %>
+    </h2>
+
   </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1884,9 +1884,11 @@ en:
       new:
         email_address:
           label: Your email address (use an account you can access)
+          not_found: Sorry, we don’t have an account registered for that email. Would you like to sign in with a different email?
           title: Sign in with your email address. To continue filing your state tax return safely, we’ll send you a secure code.
         sms_phone_number:
           label: Your phone number
+          not_found: Sorry, we don’t have an account registered for that phone number. Would you like to sign in with a different phone number?
           title: Sign in with your phone number. To continue filing your state tax return safely, we’ll send you a secure code.
       no_match_sms: Someone tried to sign in to FileYourStateTaxes with this phone number, but we couldn't find a match. Did you sign up with a different phone number? You can also visit %{url} to get started.
     questions:
@@ -2162,6 +2164,7 @@ en:
           title: Now, let’s complete your state tax return
       landing_page:
         edit:
+          already_started_html: Already started filing your state return? <a href="%{sign_in_url}">Sign in</a>.
           az:
             built_with_html: "<strong>FileYourStateTaxes</strong> is built in partnership with the state of Arizona to integrate with the IRS Direct File tool."
             supported_by: Supported by the state of Arizona

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1866,9 +1866,11 @@ es:
       new:
         email_address:
           label: Tu dirección de correo electrónico (utiliza un correo electrónico al que puedas acceder)
+          not_found: Lo sentimos, no tenemos una cuenta registrada para ese correo electrónico. ¿Quieres iniciar sesión con un correo electrónico diferente?
           title: Inicia sesión con tu dirección de correo electrónico. Para continuar presentando tu declaración de impuestos estatales de manera segura, te enviaremos un código seguro.
         sms_phone_number:
           label: Tu número de teléfono
+          not_found: Lo sentimos, no tenemos una cuenta registrada para ese número de teléfono. ¿Quieres iniciar sesión con un número de teléfono diferente?
           title: Inicia sesión con tu número de teléfono. Para continuar presentando tu declaración de impuestos estatales de manera segura, te enviaremos un código seguro.
       no_match_sms: Alguien intentó iniciar sesión en FileYourStateTaxes con este número de teléfono, pero no pudimos encontrar una coincidencia. ¿Te registraste con otro número de teléfono? También puedes visitar %{url} para comenzar.
     questions:
@@ -2153,6 +2155,7 @@ es:
           title: Ahora completemos tu declaración de impuestos estatales
       landing_page:
         edit:
+          already_started_html: ¿Ya comenzó a presentar su declaración estatal? <a href="%{sign_in_url}">Iniciar sesión</a>.
           az:
             built_with_html: "<strong>FileYourStateTaxes</strong> ha sido creado en colaboración con el estado de Arizona para integrarse con la herramienta Direct File del IRS."
             supported_by: Respaldada por el estado de Arizona

--- a/spec/controllers/state_file/intake_logins_controller_spec.rb
+++ b/spec/controllers/state_file/intake_logins_controller_spec.rb
@@ -5,10 +5,11 @@ RSpec.describe StateFile::IntakeLoginsController, type: :controller do
     create(
       :state_file_az_intake,
       email_address: "client@example.com",
-      sms_phone_number: "+15105551234",
+      phone_number: "+15105551234",
       hashed_ssn: "hashed_ssn"
     )
   end
+  before { intake }
   let(:intake_query) { StateFileAzIntake.where(id: intake) }
 
   before do

--- a/spec/controllers/state_file/intake_logins_controller_spec.rb
+++ b/spec/controllers/state_file/intake_logins_controller_spec.rb
@@ -42,10 +42,10 @@ RSpec.describe StateFile::IntakeLoginsController, type: :controller do
     context "as an authenticated intake" do
       before { sign_in intake }
 
-      it "redirects to data review page" do
-        get :new, params: { us_state: "az" }
+      it "renders the login page" do
+        get :new, params: { us_state: "az", contact_method: "email_address" }
 
-        expect(response).to redirect_to az_questions_data_review_path(us_state: "az")
+        expect(response.status).to eq(200)
       end
     end
   end
@@ -170,10 +170,10 @@ RSpec.describe StateFile::IntakeLoginsController, type: :controller do
     context "as an authenticated intake" do
       before { sign_in intake }
 
-      it "redirects to data review page" do
-        post :create, params: { us_state: "az" }
+      it "renders the login page" do
+        post :create, params: { us_state: "az", state_file_request_intake_login_form: { sms_phone_number: "(510) 555 1234"}}
 
-        expect(response).to redirect_to az_questions_data_review_path(us_state: "az")
+        expect(response.status).to eq(200)
       end
     end
   end
@@ -370,18 +370,9 @@ RSpec.describe StateFile::IntakeLoginsController, type: :controller do
         sign_in intake
       end
 
-      it "redirects to data review page" do
+      it "still displays the login page" do
         get :edit, params: params
-        expect(response).to redirect_to az_questions_data_review_path(us_state: "az")
-      end
-
-      context "when the intake has a current step" do
-        before { intake.update(current_step: "/en/questions/name-dob") }
-
-        it "redirects to the current step" do
-          post :update, params: params
-          expect(response).to redirect_to az_questions_name_dob_path(us_state: "az")
-        end
+        expect(response.status).to eq(200)
       end
 
       context "when the intake does not have an ssn" do
@@ -422,6 +413,15 @@ RSpec.describe StateFile::IntakeLoginsController, type: :controller do
 
             expect(subject.current_state_file_az_intake).to eq(intake)
             expect(response).to redirect_to az_questions_data_review_path(us_state: "az")
+            expect(session["warden.user.state_file_az_intake.key"].first.first).to eq intake.id
+          end
+
+          it "signs in the intake, updates the session, and redirects to the current step" do
+            intake.update(current_step: "/en/questions/name-dob")
+            post :update, params: params
+
+            expect(subject.current_state_file_az_intake).to eq(intake)
+            expect(response).to redirect_to az_questions_name_dob_path(us_state: "az")
             expect(session["warden.user.state_file_az_intake.key"].first.first).to eq intake.id
           end
 
@@ -515,31 +515,9 @@ RSpec.describe StateFile::IntakeLoginsController, type: :controller do
         sign_in intake
       end
 
-      it "redirects to data review page if they have no submitted return" do
+      it "displays the form" do
         get :new, params: { contact_method: :email_address, us_state: "az" }
-
-        expect(response).to redirect_to az_questions_data_review_path(us_state: "az")
-      end
-
-      context "when the intake has a submitted return" do
-        before do
-          intake.efile_submissions.create!
-        end
-
-        it "redirects to return status page" do
-          get :new, params: { contact_method: :email_address, us_state: "az" }
-
-          expect(response).to redirect_to az_questions_return_status_path(us_state: "az")
-        end
-      end
-
-      context "when the intake has a current step" do
-        before { intake.update(current_step: "/en/questions/name-dob") }
-
-        it "redirects to the current step" do
-          post :update, params: params
-          expect(response).to redirect_to az_questions_name_dob_path(us_state: "az")
-        end
+        expect(response.status).to eq(200)
       end
     end
   end


### PR DESCRIPTION
Added some links to the landing pages.
![image](https://github.com/codeforamerica/vita-min/assets/17094895/5703d1cf-b65d-4824-a774-8ba465d9651e)

Also - if you try to log into an account that does not exist you get a message in the UI (I think this is okay because we lock accounts):
![image](https://github.com/codeforamerica/vita-min/assets/17094895/e7087eca-74de-4a13-9ffb-69162ca54919)

One more thing: If you hit the login page and you are already logged in, you now still see the login page (Rather than being taken to the last step of your logged in intake). I figure this makes sense as visiting a login page implies intent to login, and allows us to support use cases where a user wants to switch profiles (For example, if older folks share a family computer and don't have different profiles set up because they don't know what that is.)
