### PR TITLE
Add lock on the tax return record

### DIFF
--- a/app/services/tax_return_service.rb
+++ b/app/services/tax_return_service.rb
@@ -1,7 +1,10 @@
 class TaxReturnService
   def self.handle_state_change(form)
     action_list = []
-    form.tax_return.transition_to!(form.status, initiated_by_user_id: form.current_user.id)
+    tax_return = form.tax_return
+    tax_return.with_lock do
+      tax_return.transition_to!(form.status, initiated_by_user_id: form.current_user.id)
+    end
     action_list << I18n.t("hub.clients.update_take_action.flash_message.status")
     SystemNote::StatusChange.generate!(initiated_by: form.current_user, tax_return: form.tax_return)
     if form.message_body.present?

--- a/app/services/tax_return_service.rb
+++ b/app/services/tax_return_service.rb
@@ -1,10 +1,11 @@
 class TaxReturnService
   def self.handle_state_change(form)
     action_list = []
-    tax_return = form.tax_return
-    tax_return.with_lock do
-      tax_return.transition_to!(form.status, initiated_by_user_id: form.current_user.id)
-    end
+    form.tax_return.transition_to!(form.status, initiated_by_user_id: form.current_user.id)
+    # tax_return = form.tax_return
+    # tax_return.with_lock do
+    #   tax_return.transition_to!(form.status, initiated_by_user_id: form.current_user.id)
+    # end
     action_list << I18n.t("hub.clients.update_take_action.flash_message.status")
     SystemNote::StatusChange.generate!(initiated_by: form.current_user, tax_return: form.tax_return)
     if form.message_body.present?


### PR DESCRIPTION
## Link to pivotal/JIRA issue
(https://www.pivotaltracker.com/story/show/187262451)

## What was done?
https://codeforamerica.sentry.io/issues/4970985269/?project=1880327&referrer=pivotal_plugin

The sentry error indicates the investigation where a few TaxReturnTransitions on tax returns are getting marked as `most_recent` concurrently which breaks the uniqueness constraint on the index.  This could happen when there are multiple tabs open or when a user is doing a bulk action update on the status while immediately after updating an individual tax return.

The goal of this implementation fix is to prevent multiple transitions from being created concurrently or virtually concurrently which is causing this error.

Any alternative considered could also add an UI layer to prevent the user, but I think it would ultimately rely on some underlying lock on the resource.

## How to test?
- TODO (Come up with specs)
- Risk Assessment
  - Deadlocks and performance impact due to concurrency bottlenecks are some of the things I am considering here.

## Screenshots (for visual changes)
N/A
