### PR TITLE
Fix Debugging Info for Gabriel

### DIFF
--- a/app/controllers/state_file/state_file_pages_controller.rb
+++ b/app/controllers/state_file/state_file_pages_controller.rb
@@ -41,5 +41,9 @@ module StateFile
       uri.query = { authorizationCode: key }.to_query
       uri.to_s
     end
+
+    def current_intake
+      @current_intake ||= current_state_file_az_intake || current_state_file_ny_intake
+    end
   end
 end

--- a/app/controllers/state_file/state_file_pages_controller.rb
+++ b/app/controllers/state_file/state_file_pages_controller.rb
@@ -43,7 +43,12 @@ module StateFile
     end
 
     def current_intake
-      @current_intake ||= current_state_file_az_intake || current_state_file_ny_intake
+      @current_intake ||= (
+        StateFileBaseIntake::STATE_CODES
+          .lazy
+          .map{|c| send("current_state_file_#{c}_intake".to_sym) }
+          .find(&:itself)
+      )
     end
   end
 end

--- a/app/views/state_file/state_file_pages/about_page.html.erb
+++ b/app/views/state_file/state_file_pages/about_page.html.erb
@@ -19,9 +19,9 @@
 <section>
   <%= link_to "Start Test AZ", Navigation::StateFileAzQuestionNavigation::FLOW.first.to_path_helper(us_state: "az"), class: "button" %>
   <%= link_to "Start Test NY", Navigation::StateFileNyQuestionNavigation::FLOW.first.to_path_helper(us_state: "ny"), class: "button" %>
-  <% if session[:state_file_intake] %>
+  <% if current_intake %>
     <div class="with-padding-med">
-      Your session has this intake: <b><%= session[:state_file_intake] %></b>
+      Your session has this intake: <b><%= current_intake.id %></b>
       <%= button_to "Clear", StateFile::StateFilePagesController.to_path_helper(action: :clear_session) %>
     </div>
   <% end %>

--- a/app/views/state_file/state_file_pages/about_page.html.erb
+++ b/app/views/state_file/state_file_pages/about_page.html.erb
@@ -21,7 +21,7 @@
   <%= link_to "Start Test NY", Navigation::StateFileNyQuestionNavigation::FLOW.first.to_path_helper(us_state: "ny"), class: "button" %>
   <% if current_intake %>
     <div class="with-padding-med">
-      Your session has this intake: <b><%= current_intake.id %></b>
+      Your session has this intake: <b><%=current_intake.state_code %> <%= current_intake.id %></b>
       <%= button_to "Clear", StateFile::StateFilePagesController.to_path_helper(action: :clear_session) %>
     </div>
   <% end %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,8 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.1].define(version: 2024_02_15_175116) do
-  create_schema "analytics"
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -2214,6 +2212,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_15_175116) do
   add_foreign_key "incoming_text_messages", "clients"
   add_foreign_key "intake_archives", "intakes", column: "id"
   add_foreign_key "intakes", "clients"
+  add_foreign_key "intakes", "drivers_licenses", column: "primary_drivers_license_id"
+  add_foreign_key "intakes", "drivers_licenses", column: "spouse_drivers_license_id"
   add_foreign_key "intakes", "intakes", column: "matching_previous_year_intake_id"
   add_foreign_key "intakes", "vita_partners"
   add_foreign_key "notes", "clients"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,8 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.1].define(version: 2024_02_15_175116) do
+  create_schema "analytics"
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -2212,8 +2214,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_15_175116) do
   add_foreign_key "incoming_text_messages", "clients"
   add_foreign_key "intake_archives", "intakes", column: "id"
   add_foreign_key "intakes", "clients"
-  add_foreign_key "intakes", "drivers_licenses", column: "primary_drivers_license_id"
-  add_foreign_key "intakes", "drivers_licenses", column: "spouse_drivers_license_id"
   add_foreign_key "intakes", "intakes", column: "matching_previous_year_intake_id"
   add_foreign_key "intakes", "vita_partners"
   add_foreign_key "notes", "clients"


### PR DESCRIPTION
This dropped off when we swapped over to using devise for all session management:
<img width="475" alt="image" src="https://github.com/codeforamerica/vita-min/assets/17094895/1d2a83a3-9796-43be-afb8-6b21189e5c28">


