### PR TITLE
Padding for GYR Portal

### DIFF
--- a/app/views/portal/portal/home.html.erb
+++ b/app/views/portal/portal/home.html.erb
@@ -14,8 +14,9 @@
 
   <% if @tax_returns.present? %>
     <% @tax_returns.each_with_index do |tax_return, index| %>
+      <div class="spacing-below-25">
       <%= render "tax_return_card", tax_return: tax_return %>
-
+      </div>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/portal/portal/home.html.erb
+++ b/app/views/portal/portal/home.html.erb
@@ -15,7 +15,7 @@
   <% if @tax_returns.present? %>
     <% @tax_returns.each_with_index do |tax_return, index| %>
       <div class="spacing-below-25">
-      <%= render "tax_return_card", tax_return: tax_return %>
+        <%= render "tax_return_card", tax_return: tax_return %>
       </div>
     <% end %>
   <% end %>


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- [Padding for Hub Portal](https://codeforamerica.atlassian.net/browse/GYR1-139)
## What was done?
- Spacing was added between returns for the portal for users 
## How to test?
You will have to make a client with returns from different years and then log into the portal to see how it looks
## Screenshots
Before
<img width="878" alt="Screenshot 2024-06-10 at 5 50 34 PM" src="https://github.com/codeforamerica/vita-min/assets/79296603/fe3ff410-7593-4423-b28c-d3183d94c27d">
After
![Screenshot 2024-06-10 at 4 55 13 PM](https://github.com/codeforamerica/vita-min/assets/79296603/8ddede1e-b97d-411a-9239-5ab884cf8f7f)

