### PR TITLE
FYST-136 Fix for text message login

### DIFF
--- a/app/controllers/state_file/questions/verification_code_controller.rb
+++ b/app/controllers/state_file/questions/verification_code_controller.rb
@@ -67,7 +67,6 @@ module StateFile
         )
         @form.intake = existing_intake
         intake.destroy unless intake.id == existing_intake.id
-        sign_in existing_intake
         redirect_to IntakeLoginsController.to_path_helper(
           action: :edit,
           id: hashed_verification_code,

--- a/app/forms/phone_verification_form.rb
+++ b/app/forms/phone_verification_form.rb
@@ -4,9 +4,18 @@ class PhoneVerificationForm < QuestionsForm
   validates_presence_of :verification_code
 
   def valid?
-    return true if Rails.configuration.allow_magic_verification_code && verification_code == "000000"
-
     hashed_verification_code = VerificationCodeService.hash_verification_code_with_contact_info(@intake.sms_phone_number, verification_code)
+    # Magic codes provide a way of bypassing security in a development context.
+    # The easiest way to do this was to update the last entry to actually have the magic code.
+    if Rails.configuration.allow_magic_verification_code && verification_code == "000000"
+      token = TextMessageAccessToken.where(sms_phone_number: @intake.phone_number).last
+      if token.present?
+        token.update(
+          token: Devise.token_generator.digest(TextMessageAccessToken, :token, hashed_verification_code),
+          )
+      end
+      return true
+    end
 
     valid_code = TextMessageAccessToken.lookup(hashed_verification_code).exists?
 


### PR DESCRIPTION
## [FYST-136](https://codeforamerica.atlassian.net/browse/FYST-136)
## Is PM acceptance required?
- [X] Yes - don't merge until JIRA issue is accepted!
## What was done?
- Copied approach from `EmailVerificationForm.valid?` to  `PhoneVerificationForm.valid?` - this code resets the token in the database.
- I noticed that we were logging users in if they come in through sign up before verifying their SSN - we showed the ssn verification step but they were actually logged in before that. :(
## How to test?
- No visual changes
- I did a run through of the following scenarios
  - An AZ intake sign up with a new phone number
  - An AZ intake sign up with an existing phone number that has transferred data from DF (So will need to enter an SSN)
  - An AZ intake sign up with an existing phone number that has not yet transferred data from DF (So won't need to enter an SSN)