### PR TITLE
Audit and add validations to XML for AZ-140 (and other documents, including NY stuff because it was easier than not doing it)

### DIFF
--- a/app/lib/submission_builder/document.rb
+++ b/app/lib/submission_builder/document.rb
@@ -99,13 +99,13 @@ module SubmissionBuilder
     def process_mailing_street(xml)
       return unless @submission.data_source.direct_file_data.mailing_street.present?
 
-      mailing_street = @submission.data_source.direct_file_data.mailing_street.strip.gsub(/\s+/, ' ')
+      mailing_street = sanitize_for_xml(@submission.data_source.direct_file_data.mailing_street)
 
       if mailing_street.length > 30
         process_long_mailing_street(xml, mailing_street)
       else
-        xml.MAIL_LN_1_ADR @submission.data_source.direct_file_data.mailing_apartment.strip.gsub(/\s+/, ' ') if @submission.data_source.direct_file_data.mailing_apartment.present?
-        xml.MAIL_LN_2_ADR mailing_street
+        xml.MAIL_LN_1_ADR sanitize_for_xml(@submission.data_source.direct_file_data.mailing_apartment, 30) if @submission.data_source.direct_file_data.mailing_apartment.present?
+        xml.MAIL_LN_2_ADR sanitize_for_xml(mailing_street, 30)
       end
     end
 
@@ -125,7 +125,7 @@ module SubmissionBuilder
 
     def process_mailing_apartment(xml, excess_characters, truncated_mailing_street)
       if @submission.data_source.direct_file_data.mailing_apartment.present?
-        apartment = @submission.data_source.direct_file_data.mailing_apartment.strip.gsub(/\s+/, ' ')
+        apartment = sanitize_for_xml(@submission.data_source.direct_file_data.mailing_apartment)
         if apartment.length + excess_characters.length > 30
           truncated_apartment = apartment[0, 30 - excess_characters.length].rpartition(' ').first
           xml.MAIL_LN_1_ADR excess_characters + " " + truncated_apartment
@@ -141,13 +141,13 @@ module SubmissionBuilder
     def process_permanent_street(xml)
       return unless @submission.data_source.permanent_street.present?
 
-      permanent_street = @submission.data_source.permanent_street.strip.gsub(/\s+/, ' ')
+      permanent_street = sanitize_for_xml(@submission.data_source.permanent_street)
 
       if permanent_street.length > 30
         process_long_permanent_street(xml, permanent_street)
       else
-        xml.PERM_LN_1_ADR @submission.data_source.permanent_apartment.strip.gsub(/\s+/, ' ') if @submission.data_source.permanent_apartment.present?
-        xml.PERM_LN_2_ADR permanent_street
+        xml.PERM_LN_1_ADR sanitize_for_xml(@submission.data_source.permanent_apartment, 30) if @submission.data_source.permanent_apartment.present?
+        xml.PERM_LN_2_ADR sanitize_for_xml(permanent_street, 30)
       end
     end
 
@@ -167,7 +167,7 @@ module SubmissionBuilder
 
     def process_permanent_apartment(xml, excess_characters, truncated_permanent_street)
       if @submission.data_source.permanent_apartment.present?
-        apartment = @submission.data_source.permanent_apartment.strip.gsub(/\s+/, ' ')
+        apartment = sanitize_for_xml(@submission.data_source.permanent_apartment)
         if apartment.length + excess_characters.length > 30
           truncated_apartment = apartment[0, 30 - excess_characters.length].rpartition(' ').first
           xml.PERM_LN_1_ADR excess_characters + " " + truncated_apartment

--- a/app/lib/submission_builder/formatting_methods.rb
+++ b/app/lib/submission_builder/formatting_methods.rb
@@ -6,8 +6,12 @@ module SubmissionBuilder
       string.squish.first(length)&.strip
     end
 
-    def truncate(string, length)
-      string&.gsub(/\s+/, ' ')&.slice(0, length)&.strip
+    def sanitize_for_xml(string, length = nil)
+      sanitized_string = string&.gsub(/\s+/, ' ')
+      if length
+        sanitized_string = sanitized_string&.first(length)
+      end
+      sanitized_string&.strip
     end
 
     def datetime_type(datetime)

--- a/app/lib/submission_builder/return_header.rb
+++ b/app/lib/submission_builder/return_header.rb
@@ -19,9 +19,9 @@ module SubmissionBuilder
         xml.Filer do
           xml.Primary do
             xml.TaxpayerName do
-              xml.FirstName @submission.data_source.primary.first_name.strip.gsub(/\s+/, ' ') if @submission.data_source.primary.first_name.present?
-              xml.MiddleInitial @submission.data_source.primary.middle_initial.strip.gsub(/\s+/, ' ') if @submission.data_source.primary.middle_initial.present?
-              xml.LastName @submission.data_source.primary.last_name.strip.gsub(/\s+/, ' ') if @submission.data_source.primary.last_name.present?
+              xml.FirstName sanitize_for_xml(@submission.data_source.primary.first_name, 16) if @submission.data_source.primary.first_name.present?
+              xml.MiddleInitial sanitize_for_xml(@submission.data_source.primary.middle_initial, 1) if @submission.data_source.primary.middle_initial.present?
+              xml.LastName sanitize_for_xml(@submission.data_source.primary.last_name, 32) if @submission.data_source.primary.last_name.present?
               xml.NameSuffix @submission.data_source.primary.suffix if @submission.data_source.primary.suffix.present?
             end
             xml.TaxpayerSSN @submission.data_source.primary.ssn if @submission.data_source.primary.ssn.present?
@@ -30,9 +30,9 @@ module SubmissionBuilder
           if @submission.data_source&.spouse.ssn.present? && @submission.data_source&.spouse.first_name.present?
             xml.Secondary do
               xml.TaxpayerName do
-                xml.FirstName @submission.data_source.spouse.first_name.strip.gsub(/\s+/, ' ') if @submission.data_source.spouse.first_name.present?
-                xml.MiddleInitial @submission.data_source.spouse.middle_initial.strip.gsub(/\s+/, ' ') if @submission.data_source.spouse.middle_initial.present?
-                xml.LastName @submission.data_source.spouse.last_name.strip.gsub(/\s+/, ' ') if @submission.data_source.spouse.last_name.present?
+                xml.FirstName sanitize_for_xml(@submission.data_source.spouse.first_name, 16) if @submission.data_source.spouse.first_name.present?
+                xml.MiddleInitial sanitize_for_xml(@submission.data_source.spouse.middle_initial, 1) if @submission.data_source.spouse.middle_initial.present?
+                xml.LastName sanitize_for_xml(@submission.data_source.spouse.last_name, 32) if @submission.data_source.spouse.last_name.present?
                 xml.NameSuffix @submission.data_source.spouse.suffix if @submission.data_source.spouse.suffix.present?
               end
               xml.TaxpayerSSN @submission.data_source.spouse.ssn if @submission.data_source.spouse.ssn.present?
@@ -41,9 +41,9 @@ module SubmissionBuilder
             end
           end
           xml.USAddress do |xml|
-            xml.AddressLine1Txt @submission.data_source.direct_file_data.mailing_street.strip.gsub(/\s+/, ' ') if @submission.data_source.direct_file_data.mailing_street.present?
-            xml.AddressLine2Txt @submission.data_source.direct_file_data.mailing_apartment.strip.gsub(/\s+/, ' ') if @submission.data_source.direct_file_data.mailing_apartment.present?
-            xml.CityNm @submission.data_source.direct_file_data.mailing_city.strip.gsub(/\s+/, ' ') if @submission.data_source.direct_file_data.mailing_city.present?
+            xml.AddressLine1Txt sanitize_for_xml(@submission.data_source.direct_file_data.mailing_street, 35) if @submission.data_source.direct_file_data.mailing_street.present?
+            xml.AddressLine2Txt sanitize_for_xml(@submission.data_source.direct_file_data.mailing_apartment, 35) if @submission.data_source.direct_file_data.mailing_apartment.present?
+            xml.CityNm sanitize_for_xml(@submission.data_source.direct_file_data.mailing_city, 22) if @submission.data_source.direct_file_data.mailing_city.present?
             xml.StateAbbreviationCd @submission.data_source.state_code.upcase
             xml.ZIPCd @submission.data_source.direct_file_data.mailing_zip if @submission.data_source.direct_file_data.mailing_zip.present?
           end

--- a/app/lib/submission_builder/ty2022/states/az/az_return_xml.rb
+++ b/app/lib/submission_builder/ty2022/states/az/az_return_xml.rb
@@ -46,12 +46,12 @@ module SubmissionBuilder
 
           def documents_wrapper
             xml_doc = build_xml_doc("Form140") do |xml|
-              xml.LNPriorYrs @submission.data_source.prior_last_names&.strip&.gsub(/\s+/, ' ')
+              xml.LNPriorYrs sanitize_for_xml(@submission.data_source.prior_last_names)
               xml.FilingStatus filing_status
               if @submission.data_source.hoh_qualifying_person_name.present?
                 xml.QualChildDependentName do
-                  xml.FirstName truncate(@submission.data_source.hoh_qualifying_person_name[:first_name], 16)
-                  xml.LastName @submission.data_source.hoh_qualifying_person_name[:last_name]&.strip&.gsub(/\s+/, ' ')
+                  xml.FirstName sanitize_for_xml(@submission.data_source.hoh_qualifying_person_name[:first_name], 16)
+                  xml.LastName sanitize_for_xml(@submission.data_source.hoh_qualifying_person_name[:last_name], 32)
                 end
               end
               xml.Exemptions do
@@ -66,14 +66,14 @@ module SubmissionBuilder
                 @submission.data_source.dependents.reject(&:is_qualifying_parent_or_grandparent?).each do |dependent|
                   xml.DependentDetails do
                     xml.Name do
-                      xml.FirstName truncate(dependent.first_name, 16)
-                      xml.MiddleInitial dependent.middle_initial&.strip&.gsub(/\s+/, ' ') if dependent.middle_initial.present?
-                      xml.LastName dependent.last_name&.strip&.gsub(/\s+/, ' ')
+                      xml.FirstName sanitize_for_xml(dependent.first_name, 16)
+                      xml.MiddleInitial sanitize_for_xml(dependent.middle_initial, 1) if dependent.middle_initial.present?
+                      xml.LastName sanitize_for_xml(dependent.last_name, 32)
                     end
                     unless dependent.ssn.nil?
                       xml.DependentSSN dependent.ssn.delete('-')
                     end
-                    xml.RelationShip relationship_key(dependent.relationship)&.strip&.gsub(/\s+/, ' ')
+                    xml.RelationShip relationship_key(dependent.relationship)
                     xml.NumMonthsLived dependent.months_in_home
                     if dependent.under_17?
                       xml.DepUnder17 'X'
@@ -85,9 +85,9 @@ module SubmissionBuilder
                 @submission.data_source.dependents.select(&:is_qualifying_parent_or_grandparent?).each do |dependent|
                   xml.QualParentsAncestors do
                     xml.Name do
-                      xml.FirstName truncate(dependent.first_name, 16)
-                      xml.MiddleInitial dependent.middle_initial&.strip&.gsub(/\s+/, ' ') if dependent.middle_initial.present?
-                      xml.LastName dependent.last_name&.strip&.gsub(/\s+/, ' ')
+                      xml.FirstName sanitize_for_xml(dependent.first_name, 16)
+                      xml.MiddleInitial sanitize_for_xml(dependent.middle_initial, 1) if dependent.middle_initial.present?
+                      xml.LastName sanitize_for_xml(dependent.last_name, 32)
                     end
                     unless dependent.ssn.nil?
                       xml.DependentSSN dependent.ssn.delete('-')

--- a/app/lib/submission_builder/ty2022/states/az/documents/state1099_g.rb
+++ b/app/lib/submission_builder/ty2022/states/az/documents/state1099_g.rb
@@ -12,11 +12,11 @@ module SubmissionBuilder
               build_xml_doc("State1099G", documentId: "State1099G-#{form1099g.id}") do |xml|
                 if form1099g.payer_name && form1099g.payer_name != ''
                   xml.PayerName payerNameControl: form1099g.payer_name.gsub(/\s+|-/, '').upcase[0..3] do
-                    xml.BusinessNameLine1Txt truncate(form1099g.payer_name.tr('-', ' '), 75)
+                    xml.BusinessNameLine1Txt sanitize_for_xml(form1099g.payer_name.tr('-', ' '), 75)
                   end
                   xml.PayerUSAddress do
-                    xml.AddressLine1Txt truncate(form1099g.payer_street_address.tr('-', ' '), 35)
-                    xml.CityNm truncate(form1099g.payer_city, 22)
+                    xml.AddressLine1Txt sanitize_for_xml(form1099g.payer_street_address.tr('-', ' '), 35)
+                    xml.CityNm sanitize_for_xml(form1099g.payer_city, 22)
                     xml.StateAbbreviationCd "AZ"
                     xml.ZIPCd form1099g.payer_zip
                   end
@@ -28,13 +28,13 @@ module SubmissionBuilder
                   form1099g.intake.spouse
                 end
                 xml.RecipientSSN recipient.ssn
-                xml.RecipientName recipient.full_name.gsub(/\s+/, ' ')&.strip
+                xml.RecipientName sanitize_for_xml(recipient.full_name)
                 xml.RecipientUSAddress do
-                  xml.AddressLine1Txt truncate(form1099g.recipient_address_line1, 35)
-                  xml.AddressLine2Txt truncate(form1099g.recipient_address_line2, 35) if form1099g.recipient_address_line2.present?
-                  xml.CityNm truncate(form1099g.recipient_city, 22)
+                  xml.AddressLine1Txt sanitize_for_xml(form1099g.recipient_address_line1, 35)
+                  xml.AddressLine2Txt sanitize_for_xml(form1099g.recipient_address_line2, 35) if form1099g.recipient_address_line2.present?
+                  xml.CityNm sanitize_for_xml(form1099g.recipient_city, 22)
                   xml.StateAbbreviationCd "AZ"
-                  xml.ZIPCd form1099g.recipient_zip
+                  xml.ZIPCd sanitize_for_xml(form1099g.recipient_zip)
                 end
                 xml.UnemploymentCompensation form1099g.unemployment_compensation
                 xml.FederalTaxWithheld form1099g.federal_income_tax_withheld

--- a/app/lib/submission_builder/ty2022/states/az/financial_transaction.rb
+++ b/app/lib/submission_builder/ty2022/states/az/financial_transaction.rb
@@ -8,8 +8,8 @@ module SubmissionBuilder
             build_xml_doc("FinancialTransaction") do |xml|
               if (@kwargs[:refund_amount] || 0).positive? # REFUND
                 xml.RefundDirectDeposit do
-                  xml.RoutingTransitNumber @submission.data_source.routing_number.strip.gsub(/\s+/, ' ') if @submission.data_source.routing_number.present?
-                  xml.BankAccountNumber @submission.data_source.account_number.strip.gsub(/\s+/, ' ') if @submission.data_source.account_number.present?
+                  xml.RoutingTransitNumber sanitize_for_xml(@submission.data_source.routing_number) if @submission.data_source.routing_number.present?
+                  xml.BankAccountNumber sanitize_for_xml(@submission.data_source.account_number) if @submission.data_source.account_number.present?
                   xml.Amount @kwargs[:refund_amount]
                   case @submission.data_source.account_type
                   when 'checking'
@@ -27,8 +27,8 @@ module SubmissionBuilder
                   when 'savings'
                     xml.Savings 'X'
                   end
-                  xml.RoutingTransitNumber @submission.data_source.routing_number.strip.gsub(/\s+/, ' ') if @submission.data_source.routing_number.present?
-                  xml.BankAccountNumber @submission.data_source.account_number.strip.gsub(/\s+/, ' ') if @submission.data_source.account_number.present?
+                  xml.RoutingTransitNumber sanitize_for_xml(@submission.data_source.routing_number) if @submission.data_source.routing_number.present?
+                  xml.BankAccountNumber sanitize_for_xml(@submission.data_source.account_number) if @submission.data_source.account_number.present?
                   xml.PaymentAmount @submission.data_source.withdraw_amount if @submission.data_source.withdraw_amount.present?
                   xml.RequestedPaymentDate date_type(@submission.data_source.date_electronic_withdrawal) if @submission.data_source.date_electronic_withdrawal.present?
                   xml.NotIATTransaction 'X'

--- a/app/lib/submission_builder/ty2022/states/ny/documents/it201.rb
+++ b/app/lib/submission_builder/ty2022/states/ny/documents/it201.rb
@@ -79,17 +79,17 @@ module SubmissionBuilder
                 add_non_zero_claimed_value(xml, :RFND_B4_EDU_AMT, :IT201_LINE_78)
                 add_non_zero_claimed_value(xml, :RFND_AMT, :IT201_LINE_78B)
                 if @submission.data_source.confirmed_third_party_designee_yes?
-                  xml.THRD_PRTY_NAME claimed: truncate(intake.direct_file_data.third_party_designee_name, 29) if @submission.data_source.direct_file_data.third_party_designee_name.present?
-                  xml.THRD_PRTY_PH_NMBR claimed: intake.direct_file_data.third_party_designee_phone_number.strip.gsub(/\s+/, ' ') if @submission.data_source.direct_file_data.third_party_designee_phone_number.present?
+                  xml.THRD_PRTY_NAME claimed: sanitize_for_xml(intake.direct_file_data.third_party_designee_name, 29) if @submission.data_source.direct_file_data.third_party_designee_name.present?
+                  xml.THRD_PRTY_PH_NMBR claimed: sanitize_for_xml(intake.direct_file_data.third_party_designee_phone_number, 12) if @submission.data_source.direct_file_data.third_party_designee_phone_number.present?
                 end
                 xml.PR_SGN_IND claimed: 1
                 if @submission.data_source.spouse_esigned_yes?
                   xml.SP_SGN_IND claimed: 1
                 end
                 if intake.email_address.present?
-                  xml.TP_EMAIL_ADR claimed: intake.email_address.strip.gsub(/\s+/, ' ')
+                  xml.TP_EMAIL_ADR claimed: sanitize_for_xml(intake.email_address, 138)
                 elsif intake.direct_file_data.tax_payer_email.present?
-                  xml.TP_EMAIL_ADR claimed: intake.direct_file_data.tax_payer_email.strip.gsub(/\s+/, ' ')
+                  xml.TP_EMAIL_ADR claimed: sanitize_for_xml(intake.direct_file_data.tax_payer_email, 138)
                 end
                 if intake.direct_file_data.fed_adjustments_claimed.present?
                   xml.IT201FEDADJID do
@@ -105,9 +105,9 @@ module SubmissionBuilder
                   xml.IT201DepExmpInfo do
                     intake.dependents.each do |dependent|
                       xml.depInfo do
-                        xml.DEP_CHLD_FRST_NAME claimed: truncate(dependent.first_name, 16) if dependent.first_name.present?
-                        xml.DEP_CHLD_MI_NAME claimed: dependent.middle_initial.strip.gsub(/\s+/, ' ') if dependent.middle_initial.present?
-                        xml.DEP_CHLD_LAST_NAME claimed: dependent.last_name.strip.gsub(/\s+/, ' ') if dependent.last_name.present?
+                        xml.DEP_CHLD_FRST_NAME claimed: sanitize_for_xml(dependent.first_name, 16) if dependent.first_name.present?
+                        xml.DEP_CHLD_MI_NAME claimed: sanitize_for_xml(dependent.middle_initial, 1) if dependent.middle_initial.present?
+                        xml.DEP_CHLD_LAST_NAME claimed: sanitize_for_xml(dependent.last_name, 32) if dependent.last_name.present?
                         xml.DEP_RELATION_DESC claimed: dependent.relationship.delete(" ") if dependent.relationship.present?
                         xml.DEP_SSN_NMBR claimed: dependent.ssn if dependent.ssn.present?
                         xml.DOB_DT claimed: dependent.dob.strftime("%Y-%m-%d") if dependent.dob.present?

--- a/app/lib/submission_builder/ty2022/states/ny/documents/rtn_header.rb
+++ b/app/lib/submission_builder/ty2022/states/ny/documents/rtn_header.rb
@@ -22,10 +22,10 @@ module SubmissionBuilder
                 # xml.COND_CODE_2_NMBR
                 if @submission.data_source.confirmed_third_party_designee_yes?
                   xml.THRD_PRTY_DSGN_IND claimed: 1
-                  xml.THRD_PRTY_PIN_NMBR claimed: @submission.data_source.direct_file_data.third_party_designee_pin.strip.gsub(/\s+/, ' ') if @submission.data_source.direct_file_data.third_party_designee_pin.present?
+                  xml.THRD_PRTY_PIN_NMBR claimed: sanitize_for_xml(@submission.data_source.direct_file_data.third_party_designee_pin) if @submission.data_source.direct_file_data.third_party_designee_pin.present?
                 end
                 xml.EXT_TP_ID claimed: @submission.data_source.primary.ssn if @submission.data_source.primary.ssn.present?
-                xml.ABA_NMBR claimed: @submission.data_source.routing_number.strip.gsub(/\s+/, ' ') if @submission.data_source.routing_number.present?
+                xml.ABA_NMBR claimed: sanitize_for_xml(@submission.data_source.routing_number) if @submission.data_source.routing_number.present?
                 xml.BANK_ACCT_NMBR claimed: @submission.data_source.account_number.delete('-') if @submission.data_source.account_number.present?
                 if @submission.data_source.account_type.present? && ACCOUNT_TYPES[@submission.data_source.account_type.to_sym] != 0
                   xml.ACCT_TYPE_CD claimed: ACCOUNT_TYPES[@submission.data_source.account_type.to_sym]

--- a/app/lib/submission_builder/ty2022/states/ny/documents/state1099_g.rb
+++ b/app/lib/submission_builder/ty2022/states/ny/documents/state1099_g.rb
@@ -12,15 +12,15 @@ module SubmissionBuilder
               build_xml_doc("State1099G", documentId: "State1099G-#{form1099g.id}") do |xml|
                 if form1099g.payer_name && form1099g.payer_name != ''
                   xml.PayerName payerNameControl: form1099g.payer_name.gsub(/\s+|-/, '').upcase[0..3] do
-                    xml.BusinessNameLine1Txt truncate(form1099g.payer_name.tr('-', ' '), 75)
+                    xml.BusinessNameLine1Txt sanitize_for_xml(form1099g.payer_name.tr('-', ' '), 75)
                   end
                   xml.PayerUSAddress do
-                    xml.AddressLine1Txt truncate(form1099g.payer_street_address.tr('-', ' '), 35) if form1099g.payer_street_address.present?
-                    xml.CityNm truncate(form1099g.payer_city, 22) if form1099g.payer_city.present?
+                    xml.AddressLine1Txt sanitize_for_xml(form1099g.payer_street_address.tr('-', ' '), 35) if form1099g.payer_street_address.present?
+                    xml.CityNm sanitize_for_xml(form1099g.payer_city, 22) if form1099g.payer_city.present?
                     xml.StateAbbreviationCd "NY"
                     xml.ZIPCd form1099g.payer_zip if form1099g.payer_zip.present?
                   end
-                  xml.PayerEIN form1099g.payer_tin.strip.gsub(/\s+/, ' ') if form1099g.payer_tin.present?
+                  xml.PayerEIN sanitize_for_xml(form1099g.payer_tin) if form1099g.payer_tin.present?
                 end
                 recipient = if form1099g.recipient_primary?
                   form1099g.intake.primary
@@ -28,11 +28,11 @@ module SubmissionBuilder
                   form1099g.intake.spouse
                 end
                 xml.RecipientSSN recipient.ssn if recipient.ssn.present?
-                xml.RecipientName recipient.full_name.strip.gsub(/\s+/, ' ') if recipient.full_name.present?
+                xml.RecipientName sanitize_for_xml(recipient.full_name) if recipient.full_name.present?
                 xml.RecipientUSAddress do
-                  xml.AddressLine1Txt truncate(form1099g.recipient_address_line1, 35) if form1099g.recipient_address_line1.present?
-                  xml.AddressLine2Txt truncate(form1099g.recipient_address_line2, 35) if form1099g.recipient_address_line2.present?
-                  xml.CityNm truncate(form1099g.recipient_city, 22)if form1099g.recipient_city.present?
+                  xml.AddressLine1Txt sanitize_for_xml(form1099g.recipient_address_line1, 35) if form1099g.recipient_address_line1.present?
+                  xml.AddressLine2Txt sanitize_for_xml(form1099g.recipient_address_line2, 35) if form1099g.recipient_address_line2.present?
+                  xml.CityNm sanitize_for_xml(form1099g.recipient_city, 22)if form1099g.recipient_city.present?
                   xml.StateAbbreviationCd "NY"
                   xml.ZIPCd form1099g.recipient_zip if form1099g.recipient_zip.present?
                 end

--- a/app/lib/submission_builder/ty2022/states/ny/ny_return_xml.rb
+++ b/app/lib/submission_builder/ty2022/states/ny/ny_return_xml.rb
@@ -28,40 +28,40 @@ module SubmissionBuilder
               end
 
               xml.tiPrime do
-                xml.FIRST_NAME @submission.data_source.primary.first_name.strip.gsub(/\s+/, ' ') if @submission.data_source.primary.first_name.present?
-                xml.MI_NAME @submission.data_source.primary.middle_initial.strip.gsub(/\s+/, ' ') if @submission.data_source.primary.middle_initial.present?
-                xml.LAST_NAME @submission.data_source.primary.last_name.strip.gsub(/\s+/, ' ') if @submission.data_source.primary.last_name.present?
+                xml.FIRST_NAME sanitize_for_xml(@submission.data_source.primary.first_name, 16) if @submission.data_source.primary.first_name.present?
+                xml.MI_NAME sanitize_for_xml(@submission.data_source.primary.middle_initial, 1) if @submission.data_source.primary.middle_initial.present?
+                xml.LAST_NAME sanitize_for_xml(@submission.data_source.primary.last_name, 138) if @submission.data_source.primary.last_name.present?
                 xml.SFX_NAME @submission.data_source.primary.suffix if @submission.data_source.primary.suffix.present?
                 if @submission.data_source.direct_file_data.mailing_street.present?
                   process_mailing_street(xml)
                 end
-                xml.MAIL_CITY_ADR truncate(@submission.data_source.direct_file_data.mailing_city, 18) if @submission.data_source.direct_file_data.mailing_city.present?
-                xml.MAIL_STATE_ADR @submission.data_source.direct_file_data.mailing_state.strip.gsub(/\s+/, ' ') if @submission.data_source.direct_file_data.mailing_state.present?
-                xml.MAIL_ZIP_5_ADR truncate(@submission.data_source.direct_file_data.mailing_zip, 5) if @submission.data_source.direct_file_data.mailing_zip.present?
-                xml.COUNTY_CD @submission.data_source.county_code.strip.gsub(/\s+/, ' ') if @submission.data_source.county_code.present?
-                xml.COUNTY_NAME truncate(@submission.data_source.county_name, 20) if @submission.data_source.county_name.present?
+                xml.MAIL_CITY_ADR sanitize_for_xml(@submission.data_source.direct_file_data.mailing_city, 18) if @submission.data_source.direct_file_data.mailing_city.present?
+                xml.MAIL_STATE_ADR sanitize_for_xml(@submission.data_source.direct_file_data.mailing_state, 2) if @submission.data_source.direct_file_data.mailing_state.present?
+                xml.MAIL_ZIP_5_ADR sanitize_for_xml(@submission.data_source.direct_file_data.mailing_zip, 5) if @submission.data_source.direct_file_data.mailing_zip.present?
+                xml.COUNTY_CD sanitize_for_xml(@submission.data_source.county_code, 4) if @submission.data_source.county_code.present?
+                xml.COUNTY_NAME sanitize_for_xml(@submission.data_source.county_name, 20) if @submission.data_source.county_name.present?
                 if @submission.data_source.permanent_street.present?
                   process_permanent_street(xml)
                 end
-                xml.PERM_CTY_ADR truncate(@submission.data_source.permanent_city, 18) if @submission.data_source.permanent_city.present?
+                xml.PERM_CTY_ADR sanitize_for_xml(@submission.data_source.permanent_city, 18) if @submission.data_source.permanent_city.present?
                 xml.PERM_ST_ADR "NY"
                 xml.PERM_ZIP_ADR @submission.data_source.permanent_zip if @submission.data_source.permanent_zip.present?
                 xml.SCHOOL_CD @submission.data_source.school_district_number if @submission.data_source.school_district_number.present?
-                xml.SCHOOL_NAME truncate(@submission.data_source.school_district, 30) if @submission.data_source.school_district.present?
-                xml.PR_EMP_DESC truncate(@submission.data_source.direct_file_data.primary_occupation, 25) if @submission.data_source.direct_file_data.primary_occupation.present?
+                xml.SCHOOL_NAME sanitize_for_xml(@submission.data_source.school_district, 30) if @submission.data_source.school_district.present?
+                xml.PR_EMP_DESC sanitize_for_xml(@submission.data_source.direct_file_data.primary_occupation, 25) if @submission.data_source.direct_file_data.primary_occupation.present?
                 # We omit country name because we don't support out of country filers
                 #xml.COUNTRY_NAME @submission.data_source.mailing_country
               end
 
               if @submission.data_source.filing_status_mfj?
                 xml.tiSpouse do
-                  xml.FIRST_NAME @submission.data_source.spouse.first_name.strip.gsub(/\s+/, ' ') if @submission.data_source.spouse.first_name.present?
-                  xml.MI_NAME @submission.data_source.spouse.middle_initial.strip.gsub(/\s+/, ' ') if @submission.data_source.spouse.middle_initial.present?
-                  xml.LAST_NAME @submission.data_source.spouse.last_name.strip.gsub(/\s+/, ' ') if @submission.data_source.spouse.last_name.present?
+                  xml.FIRST_NAME sanitize_for_xml(@submission.data_source.spouse.first_name, 16) if @submission.data_source.spouse.first_name.present?
+                  xml.MI_NAME sanitize_for_xml(@submission.data_source.spouse.middle_initial, 1) if @submission.data_source.spouse.middle_initial.present?
+                  xml.LAST_NAME sanitize_for_xml(@submission.data_source.spouse.last_name, 138) if @submission.data_source.spouse.last_name.present?
                   xml.SFX_NAME @submission.data_source.spouse.suffix if @submission.data_source.spouse.suffix.present?
                   xml.SP_SSN_NMBR @submission.data_source.spouse.ssn if @submission.data_source.spouse.ssn.present?
                   xml.DCSD_DT @submission.data_source.direct_file_data.spouse_date_of_death if @submission.data_source.spouse_deceased?
-                  xml.SP_EMP_DESC truncate(@submission.data_source.direct_file_data.spouse_occupation, 25) if @submission.data_source.direct_file_data.spouse_occupation.present?
+                  xml.SP_EMP_DESC sanitize_for_xml(@submission.data_source.direct_file_data.spouse_occupation, 25) if @submission.data_source.direct_file_data.spouse_occupation.present?
                 end
               elsif @submission.data_source.filing_status_mfs?
                 xml.tiSpouse do
@@ -80,10 +80,10 @@ module SubmissionBuilder
                     xml.DEP_FORM_ID 348 # 348 is the code for the IT-213 form
                     xml.DEP_RELATION_DESC dependent.relationship.delete(" ") if dependent.relationship.present?
                     xml.DEP_STUDENT_IND dependent.eic_student_yes? ? 1 : 2
-                    xml.DEP_CHLD_LAST_NAME dependent.last_name.strip.gsub(/\s+/, ' ') if dependent.last_name.present?
-                    xml.DEP_CHLD_FRST_NAME truncate(dependent.first_name, 16) if dependent.first_name.present?
-                    xml.DEP_CHLD_MI_NAME dependent.middle_initial.strip.gsub(/\s+/, ' ') if dependent.middle_initial.present?
-                    xml.DEP_CHLD_SFX_NAME dependent.suffix if dependent.suffix.present?
+                    xml.DEP_CHLD_LAST_NAME sanitize_for_xml(dependent.last_name, 32) if dependent.last_name.present?
+                    xml.DEP_CHLD_FRST_NAME sanitize_for_xml(dependent.first_name, 16) if dependent.first_name.present?
+                    xml.DEP_CHLD_MI_NAME sanitize_for_xml(dependent.middle_initial, 1) if dependent.middle_initial.present?
+                    xml.DEP_CHLD_SFX_NAME sanitize_for_xml(dependent.suffix) if dependent.suffix.present?
                     xml.DEP_MNTH_LVD_NMBR dependent.months_in_home if dependent.months_in_home.present?
                     xml.DOB_DT dependent.dob.strftime("%Y-%m-%d") if dependent.dob.present?
                   end
@@ -102,10 +102,10 @@ module SubmissionBuilder
                   unless dependent.eic_student_unfilled?
                     xml.DEP_STUDENT_IND dependent.eic_student_yes? ? 1 : 2
                   end
-                  xml.DEP_CHLD_LAST_NAME dependent.last_name.strip.gsub(/\s+/, ' ') if dependent.last_name.present?
-                  xml.DEP_CHLD_FRST_NAME truncate(dependent.first_name, 16) if dependent.first_name.present?
-                  xml.DEP_CHLD_MI_NAME dependent.middle_initial.strip.gsub(/\s+/, ' ') if dependent.middle_initial.present?
-                  xml.DEP_CHLD_SFX_NAME dependent.suffix.strip.gsub(/\s+/, ' ') if dependent.suffix.present?
+                  xml.DEP_CHLD_LAST_NAME sanitize_for_xml(dependent.last_name, 32) if dependent.last_name.present?
+                  xml.DEP_CHLD_FRST_NAME sanitize_for_xml(dependent.first_name, 16) if dependent.first_name.present?
+                  xml.DEP_CHLD_MI_NAME sanitize_for_xml(dependent.middle_initial, 1) if dependent.middle_initial.present?
+                  xml.DEP_CHLD_SFX_NAME sanitize_for_xml(dependent.suffix) if dependent.suffix.present?
                   xml.DEP_MNTH_LVD_NMBR dependent.months_in_home if dependent.months_in_home.present?
                   xml.DOB_DT dependent.dob.strftime("%Y-%m-%d") if dependent.dob.present?
                 end

--- a/app/services/state_file/state_information_service.rb
+++ b/app/services/state_file/state_information_service.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module StateFile
   class StateInformationService
     class << self

--- a/spec/lib/submission_builder/formatting_methods_spec.rb
+++ b/spec/lib/submission_builder/formatting_methods_spec.rb
@@ -145,4 +145,19 @@ describe SubmissionBuilder::FormattingMethods do
       end
     end
   end
+
+  describe "#truncate" do
+    include SubmissionBuilder::FormattingMethods
+    it "doesn't affect valid strings" do
+      expect(sanitize_for_xml("foo")).to eq "foo"
+    end
+
+    it "sanitizes internal and external whitespace" do
+      expect(sanitize_for_xml(" \tf  \fo \vo  \t   bar\r\n ")).to eq "f o o bar"
+    end
+
+    it "strips whitespace resulting from truncation" do
+      expect(sanitize_for_xml("Four Word Phrase", "Four Word ".length)).to eq "Four Word"
+    end
+  end
 end


### PR DESCRIPTION
unify our string output filtering and add character limits to match the output XML schema restrictions in as many places as i could find that we didn't have any (even where we're just truncating something we got from Direct File)

## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-240
## Is PM acceptance required?
- No - merge after code review approval
## What was done?
- Renamed `truncate` to `sanitize_for_xml`, made the length param optional and added a few tests
- Replaced all uses of `&.strip&.gsub("\s+", " ")` with calls to `sanitize_for_xml`
- Added truncation where we weren't enforcing a character limit present in the output XSD
## How to test?
- Unit tests, and especially our regression tests, should make sure that we still work on all previously working input
- I will add an additional test that confirms that we no longer pass through last names that won't validate, but you could also confirm that manually by going through the flow with a very long primary last name.
  - _Update: I did not add this test, as it turns out we don't actually currently validate our return headers currently. I'll look to add this in a separate PR, as the change is out of scope._