### PR TITLE
Use new docker image based on alpine linux instead of debian in order to get latest ghostscript version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,21 @@
 FROM ruby:3.2.2-alpine3.19
 
 # The Docker environment is based on Debian buster, which used to be called stable Debian, but is now called oldstable.
-RUN apt-get update --allow-releaseinfo-change
+# RUN apt-get update --allow-releaseinfo-change
 
 # System prerequisites
-RUN apt-get update \
- && apt-get -y install ca-certificates libgnutls30 build-essential libpq-dev ghostscript default-jre poppler-utils curl \
- && curl -sL https://deb.nodesource.com/setup_16.x | bash - \
- && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
- && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
- && apt-get update && apt-get install -y nodejs yarn python3 python3-pip python3-setuptools \
+RUN apk update \
+ && apk add ca-certificates libpq-dev ghostscript openjdk8-jre poppler-utils curl \
+# && curl -sL https://deb.nodesource.com/setup_16.x | bash - \
+# && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+# && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+# && apk update && apk add nodejs yarn python3 python3-pip python3-setuptools \
+ && apk add nodejs yarn python3 py3-pip py3-setuptools \
  && rm -rf /var/lib/apt/lists/*
 
 # If you require additional OS dependencies, install them here:
-# RUN apt-get update \
-#  && apt-get -y install imagemagick nodejs \
+# RUN apk update \
+#  && apk add imagemagick nodejs \
 #  && rm -rf /var/lib/apt/lists/*
 
 ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.9/supercronic-linux-amd64 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2.2
+FROM ruby:3.2.2-alpine3.19
 
 # The Docker environment is based on Debian buster, which used to be called stable Debian, but is now called oldstable.
 RUN apt-get update --allow-releaseinfo-change

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "jest-junit": "^12.0.0"
   },
   "engines": {
-    "node": ">=12.16 <19.0.0"
+    "node": ">=12.16 <21.0.0"
   },
   "scripts": {
     "test": "jest"

--- a/vendor/pdftk/install
+++ b/vendor/pdftk/install
@@ -1,7 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 set -eou pipefail
 
-pdftk_downloads_dir="${BASH_SOURCE%/*}/downloads"
-cd "$pdftk_downloads_dir/v3.3.3"
+pdftk_downloads_dir="$0/downloads"
+pwd
+cd "/app/vendor/pdftk/downloads/v3.3.3"
 curl -O "https://gitlab.com/api/v4/projects/5024297/packages/generic/pdftk-java/v3.3.3/pdftk-all.jar"
-echo "a694d49bd03e1edd4c23b3ba808bc221eb8a8ccfe7bfd2a0a884b2b2fb425188 pdftk-all.jar" | sha256sum --check
+echo "a694d49bd03e1edd4c23b3ba808bc221eb8a8ccfe7bfd2a0a884b2b2fb425188 pdftk-all.jar" | sha256sum -c

--- a/vendor/pdftk/install
+++ b/vendor/pdftk/install
@@ -1,8 +1,5 @@
 #!/bin/sh
-set -eou pipefail
 
-pdftk_downloads_dir="$0/downloads"
-pwd
 cd "/app/vendor/pdftk/downloads/v3.3.3"
 curl -O "https://gitlab.com/api/v4/projects/5024297/packages/generic/pdftk-java/v3.3.3/pdftk-all.jar"
 echo "a694d49bd03e1edd4c23b3ba808bc221eb8a8ccfe7bfd2a0a884b2b2fb425188 pdftk-all.jar" | sha256sum -c


### PR DESCRIPTION

## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/TBE-86
## Is PM acceptance required? (delete one)
- No - merge after code review approval
## What was done?
- [See this thread in slack for context](https://cfastaff.slack.com/archives/C06F5RZSD71/p1721689003372699)
- [Previous debian-based image here](https://hub.docker.com/layers/library/ruby/3.2.2/images/sha256-a91708fc81bbfea89b443e1b0ad2ddea19edacde742e47b5bf56372b8017cca5?context=explore)
- [New alpine-based image here](https://hub.docker.com/layers/library/ruby/3.2.2-alpine3.19/images/sha256-f94a95d5b837ca713c2b513a4a7125e773a708a4db21156b2a95a367efc53ead?context=explore)
## How to test?
- Deploy to staging and observe

