### PR TITLE
Submission search #187278919

### DIFF
--- a/app/assets/stylesheets/_state-file.scss
+++ b/app/assets/stylesheets/_state-file.scss
@@ -668,3 +668,18 @@ $state-colors: (
     border-bottom-right-radius: 8px;
   }
 }
+
+.state-file-submissions {
+  .pagination-wrapper {
+    align-items: center;
+
+    .search-container {
+      flex-grow: 1;
+      padding: 0 3.0rem;
+
+      .hub-searchbar__input{
+        flex-grow: 1;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/_state-file.scss
+++ b/app/assets/stylesheets/_state-file.scss
@@ -672,14 +672,10 @@ $state-colors: (
 .state-file-submissions {
   .pagination-wrapper {
     align-items: center;
-
-    .search-container {
-      flex-grow: 1;
-      padding: 0 3.0rem;
-
-      .hub-searchbar__input{
-        flex-grow: 1;
-      }
+  }
+  .search-container {
+    padding-bottom: 2rem;
+    .hub-searchbar__input{
     }
   }
 }

--- a/app/controllers/hub/state_file/efile_submissions_controller.rb
+++ b/app/controllers/hub/state_file/efile_submissions_controller.rb
@@ -5,6 +5,37 @@ module Hub
       before_action :load_efile_submissions, only: [:index]
 
       def index
+        EfileSubmission.joins(<<~SQL
+          INNER JOIN (
+            SELECT state_file_az_intakes.id, state_file_az_intakes.email_address FROM state_file_az_intakes WHERE efile_submissions.data_source_type = 'StateFileAzIntake' AND state_file_az_intakes.id = efile_submissions.data_source_id
+            UNION
+            SELECT state_file_ny_intakes.id, state_file_ny_intakes.email_address FROM state_file_ny_intakes WHERE efile_submissions.data_source_type = 'StateFileNyIntake' AND state_file_ny_intakes.id = efile_submissions.data_source_id
+          ) as datasource
+        SQL
+        ).paginate(page: 1, per_page: 30)
+
+        EfileSubmission.connection.query(<<~SQL
+          SELECT "efile_submissions"."id", "efile_submissions"."claimed_eitc", "efile_submissions"."created_at", "efile_submissions"."data_source_id", "efile_submissions"."data_source_type", "efile_submissions"."irs_submission_id", "efile_submissions"."last_checked_for_ack_at", "efile_submissions"."tax_return_id", "efile_submissions"."updated_at", "efile_submissions"."message_tracker" FROM "efile_submissions" INNER JOIN (
+            SELECT state_file_az_intakes.id, 'StateFileAzIntake' as ds_type, state_file_az_intakes.email_address FROM state_file_az_intakes WHERE state_file_az_intakes.id = efile_submissions.data_source_id
+            UNION
+            SELECT state_file_ny_intakes.id, 'StateFileNyIntake' as ds_type, state_file_ny_intakes.email_address FROM state_file_ny_intakes WHERE efile_submissions.data_source_type = 'StateFileNyIntake' AND state_file_ny_intakes.id = efile_submissions.data_source_id
+          ) as data_source ON efile_submissions.data_source_id = data_source.id AND efile_submission.data_source_type = data_source.ds_type
+          SQL
+        )
+
+
+        #EfileSubmission.joins(<<~SQL
+        #  LEFT OUTER JOIN state_file_az_intakes ON efile_submissions.data_source_id = state_file_az_intakes.id AND efile_submissions.data_source_type = 'StateFileAzIntake'
+        #  LEFT OUTER JOIN state_file_ny_intakes ON efile_submissions.data_source_id = state_file_ny_intakes.id AND efile_submissions.data_source_type = 'StateFileNyIntake'
+        #SQL
+        #).where(<<~SQL
+        #  (state_file_az_intakes.id IS NOT NULL OR state_file_ny_intakes.id IS NOT NULL)
+        #SQL
+        #).paginate(page: 1, per_page: 30)
+
+        if params[:search]
+          @efile_submissions = @efile_submissions
+        end
         @efile_submissions = @efile_submissions.includes(:efile_submission_transitions).reorder(created_at: :desc).paginate(page: params[:page], per_page: 30)
         @efile_submissions = @efile_submissions.in_state(params[:status]) if params[:status].present?
       end

--- a/app/controllers/hub/state_file/efile_submissions_controller.rb
+++ b/app/controllers/hub/state_file/efile_submissions_controller.rb
@@ -16,7 +16,7 @@ module Hub
         if search.present?
           @efile_submissions = @efile_submissions.where("email_address LIKE ? OR irs_submission_id LIKE ?", "%#{search}%", "%#{search}%")
           if search.to_i.to_s == search
-            @efile_submissions = @efile_submissions.where("id LIKE ? OR intake_id LIKE ?", search, search)
+            @efile_submissions = @efile_submissions.where("id=? OR intake_id=?", search.to_i, search.to_i)
           end
         end
 

--- a/app/controllers/hub/state_file/efile_submissions_controller.rb
+++ b/app/controllers/hub/state_file/efile_submissions_controller.rb
@@ -14,10 +14,13 @@ module Hub
 
         search = params[:search]
         if search.present?
-          @efile_submissions = @efile_submissions.where("email_address LIKE ? OR irs_submission_id LIKE ?", "%#{search}%", "%#{search}%")
+          query = "email_address LIKE ? OR irs_submission_id LIKE ?"
+          query_args = ["%#{search}%", "%#{search}%"]
           if search.to_i.to_s == search
-            @efile_submissions = @efile_submissions.where("id=? OR intake_id=?", search.to_i, search.to_i)
+            query << " OR id=? OR intake_id=?"
+            query_args.concat [search.to_i, search.to_i]
           end
+          @efile_submissions = @efile_submissions.where(query, *query_args)
         end
 
         @efile_submissions = @efile_submissions.includes(:efile_submission_transitions).reorder(created_at: :desc).paginate(page: params[:page], per_page: 30)

--- a/app/views/hub/state_file/efile_submissions/index.html.erb
+++ b/app/views/hub/state_file/efile_submissions/index.html.erb
@@ -4,17 +4,17 @@
       <%= render "state_counts", efile_submission_state_counts: @efile_submission_state_counts %>
     </div>
     <div class="slab slab--not-padded spacing-above-25 state-file-submissions">
+      <div class="search-container">
+        <%= form_tag hub_state_file_efile_submissions_path, method: "get", class: "hub-searchbar" do %>
+          <input type="text" class="hub-searchbar__input" id="search" name="search" <%= tag.attributes value: params[:search] %>>
+          <%= image_submit_tag("magnifying-glass-icon-white.svg", class: "hub-searchbar__button") %>
+        <% end %>
+      </div>
       <div class="pagination-wrapper">
         <div class="count-wrapper">
           <div>
             <%= page_entries_info @efile_submissions %>
           </div>
-        </div>
-        <div class="search-container">
-          <%= form_tag hub_state_file_efile_submissions_path, method: "get", class: "hub-searchbar" do %>
-            <input type="text" class="hub-searchbar__input" id="search" name="search" <%= tag.attributes value: params[:search] %>>
-            <%= image_submit_tag("magnifying-glass-icon-white.svg", class: "hub-searchbar__button") %>
-          <% end %>
         </div>
         <div>
           <%= will_paginate(

--- a/app/views/hub/state_file/efile_submissions/index.html.erb
+++ b/app/views/hub/state_file/efile_submissions/index.html.erb
@@ -3,12 +3,18 @@
     <div class="efile-state-counts" style="display: flex;">
       <%= render "state_counts", efile_submission_state_counts: @efile_submission_state_counts %>
     </div>
-    <div class="slab slab--not-padded spacing-above-25">
+    <div class="slab slab--not-padded spacing-above-25 state-file-submissions">
       <div class="pagination-wrapper">
         <div class="count-wrapper">
           <div>
             <%= page_entries_info @efile_submissions %>
           </div>
+        </div>
+        <div class="search-container">
+          <%= form_tag hub_state_file_efile_submissions_path, method: "get", class: "hub-searchbar" do %>
+            <input type="text" class="hub-searchbar__input" id="search" name="search">
+            <%= image_submit_tag("magnifying-glass-icon-white.svg", class: "hub-searchbar__button") %>
+          <% end %>
         </div>
         <div>
           <%= will_paginate(

--- a/app/views/hub/state_file/efile_submissions/index.html.erb
+++ b/app/views/hub/state_file/efile_submissions/index.html.erb
@@ -12,7 +12,7 @@
         </div>
         <div class="search-container">
           <%= form_tag hub_state_file_efile_submissions_path, method: "get", class: "hub-searchbar" do %>
-            <input type="text" class="hub-searchbar__input" id="search" name="search">
+            <input type="text" class="hub-searchbar__input" id="search" name="search" <%= tag.attributes value: params[:search] %>>
             <%= image_submit_tag("magnifying-glass-icon-white.svg", class: "hub-searchbar__button") %>
           <% end %>
         </div>
@@ -79,8 +79,8 @@
           <td class="index-table__cell">
             <%= submission.irs_submission_id.present? ? link_to(submission.irs_submission_id, hub_state_file_efile_submission_path(id: submission.id)) : "" %>
           </td>
-          <td class="index-table__cell"><%= submission.data_source.state_name %></td>
-          <td class="index-table__cell"><%= submission.data_source.email_address %></td>
+          <td class="index-table__cell"><%= StateFileBaseIntake::STATE_CODE_AND_NAMES[submission.data_source_state_code] %></td>
+          <td class="index-table__cell"><%= submission.email_address %></td>
         </tr>
       <% end %>
       </tbody>

--- a/app/views/hub/state_file/efile_submissions/index.html.erb
+++ b/app/views/hub/state_file/efile_submissions/index.html.erb
@@ -79,7 +79,7 @@
           <td class="index-table__cell">
             <%= submission.irs_submission_id.present? ? link_to(submission.irs_submission_id, hub_state_file_efile_submission_path(id: submission.id)) : "" %>
           </td>
-          <td class="index-table__cell"><%= StateFileBaseIntake::STATE_CODE_AND_NAMES[submission.data_source_state_code] %></td>
+          <td class="index-table__cell"><%= submission.data_source_state_code %><%=submission.data_source_id %></td>
           <td class="index-table__cell"><%= submission.email_address %></td>
         </tr>
       <% end %>

--- a/spec/features/hub/state_file/efile_submissions_spec.rb
+++ b/spec/features/hub/state_file/efile_submissions_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "View state-file efile submissions page in hub" do
       expect(page).to have_content(efile_submission.id)
       expect(page).to have_content(efile_submission.current_state.humanize(capitalize: false))
       expect(page).to have_content(efile_submission.irs_submission_id)
-      expect(page).to have_content(efile_submission.data_source.state_name)
+      expect(page).to have_content("#{efile_submission.data_source.state_code}#{efile_submission.data_source.id}")
       expect(page).to have_content(efile_submission.data_source.email_address)
     end
 


### PR DESCRIPTION
Add search to submissions page
![image](https://github.com/codeforamerica/vita-min/assets/17094895/26b64757-e7ab-4942-92cd-451cce07add0)

## So I do a few things to bypass the n+1 problem:

### I do a rather weird join...

* I build a union of all the columns I want from state intake tables, and then join the submissions to this.
* I can then query on this join
* I load data from my join table rather than relations (Not doing `submission.data_source.email_address` means we don't need to load data sources individually)
* This means we have 1 query only (2 queries if you count the existing `includes`

### 