### PR TITLE
Add before_action to OtherOptionsLinksConcern 

### DIFF
--- a/app/controllers/concerns/state_file/other_options_links_concern.rb
+++ b/app/controllers/concerns/state_file/other_options_links_concern.rb
@@ -4,6 +4,15 @@ module StateFile
     # VITA Google Form on the offboarding pages or the other state filing options on the FAQ
     extend ActiveSupport::Concern
 
+    included do
+      before_action :load_links, only: :edit
+    end
+
+    def load_links
+      @vita_link = vita_link
+      @faq_other_options_link = faq_state_filing_options_link
+    end
+
     def vita_link
       case current_state_code
       when 'ny'

--- a/app/controllers/state_file/questions/data_transfer_offboarding_controller.rb
+++ b/app/controllers/state_file/questions/data_transfer_offboarding_controller.rb
@@ -1,14 +1,8 @@
 module StateFile
   module Questions
     class DataTransferOffboardingController < StateFile::Questions::QuestionsController
-      helper_method :ineligible_reason
       include OtherOptionsLinksConcern
-
-      def edit
-        super
-        @learn_more_link = faq_state_filing_options_link
-        @vita_link = vita_link
-      end
+      helper_method :ineligible_reason
 
       def ineligible_reason
         key = current_intake.disqualifying_df_data_reason

--- a/app/controllers/state_file/questions/eligibility_offboarding_controller.rb
+++ b/app/controllers/state_file/questions/eligibility_offboarding_controller.rb
@@ -1,15 +1,9 @@
 module StateFile
   module Questions
     class EligibilityOffboardingController < QuestionsController
+      include OtherOptionsLinksConcern
       before_action :set_prev_path, only: [:edit]
       helper_method :ineligible_reason
-      include OtherOptionsLinksConcern
-
-      def edit
-        @learn_more_link = faq_state_filing_options_link
-        @vita_link = vita_link
-        super
-      end
 
       def ineligible_reason
         key = current_intake.disqualifying_eligibility_answer

--- a/app/controllers/state_file/questions/eligible_controller.rb
+++ b/app/controllers/state_file/questions/eligible_controller.rb
@@ -3,12 +3,6 @@ module StateFile
     class EligibleController < QuestionsController
       include OtherOptionsLinksConcern
 
-      def edit
-        super
-        @vita_link = vita_link
-        @faq_other_options_link = faq_state_filing_options_link
-      end
-
       private
 
       def form_class

--- a/app/controllers/state_file/questions/unemployment_controller.rb
+++ b/app/controllers/state_file/questions/unemployment_controller.rb
@@ -1,9 +1,9 @@
 module StateFile
   module Questions
     class UnemploymentController < AuthenticatedQuestionsController
-      include ReturnToReviewConcern
       include OtherOptionsLinksConcern
-      before_action :load_faq_link, only: [:new, :edit]
+      include ReturnToReviewConcern
+      before_action :load_links, only: [:new, :edit]
 
       def self.show?(intake)
         fed_unemployment = intake.direct_file_data.fed_unemployment
@@ -69,10 +69,6 @@ module StateFile
       end
 
       private
-
-      def load_faq_link
-        @faq_other_options_link = faq_state_filing_options_link
-      end
 
       def state_file1099_params
         state_file_params = params.require(:state_file1099_g).permit(

--- a/app/views/state_file/questions/eligibility_offboarding/_other_options.html.erb
+++ b/app/views/state_file/questions/eligibility_offboarding/_other_options.html.erb
@@ -5,7 +5,7 @@
   <div class="reveal__content">
     <p><%= t('.learn_more_reveal.p1', state_name: current_state_name) %></p>
     <p><%= t('.learn_more_reveal.p2') %></p>
-    <p><%= t('.learn_more_here_html', link: @learn_more_link) %></p>
+    <p><%= t('.learn_more_here_html', link: @faq_other_options_link) %></p>
   </div>
 </div>
 
@@ -19,7 +19,7 @@
       <li><%= t('.other_options_reveal.list.list3') %></li>
     </ul>
     <p><%= t('.other_options_reveal.fees') %></p>
-    <p><%= t('.learn_more_here_html', link: @learn_more_link) %></p>
+    <p><%= t('.learn_more_here_html', link: @faq_other_options_link) %></p>
   </div>
 </div>
 


### PR DESCRIPTION
...since all the controllers where basically doing the same thing (setting the links to instance variables)

## Link to pivotal/JIRA issue
- N/A
## Is PM acceptance required?
- No - merge after code review approval
## What was done?
- Noticed this little refactor opportunity while working on something else. DRYs up the code a bit.
## How to test?
- No behavior change expected so passing tests should be all we need