### PR TITLE
Silencing error #187175908

### DIFF
--- a/spec/channels/application_cable/connection_spec.rb
+++ b/spec/channels/application_cable/connection_spec.rb
@@ -28,11 +28,12 @@ RSpec.describe ApplicationCable::Connection, type: :channel do
       end
 
       it "avoids the crash and increments a datadog metric" do
-        expect { connect("/cable").current_user }.to raise_error(ActionCable::Connection::Authorization::UnauthorizedError)
+        expect { connect "/cable" }.not_to raise_error
+        expect(connection.current_user).to eq(nil)
 
         expect(@emit_point_params).to eq([
-                                           ["vita-min.dogapi.application_cable.uncaught_throw_warden_error", 1, {:tags=>["env:test"], :type=>"count"}]
-                                         ])
+          ["vita-min.dogapi.application_cable.uncaught_throw_warden_error", 1, {:tags=>["env:test"], :type=>"count"}]
+        ])
       end
     end
   end


### PR DESCRIPTION
So I've tried a few things to get this to be quiet - my previous attempt was using `rescue_from`, but this does not seem to be working as I expected. For now, I will simply have `current_user` return `nil` and log a warning in the case of an authorization error - this works because we reject if the `current_user` is `nil` anyways: https://github.com/codeforamerica/vita-min/blob/main/app/channels/client_channel.rb#L3