### PR TITLE
FYST-485 Fix AZ form card UI

### DIFF
--- a/app/views/state_file/questions/az_qualifying_organization_contributions/_form.html.erb
+++ b/app/views/state_file/questions/az_qualifying_organization_contributions/_form.html.erb
@@ -13,7 +13,7 @@
     <div class="question-with-follow-up">
       <% if show_yes_no %>
         <div class="question-with-follow-up__question">
-          <div class="blue-group">
+          <div class="white-group">
             <%= f.fields_for(:state_file_az_intake) do |ff| %>
               <%= ff.cfa_radio_set( :made_az321_contributions, collection: [ { value: :yes, label: t('general.affirmative'), input_html: { "data-follow-up": "#contribution-details", } }, { value: :no, label: t('general.negative') } ]) %>
             <% end %>
@@ -22,7 +22,7 @@
       <% end %>
 
       <div class="<%= "question-with-follow-up__follow-up" if show_yes_no %>" id="contribution-details">
-        <div class="blue-group">
+        <div class="white-group">
           <p class="form-question spacing-below-25">
           <%= t('.question_header') %>
           </p>

--- a/app/views/state_file/questions/az_qualifying_organization_contributions/index.html.erb
+++ b/app/views/state_file/questions/az_qualifying_organization_contributions/index.html.erb
@@ -6,7 +6,7 @@
 
   <% if @contributions.present? %>
     <% @contributions.each do |contribution| %>
-      <div class="blue-group">
+      <div class="white-group">
         <div>
           <h3>
             <%= t('.contribution_name', charity_name: contribution.charity_name, charity_code: contribution.charity_code) %>

--- a/app/views/state_file/questions/az_retirement_income/edit.html.erb
+++ b/app/views/state_file/questions/az_retirement_income/edit.html.erb
@@ -6,7 +6,7 @@
     <% @attributes.each do |income_type| %>
       <div class="question-with-follow-up">
         <div class="question-with-follow-up__question">
-          <div class="blue-group">
+          <div class="white-group">
             <%= f.cfa_checkbox(
                   income_type,
                   t(".#{income_type}", count: current_intake.filer_count),
@@ -16,7 +16,7 @@
           </div>
         </div>
         <div class="question-with-follow-up__follow-up" id=<%=income_type %>>
-          <div class="blue-group">
+          <div class="white-group">
             <div class="spacing-below-25">
               <p><%= t(".#{income_type}_amount") %></p>
               <p><%= t(".should_not_exceed_taxable_pensions_total_html", total: number_to_currency(current_intake.direct_file_data.fed_taxable_pensions)) %></p>

--- a/app/views/state_file/questions/az_review/edit.html.erb
+++ b/app/views/state_file/questions/az_review/edit.html.erb
@@ -52,7 +52,7 @@
     </div>
   </div>
 
-  <div id="qualifing-organization-contributions" class="blue-group">
+  <div id="qualifing-organization-contributions" class="white-group">
     <div class="spacing-below-5">
       <p class="text--bold spacing-below-5"><%=t(".made_az321_contributions") %></p>
       <p><%= current_intake.az321_contributions.present? ? t("general.affirmative") : t("general.negative") %></p>


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/FYST-485
## Is PM acceptance required? 
- Yes - don't merge until JIRA issue is accepted!

## What was done?
A few form cards in the AZ flow was using an old form card css element "blue-group" and needed to be changed to the new form style class.

## How to test?
Use heroku and go through richard retirement xml to test out the retirement income page and the charitable organizations pages 

## Screenshots (for visual changes)
- Before
<img width="738" alt="Screenshot 2024-09-04 at 11 16 27 AM" src="https://github.com/user-attachments/assets/bf763b5c-313f-4462-82a1-4f05a0cb3284">
<img width="712" alt="Screenshot 2024-09-04 at 11 15 13 AM" src="https://github.com/user-attachments/assets/16005bca-572c-4ce5-a000-190c9375b7df">

- After
<img width="737" alt="Screenshot 2024-09-04 at 11 15 30 AM" src="https://github.com/user-attachments/assets/fb96d10d-7a11-4786-9e88-a057ea19348c">
<img width="731" alt="Screenshot 2024-09-04 at 11 11 13 AM" src="https://github.com/user-attachments/assets/01243100-de3f-4bc6-9b88-d1ec4e92be2c">

