### PR TITLE
Refactor withdrawal date things and pull state time

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -413,6 +413,32 @@ class ApplicationController < ActionController::Base
   end
   helper_method :before_state_file_launch?
 
+  def withdrawal_date_deadline
+    case params[:us_state]
+    when 'ny'
+      Rails.configuration.state_file_withdrawal_date_deadline_ny
+    else
+      # Arizona's withdrawal date deadline is the same as the end-new-intakes date which is set in PDT,
+      # if this was during daylight-savings, it would be different except in the Navajo Nation
+      Rails.configuration.state_file_end_of_new_intakes
+    end
+  end
+  helper_method :withdrawal_date_deadline
+
+  def before_withdrawal_date_deadline?
+    app_time < withdrawal_date_deadline
+  end
+  helper_method :before_withdrawal_date_deadline?
+
+  def post_deadline_withdrawal_date
+    if params[:us_state] == 'ny'
+      app_time.in_time_zone('America/New_York')
+    else
+      app_time.in_time_zone('America/Phoenix')
+    end
+  end
+  helper_method :post_deadline_withdrawal_date
+
   private
 
   def locale

--- a/app/controllers/session_toggles_controller.rb
+++ b/app/controllers/session_toggles_controller.rb
@@ -23,8 +23,9 @@ class SessionTogglesController < ApplicationController
         service_url: url_for(host: MultiTenantService.new(:statefile).host, controller: :session_toggles),
         times: [
           SessionToggleTime.new(name: 'Start of open intake', property: :state_file_start_of_open_intake),
-          SessionToggleTime.new(name: 'End of New intake', property: :state_file_end_of_new_intakes),
-          SessionToggleTime.new(name: 'End of In Progress Intakes', property: :state_file_end_of_in_progress_intakes),
+          SessionToggleTime.new(name: 'Withdrawal date deadline for New York', property: :state_file_withdrawal_date_deadline_ny),
+          SessionToggleTime.new(name: 'End of new intakes', property: :state_file_end_of_new_intakes),
+          SessionToggleTime.new(name: 'End of in-progress intakes', property: :state_file_end_of_in_progress_intakes),
         ]
       },
       {

--- a/app/controllers/state_file/questions/taxes_owed_controller.rb
+++ b/app/controllers/state_file/questions/taxes_owed_controller.rb
@@ -34,7 +34,6 @@ module StateFile
       end
       helper_method :pay_mail_online_text
 
-
       private
 
       def card_postscript; end

--- a/app/forms/state_file/taxes_owed_form.rb
+++ b/app/forms/state_file/taxes_owed_form.rb
@@ -43,15 +43,19 @@ module StateFile
 
     def date_electronic_withdrawal
       if post_deadline_withdrawal_date.present?
-        post_deadline_withdrawal_date
+        date_electronic_withdrawal_post_deadline
       else
         parse_date_params(date_electronic_withdrawal_year, date_electronic_withdrawal_month, date_electronic_withdrawal_day)
       end
     end
 
+    def date_electronic_withdrawal_post_deadline
+      Date.parse(post_deadline_withdrawal_date)
+    end
+
     def date_electronic_withdrawal_is_valid_date
       if post_deadline_withdrawal_date.present?
-        Date.parse(post_deadline_withdrawal_date)
+        date_electronic_withdrawal_post_deadline
       else
         valid_text_date(date_electronic_withdrawal_year,
                         date_electronic_withdrawal_month,
@@ -71,13 +75,13 @@ module StateFile
     end
 
     def withdrawal_date_before_deadline
-      unless post_deadline_withdrawal_date.present? || date_electronic_withdrawal.between?(DateTime.parse(app_time), withdrawal_date_deadline)
+      unless date_electronic_withdrawal.between?(Date.parse(app_time), withdrawal_date_deadline)
         self.errors.add(:date_electronic_withdrawal, I18n.t("forms.errors.taxes_owed.withdrawal_date_deadline", year: withdrawal_date_deadline.year))
       end
     end
 
     def withdrawal_date_deadline
-      DateTime.parse("April 15th, #{MultiTenantService.new(:statefile).current_tax_year + 1}")
+      Date.parse("April 15th, #{MultiTenantService.new(:statefile).current_tax_year + 1}")
     end
   end
 end

--- a/app/forms/state_file/taxes_owed_form.rb
+++ b/app/forms/state_file/taxes_owed_form.rb
@@ -14,7 +14,8 @@ module StateFile
                        :date_electronic_withdrawal_month,
                        :date_electronic_withdrawal_year,
                        :date_electronic_withdrawal_day,
-                       :post_deadline_withdrawal_date
+                       :post_deadline_withdrawal_date,
+                       :app_time
 
     with_options unless: -> { payment_or_deposit_type == "mail" } do
       validate :date_electronic_withdrawal_is_valid_date
@@ -70,9 +71,13 @@ module StateFile
     end
 
     def withdrawal_date_before_deadline
-      unless date_electronic_withdrawal.between?(DateTime.current.to_date, withdrawal_date_deadline) || post_deadline_withdrawal_date.present?
+      unless post_deadline_withdrawal_date.present? || date_electronic_withdrawal.between?(DateTime.parse(app_time), withdrawal_date_deadline)
         self.errors.add(:date_electronic_withdrawal, I18n.t("forms.errors.taxes_owed.withdrawal_date_deadline", year: withdrawal_date_deadline.year))
       end
+    end
+
+    def withdrawal_date_deadline
+      DateTime.parse("April 15th, #{MultiTenantService.new(:statefile).current_tax_year + 1}")
     end
   end
 end

--- a/app/views/shared/_environment_warning.html.erb
+++ b/app/views/shared/_environment_warning.html.erb
@@ -16,7 +16,11 @@
       <div class="grid">
         <div class="grid__item">
           <strong>Active Session Toggles:</strong>
-          <div><%= session[:session_toggles] %></div>
+          <div><%= session[:session_toggles] %> UTC</div>
+          <% if state_file? %>
+            <div><%= app_time.in_time_zone('America/New_York').strftime("%A %m-%d-%Y %l:%M%P") %> EST</div>
+            <div><%= app_time.in_time_zone('America/Phoenix').strftime("%A %m-%d-%Y %l:%M%P") %> MST</div>
+          <% end %>
         </div>
       </div>
     </div>

--- a/app/views/state_file/questions/tax_refund/_bank_details.html.erb
+++ b/app/views/state_file/questions/tax_refund/_bank_details.html.erb
@@ -3,13 +3,16 @@
   <p class="text--small"><%= t(".foreign_accounts") %></p>
   <div class="form-group-tight">
     <% if owe_taxes %>
+      <%= form.hidden_field :app_time, value: app_time %>
       <%= form.cfa_input_field(:withdraw_amount, t('.withdraw_amount', owed_amount: taxes_owed), classes: ["form-width--long"]) %>
       <% if before_withdrawal_date_deadline? %>
         <div class="date-select">
           <% year = MultiTenantService.new(:statefile).current_tax_year + 1 %>
           <%= form.cfa_date_select(
                 :date_electronic_withdrawal,
-                t(".date_withdraw_text"),
+                t(".date_withdraw_text",
+                  withdrawal_deadline_date: I18n.l(withdrawal_date_deadline.to_date, format: :medium, locale: locale),
+                  with_drawal_deadline_year: withdrawal_date_deadline.year),
                 options: {
                   start_year: year,
                   end_year: year,

--- a/app/views/state_file/questions/tax_refund/_bank_details.html.erb
+++ b/app/views/state_file/questions/tax_refund/_bank_details.html.erb
@@ -40,7 +40,7 @@
   <% if owe_taxes && !before_withdrawal_date_deadline? %>
     <p>
       <%= t(".after_deadline_default_withdrawal_info",
-             with_drawal_deadline_date: I18n.l(withdrawal_date_deadline.to_date, format: :medium, locale: locale),
+             withdrawal_deadline_date: I18n.l(withdrawal_date_deadline.to_date, format: :medium, locale: locale),
              with_drawal_deadline_year: withdrawal_date_deadline.year) %>
     </p>
   <% end %>

--- a/app/views/state_file/questions/tax_refund/_bank_details.html.erb
+++ b/app/views/state_file/questions/tax_refund/_bank_details.html.erb
@@ -4,7 +4,21 @@
   <div class="form-group-tight">
     <% if owe_taxes %>
       <%= form.cfa_input_field(:withdraw_amount, t('.withdraw_amount', owed_amount: taxes_owed), classes: ["form-width--long"]) %>
-
+      <% if before_withdrawal_date_deadline? %>
+        <div class="date-select">
+          <% year = MultiTenantService.new(:statefile).current_tax_year + 1 %>
+          <%= form.cfa_date_select(
+                :date_electronic_withdrawal,
+                t(".date_withdraw_text"),
+                options: {
+                  start_year: year,
+                  end_year: year,
+                }
+              ) %>
+        </div>
+      <% else %>
+        <%= form.hidden_field :post_deadline_withdrawal_date, value: post_deadline_withdrawal_date %>
+      <% end %>
     <% end %>
 
     <%= form.cfa_input_field(:bank_name, t("views.questions.bank_details.bank_name"), classes: ["form-width--long"]) %>
@@ -23,5 +37,11 @@
     <%= form.cfa_input_field(:account_number_confirmation, t(".confirm_account_number"), classes: ["form-width--long", "disablepaste", "disablecopy"]) %>
   </div>
   <p><strong><%= t(".disclaimer") %></strong></p>
-  <p><strong><%= t(".after-deadline-default-withdrawl-info") %></strong></p>
+  <% if owe_taxes && !before_withdrawal_date_deadline? %>
+    <p>
+      <%= t(".after_deadline_default_withdrawal_info",
+             with_drawal_deadline_date: I18n.l(withdrawal_date_deadline.to_date, format: :medium, locale: locale),
+             with_drawal_deadline_year: withdrawal_date_deadline.year) %>
+    </p>
+  <% end %>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -108,6 +108,7 @@ module VitaMin
     # StateFile
     config.state_file_start_of_open_intake = Time.find_zone('America/New_York').parse('2024-02-08 09:00:00')
     config.state_file_end_of_new_intakes = Time.find_zone('America/Los_Angeles').parse('2024-04-15 23:59:59')
+    config.state_file_withdrawal_date_deadline_ny = Time.find_zone('America/New_York').parse('2024-04-15 23:59:59')
     config.state_file_end_of_in_progress_intakes = Time.find_zone('America/Los_Angeles').parse('2024-04-25 23:59:59')
 
     config.allow_magic_verification_code = (Rails.env.demo? || Rails.env.development? || Rails.env.heroku?)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2667,7 +2667,7 @@ en:
       tax_refund:
         bank_details:
           account_number: Account Number
-          after_deadline_default_withdrawal_info: Because you are submitting your return on or after %{with_drawal_deadline_date}, %{with_drawal_deadline_year}, the state will withdraw your payment as soon as they process your return.
+          after_deadline_default_withdrawal_info: Because you are submitting your return on or after %{withdrawal_deadline_date}, %{with_drawal_deadline_year}, the state will withdraw your payment as soon as they process your return.
           bank_title: 'Please provide your bank details:'
           confirm_account_number: Confirm Account Number
           confirm_routing_number: Confirm Routing Number

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2667,7 +2667,7 @@ en:
       tax_refund:
         bank_details:
           account_number: Account Number
-          after-deadline-default-withdrawl-info: Because you are submitting your return on or after April 15, 2024, the state will withdraw your payment as soon as they process your return.
+          after_deadline_default_withdrawal_info: Because you are submitting your return on or after %{with_drawal_deadline_date}, %{with_drawal_deadline_year}, the state will withdraw your payment as soon as they process your return.
           bank_title: 'Please provide your bank details:'
           confirm_account_number: Confirm Account Number
           confirm_routing_number: Confirm Routing Number

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -258,7 +258,7 @@ en:
         is_hsa: is HSA
       taxes_owed:
         withdraw_amount_higher_than_owed: Please enter in an amount less than or equal to %{owed_amount}
-        withdrawal_date_deadline: Please enter a date on or before April 15, %{year}
+        withdrawal_date_deadline: Please enter a date between today and on or before April 15, %{year}
   general:
     NA: N/A
     about: About
@@ -2671,6 +2671,7 @@ en:
           bank_title: 'Please provide your bank details:'
           confirm_account_number: Confirm Account Number
           confirm_routing_number: Confirm Routing Number
+          date_withdraw_text: 'When would you like the funds withdrawn from your account? (Must be on or before %{withdrawal_deadline_date}, %{with_drawal_deadline_year}):'
           disclaimer: Check to make sure your bank information is correct. You won’t be able to correct this after you submit your return.
           foreign_accounts: "(Foreign accounts are not accepted)"
           routing_number: Routing Number

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2647,7 +2647,7 @@ es:
       tax_refund:
         bank_details:
           account_number: Número de cuenta
-          after-deadline-default-withdrawl-info: Debido al hecho de que estás enviando tu declaración el 15 de abril o después, el estado retirará tu pago tan pronto como se procese tu declaración.
+          after_deadline_default_withdrawal_info: Debido al hecho de que estás enviando tu declaración el %{with_drawal_deadline_date}, %{with_drawal_deadline_year} o después, el estado retirará tu pago tan pronto como se procese tu declaración.
           bank_title: 'Comparte los detalles de tu cuenta bancaria:'
           confirm_account_number: Confirma el número de cuenta
           confirm_routing_number: Confirma el número de ruta bancaria (routing number)

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -259,7 +259,7 @@ es:
         is_hsa: es HSA
       taxes_owed:
         withdraw_amount_higher_than_owed: Ingresa una cantidad menor o igual a %{owed_amount}
-        withdrawal_date_deadline: Introduce una fecha en o antes del 15 de Abril, %{year}
+        withdrawal_date_deadline: Ingrese una fecha entre hoy y el 15 de abril de %{year} o antes
   general:
     NA: N/A
     about: Acerca de nosotros
@@ -2647,10 +2647,11 @@ es:
       tax_refund:
         bank_details:
           account_number: Número de cuenta
-          after_deadline_default_withdrawal_info: Debido al hecho de que estás enviando tu declaración el %{withdrawal_deadline_date}, %{with_drawal_deadline_year} o después, el estado retirará tu pago tan pronto como se procese tu declaración.
+          after_deadline_default_withdrawal_info: Debido al hecho de que estás enviando tu declaración el %{withdrawal_deadline_date} de %{with_drawal_deadline_year} o después, el estado retirará tu pago tan pronto como se procese tu declaración.
           bank_title: 'Comparte los detalles de tu cuenta bancaria:'
           confirm_account_number: Confirma el número de cuenta
           confirm_routing_number: Confirma el número de ruta bancaria (routing number)
+          date_withdraw_text: "¿Cuándo te gustaría que se retiren los fondos de tu cuenta? (debe ser antes o en el dia del %{withdrawal_deadline_date} de %{with_drawal_deadline_year}):"
           disclaimer: Verifica que la información de tu banco sea correcta. No podrás corregirla después de enviar tu declaración.
           foreign_accounts: "(Las cuentas extranjeras no son aceptadas)"
           routing_number: Número de ruta bancaria (routing number)

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2647,7 +2647,7 @@ es:
       tax_refund:
         bank_details:
           account_number: Número de cuenta
-          after_deadline_default_withdrawal_info: Debido al hecho de que estás enviando tu declaración el %{with_drawal_deadline_date}, %{with_drawal_deadline_year} o después, el estado retirará tu pago tan pronto como se procese tu declaración.
+          after_deadline_default_withdrawal_info: Debido al hecho de que estás enviando tu declaración el %{withdrawal_deadline_date}, %{with_drawal_deadline_year} o después, el estado retirará tu pago tan pronto como se procese tu declaración.
           bank_title: 'Comparte los detalles de tu cuenta bancaria:'
           confirm_account_number: Confirma el número de cuenta
           confirm_routing_number: Confirma el número de ruta bancaria (routing number)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1408,6 +1408,27 @@ RSpec.describe ApplicationController do
     end
   end
 
+  describe "#withdrawal_date_deadline" do
+    let(:state) { "ny" }
+    before { @params = { us_state: state } }
+
+    context "for a New York return" do
+      it "returns the NY withdrawal date deadline" do
+        get :index, params: @params
+        expect(subject.withdrawal_date_deadline).to eq Rails.configuration.state_file_withdrawal_date_deadline_ny
+      end
+    end
+
+    context "for an Arizona return" do
+      let(:state) { "az" }
+
+      it "returns the AZ withdrawal date deadline" do
+        get :index, params: @params
+        expect(subject.withdrawal_date_deadline).to eq Rails.configuration.state_file_end_of_new_intakes
+      end
+    end
+  end
+
   context "when receiving invalid requests from robots" do
     before do
       allow(DatadogApi).to receive(:increment)

--- a/spec/forms/state_file/taxes_owed_form_spec.rb
+++ b/spec/forms/state_file/taxes_owed_form_spec.rb
@@ -13,11 +13,8 @@ RSpec.describe StateFile::TaxesOwedForm do
     }
   end
   let(:current_year) { (MultiTenantService.new(:statefile).current_tax_year + 1).to_s }
-
-  before do
-    allow(DateTime).to receive(:now).and_return DateTime.new(current_year.to_i, 1, 1)
-    allow(DateTime).to receive(:current).and_return DateTime.new(current_year.to_i, 1, 1)
-  end
+  let(:pre_deadline_withdrawal_time) { DateTime.parse("April 15th, #{current_year} 11pm EST") }
+  let(:post_deadline_withdrawal_time) { DateTime.parse("April 16th, #{current_year} 1am EST") }
 
   describe "#save" do
     context "when params valid and payment type is mail" do
@@ -33,7 +30,7 @@ RSpec.describe StateFile::TaxesOwedForm do
     end
 
     context "when params valid and payment type is deposit" do
-      let(:valid_params) do
+      let(:bank_info_params) do
         {
           payment_or_deposit_type: "direct_deposit",
           routing_number: "019456124",
@@ -43,24 +40,80 @@ RSpec.describe StateFile::TaxesOwedForm do
           account_type: "checking",
           bank_name: "Bank official",
           withdraw_amount: withdraw_amount,
-          date_electronic_withdrawal_month: '4',
-          date_electronic_withdrawal_year: (MultiTenantService.new(:statefile).current_tax_year + 1).to_s,
-          date_electronic_withdrawal_day: '15'
         }
       end
 
-      it "updates the intake" do
-        form = described_class.new(intake, valid_params)
-        expect(form).to be_valid
-        form.save
+      context "before withdrawal date deadline" do
+        let(:valid_params) do
+          {
+            date_electronic_withdrawal_month: '4',
+            date_electronic_withdrawal_year: (MultiTenantService.new(:statefile).current_tax_year + 1).to_s,
+            date_electronic_withdrawal_day: '15',
+            app_time: pre_deadline_withdrawal_time.to_s
+          }.merge(bank_info_params)
+        end
 
-        intake.reload
-        expect(intake.payment_or_deposit_type).to eq "direct_deposit"
-        expect(intake.account_type).to eq "checking"
-        expect(intake.routing_number).to eq "019456124"
-        expect(intake.account_number).to eq "12345"
-        expect(intake.bank_name).to eq "Bank official"
+        it "updates the intake" do
+          form = described_class.new(intake, valid_params)
+          expect(form).to be_valid
+          form.save
+
+          intake.reload
+          expect(intake.payment_or_deposit_type).to eq "direct_deposit"
+          expect(intake.account_type).to eq "checking"
+          expect(intake.routing_number).to eq "019456124"
+          expect(intake.account_number).to eq "12345"
+          expect(intake.bank_name).to eq "Bank official"
+          expect(intake.date_electronic_withdrawal).to eq Date.parse("April 15th, #{current_year}")
+        end
+
+        context "after NY's deadline and before AZ's for AZ intake" do
+          let(:pre_deadline_withdrawal_time) { DateTime.parse("April 15th, #{current_year} 11:30pm MST") }
+          let!(:intake) {
+            create :state_file_az_intake,
+                   payment_or_deposit_type: "unfilled",
+                   withdraw_amount: withdraw_amount
+          }
+
+          it "updates the intake" do
+            form = described_class.new(intake, valid_params)
+            expect(form).to be_valid
+            form.save
+
+            intake.reload
+            expect(intake.payment_or_deposit_type).to eq "direct_deposit"
+            expect(intake.account_type).to eq "checking"
+            expect(intake.routing_number).to eq "019456124"
+            expect(intake.account_number).to eq "12345"
+            expect(intake.bank_name).to eq "Bank official"
+            expect(intake.date_electronic_withdrawal).to eq Date.parse("April 15th, #{current_year}")
+          end
+        end
       end
+
+      context "after withdrawal date deadline" do
+        let(:valid_params) do
+          {
+            app_time: post_deadline_withdrawal_time.to_s,
+            post_deadline_withdrawal_date: post_deadline_withdrawal_time.to_s
+          }.merge(bank_info_params)
+        end
+
+        it "updates the intake and updates electronic withdrawal date with the current date" do
+          form = described_class.new(intake, valid_params)
+          expect(form).to be_valid
+          form.save
+
+          intake.reload
+          expect(intake.payment_or_deposit_type).to eq "direct_deposit"
+          expect(intake.account_type).to eq "checking"
+          expect(intake.routing_number).to eq "019456124"
+          expect(intake.account_number).to eq "12345"
+          expect(intake.bank_name).to eq "Bank official"
+          expect(intake.date_electronic_withdrawal).to eq Date.parse("April 16th, #{current_year}")
+        end
+      end
+
     end
 
     context "when params are not valid" do
@@ -76,11 +129,12 @@ RSpec.describe StateFile::TaxesOwedForm do
           withdraw_amount: nil,
           date_electronic_withdrawal_month: '3',
           date_electronic_withdrawal_year: current_year,
-          date_electronic_withdrawal_day: '31'
+          date_electronic_withdrawal_day: '31',
+          app_time: pre_deadline_withdrawal_time.to_s
         }
       end
 
-      it "updates the intake" do
+      it "returns errors" do
         form = described_class.new(intake, invalid_params)
         expect(form).not_to be_valid
 
@@ -88,8 +142,8 @@ RSpec.describe StateFile::TaxesOwedForm do
         expect(form.errors[:account_number_confirmation]).to be_present
         expect(form.errors[:account_type]).to be_present
         expect(form.errors[:bank_name]).to be_present
-        # expect(form.errors[:withdraw_amount]).to be_present
-        # expect(form.errors[:date_electronic_withdrawal]).to be_present
+        expect(form.errors[:withdraw_amount]).to be_present
+        expect(form.errors[:date_electronic_withdrawal]).to be_present
       end
 
       it "rejects withdraw amount value 0" do
@@ -123,7 +177,8 @@ RSpec.describe StateFile::TaxesOwedForm do
         withdraw_amount: withdraw_amount,
         date_electronic_withdrawal_month: month,
         date_electronic_withdrawal_year: year,
-        date_electronic_withdrawal_day: day
+        date_electronic_withdrawal_day: day,
+        app_time: DateTime.parse("March 10th, #{current_year} 11pm EST").to_s
       }
     end
 
@@ -149,19 +204,19 @@ RSpec.describe StateFile::TaxesOwedForm do
         let(:day) { "31" }
         let(:year) { current_year }
 
-        xit "is valid" do
+        it "is valid" do
           form = described_class.new(intake, params)
           expect(form).not_to be_valid
           expect(form.errors).to include :date_electronic_withdrawal
         end
       end
 
-      context "electronic withdrawal date is after deadline" do
+      context "electronic withdrawal date is after deadline and current time is before April 15th" do
         let(:month) { "08" }
         let(:day) { "15" }
         let(:year) { current_year }
 
-        xit "is not valid" do
+        it "is not valid" do
           form = described_class.new(intake, params)
           expect(form).not_to be_valid
           expect(form.errors).to include :date_electronic_withdrawal


### PR DESCRIPTION
- [x] Link to pivotal/JIRA issue: https://www.pivotaltracker.com/story/show/187437667
- [x] What was done?
    1. If a client is filing on April 15th or after we take the current time of their app instead of asking for a withdrawal date, so for NY it would be the current EST time and in AZ it would be the current MST time
    2. We remove the electronic-withdrawal-date box if April 15th or later
    3. Add a session toggle time for the deadline in respective timezones
    4. only perform certain validations before and after tax deadline date
- [x] How to test?
    - Added various form spec tests and tests on the application controller for the additional config times/methods
    - Specify any relevant testing environments used (e.g., development, staging, demo, Heroku).
    Can test on any environment, create an app (if NY can choose the javier test case to get the taxes owed page) check the functionality of the page before and after tax deadline using the session_toggles
- [x] Risk Assessment
        - Low risk, we shouldn't have any new submissions this season and if they were to run into a transmission error we should be able to resubmit easily