### PR TITLE
GYR1-401 layout updates

### DIFF
--- a/app/assets/stylesheets/components/_index-table.scss
+++ b/app/assets/stylesheets/components/_index-table.scss
@@ -3,22 +3,24 @@ index-table is for displaying tabular information in the hub views.
 It expects to be the primary content of the given page (full width).
 */
 
-main {
-  width: fit-content;
-}
+.assigned-clients-outer, .clients-outer {
+  main {
+    width: fit-content;
+  }
 
-.left-buttons, .clients-index .pagination-wrapper>div {
-  position: sticky;
-  left: 2.5rem;
-}
+  .left-buttons, .clients-index .pagination-wrapper > div {
+    position: sticky;
+    left: 2.5rem;
+  }
 
-.right-buttons, .clients-index .count-wrapper {
-  position: sticky;
-  right: 2.5rem;
-}
+  .right-buttons, .clients-index .count-wrapper {
+    position: sticky;
+    right: 2.5rem;
+  }
 
-.scrollable-table-wrapper {
-  width: fit-content;
+  .scrollable-table-wrapper {
+    width: fit-content;
+  }
 }
 
 .index-table {

--- a/app/assets/stylesheets/components/_index-table.scss
+++ b/app/assets/stylesheets/components/_index-table.scss
@@ -3,6 +3,24 @@ index-table is for displaying tabular information in the hub views.
 It expects to be the primary content of the given page (full width).
 */
 
+main {
+  width: fit-content;
+}
+
+.slab.slab--padded {
+  position: sticky;
+  left: 0;
+  width: fit-content;
+}
+
+.count-wrapper {
+  padding-left: 2rem;
+}
+
+.scrollable-table-wrapper {
+  width: fit-content;
+}
+
 .index-table {
   // table resets
   border-collapse: collapse;

--- a/app/assets/stylesheets/components/_index-table.scss
+++ b/app/assets/stylesheets/components/_index-table.scss
@@ -8,12 +8,12 @@ It expects to be the primary content of the given page (full width).
     width: fit-content;
   }
 
-  .left-buttons, .clients-index .pagination-wrapper > div {
+  .sticky-left, .clients-index .pagination-wrapper > div {
     position: sticky;
     left: 2.5rem;
   }
 
-  .right-buttons, .clients-index .count-wrapper {
+  .sticky-right, .clients-index .count-wrapper {
     position: sticky;
     right: 2.5rem;
   }

--- a/app/assets/stylesheets/components/_index-table.scss
+++ b/app/assets/stylesheets/components/_index-table.scss
@@ -3,10 +3,6 @@ index-table is for displaying tabular information in the hub views.
 It expects to be the primary content of the given page (full width).
 */
 
-.scrollable-table-wrapper {
-  overflow-x: scroll;
-}
-
 .index-table {
   // table resets
   border-collapse: collapse;

--- a/app/assets/stylesheets/components/_index-table.scss
+++ b/app/assets/stylesheets/components/_index-table.scss
@@ -3,17 +3,17 @@ index-table is for displaying tabular information in the hub views.
 It expects to be the primary content of the given page (full width).
 */
 
-.assigned-clients-outer, .clients-outer {
-  main {
+.assigned-clients-page-body, .clients-page-body {
+  main, .flash-alerts .grid {
     width: fit-content;
   }
 
-  .sticky-left, .clients-index .pagination-wrapper > div {
+  .sticky-left, .pagination-wrapper > div, .flash-alerts .grid {
     position: sticky;
     left: 2.5rem;
   }
 
-  .sticky-right, .clients-index .count-wrapper {
+  .sticky-right, .count-wrapper {
     position: sticky;
     right: 2.5rem;
   }

--- a/app/assets/stylesheets/components/_index-table.scss
+++ b/app/assets/stylesheets/components/_index-table.scss
@@ -7,14 +7,14 @@ main {
   width: fit-content;
 }
 
-.slab.slab--padded {
+.left-buttons, .clients-index .pagination-wrapper>div {
   position: sticky;
-  left: 0;
-  width: fit-content;
+  left: 2.5rem;
 }
 
-.count-wrapper {
-  padding-left: 2rem;
+.right-buttons, .clients-index .count-wrapper {
+  position: sticky;
+  right: 2.5rem;
 }
 
 .scrollable-table-wrapper {

--- a/app/assets/stylesheets/components/_pagination.scss
+++ b/app/assets/stylesheets/components/_pagination.scss
@@ -8,7 +8,7 @@
   display: flex;
   justify-content: space-between;
   flex-direction: row-reverse;
-  align-items: flex-end;
+  align-items: center;
   .pagination {
     padding: 0;
   }

--- a/app/assets/stylesheets/components/_take-action-box.scss
+++ b/app/assets/stylesheets/components/_take-action-box.scss
@@ -3,6 +3,12 @@
   border-top: 1px solid $color-grey-medium;
   padding: $s15 3rem;
   text-align: right;
+  .button {
+    margin: 0;
+  }
+}
+
+.assigned-clients-outer, .clients-outer .take-action-box {
   height: 71px;
 
   .take-action-box-inner {
@@ -10,9 +16,5 @@
     align-items: center;
     position: sticky;
     right: 3rem;
-  }
-
-  .button {
-    margin: 0;
   }
 }

--- a/app/assets/stylesheets/components/_take-action-box.scss
+++ b/app/assets/stylesheets/components/_take-action-box.scss
@@ -8,10 +8,8 @@
   }
 }
 
-.assigned-clients-outer, .clients-outer .take-action-box {
-  height: 71px;
-
-  .take-action-box-inner {
+.assigned-clients-page-body, .clients-page-body {
+  .take-action-box .take-action-box-inner {
     display: flex;
     align-items: center;
     position: sticky;

--- a/app/assets/stylesheets/components/_take-action-box.scss
+++ b/app/assets/stylesheets/components/_take-action-box.scss
@@ -3,6 +3,15 @@
   border-top: 1px solid $color-grey-medium;
   padding: $s15 3rem;
   text-align: right;
+  height: 71px;
+
+  .take-action-box-inner {
+    display: flex;
+    align-items: center;
+    position: sticky;
+    right: 3rem;
+  }
+
   .button {
     margin: 0;
   }

--- a/app/views/hub/clients/_paginator.html.erb
+++ b/app/views/hub/clients/_paginator.html.erb
@@ -1,0 +1,25 @@
+<section class="slab slab--padded">
+  <div class="pagination-wrapper">
+    <div class="count-wrapper">
+      <% if @client_index_help_text.present? %>
+        <p class="text--help"><%= @client_index_help_text %></p>
+      <% end %>
+      <% if @missing_results_message.present? %>
+        <p class="text--help access-warning"><%= @missing_results_message %></p>
+      <% end %>
+      <div>
+        <%= page_entries_info @clients, model: "client" %>
+      </div>
+    </div>
+    <div>
+      <%= will_paginate(
+            @clients,
+            previous_label: "<i class=\"icon icon-keyboard_arrow_left\"></i><span class=\"hide-on-mobile\">Previous</span>",
+            next_label: "<span class=\"hide-on-mobile\">Next</span><i class=\"icon icon-keyboard_arrow_right\"></i>",
+            inner_window: 1,
+            outer_window: 1,
+            param_name: "page",
+            ) %>
+    </div>
+  </div>
+</section>

--- a/app/views/hub/clients/index.html.erb
+++ b/app/views/hub/clients/index.html.erb
@@ -5,8 +5,9 @@
   <% end %>
 <% end %>
 <% content_for :card do %>
+  <div class="clients-index">
   <section class="slab clients-header">
-    <div>
+    <div class="left-buttons">
       <h1> <%= @page_title %> </h1>
       <% unless @hide_filters %>
         <div class="text--no-wrap quick-filters">
@@ -21,7 +22,7 @@
       </div>
       <% end %>
     </div>
-    <div class="text--no-wrap">
+    <div class="text--no-wrap right-buttons">
       <%= link_to t("general.add_client"), new_hub_client_path, class: "button" %>
     </div>
   </section>
@@ -180,5 +181,6 @@
         <% end %>
       </div>
     </section>
+  </div>
   </div>
 <% end %>

--- a/app/views/hub/clients/index.html.erb
+++ b/app/views/hub/clients/index.html.erb
@@ -7,7 +7,7 @@
 <% content_for :card do %>
   <div class="clients-index">
   <section class="slab clients-header">
-    <div class="left-buttons">
+    <div class="sticky-left">
       <h1> <%= @page_title %> </h1>
       <% unless @hide_filters %>
         <div class="text--no-wrap quick-filters">
@@ -22,7 +22,7 @@
       </div>
       <% end %>
     </div>
-    <div class="text--no-wrap right-buttons">
+    <div class="text--no-wrap sticky-right">
       <%= link_to t("general.add_client"), new_hub_client_path, class: "button" %>
     </div>
   </section>

--- a/app/views/hub/clients/index.html.erb
+++ b/app/views/hub/clients/index.html.erb
@@ -25,7 +25,7 @@
       <%= link_to t("general.add_client"), new_hub_client_path, class: "button" %>
     </div>
   </section>
-  <%= render "paginator" %>
+  <%= render "hub/clients/paginator" %>
   <section class="scrollable-table-wrapper">
     <% if @clients.present? %>
       <table class="index-table client-table">
@@ -157,7 +157,7 @@
     <% end %>
   </section>
 
-  <%= render "paginator" %>
+  <%= render "hub/clients/paginator" %>
 
   <div class="sticky-action-footer">
     <section class="take-action-box bulk-action-footer" id="take-action-footer" style="display: none;">

--- a/app/views/hub/clients/index.html.erb
+++ b/app/views/hub/clients/index.html.erb
@@ -25,31 +25,7 @@
       <%= link_to t("general.add_client"), new_hub_client_path, class: "button" %>
     </div>
   </section>
-  <section class="slab slab--padded">
-    <div class="pagination-wrapper">
-      <div class="count-wrapper">
-        <% if @client_index_help_text.present? %>
-          <p class="text--help"><%= @client_index_help_text %></p>
-        <% end %>
-        <% if @missing_results_message.present? %>
-          <p class="text--help access-warning"><%= @missing_results_message %></p>
-        <% end %>
-        <div>
-          <%= page_entries_info @clients, model: "client" %>
-        </div>
-      </div>
-      <div>
-        <%= will_paginate(
-              @clients,
-              previous_label: "<i class=\"icon icon-keyboard_arrow_left\"></i><span class=\"hide-on-mobile\">Previous</span>",
-              next_label: "<span class=\"hide-on-mobile\">Next</span><i class=\"icon icon-keyboard_arrow_right\"></i>",
-              inner_window: 1,
-              outer_window: 1,
-              param_name: "page",
-            ) %>
-      </div>
-    </div>
-  </section>
+  <%= render "paginator" %>
   <section class="scrollable-table-wrapper">
     <% if @clients.present? %>
       <table class="index-table client-table">
@@ -180,6 +156,9 @@
       </div>
     <% end %>
   </section>
+
+  <%= render "paginator" %>
+
   <div class="sticky-action-footer">
     <section class="take-action-box bulk-action-footer" id="take-action-footer" style="display: none;">
       <span id="take-action-all-returns" class="hidden">

--- a/app/views/hub/clients/index.html.erb
+++ b/app/views/hub/clients/index.html.erb
@@ -5,7 +5,6 @@
   <% end %>
 <% end %>
 <% content_for :card do %>
-  <div class="clients-index">
   <section class="slab clients-header">
     <div class="sticky-left">
       <h1> <%= @page_title %> </h1>
@@ -181,6 +180,5 @@
         <% end %>
       </div>
     </section>
-  </div>
   </div>
 <% end %>

--- a/app/views/hub/clients/index.html.erb
+++ b/app/views/hub/clients/index.html.erb
@@ -25,7 +25,9 @@
       <%= link_to t("general.add_client"), new_hub_client_path, class: "button" %>
     </div>
   </section>
+
   <%= render "hub/clients/paginator" %>
+
   <section class="scrollable-table-wrapper">
     <% if @clients.present? %>
       <table class="index-table client-table">
@@ -161,20 +163,22 @@
 
   <div class="sticky-action-footer">
     <section class="take-action-box bulk-action-footer" id="take-action-footer" style="display: none;">
-      <span id="take-action-all-returns" class="hidden">
-         <%= form_with(url: new_hub_tax_return_selection_path, local: true, method: :get, builder: VitaMinFormBuilder) do |form| %>
-              <% @client_sorter&.filters&.each do |key, value| %>
-                <%= form.hidden_field(key, value: value, id: "#{key}_bulk") %>
-              <% end %>
-              <button type="submit" name="create_tax_return_selection[action_type]" value="all-filtered-clients" class="button--link">
-                <%= t(".take_action_on_all_html", count: @tax_return_count) %>
-              </button>
-         <% end %>
-      </span>
-      <span class="bulk-action-count"><%= t('hub.clients.bulk_action.count_html', count: 0) %></span>
-      <%= form_with(url: new_hub_tax_return_selection_path, local: true, method: :get, builder: VitaMinFormBuilder, html: { id: 'take-action-form' }) do |f| %>
-        <%= f.submit t("general.take_action"), class: "button button--primary" %>
-      <% end %>
+      <div class="take-action-box-inner">
+        <span id="take-action-all-returns" class="hidden">
+           <%= form_with(url: new_hub_tax_return_selection_path, local: true, method: :get, builder: VitaMinFormBuilder) do |form| %>
+                <% @client_sorter&.filters&.each do |key, value| %>
+                  <%= form.hidden_field(key, value: value, id: "#{key}_bulk") %>
+                <% end %>
+                <button type="submit" name="create_tax_return_selection[action_type]" value="all-filtered-clients" class="button--link">
+                  <%= t(".take_action_on_all_html", count: @tax_return_count) %>
+                </button>
+           <% end %>
+        </span>
+        <span class="bulk-action-count"><%= t('hub.clients.bulk_action.count_html', count: 0) %></span>
+        <%= form_with(url: new_hub_tax_return_selection_path, local: true, method: :get, builder: VitaMinFormBuilder, html: { id: 'take-action-form' }) do |f| %>
+          <%= f.submit t("general.take_action"), class: "button button--primary" %>
+        <% end %>
+      </div>
     </section>
   </div>
 <% end %>

--- a/app/views/layouts/hub.html.erb
+++ b/app/views/layouts/hub.html.erb
@@ -44,7 +44,7 @@
 
 </head>
 
-<body class="admin honeycrisp-compact hub">
+<body class="admin honeycrisp-compact hub <%= controller_name.gsub("_", "-") %>-outer">
 <a href="#maincontent" id="skip-content-link" class="skip-link button--green"><%= t('views.layouts.application.skip_content') %></a>
 
 <div class="columns">

--- a/app/views/layouts/hub.html.erb
+++ b/app/views/layouts/hub.html.erb
@@ -44,7 +44,7 @@
 
 </head>
 
-<body class="admin honeycrisp-compact hub <%= controller_name.gsub("_", "-") %>-outer">
+<body class="admin honeycrisp-compact hub <%= controller_name.gsub("_", "-") %>-page-body">
 <a href="#maincontent" id="skip-content-link" class="skip-link button--green"><%= t('views.layouts.application.skip_content') %></a>
 
 <div class="columns">


### PR DESCRIPTION
## [GYR1-401](https://codeforamerica.atlassian.net/browse/GYR1-401)
## What was done?
* Readjusted the page so that the table is not the element that scrolls - the main content element scrolls instead. (The table fills this.) This means that users that do not have a trackpad do not need to scroll to the bottom of the page to be able to scroll horizontally.
* Added the name of the controller to the body in hub.html.erb so that it is easier to do page specific CSS.
* Created page specific CSS so that scrolling is on the main element, and that the paginator controls and header are stuck to the left and the number of results and create button are stuck to the right 
![image](https://github.com/codeforamerica/vita-min/assets/17094895/c07b9d4b-0cfa-4d80-8537-c4bb0ec661eb)
* Take action bar now fills the width with the text stuck to the right 
![image](https://github.com/codeforamerica/vita-min/assets/17094895/3aaa031f-aeec-4a2b-a4c8-f4c6df7c59b5)
* Added a paginator to bottom of page (Created a partial for pagination for this) 
![image](https://github.com/codeforamerica/vita-min/assets/17094895/8103b1f5-8648-4608-b1b3-8b17686fae24)

## How to test?
* Test On Heroku using `admin@example.com` / `theforcevita`
* Testing on heroku may mean you need to add a bunch of items into the db. It may make sense to merge this to staging / demo.
## Risk Assessment
* Cosmetic changes only - check that pagination tests should still work. No changes were made to controllers / logic

[GYR1-401]: https://codeforamerica.atlassian.net/browse/GYR1-401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ