### PR TITLE
GYR1-534 More secure URI read

### DIFF
--- a/app/services/scrape_vita_providers_service.rb
+++ b/app/services/scrape_vita_providers_service.rb
@@ -24,7 +24,7 @@ class ScrapeVitaProvidersService
   private
 
   def request_page(url)
-    html = URI.open(url).read
+    html = Net::HTTP.get(URI.parse(url))
     @current_document = Nokogiri::HTML(html) do |config|
       config.noblanks
     end


### PR DESCRIPTION
## [GYR1-534](https://codeforamerica.atlassian.net/browse/GYR1-534)
## Is PM acceptance required?
- [X] No - merge after code review approval
## What was done?
- No functional changes - just using a method that CodeQL won't complain about.
## How to test?
Pull the PR and run the following code. It will execute the new method that loads the vita providers. (It takes a few seconds to run):
```
base_url = "https://irs.treasury.gov/freetaxprep/jsp/vita.jsp?lat=37.7726402&lng=-122.40991539999999&radius=1000000&zip=94103"
vita_sites = ScrapeVitaProvidersService.new.get_page_contents(base_url)
```
<img width="1245" alt="image" src="https://github.com/codeforamerica/vita-min/assets/17094895/82e8c78c-08ae-4241-9917-875071a707fc">

[GYR1-534]: https://codeforamerica.atlassian.net/browse/GYR1-534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ