### PR TITLE
FYST-143 Fixed staging URLs which had been broken

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -113,7 +113,7 @@ module VitaMin
     config.state_file_withdrawal_date_deadline_ny = Time.find_zone('America/New_York').parse('2024-04-15 23:59:59')
     config.state_file_end_of_in_progress_intakes = Time.find_zone('America/Los_Angeles').parse('2024-04-25 23:59:59')
 
-    config.allow_magic_verification_code = (Rails.env.demo? || Rails.env.development? || Rails.env.heroku?)
+    config.allow_magic_verification_code = (Rails.env.demo? || Rails.env.development? || Rails.env.heroku? || Rails.env.staging?)
     config.allow_magic_ssn = (Rails.env.demo? || Rails.env.development? || Rails.env.heroku? || Rails.env.staging?)
 
     config.intercom_app_id = "rird6gz6"

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -3,9 +3,9 @@ require_relative "./shared_deployment_config"
 Rails.application.configure do
   config.active_storage.service = :s3_staging
 
-  config.ctc_url = "https://ctc.demo.getyourrefund.org"
-  config.gyr_url = "https://demo.getyourrefund.org"
-  config.statefile_url = "https://demo.fileyourstatetaxes.org"
+  config.ctc_url = "https://ctc.staging.getyourrefund.org"
+  config.gyr_url = "https://staging.getyourrefund.org"
+  config.statefile_url = "https://staging.fileyourstatetaxes.org"
   gyr_email_from_domain = "mg-demo.getyourrefund-testing.org"
   ctc_email_from_domain = "mg-demo-ctc.getyourrefund-testing.org"
   statefile_email_from_domain = "mg-demo-statefile.getyourrefund-testing.org"


### PR DESCRIPTION
## [FYST-143](https://codeforamerica.atlassian.net/browse/FYST-143)
## Is PM acceptance required?
- [ ] Yes - don't merge until JIRA issue is accepted!
- [X] No - merge after code review approval
## What was done?
- This reverts a fix that was inadvertently added as part of https://github.com/codeforamerica/vita-min/pull/4548
- Also adds staging to the list of envs where magic verification codes are permitted
## How to test?
- Go to staging and make sure the following does not return a 404: https://staging.fileyourstatetaxes.org/en/az/questions/landing-page
## Screenshots (for visual changes)

### Before
![image](https://github.com/codeforamerica/vita-min/assets/17094895/6a328225-b615-480f-bcd9-770bc2786baa)

### After
![image](https://github.com/codeforamerica/vita-min/assets/17094895/493d9cbf-06ea-4b24-bd1e-759c1799dc24)


[FYST-143]: https://codeforamerica.atlassian.net/browse/FYST-143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ