### PR TITLE
Remove sensitive data from page titles #187287649

### DIFF
--- a/app/views/state_file/questions/tax_refund/edit.html.erb
+++ b/app/views/state_file/questions/tax_refund/edit.html.erb
@@ -1,6 +1,5 @@
 <% title = params[:us_state] == "az" ? t(".az_title_html", refund_amount: refund_amount) : t(".ny_title_html", refund_amount: refund_amount) %>
 
-<% content_for :page_title, title %>
 <% content_for :card do %>
   <h1 class="h2">
     <%= title %>

--- a/app/views/state_file/questions/tax_refund/edit.html.erb
+++ b/app/views/state_file/questions/tax_refund/edit.html.erb
@@ -1,8 +1,8 @@
-<% title = params[:us_state] == "az" ? t(".az_title_html", refund_amount: refund_amount) : t(".ny_title_html", refund_amount: refund_amount) %>
+<% content_for :page_title, t(".page_title") %>
 
 <% content_for :card do %>
   <h1 class="h2">
-    <%= title %>
+    <%= t(".#{current_intake.state_code}_title_html", refund_amount: refund_amount) %>
   </h1>
 
   <%= form_with model: @form, url: { action: :update }, method: :put, local: true, builder: VitaMinFormBuilder, html: { class: 'form-card form-card--long' } do |f| %>

--- a/app/views/state_file/questions/taxes_owed/edit.html.erb
+++ b/app/views/state_file/questions/taxes_owed/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t(".page_title", owed_amount: taxes_owed, state_name: state_name) %>
+<% content_for :page_title, t(".page_title") %>
 <% content_for :card do %>
   <h1 class="h2">
     <%= t(".title_html", owed_amount: taxes_owed, state_name: state_name) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2550,7 +2550,7 @@ en:
           ny_title_html: Good news, you're getting a New York State tax refund of <strong>$%{refund_amount}.</strong> How would you like to receive your refund?
       taxes_owed:
         edit:
-          page_title: You owe $%{owed_amount} in %{state_name} state taxes. How would you like to pay?
+          page_title: You owe state taxes. How would you like to pay?
           pay_bank: Pay directly from your checking or savings account (direct debit)
           pay_mail_online_html: Pay by mail or online at <a target="_blank" rel="noopener nofollow" href="%{pay_mail_online_link}">%{pay_mail_online_text}</a>
           title_html: You owe <strong>$%{owed_amount}</strong> in %{state_name} state taxes. How would you like to pay?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2548,6 +2548,7 @@ en:
           direct_deposit: Direct deposit (fastest)
           mail: Mail my payment (slower)
           ny_title_html: Good news, you're getting a New York State tax refund of <strong>$%{refund_amount}.</strong> How would you like to receive your refund?
+          page_title: Good news, you're getting a tax refund. How would you like to receive your refund?
       taxes_owed:
         edit:
           page_title: You owe state taxes. How would you like to pay?

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2531,7 +2531,7 @@ es:
           ny_title_html: Buenas noticias, recibirás un reembolso de impuestos del estado de Nueva York de <strong>%{refund_amount}.</strong> ¿Cómo te gustaría recibirlo?
       taxes_owed:
         edit:
-          page_title: Debes $%{owed_amount} en impuestos estatales de %{state_name}. ¿Cómo te gustaría pagar?
+          page_title: Debes impuestos estatales. ¿Cómo te gustaría pagar?
           pay_bank: Directamente desde tu cuenta corriente o de ahorros (débito directo)
           pay_mail_online_html: Por correo o en línea en <a target="_blank" rel="noopener nofollow" href="%{pay_mail_online_link}">%{pay_mail_online_text}</a>
           title_html: Debes <strong>$%{owed_amount}</strong> en impuestos estatales de %{state_name}. ¿Cómo te gustaría pagar?

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2529,6 +2529,7 @@ es:
           direct_deposit: Depósito directo (más rápido)
           mail: Enviar mi pago por correo (más lento)
           ny_title_html: Buenas noticias, recibirás un reembolso de impuestos del estado de Nueva York de <strong>%{refund_amount}.</strong> ¿Cómo te gustaría recibirlo?
+          page_title: Buenas noticias, recibirás un reembolso de impuestos. ¿Cómo te gustaría recibirlo?
       taxes_owed:
         edit:
           page_title: Debes impuestos estatales. ¿Cómo te gustaría pagar?


### PR DESCRIPTION
Specific amounts should NOT appear in the meta title on the as it is sensitive and is leaked into intercom:
![image](https://github.com/codeforamerica/vita-min/assets/17094895/1b785bb2-5bb3-4ee7-8cde-db271ce3b65f)


**Taxes Owed:**
![image](https://github.com/codeforamerica/vita-min/assets/17094895/797d7e5a-d361-4c51-86ea-e472a89b3d30)
ie: 
![image](https://github.com/codeforamerica/vita-min/assets/17094895/b9cd2220-828c-467b-acb3-adfd4959c3ca)

And for taxes owed (The negative number is because I manually put in the URL using the same intake):
![image](https://github.com/codeforamerica/vita-min/assets/17094895/aedfe7df-f0c8-472b-ab67-f457d3f48797)

![image](https://github.com/codeforamerica/vita-min/assets/17094895/aa8afa90-069c-4212-91d3-8a917de2fa49)

