### PR TITLE
fix xml return sample service to handle invalid keys gracefully

### DIFF
--- a/app/services/state_file/xml_return_sample_service.rb
+++ b/app/services/state_file/xml_return_sample_service.rb
@@ -1,8 +1,8 @@
 module StateFile
   class XmlReturnSampleService
     def initialize
-      @_samples = {}
-      @_submission_id_lookup = {
+      @samples = {}
+      @submission_id_lookup = {
         'ny_rudy_v2' => '1016422024027ate001k',
         'ny_javier' => '1016422024018atw000x',
         'ny_matthew_v2' => '1016422024026atw001u',
@@ -18,7 +18,7 @@ module StateFile
 
     def samples
       load_samples
-      @_samples
+      @samples
     end
 
     def self.key(us_state, sample_name)
@@ -30,7 +30,7 @@ module StateFile
     end
 
     def lookup_submission_id(key)
-      @_submission_id_lookup[key] || '12345202201011234570'
+      @submission_id_lookup[key] || '12345202201011234570'
     end
 
     def include?(key)
@@ -51,13 +51,13 @@ module StateFile
     TAX_YEAR = Rails.configuration.statefile_current_tax_year.to_s.freeze
 
     def load_samples
-      return if @_samples.present?
+      return if @samples.present?
 
       StateFile::StateInformationService.active_state_codes.each do |us_state|
-        @_samples[us_state] = []
+        @samples[us_state] = []
         xml_path_glob = File.join(BASE_PATH, TAX_YEAR, us_state, '*.xml')
         Dir.glob(xml_path_glob).each do |xml_path|
-          @_samples[us_state].push(File.basename(xml_path, ".xml"))
+          @samples[us_state].push(File.basename(xml_path, ".xml"))
         end
       end
     end
@@ -67,7 +67,7 @@ module StateFile
       return @old_sample if key == "abcdefg"
 
       us_state, sample_name = key.split("_", 2)
-      if @_samples[us_state].include? sample_name
+      if @samples.include?(us_state) && @samples[us_state].include?(sample_name)
         File.join(BASE_PATH, TAX_YEAR, us_state, "#{sample_name}.xml")
       end
     end

--- a/spec/services/state_file/xml_return_sample_service_spec.rb
+++ b/spec/services/state_file/xml_return_sample_service_spec.rb
@@ -6,7 +6,8 @@ describe StateFile::XmlReturnSampleService do
   let(:state_code) { 'az' }
   let(:sample_name) { 'superman_v2' }
   let(:key) { 'az_superman_v2' }
-  let(:bad_key) { 'az_superman_does_not_exist' }
+  let(:missing_key) { 'az_superman_does_not_exist' }
+  let(:invalid_key) { 'asdf' }
   let(:label) { 'Az superman v2' }
   let(:unique_file_contents) { 'KENT' }
   let(:old_sample_unique_file_contents) { 'TESTERSON' }
@@ -31,7 +32,7 @@ describe StateFile::XmlReturnSampleService do
     end
 
     it 'returns the default submission id if one is not found' do
-      expect(xml_return_sample_service.lookup_submission_id(bad_key)).to eq default_submission_id
+      expect(xml_return_sample_service.lookup_submission_id(missing_key)).to eq default_submission_id
     end
   end
 
@@ -41,8 +42,13 @@ describe StateFile::XmlReturnSampleService do
     end
 
     it 'returns false if the sample does not exist' do
-      expect(xml_return_sample_service.include?(bad_key)).to be_falsey
+      expect(xml_return_sample_service.include?(missing_key)).to be_falsey
     end
+
+    it 'returns false if the key is invalid' do
+      expect(xml_return_sample_service.include?(invalid_key)).to be_falsey
+    end
+
   end
 
   describe '#read' do
@@ -51,7 +57,11 @@ describe StateFile::XmlReturnSampleService do
     end
 
     it 'returns nil if the sample does not exist' do
-      expect(xml_return_sample_service.read(bad_key)).to be_nil
+      expect(xml_return_sample_service.read(missing_key)).to be_nil
+    end
+
+    it 'returns nil if the key is invalid' do
+      expect(xml_return_sample_service.read(invalid_key)).to be_nil
     end
   end
 


### PR DESCRIPTION
The XML Return Sample Service was crashing when asked whether it included a key not in the correct format, which actually happens every time we get an API response on a non-prod server. Whoops!