### PR TITLE
Activating spellcheck

### DIFF
--- a/app/views/hub/clients/edit_take_action.html.erb
+++ b/app/views/hub/clients/edit_take_action.html.erb
@@ -37,7 +37,7 @@
           <%= f.cfa_textarea(
                 :message_body,
                 t("general.send_message"),
-                options: { rows: 8 },
+                options: { rows: 8, spellcheck: true },
                 classes: ['text-message-body'],
 
                 help_text: t(".blank_no_message_sent")
@@ -57,7 +57,7 @@
       <%= f.cfa_textarea(
             :internal_note_body,
             t(".internal_note_body_label"),
-            options: { rows: 8 },
+            options: { rows: 8, spellcheck: true },
             help_text: t(".blank_no_internal_note"),
           ) %>
 


### PR DESCRIPTION
## [GYR1-433](https://codeforamerica.atlassian.net/browse/GYR1-433)
## What was done?
 * The spellcheck is off by default in honeycrisp. We want to activate it.
 * There are already other places in our codebase where we activate it: https://github.com/search?q=repo%3Acodeforamerica%2Fvita-min%20spellcheck&type=code
## How to test?
 * Go to the edit client page and click "Take Action"
![image](https://github.com/codeforamerica/vita-min/assets/17094895/97505d59-f940-427d-bef1-ef7538b8f6a3)
 * Enter text in the fields on the page to see spelling prompts
![image](https://github.com/codeforamerica/vita-min/assets/17094895/affad308-be11-44cd-be82-0d37c8cb15c4)


[GYR1-433]: https://codeforamerica.atlassian.net/browse/GYR1-433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ