### PR TITLE
fix flaky notes test

### DIFF
--- a/spec/features/hub/client/notes_spec.rb
+++ b/spec/features/hub/client/notes_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "View and add internal notes for a client" do
 
       expect(page).to have_selector("h1", text: "Bart Simpson")
       expect(page).to have_text("4:00 PM") # 4:00 PM Pacific is midnight UTC; the note is created at midnight UTC
-      expect(page).to have_text("Client added 5 documents.")
+      expect(page).to have_text("Client added 3 documents.")
       fill_in "Add a note", with: "Some pertinent info, presumably"
       click_on "Save"
 


### PR DESCRIPTION
## What was done?
- A test in `spec/features/hub/clients/notes_spec.rb` was flaky, in that would fail if it was run by itself, or if ever happened to be the case that the user and client it created had the same database ID.
- This was happening often enough that someone noticed it failing and changed it to have the incorrect expectation. It kept failing, but in the opposite scenario: when the client and user had different IDs, and was lost once more in a cloud of CircleCI flakiness.
- The actual problem is that the query the test uses wasn't differentiating properly between documents uploaded by clients and users, probably because the "client" object it receives as an argument is actually a `HubClientPresenter` that is delegating methods to a `Client` object it has a reference to. This seemed to be breaking ActiveRecord's normal handling of `where` clauses that can handle an object and use its ID and type to query a polymorphic column (in this case, `uploaded_by`).
- To fix it, we just had to constrain the `where` clause to only return documents uploaded by a Client.
## How to test?
- The unit test now passes regardless of whether another test has been run that created a User or Client, i.e. regardless of whether the User and Client created by this test have the same database ID. The CircleCI test run should be green. 
- Risk Assessment
  - Zero risk from this change, as long as it is correct per code review.
## Screenshots (for visual changes)
### Before
  - By itself (User & Client have same ID)
<img width="482" alt="image" src="https://github.com/codeforamerica/vita-min/assets/40958/dfab7fad-e181-4ef4-9091-d15d79fedfbe">

  - After another test (User & Client have different IDs)
<img width="615" alt="image" src="https://github.com/codeforamerica/vita-min/assets/40958/eee1ef00-09bf-4795-9d7e-1ac0c46f66d1">

### After
  - By itself (User & Client have same ID)
<img width="494" alt="image" src="https://github.com/codeforamerica/vita-min/assets/40958/8aeee620-1b09-4a8b-b3c4-50761296208a">

  - After another test (User & Client have different IDs)
<img width="716" alt="image" src="https://github.com/codeforamerica/vita-min/assets/40958/4c34d0ac-d7b4-4ad1-b4ff-1af5550b02e2">


