### PR TITLE
FYST Refactor: remove references to specific states logged in intakes in AuthenticatedStateFileIntakeConcern

### DIFF
--- a/app/controllers/concerns/authenticated_state_file_intake_concern.rb
+++ b/app/controllers/concerns/authenticated_state_file_intake_concern.rb
@@ -1,5 +1,6 @@
 module AuthenticatedStateFileIntakeConcern
   extend ActiveSupport::Concern
+  include StateFile::StateFileControllerConcern
 
   included do
     before_action :require_state_file_intake_login
@@ -12,7 +13,7 @@ module AuthenticatedStateFileIntakeConcern
   end
 
   def require_state_file_intake_login
-    if current_state_file_az_intake.blank? && current_state_file_ny_intake.blank?
+    if current_intake.blank?
       session[:after_state_file_intake_login_path] = request.original_fullpath if request.get?
       redirect_to StateFile::StateFilePagesController.to_path_helper(action: :login_options, us_state: params[:us_state])
     end

--- a/app/controllers/concerns/authenticated_state_file_intake_concern.rb
+++ b/app/controllers/concerns/authenticated_state_file_intake_concern.rb
@@ -15,7 +15,7 @@ module AuthenticatedStateFileIntakeConcern
   def require_state_file_intake_login
     if current_intake.blank?
       session[:after_state_file_intake_login_path] = request.original_fullpath if request.get?
-      redirect_to StateFile::StateFilePagesController.to_path_helper(action: :login_options, us_state: params[:us_state])
+      redirect_to StateFile::StateFilePagesController.to_path_helper(action: :login_options, us_state: current_state_code)
     end
   end
 end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-139, kind of
## Is PM acceptance required?
- No - merge after code review approval
## What was done?
- as part of the experiment to add a new state, i found some good refactor ideas. some of them will go into stories and some of them i am just knocking out on my own because the effort to write a story doesn't seem worth it either for how small they are or for how complicated they are to explain
- this one removes the reference to current_state_file_{state}_intake in AuthenticatedStateFileIntakeConcern and includes the StateFileControllerConcern so we can reuse the code there that looks for any logged in state file intakes
## How to test?
- hopefully any issues should be caught by the tests
