### PR TITLE
GYR1-503 [12] Hub quick filters always navigate to All Clients page

### DIFF
--- a/app/lib/client_sorter.rb
+++ b/app/lib/client_sorter.rb
@@ -113,8 +113,8 @@ class ClientSorter
     overlapping_keys.any?
   end
 
-  def filtering_only_by?(filter_values)
-    @filters.select { |_k, v| v.present? } == filter_values.transform_values { |v| v.to_s }
+  def filtering_only_by?(filter_values, ignore: [])
+    @filters.except(*ignore).select { |_k, v| v.present? } == filter_values.transform_values { |v| v.to_s }
   end
 
   private

--- a/app/views/hub/clients/index.html.erb
+++ b/app/views/hub/clients/index.html.erb
@@ -12,8 +12,8 @@
         <div class="text--no-wrap quick-filters">
         <label>Quick Filters:</label>
         <% ClientSorter::QUICK_FILTERS.each do |(filter_values, filter_label)| %>
-          <% selected = @client_sorter.filtering_only_by?(filter_values) %>
-          <%= link_to selected ? hub_clients_path(clear: true) : hub_clients_path(filter_values), class: "button button--quick-filter #{selected ? "selected" : ""}" do %>
+          <% selected = @client_sorter.filtering_only_by?(filter_values, ignore: [:assigned_to_me]) %>
+          <%= link_to selected ? {clear: true} : filter_values, class: "button button--quick-filter #{selected ? "selected" : ""}" do %>
             <%= filter_label %>
             <i class="clear-filter icon-close"></i>
           <% end %>

--- a/spec/controllers/hub/assigned_clients_controller_spec.rb
+++ b/spec/controllers/hub/assigned_clients_controller_spec.rb
@@ -42,6 +42,16 @@ RSpec.describe Hub::AssignedClientsController do
           end
         end
 
+        context "last contact filter" do
+          render_views
+
+          it "filters the Assigned Clients page" do
+            get :index
+            html = Nokogiri::HTML.parse(response.body)
+            expect(html.at_css("a.button--quick-filter").attr("href")).to include hub_assigned_clients_path
+          end
+        end
+
         context "filtering by status" do
           it "filters in with matching tax return (intake_ready)" do
             get :index, params: { status: "intake_ready" }

--- a/spec/controllers/hub/clients_controller_spec.rb
+++ b/spec/controllers/hub/clients_controller_spec.rb
@@ -747,6 +747,16 @@ RSpec.describe Hub::ClientsController do
             end
           end
 
+          context "with page contents" do
+            render_views
+
+            it "filters the All Clients page" do
+              get :index
+              html = Nokogiri::HTML.parse(response.body)
+              expect(html.at_css("a.button--quick-filter").attr("href")).to include hub_clients_path
+            end
+          end
+
           it "can filter to only clients who are approaching SLA" do
             get :index, params: { last_contact: "approaching_sla" }
             expect(assigns(:clients).map(&:preferred_name)).to eq [approaching_sla_client].map(&:preferred_name)


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/GYR1-503
## Is PM acceptance required?
- [x] Yes - don't merge until JIRA issue is accepted!
- [ ] No - merge after code review approval
## What was done?
- Change the quick-filter buttons (`Approaching SLA`, `Breached SLA`) on the All Clients and Assigned Clients pages link to the current page instead of always going to the All Clients page.
- Added tests that verify that these links are correct for both pages.
## How to test?
- I added unit tests that confirm the link contents are correct. I verified that the tests fail before the change, and pass after it.
- Manual testing (on **this PR's heroku deployment**) should be done to confirm that:
  - filters can be applied correctly for both pages - filtering a page keeps you on that page
  - filters can be cleared correctly for both pages
  - if not cleared, filters "stick" for both pages: if you navigate away and back, the filter is still applied even if the URL parameters are not present (this is the same as the old behavior, as far as I can tell)
- Risk Assessment
  - I can't think of any risks with this change, but maybe you can!