### PR TITLE
Make fake test links more obvious

### DIFF
--- a/spec/controllers/concerns/files_concern_spec.rb
+++ b/spec/controllers/concerns/files_concern_spec.rb
@@ -9,19 +9,19 @@ RSpec.describe FilesConcern, type: :controller do
   let(:attachment) { double }
 
   describe "#transient_storage_url" do
-    let(:redirect_url) { "https://gyr-demo.s3.amazonaws.com/file.png?sig=whatever&expires=whatever" }
+    let(:rspec_redirect_url) { "https://fake-gyr-demo.s3.amazonaws.com/file.png?sig=whatever&expires=whatever" }
 
     before do
-      allow(attachment).to receive(:url).and_return(redirect_url)
+      allow(attachment).to receive(:url).and_return(rspec_redirect_url)
     end
 
     it "calls #url when given a blob" do
-      expect(subject.transient_storage_url(attachment)).to eq(redirect_url)
+      expect(subject.transient_storage_url(attachment)).to eq(rspec_redirect_url)
       expect(attachment).to have_received(:url).with(disposition: :inline)
     end
 
     it "passes the optional disposition parameter" do
-      expect(subject.transient_storage_url(attachment, disposition: "attachment")).to eq(redirect_url)
+      expect(subject.transient_storage_url(attachment, disposition: "attachment")).to eq(rspec_redirect_url)
       expect(attachment).to have_received(:url).with(disposition: "attachment")
     end
   end

--- a/spec/controllers/concerns/files_concern_spec.rb
+++ b/spec/controllers/concerns/files_concern_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe FilesConcern, type: :controller do
   let(:attachment) { double }
 
   describe "#transient_storage_url" do
-    let(:rspec_redirect_url) { "https://fake-gyr-demo.s3.amazonaws.com/file.png?sig=whatever&expires=whatever" }
+    let(:rspec_redirect_url) { "https://some-fake-s3-bucket-url.com/document.pdf?sig=whatever&expires=whatever" }
 
     before do
       allow(attachment).to receive(:url).and_return(rspec_redirect_url)

--- a/spec/controllers/hub/documents_controller_spec.rb
+++ b/spec/controllers/hub/documents_controller_spec.rb
@@ -301,16 +301,16 @@ RSpec.describe Hub::DocumentsController, type: :controller do
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :show
 
     context "with a signed in user" do
-      let(:document_transient_url) { "https://gyr-demo.s3.amazonaws.com/document.pdf?sig=whatever&expires=whatever" }
+      let(:rspec_document_transient_url) { "https://fake-gyr-demo.s3.amazonaws.com/document.pdf?sig=whatever&expires=whatever" }
       before do
         sign_in(user)
-        allow(subject).to receive(:transient_storage_url).and_return(document_transient_url)
+        allow(subject).to receive(:transient_storage_url).and_return(rspec_document_transient_url)
       end
 
       it "shows the document" do
         get :show, params: params
 
-        expect(response).to redirect_to(document_transient_url)
+        expect(response).to redirect_to(rspec_document_transient_url)
         expect(subject).to have_received(:transient_storage_url).with(document.upload.blob)
       end
 

--- a/spec/controllers/hub/documents_controller_spec.rb
+++ b/spec/controllers/hub/documents_controller_spec.rb
@@ -301,7 +301,7 @@ RSpec.describe Hub::DocumentsController, type: :controller do
     it_behaves_like :a_get_action_for_authenticated_users_only, action: :show
 
     context "with a signed in user" do
-      let(:rspec_document_transient_url) { "https://fake-gyr-demo.s3.amazonaws.com/document.pdf?sig=whatever&expires=whatever" }
+      let(:rspec_document_transient_url) { "https://some-fake-s3-bucket-url.com/document.pdf?sig=whatever&expires=whatever" }
       before do
         sign_in(user)
         allow(subject).to receive(:transient_storage_url).and_return(rspec_document_transient_url)

--- a/spec/controllers/portal/documents_controller_spec.rb
+++ b/spec/controllers/portal/documents_controller_spec.rb
@@ -4,7 +4,7 @@ describe Portal::DocumentsController do
   let(:params) { { id: document.id } }
   let(:client) { create :client }
   let(:document) { create :document, client: client }
-  let(:transient_url) { "https://gyr-demo.s3.amazonaws.com/data.csv?sig=whatever&expires=whatever" }
+  let(:rspec_transient_url) { "https://fake-gyr-demo.s3.amazonaws.com/data.csv?sig=whatever&expires=whatever" }
 
   describe "#show" do
     it_behaves_like :a_get_action_for_authenticated_clients_only, action: :show
@@ -26,12 +26,12 @@ describe Portal::DocumentsController do
       context "when the document belongs to the client" do
         before do
           sign_in client
-          allow(subject).to receive(:transient_storage_url).and_return(transient_url)
+          allow(subject).to receive(:transient_storage_url).and_return(rspec_transient_url)
         end
 
         it "redirects to the document url" do
           get :show, params: params
-          expect(response).to redirect_to transient_url
+          expect(response).to redirect_to rspec_transient_url
           expect(subject).to have_received(:transient_storage_url).with document.upload.blob
         end
       end

--- a/spec/controllers/portal/documents_controller_spec.rb
+++ b/spec/controllers/portal/documents_controller_spec.rb
@@ -4,7 +4,7 @@ describe Portal::DocumentsController do
   let(:params) { { id: document.id } }
   let(:client) { create :client }
   let(:document) { create :document, client: client }
-  let(:rspec_transient_url) { "https://fake-gyr-demo.s3.amazonaws.com/data.csv?sig=whatever&expires=whatever" }
+  let(:rspec_transient_url) { "https://some-fake-s3-bucket-url.com/document.pdf?sig=whatever&expires=whatever" }
 
   describe "#show" do
     it_behaves_like :a_get_action_for_authenticated_clients_only, action: :show


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/TBE-83

## Is PM acceptance required?
- [ ] Yes - don't merge until JIRA issue is accepted!
- [x ] No - merge after code review approval

## What was done?
Links that were found to be vulnerabilities in a bugcrowd investigation are just fake links. To make it more obvious that these links do not go anywhere, the resources were renamed to include rspec and the links were prepended with fake-* to make it more obvious for future bugcrowd investigations. 
