### PR TITLE
FYST-324 Updated rake task to skip cancelled submissions

### DIFF
--- a/lib/tasks/state_file.rake
+++ b/lib/tasks/state_file.rake
@@ -34,7 +34,7 @@ namespace :state_file do
           AND efile_submissions.data_source_id = #{intake_type.table_name}.id
         ) INNER JOIN efile_submission_transitions ON (
           efile_submission_transitions.efile_submission_id = efile_submissions.id
-          AND efile_submission_transitions.to_state not in ('new', 'preparing', 'bundling', 'queued')
+          AND efile_submission_transitions.to_state not in ('new', 'preparing', 'bundling', 'queued', 'cancelled')
           AND efile_submission_transitions.most_recent = true
         ) LEFT JOIN active_storage_attachments ON (
           active_storage_attachments.record_type = '#{intake_type.name}'


### PR DESCRIPTION
## [FYST-324](https://codeforamerica.atlassian.net/browse/FYST-324)
## Is PM acceptance required? (delete one)
- No - merge after code review approval
## What was done?
- The rake task for backfilling submission PDFs got stuck on a **cancelled** submission, so I added this as a case to skip. (Along with the existing **new**, **preparing**, **bundling**, **queued**)
## How to test?
- Rake task runs locally and on staging
