### PR TITLE
FYST Refactor: IndividualReturn#return_type

### DIFF
--- a/app/controllers/state_file/questions/return_status_controller.rb
+++ b/app/controllers/state_file/questions/return_status_controller.rb
@@ -11,7 +11,7 @@ module StateFile
         @return_status = return_status
         @tax_refund_url = StateFile::StateInformationService.tax_refund_url(current_state_code)
         @tax_payment_url = StateFile::StateInformationService.tax_payment_url(current_state_code)
-        @primary_tax_form_name = StateFile::StateInformationService.primary_tax_form_name(current_state_code)
+        @voucher_form_name = StateFile::StateInformationService.voucher_form_name(current_state_code)
         @mail_voucher_address = StateFile::StateInformationService.mail_voucher_address(current_state_code)
         @voucher_path = StateFile::StateInformationService.voucher_path(current_state_code)
         @survey_link = StateFile::StateInformationService.survey_link(current_state_code)

--- a/app/lib/submission_builder/state_manifest.rb
+++ b/app/lib/submission_builder/state_manifest.rb
@@ -14,7 +14,7 @@ module SubmissionBuilder
         xml.EFIN EnvironmentCredentials.irs(:efin)
         xml.TaxYr data_source.tax_return_year
         xml.GovernmentCd "#{@submission.bundle_class.state_abbreviation}ST"
-        xml.StateSubmissionTyp @submission.bundle_class.return_type
+        xml.StateSubmissionTyp StateFile::StateInformationService.return_type(@submission.data_source.state_code)
         xml.SubmissionCategoryCd "IND"
         xml.PrimarySSN data_source.primary.ssn
         xml.PrimaryNameControlTxt name_control_type(data_source.primary.last_name)

--- a/app/lib/submission_builder/ty2022/states/az/individual_return.rb
+++ b/app/lib/submission_builder/ty2022/states/az/individual_return.rb
@@ -39,10 +39,6 @@ module SubmissionBuilder
             "AZ"
           end
 
-          def self.return_type
-            "Form140"
-          end
-
           def pdf_documents
             included_documents.map { |item| item if item.pdf }.compact
           end

--- a/app/lib/submission_builder/ty2022/states/ny/individual_return.rb
+++ b/app/lib/submission_builder/ty2022/states/ny/individual_return.rb
@@ -22,10 +22,6 @@ module SubmissionBuilder
             "NY"
           end
 
-          def self.return_type
-            "IT201"
-          end
-
           def pdf_documents
             included_documents.map { |item| item if item.pdf }.compact
           end

--- a/app/lib/submission_builder/ty2022/states/return_header.rb
+++ b/app/lib/submission_builder/ty2022/states/return_header.rb
@@ -17,7 +17,7 @@ module SubmissionBuilder
               xml.OriginatorTypeCd "OnlineFiler"
             end
             xml.SoftwareId EnvironmentCredentials.irs(:sin)
-            xml.ReturnType "#{@submission.bundle_class.return_type}" if @submission.bundle_class.return_type.present?
+            xml.ReturnType StateFile::StateInformationService.return_type(@submission.data_source.state_code)
             xml.Filer do
               xml.Primary do
                 xml.TaxpayerName do

--- a/app/services/state_file/state_information_service.rb
+++ b/app/services/state_file/state_information_service.rb
@@ -6,13 +6,13 @@ module StateFile
         :navigation_class,
         :submission_builder_class,
         :mail_voucher_address,
-        :primary_tax_form_name,
         :state_name,
         :survey_link,
         :tax_payment_info_url,
         :tax_payment_url,
         :tax_refund_url,
         :vita_link,
+        :voucher_form_name,
         :voucher_path,
       ].each do |attribute|
         define_method(attribute) do |state_code|
@@ -51,13 +51,13 @@ module StateFile
         mail_voucher_address: "Arizona Department of Revenue<br/>" \
                               "PO Box 29085<br/>" \
                               "Phoenix, AZ 85038-9085".html_safe,
-        primary_tax_form_name: "Form AZ-140V",
         state_name: "Arizona",
         survey_link: "https://codeforamerica.co1.qualtrics.com/jfe/form/SV_7UTycCvS3UEokey",
         tax_payment_info_url: "https://azdor.gov/making-payments-late-payments-and-filing-extensions",
         tax_payment_url: "AZTaxes.gov",
         tax_refund_url: "https://aztaxes.gov/home/checkrefund",
         vita_link: "https://airtable.com/appnKuyQXMMCPSvVw/pag0hcyC6juDxamHo/form",
+        voucher_form_name: "Form AZ-140V",
         voucher_path: "/pdfs/AZ-140V.pdf",
       },
       ny: {
@@ -68,13 +68,13 @@ module StateFile
                               "Processing Center<br/>" \
                               "Box 4124<br/>" \
                               "Binghamton, NY 13902-4124".html_safe,
-        primary_tax_form_name: "Form IT-201-V",
         state_name: "New York",
         survey_link: "https://codeforamerica.co1.qualtrics.com/jfe/form/SV_3pXUfy2c3SScmgu",
         tax_payment_info_url: "https://www.tax.ny.gov/pay/ind/pay-income-tax-online.htm",
         tax_payment_url: "Tax.NY.gov",
         tax_refund_url: "https://www.tax.ny.gov/pit/file/refund.htm",
         vita_link: "https://airtable.com/appQS3abRZGjT8wII/pagtpLaX0wokBqnuA/form",
+        voucher_form_name: "Form IT-201-V",
         voucher_path: "/pdfs/it201v_1223.pdf",
       }
     }).with_indifferent_access

--- a/app/services/state_file/state_information_service.rb
+++ b/app/services/state_file/state_information_service.rb
@@ -6,6 +6,7 @@ module StateFile
         :navigation_class,
         :submission_builder_class,
         :mail_voucher_address,
+        :return_type,
         :state_name,
         :survey_link,
         :tax_payment_info_url,
@@ -51,6 +52,7 @@ module StateFile
         mail_voucher_address: "Arizona Department of Revenue<br/>" \
                               "PO Box 29085<br/>" \
                               "Phoenix, AZ 85038-9085".html_safe,
+        return_type: "Form140",
         state_name: "Arizona",
         survey_link: "https://codeforamerica.co1.qualtrics.com/jfe/form/SV_7UTycCvS3UEokey",
         tax_payment_info_url: "https://azdor.gov/making-payments-late-payments-and-filing-extensions",
@@ -68,6 +70,7 @@ module StateFile
                               "Processing Center<br/>" \
                               "Box 4124<br/>" \
                               "Binghamton, NY 13902-4124".html_safe,
+        return_type: "IT201",
         state_name: "New York",
         survey_link: "https://codeforamerica.co1.qualtrics.com/jfe/form/SV_3pXUfy2c3SScmgu",
         tax_payment_info_url: "https://www.tax.ny.gov/pay/ind/pay-income-tax-online.htm",

--- a/app/views/state_file/questions/return_status/_accepted.html.erb
+++ b/app/views/state_file/questions/return_status/_accepted.html.erb
@@ -32,7 +32,7 @@
 
     <p>
       <%= t('.include_payment') %>
-      (<%= @primary_tax_form_name %>)
+      (<%= @voucher_form_name %>)
     </p>
 
     <div>

--- a/spec/controllers/state_file/questions/return_status_controller_spec.rb
+++ b/spec/controllers/state_file/questions/return_status_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe StateFile::Questions::ReturnStatusController do
 
         expect(assigns(:tax_refund_url)).to eq "https://aztaxes.gov/home/checkrefund"
         expect(assigns(:tax_payment_url)).to eq "AZTaxes.gov"
-        expect(assigns(:primary_tax_form_name)).to eq "Form AZ-140V"
+        expect(assigns(:voucher_form_name)).to eq "Form AZ-140V"
         expect(assigns(:mail_voucher_address)).to eq "Arizona Department of Revenue<br/>"\
           "PO Box 29085<br/>"\
           "Phoenix, AZ 85038-9085"

--- a/spec/lib/submission_builder/state_manifest_spec.rb
+++ b/spec/lib/submission_builder/state_manifest_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+describe SubmissionBuilder::StateManifest do
+  describe ".build" do
+    let(:intake) { create :state_file_az_intake }
+    let(:submission) { create(:efile_submission, data_source: intake) }
+
+    it "has some of the right values" do
+      doc = described_class.new(submission).document
+      expect(doc.at("StateSubmissionTyp").text).to eq "Form140"
+    end
+  end
+end

--- a/spec/lib/submission_builder/ty2022/states/return_header_spec.rb
+++ b/spec/lib/submission_builder/ty2022/states/return_header_spec.rb
@@ -42,5 +42,15 @@ describe SubmissionBuilder::Ty2022::States::ReturnHeader do
         end
       end
     end
+
+    context "misc other attributes" do
+      let(:intake) { create :state_file_az_intake }
+      let(:submission) { create(:efile_submission, data_source: intake) }
+
+      it "generates xml with the right values" do
+        doc = SubmissionBuilder::Ty2022::States::ReturnHeader.new(submission).document
+        expect(doc.at("ReturnType").text).to eq "Form140"
+      end
+    end
   end
 end

--- a/spec/services/state_file/state_information_service_spec.rb
+++ b/spec/services/state_file/state_information_service_spec.rb
@@ -84,4 +84,10 @@ describe StateFile::StateInformationService do
       expect(described_class.intake_class("az")).to eq StateFileAzIntake
     end
   end
+
+  describe ".return_type" do
+    it "returns the string that goes in ReturnType in the return header and StateSubmissionTyp in the state manifest" do
+      expect(described_class.return_type("az")).to eq "Form140"
+    end
+  end
 end

--- a/spec/services/state_file/state_information_service_spec.rb
+++ b/spec/services/state_file/state_information_service_spec.rb
@@ -41,9 +41,9 @@ describe StateFile::StateInformationService do
     end
   end
 
-  describe ".primary_tax_form_name" do
-    it "returns the name of the form to download" do
-      expect(described_class.primary_tax_form_name("az")).to eq 'Form AZ-140V'
+  describe ".voucher_form_name" do
+    it "returns the name of the voucher form" do
+      expect(described_class.voucher_form_name("az")).to eq 'Form AZ-140V'
     end
   end
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-139, kind of
## Is PM acceptance required?
- No - merge after code review approval
## What was done?
- as part of the experiment to add a new state, i found some good refactor ideas. some of them will go into stories and some of them i am just knocking out on my own because the effort to write a story doesn't seem worth it either for how small they are or for how complicated they are to explain
- this one removes the `return_type` method from `IndividualReturn`s and adds this info to the StateInformationService
- also renames primary_tax_form_name on the information service because those aren't actually the primary tax form names
## How to test?
- any issues should be caught by tests
