### PR TITLE
Added active flag to Unique Links

### DIFF
--- a/app/assets/stylesheets/components/_organization-list.scss
+++ b/app/assets/stylesheets/components/_organization-list.scss
@@ -15,5 +15,11 @@
         color: $color-grey-medium !important;
       }
     }
+    .link {
+      flex-grow: 1
+    }
+    .toggle-switch {
+      margin: 0.5rem 1rem;
+    }
   }
 }

--- a/app/controllers/hub/source_params_controller.rb
+++ b/app/controllers/hub/source_params_controller.rb
@@ -16,6 +16,14 @@ module Hub
       end
     end
 
+    def update
+      @source_param = SourceParameter.find(params[:id])
+      @source_param.update(active: params[:source_parameter][:active] == "1")
+      respond_to do |format|
+        format.js
+      end
+    end
+
     def destroy
       @source_param = SourceParameter.find(params[:id])
 

--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -15,10 +15,14 @@ class PublicPagesController < ApplicationController
 
     # redirect to home hiding original source param
     if params[:source].present?
-      vita_partner = SourceParameter.find_vita_partner_by_code(params[:source])
-      if vita_partner.present?
-        flash[:notice] = I18n.t("controllers.public_pages.partner_welcome_notice", partner_name: vita_partner.name)
-        cookies[:used_unique_link] = { value: "yes", expiration: 1.year.from_now.utc }
+      source_parameter = SourceParameter.find_by(code: params[:source]&.downcase)
+      if source_parameter.present?
+        if source_parameter.active?
+          flash[:notice] = I18n.t("controllers.public_pages.partner_welcome_notice", partner_name: source_parameter.vita_partner.name)
+          cookies[:used_unique_link] = { value: "yes", expiration: 1.year.from_now.utc }
+        else
+          flash[:notice] = I18n.t("controllers.public_pages.inactive_unique_link_notice", partner_name: source_parameter.vita_partner.name)
+        end
       end
       redirect_to root_path and return
     end

--- a/app/controllers/state_file/intake_logins_controller.rb
+++ b/app/controllers/state_file/intake_logins_controller.rb
@@ -73,10 +73,10 @@ module StateFile
     def increment_failed_attempts_on_login_records
       contact_info = params[:portal_verification_code_form][:contact_info]
       intake_classes = client_login_service.intake_classes
-      intake_classes.each do |intake_class|
-        @records = intake_class.where(email_address: contact_info).or(intake_class.where(phone_number: contact_info))
-        @records.map(&:increment_failed_attempts)
+      @records = intake_classes.flat_map do |intake_class|
+        intake_class.where(email_address: contact_info).or(intake_class.where(phone_number: contact_info))
       end
+      @records.map(&:increment_failed_attempts)
     end
 
     def request_login_form_class

--- a/app/models/source_parameter.rb
+++ b/app/models/source_parameter.rb
@@ -28,7 +28,7 @@ class SourceParameter < ApplicationRecord
   before_validation :downcase_code
 
   def self.find_vita_partner_by_code(code)
-    SourceParameter.includes(:vita_partner).find_by(code: code&.downcase)&.vita_partner
+    SourceParameter.includes(:vita_partner).where(active: true).find_by(code: code&.downcase)&.vita_partner
   end
 
   def self.source_skips_triage(source)

--- a/app/models/source_parameter.rb
+++ b/app/models/source_parameter.rb
@@ -3,6 +3,7 @@
 # Table name: source_parameters
 #
 #  id              :bigint           not null, primary key
+#  active          :boolean          default(TRUE), not null
 #  code            :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/app/services/partner_routing_service.rb
+++ b/app/services/partner_routing_service.rb
@@ -65,8 +65,7 @@ class PartnerRoutingService
   def vita_partner_from_source_param
     return unless @source_param.present?
 
-    source_param_downcase = @source_param.downcase
-    vita_partner = SourceParameter.includes(:vita_partner).where(active: true).find_by(code: source_param_downcase)&.vita_partner
+    vita_partner = SourceParameter.find_vita_partner_by_code(@source_param.downcase)
 
     if vita_partner.present?
       @routing_method = :source_param

--- a/app/services/partner_routing_service.rb
+++ b/app/services/partner_routing_service.rb
@@ -66,7 +66,7 @@ class PartnerRoutingService
     return unless @source_param.present?
 
     source_param_downcase = @source_param.downcase
-    vita_partner = SourceParameter.includes(:vita_partner).find_by(code: source_param_downcase)&.vita_partner
+    vita_partner = SourceParameter.includes(:vita_partner).where(active: true).find_by(code: source_param_downcase)&.vita_partner
 
     if vita_partner.present?
       @routing_method = :source_param

--- a/app/views/hub/source_params/_form.html.erb
+++ b/app/views/hub/source_params/_form.html.erb
@@ -8,7 +8,15 @@
   <% record.source_parameters.each do |sp| %>
     <% next unless sp.id.present? %>
     <li id="<%= "source-param-#{sp.id}" %>">
-      <%= sp.code %>
+      <label class="link"><%= sp.code %></label>
+      <%= form_for sp, authenticity_token: true, url: url_for(controller: "source_params", id: sp.id, action: "update"), method: :patch, remote: true do |f|%>
+        <label class="toggle-switch">
+          <span class="sr-only"><%= sp.active ? "Active" : "Inactive" %></span>
+          <%= f.check_box(:active, onchange: "document.querySelector('#remote-submit-#{sp.id}').click()") %>
+          <span class="slider slider-green round"></span>
+          <%= f.submit "", id: "remote-submit-#{sp.id}", style: "display:none;" %>
+        </label>
+      <% end %>
       <%= link_to t("general.delete"), hub_source_param_path(id: sp.id), method: :delete, remote: true, "data-confirm": I18n.t("hub.source_params.confirm", code: sp.code, name: record.name), class: "button button--small spacing-below-0" %>
     </li>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,6 +19,7 @@ en:
     dependents_controller:
       removed_dependent: Removed %{full_name}.
     public_pages:
+      inactive_unique_link_notice: Unique URL is not in use.
       partner_welcome_notice: Thanks for visiting via %{partner_name}!
     tax_returns_controller:
       errors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,7 +19,7 @@ en:
     dependents_controller:
       removed_dependent: Removed %{full_name}.
     public_pages:
-      inactive_unique_link_notice: %{partner_name} is currently not accepting clients via this unique url. You can still get started with another tax team below!
+      inactive_unique_link_notice: "%{partner_name} is currently not accepting clients via this unique url. You can still get started with another tax team below!"
       partner_welcome_notice: Thanks for visiting via %{partner_name}!
     tax_returns_controller:
       errors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,7 +19,7 @@ en:
     dependents_controller:
       removed_dependent: Removed %{full_name}.
     public_pages:
-      inactive_unique_link_notice: Unique URL is not in use.
+      inactive_unique_link_notice: %{partner_name} is currently not accepting clients via this unique url. You can still get started with another tax team below!
       partner_welcome_notice: Thanks for visiting via %{partner_name}!
     tax_returns_controller:
       errors:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -19,7 +19,7 @@ es:
     dependents_controller:
       removed_dependent: Eliminó %{full_name}.
     public_pages:
-      inactive_unique_link_notice: La URL única no está en uso.
+      inactive_unique_link_notice: %{partner_name} actualmente no acepta clientes a través de esta URL única. ¡Aún puedes comenzar con otro equipo de impuestos a continuación!
       partner_welcome_notice: "¡Gracias por visitarnos a través de %{partner_name}!"
     tax_returns_controller:
       errors:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -19,7 +19,7 @@ es:
     dependents_controller:
       removed_dependent: Eliminó %{full_name}.
     public_pages:
-      inactive_unique_link_notice: %{partner_name} actualmente no acepta clientes a través de esta URL única. ¡Aún puedes comenzar con otro equipo de impuestos a continuación!
+      inactive_unique_link_notice: "%{partner_name} actualmente no acepta clientes a través de esta URL única. ¡Aún puedes comenzar con otro equipo de impuestos a continuación!"
       partner_welcome_notice: "¡Gracias por visitarnos a través de %{partner_name}!"
     tax_returns_controller:
       errors:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -19,6 +19,7 @@ es:
     dependents_controller:
       removed_dependent: Eliminó %{full_name}.
     public_pages:
+      inactive_unique_link_notice: La URL única no está en uso.
       partner_welcome_notice: "¡Gracias por visitarnos a través de %{partner_name}!"
     tax_returns_controller:
       errors:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -326,7 +326,7 @@ Rails.application.routes.draw do
         end
 
         resources :zip_codes, only: [:create, :destroy]
-        resources :source_params, only: [:create, :destroy]
+        resources :source_params, only: [:create, :update, :destroy]
 
         resources :tax_returns, only: [] do
           patch "update_certification", to: "tax_returns/certifications#update", on: :member

--- a/db/migrate/20240516154446_add_active_to_source_parameters.rb
+++ b/db/migrate/20240516154446_add_active_to_source_parameters.rb
@@ -1,0 +1,5 @@
+class AddActiveToSourceParameters < ActiveRecord::Migration[7.1]
+  def change
+    add_column :source_parameters, :active, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_16_180539) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_16_154446) do
+  create_schema "analytics"
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -1560,6 +1562,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_16_180539) do
   end
 
   create_table "source_parameters", force: :cascade do |t|
+    t.boolean "active", default: true, null: false
     t.string "code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/controllers/hub/source_params_controller_spec.rb
+++ b/spec/controllers/hub/source_params_controller_spec.rb
@@ -89,4 +89,27 @@ describe Hub::SourceParamsController do
       end
     end
   end
+
+  describe "#update" do
+    let(:source_parameter) { create :source_parameter, vita_partner: create(:organization), code: "code" }
+    before do
+      sign_in admin_user
+    end
+
+    it "deactivates successfully" do
+      post :update, format: :js, :params => { :locale => :en, :id => source_parameter.id, :source_parameter => { :active => "0" } }
+      expect(response.status).to eq 204
+      source_parameter.reload
+      expect(source_parameter.active).to be false
+    end
+
+    it "activates successfully" do
+      source_parameter.update(active: false)
+      post :update, format: :js, :params => { :locale => :en, :id => source_parameter.id, :source_parameter => { :active => "1" } }
+      expect(response.status).to eq 204
+      source_parameter.reload
+      expect(source_parameter.active).to be true
+    end
+
+  end
 end

--- a/spec/controllers/public_pages_controller_spec.rb
+++ b/spec/controllers/public_pages_controller_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe PublicPagesController do
       it "redirects to home" do
         get :home, params: { source: source_parameter.code }
         expect(response).to redirect_to :root
-        expect(flash[:notice]).to eq "Unique URL is not in use."
+        expect(flash[:notice]).to eq "Oregano Organization is currently not accepting clients via this unique url. You can still get started with another tax team below!"
       end
 
       it "does not set the used_unique_link cookie" do

--- a/spec/controllers/public_pages_controller_spec.rb
+++ b/spec/controllers/public_pages_controller_spec.rb
@@ -184,6 +184,21 @@ RSpec.describe PublicPagesController do
         expect(cookies[:used_unique_link]).to be_nil
       end
     end
+
+    context "when there is an inactive matching source parameter" do
+      let(:source_parameter) { create :source_parameter, active: false, vita_partner: (create :organization, name: "Oregano Organization") }
+
+      it "redirects to home" do
+        get :home, params: { source: source_parameter.code }
+        expect(response).to redirect_to :root
+        expect(flash[:notice]).to eq "Unique URL is not in use."
+      end
+
+      it "does not set the used_unique_link cookie" do
+        get :home, params: { source: source_parameter.code }
+        expect(cookies[:used_unique_link]).to be_nil
+      end
+    end
   end
 
   describe "#privacy_policy" do

--- a/spec/controllers/questions/triage_diy_controller_spec.rb
+++ b/spec/controllers/questions/triage_diy_controller_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe Questions::TriageDiyController do
+  describe "#edit" do
+    before do
+      session[:source] = "some-source"
+      vita_partner = create :organization, accepts_itin_applicants: false
+      create :source_parameter, code: "some-source", vita_partner: vita_partner
+    end
+
+    context "with an active skip parameter" do
+      it "skips triage" do
+        get :edit
+        expect(response).to redirect_to('/en/questions/environment-warning')
+      end
+    end
+
+    context "with an inactive skip parameter" do
+      it "does not skip triage" do
+        SourceParameter.last.update(active: false)
+        get :edit
+        expect(response).to be_ok
+      end
+    end
+  end
+end

--- a/spec/factories/source_parameters.rb
+++ b/spec/factories/source_parameters.rb
@@ -3,6 +3,7 @@
 # Table name: source_parameters
 #
 #  id              :bigint           not null, primary key
+#  active          :boolean          default(TRUE), not null
 #  code            :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/spec/models/source_parameter_spec.rb
+++ b/spec/models/source_parameter_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe SourceParameter, type: :model do
   it { should validate_presence_of(:code) }
 
   describe ".find_vita_partner_by_code" do
-    # make sure this tests both inactive and active cases
     let(:vita_partner) { create :organization, name: "Oregano Organization" }
     let!(:source_parameter) { create :source_parameter, code: "oregorg", vita_partner: vita_partner }
 

--- a/spec/models/source_parameter_spec.rb
+++ b/spec/models/source_parameter_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe SourceParameter, type: :model do
   it { should validate_presence_of(:code) }
 
   describe ".find_vita_partner_by_code" do
+    # make sure this tests both inactive and active cases
     let(:vita_partner) { create :organization, name: "Oregano Organization" }
     let!(:source_parameter) { create :source_parameter, code: "oregorg", vita_partner: vita_partner }
 

--- a/spec/models/source_parameter_spec.rb
+++ b/spec/models/source_parameter_spec.rb
@@ -3,6 +3,7 @@
 # Table name: source_parameters
 #
 #  id              :bigint           not null, primary key
+#  active          :boolean          default(TRUE), not null
 #  code            :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/spec/services/partner_routing_service_spec.rb
+++ b/spec/services/partner_routing_service_spec.rb
@@ -216,6 +216,16 @@ describe PartnerRoutingService do
           expect(subject.routing_method).to eq :at_capacity
         end
       end
+
+      context "when source param is inactive" do
+        subject { PartnerRoutingService.new(source_param: code) }
+        before { SourceParameter.last.update(active: false) }
+
+        it "returns nil" do
+          expect(subject.determine_partner).to be_nil
+          expect(subject.routing_method).to eq :at_capacity
+        end
+      end
     end
 
     context "when source param is not provided" do


### PR DESCRIPTION
## [GYR1-426](https://codeforamerica.atlassian.net/browse/GYR1-426)

## What was done?
 * Unique Links in /en/hub/organizations now has a toggle indicating whether it is active
 * I added a migration to add an active flag to the `SourceParemeter` model (boolean default: true)
 * The model name is an oddity - `SourceParameter` instead of `UniqueLink`.
 * The attribute for link is `code` which is weird. It is not validated to be a URL.
## How to test?
 * Test on Heroku: https://gyr-review-app-4534-60ec07194217.herokuapp.com/
 * Log in to the hub and go to /en/hub/organizations
 * Enable / Disable links, reloading the page between. (Demonstrating that values are persisted)
 * Create / Delete links to verify this still works.
## Risk Assessment
 * I can't see any associated increased risk of heart disease or diabetes.
## Screenshots
### Before
![image](https://github.com/codeforamerica/vita-min/assets/17094895/9969bc48-eae7-4bc6-bb9e-3f9d4c5daaf9)
## After
### Hub Page
![image](https://github.com/codeforamerica/vita-min/assets/17094895/f87c8f86-5562-4628-b656-c676c30a6f11)
### When you visit a URL with an active source:
e.g.: https://gyr-review-app-4534-60ec07194217.herokuapp.com/en/foo
![image](https://github.com/codeforamerica/vita-min/assets/17094895/9a116de5-4697-4d38-9dee-28cfa3d2dd5d)

### When you visit a URL with an inactive source:
<img width="1187" alt="image" src="https://github.com/codeforamerica/vita-min/assets/17094895/c797eeb1-cc14-4a6b-8227-168b1caa37be">

[GYR1-426]: https://codeforamerica.atlassian.net/browse/GYR1-426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ