### PR TITLE
Add flagged clients module to hub dashboard

### DIFF
--- a/.github/remove_old_heroku_review_apps.js
+++ b/.github/remove_old_heroku_review_apps.js
@@ -2,7 +2,7 @@
 
 const execSync = require('child_process').execSync;
 
-let apps = execSync("heroku apps:list --org getyourrefund").toString()
+let apps = execSync("heroku apps:list --team getyourrefund").toString()
 let prs = JSON.parse(execSync("gh pr list --json number")).map(function (line) { return line.number })
 
 function removeReviewApp(number) {

--- a/.github/workflows/heroku-pull-request.yml
+++ b/.github/workflows/heroku-pull-request.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Create Heroku app
         if: github.event.action == 'opened' || github.event.action == 'reopened'
-        run: heroku apps:create ${{ env.HEROKU_APP_NAME }} --org getyourrefund --stack heroku-22
+        run: heroku apps:create ${{ env.HEROKU_APP_NAME }} --team getyourrefund --stack heroku-22
 
       - name: Save app name and PR number as heroku environment variable
         if: github.event.action == 'opened' || github.event.action == 'reopened'

--- a/app/assets/stylesheets/pages/dashboard.scss
+++ b/app/assets/stylesheets/pages/dashboard.scss
@@ -1,9 +1,9 @@
-
-.dashboard-show-page-body{
-  .card{
+.dashboard-show-page-body {
+  .card {
     border: 0.1rem solid #757575;
   }
-  select.select__element{
+
+  select.select__element {
     border: 0.1rem solid #CFC5BF;
     border-radius: 0.5rem;
     background-image: image-url('dropdown.svg');
@@ -13,40 +13,16 @@
 
   .capacity {
     table {
-      border-collapse: collapse;
-      border-spacing: 0;
-      width: 100%;
-
-      tr th {
-        font-weight: normal;
-        color: #757575;
-        text-align: left;
-        padding: 1.2rem 0;
-      }
-
-      tr {
-        border-bottom: 0.1rem solid #BEBEBE;
-        td {
-          padding: 1.2rem 0;
-        }
-        td:last-child {
-          font-weight: bold;
-        }
-      }
-
-      tr:last-child {
-        border-bottom: none;
-      }
-
       .organization-link {
         color: #000;
         text-decoration: none;
       }
 
-      .controls>div {
+      .controls > div {
         display: flex;
         align-items: center;
         gap: 0.5rem;
+
         img {
           width: 1.8rem;
           height: 1.8rem;
@@ -66,10 +42,45 @@
     }
   }
 
+  .dashboard-table {
+    table {
+      border-collapse: collapse;
+      border-spacing: 0;
+      width: 100%;
+
+      tr th {
+        font-weight: normal;
+        color: $color-grey-medium;
+        text-align: left;
+        padding: 1.2rem 0;
+      }
+
+      tr {
+        border-bottom: 0.1rem solid $color-grey-medium-light;
+
+        td {
+          padding: 1.2rem 0;
+        }
+
+        td:last-child {
+          font-weight: bold;
+        }
+      }
+
+      tr:last-child {
+        border-bottom: none;
+      }
+    }
+  }
+
   .paging {
     display: flex;
     justify-content: flex-end;
     gap: 2rem;
+
+    p {
+      color: $color-grey-medium;
+    }
   }
 
   .resources {
@@ -92,4 +103,5 @@
       margin-right: .8rem;
     }
   }
+
 }

--- a/app/controllers/hub/dashboard_controller.rb
+++ b/app/controllers/hub/dashboard_controller.rb
@@ -5,6 +5,7 @@ module Hub
     before_action :load_filter_options, only: [:index, :show]
     helper_method :capacity_css_class
     helper_method :capacity_count
+    before_action :load_flagged_clients, only: [:index, :show]
 
     def index
       model = @filter_options.first.model
@@ -83,6 +84,13 @@ module Hub
         add_filter_option(partner, parent_value, options, options_by_value)
       end
       options
+    end
+
+    def load_flagged_clients
+      @flagged_clients = Client.accessible_by(current_ability)
+                               .where.not(flagged_at: nil)
+                               .distinct.joins(:intake)
+                               .merge(Intake.current_product_year)
     end
 
     def self.flatten_filter_options(filter_options, result)

--- a/app/controllers/hub/dashboard_controller.rb
+++ b/app/controllers/hub/dashboard_controller.rb
@@ -6,6 +6,7 @@ module Hub
     helper_method :capacity_css_class
     helper_method :capacity_count
     before_action :load_flagged_clients, only: [:index, :show]
+    authorize_resource :client, parent: false, only: [:index, :show]
 
     def index
       model = @filter_options.first.model

--- a/app/controllers/hub/dashboard_controller.rb
+++ b/app/controllers/hub/dashboard_controller.rb
@@ -5,8 +5,9 @@ module Hub
     before_action :load_filter_options, only: [:index, :show]
     helper_method :capacity_css_class
     helper_method :capacity_count
-    before_action :load_flagged_clients, only: [:index, :show]
+    before_action :load_clients, only: [:index, :show]
     authorize_resource :client, parent: false, only: [:index, :show]
+    before_action :load_flagged_clients, only: [:index, :show]
 
     def index
       model = @filter_options.first.model
@@ -21,6 +22,12 @@ module Hub
     end
 
     private
+
+    def selected_vita_partner
+      selected_value = "#{params[:type]}/#{params[:id]}"
+      selected_option = @filter_options.find{ |option| option.value == selected_value }
+      selected_option&.model || @filter_options&.first&.model
+    end
 
     def require_dashboard_user
       is_dashboard_user = (
@@ -88,10 +95,28 @@ module Hub
     end
 
     def load_flagged_clients
-      @flagged_clients = Client.accessible_by(current_ability)
-                               .where.not(flagged_at: nil)
-                               .distinct.joins(:intake)
-                               .merge(Intake.current_product_year)
+      vita_partner = selected_vita_partner
+      @flagged_clients = @clients.where.not(flagged_at: nil)
+                                 .distinct
+                                 .joins(:intake)
+                                 .merge(Intake.current_product_year)
+
+      valid_vita_partners = case vita_partner
+                            when Coalition
+                              child_orgs = vita_partner.organizations
+                              child_sites = child_orgs.flat_map(&:child_sites)
+                              [vita_partner, *child_orgs, *child_sites]
+                            when Organization
+                              child_sites = VitaPartner.sites.where(parent_organization: vita_partner)
+                              [vita_partner, *child_sites]
+                            when Site
+                              vita_partner
+                            end
+      @flagged_clients = @flagged_clients.where(vita_partner: valid_vita_partners)
+    end
+
+    def load_clients
+      @clients = Client.accessible_by(current_ability)
     end
 
     def self.flatten_filter_options(filter_options, result)

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -409,6 +409,7 @@ class Intake < ApplicationRecord
   }
 
   scope :accessible_intakes, -> { where(primary_consented_to_service: "yes", product_year: Rails.configuration.product_year) }
+  scope :current_product_year, -> { where(product_year: Rails.configuration.product_year) }
 
   def duplicates
     return itin_duplicates if itin_applicant?

--- a/app/views/hub/dashboard/_action_required_flagged_clients.html.erb
+++ b/app/views/hub/dashboard/_action_required_flagged_clients.html.erb
@@ -1,4 +1,39 @@
-<div class="card">
+<div class="card dashboard-table">
   <h2>Action Required: Flagged Clients</h2>
-  <p>TODO: Implement</p>
+  <table>
+    <thead>
+      <tr>
+        <th scope="col">Client Name</th>
+        <th scope="col">Client ID</th>
+        <th scope="col">Updated At</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% if @flagged_clients.exists? %>
+        <% @flagged_clients.limit(3).each do |client| %>
+          <tr>
+            <td>
+              <%= link_to client.preferred_name, hub_client_path(client.id) %>
+            </td>
+            <td>
+              <%= client.id %>
+            </td>
+            <td>
+              <%= client.updated_at.strftime("%b %d %l:%M%P") %>
+            </td>
+          </tr>
+        <% end %>
+      <% end %>
+    </tbody>
+  </table>
+
+  <% if @flagged_clients.exists? %>
+    <div class="paging">
+      <p><%= @flagged_clients.limit(3).count %> of <%= @flagged_clients.count %></p>
+      <%= link_to "View All", hub_clients_path(flagged: true), class: "text--centered" %>
+    </div>
+  <% else %>
+    <p>No clients to display at the moment</p>
+  <% end %>
+
 </div>

--- a/app/views/hub/dashboard/_action_required_flagged_clients.html.erb
+++ b/app/views/hub/dashboard/_action_required_flagged_clients.html.erb
@@ -1,11 +1,11 @@
 <div class="card dashboard-table">
-  <h2>Action Required: Flagged Clients</h2>
+  <h2><%= t("hub.dashboard.show.action_required.title") %></h2>
   <table>
     <thead>
       <tr>
-        <th scope="col">Client Name</th>
-        <th scope="col">Client ID</th>
-        <th scope="col">Updated At</th>
+        <th scope="col"><%= t("hub.dashboard.show.action_required.client_name") %></th>
+        <th scope="col"><%= t("hub.dashboard.show.action_required.client_id") %></th>
+        <th scope="col"><%= t("hub.dashboard.show.action_required.updated") %></th>
       </tr>
     </thead>
     <tbody>
@@ -30,10 +30,10 @@
   <% if @flagged_clients.exists? %>
     <div class="paging">
       <p><%= @flagged_clients.limit(3).count %> of <%= @flagged_clients.count %></p>
-      <%= link_to "View All", hub_clients_path(flagged: true), class: "text--centered" %>
+      <%= link_to t("hub.dashboard.show.view_all"), hub_clients_path(flagged: true), class: "text--centered" %>
     </div>
   <% else %>
-    <p>No clients to display at the moment</p>
+    <p><%= t("hub.dashboard.show.action_required.no_clients") %></p>
   <% end %>
 
 </div>

--- a/app/views/hub/dashboard/_capacity.html.erb
+++ b/app/views/hub/dashboard/_capacity.html.erb
@@ -1,4 +1,4 @@
-<div class="card dashboard-table">
+<div class="card capacity dashboard-table">
   <h2><%= I18n.t("hub.dashboard.show.capacity") %></h2>
   <table>
     <thead>

--- a/app/views/hub/dashboard/_capacity.html.erb
+++ b/app/views/hub/dashboard/_capacity.html.erb
@@ -1,4 +1,4 @@
-<div class="card capacity">
+<div class="card dashboard-table">
   <h2><%= I18n.t("hub.dashboard.show.capacity") %></h2>
   <table>
     <thead>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -961,6 +961,12 @@ en:
         title: Add a new CTC client
     dashboard:
       show:
+        action_required:
+          client_id: Client ID
+          client_name: Client Name
+          no_clients: No clients to display at the moment
+          title: 'Action Required: Flagged Clients'
+          updated: Updated At
         capacity: Capacity
         current_capacity: Current Capacity
         org_name: Organization Name

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -970,6 +970,12 @@ es:
         title: Agregar un nuevo cliente
     dashboard:
       show:
+        action_required:
+          client_id: ID de cliente
+          client_name: nombre del cliente
+          no_clients: No hay clientes para mostrar en este momento
+          title: 'Acción requerida: Clientes marcados'
+          updated: Actualizado en
         capacity: Capacidad
         current_capacity: Capacidad actual
         org_name: Nombre de la Organización


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. https://codeforamerica.atlassian.net/browse/GYR1-493?atlOrigin=eyJpIjoiNzZiODViMmU2MjY2NGEwY2ExMzViYWEwMDk0NjhjNjciLCJwIjoiaiJ9
## Is PM acceptance required?
- Yes - don't merge until JIRA issue is accepted!
## What was done?
Added an "Action Required" module to display the top three flagged clients 
## How to test?
Go to heroku, sign in and flag some clients from the all clients list. Then observe that they are displayed on the dashboards page
- Describe the testing approach taken to verify the changes, including:
  - tested locally as well as including dashboard controller tests
- Risk Assessment
  - IDOR risk, showing clients that are not in the vita partner group; protected against this by using CanCanCan to grab only the accessible clients
## Screenshots (for visual changes)
- Before
![Screenshot 2024-07-16 at 3 33 43 PM](https://github.com/user-attachments/assets/85f43d68-f71a-48f0-af1d-857e1b5159a4)

- After
<img width="435" alt="Screenshot 2024-07-16 at 12 25 41 PM" src="https://github.com/user-attachments/assets/f1d19101-c229-414a-a23d-70a69ab183cd">
