### PR TITLE
GYR1-556 Update filtering for hub dashboard links

### DIFF
--- a/app/presenters/hub/dashboard/action_required_flagged_clients_presenter.rb
+++ b/app/presenters/hub/dashboard/action_required_flagged_clients_presenter.rb
@@ -9,6 +9,10 @@ module Hub
       def flagged_clients
         @flagged_clients ||= @clients.where.not(flagged_at: nil).where(vita_partner: @selected_orgs_and_sites)
       end
+
+      def vita_partner_ids
+        @selected_orgs_and_sites.map(&:id)
+      end
     end
   end
 end

--- a/app/presenters/hub/dashboard/returns_by_status_presenter.rb
+++ b/app/presenters/hub/dashboard/returns_by_status_presenter.rb
@@ -48,6 +48,10 @@ module Hub
         (value.to_f * 100 / returns_by_status_count).round
       end
 
+      def vita_partner_ids
+        @selected_orgs_and_sites.map(&:id)
+      end
+
       private
 
       def count_tax_returns_by_status

--- a/app/views/hub/dashboard/_action_required_flagged_clients.html.erb
+++ b/app/views/hub/dashboard/_action_required_flagged_clients.html.erb
@@ -31,7 +31,7 @@
   <% if p.flagged_clients.exists? %>
     <div class="paging">
       <p><%= p.flagged_clients.limit(3).count %> of <%= p.flagged_clients.count %></p>
-      <p> <%= link_to t("hub.dashboard.show.view_all"), hub_clients_path(flagged: true), class: "text--centered" %></p>
+      <p> <%= link_to t("hub.dashboard.show.view_all"), hub_clients_path(flagged: true, vita_partners: p.vita_partner_ids.to_json), class: "text--centered" %></p>
     </div>
   <% else %>
     <p><%= t("hub.dashboard.show.action_required.no_clients") %></p>

--- a/app/views/hub/dashboard/_returns_by_status_content.html.erb
+++ b/app/views/hub/dashboard/_returns_by_status_content.html.erb
@@ -35,7 +35,7 @@
   <% p.returns_by_status.each do |return_summary| %>
     <tr>
       <td>
-        <%= link_to I18n.t("hub.tax_returns.#{return_summary.type}.#{return_summary.code}"), hub_clients_path(status: return_summary.code) %>
+        <%= link_to I18n.t("hub.tax_returns.#{return_summary.type}.#{return_summary.code}"), hub_clients_path(status: return_summary.code, vita_partners: p.vita_partner_ids.to_json)  %>
       </td>
       <td>
         <div class="bar-container <%= return_summary.stage %>">


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/GYR1-556

## Is PM acceptance required? 
- Yes - don't merge until JIRA issue is accepted!

## What was done?
The links were updated for the “Return by Status” and “Action Required: Flagged Clients” modules on the dashboard so that it correctly filters the appropriate Orgs & Sites into the All Clients filter bar in the All Clients table in the hub 

## How to test?
The heroku link can be used to login to a partner account 

## Screenshots (for visual changes)
- Before
<img width="276" alt="Screenshot 2024-08-21 at 6 22 54 PM" src="https://github.com/user-attachments/assets/4045a6fc-041a-4d34-90be-25d1c9b9fb88">

- After
<img width="286" alt="Screenshot 2024-08-21 at 6 22 22 PM" src="https://github.com/user-attachments/assets/a4a0d5b2-c97f-4d01-a4a4-14ea2f1d86fb">

