### PR TITLE
Bug fix: sometimes the state param is 'us'

### DIFF
--- a/app/controllers/state_file/questions/questions_controller.rb
+++ b/app/controllers/state_file/questions/questions_controller.rb
@@ -18,7 +18,7 @@ module StateFile
 
       def state_code
         state_from_params = params[:us_state]
-        unless StateFile::StateInformationService.active_state_codes.include?(state_from_params)
+        unless StateFile::StateInformationService.active_state_codes.append("us").include?(state_from_params)
           raise StandardError, state_from_params
         end
         state_from_params

--- a/spec/controllers/state_file/questions/questions_controller_spec.rb
+++ b/spec/controllers/state_file/questions/questions_controller_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe StateFile::Questions::QuestionsController do
       expect(subject.state_code).to eq "az"
     end
 
+    it "accepts us as a state code" do
+      controller.params[:us_state] = "us"
+
+      expect(subject.state_code).to eq "us"
+    end
+
     it "raises an error when the state code is invalid" do
       controller.params[:us_state] = "na"
 


### PR DESCRIPTION
from slack:

FYI it looks like the state info service change caused an [error on demo](https://codeforamerica.sentry.io/issues/5488333520/?project=1880321&referrer=github-pr-bot). I'm not sure how this path (https://demo.fileyourstatetaxes.org/en/us/code-verified) was generated, but it seems like it caused StateFile::QuestionsController#state_code to fail due to the us where a state_code param should be in the url. FYST is not live so this shouldn't happen in prod, so I'm just giving a heads up instead of fully investigating right now.
