### PR TITLE
FYST Refactor: move some methods from IndividualReturn classes to parent class SubmissionBuilder::Document

### DIFF
--- a/app/lib/submission_builder/document.rb
+++ b/app/lib/submission_builder/document.rb
@@ -50,26 +50,6 @@ module SubmissionBuilder
     COMMON_ADDRESS_ABBREV = ["bldg", "bsmt", "dept", "fl", "frnt", "hngr", "key", "lbby", "lot", "lowr", "ofc", "ph", "pier", "rear", "rm", "side", "slip", "spc", "ste", "suite", "stop", "trlr", "unit", "uppr", "Bldg", "Bsmt", "Dept", "Fl", "Frnt", "Hngr", "Key", "Lbby", "Lot", "Lowr", "Ofc", "Ph", "Pier", "Rear", "Rm", "Side", "Slip", "Spc", "Ste", "Suite", "Stop", "Trlr", "Unit", "Uppr", "APT", "BLDG", "BSMT", "DEPT", "FL", "FRNT", "HNGR", "KEY", "LBBY", "LOT", "LOWR", "OFC", "PH", "PIER", "REAR", "RM", "SIDE", "SLIP", "SPC", "STE", "SUITE", "STOP", "TRLR", "UNIT", "UPPR"].freeze
     ADDRESS_ABBREV_REGEX = /\b(?:#{Regexp.union(COMMON_ADDRESS_ABBREV)})\b/
 
-    def authentication_header
-      SubmissionBuilder::Ty2022::States::AuthenticationHeader.build(@submission, validate: false).document.at("*")
-    end
-
-    def return_header
-      SubmissionBuilder::Ty2022::States::ReturnHeader.build(@submission, validate: false).document.at("*")
-    end
-
-    def attached_documents
-      @attached_documents ||= xml_documents.map { |doc| { xml_class: doc.xml, kwargs: doc.kwargs } }
-    end
-
-    def xml_documents
-      included_documents.map { |item| item if item.xml }.compact
-    end
-
-    def included_documents
-      supported_documents.map { |item| OpenStruct.new(**item, kwargs: item[:kwargs] || {}) if item[:include] }.compact
-    end
-
     def build_xml_doc(tag_name, **root_node_attributes)
       default_attributes = { 'xmlns:efile' => 'http://www.irs.gov/efile' }
       return_state_attributes = { 'xmlns' => 'http://www.irs.gov/efile' }

--- a/app/lib/submission_builder/document.rb
+++ b/app/lib/submission_builder/document.rb
@@ -50,6 +50,26 @@ module SubmissionBuilder
     COMMON_ADDRESS_ABBREV = ["bldg", "bsmt", "dept", "fl", "frnt", "hngr", "key", "lbby", "lot", "lowr", "ofc", "ph", "pier", "rear", "rm", "side", "slip", "spc", "ste", "suite", "stop", "trlr", "unit", "uppr", "Bldg", "Bsmt", "Dept", "Fl", "Frnt", "Hngr", "Key", "Lbby", "Lot", "Lowr", "Ofc", "Ph", "Pier", "Rear", "Rm", "Side", "Slip", "Spc", "Ste", "Suite", "Stop", "Trlr", "Unit", "Uppr", "APT", "BLDG", "BSMT", "DEPT", "FL", "FRNT", "HNGR", "KEY", "LBBY", "LOT", "LOWR", "OFC", "PH", "PIER", "REAR", "RM", "SIDE", "SLIP", "SPC", "STE", "SUITE", "STOP", "TRLR", "UNIT", "UPPR"].freeze
     ADDRESS_ABBREV_REGEX = /\b(?:#{Regexp.union(COMMON_ADDRESS_ABBREV)})\b/
 
+    def authentication_header
+      SubmissionBuilder::Ty2022::States::AuthenticationHeader.build(@submission, validate: false).document.at("*")
+    end
+
+    def return_header
+      SubmissionBuilder::Ty2022::States::ReturnHeader.build(@submission, validate: false).document.at("*")
+    end
+
+    def attached_documents
+      @attached_documents ||= xml_documents.map { |doc| { xml_class: doc.xml, kwargs: doc.kwargs } }
+    end
+
+    def xml_documents
+      included_documents.map { |item| item if item.xml }.compact
+    end
+
+    def included_documents
+      supported_documents.map { |item| OpenStruct.new(**item, kwargs: item[:kwargs] || {}) if item[:include] }.compact
+    end
+
     def build_xml_doc(tag_name, **root_node_attributes)
       default_attributes = { 'xmlns:efile' => 'http://www.irs.gov/efile' }
       return_state_attributes = { 'xmlns' => 'http://www.irs.gov/efile' }

--- a/app/lib/submission_builder/ty2022/states/az/individual_return.rb
+++ b/app/lib/submission_builder/ty2022/states/az/individual_return.rb
@@ -182,14 +182,6 @@ module SubmissionBuilder
             document[:xml_class].build(@submission, validate: false, kwargs: document[:kwargs]).document.at("*")
           end
 
-          def authentication_header
-            SubmissionBuilder::Ty2022::States::AuthenticationHeader.build(@submission, validate: false).document.at("*")
-          end
-
-          def return_header
-            SubmissionBuilder::Ty2022::States::ReturnHeader.build(@submission, validate: false).document.at("*")
-          end
-
           def financial_transaction
             SubmissionBuilder::Ty2022::States::FinancialTransaction.build(
               @submission,
@@ -200,18 +192,6 @@ module SubmissionBuilder
 
           def schema_file
             SchemaFileLoader.load_file("us_states", "unpacked", "AZIndividual2023v1.0", "AZIndividual", "IndividualReturnAZ140.xsd")
-          end
-
-          def attached_documents
-            @attached_documents ||= xml_documents.map { |doc| { xml_class: doc.xml, kwargs: doc.kwargs } }
-          end
-
-          def xml_documents
-            included_documents.map { |item| item if item.xml }.compact
-          end
-
-          def included_documents
-            supported_documents.map { |item| OpenStruct.new(**item, kwargs: item[:kwargs] || {}) if item[:include] }.compact
           end
 
           def supported_documents

--- a/app/lib/submission_builder/ty2022/states/az/individual_return.rb
+++ b/app/lib/submission_builder/ty2022/states/az/individual_return.rb
@@ -3,7 +3,7 @@ module SubmissionBuilder
   module Ty2022
     module States
       module Az
-        class IndividualReturn < SubmissionBuilder::Document
+        class IndividualReturn < StateReturn
           include DependentRelationshipTable
 
           FILING_STATUS_OPTIONS = {

--- a/app/lib/submission_builder/ty2022/states/ny/individual_return.rb
+++ b/app/lib/submission_builder/ty2022/states/ny/individual_return.rb
@@ -3,7 +3,7 @@ module SubmissionBuilder
   module Ty2022
     module States
       module Ny
-        class IndividualReturn < SubmissionBuilder::Document
+        class IndividualReturn < StateReturn
           DEPENDENT_OVERFLOW_THRESHOLD = 6
 
           def document

--- a/app/lib/submission_builder/ty2022/states/ny/individual_return.rb
+++ b/app/lib/submission_builder/ty2022/states/ny/individual_return.rb
@@ -139,28 +139,8 @@ module SubmissionBuilder
             document[:xml_class].build(@submission, validate: false, kwargs: document[:kwargs]).document.at("*")
           end
 
-          def authentication_header
-            SubmissionBuilder::Ty2022::States::AuthenticationHeader.build(@submission, validate: false).document.at("*")
-          end
-
-          def return_header
-            SubmissionBuilder::Ty2022::States::ReturnHeader.build(@submission, validate: false).document.at("*")
-          end
-
           def schema_file
             SchemaFileLoader.load_file("us_states", "unpacked", "NYSIndividual2023V4.0", "Common", "NysReturnState.xsd")
-          end
-
-          def attached_documents
-            @attached_documents ||= xml_documents.map { |doc| { xml_class: doc.xml, kwargs: doc.kwargs } }
-          end
-
-          def xml_documents
-            included_documents.map { |item| item if item.xml }.compact
-          end
-
-          def included_documents
-            supported_documents.map { |item| OpenStruct.new(**item, kwargs: item[:kwargs] || {}) if item[:include] }.compact
           end
 
           def supported_documents

--- a/app/lib/submission_builder/ty2022/states/state_return.rb
+++ b/app/lib/submission_builder/ty2022/states/state_return.rb
@@ -1,0 +1,27 @@
+module SubmissionBuilder
+  module Ty2022
+    module States
+      class StateReturn < SubmissionBuilder::Document
+        def authentication_header
+          SubmissionBuilder::Ty2022::States::AuthenticationHeader.build(@submission, validate: false).document.at("*")
+        end
+
+        def return_header
+          SubmissionBuilder::Ty2022::States::ReturnHeader.build(@submission, validate: false).document.at("*")
+        end
+
+        def attached_documents
+          @attached_documents ||= xml_documents.map { |doc| { xml_class: doc.xml, kwargs: doc.kwargs } }
+        end
+
+        def xml_documents
+          included_documents.map { |item| item if item.xml }.compact
+        end
+
+        def included_documents
+          supported_documents.map { |item| OpenStruct.new(**item, kwargs: item[:kwargs] || {}) if item[:include] }.compact
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-139, kind of
## Is PM acceptance required?
- No - merge after code review approval
## What was done?
- as part of the experiment to add a new state, i found some good refactor ideas. some of them will go into stories and some of them i am just knocking out on my own because the effort to write a story doesn't seem worth it either for how small they are or for how complicated they are to explain
- this PR moves some methods into the `SubmissionBuilder::Document` class
- this one i actually feel somewhat unsure about because these methods are exact duplicates across the `IndividualReturn` classes for each state but they _only_ apply to those classes. other classes that inherit from `SubmissionBuilder::Document` either:
  - don't reference them at all, in the case of state-specific supplementary documents like `SubmissionBuilder::Ty2022::States::Ny::Documents::It215` or 
  - have them defined separately, in the case of federal submission builders like `SubmissionBuilder::Ty2021::Documents::Irs1040`
- since we will be keeping the federal submission building code for another year or so this feels a little more complicated to me. please share your thoughts!
## How to test?
- any issues should be caught by the individual return tests
