### PR TITLE
GYR1-432 Now passing organization to row

### DIFF
--- a/app/views/hub/metrics/index.html.erb
+++ b/app/views/hub/metrics/index.html.erb
@@ -49,7 +49,7 @@
       </tr>
       <% @organizations.each do |organization| %>
         <tbody class="index-table__body org-metrics" data-js-vita-partner-name="<%= organization.name %>">
-        <%= render 'breach_row', type: 'org', id: organization.id, name: organization.name %>
+        <%= render 'breach_row', organization: organization, type: 'org', id: organization.id, name: organization.name %>
         <% if organization.child_sites.present? %>
           <!--           Add a row for the organization to track org-level breaches.-->
           <%= render 'breach_row', type: 'site', id: organization.id, name: organization.name %>


### PR DESCRIPTION
## [GYR1-432](https://codeforamerica.atlassian.net/browse/GYR1-432)
## What was done?
This page uses a partial [_breach_row.html.erb](app/views/hub/metrics/_breach_row.html.erb) to render each row, and a piece of javascript calculates the totals. We were not passing the organization object into each of these rows, so I added it.
## How to test?
* Test on Heroku. Go to `/en/hub/metrics`. You may want to change capacities / values in each org.
## Screenshots (for visual changes)
### Before
![image](https://github.com/codeforamerica/vita-min/assets/17094895/8561b281-2b14-49b6-afcd-51d14f94e89e)
### After 
![image](https://github.com/codeforamerica/vita-min/assets/17094895/7c524801-8d7b-40e3-aae5-070959b94ba9)


[GYR1-432]: https://codeforamerica.atlassian.net/browse/GYR1-432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ