### PR TITLE
Gyr 569/add hold status to greeter access

### DIFF
--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -95,7 +95,8 @@ class Ability
         Client,
         tax_returns: {
           current_state: [
-            'file_not_filing'
+            'file_not_filing',
+            'file_hold',
           ],
           assigned_user: user,
         },

--- a/app/state_machines/tax_return_state_machine.rb
+++ b/app/state_machines/tax_return_state_machine.rb
@@ -67,7 +67,8 @@ class TaxReturnStateMachine
         'intake_needs_doc_help'
       ],
       'file' => [
-        'file_not_filing'
+        'file_not_filing',
+        'file_hold',
       ]
     }
   }

--- a/spec/controllers/hub/clients_controller_spec.rb
+++ b/spec/controllers/hub/clients_controller_spec.rb
@@ -2397,5 +2397,6 @@ RSpec.describe Hub::ClientsController do
     it_behaves_like "it doesn't require being assigned to a user", :intake_needs_doc_help
 
     it_behaves_like "it requires being assigned to a user", :file_not_filing
+    it_behaves_like "it requires being assigned to a user", :file_hold
   end
 end

--- a/spec/helpers/tax_return_status_helper_spec.rb
+++ b/spec/helpers/tax_return_status_helper_spec.rb
@@ -69,7 +69,7 @@ describe TaxReturnStatusHelper do
                      [["Ready for review", "intake_ready"],
                       ["Greeter - info requested", "intake_greeter_info_requested"],
                       ["Needs doc help", "intake_needs_doc_help"]]],
-                    ["Final steps", [["Not filing", "file_not_filing"]]]]
+                    ["Final steps", [["Not filing", "file_not_filing"], ["Hold", "file_hold"]]]]
                  )
       end
     end

--- a/spec/state_machines/tax_return_state_machine_spec.rb
+++ b/spec/state_machines/tax_return_state_machine_spec.rb
@@ -66,7 +66,7 @@ describe TaxReturnStateMachine do
           "intake_greeter_info_requested",
           "intake_needs_doc_help"
         ]
-        expect(result["file"]).to eq ["file_not_filing"]
+        expect(result["file"]).to eq ["file_not_filing", "file_hold"]
       end
     end
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/GYR1-569

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Users that were in the `file_hold` status were not being considered. We modified the ability file to enable them to display if and only if they are assigned to the given greeter for the user.
- **Note** If a user has multiple intakes, and those other intakes are in a status that does not require a user to be assigned (namely `intake_ready`, `intake_greeter_info_requested`, `intake_needs_doc_help`), the user will still be displayed. This is because while we scope on returns we are beginning from the context of the client and not the context of the tax return. To modify this likely would require inverting how that happens

## How to test?
- Unit tests are provided in the PR

### Manual Testing
- Navigate to `/en/hub/clients`
  - Authenticate as a greeter if necessary
- Note that there are only two clients available, each with two intakes.
  - Captain Hook
    - `intake_ready`
    - `intake_ready`
  - Peter Pan
    - `intake_ready`
    - `intake_ready`
- Manipulate intake to be in a state other than those that do not require a user to be assigned. In other words not:
  - `intake_ready`,
  - `intake_greeter_info_requested`,
  - `intake_needs_doc_help`,
- Note that the client is no longer accessible

## Screenshots (for visual changes)
- Before
![image](https://github.com/user-attachments/assets/54dc1b57-6ae2-476b-a567-793515f1b453)

- After
![image](https://github.com/user-attachments/assets/98fd47ab-3d21-4aeb-8782-5405292e849f)

