### PR TITLE
Reassigning the to org lead keeps client at site level

### DIFF
--- a/spec/services/tax_return_assignment_service_spec.rb
+++ b/spec/services/tax_return_assignment_service_spec.rb
@@ -69,10 +69,17 @@ describe TaxReturnAssignmentService do
     end
 
     context "when assigned_user is a org lead" do
-      let(:assigned_user) { create :organization_lead_user }
+      let(:assigned_user) { create :organization_lead_user, organization: create(:organization, child_sites: [site]) }
 
       it "updates the user" do
         expect { subject.assign! }.to change(tax_return.reload, :assigned_user_id).to(assigned_user.id)
+      end
+
+      context "their original vita partner is a site" do
+        it "keeps them at the site" do
+          expect { subject.assign! }.not_to change(tax_return.client.reload, :vita_partner)
+          expect(tax_return.client.vita_partner).to eq site
+        end
       end
     end
   end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g.[ link here](https://codeforamerica.atlassian.net/browse/GYR1-266?atlOrigin=eyJpIjoiYmU0M2QwOWMyZGM2NGJmYmI3NmM2ZTZmY2EyNDI3ZTciLCJwIjoiaiJ9)
## Is PM acceptance required?
- [X ] Yes - don't merge until JIRA issue is accepted!
- [ ] No - merge after code review approval
## What was done?
- when a client has a vita partner site and is reassigned to an org lead that is part of that site family they should stay assigned to that site
## How to test?
1. go to heroku and go to a client's profile in the hub
2. assign them to a site (Liberry Site) and a site coordinator
3. then assign them to an org lead (of the Oregano Org)
4. refresh the page, make sure the vita partner assignment didn't change

<img width="905" alt="Screenshot 2024-07-09 at 12 51 02 PM" src="https://github.com/codeforamerica/vita-min/assets/49880002/39e74d74-4ba2-42f4-8ed4-edea14e45409">
<img width="936" alt="Screenshot 2024-07-09 at 12 51 33 PM" src="https://github.com/codeforamerica/vita-min/assets/49880002/d4a24ac2-7ee0-4ccc-a568-25473f958b03">

