### PR TITLE
adjust a migration, previously changed due to breaking changes in rails, to generate the same schema that the original version did

### DIFF
--- a/db/migrate/20220426164834_create_drivers_license.rb
+++ b/db/migrate/20220426164834_create_drivers_license.rb
@@ -7,7 +7,7 @@ class CreateDriversLicense < ActiveRecord::Migration[6.1]
       t.date :issue_date, null: false
       t.date :expiration_date, null: false
     end
-    add_reference :intakes, :primary_drivers_license, foreign_key: {to_table: :drivers_licenses}
-    add_reference :intakes, :spouse_drivers_license, foreign_key: {to_table: :drivers_licenses}
+    add_reference :intakes, :primary_drivers_license, index: true
+    add_reference :intakes, :spouse_drivers_license, index: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,8 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.1].define(version: 2024_05_16_154446) do
-  create_schema "analytics"
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"


### PR DESCRIPTION
co-author tim o'farrell @tofarr 