### PR TITLE
[FYST-164] adds the truste image and link to the fyst privacy policy page

### DIFF
--- a/app/views/state_file/state_file_pages/privacy_policy.html.erb
+++ b/app/views/state_file/state_file_pages/privacy_policy.html.erb
@@ -9,6 +9,11 @@
           <p><%= t(".header_1_html", link: url_for(host: MultiTenantService.new(:statefile).host, controller: "state_file/state_file_pages", action: 'about_page')) %></p>
           <p><%= t(".header_2_html") %></p>
           <p><%= t(".header_3_html") %></p>
+          <p>
+            <a href="//privacy.truste.com/privacy-seal/validation?rid=fbd38521-2463-471b-85e2-9f705e4d0772 " target="_blank">
+              <img style="border: none" src="//privacy-policy.truste.com/privacy-seal/seal?rid=fbd38521-2463-471b-85e2-9f705e4d0772" alt="TRUSTe"/>
+            </a>
+          </p>
           <h2><%= t(".overview") %></h2>
           <h3><%= t(".info_we_collect_header") %></h3>
           <p><%= t(".info_we_collect_1") %>

--- a/app/views/state_file/state_file_pages/privacy_policy.html.erb
+++ b/app/views/state_file/state_file_pages/privacy_policy.html.erb
@@ -10,7 +10,7 @@
           <p><%= t(".header_2_html") %></p>
           <p><%= t(".header_3_html") %></p>
           <p>
-            <a href="//privacy.truste.com/privacy-seal/validation?rid=fbd38521-2463-471b-85e2-9f705e4d0772 " target="_blank">
+            <a style="display: inline-block" href="//privacy.truste.com/privacy-seal/validation?rid=fbd38521-2463-471b-85e2-9f705e4d0772 " target="_blank">
               <img style="border: none" src="//privacy-policy.truste.com/privacy-seal/seal?rid=fbd38521-2463-471b-85e2-9f705e4d0772" alt="TRUSTe"/>
             </a>
           </p>


### PR DESCRIPTION
## Link to pivotal/JIRA issue
-  [FYST-164](https://codeforamerica.atlassian.net/browse/FYST-164)
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!
## What was done?
- added a plain html snippet to the privacy policy page to reflect our TrustArc status
## How to test?
- visit the [fyst privacy policy page](https://statefile.pr-4668.getyourrefund-testing.org/en/privacy-policy)
- verify truste image is present
- click image, verify trustarc info page opens in a new tab
- Risk Assessment
  - very low; plain html snippet is provided by trustarc.
## Screenshots (for visual changes)
- Before
    ![image](https://github.com/user-attachments/assets/ae4d076b-612e-431c-94a4-c4db016dfbd6)
- After
    ![image](https://github.com/user-attachments/assets/338092f0-15cd-4820-90e2-da50fd2b007f)



[FYST-164]: https://codeforamerica.atlassian.net/browse/FYST-164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ