### PR TITLE
dynamically generate list of message classes for FYST Hub AutomatedMessages page

### DIFF
--- a/app/controllers/hub/automated_messages_controller.rb
+++ b/app/controllers/hub/automated_messages_controller.rb
@@ -10,39 +10,24 @@ module Hub
     private
 
     def messages_preview
-      automated_messages = [
-        [AutomatedMessage::SuccessfulSubmissionDropOff, {}],
-        [AutomatedMessage::SuccessfulSubmissionOnlineIntake, {}],
-        [SurveyMessages::GyrCompletionSurvey, { survey_link: "https://fakecodeforamerica.co1.qualtrics.com" }],
-        [SurveyMessages::CtcExperienceSurvey, { survey_link: "https://fakecodeforamerica.co1.qualtrics.com" }],
-        [AutomatedMessage::DocumentsReminderLink, { body_args: { doc_type: "ID" } }],
-        [AutomatedMessage::EfileAcceptance, {}],
-        [AutomatedMessage::EfilePreparing, {}],
-        [AutomatedMessage::EfileRejected, {}],
-        [AutomatedMessage::EfileRejectedAndCancelled, {}],
-        [AutomatedMessage::EfileFailed, {}],
-        [AutomatedMessage::CtcGettingStarted, {}],
-        [AutomatedMessage::ClosingSoon, {}],
-        [AutomatedMessage::SaveCtcLetter, { body_args: { service_name: MultiTenantService.new(:ctc).service_name } }],
-        [AutomatedMessage::ContactInfoChange, {}],
-        [AutomatedMessage::FirstNotReadyReminder, {}],
-        [AutomatedMessage::SecondNotReadyReminder, {}],
-        [AutomatedMessage::InformOfFraudHold, {}],
-        [AutomatedMessage::NewPhotosRequested, {}],
-        [AutomatedMessage::VerificationAttemptDenied, {}],
-        [AutomatedMessage::Ctc2022OpenMessage, {}],
-        [AutomatedMessage::PuertoRicoOpenMessage, {}],
-        [AutomatedMessage::IntercomForwarding, {}],
-        [AutomatedMessage::UnmonitoredReplies, { support_email: Rails.configuration.email_from[:support][:gyr] }],
-        [AutomatedMessage::InProgress, {}],
-        [AutomatedMessage::Welcome, {}],
-      ]
+      Rails.application.eager_load!
+      message_classes = AutomatedMessage::AutomatedMessage.descendants + [SurveyMessages::GyrCompletionSurvey, SurveyMessages::CtcExperienceSurvey]
 
-      automated_messages_and_mailers = automated_messages.map do |m|
-        message = m[0].new
+      # TODO: These were not being used in the previous implementation of this code, so either figure out how to use them or delete them
+      #   The issue is that different message classes take their args differently,
+      message_params = {
+        SurveyMessages::GyrCompletionSurvey => { survey_link: "https://fakecodeforamerica.co1.qualtrics.com" },
+        SurveyMessages::CtcExperienceSurvey => { survey_link: "https://fakecodeforamerica.co1.qualtrics.com" },
+        AutomatedMessage::DocumentsReminderLink => { body_args: { doc_type: "ID" } },
+        AutomatedMessage::SaveCtcLetter => { body_args: { service_name: MultiTenantService.new(:ctc).service_name } },
+        AutomatedMessage::UnmonitoredReplies => { support_email: Rails.configuration.email_from[:support][:gyr] },
+      }
+
+      automated_messages_and_mailers = message_classes.to_h do |klass|
+        message = klass.new
         replaced_body = message.email_body.gsub('<<', '&lt;&lt;').gsub('>>', '&gt;&gt;')
         email = OutgoingEmail.new(to: "example@example.com", body: replaced_body, subject: message.email_subject, client: Client.new(intake: Intake::GyrIntake.new))
-        [m[0], OutgoingEmailMailer.user_message(outgoing_email: email)]
+        [klass, OutgoingEmailMailer.user_message(outgoing_email: email)]
       end.to_h
 
       emails = {

--- a/app/controllers/hub/automated_messages_controller.rb
+++ b/app/controllers/hub/automated_messages_controller.rb
@@ -14,9 +14,8 @@ module Hub
       message_classes = AutomatedMessage::AutomatedMessage.descendants + [SurveyMessages::GyrCompletionSurvey, SurveyMessages::CtcExperienceSurvey]
 
       automated_messages_and_mailers = message_classes.to_h do |klass|
-        message = klass.new
-        replaced_body = message.email_body.gsub('<<', '&lt;&lt;').gsub('>>', '&gt;&gt;')
-        email = OutgoingEmail.new(to: "example@example.com", body: replaced_body, subject: message.email_subject, client: Client.new(intake: Intake::GyrIntake.new))
+        replaced_body = klass.new.email_body.gsub('<<', '&lt;&lt;').gsub('>>', '&gt;&gt;')
+        email = OutgoingEmail.new(to: "example@example.com", body: replaced_body, subject: klass.new.email_subject, client: Client.new(intake: Intake::GyrIntake.new))
         [klass, OutgoingEmailMailer.user_message(outgoing_email: email)]
       end.to_h
 

--- a/app/controllers/hub/automated_messages_controller.rb
+++ b/app/controllers/hub/automated_messages_controller.rb
@@ -13,16 +13,6 @@ module Hub
       Rails.application.eager_load!
       message_classes = AutomatedMessage::AutomatedMessage.descendants + [SurveyMessages::GyrCompletionSurvey, SurveyMessages::CtcExperienceSurvey]
 
-      # TODO: These were not being used in the previous implementation of this code, so either figure out how to use them or delete them
-      #   The issue is that different message classes take their args differently,
-      message_params = {
-        SurveyMessages::GyrCompletionSurvey => { survey_link: "https://fakecodeforamerica.co1.qualtrics.com" },
-        SurveyMessages::CtcExperienceSurvey => { survey_link: "https://fakecodeforamerica.co1.qualtrics.com" },
-        AutomatedMessage::DocumentsReminderLink => { body_args: { doc_type: "ID" } },
-        AutomatedMessage::SaveCtcLetter => { body_args: { service_name: MultiTenantService.new(:ctc).service_name } },
-        AutomatedMessage::UnmonitoredReplies => { support_email: Rails.configuration.email_from[:support][:gyr] },
-      }
-
       automated_messages_and_mailers = message_classes.to_h do |klass|
         message = klass.new
         replaced_body = message.email_body.gsub('<<', '&lt;&lt;').gsub('>>', '&gt;&gt;')

--- a/app/controllers/hub/automated_messages_controller.rb
+++ b/app/controllers/hub/automated_messages_controller.rb
@@ -11,8 +11,10 @@ module Hub
 
     def messages_preview
       Rails.application.eager_load!
-      message_classes = AutomatedMessage::AutomatedMessage.descendants + [SurveyMessages::GyrCompletionSurvey, SurveyMessages::CtcExperienceSurvey]
+      automated_message_subclasses = AutomatedMessage::AutomatedMessage.descendants
+      survey_message_classes = [SurveyMessages::GyrCompletionSurvey, SurveyMessages::CtcExperienceSurvey]
 
+      message_classes = automated_message_subclasses + survey_message_classes
       automated_messages_and_mailers = message_classes.to_h do |klass|
         replaced_body = klass.new.email_body.gsub('<<', '&lt;&lt;').gsub('>>', '&gt;&gt;')
         email = OutgoingEmail.new(to: "example@example.com", body: replaced_body, subject: klass.new.email_subject, client: Client.new(intake: Intake::GyrIntake.new))
@@ -23,7 +25,8 @@ module Hub
         "UserMailer.assignment_email" => UserMailer.assignment_email(assigned_user: User.last, assigning_user: User.first, tax_return: TaxReturn.last, assigned_at: TaxReturn.last.updated_at),
         "VerificationCodeMailer.with_code" => VerificationCodeMailer.with(to: "example@example.com", locale: :en, service_type: :gyr, verification_code: '000000').with_code,
         "VerificationCodeMailer.no_match_found" => VerificationCodeMailer.no_match_found(to: "example@example.com", locale: :en, service_type: :gyr),
-        "DiyIntakeEmailMailer.high_support_message" => DiyIntakeEmailMailer.high_support_message(diy_intake: DiyIntake.new(email_address: 'example@example.com', preferred_first_name: "Preferredfirstname"))
+        "DiyIntakeEmailMailer.high_support_message" => DiyIntakeEmailMailer.high_support_message(diy_intake: DiyIntake.new(email_address: 'example@example.com', preferred_first_name: "Preferredfirstname")),
+        "CtcSignupMailer.launch_announcement" => CtcSignupMailer.launch_announcement(email_address: "example@example.com", name: "Preferredfirstname")
       }
 
       emails.merge(automated_messages_and_mailers).transform_values do |message|

--- a/app/controllers/hub/state_file/automated_messages_controller.rb
+++ b/app/controllers/hub/state_file/automated_messages_controller.rb
@@ -8,32 +8,19 @@ module Hub::StateFile
     private
 
     def messages_preview
-      automated_messages = [
-        [StateFile::AutomatedMessage::Welcome, {}],
-        [StateFile::AutomatedMessage::AcceptedRefund, {}],
-        [StateFile::AutomatedMessage::AcceptedOwe, {}],
-        [StateFile::AutomatedMessage::Rejected, {}],
-        [StateFile::AutomatedMessage::IssueResolved, {}],
-        [StateFile::AutomatedMessage::StillProcessing, {}],
-        [StateFile::AutomatedMessage::SuccessfulSubmission, {}],
-        [StateFile::AutomatedMessage::RejectResolutionReminder, {}],
-        [StateFile::AutomatedMessage::PostDeadlineReminder, {}],
-      ]
-
-      automated_messages_and_mailers = automated_messages.map do |m|
-        message = m[0].new
-        replaced_body = message.email_body.gsub('<<', '&lt;&lt;').gsub('>>', '&gt;&gt;')
+      Rails.application.eager_load!
+      message_classes = StateFile::AutomatedMessage::BaseAutomatedMessage.descendants
+      message_classes.to_h do |klass|
+        # TODO: make all AutomatedMessage methods class rather than instance methods
+        replaced_body = klass.new.email_body.gsub('<<', '&lt;&lt;').gsub('>>', '&gt;&gt;')
         email = StateFileNotificationEmail.new(to: "example@example.com",
                                                body: replaced_body,
-                                               subject: message.email_subject)
-        [m[0], StateFile::NotificationMailer.user_message(notification_email: email)]
-      end.to_h
-
-      automated_messages_and_mailers.transform_values do |message|
+                                               subject: klass.new.email_subject)
+        message = StateFile::NotificationMailer.user_message(notification_email: email)
         ActionMailer::Base.preview_interceptors.each do |interceptor|
           interceptor.previewing_email(message)
         end
-        message
+        [klass, message]
       end
     end
   end

--- a/app/controllers/hub/state_file/automated_messages_controller.rb
+++ b/app/controllers/hub/state_file/automated_messages_controller.rb
@@ -11,7 +11,6 @@ module Hub::StateFile
       Rails.application.eager_load!
       message_classes = StateFile::AutomatedMessage::BaseAutomatedMessage.descendants
       message_classes.to_h do |klass|
-        # TODO: make all AutomatedMessage methods class rather than instance methods
         replaced_body = klass.new.email_body.gsub('<<', '&lt;&lt;').gsub('>>', '&gt;&gt;')
         email = StateFileNotificationEmail.new(to: "example@example.com",
                                                body: replaced_body,

--- a/app/views/hub/state_file/automated_messages/index.html.erb
+++ b/app/views/hub/state_file/automated_messages/index.html.erb
@@ -22,7 +22,7 @@
                 </div>
               </div>
             </div>
-            <% if message_class.respond_to?(:new) %>
+            <% if message_class.respond_to?(:new) and message_class.new.respond_to?(:sms_body) %>
               <div class="with-padding-med" style="display: inline-block; width: 35%; margin-right: 8px;">
                 <div class="client-messages__sms">
                   <div style="white-space: pre-line;"><%= message_class.new.sms_body %></div>

--- a/spec/controllers/hub/automated_messages_controller_spec.rb
+++ b/spec/controllers/hub/automated_messages_controller_spec.rb
@@ -25,8 +25,8 @@ describe Hub::AutomatedMessagesController do
       it "includes every AutomatedMessage class" do
         get :index
 
-        shown_message_classes = assigns(:messages).map{ |m| m[0] }
-        message_class_names = (AutomatedMessage::AutomatedMessage.descendants + ["UserMailer.assignment_email", "VerificationCodeMailer.with_code", "VerificationCodeMailer.no_match_found", "DiyIntakeEmailMailer.high_support_message", SurveyMessages::GyrCompletionSurvey, SurveyMessages::CtcExperienceSurvey])
+        shown_message_classes = assigns(:messages).keys
+        message_class_names = (AutomatedMessage::AutomatedMessage.descendants + ["UserMailer.assignment_email", "VerificationCodeMailer.with_code", "VerificationCodeMailer.no_match_found", "DiyIntakeEmailMailer.high_support_message", "CtcSignupMailer.launch_announcement", SurveyMessages::GyrCompletionSurvey, SurveyMessages::CtcExperienceSurvey])
 
         expect(shown_message_classes).to match_array(message_class_names)
       end


### PR DESCRIPTION
WIP - PR description TBD
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-64
## What was done?
- I changed the contents of the two AutomatedMessages pages in the Hub (one for GYR/CTC, one for FYST), which show previews of all the email and SMS messages we send. They previously had been missing some messages. I changed their implementations so that most messages will now be included automatically if they are implemented as subclasses of our two main message classes, `AutomatedMessage::AutomatedMessage` or `StateFile::AutomatedMessage::BaseAutomatedMessage`. I also added another type of message to the page which had been missed previously.
- Alternatives considered: 
  - I did not consolidate all of our message sending to use one message class and mailer, although I do think that we should do that - both to make these pages fully automatic and to make our codebase more consistent and concise. 
  - I also did not take the smaller step of making all the AutomatedMessage-style subclasses share a common interface of class methods, although I also think that would be a good minor improvement.
  - I also did not add the templates that are available for various actions that can be taken by Hub users on client pages. If we would like to see those templates here, I can add them.
## How to test?
- I did not add any automated tests, but all of our tests still pass.
- To verify that the messages have been added, compare the AutomatedMessages pages on Demo
  - https://demo.getyourrefund.org/en/hub/automated_messages
  - https://demo.getyourrefund.org/en/hub/state-file/automated_messages
- with those on the acceptance deployment
  - https://gyr-review-app-4566-7c8a6daaf351.herokuapp.com/en/hub/automated_messages
  - https://gyr-review-app-4566-7c8a6daaf351.herokuapp.com/en/hub/state-file/automated_messages