### PR TITLE
Rescue CombinePDF::ParsingError on 8879 signature pages

### DIFF
--- a/app/forms/portal/primary_sign_form8879.rb
+++ b/app/forms/portal/primary_sign_form8879.rb
@@ -14,7 +14,7 @@ module Portal
 
       begin
         @tax_return.sign_primary!(ip)
-      rescue ::AlreadySignedError, ::FailedToSignReturnError
+      rescue ::AlreadySignedError, ::FailedToSignReturnError, CombinePDF::ParsingError
         errors.add(:transaction_failed)
         false
       end

--- a/app/forms/portal/spouse_sign_form8879.rb
+++ b/app/forms/portal/spouse_sign_form8879.rb
@@ -14,7 +14,7 @@ module Portal
 
       begin
         @tax_return.sign_spouse!(ip)
-      rescue ::AlreadySignedError, ::FailedToSignReturnError
+      rescue ::AlreadySignedError, ::FailedToSignReturnError, CombinePDF::ParsingError
         errors.add(:transaction_failed)
         false
       end


### PR DESCRIPTION
## [Link to pivotal/JIRA issue](https://www.pivotaltracker.com/story/show/187083156)
## What was done?
Investigation summary: I think the reason we get this error is that sometimes Hub users upload wonky PDFs as unsigned 8879 document types and our code that signs this document barfs and results in the client seeing an error page. I recreated this by finding the clients who got this error (for once the Sentry page had an ID of a record) and trying to sign one of their unsigned 8879 documents locally.

In order to avoid showing the error page I've done a very minimal fix to catch the error where we catch other errors (e.g. when the client has already signed). This isn't necessarily that helpful to the client but at least the banner says to contact support. There could be a more robust solution in future but we already have a feature that asks the Hub user to confirm that what they're uploading is an unsigned 8879 PDF, and this has only happened to 5 people.
## How to test?
    - WIP
## Screenshots (for visual change)
<img width="1440" alt="image" src="https://github.com/codeforamerica/vita-min/assets/43800769/7004c719-d514-4aef-9c6b-4026fcde2b76">

