### PR TITLE
FYST-325 Rake task to backfill submission pdfs.

### DIFF
--- a/crontab
+++ b/crontab
@@ -11,3 +11,5 @@
 0 19 23 4 * bundle exec rake state_file:post_deadline_reminder
 0 21 23 4 * bundle exec rake send_reject_resolution_reminder_notifications:send
 0 21 27 10 * bundle exec rake users:suspend_non_admins
+# TODO: Delete this once FYST-324 is complete.
+* * * * * bundle exec rake state_file:backfill_intake_submission_pdfs

--- a/lib/tasks/state_file.rake
+++ b/lib/tasks/state_file.rake
@@ -44,6 +44,7 @@ namespace :state_file do
         LIMIT #{batch_size}
       SQL
       ids = ActiveRecord::Base.connection.query(sql).flatten
+      Rails.logger.info("backfill_intake_submission_pdfs: #{intake_type.name}: #{ids}") if ids.present?
       intake_type.includes(:efile_submissions, :dependents, :state_file_w2s, :state_file1099_gs).with_attached_submission_pdf.find(ids).each do |intake|
         submission = intake.efile_submissions.last
         intake.submission_pdf.attach(

--- a/lib/tasks/state_file.rake
+++ b/lib/tasks/state_file.rake
@@ -4,7 +4,7 @@ namespace :state_file do
   task reminder_to_finish_state_return: :environment do
     StateFile::ReminderToFinishStateReturnService.run
   end
-  
+
   task pre_deadline_reminder: :environment do
     return unless DateTime.now.year == 2024
     StateFile::SendPreDeadlineReminderService.run
@@ -20,5 +20,39 @@ namespace :state_file do
     return if ENV["DO_NOT_SEND_APOLOGY_EMAIL"].present?
 
     StateFile::SendReminderApologyService.run
+  end
+
+  task backfill_intake_submission_pdfs: :environment do
+    batch_size = 5
+    intake_types = StateFile::StateInformationService.state_intake_classes
+    intake_types.find do |intake_type|
+      sql = <<~SQL
+        SELECT #{intake_type.table_name}.id 
+        FROM #{intake_type.table_name}
+        INNER JOIN efile_submissions ON (
+          efile_submissions.data_source_type = '#{intake_type.name}'
+          AND efile_submissions.data_source_id = #{intake_type.table_name}.id
+        ) INNER JOIN efile_submission_transitions ON (
+          efile_submission_transitions.efile_submission_id = efile_submissions.id
+          AND efile_submission_transitions.to_state not in ('new', 'preparing', 'bundling', 'queued')
+          AND efile_submission_transitions.most_recent = true
+        ) LEFT JOIN active_storage_attachments ON (
+          active_storage_attachments.record_type = '#{intake_type.name}'
+          AND active_storage_attachments.record_id = #{intake_type.table_name}.id
+          AND active_storage_attachments.name = 'submission_pdf'
+        ) WHERE active_storage_attachments.id IS NULL
+        LIMIT #{batch_size}
+      SQL
+      ids = ActiveRecord::Base.connection.query(sql).flatten
+      intake_type.includes(:efile_submissions, :dependents, :state_file_w2s, :state_file1099_gs).with_attached_submission_pdf.find(ids).each do |intake|
+        submission = intake.efile_submissions.last
+        intake.submission_pdf.attach(
+          io: submission.generate_filing_pdf,
+          filename: "#{submission.irs_submission_id}.pdf",
+          content_type: 'application/pdf'
+        )
+      end
+      ids.present?
+    end
   end
 end


### PR DESCRIPTION
## [FYST-325](https://codeforamerica.atlassian.net/browse/FYST-325)
## Is PM acceptance required? (delete one)
- No - merge after code review approval
## What was done?
We need to backfill the submission_pdf field for all existing state file intakes with permissions. This takes 4-7 seconds per intake. There are ~20,000 intakes on production, so running as a single task this will take 1-2 days at a minimum.

I broke it up into a rake task to be run on the cron - once a minute it will process 5 intakes. This should mean that the server does not get overloaded. Once the task is finished and FYST-324 is merged we can remove the cron job
## How to test?
- Run the rake task locally / on heroku - see that PDFs are created.

[FYST-325]: https://codeforamerica.atlassian.net/browse/FYST-325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

I deployed this to staging. Before starting counts were as followed:
* 150 AZ submissions
* 25 NY submissions.

I am watching it churn through the intakes applying submissions:
![image](https://github.com/user-attachments/assets/d2a751b7-cef3-4710-8d3a-ba92d9198146)

## Production:
I ran the query and found the following on production as the scale of this job:
NY: 12952
AZ: 2138
