### PR TITLE
URLs fix for production issues #187080649

### DIFF
--- a/app/controllers/state_file/questions/canceled_data_transfer_controller.rb
+++ b/app/controllers/state_file/questions/canceled_data_transfer_controller.rb
@@ -3,6 +3,7 @@ module StateFile
     class CanceledDataTransferController < QuestionsController
       include IrsDataTransferLinksConcern
       before_action :redirect_if_no_us_state_in_params
+      skip_before_action :set_current_step
 
       def self.show?(_intake)
         false

--- a/app/controllers/state_file/questions/canceled_data_transfer_controller.rb
+++ b/app/controllers/state_file/questions/canceled_data_transfer_controller.rb
@@ -25,11 +25,6 @@ module StateFile
 
       private
 
-      # this page sometimes doesn't have us_state in the params so can't use the default current_intake
-      def current_intake
-        GlobalID.find(session[:state_file_intake])
-      end
-
       # in order to give the IRS team one cancel link, this controller will redirect to the path with the us_state
       # based on the intake in the session; part of the reason for this is so we can leverage the default implementation
       # of

--- a/app/controllers/state_file/questions/pending_federal_return_controller.rb
+++ b/app/controllers/state_file/questions/pending_federal_return_controller.rb
@@ -1,6 +1,8 @@
 module StateFile
   module Questions
     class PendingFederalReturnController < QuestionsController
+      skip_before_action :set_current_step
+
       def prev_path
         nil
       end

--- a/app/controllers/state_file/questions/pending_federal_return_controller.rb
+++ b/app/controllers/state_file/questions/pending_federal_return_controller.rb
@@ -4,13 +4,6 @@ module StateFile
       def prev_path
         nil
       end
-
-      private
-
-      # edit page has no us_state in the params so default implementation of current_intake doesn't work
-      def current_intake
-        GlobalID.find(session[:state_file_intake])
-      end
     end
   end
 end

--- a/app/controllers/state_file/questions/return_status_controller.rb
+++ b/app/controllers/state_file/questions/return_status_controller.rb
@@ -1,6 +1,8 @@
 module StateFile
   module Questions
     class ReturnStatusController < AuthenticatedQuestionsController
+      before_action :redirect_if_from_efile
+      before_action :redirect_if_no_submission
 
       def edit
         @title = title
@@ -116,6 +118,21 @@ module StateFile
       private
 
       def card_postscript; end
+
+      def redirect_if_no_submission
+        if current_intake.efile_submissions.empty?
+          redirect_to StateFile::Questions::InitiateDataTransferController.to_path_helper(us_state: state_code)
+        end
+      end
+
+      def redirect_if_from_efile
+        # We had a situation where we gave the wrong URL to direct file, and they were redirecting
+        # here when the federal return was not yet approved.
+        # We have alerted them, and once they have updated their URL we can probably remove this
+        if params[:ref_location] == "df_authorize_state"
+          redirect_to state_file_questions_pending_federal_return_path
+        end
+      end
 
     end
   end

--- a/app/controllers/state_file/questions/return_status_controller.rb
+++ b/app/controllers/state_file/questions/return_status_controller.rb
@@ -130,7 +130,7 @@ module StateFile
         # here when the federal return was not yet approved.
         # We have alerted them, and once they have updated their URL we can probably remove this
         if params[:ref_location] == "df_authorize_state"
-          redirect_to state_file_questions_pending_federal_return_path
+          redirect_to StateFile::Questions::PendingFederalReturnController.to_path_helper(us_state: current_intake.state_code)
         end
       end
 

--- a/app/views/state_file/state_file_pages/fake_direct_file_transfer_page.html.erb
+++ b/app/views/state_file/state_file_pages/fake_direct_file_transfer_page.html.erb
@@ -36,7 +36,7 @@
   <%=
     link_to(
       "Cancel",
-      state_file_questions_canceled_data_transfer_path,
+      StateFile::Questions::CanceledDataTransferController.to_path_helper(us_state: current_intake.state_code),
       class: 'cancel-button'
     )
   %>
@@ -44,7 +44,7 @@
   <%=
     link_to(
       "See page for pending federal return",
-      state_file_questions_pending_federal_return_path
+      StateFile::Questions::PendingFederalReturnController.to_path_helper(us_state: current_intake.state_code),
     )
   %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -549,8 +549,6 @@ Rails.application.routes.draw do
         namespace :questions do
           get "show_xml", to: "confirmation#show_xml"
           get "explain_calculations", to: "confirmation#explain_calculations"
-          get "pending_federal_return", to: "pending_federal_return#edit"
-          get "canceled_data_transfer", to: "canceled_data_transfer#edit"
         end
       end
 
@@ -569,6 +567,8 @@ Rails.application.routes.draw do
         get "login-options", to: "state_file/state_file_pages#login_options"
         get "/faq", to: "state_file/faq#index", as: :state_faq
         get "/faq/:section_key", to: "state_file/faq#show", as: :state_faq_section
+
+        match("/questions/pending-federal-return", action: :edit, controller: "state_file/questions/pending_federal_return", via: :get)
       end
 
       scope ':us_state', as: 'az', constraints: { us_state: :az } do


### PR DESCRIPTION
This PR should:
* Fix the issue where an intake can be broken by hitting the wrong url.
* Fix the broken `/pending-federal-return` page
* Make the `/pending-federal-return` and `/canceled-data-transfer` state specific matching what we actually sent to directfile:
* Add a temporary redirect so that if direct file don't update their URL, users still get the correct message
![image](https://github.com/codeforamerica/vita-min/assets/17094895/d2a00c26-199d-4891-8b7d-7dfadf3f5d61)


You can test these by going to:
* `/en/ny/questions/pending-federal-return`
* `/en/ny/questions/canceled-data-transfer`
