### PR TITLE
Use same regex for both matching and locating the token for parsing long NY addresses

### DIFF
--- a/app/lib/submission_builder/document.rb
+++ b/app/lib/submission_builder/document.rb
@@ -48,6 +48,7 @@ module SubmissionBuilder
     private
 
     COMMON_ADDRESS_ABBREV = ["bldg", "bsmt", "dept", "fl", "frnt", "hngr", "key", "lbby", "lot", "lowr", "ofc", "ph", "pier", "rear", "rm", "side", "slip", "spc", "ste", "suite", "stop", "trlr", "unit", "uppr", "Bldg", "Bsmt", "Dept", "Fl", "Frnt", "Hngr", "Key", "Lbby", "Lot", "Lowr", "Ofc", "Ph", "Pier", "Rear", "Rm", "Side", "Slip", "Spc", "Ste", "Suite", "Stop", "Trlr", "Unit", "Uppr", "APT", "BLDG", "BSMT", "DEPT", "FL", "FRNT", "HNGR", "KEY", "LBBY", "LOT", "LOWR", "OFC", "PH", "PIER", "REAR", "RM", "SIDE", "SLIP", "SPC", "STE", "SUITE", "STOP", "TRLR", "UNIT", "UPPR"].freeze
+    ADDRESS_ABBREV_REGEX = /\b(?:#{Regexp.union(COMMON_ADDRESS_ABBREV)})\b/
 
     def build_xml_doc(tag_name, **root_node_attributes)
       default_attributes = { 'xmlns:efile' => 'http://www.irs.gov/efile' }
@@ -102,12 +103,9 @@ module SubmissionBuilder
     end
 
     def process_long_mailing_street(xml, mailing_street)
-      key_found = COMMON_ADDRESS_ABBREV.any? do |key|
-        mailing_street.include?(key)
-      end
+      key_position = mailing_street.index(ADDRESS_ABBREV_REGEX)
 
-      if key_found
-        key_position = mailing_street.index(/\b(?:#{Regexp.union(COMMON_ADDRESS_ABBREV)})\b/)
+      if key_position
         truncated_mailing_street = mailing_street[0, key_position].rstrip
         excess_characters = mailing_street[key_position..].lstrip
       else
@@ -147,10 +145,9 @@ module SubmissionBuilder
     end
 
     def process_long_permanent_street(xml, street_address)
-      address_abbrev_regex = /\b(?:#{Regexp.union(COMMON_ADDRESS_ABBREV)})\b/
+      key_position = street_address.index(ADDRESS_ABBREV_REGEX)
 
-      if street_address.match?(address_abbrev_regex)
-        key_position = street_address.index(address_abbrev_regex)
+      if key_position
         truncated_street_address = street_address[0, key_position].rstrip
         excess_characters = street_address[key_position..].lstrip
       else

--- a/app/lib/submission_builder/document.rb
+++ b/app/lib/submission_builder/document.rb
@@ -147,12 +147,10 @@ module SubmissionBuilder
     end
 
     def process_long_permanent_street(xml, street_address)
-      key_found = COMMON_ADDRESS_ABBREV.any? do |key|
-        street_address.include?(key)
-      end
+      address_abbrev_regex = /\b(?:#{Regexp.union(COMMON_ADDRESS_ABBREV)})\b/
 
-      if key_found
-        key_position = street_address.index(/\b(?:#{Regexp.union(COMMON_ADDRESS_ABBREV)})\b/)
+      if street_address.match?(address_abbrev_regex)
+        key_position = street_address.index(address_abbrev_regex)
         truncated_street_address = street_address[0, key_position].rstrip
         excess_characters = street_address[key_position..].lstrip
       else

--- a/spec/lib/submission_builder/ty2022/states/ny/individual_return_spec.rb
+++ b/spec/lib/submission_builder/ty2022/states/ny/individual_return_spec.rb
@@ -308,6 +308,20 @@ describe SubmissionBuilder::Ty2022::States::Ny::IndividualReturn do
       end
     end
 
+    context "when permanent address is longer than 30 characters with a key word within a word" do
+      let(:intake) { create(:state_file_ny_intake) }
+      let(:filing_status) { 'single' }
+      before do
+        intake.permanent_street = '1416 White Plains Road 1st Floor'
+      end
+      it "ignores the keyword if inside another word" do
+        xml = described_class.build(submission).document
+        expect(xml.at("tiPrime PERM_LN_2_ADR").text.length).to be <= 30
+        expect(xml.at("tiPrime PERM_LN_2_ADR").text).to eq('1416 White Plains Road 1st')
+        expect(xml.at("tiPrime PERM_LN_1_ADR").text).to eq('Floor')
+      end
+    end
+
     context "when permanent city is longer than 18 characters" do
       let(:intake) { create(:state_file_ny_intake) }
       let(:filing_status) { 'single' }


### PR DESCRIPTION
You can see the thread where this was found in slack here: https://cfastaff.slack.com/archives/C06JEJSGH96/p1710190303941749

The issue wasn't exactly that we are looking for “FL” in one place and “FLOOR” in another, it was that `key_found` looked for any occurrence of any token anywhere in the address string, but then the index had a regex that restricted the pattern matching to word boundaries (using `\b`). Since the key "Fl" was found within "Floor", it thought there was a match, but then the index couldn't locate it because it could not find "Fl" as a whole word. I solved this issue by extracting the regex so it can use the same pattern rules in both places.