### PR TITLE
Fix bug: on taxes owed page, state_name should be current_state_name

### DIFF
--- a/app/views/state_file/questions/taxes_owed/edit.html.erb
+++ b/app/views/state_file/questions/taxes_owed/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, t(".page_title") %>
 <% content_for :card do %>
   <h1 class="h2">
-    <%= t(".title_html", owed_amount: taxes_owed, state_name: state_name) %>
+    <%= t(".title_html", owed_amount: taxes_owed, state_name: current_state_name) %>
   </h1>
 
   <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>


### PR DESCRIPTION
[Sentry](https://codeforamerica.sentry.io/issues/5536292629/?project=1880321&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=90d&stream_index=0)

## Is PM acceptance required?
- No - seems fine to do an eng review
## What was done?
- when the state_name helper was renamed to current_state_name we missed a spot and there's no test that caught it
## How to test?
- fill out a state file intake and make sure you get the taxes owed page. see that it doesn't crash.