### PR TITLE
Don't show suspended users and don't count tax returns from archived clients in the team assignments module

### DIFF
--- a/app/presenters/hub/dashboard/team_assignment_presenter.rb
+++ b/app/presenters/hub/dashboard/team_assignment_presenter.rb
@@ -18,16 +18,16 @@ module Hub
                                      organizations = @selected_model.instance_of?(Organization) ? @selected_model : @current_user.role.coalition.organizations
                                      sites = VitaPartner.sites.where(parent_organization: organizations)
                                      roles = OrganizationLeadRole.where(organization: organizations) + SiteCoordinatorRole.assignable_to_sites(sites) + TeamMemberRole.assignable_to_sites(sites)
-                                     User.where(role: roles)
+                                     User.active.where(role: roles)
                                    elsif @current_user.org_lead?
                                      organization = @current_user.role.organization
                                      sites = @selected_model.instance_of?(Site) ? @selected_model : VitaPartner.sites.where(parent_organization: organization)
                                      roles = OrganizationLeadRole.where(organization: organization) + SiteCoordinatorRole.assignable_to_sites(sites) + TeamMemberRole.assignable_to_sites(sites)
-                                     User.where(role: roles)
+                                     User.active.where(role: roles)
                                    elsif @current_user.site_coordinator?
                                      sites = @selected_model.instance_of?(Site) ? @selected_model : @current_user.role.sites
                                      roles = SiteCoordinatorRole.assignable_to_sites(sites) + TeamMemberRole.assignable_to_sites(sites)
-                                     User.where(role: roles)
+                                     User.active.where(role: roles)
                                    end
 
         @user_count = accessible_users_by_role.count
@@ -38,10 +38,13 @@ module Hub
       def ordered_by_tr_count_users
         return unless team_assignment_users.present?
 
-        team_assignment_users.select('users.*, COUNT(tax_returns.id) AS tax_returns_count')
-                             .left_joins(:assigned_tax_returns)
-                             .group('users.id, users.name, users.role_type')
-                             .order('tax_returns_count DESC')
+        team_assignment_users
+          .select('users.*, COUNT(tax_returns.id) AS tax_returns_count')
+          .left_joins(assigned_tax_returns: :client)
+          .group('users.id, users.name, users.role_type')
+          .order('tax_returns_count DESC')
+          .where('clients.filterable_product_year = :product_year OR clients.id IS NULL', product_year: Rails.configuration.product_year)
+
       end
 
     end

--- a/app/presenters/hub/dashboard/team_assignment_presenter.rb
+++ b/app/presenters/hub/dashboard/team_assignment_presenter.rb
@@ -44,7 +44,6 @@ module Hub
           .group('users.id, users.name, users.role_type')
           .order('tax_returns_count DESC')
           .where('clients.filterable_product_year = :product_year OR clients.id IS NULL', product_year: Rails.configuration.product_year)
-
       end
 
     end

--- a/app/views/hub/dashboard/_team_assignment_content.html.erb
+++ b/app/views/hub/dashboard/_team_assignment_content.html.erb
@@ -33,7 +33,7 @@
             %>
           </td>
           <td>
-            <%= link_to user.assigned_tax_returns.count, hub_clients_path(assigned_user_id: user.id) %>
+            <%= link_to user.tax_returns_count, hub_clients_path(assigned_user_id: user.id) %>
           </td>
         </tr>
       <% end %>

--- a/spec/presenters/hub/team_assignment_presenter_spec.rb
+++ b/spec/presenters/hub/team_assignment_presenter_spec.rb
@@ -45,7 +45,7 @@ describe Hub::Dashboard::TeamAssignmentPresenter do
 
       context "when there are tax returns with archived clients" do
         it "doesn't count their tax returns" do
-          # create(:gyr_tax_return, assigned_user: site_coordinator, client: create(:client, filterable_product_year: 2023))
+          create(:gyr_tax_return, assigned_user: site_coordinator, client: create(:client, filterable_product_year: 2023))
 
           expect(subject.ordered_by_tr_count_users.first.tax_returns_count).to eq 2
         end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. [https://codeforamerica.atlassian.net/browse/GYR1-558](https://codeforamerica.atlassian.net/browse/GYR1-558)
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!
## What was done?
- removed suspended users from users shown in team assignments module
- remove tax returns with archived clients from the tax return count on the module
## How to test?
- Added unit tests to make sure the method wouldn't return those counts and those users
- test on Heroku, make sure to add a suspended user to one of the vita partners you can view on the dashboard page and an archived client
