### PR TITLE
Add NC FAQ section to statefile/hub faq pages

### DIFF
--- a/.pairs
+++ b/.pairs
@@ -2,26 +2,24 @@
 #
 pairs:
   # <initials>: <Firstname> <Lastname>[; <email-id>]
+  ac: Arin Choi
   dbd: Dimitri DeFigueiredo
   em: Em Barnard-Shao
   jh: Jenny Heath
   ti: Tahsina Islam
   tc: Tiffany Chang
-  to: Tim O'Farrell
   mr: Mike Rotondo
-  rk: Ricardo Kreyhsig
   mp: Martha Pidcock
   jf: jey flores
   kd: Kevin Diale
 email_addresses:
+  ac: achoi@codeforamerica.org
   dbd: ddefigueiredo@codeforamerica.org
   em: ebarnard@codeforamerica.org
   jh: jheath@codeforamerica.org
   ti: tislam@codeforamerica.org
   tc: tchang@codeforamerica.org
-  to: tofarrell@codeforamerica.org 
   mr: mrotondo@codeforamerica.org
-  rk: rkreyhsig@codeforamerica.org
   mp: mpidcock@codeforamerica.org
   jf: jflores@codeforamerica.org
   kd: kdiale@codeforamerica.org

--- a/app/controllers/hub/state_file/faq_categories_controller.rb
+++ b/app/controllers/hub/state_file/faq_categories_controller.rb
@@ -6,6 +6,7 @@ module Hub
       def index
         @az_faq_categories = @faq_categories.where(product_type: :state_file_az)
         @ny_faq_categories = @faq_categories.where(product_type: :state_file_ny)
+        @nc_faq_categories = @faq_categories.where(product_type: :state_file_nc)
       end
 
       private

--- a/app/models/faq_category.rb
+++ b/app/models/faq_category.rb
@@ -22,7 +22,7 @@ class FaqCategory < ApplicationRecord
   has_rich_text :description_en
   has_rich_text :description_es
 
-  enum product_type: { gyr: 0, state_file_ny: 1, state_file_az: 2 }, _prefix: :product_type
+  enum product_type: { gyr: 0, state_file_ny: 1, state_file_az: 2, state_file_nc: 3 }, _prefix: :product_type
 
   def name(locale)
     case locale

--- a/app/views/hub/state_file/faq_categories/index.html.erb
+++ b/app/views/hub/state_file/faq_categories/index.html.erb
@@ -23,6 +23,15 @@
     <% unless @ny_faq_categories.present? && current_user.admin? && current_user.role.engineer? %>
       <p>No New York FAQ categories currently...perhaps reseed (run `StateFile::FaqDatabaseExportService.export_yml_to_database` in console or rerun data migrations)</p>
     <% end %>
+    <hr/>
+    <h2 id="nc-cats">North Carolina</h2>
+    <%= link_to "Add new NC FAQ Category", new_hub_state_file_faq_category_path(product_type: "state_file_nc"), method: :get, class: "button spacing-below-35" %>
+    <% @nc_faq_categories.each do |category| %>
+      <%= render 'faq_categories_and_items', category: category %>
+    <% end %>
+    <% unless @nc_faq_categories.present? && current_user.admin? && current_user.role.engineer? %>
+      <p>No North Carolina FAQ categories currently...perhaps reseed (run `StateFile::FaqDatabaseExportService.export_yml_to_database` in console or rerun data migrations)</p>
+    <% end %>
   </div>
 <% end %>
 

--- a/app/views/hub/state_file/faq_categories/index.html.erb
+++ b/app/views/hub/state_file/faq_categories/index.html.erb
@@ -5,13 +5,14 @@
     <%= render 'hub/faq_categories/header', titles: [@title]%>
     <a href="#az-cats" class="button spacing-below-0">Jump to AZ ↓</a>
     <a href="#ny-cats" class="button spacing-below-0">Jump to NY ↓</a>
+    <a href="#nc-cats" class="button spacing-below-0">Jump to NC ↓</a>
     <hr/>
     <h2 id="az-cats">Arizona</h2>
     <%= link_to "Add new AZ FAQ Category", new_hub_state_file_faq_category_path(product_type: "state_file_az"), method: :get, class: "button spacing-below-35" %>
     <% @az_faq_categories.each do |category| %>
       <%= render 'faq_categories_and_items', category: category %>
     <% end %>
-    <% unless @az_faq_categories.present? && current_user.admin? && current_user.role.engineer? %>
+    <% if !@az_faq_categories.present? && current_user.admin? && current_user.role.engineer? %>
       <p>No Arizona FAQ categories currently...perhaps reseed (run `StateFile::FaqDatabaseExportService.export_yml_to_database` in console or rerun data migrations)</p>
     <% end %>
     <hr/>
@@ -20,7 +21,7 @@
     <% @ny_faq_categories.each do |category| %>
       <%= render 'faq_categories_and_items', category: category %>
     <% end %>
-    <% unless @ny_faq_categories.present? && current_user.admin? && current_user.role.engineer? %>
+    <% if !@ny_faq_categories.present? && current_user.admin? && current_user.role.engineer? %>
       <p>No New York FAQ categories currently...perhaps reseed (run `StateFile::FaqDatabaseExportService.export_yml_to_database` in console or rerun data migrations)</p>
     <% end %>
     <hr/>
@@ -29,7 +30,7 @@
     <% @nc_faq_categories.each do |category| %>
       <%= render 'faq_categories_and_items', category: category %>
     <% end %>
-    <% unless @nc_faq_categories.present? && current_user.admin? && current_user.role.engineer? %>
+    <% if !@nc_faq_categories.present? && current_user.admin? && current_user.role.engineer? %>
       <p>No North Carolina FAQ categories currently...perhaps reseed (run `StateFile::FaqDatabaseExportService.export_yml_to_database` in console or rerun data migrations)</p>
     <% end %>
   </div>

--- a/spec/controllers/hub/state_file/faq_categories_controller_spec.rb
+++ b/spec/controllers/hub/state_file/faq_categories_controller_spec.rb
@@ -5,6 +5,7 @@ describe Hub::StateFile::FaqCategoriesController do
   let(:faq_category) { create :faq_category, position: 1, product_type: :state_file_az }
   let(:faq_category_2) { create :faq_category, name_en: "what what?", slug: "what_what", position: 2, product_type: :state_file_az }
   let(:faq_category_ny) { create :faq_category, name_en: "new york category", slug: "new_york_category", position: 2, product_type: :state_file_ny }
+  let(:faq_category_nc) { create :faq_category, name_en: "nc category", slug: "north_carolina_category", position: 1, product_type: :state_file_nc }
   let!(:faq_item) { create :faq_item, faq_category: faq_category }
   let!(:faq_item_2) { create :faq_item, faq_category: faq_category_2, slug: "there_there" }
 
@@ -20,6 +21,7 @@ describe Hub::StateFile::FaqCategoriesController do
       expect(response).to render_template :index
       expect(assigns(:az_faq_categories)).to match_array [faq_category, faq_category_2]
       expect(assigns(:ny_faq_categories)).to match_array [faq_category_ny]
+      expect(assigns(:nc_faq_categories)).to match_array [faq_category_nc]
     end
   end
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. [https://codeforamerica.atlassian.net/browse/FYST-310?atlOrigin=eyJpIjoiZWVlZDBmMTdhOTY0NDNmMDhhNTU4M2RlYmExMDAxYWUiLCJwIjoiaiJ9](https://codeforamerica.atlassian.net/browse/FYST-310?atlOrigin=eyJpIjoiZWVlZDBmMTdhOTY0NDNmMDhhNTU4M2RlYmExMDAxYWUiLCJwIjoiaiJ9)
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!
## What was done?
- Added state_file_nc enum to FAQ product types
- Added form section to FAQ hub pages
## How to test?
- test on heroku with an admin login to the hub and go to the state file FAQ pages
- specs that test its loading the right FAQ categories into the nc instance variable
## Screenshots (for visual changes)
- Before
      nothing
- After
![Screenshot 2024-08-15 at 12 29 56 PM](https://github.com/user-attachments/assets/db496ec0-57b0-4767-bb3d-23c8cf827eb1)

