### PR TITLE
GYR1-477 Fix for Deployment Failed in Heroku

### DIFF
--- a/config/initializers/experiments.rb
+++ b/config/initializers/experiments.rb
@@ -3,6 +3,9 @@ Rails.application.reloader.to_prepare do
     if ActiveRecord::Base.connection.table_exists?(:experiments)
       ExperimentService.ensure_experiments_exist_in_database
     end
-  rescue ActiveRecord::NoDatabaseError, ActiveRecord::DatabaseConnectionError
+  rescue ActiveRecord::NoDatabaseError,
+    ActiveRecord::DatabaseConnectionError,
+    ActiveRecord::ConnectionNotEstablished
+    puts "Skipping experiments due to invalid database setup"
   end
 end


### PR DESCRIPTION
## [GYR1-477](https://codeforamerica.atlassian.net/browse/GYR1-477)

## What was done?
- This is a fix for the "Deployment Failed" message when deploying to Heroku. The `experiments.rb` is loaded during the build before the database is actually set up. We now catch an additional exception type: `ActiveRecord::ConnectionNotEstablished`

## Before
![image](https://github.com/codeforamerica/vita-min/assets/17094895/62f4e15d-caf1-46e2-b6b0-efd80cadb3aa)

## After
![image](https://github.com/codeforamerica/vita-min/assets/17094895/79021fe6-de6d-4998-bc00-12d9c4a50af5)

## Testing
 - Take a look at the deployed app - there are now no errors.

[GYR1-477]: https://codeforamerica.atlassian.net/browse/GYR1-477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ