### PR TITLE
Cleanup users without roles

### DIFF
--- a/app/helpers/role_helper.rb
+++ b/app/helpers/role_helper.rb
@@ -86,6 +86,8 @@ module RoleHelper
   end
 
   def user_group(user)
+    return if user.role.nil?
+
     if user.role_type == OrganizationLeadRole::TYPE
       user.role.organization.name
     elsif user.role_type == CoalitionLeadRole::TYPE

--- a/lib/tasks/cleanup_orphaned_users.rake
+++ b/lib/tasks/cleanup_orphaned_users.rake
@@ -1,0 +1,69 @@
+namespace :cleanup_orphaned_users do
+  desc 'Remove users that do not have a role'
+  task find_orphaned_users: [:environment] do
+    admin_orphaned_users = User.joins("LEFT JOIN admin_roles ON users.role_id = admin_roles.id AND users.role_type = 'AdminRole'")
+                               .where(admin_roles: { id: nil }, role_type: 'AdminRole')
+
+    greeter_orphaned_users = User.joins("LEFT JOIN greeter_roles ON users.role_id = greeter_roles.id AND users.role_type = 'GreeterRole'")
+                                 .where(greeter_roles: { id: nil }, role_type: 'GreeterRole')
+
+    site_coordinator_orphaned_users = User.joins("LEFT JOIN site_coordinator_roles ON users.role_id = site_coordinator_roles.id AND users.role_type = 'SiteCoordinatorRole'")
+                                     .where(site_coordinator_roles: { id: nil }, role_type: 'SiteCoordinatorRole')
+
+    client_success_orphaned_users = User.joins("LEFT JOIN client_success_roles ON users.role_id = client_success_roles.id AND users.role_type = 'ClientSuccessRole'")
+                               .where(client_success_roles: { id: nil }, role_type: 'ClientSuccessRole')
+
+    coalition_lead_orphaned_users = User.joins("LEFT JOIN coalition_lead_roles ON users.role_id = coalition_lead_roles.id AND users.role_type = 'CoalitionLeadRole'")
+                               .where(coalition_lead_roles: { id: nil }, role_type: 'CoalitionLeadRole')
+
+    organization_lead_orphaned_users = User.joins("LEFT JOIN organization_lead_roles ON users.role_id = organization_lead_roles.id AND users.role_type = 'OrganizationLeadRole'")
+                                        .where(organization_lead_roles: { id: nil }, role_type: 'OrganizationLeadRole')
+
+    team_member_orphaned_users = User.joins("LEFT JOIN team_member_roles ON users.role_id = team_member_roles.id AND users.role_type = 'TeamMemberRole'")
+                                        .where(team_member_roles: { id: nil }, role_type: 'TeamMemberRole')
+
+    orphaned_users = admin_orphaned_users + greeter_orphaned_users + site_coordinator_orphaned_users + client_success_orphaned_users + coalition_lead_orphaned_users + organization_lead_orphaned_users + team_member_orphaned_users
+
+    puts "These users have no roles: #{orphaned_users.pluck(:id)}"
+  end
+
+  desc "Replace user_id calls in other models and delete old user"
+  task :replace_user_associations_and_delete_old_user, [:old_user_id, :new_user_id] => :environment do |t, args|
+    old_user_id = args[:old_user_id]
+    new_user_id = args[:new_user_id]
+    if old_user_id.nil? || new_user_id.nil?
+      puts "Please provide a user ID."
+      next
+    end
+
+    old_user = User.find_by(id: old_user_id)
+    new_user = User.find_by(id: new_user_id)
+
+    if old_user.nil? || new_user.nil?
+      puts "Please provide users that exist"
+    else
+      if old_user.role.present?
+        puts "Role for old user ##{old_user_id} is present, are you sure you want to delete?"
+        next
+      end
+
+      logs = AccessLog.where(user: old_user)
+      logs.update(user: new_user)
+
+      notes = Note.where(user_id: old_user)
+      notes.update(user: new_user)
+
+      notifications = UserNotification.where(user_id: old_user)
+      notifications.update(user: new_user)
+
+      system_notes = SystemNote.where(user_id: old_user)
+      system_notes.update(user: new_user)
+
+      puts "User with ID #{old_user_id} and associated records have been replaced with ID #{new_user_id}."
+
+      old_user.destroy!
+
+      puts "User with ID #{old_user_id} has been deleted"
+    end
+  end
+end

--- a/spec/tasks/cleanup_orphaned_users_spec.rb
+++ b/spec/tasks/cleanup_orphaned_users_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+describe "cleanup_orphaned_users:find_orphaned_users" do
+  include_context "rake"
+
+  around { |example| capture_output { example.run } }
+
+  before(:all) do
+    Rails.application.load_tasks
+  end
+
+  let!(:team_member_user) { create :team_member_user }
+  let!(:admin_user) { create :admin_user }
+
+  context "when there are users without roles" do
+
+    before do
+      team_member_user.role.destroy
+      admin_user.role.destroy
+    end
+
+    it "it finds users without roles" do
+      expect {
+        task.invoke
+      }.to output(/These users have no roles: \[#{admin_user.id}, #{team_member_user.id}]/).to_stdout
+    end
+  end
+end
+
+describe "cleanup_orphaned_users:replace_user_associations_and_delete_old_user" do
+  include_context "rake"
+
+  around { |example| capture_output { example.run } }
+
+  before(:all) do
+    Rails.application.load_tasks
+  end
+
+  let!(:team_member_user) { create :team_member_user }
+  let!(:admin_user) { create :admin_user }
+
+  context "when old and new user exists" do
+    let!(:new_user){ create :team_member_user}
+    let!(:old_user){ create :team_member_user}
+    let!(:access_log) { create :access_log, user: old_user }
+    let!(:note) { create :note, user: old_user }
+
+    before do
+      old_user.role.destroy
+    end
+
+    it "it finds users without roles" do
+      task.invoke(old_user.id, new_user.id)
+      expect(access_log.reload.user).to eq new_user
+      expect(note.reload.user).to eq new_user
+    end
+  end
+end


### PR DESCRIPTION
## [Link to pivotal/JIRA issue](https://codeforamerica.atlassian.net/jira/software/c/projects/GYR1/boards/11/?selectedIssue=GYR1-157)
## What was done?
    - The hub/user page was breaking when you searched "mariah" because there is a user missing a role. This PR stops that page from breaking when a user is missing a role but also helps us fix bad data. The rake task helps us find orphaned users (users with a role reference but missing role). 
    - This rake task might seem overboard because there actually only seems to be one user in the database with this issue. But because our new db change processes I went this route to ensure we would be doing these data changes safely. 
## How to test?
        - I tested this by creating a unit test for the rake test as well as creating the same situation of team member with missing role in my local environment to test it locally 
    - The reviewer can test this locally by creating a user without a role and testing the rake task or going to hub/user page on heroku to test if the page breaks.
    - Risk Assessment
        - The risk seems pretty low, since we have separated find the orphaned users and any data changes. The data change task will exit if it seems it has a user with an existing role and since we only have one user with this issue it should be pretty easy to double check
