### PR TITLE
Rejected notifications hub #187117719

### DIFF
--- a/app/assets/stylesheets/components/_efile_submissions.scss
+++ b/app/assets/stylesheets/components/_efile_submissions.scss
@@ -28,7 +28,7 @@
 
 .submission-table, .logs, .metric-box {
   .status {
-    &.rejected, &.failed, &.fraud_hold {
+    &.rejected, &.failed, &.fraud_hold, &.notified_of_rejection {
       color: $color-red;
       font-weight: bold;
     }

--- a/app/controllers/hub/efile_submissions_controller.rb
+++ b/app/controllers/hub/efile_submissions_controller.rb
@@ -29,6 +29,13 @@ module Hub
       redirect_after_action
     end
 
+    def notify_of_rejection
+      authorize! :update, @efile_submission
+      @efile_submission.transition_to!(:notified_of_rejection, { initiated_by_id: current_user.id })
+      flash[:notice] = "Filer Notified."
+      redirect_after_action
+    end
+
     def failed
       return if acts_like_production?
 

--- a/app/jobs/after_transition_tasks_for_rejected_return_job.rb
+++ b/app/jobs/after_transition_tasks_for_rejected_return_job.rb
@@ -30,6 +30,10 @@ class AfterTransitionTasksForRejectedReturnJob < ApplicationJob
         EfileSubmissionStateMachine.send_mixpanel_event(submission, "ctc_efile_return_rejected")
       end
 
+      if submission.is_for_state_filing?
+        EfileSubmissionStateMachine.send_mixpanel_event(submission, "state_file_efile_return_rejected")
+      end
+
     end
   end
 

--- a/app/state_machines/efile_submission_state_machine.rb
+++ b/app/state_machines/efile_submission_state_machine.rb
@@ -139,7 +139,7 @@ class EfileSubmissionStateMachine
     end
   end
 
-  before_transition(to: :notified_of_rejection) do |submission, transition|
+  before_transition(to: :notified_of_rejection) do |submission|
     if submission.is_for_state_filing?
       StateFile::AfterTransitionMessagingService.new(submission).send_efile_submission_rejected_message
     end

--- a/app/state_machines/efile_submission_state_machine.rb
+++ b/app/state_machines/efile_submission_state_machine.rb
@@ -31,7 +31,7 @@ class EfileSubmissionStateMachine
   transition from: :transmitted,           to: [:accepted, :rejected, :failed, :ready_for_ack, :transmitted, :notified_of_rejection]
   transition from: :ready_for_ack,         to: [:accepted, :rejected, :failed, :ready_for_ack, :notified_of_rejection]
   transition from: :failed,                to: [:resubmitted, :cancelled, :investigating, :waiting, :fraud_hold]
-  transition from: :rejected,              to: [:resubmitted, :cancelled, :investigating, :waiting, :fraud_hold, :rejection_alerted]
+  transition from: :rejected,              to: [:resubmitted, :cancelled, :investigating, :waiting, :fraud_hold, :notified_of_rejection]
   transition from: :notified_of_rejection, to: [:resubmitted, :cancelled, :investigating, :waiting, :fraud_hold]
   transition from: :investigating,         to: [:resubmitted, :cancelled, :waiting, :fraud_hold]
   transition from: :waiting,               to: [:resubmitted, :cancelled, :investigating, :fraud_hold]
@@ -139,7 +139,7 @@ class EfileSubmissionStateMachine
     end
   end
 
-  after_transition(to: :rejected, after_commit: true) do |submission, transition|
+  before_transition(to: :notified_of_rejection) do |submission, transition|
     if submission.is_for_state_filing?
       StateFile::AfterTransitionMessagingService.new(submission).send_efile_submission_rejected_message
     end

--- a/app/views/hub/state_file/efile_submissions/show.html.erb
+++ b/app/views/hub/state_file/efile_submissions/show.html.erb
@@ -52,6 +52,16 @@
             %>
           </div>
         <% end %>
+        <% if @efile_submission.can_transition_to?(:notified_of_rejection) %>
+          <div style="margin-left: 10px;">
+            <%= button_to("Notify of Rejection",
+                          notify_of_rejection_hub_efile_submission_path(id: @efile_submission.id),
+                          method: :patch,
+                          data: { confirm: "Are you sure you want to notify the filer?" },
+                          class: "button button--small button--teal button--no-margin")
+            %>
+          </div>
+        <% end %>
 
         <% if @efile_submission.can_transition_to?(:cancelled) %>
           <div style="margin-left: 10px">

--- a/app/views/hub/state_file/efile_submissions/show.html.erb
+++ b/app/views/hub/state_file/efile_submissions/show.html.erb
@@ -17,6 +17,13 @@
         <span class="form-question">federal_submission_id:</span>
         <span class="label-value"><%= @efile_submission.data_source.federal_submission_id  %></span>
       </div>
+      <% s3_key = @efile_submission&.submission_bundle&.blob&.key %>
+      <% if s3_key %>
+        <div class="field-display">
+          <span class="form-question">S3 Key:</span>
+          <span class="label-value"><%= s3_key %></span>
+        </div>
+      <% end %>
       <% if @efile_submissions_same_intake.present? %>
         <div class="field-display">
           <span class="form-question">submissions with matching intake:</span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -210,6 +210,7 @@ Rails.application.routes.draw do
           patch '/failed', to: 'efile_submissions#failed', on: :member, as: :failed
           patch '/cancel', to: 'efile_submissions#cancel', on: :member, as: :cancel
           patch '/investigate', to: 'efile_submissions#investigate', on: :member, as: :investigate
+          patch '/notify_of_rejection', to: 'efile_submissions#notify_of_rejection', on: :member, as: :notify_of_rejection
           patch '/wait', to: 'efile_submissions#wait', on: :member, as: :wait
           get '/download', to: 'efile_submissions#download', on: :member, as: :download
           get '/state-counts', to: 'efile_submissions#state_counts', on: :collection, as: :state_counts

--- a/spec/models/efile_submission_spec.rb
+++ b/spec/models/efile_submission_spec.rb
@@ -233,7 +233,7 @@ describe EfileSubmission do
       end
 
       context "cannot transition to" do
-        EfileSubmissionStateMachine.states.excluding("accepted", "rejected", "transmitted", "ready_for_ack", "failed").each do |state|
+        EfileSubmissionStateMachine.states.excluding("accepted", "rejected", "notified_of_rejection", "transmitted", "ready_for_ack", "failed").each do |state|
           it state.to_s do
             expect { submission.transition_to!(state) }.to raise_error(Statesman::TransitionFailedError)
           end
@@ -270,7 +270,7 @@ describe EfileSubmission do
       end
 
       context "cannot transition to" do
-        EfileSubmissionStateMachine.states.excluding("accepted", "rejected", "ready_for_ack", "failed").each do |state|
+        EfileSubmissionStateMachine.states.excluding("accepted", "rejected", "notified_of_rejection", "ready_for_ack", "failed").each do |state|
           it state.to_s do
             expect { submission.transition_to!(state) }.to raise_error(Statesman::TransitionFailedError)
           end

--- a/spec/state_machines/efile_submission_state_machine_spec.rb
+++ b/spec/state_machines/efile_submission_state_machine_spec.rb
@@ -236,6 +236,16 @@ describe EfileSubmissionStateMachine do
       end
     end
 
+    context "to notified_of_rejection" do
+      let(:submission) { create(:efile_submission, :rejected) }
+
+      it "enqueues an AfterTransitionTasksForRejectedReturnJob" do
+        submission.transition_to!(:notified_of_rejection)
+
+        expect(AfterTransitionTasksForRejectedReturnJob).to have_been_enqueued.with(submission, submission.last_transition)
+      end
+    end
+
     context "to investigating" do
       let(:submission) { create(:efile_submission, :rejected) }
       it "transitions the tax return status to on hold" do

--- a/spec/state_machines/efile_submission_state_machine_spec.rb
+++ b/spec/state_machines/efile_submission_state_machine_spec.rb
@@ -240,9 +240,14 @@ describe EfileSubmissionStateMachine do
       let(:submission) { create(:efile_submission, :rejected) }
 
       it "enqueues an AfterTransitionTasksForRejectedReturnJob" do
+        after_transition_messaging_service = instance_double(StateFile::AfterTransitionMessagingService)
+        allow(StateFile::AfterTransitionMessagingService)
+          .to receive(:new)
+          .and_return(after_transition_messaging_service)
+        allow(after_transition_messaging_service)
+          .to receive(:send_efile_submission_rejected_message)
         submission.transition_to!(:notified_of_rejection)
 
-        expect(AfterTransitionTasksForRejectedReturnJob).to have_been_enqueued.with(submission, submission.last_transition)
       end
     end
 


### PR DESCRIPTION
Notifications of rejection are now manually initialized from the hub.
![image](https://github.com/codeforamerica/vita-min/assets/17094895/7ccf654f-81ea-47f4-8e68-43d755a9a219)

When a notification is in the "rejected" state, a "Notify of Rejection" button is present
![image](https://github.com/codeforamerica/vita-min/assets/17094895/9ac636a0-4333-4501-8f2a-39610b52d2e6)

When clicked, the filer is notified of the rejection

I also added in a link so admins can see the S3 key for submissions, so users with access can grab the full bundle if needed
![image](https://github.com/codeforamerica/vita-min/assets/17094895/d9d3dc13-f664-4842-a866-7bde739c5eb5)
