### PR TITLE
Coding more defensively

### DIFF
--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -16,8 +16,8 @@ class PublicPagesController < ApplicationController
     # redirect to home hiding original source param
     if params[:source].present?
       source_parameter = SourceParameter.find_by(code: params[:source]&.downcase)
-      if source_parameter.present?
-        if source_parameter.active? && source_parameter.vita_partner.present?
+      if source_parameter.present? && source_parameter.vita_partner.present?
+        if source_parameter.active?
           flash[:notice] = I18n.t("controllers.public_pages.partner_welcome_notice", partner_name: source_parameter.vita_partner.name)
           cookies[:used_unique_link] = { value: "yes", expiration: 1.year.from_now.utc }
         else


### PR DESCRIPTION
## [GYR1-426](https://codeforamerica.atlassian.net/browse/GYR1-426)
## What was done?
 * Making sure that vita-partner is present for the flash notice
## How to test?
 * Test on Heroku: 
 * Log in to the hub and go to /en/hub/organizations
 * Enable / Disable links, reloading the page between. (Demonstrating that values are persisted)
 * Create / Delete links to verify this still works.

[GYR1-426]: https://codeforamerica.atlassian.net/browse/GYR1-426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ