### PR TITLE
redirect back to hub client page after successfully saving any 13614-C page

### DIFF
--- a/app/controllers/hub/clients_controller.rb
+++ b/app/controllers/hub/clients_controller.rb
@@ -131,7 +131,7 @@ module Hub
         SystemNote::ClientChange.generate!(initiated_by: current_user, intake: @client.intake)
         GenerateF13614cPdfJob.perform_later(@client.intake.id, "Hub Edited 13614-C.pdf")
         flash[:notice] = "Changes saved"
-        redirect_to edit_13614c_form_page1_hub_client_path(@client)
+        redirect_to hub_client_path(id: @client.id)
       else
         flash[:alert] = I18n.t("forms.errors.general")
         render :edit_13614c_form_page1
@@ -145,7 +145,7 @@ module Hub
         SystemNote::ClientChange.generate!(initiated_by: current_user, intake: @client.intake)
         GenerateF13614cPdfJob.perform_later(@client.intake.id, "Hub Edited 13614-C.pdf")
         flash[:notice] = I18n.t("general.changes_saved")
-        redirect_to edit_13614c_form_page2_hub_client_path(@client)
+        redirect_to hub_client_path(id: @client.id)
       end
     end
 
@@ -157,7 +157,7 @@ module Hub
         @client.intake.update(demographic_questions_hub_edit: true)
         GenerateF13614cPdfJob.perform_later(@client.intake.id, "Hub Edited 13614-C.pdf")
         flash[:notice] = I18n.t("general.changes_saved")
-        redirect_to edit_13614c_form_page3_hub_client_path(@client)
+        redirect_to hub_client_path(id: @client.id)
       end
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -786,7 +786,7 @@ en:
         part_3_title: Part III – Income – Last Year, Did You (or Your Spouse) Receive
         part_4_title: Part IV – Expenses – Last Year, Did You (or Your Spouse) Pay
         part_5_title: Part V - Life Events - Last Year, Did You (or Your Spouse)
-        title: 13614-C
+        title: 13614-C page 2
       edit_13614c_form_page3:
         additional_info_title: Additional Information and Questions Related to the Preparation of Your Return
         fields:
@@ -810,7 +810,7 @@ en:
           q7_register_to_vote: Register to vote?
           q8_speak_and_understand_english: Can carry on a conversation in English, both understanding & speaking?
           q9_read_english: Can read a newspaper or book in English?
-        title: 13614-C
+        title: 13614-C page 3
       edit_take_action:
         blank_no_internal_note: If blank, no internal note is added.
         blank_no_message_sent: If blank, no message is sent to the client.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -795,7 +795,7 @@ es:
         part_3_title: Parte III - Ingresos - El año pasado, ¿recibió usted (o su cónyuge)
         part_4_title: Parte IV - Gastos - El año pasado, ¿pagó usted (o su cónyuge)?
         part_5_title: 'Parte V - Eventos de la vida: el año pasado, ¿usted (o su cónyuge)'
-        title: 13614-C
+        title: 13614-C página 2
       edit_13614c_form_page3:
         additional_info_title: Información Adicional y Preguntas Relacionadas con la Preparación de su Declaración
         fields:
@@ -819,7 +819,7 @@ es:
           q7_register_to_vote: "¿Registrarse/registrado para votar?"
           q8_speak_and_understand_english: "¿Puede llevar una conversación en inglés, y tanto entenderlo como hablarlo?"
           q9_read_english: "¿Puede leer un periódico o un libro en inglés?"
-        title: 13614-C
+        title: 13614-C página 3
       edit_take_action:
         blank_no_internal_note: Si está en blanco, no se agrega ninguna nota interna.
         blank_no_message_sent: Si está en blanco, no se envía ningún mensaje al cliente.


### PR DESCRIPTION

## [Link to pivotal/JIRA issue](https://codeforamerica.atlassian.net/browse/GYR1-436?atlOrigin=eyJpIjoiNTZkMGMxNzc2YmUyNGIxOWFiMjcwMjM1YjA1MDRmNTgiLCJwIjoiaiJ9)
## What was done?
    - After saving on any of the three 13614-C pages, we redirect to the client page (where previously we redirected back to the same 13614-C page)
    - As I noted in the JIRA ticket, navigating between the 13614-C pages trashes your changes unless you hit Save first. With this change in place, a user who wants to edit multiple 13614-C pages will now have to click from the client into the 13614-C form, edit one page, hit Save, then re-enter the form, navigate to another page and edit that one. Thus, this change removes a step for all users (by navigating them back to the client page after their last save) but adds 1-2 steps for anyone who wants to edit multiple 13614-C pages. 
    - We could also add a "Return to Client" button to the top of all 13614-C pages, if we think this change will be disruptive to enough Hub users.
    - I also added "page #" and "pagina #" text to the titles for page 2 and 3 of the 13614-C form, to match page 1.
## How to test?
    - Describe the testing approach taken to verify the changes, including:
        - I manually tested the change by editing 13614-C pages on my local Hub, and verified that I was redirected to the client page only if a save is successful (from any 13614-C page).
        - I am currently working on modifying the existing integration test so that it passes with the new functionality.
    - This change should be able to be acceptance tested on Heroku
    - Risk Assessment
        - I don't believe there are any risks from this change other than the UX impact I described above.
## Other notes
    - I also noticed that the dropdowns on pages 2 and 3 of the 13614-C are poorly laid out, so that you can't see the selected values on some of them and the value is visually truncated on others. Shouldn't be part of this change, but we could make another story for that.