### PR TITLE
Fix typo in screener offboarding pages

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2338,7 +2338,7 @@ en:
           title: You’ve declined the terms and conditions.
       eligibility_offboarding:
         edit:
-          body_html: You cannot use this tool this year because %{ineligible_reason}. <strong>Is this a mistake?</strong> <a href=%{prev_link}>Go back to correct.</a>
+          body_html: You cannot use this tool this year because you %{ineligible_reason}. <strong>Is this a mistake?</strong> <a href=%{prev_link}>Go back to correct.</a>
           ineligible_reason:
             eligibility_529_for_non_qual_expense: withdrew money from a 529 college savings account and used it for a non-qualifying expense in 2023
             eligibility_lived_in_state: did not live in %{state} for all of 2023

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2304,7 +2304,7 @@ es:
           title: 'Has rechazado los términos y condiciones. '
       eligibility_offboarding:
         edit:
-          body_html: No puedes usar esta herramienta este año porque %{ineligible_reason}. <strong>¿Es un error?</strong><a href=%{prev_link}>Regresa para corregirlo.</a>
+          body_html: No puedes usar esta herramienta este año porque tú %{ineligible_reason}. <strong>¿Es un error?</strong><a href=%{prev_link}>Regresa para corregirlo.</a>
           ineligible_reason:
             eligibility_529_for_non_qual_expense: retiraste dinero de una cuenta de ahorro universitario 529 y lo utilizaste para un gasto no calificado en el 2023
             eligibility_lived_in_state: no viviste en %{state} durante todo el 2023


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. [link](https://codeforamerica.atlassian.net/browse/FYST-313?atlOrigin=eyJpIjoiZDcxNzk3OGNiMWJkNGJmYWI4Y2EyMjNhMGU4MDg1ZDIiLCJwIjoiaiJ9)
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!
## What was done?
- There is a typo in the offboarding pages and this PR fixes it
## How to test?
-  Go to the elibility offboarding page in heroku: https://statefile.pr-4679.getyourrefund-testing.org/en/questions/eligibility-offboarding 
- you'll have to change the session time to be before the tax deadline to get it to work: https://statefile.pr-4679.getyourrefund-testing.org/session_toggles?locale=en
- click through the flow and select something that will disqualify you in the initial screener (for example you don't live in the state in question)
## Screenshots (for visual changes)
- Before
<img width="772" alt="Screenshot 2024-07-31 at 2 46 31 PM" src="https://github.com/user-attachments/assets/5491b642-cce3-4920-af15-83b59d15d3e0">

- After
<img width="787" alt="Screenshot 2024-07-31 at 2 48 12 PM" src="https://github.com/user-attachments/assets/8f5861af-06dd-49b0-8d0b-baa87caa70fe">


