### PR TITLE
Prevent accepted resubmit #187434120

### DIFF
--- a/app/forms/state_file/esign_declaration_form.rb
+++ b/app/forms/state_file/esign_declaration_form.rb
@@ -48,6 +48,7 @@ module StateFile
         .joins(:efile_submission_transitions)
         .where(efile_submission_transitions: { to_state: :accepted })
         .where(table_name => { hashed_ssn: intake.hashed_ssn })
+        .where.not(efile_submissions: {id: intake.id})
     end
   end
 end

--- a/app/forms/state_file/esign_declaration_form.rb
+++ b/app/forms/state_file/esign_declaration_form.rb
@@ -17,7 +17,10 @@ module StateFile
       efile_info = StateFileEfileDeviceInfo.find_by(event_type: "submission", intake: @intake)
       efile_info&.update!(attributes_for(:state_file_efile_device_info))
 
-      return if accepted_submissions_with_same_ssn(@intake).any?
+      if accepted_submissions_with_same_ssn(@intake).any?
+        Rails.logger.warn "#{@intake.state_code}#{@intake.id} was not submitted because there is already an accepted submission for that ssn"
+        return
+      end
 
       old_efile_submission = @intake.efile_submissions&.last
       if old_efile_submission.present?

--- a/app/forms/state_file/esign_declaration_form.rb
+++ b/app/forms/state_file/esign_declaration_form.rb
@@ -17,9 +17,11 @@ module StateFile
       efile_info = StateFileEfileDeviceInfo.find_by(event_type: "submission", intake: @intake)
       efile_info&.update!(attributes_for(:state_file_efile_device_info))
 
-      if accepted_submissions_with_same_ssn(@intake).any?
-        Rails.logger.warn "#{@intake.state_code}#{@intake.id} was not submitted because there is already an accepted submission for that ssn"
-        return
+      unless Flipper.enabled?(:allow_duplicate_submissions)
+        if accepted_submissions_with_same_ssn(@intake).any?
+          Rails.logger.warn "#{@intake.state_code}#{@intake.id} was not submitted because there is already an accepted submission for that ssn"
+          return
+        end
       end
 
       old_efile_submission = @intake.efile_submissions&.last

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -10,6 +10,7 @@ end
 begin
   Flipper.disable :sms_notifications unless Flipper.exist?(:sms_notifications)
   Flipper.enable :w2_override unless Flipper.exist?(:w2_override)
+  Flipper.disable :allow_duplicate_submissions unless Flipper.exist?(:allow_duplicate_submissions)
 rescue
   # make sure we can still run rake tasks before table has been created
   nil

--- a/spec/forms/state_file/esign_declaration_form_spec.rb
+++ b/spec/forms/state_file/esign_declaration_form_spec.rb
@@ -126,9 +126,8 @@ RSpec.describe StateFile::EsignDeclarationForm do
     context "when there is already an accepted submission in a different account with the same SSN" do
       let!(:efile_submission) { create :efile_submission, :accepted, :for_state, data_source: intake }
       before do
-        #binding.pry
-        intake = create :state_file_az_intake
-        submission = EfileSubmission.create(data_source: intake)
+        other_intake = create :state_file_az_intake
+        submission = EfileSubmission.create(data_source: other_intake)
         EfileSubmissionTransition.create(to_state: :accepted, efile_submission: submission, most_recent: true, sort_key: 1)
       end
       it "does not create a new efile submission" do
@@ -138,6 +137,23 @@ RSpec.describe StateFile::EsignDeclarationForm do
           form.save
         }.to change(intake.efile_submissions, :count).by(0)
         expect(intake.reload.efile_submissions.last.current_state).to eq("accepted")
+      end
+    end
+
+    context "when there is already a non-accepted submission in a different account with the same SSN" do
+      #let!(:efile_submission) { create :efile_submission, :accepted, :for_state, data_source: intake }
+      before do
+        other_intake = create :state_file_az_intake
+        submission = EfileSubmission.create(data_source: other_intake)
+        EfileSubmissionTransition.create(to_state: :rejected, efile_submission: submission, most_recent: true, sort_key: 1)
+      end
+      it "creates a new efile submission" do
+        form = described_class.new(intake, params)
+        expect(form).to be_valid
+        expect {
+          form.save
+        }.to change(intake.efile_submissions, :count).by(1)
+        expect(intake.reload.efile_submissions.last.current_state).to eq("bundling")
       end
     end
   end


### PR DESCRIPTION
* Do not resubmit if there is already an accepted return with the same SSN.
* Added a feature flag so we can turn this off if it is interfering with testing