### PR TITLE
GYR1-512 When filtering on an org to which the user does not have access, clear the invalid filter

### DIFF
--- a/app/controllers/concerns/client_sortable.rb
+++ b/app/controllers/concerns/client_sortable.rb
@@ -41,6 +41,7 @@ module ClientSortable
       id = id["id"] if id.instance_of?(Hash)
 
       vita_partner = @vita_partners.find { |p| p.id == id }
+      next unless vita_partner.present?
       {
         id: vita_partner.id,
         name: vita_partner.name,
@@ -48,6 +49,6 @@ module ClientSortable
         value: vita_partner.id
       }
     end
-    result.to_json
+    result.compact.to_json
   end
 end

--- a/spec/controllers/concerns/client_sortable_spec.rb
+++ b/spec/controllers/concerns/client_sortable_spec.rb
@@ -89,5 +89,21 @@ RSpec.describe ClientSortable, type: :controller do
         expect(subject.send(:vita_partners_for_tagify)).to eq vita_partners
       end
     end
+
+    context "with filters to which the user does not have access" do
+      let(:params) do
+        {
+          vita_partners: [-1, orgs.first.id, -2].to_json
+        }
+      end
+      it "returns a filters in tagify format" do
+        subject.send(:setup_sortable_client)
+        org = orgs.first
+        expected = [
+          {id: org.id, name: org.name, parentName: nil, value: org.id}
+        ].to_json
+        expect(subject.send(:vita_partners_for_tagify)).to eq expected
+      end
+    end
   end
 end


### PR DESCRIPTION
## [GYR1-512](https://codeforamerica.atlassian.net/browse/GYR1-512)
## Is PM acceptance required?
- [X] No - merge after code review approval
## What was done?
- The filter panel stores filter orgs in a cookie. The current user may not have access to these orgs if...
  - They log out and log back in as a different user.
  - Somebody deletes the org
  - The user's access to the org is revoked.
- Before this change, this would trigger an error and effectively lock the user out of the clients page.
- If for any reason an org cannot be found, we now remove that filter rather than throwing an error.
## How to test?
- Test on Heroku
- Log in as an [admin@example.com](mailto:admin@example.com) / theforcevita
- Add [GetCTC.org](http://getctc.org/) and GYR National Organization as filter sites: 
![image](https://github.com/codeforamerica/vita-min/assets/17094895/7b9e5983-248c-46e7-8980-dff20f8b8bf7)
- Log out.
- Log in as [lemon@example.com](mailto:lemon@example.com) / vitavitavitavita. Your cookie still includes the filter sites, but you don’t have access to them so you get an error.
## Risk Assessment
  - Minimal risk - I added a spec to verify the behavior
## Screenshots (for visual changes)
- Before
- After
