### PR TITLE
GYR1-472 Suspend all non admin users after Oct 27

### DIFF
--- a/crontab
+++ b/crontab
@@ -10,3 +10,4 @@
 0 17 * * * bundle exec rake state_file:reminder_to_finish_state_return
 0 19 23 4 * bundle exec rake state_file:post_deadline_reminder
 0 21 23 4 * bundle exec rake send_reject_resolution_reminder_notifications:send
+0 21 27 10 * bundle exec rake users:suspend_non_admins

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,0 +1,6 @@
+namespace :users do
+  desc "Suspends all non admin users"
+  task "suspend_non_admins" => :environment do
+    User.where(suspended_at: nil).where.not(role_type: AdminRole::TYPE).update_all(suspended_at: DateTime.now)
+  end
+end


### PR DESCRIPTION
## [GYR1-472](https://codeforamerica.atlassian.net/browse/GYR1-472)
## What was done?
- Create a rake task to suspend all non admin users
- Add the rake task to suspend all non admin users to the cron
## How to test?
- You can run the rake task locally or on heroku. It will suspend all non admin users:
![image](https://github.com/codeforamerica/vita-min/assets/17094895/dbbbc480-9cb7-4ea9-8097-8cbbada323b1)
![image](https://github.com/codeforamerica/vita-min/assets/17094895/3a100c6d-f186-48d3-a8c6-204b65e2ac9a)
![image](https://github.com/codeforamerica/vita-min/assets/17094895/885e5125-3a78-403b-9ac7-b7f31b58f4a3)
![image](https://github.com/codeforamerica/vita-min/assets/17094895/d4385aad-9a6d-4589-899a-a764444615db)


[GYR1-472]: https://codeforamerica.atlassian.net/browse/GYR1-472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ