### PR TITLE
GYR1-418 Removed 2020 from previous years

### DIFF
--- a/app/forms/backtaxes_form.rb
+++ b/app/forms/backtaxes_form.rb
@@ -28,6 +28,6 @@ class BacktaxesForm < QuestionsForm
       needs_help_previous_year_2 == "yes" ||
       needs_help_previous_year_1 == "yes" ||
       needs_help_current_year == "yes"
-    errors.add(:needs_help_previous_year_3, I18n.t("forms.errors.at_least_one_year")) unless chose_one
+    errors.add(:needs_help_current_year, I18n.t("forms.errors.at_least_one_year")) unless chose_one
   end
 end

--- a/app/views/questions/backtaxes/edit.html.erb
+++ b/app/views/questions/backtaxes/edit.html.erb
@@ -9,6 +9,9 @@
       <%=t("views.questions.backtaxes.select_all_that_apply") %>
     </p>
     <div class="form-card__stacked-checkboxes spacing-above-0">
+      <% if app_time.before?(Rails.configuration.tax_deadline) %>
+        <%= f.cfa_checkbox("needs_help_previous_year_3".to_sym, @possible_filing_years[3].to_s, options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <% end %>
       <%= f.cfa_checkbox("needs_help_previous_year_2".to_sym, @possible_filing_years[2].to_s, options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox("needs_help_previous_year_1".to_sym, @possible_filing_years[1].to_s, options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox("needs_help_current_year".to_sym, @possible_filing_years[0].to_s, options: { checked_value: "yes", unchecked_value: "no" }) %>

--- a/app/views/questions/backtaxes/edit.html.erb
+++ b/app/views/questions/backtaxes/edit.html.erb
@@ -9,7 +9,6 @@
       <%=t("views.questions.backtaxes.select_all_that_apply") %>
     </p>
     <div class="form-card__stacked-checkboxes spacing-above-0">
-      <%= f.cfa_checkbox("needs_help_previous_year_3".to_sym, @possible_filing_years[3].to_s, options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox("needs_help_previous_year_2".to_sym, @possible_filing_years[2].to_s, options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox("needs_help_previous_year_1".to_sym, @possible_filing_years[1].to_s, options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox("needs_help_current_year".to_sym, @possible_filing_years[0].to_s, options: { checked_value: "yes", unchecked_value: "no" }) %>

--- a/spec/features/web_intake/new_joint_filers_spec.rb
+++ b/spec/features/web_intake/new_joint_filers_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature "Web Intake Joint Filers", :flow_explorer_screenshot do
     screenshot_after do
       # Ask about backtaxes
       expect(page).to have_selector("h1", text: I18n.t("views.questions.backtaxes.title"))
-      check "#{current_tax_year - 3}"
+      check "#{current_tax_year - 2}"
       check "#{current_tax_year}"
     end
     click_on "Continue"
@@ -119,7 +119,7 @@ RSpec.feature "Web Intake Joint Filers", :flow_explorer_screenshot do
     end
     click_on "I agree"
     # create tax returns only after client has consented
-    expect(intake.client.tax_returns.map(&:year)).to match_array [MultiTenantService.new(:gyr).current_tax_year - 3, current_tax_year]
+    expect(intake.client.tax_returns.map(&:year)).to match_array [MultiTenantService.new(:gyr).current_tax_year - 2, current_tax_year]
     expect(intake.reload.client.tax_returns.pluck(:current_state)).to eq ["intake_in_progress", "intake_in_progress"]
 
     screenshot_after do

--- a/spec/features/web_intake/new_single_filer_spec.rb
+++ b/spec/features/web_intake/new_single_filer_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot, active_job: 
     expect(page).to have_selector("h1", text: I18n.t("views.questions.backtaxes.title"))
     current_tax_year = MultiTenantService.new(:gyr).current_tax_year
     check "#{current_tax_year}"
-    check "#{current_tax_year - 3}"
+    check "#{current_tax_year - 2}"
     click_on "Continue"
 
     # Start with current year
@@ -105,7 +105,7 @@ RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot, active_job: 
     click_on I18n.t("views.questions.consent.cta")
 
     # create tax returns only after client has consented
-    expect(intake.client.tax_returns.pluck(:year).sort).to eq [MultiTenantService.new(:gyr).current_tax_year - 3, current_tax_year]
+    expect(intake.client.tax_returns.pluck(:year).sort).to eq [MultiTenantService.new(:gyr).current_tax_year - 2, current_tax_year]
 
     # Optional consent form
     expect(page).to have_selector("h1", text: I18n.t('views.questions.optional_consent.title'))

--- a/spec/features/web_intake/returning_filer_spec.rb
+++ b/spec/features/web_intake/returning_filer_spec.rb
@@ -72,7 +72,7 @@ RSpec.feature "Web Intake Returning Filer", :flow_explorer_screenshot do
     click_on I18n.t('general.continue')
 
     # backtaxes
-    check "2020"
+    check "2021"
     click_on I18n.t('general.continue')
 
     # start with current year

--- a/spec/features/web_intake/returning_filer_spec.rb
+++ b/spec/features/web_intake/returning_filer_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature "Web Intake Returning Filer", :flow_explorer_screenshot do
     click_on I18n.t('general.continue')
 
     # backtaxes
-    check "2021"
+    check Rails.configuration.gyr_current_tax_year - 2
     click_on I18n.t('general.continue')
 
     # start with current year
@@ -72,7 +72,7 @@ RSpec.feature "Web Intake Returning Filer", :flow_explorer_screenshot do
     click_on I18n.t('general.continue')
 
     # backtaxes
-    check "2021"
+    check Rails.configuration.gyr_current_tax_year - 2
     click_on I18n.t('general.continue')
 
     # start with current year

--- a/spec/features/web_intake/routing_spec.rb
+++ b/spec/features/web_intake/routing_spec.rb
@@ -93,7 +93,7 @@ feature "Intake Routing Spec", :flow_explorer_screenshot, :active_job do
     click_on I18n.t('general.continue')
 
     expect(page).to have_text I18n.t('views.questions.backtaxes.title')
-    check "2020"
+    check "2021"
     click_on I18n.t('general.continue')
 
     expect(page).to have_text I18n.t('views.questions.start_with_current_year.title', year: current_tax_year)
@@ -119,7 +119,7 @@ feature "Intake Routing Spec", :flow_explorer_screenshot, :active_job do
     click_on I18n.t('general.continue')
 
     expect(page).to have_text I18n.t('views.questions.backtaxes.title')
-    check "2020"
+    check "2021"
     click_on I18n.t('general.continue')
 
     expect(page).to have_text I18n.t('views.questions.start_with_current_year.title', year: current_tax_year)
@@ -147,7 +147,7 @@ feature "Intake Routing Spec", :flow_explorer_screenshot, :active_job do
     click_on I18n.t('general.continue')
 
     expect(page).to have_text I18n.t('views.questions.backtaxes.title')
-    check "2020"
+    check "2021"
     click_on I18n.t('general.continue')
 
     expect(page).to have_text I18n.t('views.questions.start_with_current_year.title', year: current_tax_year)
@@ -181,7 +181,7 @@ feature "Intake Routing Spec", :flow_explorer_screenshot, :active_job do
       click_on I18n.t('general.continue')
 
       expect(page).to have_text I18n.t('views.questions.backtaxes.title')
-      check "2020"
+      check "2021"
       click_on I18n.t('general.continue')
 
       expect(page).to have_text I18n.t('views.questions.start_with_current_year.title', year: current_tax_year)

--- a/spec/features/web_intake/routing_spec.rb
+++ b/spec/features/web_intake/routing_spec.rb
@@ -93,7 +93,7 @@ feature "Intake Routing Spec", :flow_explorer_screenshot, :active_job do
     click_on I18n.t('general.continue')
 
     expect(page).to have_text I18n.t('views.questions.backtaxes.title')
-    check "2021"
+    check Rails.configuration.gyr_current_tax_year - 2
     click_on I18n.t('general.continue')
 
     expect(page).to have_text I18n.t('views.questions.start_with_current_year.title', year: current_tax_year)
@@ -119,7 +119,7 @@ feature "Intake Routing Spec", :flow_explorer_screenshot, :active_job do
     click_on I18n.t('general.continue')
 
     expect(page).to have_text I18n.t('views.questions.backtaxes.title')
-    check "2021"
+    check Rails.configuration.gyr_current_tax_year - 2
     click_on I18n.t('general.continue')
 
     expect(page).to have_text I18n.t('views.questions.start_with_current_year.title', year: current_tax_year)
@@ -147,7 +147,7 @@ feature "Intake Routing Spec", :flow_explorer_screenshot, :active_job do
     click_on I18n.t('general.continue')
 
     expect(page).to have_text I18n.t('views.questions.backtaxes.title')
-    check "2021"
+    check Rails.configuration.gyr_current_tax_year - 2
     click_on I18n.t('general.continue')
 
     expect(page).to have_text I18n.t('views.questions.start_with_current_year.title', year: current_tax_year)
@@ -181,7 +181,7 @@ feature "Intake Routing Spec", :flow_explorer_screenshot, :active_job do
       click_on I18n.t('general.continue')
 
       expect(page).to have_text I18n.t('views.questions.backtaxes.title')
-      check "2021"
+      check Rails.configuration.gyr_current_tax_year - 2
       click_on I18n.t('general.continue')
 
       expect(page).to have_text I18n.t('views.questions.start_with_current_year.title', year: current_tax_year)


### PR DESCRIPTION
## [GYR1-418](https://codeforamerica.atlassian.net/browse/GYR1-418)
## What was done?
 * Simply remove the item from the UI
## How to test?
 * Go to heroku. Get to the backtaxes section. You can use session toggles to test.
 * You should no longer see 2020 after `Tax deadline: 4/15/2024 11:59 PM EDT`
 * You should see 2020 before `Tax deadline: 4/15/2024 11:59 PM EDT`
## Screenshots (for visual changes)
  ### Before / (With session toggle set to before):
  <img width="746" alt="image" src="https://github.com/codeforamerica/vita-min/assets/17094895/d1cc72ab-fd83-47ac-b428-c64714f85218">

  ### After / (With session toggle set to after)
  <img width="841" alt="image" src="https://github.com/codeforamerica/vita-min/assets/17094895/6f243f11-c1ba-4b1c-9dd9-fdec5a19b81a">




[GYR1-418]: https://codeforamerica.atlassian.net/browse/GYR1-418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ