### PR TITLE
FYST Refactor: move tax_calculator method to base intake, define calculator class on StateInformationService

### DIFF
--- a/app/models/state_file_az_intake.rb
+++ b/app/models/state_file_az_intake.rb
@@ -98,14 +98,6 @@ class StateFileAzIntake < StateFileBaseIntake
   enum eligibility_married_filing_separately: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_married_filing_separately
   enum eligibility_529_for_non_qual_expense: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_529_for_non_qual_expense
 
-  def tax_calculator(include_source: false)
-    Efile::Az::Az140.new(
-      year: MultiTenantService.statefile.current_tax_year,
-      intake: self,
-      include_source: include_source
-    )
-  end
-
   def federal_dependent_count_under_17
     self.dependents.select{ |dependent| dependent.age < 17 }.length
   end

--- a/app/models/state_file_base_intake.rb
+++ b/app/models/state_file_base_intake.rb
@@ -71,6 +71,14 @@ class StateFileBaseIntake < ApplicationRecord
     @calculator
   end
 
+  def tax_calculator(include_source: false)
+    StateFile::StateInformationService.calculator_class(state_code).new(
+      year: MultiTenantService.statefile.current_tax_year,
+      intake: self,
+      include_source: include_source
+    )
+  end
+
   def calculated_refund_or_owed_amount
     calculator.refund_or_owed_amount
   end

--- a/app/models/state_file_ny_intake.rb
+++ b/app/models/state_file_ny_intake.rb
@@ -172,14 +172,6 @@ class StateFileNyIntake < StateFileBaseIntake
     district&.county_code
   end
 
-  def tax_calculator(include_source: false)
-    Efile::Ny::It201.new(
-      year: MultiTenantService.statefile.current_tax_year,
-      intake: self,
-      include_source: include_source
-    )
-  end
-
   def calculate_sales_use_tax
     fed_agi = direct_file_data&.fed_agi
 

--- a/app/services/state_file/state_information_service.rb
+++ b/app/services/state_file/state_information_service.rb
@@ -3,6 +3,7 @@ module StateFile
     class << self
       [
         :intake_class,
+        :calculator_class,
         :navigation_class,
         :submission_builder_class,
         :mail_voucher_address,
@@ -47,6 +48,7 @@ module StateFile
     STATES_INFO = IceNine.deep_freeze!({
       az: {
         intake_class: StateFileAzIntake,
+        calculator_class: Efile::Az::Az140,
         navigation_class: Navigation::StateFileAzQuestionNavigation,
         submission_builder_class: SubmissionBuilder::Ty2022::States::Az::IndividualReturn,
         mail_voucher_address: "Arizona Department of Revenue<br/>" \
@@ -64,6 +66,7 @@ module StateFile
       },
       ny: {
         intake_class: StateFileNyIntake,
+        calculator_class: Efile::Ny::It201,
         navigation_class: Navigation::StateFileNyQuestionNavigation,
         submission_builder_class: SubmissionBuilder::Ty2022::States::Ny::IndividualReturn,
         mail_voucher_address: "NYS Personal Income Tax<br/>" \

--- a/spec/models/state_file_base_intake_spec.rb
+++ b/spec/models/state_file_base_intake_spec.rb
@@ -44,4 +44,11 @@ describe StateFileBaseIntake do
       end
     end
   end
+
+  describe "#tax_calculator" do
+    it "returns an instance of the calculator class from the information service" do
+      intake = create(:state_file_az_intake)
+      expect(intake.tax_calculator).to be_an_instance_of(Efile::Az::Az140)
+    end
+  end
 end

--- a/spec/services/state_file/state_information_service_spec.rb
+++ b/spec/services/state_file/state_information_service_spec.rb
@@ -7,8 +7,14 @@ describe StateFile::StateInformationService do
     end
   end
 
+  describe ".calculator_class" do
+    it "returns the tax calculator class" do
+      expect(described_class.calculator_class("az")).to eq Efile::Az::Az140
+    end
+  end
+
   describe ".state_name" do
-    it "returns the name of the state from states.yml" do
+    it "returns the name of the state" do
       expect(described_class.state_name("az")).to eq "Arizona"
     end
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-139, kind of
## Is PM acceptance required?
- No - merge after code review approval
## What was done?
- as part of the experiment to add a new state, i found some good refactor ideas. some of them will go into stories and some of them i am just knocking out on my own because the effort to write a story doesn't seem worth it either for how small they are or for how complicated they are to explain
- this one moves the `tax_calculator` method to the base intake class and puts the calculator classes in the information service
## How to test?
- hopefully any issues should be caught by the tests
