### PR TITLE
Fixing to_state #187136341

### DIFF
--- a/app/state_machines/efile_submission_state_machine.rb
+++ b/app/state_machines/efile_submission_state_machine.rb
@@ -193,7 +193,7 @@ class EfileSubmissionStateMachine
     if submission.is_for_state_filing?
       Rails.logger.info({
         event_type: "submission_transition",
-        from_status: EfileSubmissionTransition.where(efile_submission_id: transition.efile_submission_id).last&.id,
+        from_status: EfileSubmissionTransition.where(efile_submission_id: transition.efile_submission_id).last&.to_state,
         to_status: transition.to_state,
         state_code: submission.data_source.state_code,
         intake_id: submission.data_source_id,


### PR DESCRIPTION
Fix for this:
<img width="722" alt="image" src="https://github.com/codeforamerica/vita-min/assets/17094895/f3d820d1-6b43-4801-a7e4-a5145cfd1cd2">
We need a from_state so I can filter out duplicates here in datadog - when state goes from `transmitted` to `transmitted`.