### PR TITLE
memoize state sugar methods

### DIFF
--- a/app/services/state_file/state_information_service.rb
+++ b/app/services/state_file/state_information_service.rb
@@ -113,6 +113,6 @@ module StateFile
         voucher_form_name: "Form IT-201-V",
         voucher_path: "/pdfs/it201v_1223.pdf",
       }
-    }).with_indifferent_access
+    }.with_indifferent_access)
   end
 end

--- a/app/services/state_file/state_information_service.rb
+++ b/app/services/state_file/state_information_service.rb
@@ -29,11 +29,11 @@ module StateFile
       end
 
       def active_state_codes
-        @_active_state_codes ||= STATES_INFO.keys.map(&:to_s)
+        @_active_state_codes ||= STATES_INFO.keys.map(&:to_s).freeze
       end
 
       def state_intake_classes
-        @_state_intake_classes ||= STATES_INFO.map { |_, attrs| attrs[:intake_class] }
+        @_state_intake_classes ||= STATES_INFO.map { |_, attrs| attrs[:intake_class] }.freeze
       end
 
       def state_intake_class_names
@@ -41,11 +41,11 @@ module StateFile
       end
 
       def state_schema_file_names
-        @_state_schema_file_names ||= STATES_INFO.map { |_, attrs| attrs[:schema_file_name] }
+        @_state_schema_file_names ||= STATES_INFO.map { |_, attrs| attrs[:schema_file_name] }.freeze
       end
 
       def state_code_to_name_map
-        @_state_code_to_name_map ||= active_state_codes.to_h { |state_code, _| [state_code, state_name(state_code)] }
+        @_state_code_to_name_map ||= active_state_codes.to_h { |state_code, _| [state_code, state_name(state_code)] }.freeze
       end
     end
 

--- a/app/services/state_file/state_information_service.rb
+++ b/app/services/state_file/state_information_service.rb
@@ -29,23 +29,23 @@ module StateFile
       end
 
       def active_state_codes
-        STATES_INFO.keys.map(&:to_s)
+        @_active_state_codes ||= STATES_INFO.keys.map(&:to_s)
       end
 
       def state_intake_classes
-        STATES_INFO.map { |_, attrs| attrs[:intake_class] }
+        @_state_intake_classes ||= STATES_INFO.map { |_, attrs| attrs[:intake_class] }
       end
 
       def state_intake_class_names
-        state_intake_classes.map(&:to_s).freeze
+        @_state_intake_class_names ||= state_intake_classes.map(&:to_s).freeze
       end
 
       def state_schema_file_names
-        STATES_INFO.map { |_, attrs| attrs[:schema_file_name] }
+        @_state_schema_file_names ||= STATES_INFO.map { |_, attrs| attrs[:schema_file_name] }
       end
 
       def state_code_to_name_map
-        active_state_codes.to_h { |state_code, _| [state_code, state_name(state_code)] }
+        @_state_code_to_name_map ||= active_state_codes.to_h { |state_code, _| [state_code, state_name(state_code)] }
       end
     end
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- none

## Is PM acceptance required? (delete one)
- No - merge after code review approval

## What was done?
`STATES_INFO` is the foundation of the `StateInformationService`. We have a handful of sugar/convenience methods in that class that all derive structures from `STATES_INFO`. This PR does two things:

1. We weren't truly freezing the definition of `STATES_INFO`. Calling `#with_indifferent_access` on the hash _after_ it was frozen was returning a new, unfrozen object. This moves that call onto the hash literal prior to freezing.
2. Adds new instance variables to hold a memoized output of calls to a few of the convenience methods. All the changed methods munge data from `STATES_INFO` into different representations without relying on passed parameters. That is to say, that after freezing `STATES_INFO`, calling any of these methods should be idempotent. Memoizing saves a bit a runtime complexity.

## Question to the team (answered)
Given these convenience methods are defined on the class itself, are class variables more appropriate for memoizing? We don't ever instantiate `StateInformationService`, as best I can tell, so it's not really a singleton, but we're kind of treating it like one. So what's the right approach here for memoization -- instance or class variable?

**Answer:** Ruby classes are effectively singletons, especially given how we use them. Instance variable or class variable isn't really that important in this context. 

## How to test?
- No functional change; minor optimizations/refactor. As long as CI is green we should be good.

## Screenshots (for visual changes)
n/a
