### PR TITLE
FYST Refactor: stop getting state code from bundle class, pull from intake instead

### DIFF
--- a/app/lib/submission_builder/state_manifest.rb
+++ b/app/lib/submission_builder/state_manifest.rb
@@ -13,7 +13,7 @@ module SubmissionBuilder
         xml.SubmissionId @submission.irs_submission_id
         xml.EFIN EnvironmentCredentials.irs(:efin)
         xml.TaxYr data_source.tax_return_year
-        xml.GovernmentCd "#{@submission.bundle_class.state_abbreviation}ST"
+        xml.GovernmentCd "#{@submission.data_source.state_code.upcase}ST"
         xml.StateSubmissionTyp StateFile::StateInformationService.return_type(@submission.data_source.state_code)
         xml.SubmissionCategoryCd "IND"
         xml.PrimarySSN data_source.primary.ssn

--- a/app/lib/submission_builder/ty2022/states/az/individual_return.rb
+++ b/app/lib/submission_builder/ty2022/states/az/individual_return.rb
@@ -35,10 +35,6 @@ module SubmissionBuilder
             document
           end
 
-          def self.state_abbreviation
-            "AZ"
-          end
-
           def pdf_documents
             included_documents.map { |item| item if item.pdf }.compact
           end

--- a/app/lib/submission_builder/ty2022/states/ny/individual_return.rb
+++ b/app/lib/submission_builder/ty2022/states/ny/individual_return.rb
@@ -18,10 +18,6 @@ module SubmissionBuilder
             document
           end
 
-          def self.state_abbreviation
-            "NY"
-          end
-
           def pdf_documents
             included_documents.map { |item| item if item.pdf }.compact
           end

--- a/app/lib/submission_builder/ty2022/states/return_header.rb
+++ b/app/lib/submission_builder/ty2022/states/return_header.rb
@@ -7,7 +7,7 @@ module SubmissionBuilder
 
         def document
           build_xml_doc("ReturnHeaderState") do |xml|
-            xml.Jurisdiction "#{@submission.bundle_class.state_abbreviation}ST" if @submission.bundle_class.state_abbreviation.present?
+            xml.Jurisdiction "#{@submission.data_source.state_code.upcase}ST"
             xml.ReturnTs datetime_type(@submission.created_at) if @submission.created_at.present?
             xml.TaxPeriodBeginDt date_type(Date.new(@submission.data_source.tax_return_year, 1, 1))
             xml.TaxPeriodEndDt date_type(Date.new(@submission.data_source.tax_return_year, 12, 31))
@@ -46,7 +46,7 @@ module SubmissionBuilder
                 xml.AddressLine1Txt @submission.data_source.direct_file_data.mailing_street.strip.gsub(/\s+/, ' ') if @submission.data_source.direct_file_data.mailing_street.present?
                 xml.AddressLine2Txt @submission.data_source.direct_file_data.mailing_apartment.strip.gsub(/\s+/, ' ') if @submission.data_source.direct_file_data.mailing_apartment.present?
                 xml.CityNm @submission.data_source.direct_file_data.mailing_city.strip.gsub(/\s+/, ' ') if @submission.data_source.direct_file_data.mailing_city.present?
-                xml.StateAbbreviationCd @submission.bundle_class.state_abbreviation if @submission.bundle_class.state_abbreviation.present?
+                xml.StateAbbreviationCd @submission.data_source.state_code.upcase
                 xml.ZIPCd @submission.data_source.direct_file_data.mailing_zip if @submission.data_source.direct_file_data.mailing_zip.present?
               end
             end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-139, kind of
## Is PM acceptance required?
- No - merge after code review approval
## What was done?
- as part of the experiment to add a new state, i found some good refactor ideas. some of them will go into stories and some of them i am just knocking out on my own because the effort to write a story doesn't seem worth it either for how small they are or for how complicated they are to explain
- this one removes the `state_abbreviation` method from `IndividualReturn`s because we don't need yet another place where we get define state abbrevations
## How to test?
- any issues should be caught by tests

