### PR TITLE
Do Not Redirect on Login #187042699

### DIFF
--- a/app/controllers/state_file/intake_logins_controller.rb
+++ b/app/controllers/state_file/intake_logins_controller.rb
@@ -1,7 +1,6 @@
 module StateFile
   class IntakeLoginsController < Portal::ClientLoginsController
     helper_method :prev_path, :illustration_path
-    before_action :redirect_to_data_review_if_intake_authenticated
     layout "state_file/question"
 
     def new
@@ -93,19 +92,6 @@ module StateFile
       when "az" then :statefile_az
       when "ny" then :statefile_ny
       when "us" then :statefile
-      end
-    end
-
-    def redirect_to_data_review_if_intake_authenticated
-      intake = current_state_file_az_intake || current_state_file_ny_intake
-      if intake.present?
-        # Redirect to last step
-        controller = intake.controller_for_current_step
-        to_path = controller.to_path_helper(
-          action: controller.navigation_actions.first,
-          us_state: intake.state_code
-        )
-        redirect_to to_path
       end
     end
 

--- a/spec/controllers/state_file/intake_logins_controller_spec.rb
+++ b/spec/controllers/state_file/intake_logins_controller_spec.rb
@@ -40,12 +40,14 @@ RSpec.describe StateFile::IntakeLoginsController, type: :controller do
     end
 
     context "as an authenticated intake" do
+      render_views
       before { sign_in intake }
 
       it "renders the login page" do
         get :new, params: { us_state: "az", contact_method: "email_address" }
 
         expect(response.status).to eq(200)
+        expect(response.body).to include "Sign in with your email address. To continue filing your state tax return safely, we’ll send you a secure code."
       end
     end
   end
@@ -168,12 +170,14 @@ RSpec.describe StateFile::IntakeLoginsController, type: :controller do
     end
 
     context "as an authenticated intake" do
+      render_views
       before { sign_in intake }
 
       it "renders the login page" do
         post :create, params: { us_state: "az", state_file_request_intake_login_form: { sms_phone_number: "(510) 555 1234"}}
 
         expect(response.status).to eq(200)
+        expect(response.body).to include "Enter the code to continue"
       end
     end
   end
@@ -365,6 +369,7 @@ RSpec.describe StateFile::IntakeLoginsController, type: :controller do
     end
 
     context "as an authenticated intake" do
+      render_views
       before do
         allow_any_instance_of(ClientLoginService).to receive(:login_records_for_token).and_return(intake_query)
         sign_in intake
@@ -373,6 +378,7 @@ RSpec.describe StateFile::IntakeLoginsController, type: :controller do
       it "still displays the login page" do
         get :edit, params: params
         expect(response.status).to eq(200)
+        expect(response.body).to include "Code verified! Authentication needed to continue."
       end
 
       context "when the intake does not have an ssn" do
@@ -510,6 +516,7 @@ RSpec.describe StateFile::IntakeLoginsController, type: :controller do
     end
 
     context "as an authenticated intake" do
+      render_views
       before do
         allow_any_instance_of(ClientLoginService).to receive(:login_records_for_token).and_return(intake_query)
         sign_in intake
@@ -518,6 +525,7 @@ RSpec.describe StateFile::IntakeLoginsController, type: :controller do
       it "displays the form" do
         get :new, params: { contact_method: :email_address, us_state: "az" }
         expect(response.status).to eq(200)
+        expect(response.body).to include "Sign in with your email address. To continue filing your state tax return safely, we’ll send you a secure code."
       end
     end
   end

--- a/spec/controllers/state_file/intake_logins_controller_spec.rb
+++ b/spec/controllers/state_file/intake_logins_controller_spec.rb
@@ -42,10 +42,10 @@ RSpec.describe StateFile::IntakeLoginsController, type: :controller do
     context "as an authenticated intake" do
       before { sign_in intake }
 
-      it "redirects to data review page" do
-        get :new, params: { us_state: "az" }
+      it "renders the login page" do
+        get :new, params: { us_state: "az", contact_method: "email_address" }
 
-        expect(response).to redirect_to az_questions_data_review_path(us_state: "az")
+        expect(response.status).to eq(200)
       end
     end
   end
@@ -170,10 +170,10 @@ RSpec.describe StateFile::IntakeLoginsController, type: :controller do
     context "as an authenticated intake" do
       before { sign_in intake }
 
-      it "redirects to data review page" do
-        post :create, params: { us_state: "az" }
+      it "renders the login page" do
+        post :create, params: { us_state: "az", state_file_request_intake_login_form: { sms_phone_number: "(510) 555 1234"}}
 
-        expect(response).to redirect_to az_questions_data_review_path(us_state: "az")
+        expect(response.status).to eq(200)
       end
     end
   end
@@ -370,18 +370,9 @@ RSpec.describe StateFile::IntakeLoginsController, type: :controller do
         sign_in intake
       end
 
-      it "redirects to data review page" do
+      it "still displays the login page" do
         get :edit, params: params
-        expect(response).to redirect_to az_questions_data_review_path(us_state: "az")
-      end
-
-      context "when the intake has a current step" do
-        before { intake.update(current_step: "/en/questions/name-dob") }
-
-        it "redirects to the current step" do
-          post :update, params: params
-          expect(response).to redirect_to az_questions_name_dob_path(us_state: "az")
-        end
+        expect(response.status).to eq(200)
       end
 
       context "when the intake does not have an ssn" do
@@ -422,6 +413,15 @@ RSpec.describe StateFile::IntakeLoginsController, type: :controller do
 
             expect(subject.current_state_file_az_intake).to eq(intake)
             expect(response).to redirect_to az_questions_data_review_path(us_state: "az")
+            expect(session["warden.user.state_file_az_intake.key"].first.first).to eq intake.id
+          end
+
+          it "signs in the intake, updates the session, and redirects to the current step" do
+            intake.update(current_step: "/en/questions/name-dob")
+            post :update, params: params
+
+            expect(subject.current_state_file_az_intake).to eq(intake)
+            expect(response).to redirect_to az_questions_name_dob_path(us_state: "az")
             expect(session["warden.user.state_file_az_intake.key"].first.first).to eq intake.id
           end
 
@@ -515,31 +515,9 @@ RSpec.describe StateFile::IntakeLoginsController, type: :controller do
         sign_in intake
       end
 
-      it "redirects to data review page if they have no submitted return" do
+      it "displays the form" do
         get :new, params: { contact_method: :email_address, us_state: "az" }
-
-        expect(response).to redirect_to az_questions_data_review_path(us_state: "az")
-      end
-
-      context "when the intake has a submitted return" do
-        before do
-          intake.efile_submissions.create!
-        end
-
-        it "redirects to return status page" do
-          get :new, params: { contact_method: :email_address, us_state: "az" }
-
-          expect(response).to redirect_to az_questions_return_status_path(us_state: "az")
-        end
-      end
-
-      context "when the intake has a current step" do
-        before { intake.update(current_step: "/en/questions/name-dob") }
-
-        it "redirects to the current step" do
-          post :update, params: params
-          expect(response).to redirect_to az_questions_name_dob_path(us_state: "az")
-        end
+        expect(response.status).to eq(200)
       end
     end
   end


### PR DESCRIPTION
Going to the login page implies intent, so we should not bypass it. I was previously going to delay this PR until Tiffany got back, but Gabriel found a more severe manifestation - hence this PR today.

**Example of Why this is a Problem:**

Open a new incognito tab and go to NY:
<img width="683" alt="image" src="https://github.com/codeforamerica/vita-min/assets/17094895/7323ae0b-63dd-4f67-ad0c-b4c85c75120c">

Click "Get Started"
<img width="590" alt="image" src="https://github.com/codeforamerica/vita-min/assets/17094895/dcd3ab2f-18ff-48ee-bcac-4ea9739d7dd3">

At this point a user may realize they already have an account and click "Sign in":
<img width="1184" alt="image" src="https://github.com/codeforamerica/vita-min/assets/17094895/c04e9309-6456-4342-8b55-f8ef9917323a">
<img width="527" alt="image" src="https://github.com/codeforamerica/vita-min/assets/17094895/a3625f33-fb69-4a3d-9058-e502552d05eb">


Use is taken back to their previous step. They cannot sign in. Their disappointment is immeasurable and their day is ruined!
<img width="1146" alt="image" src="https://github.com/codeforamerica/vita-min/assets/17094895/bc0230b5-3e82-4920-8e01-335051b09d41">

Until Now...



