### PR TITLE
GYR1-552 Remove TrustArc for GetCTC

### DIFF
--- a/app/views/ctc/ctc_pages/privacy_policy.html.erb
+++ b/app/views/ctc/ctc_pages/privacy_policy.html.erb
@@ -15,8 +15,6 @@
 
           <p><%= t("views.ctc_pages.privacy_policy.02_questions_html", email_link: mail_to("support@getctc.org")) %></p>
 
-          <div><a href="//privacy.truste.com/privacy-seal/validation?rid=fbd38521-2463-471b-85e2-9f705e4d0772" target="_blank" rel="noopener"><img style="border: none" src="//privacy-policy.truste.com/privacy-seal/seal?rid=fbd38521-2463-471b-85e2-9f705e4d0772" alt="TRUSTe"/></a></div>
-
           <h2 class="text--caption"><%= t("views.ctc_pages.privacy_policy.03_overview") %></h2>
 
           <h3><%= t("views.ctc_pages.privacy_policy.04_info_we_collect") %></h3>


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/GYR1-552

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
Removed trust arc seal for the privacy policy for GetCTC

## How to test?
Visit heroku link for the PR at https://ctc.pr-4696.getyourrefund-testing.org/en/privacy and check if format is correct without the seal

## Screenshots (for visual changes)
- Before
<img width="816" alt="Screenshot 2024-08-09 at 12 09 16 PM" src="https://github.com/user-attachments/assets/6c383aa2-7cb9-4673-b186-b7eea35d97d0">

- After
<img width="792" alt="Screenshot 2024-08-09 at 12 09 28 PM" src="https://github.com/user-attachments/assets/10bc3f0a-0f2c-47ca-a2f4-ae038184513b">

