### PR TITLE
Filter logic fix #187136591

### DIFF
--- a/app/assets/stylesheets/_state-file.scss
+++ b/app/assets/stylesheets/_state-file.scss
@@ -557,13 +557,6 @@
     text-decoration: none;
   }
 
-  .ny-w2-locality-nm .select {
-    width: 400px;
-
-    select {
-      width: 100%;
-    }
-  }
 }
 
 $state-colors: (

--- a/app/controllers/state_file/questions/ny_w2_controller.rb
+++ b/app/controllers/state_file/questions/ny_w2_controller.rb
@@ -52,10 +52,12 @@ module StateFile
       end
 
       def self.w2s_for_intake(intake)
-        self.invalid_w2s(intake).each_with_index.map do |_, i|
-          existing_record = intake.state_file_w2s.find { |intake_w2| intake_w2.w2_index == i }
-          existing_record.present? ? existing_record : StateFileW2.new(state_file_intake: intake, w2_index: i)
-        end
+        (intake.direct_file_data.w2s.each_with_index.map do |w2, index|
+          if invalid_w2?(intake, w2)
+            existing_record = intake.state_file_w2s.find { |intake_w2| intake_w2.w2_index == index }
+            existing_record.present? ? existing_record : StateFileW2.new(state_file_intake: intake, w2_index: index)
+          end
+        end).compact
       end
 
       def self.invalid_w2s(intake)

--- a/app/controllers/state_file/questions/ny_w2_controller.rb
+++ b/app/controllers/state_file/questions/ny_w2_controller.rb
@@ -75,7 +75,7 @@ module StateFile
         return true if w2.LocalIncomeTaxAmt != 0 && w2.LocalWagesAndTipsAmt == 0
         return true if w2.StateIncomeTaxAmt != 0 && w2.StateWagesAmt == 0
         return true if w2.StateWagesAmt != 0 && w2.EmployerStateIdNum.blank?
-        return true if w2.LocalityNm.present? && !StateFileNyIntake::LOCALITIES.include?(w2.LocalityNm)
+        return true if w2.LocalityNm.present? && !StateFileNyIntake.locality_nm_valid?(w2.LocalityNm)
 
         false
       end

--- a/app/helpers/df_xml_crud_methods.rb
+++ b/app/helpers/df_xml_crud_methods.rb
@@ -44,4 +44,20 @@ module DfXmlCrudMethods
   def to_pretty_s
     Nokogiri::XML(node.to_s, &:noblanks).to_xhtml(indent: 2)
   end
+
+  def delete_blank_nodes(node)
+    return unless [1, 9].include?(node.node_type) # <nodesWithChildren></nodesWithChildren>
+    node.children.to_a.each do |child|
+      delete_blank_nodes(child)
+    end
+    content = node.inner_html.strip
+    if content == "" || content == "0"
+      node.remove
+      return
+    end
+    node.inner_html = content
+    if node.children.empty?
+      node.remove
+    end
+  end
 end

--- a/app/models/state_file_base_intake.rb
+++ b/app/models/state_file_base_intake.rb
@@ -131,6 +131,10 @@ class StateFileBaseIntake < ApplicationRecord
     direct_file_data.spouse_deceased?
   end
 
+  def self.locality_nm_valid?(locality)
+    true
+  end
+
   class Person
     attr_reader :first_name
     attr_reader :middle_initial

--- a/app/models/state_file_ny_intake.rb
+++ b/app/models/state_file_ny_intake.rb
@@ -127,7 +127,8 @@ class StateFileNyIntake < StateFileBaseIntake
     "CITY OFNY",
     "CITYOFN Y",
     "CTY OF NY",
-    "MANHATTAN"
+    "MANHATTAN",
+    "NEW YORK CIT",
   ].freeze
 
   encrypts :account_number, :routing_number, :raw_direct_file_data
@@ -257,6 +258,12 @@ class StateFileNyIntake < StateFileBaseIntake
       nyc_residency: "part_year",
       nyc_maintained_home: "yes"
     }
+  end
+
+  def self.locality_nm_valid?(locality)
+    (LOCALITIES.detect do |loc|
+      locality.starts_with?(loc)
+    end).present?
   end
 
   private

--- a/app/models/state_file_ny_intake.rb
+++ b/app/models/state_file_ny_intake.rb
@@ -108,9 +108,7 @@ class StateFileNyIntake < StateFileBaseIntake
     STATE_CODE => STATE_NAME
   }.freeze
   LOCALITIES = [
-    "NEW YORK CITY",
     "NY",
-    "NYC",
     "N Y",
     "NWY",
     "NW Y",

--- a/app/models/state_file_w2.rb
+++ b/app/models/state_file_w2.rb
@@ -50,10 +50,10 @@ class StateFileW2 < ApplicationRecord
     if local_income_tax_amt.present? && local_income_tax_amt.positive? && local_wages_and_tips_amt <= 0
       errors.add(:local_income_tax_amt, I18n.t("state_file.questions.ny_w2.edit.local_wages_and_tips_amt_error"))
     end
-    if state_wages_amt.present? && state_income_tax_amt > state_wages_amt
+    if state_income_tax_amt > state_wages_amt
       errors.add(:state_income_tax_amt, I18n.t("state_file.questions.ny_w2.edit.state_income_tax_amt_error"))
     end
-    if local_wages_and_tips_amt.present? && local_income_tax_amt > local_wages_and_tips_amt
+    if local_income_tax_amt > local_wages_and_tips_amt
       errors.add(:local_income_tax_amt, I18n.t("state_file.questions.ny_w2.edit.local_income_tax_amt_error"))
     end
   end

--- a/app/models/state_file_w2.rb
+++ b/app/models/state_file_w2.rb
@@ -26,19 +26,35 @@ class StateFileW2 < ApplicationRecord
 
   validates :employer_state_id_num, format: { with: /\A(\d{0,17})\z/ }
   validates :state_wages_amt, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, if: -> { state_wages_amt.present? }
-  validates :state_income_tax_amt, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, if: -> { state_wages_amt.present? }
-  validates :local_wages_and_tips_amt, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, if: -> { state_wages_amt.present? }
-  validates :local_income_tax_amt, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, if: -> { state_wages_amt.present? }
+  validates :state_income_tax_amt, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, if: -> { state_income_tax_amt.present? }
+  validates :local_wages_and_tips_amt, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, if: -> { local_wages_and_tips_amt.present? }
+  validates :local_income_tax_amt, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, if: -> { local_income_tax_amt.present? }
   validates :locality_nm, presence: true, if: -> { local_wages_and_tips_amt.present? && local_wages_and_tips_amt.positive? }
-  validates :local_wages_and_tips_amt, numericality: { only_integer: true, greater_than_or_equal_to: 1 }, if: -> { local_income_tax_amt.present? && local_income_tax_amt.positive? }
-  validates :state_wages_amt, numericality: { only_integer: true, greater_than_or_equal_to: 1 }, if: -> { state_income_tax_amt.present? && state_income_tax_amt.positive? }
   validates :employer_state_id_num, presence: true, if: -> { state_wages_amt.present? && state_wages_amt.positive? }
+  validates :locality_nm, format: { with: /\A[a-zA-Z]{1}([A-Za-z\-\s']{0,137})\z/ }, if: -> { locality_nm.present? }
+  validate :validate_tax_amts
   validate :locality_nm_validation
   before_validation :locality_nm_to_upper_case
 
   def locality_nm_validation
+    return unless locality_nm.present?
     unless state_file_intake_type.constantize.locality_nm_valid?(locality_nm)
       errors.add(:locality_nm, I18n.t("state_file.questions.ny_w2.edit.locality_nm_error"))
+    end
+  end
+
+  def validate_tax_amts
+    if state_income_tax_amt.present? && state_income_tax_amt.positive? && state_wages_amt <= 0
+      errors.add(:state_income_tax_amt, I18n.t("state_file.questions.ny_w2.edit.state_wages_amt_error"))
+    end
+    if local_income_tax_amt.present? && local_income_tax_amt.positive? && local_wages_and_tips_amt <= 0
+      errors.add(:local_income_tax_amt, I18n.t("state_file.questions.ny_w2.edit.local_wages_and_tips_amt_error"))
+    end
+    if state_income_tax_amt > state_wages_amt
+      errors.add(:state_income_tax_amt, I18n.t("state_file.questions.ny_w2.edit.state_income_tax_amt_error"))
+    end
+    if local_income_tax_amt > local_wages_and_tips_amt
+      errors.add(:local_income_tax_amt, I18n.t("state_file.questions.ny_w2.edit.local_income_tax_amt_error"))
     end
   end
 

--- a/app/models/state_file_w2.rb
+++ b/app/models/state_file_w2.rb
@@ -50,10 +50,10 @@ class StateFileW2 < ApplicationRecord
     if local_income_tax_amt.present? && local_income_tax_amt.positive? && local_wages_and_tips_amt <= 0
       errors.add(:local_income_tax_amt, I18n.t("state_file.questions.ny_w2.edit.local_wages_and_tips_amt_error"))
     end
-    if state_income_tax_amt > state_wages_amt
+    if state_wages_amt.present? && state_income_tax_amt > state_wages_amt
       errors.add(:state_income_tax_amt, I18n.t("state_file.questions.ny_w2.edit.state_income_tax_amt_error"))
     end
-    if local_income_tax_amt > local_wages_and_tips_amt
+    if local_wages_and_tips_amt.present? && local_income_tax_amt > local_wages_and_tips_amt
       errors.add(:local_income_tax_amt, I18n.t("state_file.questions.ny_w2.edit.local_income_tax_amt_error"))
     end
   end

--- a/app/models/state_file_w2.rb
+++ b/app/models/state_file_w2.rb
@@ -25,13 +25,27 @@ class StateFileW2 < ApplicationRecord
   validates :w2_index, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
   validates :employer_state_id_num, format: { with: /\A(\d{0,17})\z/ }
-  validates :state_wages_amt, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
-  validates :state_income_tax_amt, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
-  validates :local_wages_and_tips_amt, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
-  validates :local_income_tax_amt, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :state_wages_amt, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, if: -> { state_wages_amt.present? }
+  validates :state_income_tax_amt, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, if: -> { state_wages_amt.present? }
+  validates :local_wages_and_tips_amt, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, if: -> { state_wages_amt.present? }
+  validates :local_income_tax_amt, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, if: -> { state_wages_amt.present? }
   validates :locality_nm, presence: true, if: -> { local_wages_and_tips_amt.present? && local_wages_and_tips_amt.positive? }
   validates :local_wages_and_tips_amt, numericality: { only_integer: true, greater_than_or_equal_to: 1 }, if: -> { local_income_tax_amt.present? && local_income_tax_amt.positive? }
   validates :state_wages_amt, numericality: { only_integer: true, greater_than_or_equal_to: 1 }, if: -> { state_income_tax_amt.present? && state_income_tax_amt.positive? }
   validates :employer_state_id_num, presence: true, if: -> { state_wages_amt.present? && state_wages_amt.positive? }
+  validate :locality_nm_validation
+  before_validation :locality_nm_to_upper_case
+
+  def locality_nm_validation
+    unless state_file_intake_type.constantize.locality_nm_valid?(locality_nm)
+      errors.add(:locality_nm, I18n.t("state_file.questions.ny_w2.edit.locality_nm_error"))
+    end
+  end
+
+  def locality_nm_to_upper_case
+    if locality_nm.present?
+      self.locality_nm = locality_nm.upcase
+    end
+  end
 
 end

--- a/app/models/state_file_w2.rb
+++ b/app/models/state_file_w2.rb
@@ -29,7 +29,7 @@ class StateFileW2 < ApplicationRecord
   validates :state_income_tax_amt, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, if: -> { state_income_tax_amt.present? }
   validates :local_wages_and_tips_amt, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, if: -> { local_wages_and_tips_amt.present? }
   validates :local_income_tax_amt, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, if: -> { local_income_tax_amt.present? }
-  validates :locality_nm, presence: true, if: -> { local_wages_and_tips_amt.present? && local_wages_and_tips_amt.positive? }
+  validates :locality_nm, presence: { message: -> (_object, _data) { I18n.t('state_file.questions.ny_w2.edit.locality_nm_missing_error') } }, if: -> { local_wages_and_tips_amt.present? && local_wages_and_tips_amt.positive? }
   validates :employer_state_id_num, presence: true, if: -> { state_wages_amt.present? && state_wages_amt.positive? }
   validates :locality_nm, format: { with: /\A[a-zA-Z]{1}([A-Za-z\-\s']{0,137})\z/ }, if: -> { locality_nm.present? }
   validate :validate_tax_amts

--- a/app/views/state_file/questions/ny_w2/edit.html.erb
+++ b/app/views/state_file/questions/ny_w2/edit.html.erb
@@ -23,7 +23,7 @@
         <%= f.cfa_input_field(:local_income_tax_amt, t(".box19_html"), classes: ["form-width--long"]) %>
       </div>
       <div class="form-question spacing-below-25 ny-w2-locality-nm">
-        <%= f.cfa_select(:locality_nm, t(".box20_locality_name"), StateFileNyIntake::LOCALITIES, include_blank: true) %>
+        <%= f.cfa_input_field(:locality_nm, t(".box20_locality_name"), classes: ["form-width--long"]) %>
       </div>
       <button class="button button--primary button--wide" type="submit">
         <%= t("general.continue") %>

--- a/app/views/state_file/questions/ny_w2/edit.html.erb
+++ b/app/views/state_file/questions/ny_w2/edit.html.erb
@@ -3,8 +3,9 @@
   <h2 class="form-question"><%= t(".instructions_2") %></h2>
   <%= form_with model: @w2, url: { action: :update }, method: :patch, local: true, builder: VitaMinFormBuilder, html: { class: 'form-card form-card--long' } do |f| %>
     <div class="blue-group">
-      <div class="form-question spacing-below-15">
-        <div class="text--bold"><%=t("general.state") %></div>
+      <div class="form-question spacing-below-25">
+        <div class="text--bold spacing-below-15"><%=t("general.state") %></div>
+        <div><%=current_intake.state_name %></div>
       </div>
       <div class="form-question spacing-below-25">
         <%= f.cfa_input_field(:employer_state_id_num, t(".box15_html"), classes: ["form-width--long"]) %>

--- a/app/views/state_file/questions/ny_w2/index.html.erb
+++ b/app/views/state_file/questions/ny_w2/index.html.erb
@@ -31,5 +31,9 @@
     <button class="button button--primary button--disabled button--wide text--centered" disabled>
       <%= t("general.continue") %>
     </button>
+    <span class="text--error" id="state_file_w2_local_income_tax_amt__errors">
+      <i class="icon-warning"></i>
+      <%= I18n.t("state_file.questions.ny_w2.edit.w2s_error") %>
+    </span>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2351,9 +2351,9 @@ en:
           instructions_2: If any of these boxes are blank on your W-2, leave them blank here.
           locality_nm_error: "Please type in “NYC” if the locality name on your W-2 is New York City or any of the five boroughs."
           locality_nm_missing_error: Please select locality name
-          local_income_tax_amt_error: Please enter local wages and tips
+          local_income_tax_amt_error: Cannot be greater than local wages and tips.
           local_wages_and_tips_amt_error: Please enter local wages and tips
-          state_income_tax_amt_error: Please enter state wages and tips
+          state_income_tax_amt_error: Cannot be greater than State wages and tips.
           state_wages_amt_error: Please enter State wages and tips
           w2s_error: Please update all of the W-2s listed above to continue.
         index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2350,10 +2350,12 @@ en:
           instructions_1: We need a little more information about the state and local tax information on your W-2 from %{employer_name} for %{total_wages_amt}.
           instructions_2: If any of these boxes are blank on your W-2, leave them blank here.
           locality_nm_error: "Please type in “NYC” if the locality name on your W-2 is New York City or any of the five boroughs."
+          locality_nm_missing_error: Please select locality name
           local_income_tax_amt_error: Please enter local wages and tips
           local_wages_and_tips_amt_error: Please enter local wages and tips
           state_income_tax_amt_error: Please enter state wages and tips
           state_wages_amt_error: Please enter State wages and tips
+          w2s_error: Please update all of the W-2s listed above to continue.
         index:
           title: Please provide state tax information for the following W-2s. Do not worry if you have multiple W-2s and not all of them are listed below.
           updated: You've updated this W-2

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2349,6 +2349,7 @@ en:
           box20_locality_name: "<strong>Box 20</strong>: Locality name"
           instructions_1: We need a little more information about the state and local tax information on your W-2 from %{employer_name} for %{total_wages_amt}.
           instructions_2: If any of these boxes are blank on your W-2, leave them blank here.
+          locality_nm_error: "Please type in “NYC” if the locality name on your W-2 is New York City or any of the five boroughs."
         index:
           title: Please provide state tax information for the following W-2s. Do not worry if you have multiple W-2s and not all of them are listed below.
           updated: You've updated this W-2

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2349,10 +2349,10 @@ en:
           box20_locality_name: "<strong>Box 20</strong>: Locality name"
           instructions_1: We need a little more information about the state and local tax information on your W-2 from %{employer_name} for %{total_wages_amt}.
           instructions_2: If any of these boxes are blank on your W-2, leave them blank here.
-          locality_nm_error: "Please type in “NYC” if the locality name on your W-2 is New York City or any of the five boroughs."
-          locality_nm_missing_error: Please select locality name
           local_income_tax_amt_error: Cannot be greater than local wages and tips.
           local_wages_and_tips_amt_error: Please enter local wages and tips
+          locality_nm_error: Please type in “NYC” if the locality name on your W-2 is New York City or any of the five boroughs.
+          locality_nm_missing_error: Please select locality name
           state_income_tax_amt_error: Cannot be greater than State wages and tips.
           state_wages_amt_error: Please enter State wages and tips
           w2s_error: Please update all of the W-2s listed above to continue.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2350,7 +2350,7 @@ en:
           instructions_1: We need a little more information about the state and local tax information on your W-2 from %{employer_name} for %{total_wages_amt}.
           instructions_2: If any of these boxes are blank on your W-2, leave them blank here.
         index:
-          title: We need a little more information about the state and local tax information on your W-2s
+          title: Please provide state tax information for the following W-2s. Do not worry if you have multiple W-2s and not all of them are listed below.
           updated: You've updated this W-2
           w2_for: 'W-2 for: %{employer_name}'
           wages_amount: 'Total wages amount: $%{wages_amount}'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2350,6 +2350,10 @@ en:
           instructions_1: We need a little more information about the state and local tax information on your W-2 from %{employer_name} for %{total_wages_amt}.
           instructions_2: If any of these boxes are blank on your W-2, leave them blank here.
           locality_nm_error: "Please type in “NYC” if the locality name on your W-2 is New York City or any of the five boroughs."
+          local_income_tax_amt_error: Please enter local wages and tips
+          local_wages_and_tips_amt_error: Please enter local wages and tips
+          state_income_tax_amt_error: Please enter state wages and tips
+          state_wages_amt_error: Please enter State wages and tips
         index:
           title: Please provide state tax information for the following W-2s. Do not worry if you have multiple W-2s and not all of them are listed below.
           updated: You've updated this W-2

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2349,7 +2349,9 @@ es:
           instructions_2: Si alguna de estas casillas está en blanco en su W-2, déjela en blanco aquí.
           locality_nm_error: "Escriba “NYC” si el nombre de la localidad en su W-2 es la ciudad de Nueva York o cualquiera de los cinco condados."
           locality_nm_missing_error: Por favor seleccione el nombre de la localidad
+          local_income_tax_amt_error: No puede ser mayor que los salarios y propinas locales.
           local_wages_and_tips_amt_error: Por favor ingrese salarios y propinas locales
+          state_income_tax_amt_error: No puede ser mayor que los salarios y propinas estatales.
           state_wages_amt_error: Por favor ingrese los salarios y propinas estatales.
           w2s_error: Actualice todos los formularios W-2 enumerados anteriormente para continuar.
         index:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2347,10 +2347,10 @@ es:
           box20_locality_name: "<strong>Cuadro 20</strong>: Nombre de la localidad"
           instructions_1: Necesitamos un poco más de información sobre los impuestos estatales y locales en su W-2 de %{employer_name} para %{total_wages_amt}.
           instructions_2: Si alguna de estas casillas está en blanco en su W-2, déjela en blanco aquí.
-          locality_nm_error: "Escriba “NYC” si el nombre de la localidad en su W-2 es la ciudad de Nueva York o cualquiera de los cinco condados."
-          locality_nm_missing_error: Por favor seleccione el nombre de la localidad
           local_income_tax_amt_error: No puede ser mayor que los salarios y propinas locales.
           local_wages_and_tips_amt_error: Por favor ingrese salarios y propinas locales
+          locality_nm_error: Escriba “NYC” si el nombre de la localidad en su W-2 es la ciudad de Nueva York o cualquiera de los cinco condados.
+          locality_nm_missing_error: Por favor seleccione el nombre de la localidad
           state_income_tax_amt_error: No puede ser mayor que los salarios y propinas estatales.
           state_wages_amt_error: Por favor ingrese los salarios y propinas estatales.
           w2s_error: Actualice todos los formularios W-2 enumerados anteriormente para continuar.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2347,6 +2347,7 @@ es:
           box20_locality_name: "<strong>Cuadro 20</strong>: Nombre de la localidad"
           instructions_1: Necesitamos un poco más de información sobre los impuestos estatales y locales en su W-2 de %{employer_name} para %{total_wages_amt}.
           instructions_2: Si alguna de estas casillas está en blanco en su W-2, déjela en blanco aquí.
+          locality_nm_error: "Escriba “NYC” si el nombre de la localidad en su W-2 es la ciudad de Nueva York o cualquiera de los cinco condados."
         index:
           title: Necesitamos un poco más de información sobre la información fiscal estatal y local en sus formularios W-2.
           updated: Has actualizado este W-2

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2348,8 +2348,10 @@ es:
           instructions_1: Necesitamos un poco más de información sobre los impuestos estatales y locales en su W-2 de %{employer_name} para %{total_wages_amt}.
           instructions_2: Si alguna de estas casillas está en blanco en su W-2, déjela en blanco aquí.
           locality_nm_error: "Escriba “NYC” si el nombre de la localidad en su W-2 es la ciudad de Nueva York o cualquiera de los cinco condados."
+          locality_nm_missing_error: Por favor seleccione el nombre de la localidad
           local_wages_and_tips_amt_error: Por favor ingrese salarios y propinas locales
           state_wages_amt_error: Por favor ingrese los salarios y propinas estatales.
+          w2s_error: Actualice todos los formularios W-2 enumerados anteriormente para continuar.
         index:
           title: Necesitamos un poco más de información sobre la información fiscal estatal y local en sus formularios W-2.
           updated: Has actualizado este W-2

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2348,6 +2348,8 @@ es:
           instructions_1: Necesitamos un poco más de información sobre los impuestos estatales y locales en su W-2 de %{employer_name} para %{total_wages_amt}.
           instructions_2: Si alguna de estas casillas está en blanco en su W-2, déjela en blanco aquí.
           locality_nm_error: "Escriba “NYC” si el nombre de la localidad en su W-2 es la ciudad de Nueva York o cualquiera de los cinco condados."
+          local_wages_and_tips_amt_error: Por favor ingrese salarios y propinas locales
+          state_wages_amt_error: Por favor ingrese los salarios y propinas estatales.
         index:
           title: Necesitamos un poco más de información sobre la información fiscal estatal y local en sus formularios W-2.
           updated: Has actualizado este W-2

--- a/spec/controllers/state_file/questions/ny_w2_controller_spec.rb
+++ b/spec/controllers/state_file/questions/ny_w2_controller_spec.rb
@@ -186,6 +186,22 @@ RSpec.describe StateFile::Questions::NyW2Controller do
 
       # TODO: render_views and check that id in link is w2_index?
     end
+
+    context "with both valid and invalid W2s" do
+      let(:direct_file_xml) do
+        xml = super()
+        # Lets fix the first W2...
+        xml.at("StateWagesAmt").content = "600"
+        xml
+      end
+
+      it "filters correctly" do
+        get :index, params: { us_state: :ny }
+        w2s_list = assigns(:w2s)
+        expect(w2s_list.count).to eq 1
+        expect(w2s_list[0].w2_index).to eq 1
+      end
+    end
   end
 
   describe "#update" do

--- a/spec/controllers/state_file/questions/ny_w2_controller_spec.rb
+++ b/spec/controllers/state_file/questions/ny_w2_controller_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe StateFile::Questions::NyW2Controller do
             employer_state_id_num: "12345",
             state_wages_amt: 10005,
             state_income_tax_amt: 500,
-            local_wages_and_tips_amt: 20,
+            local_wages_and_tips_amt: 40,
             local_income_tax_amt: 30,
             locality_nm: "NYC"
           }
@@ -245,7 +245,7 @@ RSpec.describe StateFile::Questions::NyW2Controller do
           expect(w2.employer_state_id_num).to eq "12345"
           expect(w2.state_wages_amt).to eq 10005
           expect(w2.state_income_tax_amt).to eq 500
-          expect(w2.local_wages_and_tips_amt).to eq 20
+          expect(w2.local_wages_and_tips_amt).to eq 40
           expect(w2.local_income_tax_amt).to eq 30
           expect(w2.locality_nm).to eq "NYC"
 
@@ -268,7 +268,7 @@ RSpec.describe StateFile::Questions::NyW2Controller do
           expect(new_w2.employer_state_id_num).to eq "12345"
           expect(new_w2.state_wages_amt).to eq 10005
           expect(new_w2.state_income_tax_amt).to eq 500
-          expect(new_w2.local_wages_and_tips_amt).to eq 20
+          expect(new_w2.local_wages_and_tips_amt).to eq 40
           expect(new_w2.local_income_tax_amt).to eq 30
           expect(new_w2.locality_nm).to eq "NYC"
 
@@ -334,7 +334,7 @@ RSpec.describe StateFile::Questions::NyW2Controller do
         post :update, params: params
 
         expect(response).to render_template(:edit)
-        expect(response.body).to include "must be greater than or equal to 1"
+        expect(response.body).to include "Cannot be greater than State wages and tips."
       end
     end
   end

--- a/spec/helpers/df_xml_crud_methods_spec.rb
+++ b/spec/helpers/df_xml_crud_methods_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe DfXmlCrudMethods do
+  describe "#delete_blank_nodes" do
+    it "deletes nodes" do
+      content = <<~XML
+        <outer>
+          <inner1></inner1>
+          <inner2>0</inner2>
+          <inner3>1</inner3>
+          <inner4/>
+        </outer>
+      XML
+      xml = Nokogiri::XML(content)
+      Class.new.extend(DfXmlCrudMethods).delete_blank_nodes(xml)
+      result = "<?xml version=\"1.0\"?>\n<outer>\n  <inner3>1</inner3>\n</outer>\n"
+      expect(xml.to_xml).to eq result
+    end
+  end
+end

--- a/spec/models/state_file_w2_spec.rb
+++ b/spec/models/state_file_w2_spec.rb
@@ -110,5 +110,16 @@ describe StateFileW2 do
       expect(w2).to be_valid
     end
 
+    it "rejects localities without the correct prefix" do
+      w2.locality_nm = "YONKERS"
+      expect(w2).not_to be_valid
+      expect(w2.errors[:locality_nm]).to be_present
+    end
+
+    it "permits localities prefixed with an approved value" do
+      w2.locality_nm = "NYC LOL JUST KIDDING ITS YONKERS"
+      expect(w2).to be_valid
+    end
+
   end
 end

--- a/spec/models/state_file_w2_spec.rb
+++ b/spec/models/state_file_w2_spec.rb
@@ -79,16 +79,16 @@ describe StateFileW2 do
       expect(w2).to be_valid
     end
 
-    it "requires local_wages_and_tips_amt to be present if local_income_tax_amt is present" do
+    it "requires local_income_tax_amt to be less than local_wages_and_tips_amt" do
       w2.local_wages_and_tips_amt = 0
       expect(w2).not_to be_valid
-      expect(w2.errors[:local_wages_and_tips_amt]).to be_present
+      expect(w2.errors[:local_income_tax_amt]).to be_present
     end
 
-    it "requires state_wages_amt to be present if state_income_tax_amt is present" do
+    it "requires state_income_tax_amt to be less than state_wages_amt" do
       w2.state_wages_amt = 0
       expect(w2).not_to be_valid
-      expect(w2.errors[:state_wages_amt]).to be_present
+      expect(w2.errors[:state_income_tax_amt]).to be_present
     end
 
     it "permits state_wages_amt to be blank if state_income_tax_amt is blank" do


### PR DESCRIPTION
Fix for issue found by Gabriel. The NY_W2 index page should only show suspicious W2s. It was leaving in one that was fine, and filtering out one that was sus:
![image](https://github.com/codeforamerica/vita-min/assets/17094895/c86561e6-f442-4d4f-bbfb-ff4445bad69e)
This is because we were incorrectly matching by index.

I fixed the issue and added a spec to verify