### PR TITLE
GYR1-539 Better error handling for Twilio attachments

### DIFF
--- a/app/services/twilio_service.rb
+++ b/app/services/twilio_service.rb
@@ -25,8 +25,8 @@ class TwilioService
     end
 
     def fetch_attachment(url)
-      response = Net::HTTP.get_response(URI(url)) # first we get a redirect from Twilio to S3
       begin
+        response = Net::HTTP.get_response(URI(url)) # first we get a redirect from Twilio to S3
         response = Net::HTTP.get_response(URI(response['location'])) # then we get a redirect from S3 to S3
         response = Net::HTTP.get_response(URI(response['location'])) # finally we should get a 200 OK with the file
         filename_from_s3 = response['content-disposition'].split('"').last # S3 gives us the original filename
@@ -35,7 +35,7 @@ class TwilioService
           body: response.body,
         }
       rescue ArgumentError => e
-        Rails.logger.error("Error getting attachment from Twilio: #{url}: #{response&.status}: #{response&.headers}")
+        Rails.logger.error("Error getting attachment from Twilio: #{url}: #{response&.code}: #{response&.to_hash}")
         {
           filename: "unknown-file",
           body: nil

--- a/app/services/twilio_service.rb
+++ b/app/services/twilio_service.rb
@@ -26,14 +26,21 @@ class TwilioService
 
     def fetch_attachment(url)
       response = Net::HTTP.get_response(URI(url)) # first we get a redirect from Twilio to S3
-      response = Net::HTTP.get_response(URI(response['location'])) # then we get a redirect from S3 to S3
-      response = Net::HTTP.get_response(URI(response['location'])) # finally we should get a 200 OK with the file
-      filename_from_s3 = response['content-disposition'].split('"').last # S3 gives us the original filename
-
-      {
-        filename: filename_from_s3,
-        body: response.body,
-      }
+      begin
+        response = Net::HTTP.get_response(URI(response['location'])) # then we get a redirect from S3 to S3
+        response = Net::HTTP.get_response(URI(response['location'])) # finally we should get a 200 OK with the file
+        filename_from_s3 = response['content-disposition'].split('"').last # S3 gives us the original filename
+        {
+          filename: filename_from_s3,
+          body: response.body,
+        }
+      rescue ArgumentError => e
+        Rails.logger.error("Error getting attachment from Twilio: #{url}: #{response&.status}: #{response&.headers}")
+        {
+          filename: "unknown-file",
+          body: nil
+        }
+      end
     end
 
     def parse_attachments(params)

--- a/jmeter_test/fyst_az_5_minute_stress_test.jmx
+++ b/jmeter_test/fyst_az_5_minute_stress_test.jmx
@@ -3445,7 +3445,7 @@ Connect to 5s</stringProp>
         </HTTPSamplerProxy>
         <hashTree/>
       </hashTree>
-      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree">
+      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
         <boolProp name="ResultCollector.error_logging">false</boolProp>
         <objProp>
           <name>saveConfig</name>

--- a/jmeter_test/fyst_az_5_minute_stress_test.jmx
+++ b/jmeter_test/fyst_az_5_minute_stress_test.jmx
@@ -3445,7 +3445,7 @@ Connect to 5s</stringProp>
         </HTTPSamplerProxy>
         <hashTree/>
       </hashTree>
-      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
+      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree">
         <boolProp name="ResultCollector.error_logging">false</boolProp>
         <objProp>
           <name>saveConfig</name>


### PR DESCRIPTION
## [GYR1-539](https://codeforamerica.atlassian.net/browse/GYR1-539)
## Is PM acceptance required? (delete one)
- No - merge after code review approval
## What was done?

We've had this weird thing happening since July 10th where attachments from Twilio sometimes fail to load. There was no change on our end at this time that I can see. Twilio invokes our webhook with a request that includes a url where we should load the attachment, but from what I can see it simply does not load. Interestingly, I have been able to load these attachments later using the same URL. My working theory is that there is some kind of race condition on Twilio's end, where they invoke the webhook before the data is actually available in S3. But I need more data - hence this PR.

TLDR: Rather than simply having the process fail with no explanation, this PR captures the ArgumentError we have seen in the logs and returns a broken attachment mimicking what happens if the attachment does load but is of an unsupported type. It also prints some additional info to the log.

## How to test?
- Specs still pass
- I also tested this on Staging: (Sent an image from my phone via text)
<img width="715" alt="image" src="https://github.com/user-attachments/assets/c6ab82f3-1eb3-4f6e-a89e-f572d7ac602b">


## Risk Assessment
  - This code will only be invoked in cases where the read attachment has failed anyway - and provides some better error handling. Low risk

[GYR1-539]: https://codeforamerica.atlassian.net/browse/GYR1-539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ