### PR TITLE
Fix error on chat with us page

### DIFF
--- a/app/helpers/tax_return_card_helper.rb
+++ b/app/helpers/tax_return_card_helper.rb
@@ -8,7 +8,17 @@ module TaxReturnCardHelper
     if ask_for_answers
       current_step = intake.current_step
       if current_step.in?(Questions::AtCapacityController.all_localized_paths)
-        current_step = Questions::ConsentController.to_path_helper
+        # check if the appropriate partner is still at capacity
+        routing_service = PartnerRoutingService.new(
+          intake: intake,
+          source_param: intake.source,
+          zip_code: intake.zip_code,
+          )
+        intake.client.update(vita_partner: routing_service.determine_partner, routing_method: routing_service.routing_method)
+
+        unless intake.client.routing_method_at_capacity?
+          current_step = Questions::ConsentController.to_path_helper
+        end
       end
     end
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
    - https://codeforamerica.atlassian.net/browse/GYR1-455?atlOrigin=eyJpIjoiOGZlNDljZTRkOTdhNDk2N2JjMTFlNzdiZjZlOWU1NzIiLCJwIjoiaiJ9
## What was done?
    - Before when client was at capacity it was routing to consent page when they logged back in because that used to be the last page a client would see before seeing at capacity. Now we are checking if the client is truly at capacity or not. 
## How to test?
    - Run it locally with tiffany 

