### PR TITLE
Fix GYR dates

### DIFF
--- a/app/views/portal/still_needs_helps/edit.html.erb
+++ b/app/views/portal/still_needs_helps/edit.html.erb
@@ -10,7 +10,10 @@
           </div>
           <h1 class="h2 spacing-above-0"><%= t(".title") %></h1>
 
-          <p class="help-text"><%= t(".help_text") %></p>
+          <% docs_deadline = I18n.l(Rails.configuration.end_of_docs.to_date, format: :medium, locale: locale) %>
+          <% end_of_closing = I18n.l(Rails.configuration.end_of_closing.to_date, format: :medium, locale: locale) %>
+
+          <p class="help-text"><%= t(".help_text", docs_deadline: docs_deadline, end_of_closing: end_of_closing) %></p>
 
           <%= form_with(url: portal_update_still_needs_help_path, local: true, method: :put, builder: VitaMinFormBuilder) do |f| %>
             <%= f.button name: "still_needs_help", value: "yes", class: "button button--primary button--wide" do %>

--- a/app/views/portal/still_needs_helps/upload_documents.html.erb
+++ b/app/views/portal/still_needs_helps/upload_documents.html.erb
@@ -10,7 +10,7 @@
           </div>
           <h1 class="h2 spacing-above-0"><%= t(".title") %></h1>
 
-          <p class="help-text"><%= t(".help_text") %></p>
+          <p class="help-text"><%= t(".help_text", docs_deadline: I18n.l(Rails.configuration.end_of_docs.to_date, format: :medium, locale: locale)) %></p>
 
 
           <%= link_to portal_edit_upload_documents_path, class: "button button--wide text--centered" do %>

--- a/app/views/questions/at_capacity/edit.html.erb
+++ b/app/views/questions/at_capacity/edit.html.erb
@@ -16,7 +16,7 @@
         </div>
 
         <div class="notice--warning">
-          <p><%= t("views.questions.at_capacity.warning_html") %></p>
+          <p><%= t("views.questions.at_capacity.warning_html", tax_deadline: I18n.l(Rails.configuration.tax_deadline.to_date, format: :medium, locale: locale)) %></p>
         </div>
 
         <div class="offboarding--help-text text--bold">

--- a/config/application.rb
+++ b/config/application.rb
@@ -93,6 +93,7 @@ module VitaMin
     config.tax_deadline = Time.find_zone('America/New_York').parse('2024-04-15 23:59:59')
     config.end_of_intake = Time.find_zone('America/New_York').parse('2024-10-01 23:59:59')
     config.end_of_docs = Time.find_zone('America/New_York').parse('2024-10-08 23:59:59')
+    config.end_of_closing = Time.find_zone('America/New_York').parse('2024-10-15 23:59:59')
     config.end_of_in_progress_intake = Time.find_zone('America/New_York').parse('2024-10-16 23:59:59')
     config.end_of_login = Time.find_zone('America/New_York').parse('2024-10-23 23:59:00')
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1920,7 +1920,7 @@ en:
         title: Great! We'll chat with you in June.
         upload_additional_documents: Upload additional documents
       edit:
-        help_text: We are closing GetYourRefund for the tax season on October 15th. We will need all required documentation by October 8th; otherwise, we will not be able to prepare your taxes.
+        help_text: We are closing GetYourRefund for the tax season on %{end_of_closing}. We will need all required documentation by %{docs_deadline}; otherwise, we will not be able to prepare your taxes.
         not_interested: No, I'm not interested
         still_needs_help: Yes, I still need help
         title: Are you still interested in filing your taxes with us?
@@ -1932,7 +1932,7 @@ en:
         survey_question: How was your experience with GetYourRefund?
         title: Thank you for using GetYourRefund.
       upload_documents:
-        help_text: If you have any additional documents that you need to upload, please use the button below. We need all of your documents by October 8th.
+        help_text: If you have any additional documents that you need to upload, please use the button below. We need all of your documents by %{docs_deadline}.
         no_additional_documents: I have no additional documents
         title: Great! If you have additional documents, please upload them below.
         upload_additional_documents: Upload additional documents

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4802,7 +4802,7 @@ en:
         continue_to_diy: Continue to File Myself
         file_myself: File today using File Myself, our online service that lets you prepare your taxes for free.
         title: Wow, it looks like we are at capacity right now.
-        warning_html: "<b>A friendly reminder that the filing deadline is {tax_deadline}.</b> We recommend filing as soon as possible."
+        warning_html: "<b>A friendly reminder that the filing deadline is %{tax_deadline}.</b> We recommend filing as soon as possible."
       backtaxes:
         select_all_that_apply: 'Select all the years you would like to file for:'
         title: Which of the following years would you like to file for?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4802,7 +4802,7 @@ en:
         continue_to_diy: Continue to File Myself
         file_myself: File today using File Myself, our online service that lets you prepare your taxes for free.
         title: Wow, it looks like we are at capacity right now.
-        warning_html: "<b>A friendly reminder that the filing deadline is April 15th.</b> We recommend filing as soon as possible."
+        warning_html: "<b>A friendly reminder that the filing deadline is {tax_deadline}.</b> We recommend filing as soon as possible."
       backtaxes:
         select_all_that_apply: 'Select all the years you would like to file for:'
         title: Which of the following years would you like to file for?

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4804,7 +4804,7 @@ es:
         continue_to_diy: Continuar a File Myself--declarar yo mismo
         file_myself: Presente su declaración hoy usando File Myself, nuestro servicio en línea que le permite preparar sus impuestos de forma gratuita.
         title: Vaya, parece que estamos al límite de capacidad en este momento.
-        warning_html: "<b>Un recordatorio amistoso de que la fecha límite de presentación es el {tax_deadline}.</b> Recomendamos presentar la solicitud lo antes posible."
+        warning_html: "<b>Un recordatorio amistoso de que la fecha límite de presentación es el %{tax_deadline}.</b> Recomendamos presentar la solicitud lo antes posible."
       backtaxes:
         select_all_that_apply: 'Seleccione todos los años que desea declarar:'
         title: "¿Para cuál o cuáles de los siguientes años le gustaría declarar?"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4804,7 +4804,7 @@ es:
         continue_to_diy: Continuar a File Myself--declarar yo mismo
         file_myself: Presente su declaración hoy usando File Myself, nuestro servicio en línea que le permite preparar sus impuestos de forma gratuita.
         title: Vaya, parece que estamos al límite de capacidad en este momento.
-        warning_html: "<b>Un recordatorio amistoso de que la fecha límite de presentación es el 15 de abril.</b> Recomendamos presentar la solicitud lo antes posible."
+        warning_html: "<b>Un recordatorio amistoso de que la fecha límite de presentación es el {tax_deadline}.</b> Recomendamos presentar la solicitud lo antes posible."
       backtaxes:
         select_all_that_apply: 'Seleccione todos los años que desea declarar:'
         title: "¿Para cuál o cuáles de los siguientes años le gustaría declarar?"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1878,7 +1878,7 @@ es:
         title: "¡Genial! Le hablaremos en junio."
         upload_additional_documents: Subir documentos adicionales
       edit:
-        help_text: Cerramos la temporada de impuestos de GetYourRefund el 15 de octubre. Necesitamos todos los documentos requeridos antes del 8 de octubre; de lo contrario, no podremos preparar su declaración de impuestos.
+        help_text: Cerramos la temporada de impuestos de GetYourRefund el %{end_of_closing}. Necesitamos todos los documentos requeridos antes del %{docs_deadline}; de lo contrario, no podremos preparar su declaración de impuestos.
         not_interested: No, no estoy interesado
         still_needs_help: Sí, todavía necesito ayuda
         title: "¿Todavía le interesa declarar sus impuestos con nosotros?"
@@ -1890,7 +1890,7 @@ es:
         survey_question: "¿Cómo fue su experiencia con GetYourRefund?"
         title: Gracias por usar GetYourRefund.
       upload_documents:
-        help_text: Si tiene documentos adicionales que necesita subir, por favor use el botón a continuación. Necesitamos todos sus documentos antes del 8 de octubre.
+        help_text: Si tiene documentos adicionales que necesita subir, por favor use el botón a continuación. Necesitamos todos sus documentos antes del %{docs_deadline}.
         no_additional_documents: No tengo documentos adicionales.
         title: "!Excelente! Si tiene documentos adicionales, favor de subirlos a continuación."
         upload_additional_documents: Subir documentos adicionales


### PR DESCRIPTION
## Link to pivotal/JIRA issue
[Automatically shut down intake/login based on year's filing deadline date](https://codeforamerica.atlassian.net/browse/GYR1-3)
## What was done?
In addition to checking the dates for dhutting down intake and login this story also fixes the following found from the audit story:

- At Capacity page warning notice

  - Solution: put in a config.document_submission_deadline in application.rb file for April 1 deadline and also use config.tax_deadline for April 15 date

- Portal Still Need Helps page 

  - Edit page: help_text: We are closing GetYourRefund for the tax season on October 15th. We will need all required documentation by October 8th; otherwise, we will not be able to prepare your taxes.
  - Upload Documents page: “If you have any additional documents that you need to upload, please use the button below. We need all of your documents by October 8th.”

  - Solution: Use config.end_of_docs for Oct 8 from application.rb and add in a config for October 15th closing

## How to test?
PM to check the login and intake shutting down using session toggles. And also make sure the at capacity page and the portal Still Needs Help page are formatted correctly
