### PR TITLE
GYR1-473 Make hub layout rules endpoint specific

### DIFF
--- a/app/assets/stylesheets/components/_index-table.scss
+++ b/app/assets/stylesheets/components/_index-table.scss
@@ -3,7 +3,7 @@ index-table is for displaying tabular information in the hub views.
 It expects to be the primary content of the given page (full width).
 */
 
-.assigned-clients-page-body, .clients-page-body {
+.assigned-clients-index-page-body, .clients-index-page-body {
   main, .flash-alerts .grid {
     width: fit-content;
   }

--- a/app/assets/stylesheets/components/_take-action-box.scss
+++ b/app/assets/stylesheets/components/_take-action-box.scss
@@ -8,7 +8,7 @@
   }
 }
 
-.assigned-clients-page-body, .clients-page-body {
+.assigned-clients-index-page-body, .clients-index-page-body {
   .take-action-box .take-action-box-inner {
     display: flex;
     align-items: center;

--- a/app/views/layouts/hub.html.erb
+++ b/app/views/layouts/hub.html.erb
@@ -44,7 +44,7 @@
 
 </head>
 
-<body class="admin honeycrisp-compact hub <%= controller_name.gsub("_", "-") %>-page-body">
+<body class="admin honeycrisp-compact hub <%= controller_name.gsub("_", "-") %>-<%= action_name.gsub("_", "-") %>-page-body">
 <a href="#maincontent" id="skip-content-link" class="skip-link button--green"><%= t('views.layouts.application.skip_content') %></a>
 
 <div class="columns">


### PR DESCRIPTION
## [GYR1-743](https://codeforamerica.atlassian.net/browse/GYR1-473)
## What was done?
The recent layout updates were too general, and went beyond the index pages. We are now limiting these rules to the endpoint as well as the controller
## How to test?
* Test on Heroku - go to the clients index pages and make sure that scrolling is still as expected. Then go to the edit clients pages and make sure that content stretches to fit the screen
## Screenshots (for visual changes)
### No Change to index pages:
![image](https://github.com/codeforamerica/vita-min/assets/17094895/aeeb78f2-b852-4abb-8c59-05c41726de66)
![image](https://github.com/codeforamerica/vita-min/assets/17094895/9cc0a61f-f24d-44a4-84a0-2ab768405096)

### Before: Edit pages do not stretch to fit screen
![image](https://github.com/codeforamerica/vita-min/assets/17094895/748648ed-303d-49a7-9248-cb6de10a076d)

#### After: Edit pages stretch to fit screen
![image](https://github.com/codeforamerica/vita-min/assets/17094895/32f2e5e4-9918-45a3-891b-6d2e84c4692f)

