### PR TITLE
fix missing global namespace indicator in Hub::StateFile::EfileSubmissionsController#show_xml

### DIFF
--- a/app/controllers/hub/state_file/efile_submissions_controller.rb
+++ b/app/controllers/hub/state_file/efile_submissions_controller.rb
@@ -35,7 +35,7 @@ module Hub
         return nil if acts_like_production?
 
         submission = EfileSubmission.find(params[:efile_submission_id])
-        builder = StateFile::StateInformationService.submission_builder_class(submission.data_source.state_code)
+        builder = ::StateFile::StateInformationService.submission_builder_class(submission.data_source.state_code)
         builder_response = builder.build(submission)
         builder_response.errors.present? ? render(plain: builder_response.errors.join("\n") + "\n\n" + builder_response.document.to_xml) : render(xml: builder_response.document)
       end

--- a/spec/controllers/hub/state_file/efile_submissions_controller_spec.rb
+++ b/spec/controllers/hub/state_file/efile_submissions_controller_spec.rb
@@ -38,6 +38,26 @@ describe Hub::StateFile::EfileSubmissionsController do
     end
   end
 
+  describe '#show_xml' do
+    let(:intake) { create :state_file_ny_intake, :with_efile_device_infos }
+    let!(:state_efile_submission) { create :efile_submission, :for_state, data_source: intake }
+    let(:params) do
+      { efile_submission_id: state_efile_submission.id }
+    end
+
+    context "with an authenticated state file admin" do
+      render_views
+      before { sign_in(create(:state_file_admin_user)) }
+
+      it "shows the state efile submission xml" do
+        get :show_xml, params: params
+        expect(response).to be_successful
+        xml = Nokogiri::XML(response.body)
+        expect(xml.at("ReturnState Filer Primary LastName").text).to eq "Yorker"
+      end
+    end
+  end
+
   describe "#state_counts" do
     context "when authenticated as an admin" do
       let(:user) { create :state_file_admin_user }

--- a/spec/controllers/hub/state_file/efile_submissions_controller_spec.rb
+++ b/spec/controllers/hub/state_file/efile_submissions_controller_spec.rb
@@ -53,7 +53,7 @@ describe Hub::StateFile::EfileSubmissionsController do
         get :show_xml, params: params
         expect(response).to be_successful
         xml = Nokogiri::XML(response.body)
-        expect(xml.at("ReturnState Filer Primary LastName").text).to eq "Yorker"
+        expect(xml.at("ReturnState Filer Primary LastName").text).to eq intake.primary_last_name
       end
     end
   end


### PR DESCRIPTION
## Is PM acceptance required?
- No - merge after code review approval
## What was done?
- A [bug showed up in Sentry](https://codeforamerica.sentry.io/issues/5560918691) with a name resolution error on the StateFileInformationService. The issue was that it was looking for it in the Hub namespace, since the controller in question is in that namespace.
- I added `::` so that it would look in the global namespace, and added a test that ensures that this action (and view) execute and render correctly
## How to test?
- This should be covered by automated tests