### PR TITLE
FYST-141 Removed w2_override feature flag

### DIFF
--- a/app/controllers/state_file/questions/w2_controller.rb
+++ b/app/controllers/state_file/questions/w2_controller.rb
@@ -6,7 +6,7 @@ module StateFile
       before_action :load_w2, only: [:edit, :update]
 
       def self.show?(intake)
-        Flipper.enabled?(:w2_override) && invalid_df_w2s(intake).any?
+        invalid_df_w2s(intake).any?
       end
 
       def index

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -9,7 +9,6 @@ end
 # Make sure that each feature we reference in code is present in the UI, as long as we have a Database already
 begin
   Flipper.disable :sms_notifications unless Flipper.exist?(:sms_notifications)
-  Flipper.remove :w2_override if Flipper.exist?(:w2_override)
 rescue
   # make sure we can still run rake tasks before table has been created
   nil

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -9,7 +9,7 @@ end
 # Make sure that each feature we reference in code is present in the UI, as long as we have a Database already
 begin
   Flipper.disable :sms_notifications unless Flipper.exist?(:sms_notifications)
-  Flipper.enable :w2_override unless Flipper.exist?(:w2_override)
+  Flipper.remove :w2_override if Flipper.exist?(:w2_override)
 rescue
   # make sure we can still run rake tasks before table has been created
   nil

--- a/spec/controllers/state_file/questions/w2_controller_spec.rb
+++ b/spec/controllers/state_file/questions/w2_controller_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe StateFile::Questions::W2Controller do
     create :state_file_ny_intake, raw_direct_file_data: direct_file_xml.to_xml
   end
   before do
-    Flipper.enable(:w2_override)
     sign_in intake
   end
 


### PR DESCRIPTION
## [FYST-141](https://codeforamerica.atlassian.net/browse/FYST-141)
## Is PM acceptance required?
- [ ] Yes - don't merge until JIRA issue is accepted!
- [X] No - merge after code review approval
## What was done?
- Removed all reference to `w2_override` feature flag
## How to test?
- Make sure the w2_override feature flag is gone from `/hub/flipper`
- Set the session toggles to during tax season, move through the AZ intake process and make sure the W2 page still works.



[FYST-141]: https://codeforamerica.atlassian.net/browse/FYST-141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ