### PR TITLE
GYR1-557 SLA Module count bug fix

### DIFF
--- a/app/presenters/hub/dashboard/service_level_agreements_notifications_presenter.rb
+++ b/app/presenters/hub/dashboard/service_level_agreements_notifications_presenter.rb
@@ -7,7 +7,7 @@ module Hub
       end
 
       def approaching_sla_clients
-        @approaching_sla_clients ||= @clients.select("clients.vita_partner_id, COUNT(clients.id) AS number_of_clients")
+        @approaching_sla_clients ||= @clients.select("clients.vita_partner_id, COUNT(DISTINCT clients.id) AS number_of_clients")
                                              .sla_tracked
                                              .where(vita_partner_id: @selected_orgs_and_sites.map(&:id))
                                              .where(last_outgoing_communication_at: 6.business_days.ago..4.business_days.ago)
@@ -23,7 +23,7 @@ module Hub
       end
 
       def breached_sla_clients
-        @breached_sla_clients ||= @clients.select("clients.vita_partner_id, COUNT(clients.id) AS number_of_clients")
+        @breached_sla_clients ||= @clients.select("clients.vita_partner_id, COUNT(DISTINCT clients.id) AS number_of_clients")
                                              .sla_tracked
                                              .where(vita_partner_id: @selected_orgs_and_sites.map(&:id))
                                              .where("last_outgoing_communication_at < ?", 6.business_days.ago)

--- a/app/presenters/hub/dashboard/service_level_agreements_notifications_presenter.rb
+++ b/app/presenters/hub/dashboard/service_level_agreements_notifications_presenter.rb
@@ -7,11 +7,11 @@ module Hub
       end
 
       def approaching_sla_clients
-        @approaching_sla_clients ||= @clients.select("vita_partner_id, COUNT(clients.id) AS number_of_clients")
+        @approaching_sla_clients ||= @clients.select("clients.vita_partner_id, COUNT(clients.id) AS number_of_clients")
+                                             .sla_tracked
                                              .where(vita_partner_id: @selected_orgs_and_sites.map(&:id))
                                              .where(last_outgoing_communication_at: 6.business_days.ago..4.business_days.ago)
-                                             .where("filterable_tax_return_properties @> ?::jsonb", [{ active: true }].to_json)
-                                             .group("vita_partner_id")
+                                             .group("clients.vita_partner_id")
       end
 
       def approaching_sla_clients_count
@@ -23,11 +23,11 @@ module Hub
       end
 
       def breached_sla_clients
-        @breached_sla_clients ||= @clients.select("vita_partner_id, COUNT(clients.id) AS number_of_clients")
+        @breached_sla_clients ||= @clients.select("clients.vita_partner_id, COUNT(clients.id) AS number_of_clients")
+                                             .sla_tracked
                                              .where(vita_partner_id: @selected_orgs_and_sites.map(&:id))
                                              .where("last_outgoing_communication_at < ?", 6.business_days.ago)
-                                             .where("filterable_tax_return_properties @> ?::jsonb", [{ active: true }].to_json)
-                                             .group("vita_partner_id")
+                                             .group("clients.vita_partner_id")
       end
 
       def breached_sla_clients_count

--- a/app/presenters/hub/dashboard/service_level_agreements_notifications_presenter.rb
+++ b/app/presenters/hub/dashboard/service_level_agreements_notifications_presenter.rb
@@ -10,6 +10,7 @@ module Hub
         @approaching_sla_clients ||= @clients.select("vita_partner_id, COUNT(clients.id) AS number_of_clients")
                                              .where(vita_partner_id: @selected_orgs_and_sites.map(&:id))
                                              .where(last_outgoing_communication_at: 6.business_days.ago..4.business_days.ago)
+                                             .where("filterable_tax_return_properties @> ?::jsonb", [{ active: true }].to_json)
                                              .group("vita_partner_id")
       end
 
@@ -25,6 +26,7 @@ module Hub
         @breached_sla_clients ||= @clients.select("vita_partner_id, COUNT(clients.id) AS number_of_clients")
                                              .where(vita_partner_id: @selected_orgs_and_sites.map(&:id))
                                              .where("last_outgoing_communication_at < ?", 6.business_days.ago)
+                                             .where("filterable_tax_return_properties @> ?::jsonb", [{ active: true }].to_json)
                                              .group("vita_partner_id")
       end
 

--- a/spec/presenters/hub/service_level_agreements_notifications_presenter_spec.rb
+++ b/spec/presenters/hub/service_level_agreements_notifications_presenter_spec.rb
@@ -10,13 +10,11 @@ describe Hub::Dashboard::ServiceLevelAgreementsNotificationsPresenter do
   let(:clients) { Client.all }
 
   before do
-    create :client, vita_partner: oregano_org, last_outgoing_communication_at: 5.business_days.ago, filterable_tax_return_properties: [{active: false }]
-    create :client, vita_partner: oregano_org, last_outgoing_communication_at: 5.business_days.ago, filterable_tax_return_properties: [{active: true }]
-    create :client, vita_partner: oregano_org, last_outgoing_communication_at: 7.business_days.ago, filterable_tax_return_properties: [{active: true }]
-    create :client, vita_partner: orangutan_organization, last_outgoing_communication_at: 5.business_days.ago, filterable_tax_return_properties: [{active: false }]
-    create :client, vita_partner: orangutan_organization, last_outgoing_communication_at: 5.business_days.ago, filterable_tax_return_properties: [{active: true }]
-    create :client, vita_partner: orangutan_organization, last_outgoing_communication_at: 8.business_days.ago, filterable_tax_return_properties: [{active: true }]
-    create :client, vita_partner: orangutan_organization, last_outgoing_communication_at: 9.business_days.ago, filterable_tax_return_properties: [{active: true }]
+    create :client, vita_partner: oregano_org, last_outgoing_communication_at: 5.business_days.ago, intake: (build :intake), tax_returns: [build(:gyr_tax_return, :prep_ready_for_prep)]
+    create :client, vita_partner: oregano_org, last_outgoing_communication_at: 7.business_days.ago, intake: (build :intake), tax_returns: [build(:gyr_tax_return, :prep_ready_for_prep)]
+    create :client, vita_partner: orangutan_organization, last_outgoing_communication_at: 5.business_days.ago, intake: (build :intake), tax_returns: [build(:gyr_tax_return, :prep_ready_for_prep)]
+    create :client, vita_partner: orangutan_organization, last_outgoing_communication_at: 8.business_days.ago, intake: (build :intake), tax_returns: [build(:gyr_tax_return, :prep_ready_for_prep)]
+    create :client, vita_partner: orangutan_organization, last_outgoing_communication_at: 9.business_days.ago, intake: (build :intake), tax_returns: [build(:gyr_tax_return, :prep_ready_for_prep)]
   end
 
   describe "#approaching_sla_clients" do

--- a/spec/presenters/hub/service_level_agreements_notifications_presenter_spec.rb
+++ b/spec/presenters/hub/service_level_agreements_notifications_presenter_spec.rb
@@ -10,9 +10,9 @@ describe Hub::Dashboard::ServiceLevelAgreementsNotificationsPresenter do
   let(:clients) { Client.all }
 
   before do
+    create :client, vita_partner: oregano_org, last_outgoing_communication_at: 5.business_days.ago, filterable_tax_return_properties: [{active: false }]
     create :client, vita_partner: oregano_org, last_outgoing_communication_at: 5.business_days.ago, filterable_tax_return_properties: [{active: true }]
     create :client, vita_partner: oregano_org, last_outgoing_communication_at: 7.business_days.ago, filterable_tax_return_properties: [{active: true }]
-    create :client, vita_partner: oregano_org, last_outgoing_communication_at: 7.business_days.ago, filterable_tax_return_properties: [{active: false }]
     create :client, vita_partner: orangutan_organization, last_outgoing_communication_at: 5.business_days.ago, filterable_tax_return_properties: [{active: false }]
     create :client, vita_partner: orangutan_organization, last_outgoing_communication_at: 5.business_days.ago, filterable_tax_return_properties: [{active: true }]
     create :client, vita_partner: orangutan_organization, last_outgoing_communication_at: 8.business_days.ago, filterable_tax_return_properties: [{active: true }]
@@ -20,13 +20,13 @@ describe Hub::Dashboard::ServiceLevelAgreementsNotificationsPresenter do
   end
 
   describe "#approaching_sla_clients" do
-    it "returns clients whose last communication was between 4 and 6 business days ago" do
+    it "returns clients whose last communication was between 4 and 6 business days ago, and have active returns" do
       expect(subject.approaching_sla_clients_count).to eq 2
     end
   end
 
   describe "#breached_sla_clients" do
-    it "returns clients whose last communication was more than 6 business days ago" do
+    it "returns clients whose last communication was more than 6 business days ago and have active returns" do
       expect(subject.breached_sla_clients_count).to eq 3
     end
   end

--- a/spec/presenters/hub/service_level_agreements_notifications_presenter_spec.rb
+++ b/spec/presenters/hub/service_level_agreements_notifications_presenter_spec.rb
@@ -12,6 +12,8 @@ describe Hub::Dashboard::ServiceLevelAgreementsNotificationsPresenter do
   before do
     create :client, vita_partner: oregano_org, last_outgoing_communication_at: 5.business_days.ago, filterable_tax_return_properties: [{active: true }]
     create :client, vita_partner: oregano_org, last_outgoing_communication_at: 7.business_days.ago, filterable_tax_return_properties: [{active: true }]
+    create :client, vita_partner: oregano_org, last_outgoing_communication_at: 7.business_days.ago, filterable_tax_return_properties: [{active: false }]
+    create :client, vita_partner: orangutan_organization, last_outgoing_communication_at: 5.business_days.ago, filterable_tax_return_properties: [{active: false }]
     create :client, vita_partner: orangutan_organization, last_outgoing_communication_at: 5.business_days.ago, filterable_tax_return_properties: [{active: true }]
     create :client, vita_partner: orangutan_organization, last_outgoing_communication_at: 8.business_days.ago, filterable_tax_return_properties: [{active: true }]
     create :client, vita_partner: orangutan_organization, last_outgoing_communication_at: 9.business_days.ago, filterable_tax_return_properties: [{active: true }]

--- a/spec/presenters/hub/service_level_agreements_notifications_presenter_spec.rb
+++ b/spec/presenters/hub/service_level_agreements_notifications_presenter_spec.rb
@@ -10,11 +10,11 @@ describe Hub::Dashboard::ServiceLevelAgreementsNotificationsPresenter do
   let(:clients) { Client.all }
 
   before do
-    create :client, vita_partner: oregano_org, last_outgoing_communication_at: 5.business_days.ago
-    create :client, vita_partner: oregano_org, last_outgoing_communication_at: 7.business_days.ago
-    create :client, vita_partner: orangutan_organization, last_outgoing_communication_at: 5.business_days.ago
-    create :client, vita_partner: orangutan_organization, last_outgoing_communication_at: 8.business_days.ago
-    create :client, vita_partner: orangutan_organization, last_outgoing_communication_at: 9.business_days.ago
+    create :client, vita_partner: oregano_org, last_outgoing_communication_at: 5.business_days.ago, filterable_tax_return_properties: [{active: true }]
+    create :client, vita_partner: oregano_org, last_outgoing_communication_at: 7.business_days.ago, filterable_tax_return_properties: [{active: true }]
+    create :client, vita_partner: orangutan_organization, last_outgoing_communication_at: 5.business_days.ago, filterable_tax_return_properties: [{active: true }]
+    create :client, vita_partner: orangutan_organization, last_outgoing_communication_at: 8.business_days.ago, filterable_tax_return_properties: [{active: true }]
+    create :client, vita_partner: orangutan_organization, last_outgoing_communication_at: 9.business_days.ago, filterable_tax_return_properties: [{active: true }]
   end
 
   describe "#approaching_sla_clients" do


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/GYR1-557

## Is PM acceptance required?
- Yes - but this needs to be merged after code review because it will be tested on demo

## What was done?
Before the SLA module was showing clients with inactive returns. The query for the presenter for the dashboard was edited so that it filters for only clients with active returns

## How to test?
- Visit https://demo.getyourrefund.org/en/hub/dashboard/
>     username: demo.hub.test@gmail.com
>     PW: vitavitavitavita
- Select SimplifyCT and observe SLA Overdue number
- Click “View All” 
- Observe client number

