### PR TITLE
Removing this error from sentry, but still logging in datadog

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -6,7 +6,6 @@ module ApplicationCable
     def connect; end
 
     def current_user
-      raise UnauthorizedError
       @current_user ||= env['warden'].user
     rescue UncaughtThrowError => e
       raise unless e.tag == :warden

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,10 +1,12 @@
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
     identified_by :current_user, :current_state_file_intake
+    rescue_from StandardError, with: :report_error
 
     def connect; end
 
     def current_user
+      raise UnauthorizedError
       @current_user ||= env['warden'].user
     rescue UncaughtThrowError => e
       raise unless e.tag == :warden
@@ -23,6 +25,10 @@ module ApplicationCable
       # 'uncaught throw :warden' is fired in certain circumstances, this here is to silence it
       DatadogApi.increment "application_cable.uncaught_throw_warden_error"
       reject_unauthorized_connection
+    end
+
+    def report_error(e)
+      Rails.logger.error ([e.message]+e.backtrace).join($/)
     end
   end
 end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -28,7 +28,7 @@ module ApplicationCable
     end
 
     def report_error(e)
-      Rails.logger.error ([e.message]+e.backtrace).join($/)
+      Rails.logger.warn ([e.message]+e.backtrace).join($/)
     end
   end
 end


### PR DESCRIPTION
This one has been annoying me, so I figured I'd do something about it:

On this page we create a websocket connection for live updates:
![image](https://github.com/codeforamerica/vita-min/assets/17094895/cef79311-04ec-4528-8766-b7806c25c5f1)

Every time a bot hits the websocked endpoint (`/cable`) with no session cookie, we get an error in sentry. I have turned this into a logged warning in datadog instead.
