### PR TITLE
FYST-53 Now specifying bank account type only if there is a bank account

### DIFF
--- a/app/lib/submission_builder/ty2022/states/ny/documents/rtn_header.rb
+++ b/app/lib/submission_builder/ty2022/states/ny/documents/rtn_header.rb
@@ -74,13 +74,15 @@ module SubmissionBuilder
                 # xml.FREE_FIL_IND
                 # xml.PR_SSN_VALID_IND
                 # xml.SP_SSN_VALID_IND
-                xml.BNK_ACCT_ACH_IND claimed: 2 #only personal banking accounts supported not business
+                if @submission.data_source.payment_or_deposit_type == "direct_deposit"
+                  xml.BNK_ACCT_ACH_IND claimed: 2 # only personal banking accounts supported not business
+                end
                 if @submission.data_source.calculated_refund_or_owed_amount.positive?
                   xml.PAPER_CHK_RFND_IND claimed: @submission.data_source.payment_or_deposit_type == "direct_deposit" ? 2 : 1
                   xml.DIR_DEP_IND claimed: @submission.data_source.payment_or_deposit_type == "direct_deposit" ? 1 : 2
-                else
-                  xml.PAPER_CHK_RFND_IND claimed: 2
-                  xml.DIR_DEP_IND claimed: 2
+                else # no refund
+                  xml.PAPER_CHK_RFND_IND claimed: 2 # no refund check
+                  xml.DIR_DEP_IND claimed: 2 # no direct deposit refund
                 end
                 # xml.ITIN_MSMTCH_IND
                 # xml.IMPRFCT_RTN_IND


### PR DESCRIPTION
## [FYST-53](https://codeforamerica.atlassian.net/browse/FYST-53)
## What was done?
- When a user specifies that they do not want to use direct deposit, we should not specify a bank account type. (Previously we were specifying "personal" here)
## How to test?
 - Test on staging
 - The XML produced should still have `BNK_ACCT_ACH_IND` if the payment type is direct file, but it should be missing otherwise.
## Screenshots (for visual changes)
### Before
<img width="499" alt="image" src="https://github.com/codeforamerica/vita-min/assets/17094895/969d56ea-6c01-4ab1-9004-cda113626f56">

### After
![image](https://github.com/codeforamerica/vita-min/assets/17094895/97752d94-b040-4a35-a5b3-013422d65efe)


[FYST-53]: https://codeforamerica.atlassian.net/browse/FYST-53?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ