### PR TITLE
FYST-324: Now generating and attaching PDF to intake when submitting

### DIFF
--- a/app/jobs/state_file/build_submission_pdf_job.rb
+++ b/app/jobs/state_file/build_submission_pdf_job.rb
@@ -2,7 +2,7 @@ module StateFile
   class BuildSubmissionPdfJob < ApplicationJob
     def perform(submission_id)
       submission = EfileSubmission.find(submission_id)
-      submission.submission_bundle.attach(
+      submission.data_source.submission_pdf.attach(
         io: submission.generate_filing_pdf,
         filename: "#{submission.irs_submission_id}.pdf",
         content_type: 'application/pdf'

--- a/app/jobs/state_file/build_submission_pdf_job.rb
+++ b/app/jobs/state_file/build_submission_pdf_job.rb
@@ -1,0 +1,16 @@
+module StateFile
+  class BuildSubmissionPdfJob < ApplicationJob
+    def perform(submission_id)
+      submission = EfileSubmission.find(submission_id)
+      submission.submission_bundle.attach(
+        io: submission.generate_filing_pdf,
+        filename: "#{submission.irs_submission_id}.pdf",
+        content_type: 'application/pdf'
+      )
+    end
+
+    def priority
+      PRIORITY_MEDIUM
+    end
+  end
+end

--- a/app/state_machines/efile_submission_state_machine.rb
+++ b/app/state_machines/efile_submission_state_machine.rb
@@ -91,6 +91,7 @@ class EfileSubmissionStateMachine
 
   after_transition(to: :queued) do |submission|
     StateFile::SendSubmissionJob.perform_later(submission)
+    StateFile::BuildSubmissionPdfJob.perform_later(submission.id) if submission.is_for_state_filing?
   end
 
   after_transition(to: :fraud_hold) do |submission|

--- a/spec/jobs/state_file/build_submission_pdf_job_spec.rb
+++ b/spec/jobs/state_file/build_submission_pdf_job_spec.rb
@@ -3,11 +3,11 @@ require "rails_helper"
 describe StateFile::BuildSubmissionPdfJob do
   describe "#perform" do
     let!(:submitted_intake) { create :state_file_az_intake, email_address: 'test+01@example.com', email_address_verified_at: 1.minute.ago }
-    let!(:efile_submission) { create :efile_submission, :for_state, data_source: submitted_intake }
+    let!(:submission) { create :efile_submission, :for_state, data_source: submitted_intake }
 
     it "generates and attaches the pdf" do
       described_class.perform_now(submission.id)
-      submitted_intake.reload!
+      submitted_intake.reload
       expect(submitted_intake.submission_pdf.attached?).to be_truthy
     end
   end

--- a/spec/jobs/state_file/build_submission_pdf_job_spec.rb
+++ b/spec/jobs/state_file/build_submission_pdf_job_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+describe StateFile::BuildSubmissionPdfJob do
+  describe "#perform" do
+    let!(:submitted_intake) { create :state_file_az_intake, email_address: 'test+01@example.com', email_address_verified_at: 1.minute.ago }
+    let!(:efile_submission) { create :efile_submission, :for_state, data_source: submitted_intake }
+
+    it "generates and attaches the pdf" do
+      described_class.perform_now(submission.id)
+      submitted_intake.reload!
+      expect(submitted_intake.submission_pdf.attached?).to be_truthy
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,8 @@ end
 
 WebMock.disable_net_connect!(allow_localhost: true)
 
+RSpec::Matchers.define_negated_matcher :not_have_enqueued_job, :have_enqueued_job
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
## [FYST-324](https://codeforamerica.atlassian.net/browse/FYST-324)
## Is PM acceptance required? (delete one)
- No - merge after code review approval
## What was done?
- There was always a submission_pdf attribute on the intakes, but it was not populated. Now we populate it (And upload the PDF to S3)
- Added specs to cover this new background job
## How to test?
- Specs still pass
- Run the job in the console and make sure the submission_pdf is populated
- Create a new submission in staging and make sure the submission_pdf is populated

Here is a submission I created:
<img width="952" alt="image" src="https://github.com/user-attachments/assets/86011fab-832f-47fa-bbc9-78bfd23c5330">

And you can see that the submission_pdf attached:
<img width="543" alt="image" src="https://github.com/user-attachments/assets/8e812701-cc1f-45da-8de6-22cda04d53ba">

And that it was uploaded to S3:
<img width="991" alt="image" src="https://github.com/user-attachments/assets/ab9c15c1-cfa6-44c0-8e59-28799a53ef9a">
<img width="870" alt="image" src="https://github.com/user-attachments/assets/e6f6ae8e-0797-4f5d-8b33-4a2f5120c7df">


[FYST-324]: https://codeforamerica.atlassian.net/browse/FYST-324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ