### PR TITLE
Routing percentages cannot be 29%

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+this shouldn't be here!
+
 # vita-min 💊
 
 Vita-Min is a Rails app that helps people access the VITA program through a digital intake form, provides the "Hub" to VITA volunteers for workflow management, messaging, outbound calls, etc to facilitate tax preparation, and a national landing page to find the nearest VITA site.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-this shouldn't be here!
-
 # vita-min 💊
 
 Vita-Min is a Rails app that helps people access the VITA program through a digital intake form, provides the "Hub" to VITA volunteers for workflow management, messaging, outbound calls, etc to facilitate tax preparation, and a national landing page to find the nearest VITA site.

--- a/app/models/state_routing_fraction.rb
+++ b/app/models/state_routing_fraction.rb
@@ -27,6 +27,6 @@ class StateRoutingFraction < ApplicationRecord
   belongs_to :state_routing_target, foreign_key: :state_routing_target_id
 
   def routing_percentage
-    (routing_fraction * 100).to_i
+    (routing_fraction * 100).round
   end
 end

--- a/spec/forms/hub/state_routing_form_spec.rb
+++ b/spec/forms/hub/state_routing_form_spec.rb
@@ -67,8 +67,8 @@ RSpec.describe Hub::StateRoutingForm do
           form = Hub::StateRoutingForm.new(params)
           form.save
 
-          expect(organization_1_state_routing_fraction.routing_percentage).to eq 29
-          expect(organization_2_state_routing_fraction.routing_percentage).to eq 71
+          expect(organization_1_state_routing_fraction.reload.routing_percentage).to eq 29
+          expect(organization_2_state_routing_fraction.reload.routing_percentage).to eq 71
         end
 
       end

--- a/spec/forms/hub/state_routing_form_spec.rb
+++ b/spec/forms/hub/state_routing_form_spec.rb
@@ -46,6 +46,32 @@ RSpec.describe Hub::StateRoutingForm do
         expect(organization_1_state_routing_fraction.reload.routing_fraction).to eq 0.6
         expect(organization_2_state_routing_fraction.reload.routing_fraction).to eq 0.4
       end
+
+      context "when routing fractions don't cleanly convert from ints to floats and back" do
+        let(:params) do
+          {
+            state_routing_fraction_attributes: {
+              organization_1.id => {
+                state_routing_target_id: coalition_1_state_routing_target.id,
+                routing_percentage: 29
+              },
+              organization_2.id => {
+                state_routing_target_id: coalition_1_state_routing_target.id,
+                routing_percentage: 71
+              }
+            }
+          }
+        end
+
+        it "still retains the entered values" do
+          form = Hub::StateRoutingForm.new(params)
+          form.save
+
+          expect(organization_1_state_routing_fraction.routing_percentage).to eq 29
+          expect(organization_2_state_routing_fraction.routing_percentage).to eq 71
+        end
+
+      end
     end
 
     context "when new routing fractions are added" do

--- a/spec/forms/hub/state_routing_form_spec.rb
+++ b/spec/forms/hub/state_routing_form_spec.rb
@@ -22,22 +22,22 @@ RSpec.describe Hub::StateRoutingForm do
     )
   }
 
+  def routing_params(partner_routing_percentages)
+    {
+      state_routing_fraction_attributes: partner_routing_percentages.to_h do |partner, percentage|
+        [partner.id,
+         {
+          state_routing_target_id: coalition_1_state_routing_target.id,
+          routing_percentage: percentage
+         }
+        ]
+      end
+    }
+  end
+
   describe "#save" do
     context "when no new routing fractions are added" do
-      let(:params) do
-        {
-          state_routing_fraction_attributes: {
-            organization_1.id => {
-              state_routing_target_id: coalition_1_state_routing_target.id,
-              routing_percentage: 60
-            },
-            organization_2.id => {
-              state_routing_target_id: coalition_1_state_routing_target.id,
-              routing_percentage: 40
-            }
-          }
-        }
-      end
+      let(:params) { routing_params({organization_1 => 60, organization_2 => 40}) }
 
       it "updates the existing state routing fraction objects" do
         form = Hub::StateRoutingForm.new(params)
@@ -48,20 +48,7 @@ RSpec.describe Hub::StateRoutingForm do
       end
 
       context "when routing fractions don't cleanly convert from ints to floats and back" do
-        let(:params) do
-          {
-            state_routing_fraction_attributes: {
-              organization_1.id => {
-                state_routing_target_id: coalition_1_state_routing_target.id,
-                routing_percentage: 29
-              },
-              organization_2.id => {
-                state_routing_target_id: coalition_1_state_routing_target.id,
-                routing_percentage: 71
-              }
-            }
-          }
-        end
+        let(:params) { routing_params({organization_1 => 29, organization_2 => 71}) }
 
         it "still retains the entered values" do
           form = Hub::StateRoutingForm.new(params)
@@ -76,24 +63,9 @@ RSpec.describe Hub::StateRoutingForm do
 
     context "when new routing fractions are added" do
       let(:organization_3) { create :organization }
-      let(:params) do
-        {
-          state_routing_fraction_attributes: {
-            organization_1.id => {
-              state_routing_target_id: coalition_1_state_routing_target.id,
-              routing_percentage: 50
-            },
-            organization_2.id => {
-              state_routing_target_id: coalition_1_state_routing_target.id,
-              routing_percentage: 0
-            },
-            organization_3.id => {
-              state_routing_target_id: coalition_1_state_routing_target.id,
-              routing_percentage: 50
-            }
-          }
-        }
-      end
+      let(:params) { routing_params({ organization_1 => 50,
+                                      organization_2 => 0,
+                                      organization_3 => 50}) }
 
       it "creates new state routing fraction objects" do
         expect {
@@ -112,20 +84,7 @@ RSpec.describe Hub::StateRoutingForm do
   describe "#valid?" do
     context "percentages must add up to 100" do
       context "when proposed values add up to less than to 100%" do
-        let(:params) do
-          {
-            state_routing_fraction_attributes: {
-              organization_1.id => {
-                state_routing_target_id: coalition_1_state_routing_target.id,
-                routing_percentage: 40
-              },
-              organization_2.id => {
-                state_routing_target_id: coalition_1_state_routing_target.id,
-                routing_percentage: 40
-              }
-            }
-          }
-        end
+        let(:params) { routing_params({organization_1 => 40, organization_2 => 40}) }
 
         it "adds an error" do
           form = Hub::StateRoutingForm.new(params)
@@ -135,20 +94,7 @@ RSpec.describe Hub::StateRoutingForm do
       end
 
       context "when proposed values add up to more than to 100%" do
-        let(:params) do
-          {
-            state_routing_fraction_attributes: {
-              organization_1.id => {
-                state_routing_target_id: coalition_1_state_routing_target.id,
-                routing_percentage: 60
-              },
-              organization_2.id => {
-                state_routing_target_id: coalition_1_state_routing_target.id,
-                routing_percentage: 70
-              }
-            }
-          }
-        end
+        let(:params) { routing_params({organization_1 => 60, organization_2 => 70}) }
 
         it "adds an error" do
           form = Hub::StateRoutingForm.new(params)
@@ -158,20 +104,7 @@ RSpec.describe Hub::StateRoutingForm do
       end
 
       context "when proposed values add up to exactly 100%" do
-        let(:params) do
-          {
-            state_routing_fraction_attributes: {
-              organization_1.id => {
-                state_routing_target_id: coalition_1_state_routing_target.id,
-                routing_percentage: 60
-              },
-              organization_2.id => {
-                state_routing_target_id: coalition_1_state_routing_target.id,
-                routing_percentage: 40
-              }
-            }
-          }
-        end
+        let(:params) { routing_params({organization_1 => 60, organization_2 => 40}) }
 
         it "is valid" do
           form = Hub::StateRoutingForm.new(params)
@@ -185,24 +118,9 @@ RSpec.describe Hub::StateRoutingForm do
       let!(:site_2) { create :site, parent_organization: organization_1 }
 
       context "when there are routing fractions for an organization and its child site(s)" do
-        let(:params) do
-          {
-            state_routing_fraction_attributes: {
-              organization_1.id => {
-                state_routing_target_id: coalition_1_state_routing_target.id,
-                routing_percentage: 30
-              },
-              site_1.id => {
-                state_routing_target_id: coalition_1_state_routing_target.id,
-                routing_percentage: 30
-              },
-              organization_2.id => {
-                state_routing_target_id: coalition_1_state_routing_target.id,
-                routing_percentage: 40
-              }
-            }
-          }
-        end
+        let(:params) { routing_params({ organization_1 => 30,
+                                        site_1 => 30,
+                                        organization_2 => 40}) }
 
         it "adds an error" do
           form = Hub::StateRoutingForm.new(params)
@@ -212,24 +130,9 @@ RSpec.describe Hub::StateRoutingForm do
       end
 
       context "when routing fractions are for only an organization's child sites" do
-        let(:params) do
-          {
-            state_routing_fraction_attributes: {
-              site_1.id => {
-                state_routing_target_id: coalition_1_state_routing_target.id,
-                routing_percentage: 30
-              },
-              site_2.id => {
-                state_routing_target_id: coalition_1_state_routing_target.id,
-                routing_percentage: 30
-              },
-              organization_2.id => {
-                state_routing_target_id: coalition_1_state_routing_target.id,
-                routing_percentage: 40
-              }
-            }
-          }
-        end
+        let(:params) { routing_params({ site_1 => 30,
+                                        site_2 => 30,
+                                        organization_2 => 40}) }
 
         it "is valid" do
           form = Hub::StateRoutingForm.new(params)


### PR DESCRIPTION
## [Link to pivotal/JIRA issue](https://codeforamerica.atlassian.net/browse/GYR1-424?atlOrigin=eyJpIjoiYjNmNDgwZTQwNjM1NGM3NWFlNjUzNzM0MTNiNjJjY2IiLCJwIjoiaiJ9)
## What was done?
- Previously, entering 29 as a routing percentage on the state routing page would successfully update the database, but then would be displayed in the form as 28 after saving, causing the form to say it was invalid.
- Now, it will be displayed as 29 after saving, and the form will say that it's valid
- Side note: the page doesn't handle decimal places - not a big deal
## How to test?
- I test-drove this change, so there is a unit test that verifies it. I also manually tested it locally and on heroku.
- To acceptance test it, go to the [AL routing page on this heroku instance](https://gyr-review-app-4536-c3650c4e988b.herokuapp.com/en/hub/state_routings/AL/edit) and change the routing percentages from 50/50 to 29/71, and verify that they still say 29 & 71 after saving. You can go to demo to verify that this is different from current behavior.
- There shouldn't be any risks from this change, as it only changes how already-persisted data is displayed