### PR TITLE
GYR1-531 Added a whitelist for resource references.

### DIFF
--- a/app/controllers/hub/clients_controller.rb
+++ b/app/controllers/hub/clients_controller.rb
@@ -179,7 +179,11 @@ module Hub
       resource_id = params[:id]
       resource_name = params[:resource]
       redirect_to hub_clients_path and return unless resource_name
-      resource = resource_name.camelize.constantize.find(resource_id)
+      resource = Fraud::Indicator.reference_to_resource(resource_name)&.find(resource_id)
+
+      # When the resource is not valid, resource is nil. We ought to do a regular 404 in that case
+      raise ActiveRecord::RecordNotFound unless resource
+
       client = resource.is_a?(Client) ? resource : resource.client
       redirect_to hub_client_path(id: client)
     end

--- a/app/models/fraud/indicator.rb
+++ b/app/models/fraud/indicator.rb
@@ -24,11 +24,13 @@ module Fraud
 
     TOO_SHORT_MESSAGE = "must have minimum length of %{count}"
     WRONG_LENGTH_MESSAGE = "must have length of %{count}"
+    REFERENCE_WHITELIST = ["client", "intake", "efile_submission", "bank_account", "tax_return"].freeze
+
     validates :indicator_type, presence: true, inclusion: { in: ["missing_relationship", "duplicates", "average_under", "not_in_safelist", "in_riskylist", "execute", "equals", "gem"] }
     validates :points, presence: true
     validates :query_model_name, presence: true
     validates :list_model_name, presence: true, if: -> { indicator_type.in? ["not_in_safelist", "in_riskylist"] }
-    validates :reference, presence: true, inclusion: { in: ["client", "intake", "efile_submission", "bank_account", "tax_return"] }
+    validates :reference, presence: true, inclusion: { in: REFERENCE_WHITELIST}
     validates :name, presence: true
     validates :query_model_name, :list_model_name, class_name: true
     validates :threshold, numericality: true, if: -> { indicator_type.in? ["average_under", "duplicates"] }
@@ -105,6 +107,10 @@ module Fraud
       value = indicator_attributes[1]
 
       scoped_records(references).where(attribute => value).exists? ? response(points) : passing_response
+    end
+
+    def self.reference_to_resource(resource_name)
+      resource_name.classify.constantize if REFERENCE_WHITELIST.include? resource_name
     end
 
     private

--- a/spec/controllers/hub/clients_controller_spec.rb
+++ b/spec/controllers/hub/clients_controller_spec.rb
@@ -1454,6 +1454,16 @@ RSpec.describe Hub::ClientsController do
           expect(response).to redirect_to hub_client_path(id: client.id)
         end
       end
+
+      context "when the resource is an invalid resource" do
+        let(:client) { create :client}
+
+        it "should be an internal error" do
+          expect {
+            get :resource_to_client_redirect, params: {id: client.id, resource: "foobar"}
+          }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
- Handles looking at the whitelist to maintain existing functionality
- Adds a method to make looking up tidier
- Handles 404s when the resource is invalid

## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/GYR1-531

## Is PM acceptance required?
- [ ] Yes - don't merge until JIRA issue is accepted!
- [ ] No - merge after code review approval

## What was done?
- Because the reference classes already exist, it's probably best to move them to a class constant. Call it `REFERENCE_WHITELIST`
- Should be frozen to prevent future edits
- A class method added to have a tidy solution
- Note that this accounts for valid resource names with good ids, valid resource names with bad ids, but probably will throw an unhandled exception for bad resource names with any ids (as it would become `nil`)
- Checking for nil and raising an `ActiveRecord::RecordNotFound` ought to do the trick to close that gap

## How to test?
A new test was added in rspec. I'm unsure how to actually test it but will pair with Tim shortly and maybe work it out.

- Before
- After
