### PR TITLE
GYR1-463 Pass link to hub client profile to Intercom

### DIFF
--- a/app/views/shared/_intercom.html.erb
+++ b/app/views/shared/_intercom.html.erb
@@ -17,6 +17,7 @@
   if (isClient) {
       intercomSettings.user_id = "<%= current_client&.id %>"
       intercomSettings.user_hash = "<%= IntercomService.generate_user_hash(current_client&.id) %>"
+      intercomSettings.hub_link = "<%= hub_client_url(id: current_client&.id) %>"
   }
   const hubStyles = {
       action_color: "#757575",

--- a/app/views/shared/_intercom.html.erb
+++ b/app/views/shared/_intercom.html.erb
@@ -17,7 +17,7 @@
   if (isClient) {
       intercomSettings.user_id = "<%= current_client&.id %>"
       intercomSettings.user_hash = "<%= IntercomService.generate_user_hash(current_client&.id) %>"
-      intercomSettings.hub_link = "<%= hub_client_url(id: current_client&.id) %>"
+      intercomSettings.hub_link = "<%= current_client&.id.present? ? hub_client_url(id: current_client&.id) : "" %>"
   }
   const hubStyles = {
       action_color: "#757575",


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/GYR1-463
## What was done?
- This work was mostly clicking around the Intercom settings, requesting access, asking client success questions, and being confused -JH 
- We added another attribute (a link to the client profile in the hub) to the hash passed to intercom in the case where a client is present. We kind of copied [what GCF does](https://github.com/codeforamerica/gcf-backend/blob/0ddc7129061b742b63832c6348e82760623ecf6f/app/views/shared/_intercom.html.erb).
- From the story:
  - "If a client provides their client ID through the intercom macro, provide a link in Intercom to the Hub record for that Client ID" --> actually we sometimes pass the client ID from the code (when a client is logged in). Unclear how to get client ID from the "macro" (actually called a "workflow") into the code, maybe impossible? 
  - "If a client does not provide their client ID but has an associated contact method identified from inputting their First and Last Name into the intercom macro, then link to the Hub search for that contact method (email or phone number)" --> again, no idea how to get this macro-info. the only case we handle in this PR is the case with a logged in client.
## How to test?
- We could not find any relevant tests. We could add one but it would be nontrivial because we have very few tests for this type of thing.
- Risk Assessment
  - We construct this link ourselves and we're already passing client ID so this shouldn't be risky in terms of exposing client data or exposing CS to bad actors
  - Only issue I can imagine is this line of code throws an error (which would result in a client not being able to open or use live chat) but it guards against client being missing and client id being missing so hopefully there aren't any errors left to throw
## Screenshots (for visual changes)
- settings (Intercom prod env, looks the same in test):
![image](https://github.com/codeforamerica/vita-min/assets/43800769/b91d839d-1112-4188-be95-af7c64f7a34c)
- client profile (Intercom test env):
![image](https://github.com/codeforamerica/vita-min/assets/43800769/e84f4cde-009b-4700-b3d1-976b534abb05)
  a follow-up task: CS people need to click the pin next to hub_link to get it to show up in the side bar