### PR TITLE
Fyst 182 Retirement income page

### DIFF
--- a/app/controllers/flows_controller.rb
+++ b/app/controllers/flows_controller.rb
@@ -657,6 +657,7 @@ class FlowsController < ApplicationController
         df_data_imported_at: 2.hours.ago,
         primary_received_pension: "yes",
         received_military_retirement_payment: "yes",
+        received_military_retirement_payment_amount: 100,
         spouse_received_pension: "yes",
       )
     end

--- a/app/controllers/state_file/questions/az_retirement_income_controller.rb
+++ b/app/controllers/state_file/questions/az_retirement_income_controller.rb
@@ -4,8 +4,8 @@ module StateFile
       include ReturnToReviewConcern
 
       def edit
-        puts current_intake.filing_status_mfj?
-        puts "CONTROLLER #{current_intake.id}"
+
+        puts "CONTROLLER; ID: #{current_intake} mfj? #{current_intake.filing_status_mfj?}"
         @attributes = [:received_military_retirement_payment, :primary_received_pension]
         @attributes << :spouse_received_pension if current_intake.filing_status_mfj?
         super

--- a/app/controllers/state_file/questions/az_retirement_income_controller.rb
+++ b/app/controllers/state_file/questions/az_retirement_income_controller.rb
@@ -4,8 +4,6 @@ module StateFile
       include ReturnToReviewConcern
 
       def edit
-
-        puts "CONTROLLER; ID: #{current_intake} mfj? #{current_intake.filing_status_mfj?}"
         @attributes = [:received_military_retirement_payment, :primary_received_pension]
         @attributes << :spouse_received_pension if current_intake.filing_status_mfj?
         super

--- a/app/controllers/state_file/questions/az_retirement_income_controller.rb
+++ b/app/controllers/state_file/questions/az_retirement_income_controller.rb
@@ -1,0 +1,12 @@
+module StateFile
+  module Questions
+    class AzRetirementIncomeController < QuestionsController
+      include ReturnToReviewConcern
+
+      def self.show?(intake)
+        intake.direct_file_data.form1099rs.length > 0 &&
+          intake.direct_file_data.fed_taxable_pensions > 0
+      end
+    end
+  end
+end

--- a/app/controllers/state_file/questions/az_retirement_income_controller.rb
+++ b/app/controllers/state_file/questions/az_retirement_income_controller.rb
@@ -3,6 +3,14 @@ module StateFile
     class AzRetirementIncomeController < QuestionsController
       include ReturnToReviewConcern
 
+      def edit
+        puts current_intake.filing_status_mfj?
+        puts "CONTROLLER #{current_intake.id}"
+        @attributes = [:received_military_retirement_payment, :primary_received_pension]
+        @attributes << :spouse_received_pension if current_intake.filing_status_mfj?
+        super
+      end
+
       def self.show?(intake)
         intake.direct_file_data.form1099rs.length > 0 &&
           intake.direct_file_data.fed_taxable_pensions > 0

--- a/app/controllers/state_file/questions/az_retirement_income_controller.rb
+++ b/app/controllers/state_file/questions/az_retirement_income_controller.rb
@@ -1,17 +1,19 @@
 module StateFile
   module Questions
     class AzRetirementIncomeController < QuestionsController
+      before_action :load_attributes, only: [:edit, :update]
       include ReturnToReviewConcern
-
-      def edit
-        @attributes = [:received_military_retirement_payment, :primary_received_pension]
-        @attributes << :spouse_received_pension if current_intake.filing_status_mfj?
-        super
-      end
 
       def self.show?(intake)
         intake.direct_file_data.form1099rs.length > 0 &&
           intake.direct_file_data.fed_taxable_pensions > 0
+      end
+
+      private
+
+      def load_attributes
+        @attributes = [:received_military_retirement_payment, :primary_received_pension]
+        @attributes << :spouse_received_pension if current_intake.filing_status_mfj?
       end
     end
   end

--- a/app/forms/state_file/az_retirement_income_form.rb
+++ b/app/forms/state_file/az_retirement_income_form.rb
@@ -1,0 +1,16 @@
+module StateFile
+  class AzRetirementIncomeForm < QuestionsForm
+    set_attributes_for :intake,
+                       :received_military_retirement_payment,
+                       :received_military_retirement_payment_amount,
+                       :primary_received_pension,
+                       :primary_received_pension_amount,
+                       :spouse_received_pension,
+                       :spouse_received_pension_amount
+
+    validates :received_military_retirement_payment_amount, presence: true, allow_blank: false, if: -> { received_military_retirement_payment == "yes" }
+    validates_numericality_of :received_military_retirement_payment_amount, if: -> { received_military_retirement_payment == "yes" }
+    validates_numericality_of :primary_received_pension_amount, if: -> { primary_received_pension == "yes" }
+    validates_numericality_of :spouse_received_pension_amount, if: -> { spouse_received_pension == "yes" }
+  end
+end

--- a/app/forms/state_file/az_retirement_income_form.rb
+++ b/app/forms/state_file/az_retirement_income_form.rb
@@ -8,9 +8,26 @@ module StateFile
                        :spouse_received_pension,
                        :spouse_received_pension_amount
 
-    validates :received_military_retirement_payment_amount, presence: true, allow_blank: false, if: -> { received_military_retirement_payment == "yes" }
-    validates_numericality_of :received_military_retirement_payment_amount, if: -> { received_military_retirement_payment == "yes" }
-    validates_numericality_of :primary_received_pension_amount, if: -> { primary_received_pension == "yes" }
-    validates_numericality_of :spouse_received_pension_amount, if: -> { spouse_received_pension == "yes" }
+    validates :received_military_retirement_payment_amount, presence: true, numericality: true, allow_blank: false, if: -> { received_military_retirement_payment == "yes" }
+    validates :primary_received_pension_amount, presence: true, numericality: true, allow_blank: false, if: -> { primary_received_pension == "yes" }
+    validates :spouse_received_pension_amount, presence: true, numericality: true, allow_blank: false, if: -> { spouse_received_pension == "yes" }
+    validate :below_1040_amount, if: -> { [received_military_retirement_payment_amount, primary_received_pension_amount, spouse_received_pension_amount].any?(&:present?) }
+
+    def save
+      @intake.update(attributes_for(:intake))
+    end
+
+    private
+
+    def below_1040_amount
+      amount_limit = @intake.direct_file_data.fed_taxable_pensions
+      total = received_military_retirement_payment_amount.to_i + primary_received_pension_amount.to_i + spouse_received_pension_amount.to_i
+      if total > amount_limit
+        errors.add(:base, I18n.t("forms.errors.state_credit.exceeds_limit", limit: amount_limit))
+        errors.add(:received_military_retirement_payment_amount, "")
+        errors.add(:primary_received_pension_amount, "")
+        errors.add(:spouse_received_pension_amount, "")
+      end
+    end
   end
 end

--- a/app/forms/state_file/az_retirement_income_form.rb
+++ b/app/forms/state_file/az_retirement_income_form.rb
@@ -11,7 +11,7 @@ module StateFile
     validates :received_military_retirement_payment_amount, presence: true, numericality: true, allow_blank: false, if: -> { received_military_retirement_payment == "yes" }
     validates :primary_received_pension_amount, presence: true, numericality: true, allow_blank: false, if: -> { primary_received_pension == "yes" }
     validates :spouse_received_pension_amount, presence: true, numericality: true, allow_blank: false, if: -> { spouse_received_pension == "yes" }
-    validate :below_1040_amount, if: -> { [received_military_retirement_payment_amount, primary_received_pension_amount, spouse_received_pension_amount].any?(&:present?) }
+    validate :below_1040_amount
 
     def save
       @intake.update(attributes_for(:intake))

--- a/app/forms/state_file/federal_info_form.rb
+++ b/app/forms/state_file/federal_info_form.rb
@@ -20,6 +20,7 @@ module StateFile
                        :fed_taxable_income,
                        :fed_unemployment,
                        :fed_taxable_ssb,
+                       :fed_taxable_pensions,
                        :total_state_tax_withheld,
                        :total_exempt_primary_spouse
 

--- a/app/lib/navigation/state_file_az_question_navigation.rb
+++ b/app/lib/navigation/state_file_az_question_navigation.rb
@@ -35,6 +35,7 @@ module Navigation
         Navigation::NavigationStep.new(StateFile::Questions::W2Controller),
         Navigation::NavigationStep.new(StateFile::Questions::UnemploymentController),
         Navigation::NavigationStep.new(StateFile::Questions::AzSubtractionsController),
+        Navigation::NavigationStep.new(StateFile::Questions::AzRetirementIncomeController),
         Navigation::NavigationStep.new(StateFile::Questions::AzCharitableContributionsController),
         Navigation::NavigationStep.new(StateFile::Questions::AzPublicSchoolContributionsController),
         Navigation::NavigationStep.new(StateFile::Questions::AzExciseCreditController),

--- a/app/models/direct_file_data.rb
+++ b/app/models/direct_file_data.rb
@@ -877,7 +877,8 @@ class DirectFileData
       :fed_mortgage_interest_credit_amount,
       :fed_adoption_credit_amount,
       :fed_dc_homebuyer_credit_amount,
-      :fed_adjustments_claimed
+      :fed_adjustments_claimed,
+      :fed_taxable_pensions
     ].each_with_object({}) do |field, hsh|
       hsh[field] = send(field)
     end

--- a/app/models/direct_file_data.rb
+++ b/app/models/direct_file_data.rb
@@ -21,6 +21,7 @@ class DirectFileData
     fed_wages: 'IRS1040 WagesAmt',
     fed_wages_salaries_tips: 'IRS1040 WagesSalariesAndTipsAmt',
     fed_taxable_income: 'IRS1040 TaxableInterestAmt',
+    fed_taxable_pensions: 'IRS1040 TotalTaxablePensionsAmt',
     fed_educator_expenses: 'IRS1040Schedule1 EducatorExpensesAmt',
     fed_student_loan_interest: 'IRS1040Schedule1 StudentLoanInterestDedAmt',
     fed_total_adjustments: 'IRS1040Schedule1 TotalAdjustmentsAmt',
@@ -250,6 +251,14 @@ class DirectFileData
   end
 
   def fed_taxable_income=(value)
+    write_df_xml_value(__method__, value)
+  end
+
+  def fed_taxable_pensions
+    df_xml_value(__method__)&.to_i || 0
+  end
+
+  def fed_taxable_pensions=(value)
     write_df_xml_value(__method__, value)
   end
 

--- a/app/views/state_file/questions/az_retirement_income/edit.html.erb
+++ b/app/views/state_file/questions/az_retirement_income/edit.html.erb
@@ -15,7 +15,7 @@
             %>
           </div>
         </div>
-        <div class="question-with-follow-up__follow-up" id="#{income_type}">
+        <div class="question-with-follow-up__follow-up" id=<%=income_type %>>
           <div class="blue-group">
             <div class="spacing-below-25">
               <p><%= t(".#{income_type}_amount") %></p>

--- a/app/views/state_file/questions/az_retirement_income/edit.html.erb
+++ b/app/views/state_file/questions/az_retirement_income/edit.html.erb
@@ -3,6 +3,45 @@
 <% content_for :card do %>
   <h1 class="h2"><%= title %></h1>
   <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
+    <% [:received_military_retirement_payment, :primary_received_pension, :spouse_received_pension].each do |income_type| %>
+      <div class="question-with-follow-up">
+        <div class="question-with-follow-up__question">
+          <div class="blue-group">
+            <%= f.cfa_checkbox(
+                  income_type,
+                  t(".#{income_type}", count: current_intake.filer_count),
+                  options: { checked_value: "yes", unchecked_value: "no", "data-follow-up": "##{income_type}" }
+                )
+            %>
+          </div>
+        </div>
+        <div class="question-with-follow-up__follow-up" id="#{income_type}">
+          <div class="blue-group">
+            <div class="spacing-below-25">
+              <p><%= t(".#{income_type}_amount") %></p>
+              <p><%= t(".should_not_exceed_taxable_pensions_total_html", total: number_to_currency(current_intake.direct_file_data.fed_taxable_pensions)) %></p>
+            </div>
+            <div class="form-group-tight">
+              <%= f.cfa_input_field(
+                    "#{income_type}_amount".to_sym,
+                    t(".amount_label"),
+                    classes: ["form-width--long"]
+                  )
+              %>
+            </div>
+          </div>
+        </div>
+      </div>
+    <% end %>
+
+    <% if @form.errors[:base].any? %>
+      <div class="form-group form-group--error">
+        <% @form.errors[:base].each do |error| %>
+          <p class="text--error"><i class="icon-warning"></i><%= error %></p>
+        <% end %>
+      </div>
+    <% end %>
+
     <% if params[:return_to_review].present? %>
       <%= hidden_field_tag "return_to_review", params[:return_to_review] %>
     <% end %>

--- a/app/views/state_file/questions/az_retirement_income/edit.html.erb
+++ b/app/views/state_file/questions/az_retirement_income/edit.html.erb
@@ -1,0 +1,11 @@
+<% title = t(".title") %>
+<% content_for :page_title, title %>
+<% content_for :card do %>
+  <h1 class="h2"><%= title %></h1>
+  <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
+    <% if params[:return_to_review].present? %>
+      <%= hidden_field_tag "return_to_review", params[:return_to_review] %>
+    <% end %>
+    <%= f.continue %>
+  <% end %>
+<% end %>

--- a/app/views/state_file/questions/az_retirement_income/edit.html.erb
+++ b/app/views/state_file/questions/az_retirement_income/edit.html.erb
@@ -3,7 +3,7 @@
 <% content_for :card do %>
   <h1 class="h2"><%= title %></h1>
   <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
-    <% [:received_military_retirement_payment, :primary_received_pension, :spouse_received_pension].each do |income_type| %>
+    <% @attributes.each do |income_type| %>
       <div class="question-with-follow-up">
         <div class="question-with-follow-up__question">
           <div class="blue-group">

--- a/app/views/state_file/questions/federal_info/edit.html.erb
+++ b/app/views/state_file/questions/federal_info/edit.html.erb
@@ -78,6 +78,8 @@
     <div class="federal-info-controller-subform-section with-padding-med">
       <div class="federal-info-controller-subform-section-title">1099R Zone</div>
 
+      <%= f.state_file_qa_input_field :fed_taxable_pensions, "TotalTaxablePensionsAmt" %>
+
       <div class="federal-info-controller-subform-section-content">
         <%= f.fields_for :form1099rs do |ff| %>
           <%= render "df_1099r", f: ff %>

--- a/app/views/state_file/questions/federal_info/edit.html.erb
+++ b/app/views/state_file/questions/federal_info/edit.html.erb
@@ -77,8 +77,9 @@
 
     <div class="federal-info-controller-subform-section with-padding-med">
       <div class="federal-info-controller-subform-section-title">1099R Zone</div>
-
-      <%= f.state_file_qa_input_field :fed_taxable_pensions, "TotalTaxablePensionsAmt" %>
+      <div class="federal-info-controller-subform-section-content">
+        <%= f.state_file_qa_input_field :fed_taxable_pensions, "should equal sum of 1099Rs TaxableAmt" %>
+      </div>
 
       <div class="federal-info-controller-subform-section-content">
         <%= f.fields_for :form1099rs do |ff| %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -118,6 +118,7 @@ ignore_unused:
   - 'activemodel.*'
   - 'number.currency.format.*'
   - 'state_file.navigation.*'
+  - 'state_file.questions.az_retirement_income.edit.received_military_retirement_payment.*'
 # - 'activerecord.attributes.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2172,6 +2172,19 @@ en:
           contribution_label: Contribution to %{school_name}
           delete_confirmation: Are you sure you want to delete this contribution?
           lets_review: Lets review your public school cash contributions and fees
+      az_retirement_income:
+        edit:
+          amount_label: Enter amount earned
+          primary_received_pension: You received a distribution from a qualifying federal, Arizona, or government pension plan
+          primary_received_pension_amount: What is your total taxable amount from qualifying payer(s). You can find this on form 1099-R in box 2a. If you have multiple qualifying payers, add together boxes 2a from all corresponding forms.
+          received_military_retirement_payment:
+            one: You received benefits, annuities, and/or pensions as a retired or retainer pay of the uniformed services of the United States OR You are a surviving spouse of a deceased military veteran, and are receiving payments from the uniformed services of the United States
+            other: You or your spouse received benefits, annuities, and/or pensions as a retired or retainer pay of the uniformed services of the United States OR You are a surviving spouse of a deceased military veteran, and are receiving payments from the uniformed services of the United States
+          received_military_retirement_payment_amount: What is the taxable amount (box 2a) from this payer?
+          should_not_exceed_taxable_pensions_total_html: "<strong>Note:</strong> this should not exceed %{total}"
+          spouse_received_pension: Your spouse received a distribution from a qualifying federal, Arizona, or government pension plan
+          spouse_received_pension_amount: What is your spouse’s total taxable amount from qualifying payer(s). You can find this on 1099-R in box 2a for qualifying payer(s).
+          title: Arizona allows for a subtraction for certain types of retirement and pension income. Select any of the following situations that apply to you.
       az_review:
         edit:
           armed_forces_member: Member of the U.S. Armed Forces
@@ -2756,9 +2769,6 @@ en:
       waiting_to_load_data:
         edit:
           title_html: Just a moment, we’re transferring your federal tax return to complete parts of your state return. <br/><br/> This usually takes a few minutes. Don’t close this page.
-      az_retirement_income:
-        edit:
-          title: "Arizona allows for a subtraction for certain types of retirement and pension income. Select any of the following situations that apply to you."
     state_file_pages:
       about_page:
         closed_subheader_html: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2756,6 +2756,9 @@ en:
       waiting_to_load_data:
         edit:
           title_html: Just a moment, we’re transferring your federal tax return to complete parts of your state return. <br/><br/> This usually takes a few minutes. Don’t close this page.
+      az_retirement_income:
+        edit:
+          title: "Arizona allows for a subtraction for certain types of retirement and pension income. Select any of the following situations that apply to you."
     state_file_pages:
       about_page:
         closed_subheader_html: |

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2139,6 +2139,19 @@ es:
           contribution_label: Contribución a %{school_name}
           delete_confirmation: "¿Estás seguro de que quieres eliminar esta contribución?"
           lets_review: Revisión de tus hiciste contribuciones y tarifas a la escuela pública
+      az_retirement_income:
+        edit:
+          amount_label: Ingrese la cantidad ganada
+          primary_received_pension: Recibió una distribución de un plan de pensiones federal, de Arizona o gubernamental calificado.
+          primary_received_pension_amount: "¿Cuál es el monto total imponible de los pagadores calificados? Puede encontrarlo en el formulario 1099-R en el cuadro 2a. Si tiene varios pagadores calificados, sume las casillas 2a de todos los formularios correspondientes."
+          received_military_retirement_payment:
+            one: Recibió beneficios, anualidades y/o pensiones como pago jubilado o anticipo de los servicios uniformados de los Estados Unidos O Es cónyuge sobreviviente de un veterano militar fallecido y está recibiendo pagos de los servicios uniformados de los Estados Unidos.
+            other: Usted o su cónyuge recibieron beneficios, anualidades y/o pensiones como jubilado o pago de anticipo de los servicios uniformados de los Estados Unidos O Es cónyuge sobreviviente de un veterano militar fallecido y está recibiendo pagos de los servicios uniformados de los Estados Unidos.
+          received_military_retirement_payment_amount: "¿Cuál es la base imponible (casilla 2a) de este pagador?"
+          should_not_exceed_taxable_pensions_total_html: "<strong>Nota:</strong> esto no debe exceder %{total}"
+          spouse_received_pension: Su cónyuge recibió una distribución de un plan de pensiones federal, de Arizona o gubernamental calificado.
+          spouse_received_pension_amount: "¿Cuál es el monto total imponible de su cónyuge según los pagadores calificados? Puede encontrar esto en el formulario 1099-R en el cuadro 2a para los pagadores que califican."
+          title: Arizona permite una resta para ciertos tipos de ingresos de jubilación y pensión. Seleccione cualquiera de las siguientes situaciones que se apliquen a usted.
       az_review:
         edit:
           armed_forces_member: Miembro de las Fuerzas Armadas de los Estados Unidos

--- a/spec/controllers/state_file/questions/az_retirement_income_controller_spec.rb
+++ b/spec/controllers/state_file/questions/az_retirement_income_controller_spec.rb
@@ -8,16 +8,17 @@ RSpec.describe StateFile::Questions::AzRetirementIncomeController do
 
   describe ".show?" do
     it "returns true if they have a 1099R and TotalTaxablePensionsAmt is > 0" do
-      intake.direct_file_data.fed_taxable_pensions = 300
       expect(described_class.show?(intake)).to eq true
     end
 
     it "returns false when TotalTaxablePensionsAmt is 0" do
+      intake.direct_file_data.fed_taxable_pensions = 0
       expect(described_class.show?(intake)).to eq false
     end
 
     it "returns false if 1099R missing" do
-      intake.update(raw_direct_file_data:  StateFile::XmlReturnSampleService.new.read("az_unemployment"))
+      intake = create :state_file_az_intake, raw_direct_file_data: StateFile::XmlReturnSampleService.new.read("az_unemployment")
+      sign_in intake
       expect(described_class.show?(intake)).to eq false
     end
   end

--- a/spec/controllers/state_file/questions/az_retirement_income_controller_spec.rb
+++ b/spec/controllers/state_file/questions/az_retirement_income_controller_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe StateFile::Questions::AzRetirementIncomeController do
+  let(:intake) { create :state_file_az_intake, raw_direct_file_data: StateFile::XmlReturnSampleService.new.read("az_richard_retirement_1099r") }
+  before do
+    sign_in intake
+  end
+
+  describe ".show?" do
+    it "returns true if they have a 1099R and TotalTaxablePensionsAmt is > 0" do
+      intake.direct_file_data.fed_taxable_pensions = 300
+      expect(described_class.show?(intake)).to eq true
+    end
+
+    it "returns false when TotalTaxablePensionsAmt is 0" do
+      expect(described_class.show?(intake)).to eq false
+    end
+
+    it "returns false if 1099R missing" do
+      intake.update(raw_direct_file_data:  StateFile::XmlReturnSampleService.new.read("az_unemployment"))
+      expect(described_class.show?(intake)).to eq false
+    end
+  end
+
+  describe "#edit" do
+  # TODO: test that only mfj sees the spouse checkbox
+  end
+
+  describe "#update" do
+    it_behaves_like :return_to_review_concern do
+      let(:form_params) do
+        {
+          state_file_az_retirement_income_form: {
+          #  TODO: add actual params
+          }
+        }
+      end
+    end
+  end
+end

--- a/spec/controllers/state_file/questions/az_retirement_income_controller_spec.rb
+++ b/spec/controllers/state_file/questions/az_retirement_income_controller_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
 
 RSpec.describe StateFile::Questions::AzRetirementIncomeController do
-  let(:intake) { create :state_file_az_intake, raw_direct_file_data: StateFile::XmlReturnSampleService.new.read("az_richard_retirement_1099r") }
+  let(:intake) { create :state_file_az_intake, raw_direct_file_data: StateFile::XmlReturnSampleService.new.read("az_richard_retirement_1099r"), filing_status: filing_status }
+  let(:filing_status) { 'single' }
   before do
     sign_in intake
   end
@@ -27,22 +28,19 @@ RSpec.describe StateFile::Questions::AzRetirementIncomeController do
     render_views
 
     it "does not show the spouse checkbox if single" do
-      allow(intake).to receive(:filing_status_mfj?).and_return false
-      puts "TEST #{intake.id}"
-      puts intake.filing_status_mfj?
       get :edit
 
       expect(response.body).not_to include I18n.t("state_file.questions.az_retirement_income.edit.spouse_received_pension")
     end
 
-    # TODO WHY DOESN'T IT WORK
-    it "shows the spouse checkbox if mfj" do
-      allow(intake).to receive(:filing_status_mfj?).and_return true
-      puts "TEST #{intake.id}"
-      puts intake.filing_status_mfj?
-      get :edit
+    context "filing status mfj" do
+      let(:filing_status) { 'married_filing_jointly' }
 
-      expect(response.body).to include I18n.t("state_file.questions.az_retirement_income.edit.spouse_received_pension")
+      it "shows the spouse checkbox" do
+        get :edit
+
+        expect(response.body).to include I18n.t("state_file.questions.az_retirement_income.edit.spouse_received_pension")
+      end
     end
   end
 

--- a/spec/controllers/state_file/questions/az_retirement_income_controller_spec.rb
+++ b/spec/controllers/state_file/questions/az_retirement_income_controller_spec.rb
@@ -24,7 +24,26 @@ RSpec.describe StateFile::Questions::AzRetirementIncomeController do
   end
 
   describe "#edit" do
-  # TODO: test that only mfj sees the spouse checkbox
+    render_views
+
+    it "does not show the spouse checkbox if single" do
+      allow(intake).to receive(:filing_status_mfj?).and_return false
+      puts "TEST #{intake.id}"
+      puts intake.filing_status_mfj?
+      get :edit
+
+      expect(response.body).not_to include I18n.t("state_file.questions.az_retirement_income.edit.spouse_received_pension")
+    end
+
+    # TODO WHY DOESN'T IT WORK
+    it "shows the spouse checkbox if mfj" do
+      allow(intake).to receive(:filing_status_mfj?).and_return true
+      puts "TEST #{intake.id}"
+      puts intake.filing_status_mfj?
+      get :edit
+
+      expect(response.body).to include I18n.t("state_file.questions.az_retirement_income.edit.spouse_received_pension")
+    end
   end
 
   describe "#update" do
@@ -32,7 +51,12 @@ RSpec.describe StateFile::Questions::AzRetirementIncomeController do
       let(:form_params) do
         {
           state_file_az_retirement_income_form: {
-          #  TODO: add actual params
+            received_military_retirement_payment: "yes",
+            received_military_retirement_payment_amount: 100,
+            primary_received_pension: "yes",
+            primary_received_pension_amount: 100,
+            spouse_received_pension: "yes",
+            spouse_received_pension_amount: 100
           }
         }
       end

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -227,6 +227,10 @@ RSpec.feature "Completing a state file intake", active_job: true do
       fill_in "state_file_az_subtractions_form_armed_forces_wages", with: "100"
       click_on I18n.t("general.continue")
 
+      expect(page).to have_text  I18n.t("state_file.questions.az_retirement_income.edit.title")
+      # TODO add checkboxes etc.
+      click_on I18n.t("general.continue")
+
       expect(page).to have_text I18n.t("state_file.questions.az_charitable_contributions.edit.title.one", tax_year: MultiTenantService.statefile.current_tax_year)
       choose I18n.t("general.affirmative")
       fill_in "Enter the total amount of cash contributions made in #{MultiTenantService.statefile.current_tax_year}. (Round to the nearest whole number. Note: you may be asked to provide receipts for donations over $250.)", with: "123"

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -228,7 +228,8 @@ RSpec.feature "Completing a state file intake", active_job: true do
       click_on I18n.t("general.continue")
 
       expect(page).to have_text  I18n.t("state_file.questions.az_retirement_income.edit.title")
-      # TODO add checkboxes etc.
+      check "state_file_az_retirement_income_form_received_military_retirement_payment"
+      fill_in "state_file_az_retirement_income_form_received_military_retirement_payment_amount", with: "100"
       click_on I18n.t("general.continue")
 
       expect(page).to have_text I18n.t("state_file.questions.az_charitable_contributions.edit.title.one", tax_year: MultiTenantService.statefile.current_tax_year)

--- a/spec/features/state_file/editing_df_xml_spec.rb
+++ b/spec/features/state_file/editing_df_xml_spec.rb
@@ -68,6 +68,8 @@ RSpec.feature "editing direct file XML with the FederalInfoController", active_j
     fill_in "LocalityNm", with: "Pelicanville"
 
     # 1099R
+    fill_in "TotalTaxablePensionsAmt", with: 200
+
     fill_in "PayerName", with: "Rose Apothecary"
     fill_in "PayerNameControlTxt", with: "ROSEAPC"
     fill_in "AddressLine1Txt", with: "123 Schit Street"
@@ -94,6 +96,7 @@ RSpec.feature "editing direct file XML with the FederalInfoController", active_j
     expect(StateFileAzIntake.last.direct_file_data.w2s[0].LocalIncomeTaxAmt).to eq 4400
     expect(StateFileAzIntake.last.direct_file_data.w2s[0].LocalityNm).to eq "Pelicanville"
 
+    expect(StateFileAzIntake.last.direct_file_data.fed_taxable_pensions).to eq 200
     expect(StateFileAzIntake.last.direct_file_data.form1099rs[0].PayerName).to eq "Rose Apothecary"
     expect(StateFileAzIntake.last.direct_file_data.form1099rs[0].PayerNameControlTxt).to eq "ROSEAPC"
     expect(StateFileAzIntake.last.direct_file_data.form1099rs[0].AddressLine1Txt).to eq "123 Schit Street"

--- a/spec/fixtures/state_file/fed_return_xmls/2023/az/old_sample.xml
+++ b/spec/fixtures/state_file/fed_return_xmls/2023/az/old_sample.xml
@@ -103,7 +103,7 @@
       <NontxCombatPayElectionAmt>0</NontxCombatPayElectionAmt>
       <WagesSalariesAndTipsAmt>21000</WagesSalariesAndTipsAmt>
       <TaxableInterestAmt>24</TaxableInterestAmt>
-      <TotalTaxablePensionsAmt>0</TotalTaxablePensionsAmt>
+      <TotalTaxablePensionsAmt>1500</TotalTaxablePensionsAmt>
       <SocSecBnftAmt>12203</SocSecBnftAmt>
       <TaxableSocSecAmt>5627</TaxableSocSecAmt>
       <CapitalGainLossAmt>0</CapitalGainLossAmt>
@@ -259,5 +259,24 @@
       </W2StateLocalTaxGrp>
       <StandardOrNonStandardCd>S</StandardOrNonStandardCd>
     </IRSW2>
+    <IRS1099R documentId="IRS1099R0001">
+      <PayerNameControlTxt>PAYE</PayerNameControlTxt>
+      <PayerName>
+        <BusinessNameLine1Txt>Payer Name</BusinessNameLine1Txt>
+      </PayerName>
+      <PayerUSAddress>
+        <AddressLine1Txt>2030 Pecan Street</AddressLine1Txt>
+        <CityNm>Monroe</CityNm>
+        <StateAbbreviationCd>MA</StateAbbreviationCd>
+        <ZIPCd>05502</ZIPCd>
+      </PayerUSAddress>
+      <PayerEIN>000000001</PayerEIN>
+      <PhoneNum>2025551212</PhoneNum>
+      <GrossDistributionAmt>200</GrossDistributionAmt>
+      <TaxableAmt>1000</TaxableAmt>
+      <FederalIncomeTaxWithheldAmt>300</FederalIncomeTaxWithheldAmt>
+      <F1099RDistributionCd>7</F1099RDistributionCd>
+      <StandardOrNonStandardCd>S</StandardOrNonStandardCd>
+    </IRS1099R>
   </ReturnData>
 </Return>

--- a/spec/fixtures/state_file/fed_return_xmls/2023/az/richard_retirement_1099r.xml
+++ b/spec/fixtures/state_file/fed_return_xmls/2023/az/richard_retirement_1099r.xml
@@ -52,7 +52,7 @@
       <TaxableInterestAmt>0</TaxableInterestAmt>
       <QualifiedDividendsAmt>0</QualifiedDividendsAmt>
       <OrdinaryDividendsAmt>0</OrdinaryDividendsAmt>
-      <TotalTaxablePensionsAmt>0</TotalTaxablePensionsAmt>
+      <TotalTaxablePensionsAmt>1500</TotalTaxablePensionsAmt>
       <CapitalGainLossAmt>0</CapitalGainLossAmt>
       <TotalAdditionalIncomeAmt>5000</TotalAdditionalIncomeAmt>
       <TotalIncomeAmt>5000</TotalIncomeAmt>

--- a/spec/forms/state_file/az_retirement_income_form_spec.rb
+++ b/spec/forms/state_file/az_retirement_income_form_spec.rb
@@ -1,0 +1,118 @@
+require "rails_helper"
+
+RSpec.describe StateFile::AzRetirementIncomeForm do
+  describe "#valid?" do
+    let(:intake) { create :state_file_az_intake }
+    let(:form) { described_class.new(intake, params) }
+
+    context "dollar amounts are of the correct type" do
+      let(:params) do
+        {
+          received_military_retirement_payment: "yes",
+          received_military_retirement_payment_amount: "yes i am an amount",
+          primary_received_pension: "yes",
+          primary_received_pension_amount: "&*()$",
+          spouse_received_pension: "yes",
+          spouse_received_pension_amount: "beepboop",
+        }
+      end
+
+      it "is invalid and attaches the correct error" do
+        allow(intake).to receive(:filing_status_mfj?).and_return true
+
+        expect(form).not_to be_valid
+        expect(form.errors[:received_military_retirement_payment_amount]).to include "is not a number"
+        expect(form.errors[:primary_received_pension_amount]).to include "is not a number"
+        expect(form.errors[:spouse_received_pension_amount]).to include "is not a number"
+      end
+
+    #  TODO: maybe check that something like 30.3456 is not valid
+    end
+
+    context "single filer" do
+      before do
+        allow(intake).to receive(:filing_status_single?).and_return true
+      end
+
+      context "received_military_retirement_payment, primary_received_pension are no" do
+        let(:params) do
+          {
+            received_military_retirement_payment: "no",
+            primary_received_pension: "no",
+          }
+        end
+
+        it "is valid" do
+          expect(form).to be_valid
+        end
+      end
+
+      context "received_military_retirement_payment is yes" do
+        let(:params) do
+          {
+            received_military_retirement_payment: "yes",
+            received_military_retirement_payment_amount: received_military_retirement_payment_amount,
+            primary_received_pension: "no",
+          }
+        end
+
+        context "received_military_retirement_payment_amount is present" do
+          let(:received_military_retirement_payment_amount) { 1500 }
+
+          it "is valid" do
+            expect(form).to be_valid
+          end
+        end
+
+        context "received_military_retirement_payment_amount is blank" do
+          let(:received_military_retirement_payment_amount) { nil }
+
+          it "is invalid" do
+            expect(form).not_to be_valid
+            expect(form.errors[:received_military_retirement_payment_amount]).to include "Can't be blank."
+          end
+        end
+      end
+
+      context "primary_received_pension is yes" do
+        it "is valid if primary_received_pension_amount is present" do; end
+
+        it "is invalid if primary_received_pension_amount is blank" do; end
+      end
+
+      context "total amount" do
+        it "is valid if below total from df xml" do; end
+
+        it "is invalid if above total from df xml" do; end
+      end
+    end
+
+    context "mfj filers" do
+      before do
+        allow(intake).to receive(:filing_status_mfj?).and_return true
+      end
+
+      context "received_military_retirement_payment, primary_received_pension, spouse_received_pension are no" do
+        it "is valid" do; end
+      end
+
+      context "spouse_received_pension is yes" do
+        it "is valid if spouse_received_pension_amount is present" do; end
+
+        it "is invalid if spouse_received_pension_amount is blank" do; end
+      end
+
+      context "total amount" do
+        it "is valid if below total from df xml" do; end
+
+        it "is invalid if above total from df xml" do; end
+      end
+    end
+  end
+
+  describe "#save" do
+  end
+end
+
+
+

--- a/spec/forms/state_file/az_retirement_income_form_spec.rb
+++ b/spec/forms/state_file/az_retirement_income_form_spec.rb
@@ -1,11 +1,14 @@
 require "rails_helper"
 
 RSpec.describe StateFile::AzRetirementIncomeForm do
-  describe "#valid?" do
-    let(:intake) { create :state_file_az_intake }
-    let(:form) { described_class.new(intake, params) }
+  let(:intake) { create :state_file_az_intake }
+  let(:form) { described_class.new(intake, params) }
+  before do
+    intake.direct_file_data.fed_taxable_pensions = 1000
+  end
 
-    context "dollar amounts are of the correct type" do
+  describe "#valid?" do
+    context "non-numerical values" do
       let(:params) do
         {
           received_military_retirement_payment: "yes",
@@ -25,8 +28,6 @@ RSpec.describe StateFile::AzRetirementIncomeForm do
         expect(form.errors[:primary_received_pension_amount]).to include "is not a number"
         expect(form.errors[:spouse_received_pension_amount]).to include "is not a number"
       end
-
-    #  TODO: maybe check that something like 30.3456 is not valid
     end
 
     context "single filer" do
@@ -57,7 +58,7 @@ RSpec.describe StateFile::AzRetirementIncomeForm do
         end
 
         context "received_military_retirement_payment_amount is present" do
-          let(:received_military_retirement_payment_amount) { 1500 }
+          let(:received_military_retirement_payment_amount) { 500.50 }
 
           it "is valid" do
             expect(form).to be_valid
@@ -75,15 +76,64 @@ RSpec.describe StateFile::AzRetirementIncomeForm do
       end
 
       context "primary_received_pension is yes" do
-        it "is valid if primary_received_pension_amount is present" do; end
+        let(:params) do
+          {
+            received_military_retirement_payment: "no",
+            primary_received_pension: "yes",
+            primary_received_pension_amount: primary_received_pension_amount,
+          }
+        end
 
-        it "is invalid if primary_received_pension_amount is blank" do; end
+        context "primary_received_pension_amount is present" do
+          let(:primary_received_pension_amount) { 500.25 }
+
+          it "is valid" do
+            expect(form).to be_valid
+          end
+        end
+
+        context "primary_received_pension_amount is blank" do
+          let(:primary_received_pension_amount) { nil }
+
+          it "is invalid" do
+            expect(form).not_to be_valid
+            expect(form.errors[:primary_received_pension_amount]).to include "Can't be blank."
+          end
+        end
       end
 
       context "total amount" do
-        it "is valid if below total from df xml" do; end
+        let(:params) do
+          {
+            received_military_retirement_payment: "yes",
+            received_military_retirement_payment_amount: received_military_retirement_payment_amount,
+            primary_received_pension: "yes",
+            primary_received_pension_amount: primary_received_pension_amount,
+          }
+        end
 
-        it "is invalid if above total from df xml" do; end
+        before do
+          intake.direct_file_data.fed_taxable_pensions = 1000
+        end
+
+        context "total is less than or equal to TotalTaxablePensionsAmt" do
+          let(:received_military_retirement_payment_amount) { 500 }
+          let(:primary_received_pension_amount) { 500 }
+
+          it "is valid" do
+            expect(form).to be_valid
+          end
+        end
+
+        context "total is greater than TotalTaxablePensionsAmt" do
+          let(:received_military_retirement_payment_amount) { 500 }
+          let(:primary_received_pension_amount) { 501 }
+
+          it "is invalid" do
+            expect(form).not_to be_valid
+            expect(form.errors[:base]).to include "Total amount entered must not exceed $1000"
+          end
+        end
       end
     end
 
@@ -93,24 +143,137 @@ RSpec.describe StateFile::AzRetirementIncomeForm do
       end
 
       context "received_military_retirement_payment, primary_received_pension, spouse_received_pension are no" do
-        it "is valid" do; end
+        let(:params) do
+          {
+            received_military_retirement_payment: "no",
+            primary_received_pension: "no",
+            spouse_received_pension: "no",
+          }
+        end
+
+        it "is valid" do
+          expect(form).to be_valid
+        end
       end
 
       context "spouse_received_pension is yes" do
-        it "is valid if spouse_received_pension_amount is present" do; end
+        let(:params) do
+          {
+            received_military_retirement_payment: "no",
+            primary_received_pension: "no",
+            spouse_received_pension: "yes",
+            spouse_received_pension_amount: spouse_received_pension_amount,
+          }
+        end
 
-        it "is invalid if spouse_received_pension_amount is blank" do; end
+        context "spouse_received_pension_amount is present" do
+          let(:spouse_received_pension_amount) { 500 }
+
+          it "is valid" do
+            expect(form).to be_valid
+          end
+        end
+
+        context "spouse_received_pension_amount is blank" do
+          let(:spouse_received_pension_amount) { nil }
+
+          it "is invalid" do
+            expect(form).not_to be_valid
+            expect(form.errors[:spouse_received_pension_amount]).to include "Can't be blank."
+          end
+        end
       end
 
       context "total amount" do
-        it "is valid if below total from df xml" do; end
+        let(:params) do
+          {
+            received_military_retirement_payment: "yes",
+            received_military_retirement_payment_amount: received_military_retirement_payment_amount,
+            primary_received_pension: "yes",
+            primary_received_pension_amount: primary_received_pension_amount,
+            spouse_received_pension: "yes",
+            spouse_received_pension_amount: spouse_received_pension_amount,
+          }
+        end
 
-        it "is invalid if above total from df xml" do; end
+        before do
+          intake.direct_file_data.fed_taxable_pensions = 1500
+        end
+
+        context "total is less than or equal to TotalTaxablePensionsAmt" do
+          let(:received_military_retirement_payment_amount) { 500 }
+          let(:primary_received_pension_amount) { 500 }
+          let(:spouse_received_pension_amount) { 500 }
+
+          it "is valid" do
+            expect(form).to be_valid
+          end
+        end
+
+        context "total is greater than TotalTaxablePensionsAmt" do
+          let(:received_military_retirement_payment_amount) { 500 }
+          let(:primary_received_pension_amount) { 500 }
+          let(:spouse_received_pension_amount) { 501 }
+
+          it "is invalid" do
+            expect(form).not_to be_valid
+            expect(form.errors[:base]).to include "Total amount entered must not exceed $1500"
+          end
+        end
       end
     end
   end
 
   describe "#save" do
+    let(:params) do
+      {
+        received_military_retirement_payment: "yes",
+        received_military_retirement_payment_amount: 100,
+        primary_received_pension: "yes",
+        primary_received_pension_amount: 200,
+        spouse_received_pension: "yes",
+        spouse_received_pension_amount: 300,
+      }
+    end
+
+    it "saves the answers to the intake" do
+      form.save
+      intake.reload
+      expect(intake.received_military_retirement_payment_yes?).to eq true
+      expect(intake.received_military_retirement_payment_amount).to eq 100
+      expect(intake.primary_received_pension_yes?).to eq true
+      expect(intake.primary_received_pension_amount).to eq 200
+      expect(intake.spouse_received_pension_yes?).to eq true
+      expect(intake.spouse_received_pension_amount).to eq 300
+    end
+
+    # the more i search the internet for questions having to do with validating and saving decimals for money values,
+    # the more i see people saying you shouldn't do this in rails and should instead use the money gem.
+    # for now we're going with the built-in functionality which will round any extra decimal places but may want to
+    # reconsider the whole data type.
+    context "rounding decimals" do
+      let(:params) do
+        {
+          received_military_retirement_payment: "yes",
+          received_military_retirement_payment_amount: 20.255,
+          primary_received_pension: "yes",
+          primary_received_pension_amount: 400.1234,
+          spouse_received_pension: "yes",
+          spouse_received_pension_amount: 50.98076,
+        }
+      end
+
+      it "rounds the values when saving" do
+        form.save
+        intake.reload
+        expect(intake.received_military_retirement_payment_yes?).to eq true
+        expect(intake.received_military_retirement_payment_amount).to eq 20.26
+        expect(intake.primary_received_pension_yes?).to eq true
+        expect(intake.primary_received_pension_amount).to eq 400.12
+        expect(intake.spouse_received_pension_yes?).to eq true
+        expect(intake.spouse_received_pension_amount).to eq 50.98
+      end
+    end
   end
 end
 

--- a/spec/forms/state_file/az_subtractions_form_spec.rb
+++ b/spec/forms/state_file/az_subtractions_form_spec.rb
@@ -77,7 +77,6 @@ RSpec.describe StateFile::AzSubtractionsForm do
       end
     end
 
-
     context "with just armed forces member and wages" do
       let(:params) do
         {

--- a/spec/lib/navigation/state_file_az_question_navigation_spec.rb
+++ b/spec/lib/navigation/state_file_az_question_navigation_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Navigation::StateFileAzQuestionNavigation do
         StateFile::Questions::W2Controller,
         StateFile::Questions::UnemploymentController,
         StateFile::Questions::AzSubtractionsController,
+        StateFile::Questions::AzRetirementIncomeController,
         StateFile::Questions::AzCharitableContributionsController,
         StateFile::Questions::AzPublicSchoolContributionsController,
         StateFile::Questions::AzExciseCreditController,

--- a/spec/models/efile_error_spec.rb
+++ b/spec/models/efile_error_spec.rb
@@ -42,6 +42,7 @@ describe 'EfileError' do
       "az-primary-state-id",
       "az-prior-last-names",
       "az-public-school-contributions",
+      "az-retirement-income",
       "az-review",
       "az-senior-dependents",
       "az-spouse-state-id",


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-182
## Is PM acceptance required?
- Yes - don't merge until JIRA issue is accepted!
## What was done?
- Adds a page to ask about retirement income
- Page is shown if fed xml indicates value for total pension amount and presence of 1099R(s)
- Checkboxes reveal inputs for amounts
- Page shows additional checkbox for spouse pensions
## How to test?
- Unit tests on controller check: show logic, spouse checkbox presence, return to review functionality
- Unit tests on form check: validations, saving values
- Section added to feature spec and corresponding fixture
- Manual test cases:
  - With fed return that has retirement income (page shows)
  - Without fed return that has retirement income (page does not show)
  - Mfj filers (spouse checkbox present)
  - Non-mfj filer (spouse checkbox absent)
  - Can't enter non-numerical value
  - Can't check box and not enter value
  - Can't enter values that add up to total over TotalTaxablePensionsAmt
## Screenshots (for visual changes)
- <img width="927" alt="image" src="https://github.com/user-attachments/assets/384c00f2-3e68-4c33-a14d-adf6291b612e">