### PR TITLE
fix flaky test by removing hardcoded ID expectation (via its presence in coalition name)

### DIFF
--- a/spec/presenters/hub/dashboard_presenter_spec.rb
+++ b/spec/presenters/hub/dashboard_presenter_spec.rb
@@ -13,7 +13,7 @@ describe Hub::Dashboard::DashboardPresenter do
 
     it "presents filter options including the coalition and all organizations in the correct order" do
       expect(subject.filter_options.length).to eq 3
-      expect(subject.filter_options.map(&:model).map(&:name)).to eq ["Coalition 1", "Orangutan Organization", "Oregano Org"]
+      expect(subject.filter_options.map(&:model).map(&:name)).to eq [coalition.name, "Orangutan Organization", "Oregano Org"]
     end
 
     it "selects the correct coalition" do


### PR DESCRIPTION
The issue is that if this runs after any other tests that create Coalitions, even if they clean up their database changes, the auto-incrementing ID will give the Coalition this test creates an ID (and thus a name) greater than 1. 