### PR TITLE
[AFTER TAX SEASON] updates lograge to ignore the apitble healthcheck request

### DIFF
--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -11,6 +11,9 @@ Rails.application.configure do
   # Log to the same place as Rails logs
   config.lograge.logger = Rails.logger
 
+  # Let's not log the healthcheck (and maybe other things, eventually)
+  config.lograge.ignore_actions = ['PublicPagesController#healthcheck']
+
   # This is useful if you want to log query parameters
   config.lograge.custom_options = lambda do |event|
     {


### PR DESCRIPTION
we already ignore this for mixpanel, but we've been sending thousands and thousands of healthcheck events to datadog.