### PR TITLE
Submission search fix #187278919

### DIFF
--- a/app/assets/stylesheets/_state-file.scss
+++ b/app/assets/stylesheets/_state-file.scss
@@ -469,7 +469,7 @@
     p { text-align: center; }
     img { height: 80px; width: 80px;}
   }
-  
+
   .info-link {
     font-size: 1.6rem;
     color: black;
@@ -685,5 +685,16 @@ $state-colors: (
     border-color: black;
     border-bottom-left-radius: 8px;
     border-bottom-right-radius: 8px;
+  }
+}
+
+.state-file-submissions {
+  .pagination-wrapper {
+    align-items: center;
+  }
+  .search-container {
+    padding-bottom: 2rem;
+    .hub-searchbar__input{
+    }
   }
 }

--- a/app/assets/stylesheets/_state-file.scss
+++ b/app/assets/stylesheets/_state-file.scss
@@ -687,14 +687,3 @@ $state-colors: (
     border-bottom-right-radius: 8px;
   }
 }
-
-.state-file-submissions {
-  .pagination-wrapper {
-    align-items: center;
-  }
-  .search-container {
-    padding-bottom: 2rem;
-    .hub-searchbar__input{
-    }
-  }
-}

--- a/app/controllers/hub/state_file/efile_submissions_controller.rb
+++ b/app/controllers/hub/state_file/efile_submissions_controller.rb
@@ -5,24 +5,6 @@ module Hub
       before_action :load_efile_submissions, only: [:index]
 
       def index
-
-        join_sql = StateFileBaseIntake::STATE_CODES.map do |state_code|
-          "SELECT state_file_#{state_code}_intakes.id as intake_id, 'StateFile#{state_code.to_s.titleize}Intake' as ds_type, '#{state_code}' as data_source_state_code, state_file_#{state_code}_intakes.email_address FROM state_file_#{state_code}_intakes"
-        end
-        join_sql = "INNER JOIN (#{join_sql.join(" UNION ")}) data_source ON data_source.ds_type = efile_submissions.data_source_type and data_source.ds_type = efile_submissions.data_source_type"
-        @efile_submissions = EfileSubmission.joins(join_sql).select("efile_submissions.*, data_source.*")
-
-        search = params[:search]
-        if search.present?
-          query = "email_address LIKE ? OR irs_submission_id LIKE ?"
-          query_args = ["%#{search}%", "%#{search}%"]
-          if search.to_i.to_s == search
-            query << " OR id=? OR intake_id=?"
-            query_args.concat [search.to_i, search.to_i]
-          end
-          @efile_submissions = @efile_submissions.where(query, *query_args)
-        end
-
         @efile_submissions = @efile_submissions.includes(:efile_submission_transitions).reorder(created_at: :desc).paginate(page: params[:page], per_page: 30)
         @efile_submissions = @efile_submissions.in_state(params[:status]) if params[:status].present?
 

--- a/app/controllers/hub/state_file/efile_submissions_controller.rb
+++ b/app/controllers/hub/state_file/efile_submissions_controller.rb
@@ -5,6 +5,24 @@ module Hub
       before_action :load_efile_submissions, only: [:index]
 
       def index
+
+        join_sql = StateFileBaseIntake::STATE_CODES.map do |state_code|
+          "SELECT state_file_#{state_code}_intakes.id as intake_id, 'StateFile#{state_code.to_s.titleize}Intake' as ds_type, '#{state_code}' as data_source_state_code, state_file_#{state_code}_intakes.email_address FROM state_file_#{state_code}_intakes"
+        end
+        join_sql = "INNER JOIN (#{join_sql.join(" UNION ")}) data_source ON data_source.ds_type = efile_submissions.data_source_type and data_source.ds_type = efile_submissions.data_source_type"
+        @efile_submissions = EfileSubmission.joins(join_sql).select("efile_submissions.*, data_source.*")
+
+        search = params[:search]
+        if search.present?
+          query = "email_address LIKE ? OR irs_submission_id LIKE ?"
+          query_args = ["%#{search}%", "%#{search}%"]
+          if search.to_i.to_s == search
+            query << " OR id=? OR intake_id=?"
+            query_args.concat [search.to_i, search.to_i]
+          end
+          @efile_submissions = @efile_submissions.where(query, *query_args)
+        end
+
         @efile_submissions = @efile_submissions.includes(:efile_submission_transitions).reorder(created_at: :desc).paginate(page: params[:page], per_page: 30)
         @efile_submissions = @efile_submissions.in_state(params[:status]) if params[:status].present?
 

--- a/app/controllers/hub/state_file/efile_submissions_controller.rb
+++ b/app/controllers/hub/state_file/efile_submissions_controller.rb
@@ -16,7 +16,7 @@ module Hub
         if search.present?
           query = "email_address LIKE ? OR irs_submission_id LIKE ?"
           query_args = ["%#{search}%", "%#{search}%"]
-          if search.to_i.to_s == search && search.to_i.abs < (2 ** 23)
+          if search.to_i.to_s == search && search.to_i.abs < (2 ** 32)
             query << " OR id=? OR intake_id=?"
             query_args.concat [search.to_i, search.to_i]
           end

--- a/app/views/hub/state_file/efile_submissions/index.html.erb
+++ b/app/views/hub/state_file/efile_submissions/index.html.erb
@@ -3,7 +3,7 @@
     <div class="efile-state-counts" style="display: flex;">
       <%= render "state_counts", efile_submission_state_counts: @efile_submission_state_counts %>
     </div>
-    <div class="slab slab--not-padded spacing-above-25 state-file-submissions">
+    <div class="slab slab--not-padded spacing-above-25">
       <div class="search-container">
         <%= form_tag hub_state_file_efile_submissions_path, method: "get", class: "hub-searchbar" do %>
           <input type="text" class="hub-searchbar__input" id="search" name="search" <%= tag.attributes value: params[:search] %>>
@@ -79,8 +79,8 @@
           <td class="index-table__cell">
             <%= submission.irs_submission_id.present? ? link_to(submission.irs_submission_id, hub_state_file_efile_submission_path(id: submission.id)) : "" %>
           </td>
-          <td class="index-table__cell"><%= submission.data_source_state_code %><%=submission.data_source_id %></td>
-          <td class="index-table__cell"><%= submission.email_address %></td>
+          <td class="index-table__cell"><%= submission.data_source.state_name %></td>
+          <td class="index-table__cell"><%= submission.data_source.email_address %></td>
         </tr>
       <% end %>
       </tbody>

--- a/app/views/hub/state_file/efile_submissions/index.html.erb
+++ b/app/views/hub/state_file/efile_submissions/index.html.erb
@@ -3,7 +3,7 @@
     <div class="efile-state-counts" style="display: flex;">
       <%= render "state_counts", efile_submission_state_counts: @efile_submission_state_counts %>
     </div>
-    <div class="slab slab--not-padded spacing-above-25">
+    <div class="slab slab--not-padded spacing-above-25 state-file-submissions">
       <div class="search-container">
         <%= form_tag hub_state_file_efile_submissions_path, method: "get", class: "hub-searchbar" do %>
           <input type="text" class="hub-searchbar__input" id="search" name="search" <%= tag.attributes value: params[:search] %>>
@@ -79,8 +79,8 @@
           <td class="index-table__cell">
             <%= submission.irs_submission_id.present? ? link_to(submission.irs_submission_id, hub_state_file_efile_submission_path(id: submission.id)) : "" %>
           </td>
-          <td class="index-table__cell"><%= submission.data_source.state_name %></td>
-          <td class="index-table__cell"><%= submission.data_source.email_address %></td>
+          <td class="index-table__cell"><%= submission.data_source_state_code %><%=submission.data_source_id %></td>
+          <td class="index-table__cell"><%= submission.email_address %></td>
         </tr>
       <% end %>
       </tbody>

--- a/spec/features/hub/state_file/efile_submissions_spec.rb
+++ b/spec/features/hub/state_file/efile_submissions_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "View state-file efile submissions page in hub" do
       expect(page).to have_content(efile_submission.id)
       expect(page).to have_content(efile_submission.current_state.humanize(capitalize: false))
       expect(page).to have_content(efile_submission.irs_submission_id)
-      expect(page).to have_content(efile_submission.data_source.state_name)
+      expect(page).to have_content("#{efile_submission.data_source.state_code}#{efile_submission.data_source.id}")
       expect(page).to have_content(efile_submission.data_source.email_address)
     end
 

--- a/spec/features/hub/state_file/efile_submissions_spec.rb
+++ b/spec/features/hub/state_file/efile_submissions_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "View state-file efile submissions page in hub" do
       expect(page).to have_content(efile_submission.id)
       expect(page).to have_content(efile_submission.current_state.humanize(capitalize: false))
       expect(page).to have_content(efile_submission.irs_submission_id)
-      expect(page).to have_content("#{efile_submission.data_source.state_code}#{efile_submission.data_source.id}")
+      expect(page).to have_content(efile_submission.data_source.state_name)
       expect(page).to have_content(efile_submission.data_source.email_address)
     end
 


### PR DESCRIPTION
This re-applies the submission search, but with a fix for the join, and filtering on integers  (Previously the join would return too many elements, and the integer filter would fail if the value was too large)
![image](https://github.com/codeforamerica/vita-min/assets/17094895/bc22b90b-c11d-40a4-bdcc-99cb83a5e28a)
![image](https://github.com/codeforamerica/vita-min/assets/17094895/2354316f-d83a-4ca7-bbd2-70a6aaff9583)
