### PR TITLE
Remove --force push from production deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,7 +201,7 @@ jobs:
       - checkout
       - run: echo $APTIBLE_PUBLIC_KEY >> ~/.ssh/known_hosts
       - run: git fetch --depth=1000000
-      - run: git push --force git@beta.aptible.com:vita-min-prod/vita-min-prod.git $CIRCLE_SHA1:master
+      - run: git push git@beta.aptible.com:vita-min-prod/vita-min-prod.git $CIRCLE_SHA1:master
     parallelism: 1
 workflows:
   version: 2


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/TBE-9
## What was done?
- Now that the git history for the release branch has been cleaned up and deployed to aptible, --force should no longer be required
## How to test?
- planning to try it out in circleci and revert if it doesn't work
