### PR TITLE
Updated truncation #187105238

### DIFF
--- a/app/lib/submission_builder/ty2022/states/ny/individual_return.rb
+++ b/app/lib/submission_builder/ty2022/states/ny/individual_return.rb
@@ -63,7 +63,7 @@ module SubmissionBuilder
                 xml.PERM_ZIP_ADR @submission.data_source.permanent_zip if @submission.data_source.permanent_zip.present?
                 xml.SCHOOL_CD @submission.data_source.school_district_number if @submission.data_source.school_district_number.present?
                 xml.SCHOOL_NAME @submission.data_source.school_district&.truncate(30) if @submission.data_source.school_district.present?
-                xml.PR_EMP_DESC @submission.data_source.direct_file_data.primary_occupation.truncate(25) if @submission.data_source.direct_file_data.primary_occupation.present?
+                xml.PR_EMP_DESC @submission.data_source.direct_file_data.primary_occupation[0..24] if @submission.data_source.direct_file_data.primary_occupation.present?
                 # We omit country name because we don't support out of country filers
                 #xml.COUNTRY_NAME @submission.data_source.mailing_country
               end
@@ -74,7 +74,7 @@ module SubmissionBuilder
                   xml.MI_NAME @submission.data_source.spouse.middle_initial if @submission.data_source.spouse.middle_initial.present?
                   xml.LAST_NAME @submission.data_source.spouse.last_name if @submission.data_source.spouse.last_name.present?
                   xml.SP_SSN_NMBR @submission.data_source.spouse.ssn if @submission.data_source.spouse.ssn.present?
-                  xml.SP_EMP_DESC @submission.data_source.direct_file_data.spouse_occupation.truncate(25) if @submission.data_source.direct_file_data.spouse_occupation.present?
+                  xml.SP_EMP_DESC @submission.data_source.direct_file_data.spouse_occupation[0..24] if @submission.data_source.direct_file_data.spouse_occupation.present?
                 end
               elsif @submission.data_source.filing_status_mfs?
                 xml.tiSpouse do

--- a/app/lib/submission_builder/ty2022/states/ny/individual_return.rb
+++ b/app/lib/submission_builder/ty2022/states/ny/individual_return.rb
@@ -63,7 +63,7 @@ module SubmissionBuilder
                 xml.PERM_ZIP_ADR @submission.data_source.permanent_zip if @submission.data_source.permanent_zip.present?
                 xml.SCHOOL_CD @submission.data_source.school_district_number if @submission.data_source.school_district_number.present?
                 xml.SCHOOL_NAME @submission.data_source.school_district&.truncate(30) if @submission.data_source.school_district.present?
-                xml.PR_EMP_DESC @submission.data_source.direct_file_data.primary_occupation[0..25] if @submission.data_source.direct_file_data.primary_occupation.present?
+                xml.PR_EMP_DESC @submission.data_source.direct_file_data.primary_occupation.truncate(25) if @submission.data_source.direct_file_data.primary_occupation.present?
                 # We omit country name because we don't support out of country filers
                 #xml.COUNTRY_NAME @submission.data_source.mailing_country
               end
@@ -74,7 +74,7 @@ module SubmissionBuilder
                   xml.MI_NAME @submission.data_source.spouse.middle_initial if @submission.data_source.spouse.middle_initial.present?
                   xml.LAST_NAME @submission.data_source.spouse.last_name if @submission.data_source.spouse.last_name.present?
                   xml.SP_SSN_NMBR @submission.data_source.spouse.ssn if @submission.data_source.spouse.ssn.present?
-                  xml.SP_EMP_DESC @submission.data_source.direct_file_data.spouse_occupation[0..25] if @submission.data_source.direct_file_data.spouse_occupation.present?
+                  xml.SP_EMP_DESC @submission.data_source.direct_file_data.spouse_occupation.truncate(25) if @submission.data_source.direct_file_data.spouse_occupation.present?
                 end
               elsif @submission.data_source.filing_status_mfs?
                 xml.tiSpouse do

--- a/app/lib/submission_builder/ty2022/states/ny/individual_return.rb
+++ b/app/lib/submission_builder/ty2022/states/ny/individual_return.rb
@@ -63,7 +63,7 @@ module SubmissionBuilder
                 xml.PERM_ZIP_ADR @submission.data_source.permanent_zip if @submission.data_source.permanent_zip.present?
                 xml.SCHOOL_CD @submission.data_source.school_district_number if @submission.data_source.school_district_number.present?
                 xml.SCHOOL_NAME @submission.data_source.school_district&.truncate(30) if @submission.data_source.school_district.present?
-                xml.PR_EMP_DESC @submission.data_source.direct_file_data.primary_occupation[0..24] if @submission.data_source.direct_file_data.primary_occupation.present?
+                xml.PR_EMP_DESC @submission.data_source.direct_file_data.primary_occupation.truncate(25) if @submission.data_source.direct_file_data.primary_occupation.present?
                 # We omit country name because we don't support out of country filers
                 #xml.COUNTRY_NAME @submission.data_source.mailing_country
               end
@@ -74,7 +74,7 @@ module SubmissionBuilder
                   xml.MI_NAME @submission.data_source.spouse.middle_initial if @submission.data_source.spouse.middle_initial.present?
                   xml.LAST_NAME @submission.data_source.spouse.last_name if @submission.data_source.spouse.last_name.present?
                   xml.SP_SSN_NMBR @submission.data_source.spouse.ssn if @submission.data_source.spouse.ssn.present?
-                  xml.SP_EMP_DESC @submission.data_source.direct_file_data.spouse_occupation[0..24] if @submission.data_source.direct_file_data.spouse_occupation.present?
+                  xml.SP_EMP_DESC @submission.data_source.direct_file_data.spouse_occupation.truncate(25) if @submission.data_source.direct_file_data.spouse_occupation.present?
                 end
               elsif @submission.data_source.filing_status_mfs?
                 xml.tiSpouse do

--- a/spec/lib/submission_builder/ty2022/states/ny/individual_return_spec.rb
+++ b/spec/lib/submission_builder/ty2022/states/ny/individual_return_spec.rb
@@ -56,8 +56,8 @@ describe SubmissionBuilder::Ty2022::States::Ny::IndividualReturn do
         intake.direct_file_data.spouse_occupation = "Manufacturer of artisan lightbulbs"
 
         xml = described_class.build(submission).document
-        expect(xml.at("PR_EMP_DESC").text).to eq("Professional Juggler a...")
-        expect(xml.at("tiSpouse SP_EMP_DESC").text).to eq("Manufacturer of artisa...")
+        expect(xml.at("PR_EMP_DESC").text).to eq("Professional Juggler and ")
+        expect(xml.at("tiSpouse SP_EMP_DESC").text).to eq("Manufacturer of artisan l")
       end
     end
 

--- a/spec/lib/submission_builder/ty2022/states/ny/individual_return_spec.rb
+++ b/spec/lib/submission_builder/ty2022/states/ny/individual_return_spec.rb
@@ -56,8 +56,8 @@ describe SubmissionBuilder::Ty2022::States::Ny::IndividualReturn do
         intake.direct_file_data.spouse_occupation = "Manufacturer of artisan lightbulbs"
 
         xml = described_class.build(submission).document
-        expect(xml.at("PR_EMP_DESC").text).to eq("Professional Juggler and u")
-        expect(xml.at("tiSpouse SP_EMP_DESC").text).to eq("Manufacturer of artisan li")
+        expect(xml.at("PR_EMP_DESC").text).to eq("Professional Juggler and ")
+        expect(xml.at("tiSpouse SP_EMP_DESC").text).to eq("Manufacturer of artisan l")
       end
     end
 

--- a/spec/lib/submission_builder/ty2022/states/ny/individual_return_spec.rb
+++ b/spec/lib/submission_builder/ty2022/states/ny/individual_return_spec.rb
@@ -56,8 +56,8 @@ describe SubmissionBuilder::Ty2022::States::Ny::IndividualReturn do
         intake.direct_file_data.spouse_occupation = "Manufacturer of artisan lightbulbs"
 
         xml = described_class.build(submission).document
-        expect(xml.at("PR_EMP_DESC").text).to eq("Professional Juggler and ")
-        expect(xml.at("tiSpouse SP_EMP_DESC").text).to eq("Manufacturer of artisan l")
+        expect(xml.at("PR_EMP_DESC").text).to eq("Professional Juggler a...")
+        expect(xml.at("tiSpouse SP_EMP_DESC").text).to eq("Manufacturer of artisa...")
       end
     end
 


### PR DESCRIPTION
So it turns out that truncation in ruby when using [x..y] is by inclusive (Unlike python / java /javascript substring / slice methods which are exclusive on the end index). Funnily enough, I saw the other parts of the code using `truncate` when writing this and thought about matching for a moment before saying to myself "Nah - this is shorter".

I guess this is a lesson for me in sticking to what is already there.