### PR TITLE
GYR1-508 Preventing access to bank details for greeters

### DIFF
--- a/app/controllers/concerns/access_controllable.rb
+++ b/app/controllers/concerns/access_controllable.rb
@@ -36,4 +36,10 @@ module AccessControllable
       head :forbidden
     end
   end
+
+  def prevent_greeter_access
+    if current_user.present? && current_user.greeter?
+      head :forbidden
+    end
+  end
 end

--- a/app/controllers/hub/clients/bank_accounts_controller.rb
+++ b/app/controllers/hub/clients/bank_accounts_controller.rb
@@ -1,7 +1,9 @@
 module Hub
   module Clients
     class BankAccountsController < Hub::BaseController
+      # Authorize this?
       load_and_authorize_resource :client, parent: false
+      before_action :prevent_greeter_access
 
       def show
         @client = Hub::ClientsController::HubClientPresenter.new(@client)

--- a/app/controllers/hub/clients/bank_accounts_controller.rb
+++ b/app/controllers/hub/clients/bank_accounts_controller.rb
@@ -1,7 +1,6 @@
 module Hub
   module Clients
     class BankAccountsController < Hub::BaseController
-      # Authorize this?
       load_and_authorize_resource :client, parent: false
       before_action :prevent_greeter_access
 

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -87,7 +87,7 @@ class Ability
     cannot :manage, StateFileW2
     cannot :manage, StateId
 
-    if user.role_type == CoalitionLeadRole::TYPE
+    if user.coalition_lead?
       can :read, Coalition, id: user.role.coalition_id
 
       # Coalition leads can view and edit users who are coalition leads, organization leads, site coordinators, and team members in their coalition
@@ -100,7 +100,7 @@ class Ability
       can :manage, TeamMemberRole, sites: { parent_organization: { coalition: user.role.coalition } }
     end
 
-    if user.role_type == OrganizationLeadRole::TYPE
+    if user.org_lead?
 
       # Organization leads can view and edit users who are organization leads, site coordinators, and team members in their coalition
       can :manage, User, id: user.accessible_users.pluck(:id)
@@ -111,7 +111,7 @@ class Ability
       can :manage, TeamMemberRole, sites: { parent_organization: user.role.organization }
     end
 
-    if user.role_type == SiteCoordinatorRole::TYPE
+    if user.site_coordinator?
       # Site coordinators can create site coordinators and team members in their site
       can :manage, SiteCoordinatorRole do |role|
         user.role.sites.map.any? { |site| role.sites.map(&:id).include? site.id }

--- a/app/views/hub/clients/_hidden_bank_account_info.html.erb
+++ b/app/views/hub/clients/_hidden_bank_account_info.html.erb
@@ -2,7 +2,7 @@
 <div>
   <div class="field-display">
     <span class="form-question"><%= t("hub.bank_accounts.bank_name") %>:</span>
-    <span class="label-value" aria-hidden="true"><%= bank_account.bank_name %></span>
+    <span class="label-value" aria-hidden="true">●●●●●●●●●●●</span>
     <span class="sr-only">Hidden</span>
   </div>
   <div class="field-display">

--- a/app/views/hub/clients/show.html.erb
+++ b/app/views/hub/clients/show.html.erb
@@ -115,27 +115,27 @@
 
           <!-- Payment info-->
           <div class="client-profile__field-group client-bank-account-info">
-              <h2 class="text--bold">
-                Refund Payment Info
-                <% if @client.intake.bank_account.present? && !current_user.greeter? %>
-                  <span id="js-toggle-bank-account-info">
-                    <%= link_to("View", show_bank_account_hub_client_path, remote: true) %>
-                  </span>
-                <% end %>
-              </h2>
-              <div class="field-display spacing-below-15">
-                <span class="form-question">Refund delivery method:</span>
-                <span class="label-value"><%= @client.intake.refund_payment_method&.humanize %> </span>
-              </div>
-              <% if @client.intake.bank_account.present? %>
-                <div id="js-bank-account-info">
-                  <%= render "hub/clients/hidden_bank_account_info", bank_account: @client.intake.bank_account %>
-                </div>
-              <% else %>
-                <div>
-                  <span class="label-value"><em>No bank account info provided.</em></span>
-                </div>
+            <h2 class="text--bold">
+              Refund Payment Info
+              <% if @client.intake.bank_account.present? && !current_user.greeter? %>
+                <span id="js-toggle-bank-account-info">
+                  <%= link_to("View", show_bank_account_hub_client_path, remote: true) %>
+                </span>
               <% end %>
+            </h2>
+            <div class="field-display spacing-below-15">
+              <span class="form-question">Refund delivery method:</span>
+              <span class="label-value"><%= @client.intake.refund_payment_method&.humanize %> </span>
+            </div>
+            <% if @client.intake.bank_account.present? %>
+              <div id="js-bank-account-info">
+                <%= render "hub/clients/hidden_bank_account_info", bank_account: @client.intake.bank_account %>
+              </div>
+            <% else %>
+              <div>
+                <span class="label-value"><em>No bank account info provided.</em></span>
+              </div>
+            <% end %>
 
             <% if @client.intake.is_ctc? %>
               <div class="client-profile__field-group client-recovery-rebate-credit-amount">

--- a/app/views/hub/clients/show.html.erb
+++ b/app/views/hub/clients/show.html.erb
@@ -96,7 +96,7 @@
             </div>
             <div class="field-display">
               <span class="form-question"><%= t(".filing_status") %>:</span>
-              <div class="label-indented"><%= filing_status(@client) %></div>
+              <span class="label-value"><%= filing_status(@client) %></span>
             </div>
             <% if @client.intake&.product_year == 2022 %>
               <div class="field-display">
@@ -115,29 +115,29 @@
 
           <!-- Payment info-->
           <div class="client-profile__field-group client-bank-account-info">
-              <% unless current_user.greeter? %>
-                <h2 class="text--bold">
-                  Refund Payment Info
-                  <% if @client.intake.bank_account.present? %>
-                    <span id="js-toggle-bank-account-info">
-                      <%= link_to("View", show_bank_account_hub_client_path, remote: true) %>
-                    </span>
-                  <% end %>
-                </h2>
-                <div class="field-display">
+              <h2 class="text--bold">
+                Refund Payment Info
+                <% if @client.intake.bank_account.present? && !current_user.greeter? %>
+                  <span id="js-toggle-bank-account-info">
+                    <%= link_to("View", show_bank_account_hub_client_path, remote: true) %>
+                  </span>
+                <% end %>
+              </h2>
+              <div class="field-display">
+                <div class="spacing-below-15">
                   <span class="form-question">Refund delivery method:</span>
                   <span class="label-value"><%= @client.intake.refund_payment_method&.humanize %> </span>
-                    <% if @client.intake.bank_account.present? %>
-                      <div id="js-bank-account-info">
-                        <%= render "hub/clients/hidden_bank_account_info", bank_account: @client.intake.bank_account %>
-                      </div>
-                    <% else %>
-                      <div>
-                        <span class="label-value"><em>No bank account info provided.</em></span>
-                      </div>
-                    <% end %>
                 </div>
-            <% end %>
+                <% if @client.intake.bank_account.present? %>
+                  <div id="js-bank-account-info">
+                    <%= render "hub/clients/hidden_bank_account_info", bank_account: @client.intake.bank_account %>
+                  </div>
+                <% else %>
+                  <div>
+                    <span class="label-value"><em>No bank account info provided.</em></span>
+                  </div>
+                <% end %>
+              </div>
 
             <% if @client.intake.is_ctc? %>
               <div class="client-profile__field-group client-recovery-rebate-credit-amount">

--- a/app/views/hub/clients/show.html.erb
+++ b/app/views/hub/clients/show.html.erb
@@ -115,29 +115,29 @@
 
           <!-- Payment info-->
           <div class="client-profile__field-group client-bank-account-info">
-            <h2 class="text--bold">
-              Refund Payment Info
-              <% if @client.intake.bank_account.present? %>
-                <span id="js-toggle-bank-account-info">
-                  <%= link_to("View", show_bank_account_hub_client_path, remote: true) %>
-                </span>
-              <% end %>
-            </h2>
-            <div class="field-display">
-              <span class="form-question">Refund delivery method:</span>
-              <span class="label-value"><%= @client.intake.refund_payment_method&.humanize %> </span>
-
-                <% if @client.intake.bank_account.present? %>
-                  <div id="js-bank-account-info">
-                    <%= render "hub/clients/hidden_bank_account_info", bank_account: @client.intake.bank_account %>
-                  </div>
-                <% else %>
-                  <div>
-                    <span class="label-value"><em>No bank account info provided.</em></span>
-                  </div>
-                <% end %>
-
-            </div>
+              <% unless current_user.greeter? %>
+                <h2 class="text--bold">
+                  Refund Payment Info
+                  <% if @client.intake.bank_account.present? %>
+                    <span id="js-toggle-bank-account-info">
+                      <%= link_to("View", show_bank_account_hub_client_path, remote: true) %>
+                    </span>
+                  <% end %>
+                </h2>
+                <div class="field-display">
+                  <span class="form-question">Refund delivery method:</span>
+                  <span class="label-value"><%= @client.intake.refund_payment_method&.humanize %> </span>
+                    <% if @client.intake.bank_account.present? %>
+                      <div id="js-bank-account-info">
+                        <%= render "hub/clients/hidden_bank_account_info", bank_account: @client.intake.bank_account %>
+                      </div>
+                    <% else %>
+                      <div>
+                        <span class="label-value"><em>No bank account info provided.</em></span>
+                      </div>
+                    <% end %>
+                </div>
+            <% end %>
 
             <% if @client.intake.is_ctc? %>
               <div class="client-profile__field-group client-recovery-rebate-credit-amount">

--- a/app/views/hub/clients/show.html.erb
+++ b/app/views/hub/clients/show.html.erb
@@ -123,21 +123,19 @@
                   </span>
                 <% end %>
               </h2>
-              <div class="field-display">
-                <div class="spacing-below-15">
-                  <span class="form-question">Refund delivery method:</span>
-                  <span class="label-value"><%= @client.intake.refund_payment_method&.humanize %> </span>
-                </div>
-                <% if @client.intake.bank_account.present? %>
-                  <div id="js-bank-account-info">
-                    <%= render "hub/clients/hidden_bank_account_info", bank_account: @client.intake.bank_account %>
-                  </div>
-                <% else %>
-                  <div>
-                    <span class="label-value"><em>No bank account info provided.</em></span>
-                  </div>
-                <% end %>
+              <div class="field-display spacing-below-15">
+                <span class="form-question">Refund delivery method:</span>
+                <span class="label-value"><%= @client.intake.refund_payment_method&.humanize %> </span>
               </div>
+              <% if @client.intake.bank_account.present? %>
+                <div id="js-bank-account-info">
+                  <%= render "hub/clients/hidden_bank_account_info", bank_account: @client.intake.bank_account %>
+                </div>
+              <% else %>
+                <div>
+                  <span class="label-value"><em>No bank account info provided.</em></span>
+                </div>
+              <% end %>
 
             <% if @client.intake.is_ctc? %>
               <div class="client-profile__field-group client-recovery-rebate-credit-amount">

--- a/spec/controllers/hub/clients/bank_accounts_controller_spec.rb
+++ b/spec/controllers/hub/clients/bank_accounts_controller_spec.rb
@@ -59,6 +59,15 @@ describe Hub::Clients::BankAccountsController, type: :controller do
           expect(response.body).to include(archived_bank_account.routing_number)
         end
       end
+
+      context "for a greeter" do
+        let(:user) { create(:greeter_user) }
+
+        it "prevents access" do
+          get :show, params: params, format: :js, xhr: true
+          expect(response).to be_forbidden
+        end
+      end
     end
   end
 

--- a/spec/controllers/hub/clients_controller_spec.rb
+++ b/spec/controllers/hub/clients_controller_spec.rb
@@ -259,6 +259,8 @@ RSpec.describe Hub::ClientsController do
         expect(profile).to have_text("Pacific Time (US & Canada)")
         expect(profile).to have_text("I'm available every morning except Fridays.")
         expect(profile).to have_text("2")
+
+        expect(profile).to have_text "Refund Payment Info"
       end
 
       context "when a client needs a response" do
@@ -295,6 +297,16 @@ RSpec.describe Hub::ClientsController do
 
           expect(response.body).to have_text "Unlock account"
         end
+      end
+    end
+
+    context "as an authenticated greeter" do
+      before { sign_in create(:greeter_user) }
+      render_views
+
+      it "does not show bank details" do
+        get :show, params: params
+        expect(response.body).not_to have_text "Refund Payment Info"
       end
     end
   end

--- a/spec/features/hub/client/show_client_spec.rb
+++ b/spec/features/hub/client/show_client_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "a user viewing a client" do
         expect(page).to have_content(archived_intake.preferred_name)
         expect(page).to have_content(archived_dependent_1.full_name)
         expect(page).to have_content(archived_dependent_2.full_name)
-        expect(page).to have_content(archived_bank_account.bank_name)
+        expect(page).not_to have_content(archived_bank_account.bank_name)
         expect(page).to have_content("Primary Prior Year (2020) AGI")
       end
     end

--- a/spec/features/hub/client/toggle_client_bank_account_info_spec.rb
+++ b/spec/features/hub/client/toggle_client_bank_account_info_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Toggle bank account info" do
         expect(page).to have_text "Account type"
         expect(page).to have_text "Account number"
         expect(page).to have_text "Routing number"
-        expect(page).to have_text "Self-help United"
+        expect(page).not_to have_text client.intake.bank_name
         expect(page).not_to have_text client.intake.bank_account_number
         expect(page).not_to have_text client.intake.bank_routing_number
         expect(page).not_to have_text client.intake.bank_account_type


### PR DESCRIPTION
## [GYR1-508](https://codeforamerica.atlassian.net/browse/GYR1-508)
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!
## What was done?
- Added a check to return a 404 if a greeter accesses the BankAccountsController
- Added a check in the clients show.html.erb to hide the bank details section if the user is a greeter.
- Added specs to cover cases where a user can view bank details and when they can't.
## How to test?
- Test on heroku.
- Create a client that has bank details.
- Try to view the client as a non greeter, and you should see the bank details.
- Try to view the client as a greeter and you should not see the bank details
## Risk Assessment
  - Low risk - preventing access to something that was accessible before. Specs mitigate inadvertent access removal

### Greeter does not see bank details
<img width="1095" alt="image" src="https://github.com/user-attachments/assets/52c90cf7-2473-47c3-9554-7846a5c9c762">

### Others still see bank details
<img width="783" alt="image" src="https://github.com/user-attachments/assets/d3e5eaff-3648-4a0d-87cc-63a4eacabaa3">




[GYR1-508]: https://codeforamerica.atlassian.net/browse/GYR1-508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ