### PR TITLE
GYR1-533 - using ends_with? rather than includes?

### DIFF
--- a/app/services/irs_api_service.rb
+++ b/app/services/irs_api_service.rb
@@ -41,7 +41,7 @@ class IrsApiService
     http = Net::HTTP.new(server_url.host, server_url.port)
     http.use_ssl = true
 
-    if server_url.host.include?('irs.gov')
+    if is_host_irs?
       # Just cert and key are required
       http.cert = cert_finder.client_cert
       http.key = cert_finder.client_key
@@ -123,7 +123,7 @@ class IrsApiService
     end
 
     def client_cert_bytes
-      if server_url.host.include?('irs.gov')
+      if is_host_irs?
         Base64.decode64(EnvironmentCredentials.dig('statefile', state_code, "cert_base64"))
       elsif server_url.host.include?('localhost')
         File.read(File.join(certs_dir, 'client.crt'))
@@ -135,12 +135,16 @@ class IrsApiService
     end
 
     def client_key_bytes
-      if server_url.host.include?('irs.gov')
+      if is_host_irs?
         Base64.decode64(EnvironmentCredentials.dig('statefile', state_code, "private_key_base64"))
       elsif server_url.host.include?('localhost')
         File.read(File.join(certs_dir, 'client.key'))
       end
     end
+  end
+
+  def is_host_irs?
+    server_url.host.ends_with?('irs.gov')
   end
 
   def self.server_url

--- a/app/services/irs_api_service.rb
+++ b/app/services/irs_api_service.rb
@@ -41,7 +41,7 @@ class IrsApiService
     http = Net::HTTP.new(server_url.host, server_url.port)
     http.use_ssl = true
 
-    if is_host_irs?
+    if server_url.host.ends_with?('irs.gov')
       # Just cert and key are required
       http.cert = cert_finder.client_cert
       http.key = cert_finder.client_key
@@ -123,7 +123,7 @@ class IrsApiService
     end
 
     def client_cert_bytes
-      if is_host_irs?
+      if server_url.host.ends_with?('irs.gov')
         Base64.decode64(EnvironmentCredentials.dig('statefile', state_code, "cert_base64"))
       elsif server_url.host.include?('localhost')
         File.read(File.join(certs_dir, 'client.crt'))
@@ -135,16 +135,12 @@ class IrsApiService
     end
 
     def client_key_bytes
-      if is_host_irs?
+      if server_url.host.ends_with?('irs.gov')
         Base64.decode64(EnvironmentCredentials.dig('statefile', state_code, "private_key_base64"))
       elsif server_url.host.include?('localhost')
         File.read(File.join(certs_dir, 'client.key'))
       end
     end
-  end
-
-  def is_host_irs?
-    server_url.host.ends_with?('irs.gov')
   end
 
   def self.server_url


### PR DESCRIPTION
## [GYR1-533](https://codeforamerica.atlassian.net/browse/GYR1-533)
## Is PM acceptance required?
- [X] No - merge after code review approval
## What was done?
- Checking urls with `ends_with?` rather than `include?` so that `irs.gov` is at the end of the URL.
- This doesn't change the behavior but will stop CodeQL complaining.
## How to test?
- Pull the branch and run the following code:
```
IrsApiService::CertificateFinder.new(IrsApiService.server_url, 'az').client_cert_bytes
```

[GYR1-533]: https://codeforamerica.atlassian.net/browse/GYR1-533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ