### PR TITLE
Fyst 328 add return header tests

### DIFF
--- a/app/controllers/state_file/questions/df_return_sample.xml
+++ b/app/controllers/state_file/questions/df_return_sample.xml
@@ -27,6 +27,7 @@
             <PrimaryNameControlTxt>TEST</PrimaryNameControlTxt>
             <USAddress>
                 <AddressLine1Txt>123 Sesame St</AddressLine1Txt>
+                <AddressLine2Txt>A</AddressLine2Txt>
                 <CityNm>New York</CityNm>
                 <StateAbbreviationCd>NY</StateAbbreviationCd>
                 <ZIPCd>10128</ZIPCd>

--- a/app/models/direct_file_data.rb
+++ b/app/models/direct_file_data.rb
@@ -201,6 +201,10 @@ class DirectFileData
     df_xml_value(__method__)
   end
 
+  def mailing_apartment=(value)
+    write_df_xml_value(__method__, value)
+  end
+
   def mailing_state
     df_xml_value(__method__)
   end

--- a/spec/fixtures/state_file/fed_return_xmls/2023/nc/nick.xml
+++ b/spec/fixtures/state_file/fed_return_xmls/2023/nc/nick.xml
@@ -14,6 +14,7 @@
       <SpouseNameControlTxt>CAVE</SpouseNameControlTxt>
       <USAddress>
         <AddressLine1Txt>123 Red Right Hand St Apt 1</AddressLine1Txt>
+        <AddressLine2Txt>Apt 1</AddressLine2Txt>
         <CityNm>Raleigh</CityNm>
         <StateAbbreviationCd>NC</StateAbbreviationCd>
         <ZIPCd>27513</ZIPCd>

--- a/spec/lib/submission_builder/ty2022/states/ny/ny_return_xml_spec.rb
+++ b/spec/lib/submission_builder/ty2022/states/ny/ny_return_xml_spec.rb
@@ -299,6 +299,7 @@ describe SubmissionBuilder::Ty2022::States::Ny::IndividualReturn, required_schem
       let(:filing_status) { 'single' }
       before do
         intake.direct_file_data.mailing_street = '211212 SUBDIVISION DR POBOX #157'
+        intake.direct_file_data.mailing_apartment = ''
       end
       it 'truncates under 30 characters' do
         xml = described_class.build(submission).document
@@ -313,6 +314,7 @@ describe SubmissionBuilder::Ty2022::States::Ny::IndividualReturn, required_schem
       let(:filing_status) { 'single' }
       before do
         intake.direct_file_data.mailing_street = '211212 SUBDIVISION DR Suite 157'
+        intake.direct_file_data.mailing_apartment = ''
       end
       it 'truncates before the key word' do
         xml = described_class.build(submission).document

--- a/spec/lib/submission_builder/ty2022/states/return_header_spec.rb
+++ b/spec/lib/submission_builder/ty2022/states/return_header_spec.rb
@@ -7,6 +7,40 @@ describe SubmissionBuilder::ReturnHeader do
       let(:submission) { create(:efile_submission, data_source: intake) }
       let(:doc) { SubmissionBuilder::ReturnHeader.new(submission).document }
 
+      context "misc basic attributes" do
+        let(:mailing_street) { "1234 Main Street" }
+        let(:mailing_apartment) { "B" }
+        let(:mailing_city) { "Citayy" }
+        let(:mailing_zip) { "54321" }
+        let(:tax_return_year) { 2024 }
+        before do
+          intake.direct_file_data.mailing_street = mailing_street
+          intake.direct_file_data.mailing_apartment = mailing_apartment
+          intake.direct_file_data.mailing_city = mailing_city
+          intake.direct_file_data.mailing_zip = mailing_zip
+          intake.direct_file_data.tax_return_year = tax_return_year
+        end
+
+        it "generates xml with the right values" do
+          expect(doc.at("Jurisdiction").text).to eq "#{state_code.upcase}ST"
+          expect(doc.at("ReturnTs").text).to eq submission.created_at.strftime("%FT%T%:z")
+          expect(doc.at("TaxPeriodBeginDt").text).to eq Date.new(tax_return_year, 1, 1).strftime("%F")
+          expect(doc.at("TaxPeriodEndDt").text).to eq Date.new(tax_return_year, 12, 31).strftime("%F")
+          expect(doc.at("TaxYr").text).to eq tax_return_year.to_s
+
+          # "OriginatorGrp EFIN"
+          # "OriginatorGrp OriginatorTypeCd"
+          # "SoftwareId"
+
+          expect(doc.at("ReturnType").text).to eq StateFile::StateInformationService.return_type(state_code)
+          expect(doc.at("USAddress AddressLine1Txt").text).to eq mailing_street
+          expect(doc.at("USAddress AddressLine2Txt").text).to eq mailing_apartment
+          expect(doc.at("USAddress CityNm").text).to eq mailing_city
+          expect(doc.at("USAddress StateAbbreviationCd").text).to eq state_code.upcase
+          expect(doc.at("USAddress ZIPCd").text).to eq mailing_zip
+        end
+      end
+
       context "filer personal info" do
         let(:intake) {
           create(
@@ -71,28 +105,6 @@ describe SubmissionBuilder::ReturnHeader do
             expect(doc.at('Filer Secondary TaxpayerName MiddleInitial').content).to eq spouse_middle_initial
             expect(doc.at('Filer Secondary TaxpayerName LastName').content).to eq spouse_last_name
           end
-        end
-      end
-
-      context "misc basic attributes" do
-        let(:mailing_street) { "1234 Main Street" }
-        let(:mailing_apartment) { "B" }
-        let(:mailing_city) { "Citayy" }
-        let(:mailing_zip) { "54321" }
-        before do
-          intake.direct_file_data.mailing_street = mailing_street
-          intake.direct_file_data.mailing_apartment = mailing_apartment
-          intake.direct_file_data.mailing_city = mailing_city
-          intake.direct_file_data.mailing_zip = mailing_zip
-        end
-
-        it "generates xml with the right values" do
-          expect(doc.at("ReturnType").text).to eq StateFile::StateInformationService.return_type(state_code)
-          expect(doc.at("USAddress AddressLine1Txt").text).to eq mailing_street
-          expect(doc.at("USAddress AddressLine2Txt").text).to eq mailing_apartment
-          expect(doc.at("USAddress CityNm").text).to eq mailing_city
-          expect(doc.at("USAddress StateAbbreviationCd").text).to eq state_code.upcase
-          expect(doc.at("USAddress ZIPCd").text).to eq mailing_zip
         end
       end
     end

--- a/spec/lib/submission_builder/ty2022/states/return_header_spec.rb
+++ b/spec/lib/submission_builder/ty2022/states/return_header_spec.rb
@@ -1,55 +1,99 @@
 require 'rails_helper'
 
 describe SubmissionBuilder::ReturnHeader do
-  describe '.document' do
-    context "filer DOBs" do
+  StateFile::StateInformationService.active_state_codes.each do |state_code|
+    describe '.document' do
+      let(:intake) { create "state_file_#{state_code}_intake".to_sym }
       let(:submission) { create(:efile_submission, data_source: intake) }
+      let(:doc) { SubmissionBuilder::ReturnHeader.new(submission).document }
 
-      context "single filer" do
-        let(:primary_birth_date) { 40.years.ago }
+      context "filer personal info" do
         let(:intake) {
           create(
-            :state_file_ny_intake,
-            primary_birth_date: primary_birth_date
-          )
-        }
-
-        it "generates xml with primary filer DOB only" do
-          doc = SubmissionBuilder::ReturnHeader.new(submission).document
-          expect(doc.at("Filer Primary DateOfBirth").text).to eq primary_birth_date.strftime("%F")
-          expect(doc.at("Filer Secondary DateOfBirth")).not_to be_present
-        end
-      end
-
-      context "filer with spouse" do
-        let(:primary_birth_date) { 40.years.ago }
-        let(:spouse_birth_date) { 42.years.ago }
-        let(:intake) {
-          create(
-            :state_file_ny_intake,
+            "state_file_#{state_code}_intake".to_sym,
+            filing_status: filing_status,
             primary_birth_date: primary_birth_date,
-            filing_status: "married_filing_jointly",
-            spouse_first_name: "Spouse",
+            primary_first_name: primary_first_name,
+            primary_middle_initial: primary_middle_initial,
+            primary_last_name: primary_last_name,
+            spouse_first_name: spouse_first_name,
             spouse_birth_date: spouse_birth_date,
-            raw_direct_file_data: StateFile::XmlReturnSampleService.new.read("ny_robert_mfj")
+            spouse_middle_initial: spouse_middle_initial,
+            spouse_last_name: spouse_last_name,
           )
         }
+        let(:primary_birth_date) { 40.years.ago }
+        let(:primary_ssn) { "100000030" }
+        let(:primary_first_name) { "Prim" }
+        let(:primary_middle_initial) { "W" }
+        let(:primary_last_name) { "Filerton" }
+        let(:spouse_birth_date) { nil }
+        let(:spouse_ssn) { nil }
+        let(:spouse_first_name) { nil }
+        let(:spouse_middle_initial) { nil }
+        let(:spouse_last_name) { nil }
+        before do
+          intake.direct_file_data.primary_ssn = primary_ssn
+          intake.direct_file_data.spouse_ssn = spouse_ssn
+        end
 
-        it "generates xml with primary and spouse DOBs" do
-          doc = SubmissionBuilder::ReturnHeader.new(submission).document
-          expect(doc.at("Filer Primary DateOfBirth").text).to eq primary_birth_date.strftime("%F")
-          expect(doc.at("Filer Secondary DateOfBirth").text).to eq spouse_birth_date.strftime("%F")
+        context "single filer" do
+          let(:filing_status) { "single" }
+
+          it "generates xml with primary filer DOB only" do
+            expect(doc.at("Filer Primary DateOfBirth").text).to eq primary_birth_date.strftime("%F")
+            expect(doc.at('Filer Primary TaxpayerSSN').content).to eq primary_ssn
+            expect(doc.at('Filer Primary TaxpayerName FirstName').content).to eq primary_first_name
+            expect(doc.at('Filer Primary TaxpayerName MiddleInitial').content).to eq primary_middle_initial
+            expect(doc.at('Filer Primary TaxpayerName LastName').content).to eq primary_last_name
+
+            expect(doc.at("Filer Secondary DateOfBirth")).not_to be_present
+            expect(doc.at('Filer Secondary TaxpayerSSN')).not_to be_present
+            expect(doc.at('Filer Secondary TaxpayerName FirstName')).not_to be_present
+            expect(doc.at('Filer Secondary TaxpayerName MiddleInitial')).not_to be_present
+            expect(doc.at('Filer Secondary TaxpayerName LastName')).not_to be_present
+          end
+        end
+
+        context "filer with spouse" do
+          let(:filing_status) { "married_filing_jointly" }
+          let(:spouse_birth_date) { 42.years.ago }
+          let(:spouse_ssn) { "200000030" }
+          let(:spouse_first_name) { "Sec" }
+          let(:spouse_middle_initial) { "Z" }
+          let(:spouse_last_name) { "Filerton" }
+
+          it "generates xml with primary and spouse DOBs" do
+            expect(doc.at("Filer Primary DateOfBirth").text).to eq primary_birth_date.strftime("%F")
+            expect(doc.at("Filer Secondary DateOfBirth").text).to eq spouse_birth_date.strftime("%F")
+            expect(doc.at('Filer Secondary TaxpayerSSN').content).to eq spouse_ssn
+            expect(doc.at('Filer Secondary TaxpayerName FirstName').content).to eq spouse_first_name
+            expect(doc.at('Filer Secondary TaxpayerName MiddleInitial').content).to eq spouse_middle_initial
+            expect(doc.at('Filer Secondary TaxpayerName LastName').content).to eq spouse_last_name
+          end
         end
       end
-    end
 
-    context "misc other attributes" do
-      let(:intake) { create :state_file_az_intake }
-      let(:submission) { create(:efile_submission, data_source: intake) }
+      context "misc basic attributes" do
+        let(:mailing_street) { "1234 Main Street" }
+        let(:mailing_apartment) { "B" }
+        let(:mailing_city) { "Citayy" }
+        let(:mailing_zip) { "54321" }
+        before do
+          intake.direct_file_data.mailing_street = mailing_street
+          intake.direct_file_data.mailing_apartment = mailing_apartment
+          intake.direct_file_data.mailing_city = mailing_city
+          intake.direct_file_data.mailing_zip = mailing_zip
+        end
 
-      it "generates xml with the right values" do
-        doc = SubmissionBuilder::ReturnHeader.new(submission).document
-        expect(doc.at("ReturnType").text).to eq "Form140"
+        it "generates xml with the right values" do
+          expect(doc.at("ReturnType").text).to eq StateFile::StateInformationService.return_type(state_code)
+          expect(doc.at("USAddress AddressLine1Txt").text).to eq mailing_street
+          expect(doc.at("USAddress AddressLine2Txt").text).to eq mailing_apartment
+          expect(doc.at("USAddress CityNm").text).to eq mailing_city
+          expect(doc.at("USAddress StateAbbreviationCd").text).to eq state_code.upcase
+          expect(doc.at("USAddress ZIPCd").text).to eq mailing_zip
+        end
       end
     end
   end

--- a/spec/lib/submission_builder/ty2024/states/nc/nc_return_xml_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nc/nc_return_xml_spec.rb
@@ -2,13 +2,13 @@ require 'rails_helper'
 
 describe SubmissionBuilder::Ty2024::States::Nc::NcReturnXml, required_schema: "nc" do
   describe '.build' do
-    let(:intake) { create(:state_file_nc_intake, filing_status: :single) }
+    let(:intake) { create(:state_file_nc_intake) }
     let(:submission) { create(:efile_submission, data_source: intake) }
     let!(:initial_efile_device_info) { create :state_file_efile_device_info, :initial_creation, :filled, intake: intake }
     let!(:submission_efile_device_info) { create :state_file_efile_device_info, :submission, :filled, intake: intake }
+    let(:xml) { Nokogiri::XML::Document.parse(described_class.build(submission).document.to_xml) }
 
     it "generates basic components of return" do
-      xml = Nokogiri::XML::Document.parse(described_class.build(submission).document.to_xml)
       expect(xml.document.root.namespaces).to include({ "xmlns:efile" => "http://www.irs.gov/efile", "xmlns" => "http://www.irs.gov/efile" })
       expect(xml.document.at('AuthenticationHeader').to_s).to include('xmlns="http://www.irs.gov/efile"')
       expect(xml.document.at('ReturnHeaderState').to_s).to include('xmlns="http://www.irs.gov/efile"')


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-328
## Is PM acceptance required? (delete one)
- No - merge after code review approval
## What was done?
- some of the xml fields specified in the story are already handled by classes like ReturnHeader, so just by inheriting from StateReturn we get those for free for NC
- realized though that we don't really have thorough test coverage for those attributes so added some more tests and had the test loop over all states instead of just testing NY
## How to test?
- This PR is mostly the addition of unit tests and doesn't add new functionality
