### PR TITLE
Remove Validation #187372076

### DIFF
--- a/app/models/state_file_w2.rb
+++ b/app/models/state_file_w2.rb
@@ -73,9 +73,6 @@ class StateFileW2 < ApplicationRecord
     end
     w2 = state_file_intake.direct_file_data.w2s[w2_index]
     if w2.present?
-      if local_wages_and_tips_amt.present? && local_wages_and_tips_amt > w2.WagesAmt
-        errors.add(:local_wages_and_tips_amt, I18n.t("errors.messages.less_than_or_equal_to", count: w2.WagesAmt))
-      end
       if state_income_tax_amt.present? && local_income_tax_amt.present? && (state_income_tax_amt + local_income_tax_amt > w2.WagesAmt)
         errors.add(:local_income_tax_amt, I18n.t("state_file.questions.w2.edit.wages_amt_error", wages_amount: w2.WagesAmt))
         errors.add(:state_income_tax_amt, I18n.t("state_file.questions.w2.edit.wages_amt_error", wages_amount: w2.WagesAmt))

--- a/spec/models/state_file_w2_spec.rb
+++ b/spec/models/state_file_w2_spec.rb
@@ -121,6 +121,11 @@ describe StateFileW2 do
       expect(w2).to be_valid
     end
 
+    it "permits local_wages_and_tips_amt to be greater than w2.wagesAmt" do
+      w2.local_wages_and_tips_amt = 1000000
+      expect(w2).to be_valid
+    end
+
   end
 
   describe "generating xml" do


### PR DESCRIPTION
The following validation should **No Longer** occur:
![image](https://github.com/codeforamerica/vita-min/assets/17094895/3379353a-8979-43d7-8c8d-9b0d5e536b3a)

Added a spec to validate this behavior
