### PR TITLE
FYST-147 Update step indicator colors

### DIFF
--- a/app/assets/stylesheets/_state-file.scss
+++ b/app/assets/stylesheets/_state-file.scss
@@ -117,14 +117,14 @@
 
     .progress-step {
       height: 10px;
-      background: $color-grey-medium-light;
+      background: #808080;
       flex-shrink: 1;
       flex-grow: 1;
       border-radius: 5px;
     }
 
     .completed-step {
-      background: $color-state-file-primary;
+      background: #008817;
     }
   }
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/FYST-147

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
Colors for the status bar changed for FYST flow

## How to test?
Use heroku link and make sure to toggle session to intake time. Start an intake and check and navigation bar

## Screenshots (for visual changes)
- Before
<img width="700" alt="Screenshot 2024-08-09 at 12 47 07 PM" src="https://github.com/user-attachments/assets/e2ee550f-d3da-4377-b218-ab942af51c18">

- After
<img width="686" alt="Screenshot 2024-08-09 at 12 48 17 PM" src="https://github.com/user-attachments/assets/bba968d5-2d88-40e5-b25b-da62a93fc834">
