### PR TITLE
FYST Refactor: iterate over active states on about page for non-prod links to start intake

### DIFF
--- a/app/views/state_file/state_file_pages/about_page.html.erb
+++ b/app/views/state_file/state_file_pages/about_page.html.erb
@@ -30,8 +30,11 @@
 
 <% unless acts_like_production? %>
 <section>
-  <%= link_to "Start Test AZ", Navigation::StateFileAzQuestionNavigation::FLOW.first.to_path_helper(us_state: "az"), class: "button" %>
-  <%= link_to "Start Test NY", Navigation::StateFileNyQuestionNavigation::FLOW.first.to_path_helper(us_state: "ny"), class: "button" %>
+  <% StateFile::StateInformationService.active_state_codes.each do |state_code| %>
+    <%= link_to "Start Test #{state_code.upcase}",
+                StateFile::StateInformationService.navigation_class(state_code)::FLOW.first.to_path_helper(us_state: state_code),
+                class: "button" %>
+  <% end %>
   <% if current_intake %>
     <div class="with-padding-med">
       Your session has this intake: <b><%= current_state_code %> <%= current_intake.id %></b>


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-139, kind of
## Is PM acceptance required?
- No - merge after code review approval
## What was done?
- as part of the experiment to add a new state, i found some good refactor ideas. some of them will go into stories and some of them i am just knocking out on my own because the effort to write a story doesn't seem worth it either for how small they are or for how complicated they are to explain
- this one removes the hard coded list of states in the about page that shows links to start intake on non-prod environments
## How to test?
- looks fine
<img width="680" alt="image" src="https://github.com/codeforamerica/vita-min/assets/43800769/4c379db9-5482-45a3-9fa5-e8003fffb7f7">

