### PR TITLE
Bugcrowd: Email Subscription URL Bug

### DIFF
--- a/app/controllers/notifications_settings_controller.rb
+++ b/app/controllers/notifications_settings_controller.rb
@@ -3,6 +3,11 @@ class NotificationsSettingsController < ApplicationController
   def unsubscribe_from_emails
     verifier = ActiveSupport::MessageVerifier.new(Rails.application.secret_key_base)
 
+    if params[:email_address].blank?
+      flash[:alert] = "No record found"
+      return
+    end
+
     begin
       email_address = verifier.verify(params[:email_address])
       matching_intakes = matching_intakes(email_address)
@@ -21,6 +26,11 @@ class NotificationsSettingsController < ApplicationController
 
   def subscribe_to_emails
     verifier = ActiveSupport::MessageVerifier.new(Rails.application.secret_key_base)
+
+    if params[:email_address].blank?
+      flash[:alert] = "No record found"
+      return
+    end
 
     begin
       email_address = verifier.verify(params[:email_address])

--- a/app/controllers/state_file/notifications_settings_controller.rb
+++ b/app/controllers/state_file/notifications_settings_controller.rb
@@ -5,6 +5,11 @@ module StateFile
     def unsubscribe_email
       verifier = ActiveSupport::MessageVerifier.new(Rails.application.secret_key_base)
 
+      if params[:email_address].blank?
+        flash[:alert] = "No record found"
+        return
+      end
+
       begin
         email_address = verifier.verify(params[:email_address])
         matching_intakes = matching_intakes(email_address)
@@ -23,6 +28,11 @@ module StateFile
 
     def subscribe_email
       verifier = ActiveSupport::MessageVerifier.new(Rails.application.secret_key_base)
+
+      if params[:email_address].blank?
+        flash[:alert] = "No record found"
+        return
+      end
 
       begin
         email_address = verifier.verify(params[:email_address])

--- a/app/mailers/outgoing_email_mailer.rb
+++ b/app/mailers/outgoing_email_mailer.rb
@@ -9,6 +9,9 @@ class OutgoingEmailMailer < ApplicationMailer
 
     @body = outgoing_email.body
 
+    verifier = ActiveSupport::MessageVerifier.new(Rails.application.secret_key_base)
+    @signed_email_address = verifier.generate(outgoing_email.to)
+
     @unsubscribe_link = Rails.application.routes.url_helpers.url_for(
       {
         host: MultiTenantService.new(:gyr).host,
@@ -16,7 +19,7 @@ class OutgoingEmailMailer < ApplicationMailer
         action: :unsubscribe_from_emails,
         locale: I18n.locale,
         _recall: {},
-        email_address: outgoing_email.to
+        email_address: @signed_email_address
       }
     )
     @subject = outgoing_email.subject

--- a/app/mailers/outgoing_email_mailer.rb
+++ b/app/mailers/outgoing_email_mailer.rb
@@ -10,7 +10,7 @@ class OutgoingEmailMailer < ApplicationMailer
     @body = outgoing_email.body
 
     verifier = ActiveSupport::MessageVerifier.new(Rails.application.secret_key_base)
-    @signed_email_address = verifier.generate(outgoing_email.to)
+    signed_email = verifier.generate(outgoing_email.to)
 
     @unsubscribe_link = Rails.application.routes.url_helpers.url_for(
       {
@@ -19,7 +19,7 @@ class OutgoingEmailMailer < ApplicationMailer
         action: :unsubscribe_from_emails,
         locale: I18n.locale,
         _recall: {},
-        email_address: @signed_email_address
+        email_address: signed_email
       }
     )
     @subject = outgoing_email.subject

--- a/app/mailers/state_file/notification_mailer.rb
+++ b/app/mailers/state_file/notification_mailer.rb
@@ -15,7 +15,7 @@ module StateFile
           action: :unsubscribe_email,
           locale: I18n.locale,
           _recall: {},
-          email_address: signed_email.to
+          email_address: signed_email
         }
       )
       mail(

--- a/app/mailers/state_file/notification_mailer.rb
+++ b/app/mailers/state_file/notification_mailer.rb
@@ -4,6 +4,10 @@ module StateFile
       service = MultiTenantService.new(:statefile)
       @body = notification_email.body
       attachments.inline['logo.png'] = service.email_logo
+
+      verifier = ActiveSupport::MessageVerifier.new(Rails.application.secret_key_base)
+      signed_email = verifier.generate(notification_email.to)
+
       @unsubscribe_link = Rails.application.routes.url_helpers.url_for(
         {
           host: MultiTenantService.new(:statefile).host,
@@ -11,7 +15,7 @@ module StateFile
           action: :unsubscribe_email,
           locale: I18n.locale,
           _recall: {},
-          email_address: notification_email.to
+          email_address: signed_email.to
         }
       )
       mail(

--- a/spec/controllers/notifications_settings_controller_spec.rb
+++ b/spec/controllers/notifications_settings_controller_spec.rb
@@ -1,24 +1,24 @@
 require "rails_helper"
 
-RSpec.describe StateFile::NotificationsSettingsController do
-  describe "#unsubscribe_email" do
+RSpec.describe NotificationsSettingsController do
+  describe "#unsubscribe_from_emails" do
     render_views
 
-    let!(:intake) { create :state_file_ny_intake, email_address: "unsubscribe_me@example.com", unsubscribed_from_email: false }
+    let!(:intake) { create :intake, email_address: "unsubscribe_me@example.com", email_notification_opt_in: "yes" }
     let(:verifier) { ActiveSupport::MessageVerifier.new(Rails.application.secret_key_base) }
     let(:signed_email) { verifier.generate("unsubscribe_me@example.com") }
     let(:signed_email_without_intake) { verifier.generate("rando@example.com") }
 
     it "unsubscribes the intake from email" do
-      get :unsubscribe_email, params: { email_address: signed_email }
+      get :unsubscribe_from_emails, params: { email_address: signed_email }
 
-      expect(intake.reload.unsubscribed_from_email).to eq true
-      expect(response.body).to include state_file_subscribe_email_path(email_address: signed_email)
+      expect(intake.reload.email_notification_opt_in).to eq "no"
+      expect(response.body).to include subscribe_to_emails_path(email_address: signed_email)
     end
 
     context "no matching intakes" do
       it "shows a message" do
-        get :unsubscribe_email, params: { email_address: signed_email_without_intake }
+        get :unsubscribe_from_emails, params: { email_address: signed_email_without_intake }
 
         expect(flash[:alert]).to eq "No record found"
       end
@@ -26,41 +26,41 @@ RSpec.describe StateFile::NotificationsSettingsController do
 
     context "unsigned email" do
       it "shows a message" do
-        get :unsubscribe_email, params: { email_address: "unsubscribe_me@example.com" }
+        get :unsubscribe_from_emails, params: { email_address: "unsubscribe_me@example.com" }
 
         expect(flash[:alert]).to eq "Invalid unsubscribe link"
       end
     end
 
     context "no email address" do
-      let!(:intake) { create :state_file_ny_intake, email_address: nil }
+      let!(:intake) { create :intake, email_address: nil }
 
       it "does not match with intakes that have nil email address" do
-        get :unsubscribe_email
+        get :unsubscribe_from_emails
 
         expect(flash[:alert]).to eq "No record found"
       end
     end
   end
 
-  describe "#subscribe_email" do
-    let!(:intake) { create :state_file_ny_intake, email_address: "unsubscribe_me@example.com", unsubscribed_from_email: true }
-    let!(:matching_intake) { create :state_file_az_intake, email_address: "unsubscribe_me@example.com", unsubscribed_from_email: true }
+  describe "#subscribe_to_emails" do
+    let!(:intake) { create :intake, email_address: "unsubscribe_me@example.com", email_notification_opt_in: "no" }
+    let!(:matching_intake) { create :intake, email_address: "unsubscribe_me@example.com", email_notification_opt_in: "no" }
     let(:verifier) { ActiveSupport::MessageVerifier.new(Rails.application.secret_key_base) }
     let(:signed_email) { verifier.generate("unsubscribe_me@example.com") }
     let(:signed_email_without_intake) { verifier.generate("rando@example.com") }
 
     it "resubscribes all intakes with matching email to email notifications" do
-      post :subscribe_email, params: { email_address: signed_email }
+      post :subscribe_to_emails, params: { email_address: signed_email }
 
-      expect(intake.reload.unsubscribed_from_email).to eq false
-      expect(matching_intake.reload.unsubscribed_from_email).to eq false
+      expect(intake.reload.email_notification_opt_in).to eq "yes"
+      expect(matching_intake.reload.email_notification_opt_in).to eq "yes"
       expect(flash[:notice]).to eq "You are successfully re-subscribed to email notifications."
     end
 
     context "no matching intakes" do
       it "shows a message" do
-        get :subscribe_email, params: { email_address: signed_email_without_intake }
+        get :subscribe_to_emails, params: { email_address: signed_email_without_intake }
 
         expect(flash[:alert]).to eq "No record found"
       end
@@ -68,17 +68,17 @@ RSpec.describe StateFile::NotificationsSettingsController do
 
     context "unsigned email" do
       it "shows a message" do
-        get :subscribe_email, params: { email_address: "unsubscribe_me@example.com" }
+        get :subscribe_to_emails, params: { email_address: "unsubscribe_me@example.com" }
 
         expect(flash[:alert]).to eq "Invalid subscribe link"
       end
     end
 
     context "no email address" do
-      let!(:intake) { create :state_file_ny_intake, email_address: nil }
+      let!(:intake) { create :intake, email_address: nil }
 
       it "does not match with intakes that have nil email address" do
-        get :subscribe_email
+        get :subscribe_to_emails
 
         expect(flash[:alert]).to eq "No record found"
       end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/TBE-85

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
Before anyone can pass in an email address to the unsubscribe page and can unsubsribe someone else. Now we added verification so that one can only unsubscribe if they click the link from an email it is in. 

## How to test?
Check to see on heroku using the following [en/unsubscribe_from_emails?email_address=](https://demo.getyourrefund.org/en/unsubscribe_from_emails?email_address=) and passing in a email. It should say invalid unsubscribe link. 
Also check that you can do it with a valid user by completing an intake for GYR and FYST and checking in the hub that the link unsubscribes the user. 

- Risk Assessment
  - Risks or side effects associated with the changes and how they were mitigated.
  - Highlight areas that may need extra attention during code review or testing.
  - Paste SQL queries or output where relevant
## Screenshots (for visual changes)
- Before
- After
