### PR TITLE
Fix schema file loader to skip NJ for now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ coverage
 # Ignore rspec example persistence file
 spec/examples.txt
 
+.rspec-local
+
 # Ignore RubyMine files
 .generators
 .rakeTasks

--- a/.rspec-local.example
+++ b/.rspec-local.example
@@ -1,0 +1,1 @@
+--tag ~required_schema:nj

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ bin/setup
 ```
 > ℹ️ **Note:** If `bundler` is not installing, ensure that you have `rbenv` installed and are not using the system Ruby version. Check the `.ruby-version` file in the repository to match the version specified. If necessary, update to the correct Ruby version and modify your `.zprofile` or `.zshrc` to point to the correct path.
 
+> ℹ️ **Note:** You may consider at this point copying or symlinking `.rspec-local.example` to `.rspec-local` to exclude specs that are not core to CfA yet. Copying enables you to set other custom flags for your local environment, symlinking enables the flags to automatically go away when they are removed from the example file. Just be careful not to commit any local changes!
 
 #### Add efile resources locally
 

--- a/app/lib/schema_file_loader.rb
+++ b/app/lib/schema_file_loader.rb
@@ -36,11 +36,15 @@ class SchemaFileLoader
     def download_schemas_from_s3(dest_dir)
       s3_client = Aws::S3::Client.new(region: REGION, credentials: s3_credentials)
       get_missing_downloads(dest_dir).each do |download_path|
-        s3_client.get_object(
-          response_target: download_path,
-          bucket: BUCKET,
-          key: File.basename(download_path),
-        )
+        begin
+          puts "this path #{download_path}"
+          s3_client.get_object(
+            response_target: download_path,
+            bucket: BUCKET,
+            key: File.basename(download_path),
+            )
+        rescue Aws::S3::Errors::NoSuchKey
+        end
       end
     end
 

--- a/app/lib/schema_file_loader.rb
+++ b/app/lib/schema_file_loader.rb
@@ -4,12 +4,14 @@ class SchemaFileLoader
   REGION = "us-east-1".freeze
   EFILE_SCHEMAS_FILENAMES = (
     [
+      # Format is schema name, directory, and whether the file is optional
       ["efile1040x_2020v5.1.zip", "irs", false],
       ["efile1040x_2021v5.2.zip", "irs", false],
       ["efile1040x_2022v5.3.zip", "irs", false],
       ["efile1040x_2023v5.0.zip", "irs", false]
     ] +
       StateFile::StateInformationService::STATES_INFO.map do |key, values|
+        # TODO: If adding another member to this array, consider refactoring to a hash instead
         [values[:schema_file_name], "us_states", values[:optional]]
       end
   ).freeze

--- a/app/lib/schema_file_loader.rb
+++ b/app/lib/schema_file_loader.rb
@@ -43,12 +43,8 @@ class SchemaFileLoader
           bucket: BUCKET,
           key: File.basename(download_path),
         )
-      rescue Aws::S3::Errors::NoSuchKey => error
-        if optional
-          next
-        else
-          raise error
-        end
+      rescue Aws::S3::Errors::NoSuchKey => e
+        raise e unless optional
       end
     end
 

--- a/app/lib/schema_file_loader.rb
+++ b/app/lib/schema_file_loader.rb
@@ -43,8 +43,12 @@ class SchemaFileLoader
           bucket: BUCKET,
           key: File.basename(download_path),
         )
-      rescue Aws::S3::Errors::NoSuchKey
-        next if optional
+      rescue Aws::S3::Errors::NoSuchKey => error
+        if optional
+          next
+        else
+          raise error
+        end
       end
     end
 

--- a/app/services/state_file/state_information_service.rb
+++ b/app/services/state_file/state_information_service.rb
@@ -74,6 +74,7 @@ module StateFile
         vita_link: "https://airtable.com/appnKuyQXMMCPSvVw/pag0hcyC6juDxamHo/form",
         voucher_form_name: "Form AZ-140V",
         voucher_path: "/pdfs/AZ-140V.pdf",
+        optional: false
       },
       nc: {
         intake_class: StateFileNcIntake,
@@ -95,6 +96,7 @@ module StateFile
         vita_link: "",
         voucher_form_name: "Form D-400V",
         voucher_path: "/pdfs/d400v-TY2023.pdf",
+        optional: false
       },
       nj: {
         intake_class: StateFileNjIntake,
@@ -103,7 +105,8 @@ module StateFile
         submission_builder_class: SubmissionBuilder::Ty2024::States::Nj::NjReturnXml,
         state_name: "New Jersey",
         return_type: "Resident",
-        schema_file_name: "NJIndividual2023V0.4.zip"
+        schema_file_name: "NJIndividual2023V0.4.zip",
+        optional: true
         # mail_voucher_address: "New Jersey Personal Income Tax<br/>" \
         #                       "Processing Center<br/>" \
         #                       "Trenton, NJ".html_safe,
@@ -137,6 +140,7 @@ module StateFile
         vita_link: "https://airtable.com/appQS3abRZGjT8wII/pagtpLaX0wokBqnuA/form",
         voucher_form_name: "Form IT-201-V",
         voucher_path: "/pdfs/it201v_1223.pdf",
+        optional: false
       }
     }.with_indifferent_access)
   end

--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -20,7 +20,7 @@ namespace :setup do
   task unzip_efile_schemas: :environment do |_task|
     SchemaFileLoader.unzip_schemas(vendor_dir)
     missing_files = SchemaFileLoader.get_missing_downloads(vendor_dir)
-    if missing_files.present?
+    if missing_files.keep_if { |(_path, optional)| optional == false }.present?
       message = <<~MESSAGE
         Download the following files from https://drive.google.com/drive/u/0/folders/1ssEXuz5WDrlr9Ng7Ukp6duSksNJtRATa
         #{missing_files.map { |(filename, download_folder)| "#{filename} to vendor/#{download_folder}" }.join("\n")}

--- a/spec/lib/schema_file_loader_spec.rb
+++ b/spec/lib/schema_file_loader_spec.rb
@@ -64,6 +64,22 @@ describe SchemaFileLoader do
       end
       SchemaFileLoader.download_schemas_from_s3("testy")
     end
+
+    context "when file is not found" do
+      it "should raise an error for non-optional schemas" do
+        allow(SchemaFileLoader).to receive(:get_missing_downloads).with('some_dir').and_return [["state_secrets.zip", false]]
+        allow_any_instance_of(Aws::S3::Client).to receive(:get_object).and_raise Aws::S3::Errors::NoSuchKey.new("Meant to be a context", "Meant to be a message")
+
+        expect { SchemaFileLoader.download_schemas_from_s3('some_dir') }.to raise_error Aws::S3::Errors::NoSuchKey
+      end
+
+      it "should not raise an error for optional schemas" do
+        allow(SchemaFileLoader).to receive(:get_missing_downloads).with('some_dir').and_return [["state_secrets.zip", true]]
+        allow_any_instance_of(Aws::S3::Client).to receive(:get_object).and_raise Aws::S3::Errors::NoSuchKey.new("Meant to be a context", "Meant to be a message")
+
+        expect { SchemaFileLoader.download_schemas_from_s3('some_dir') }.not_to raise_error
+      end
+    end
   end
 
   context "#get_missing_downloads" do

--- a/spec/lib/schema_file_loader_spec.rb
+++ b/spec/lib/schema_file_loader_spec.rb
@@ -70,14 +70,14 @@ describe SchemaFileLoader do
     it "gets missing downloads" do
       expect(SchemaFileLoader.get_missing_downloads("testy")).
         to eq [
-          "testy/irs/efile1040x_2020v5.1.zip",
-          "testy/irs/efile1040x_2021v5.2.zip",
-          "testy/irs/efile1040x_2022v5.3.zip",
-          "testy/irs/efile1040x_2023v5.0.zip",
-          "testy/us_states/AZIndividual2023v1.0.zip",
-          "testy/us_states/NCIndividual2023v1.0.zip",
-          "testy/us_states/NJIndividual2023V0.4.zip",
-          "testy/us_states/NYSIndividual2023V4.0.zip"
+          ["testy/irs/efile1040x_2020v5.1.zip", false],
+          ["testy/irs/efile1040x_2021v5.2.zip", false],
+          ["testy/irs/efile1040x_2022v5.3.zip", false],
+          ["testy/irs/efile1040x_2023v5.0.zip", false],
+          ["testy/us_states/AZIndividual2023v1.0.zip", false],
+          ["testy/us_states/NCIndividual2023v1.0.zip", false],
+          ["testy/us_states/NJIndividual2023V0.4.zip", true],
+          ["testy/us_states/NYSIndividual2023V4.0.zip", false],
         ]
     end
   end

--- a/spec/lib/schema_file_loader_spec.rb
+++ b/spec/lib/schema_file_loader_spec.rb
@@ -4,14 +4,14 @@ describe SchemaFileLoader do
 
   it "all required schema files are present" do
     expect(SchemaFileLoader::EFILE_SCHEMAS_FILENAMES).to eq [
-      ["efile1040x_2020v5.1.zip", "irs"],
-      ["efile1040x_2021v5.2.zip", "irs"],
-      ["efile1040x_2022v5.3.zip", "irs"],
-      ["efile1040x_2023v5.0.zip", "irs"],
-      ["AZIndividual2023v1.0.zip", "us_states"],
-      ["NCIndividual2023v1.0.zip", "us_states"],
-      ["NJIndividual2023V0.4.zip", "us_states"],
-      ["NYSIndividual2023V4.0.zip", "us_states"],
+      ["efile1040x_2020v5.1.zip", "irs", false],
+      ["efile1040x_2021v5.2.zip", "irs", false],
+      ["efile1040x_2022v5.3.zip", "irs", false],
+      ["efile1040x_2023v5.0.zip", "irs", false],
+      ["AZIndividual2023v1.0.zip", "us_states", false],
+      ["NCIndividual2023v1.0.zip", "us_states", false],
+      ["NJIndividual2023V0.4.zip", "us_states", true],
+      ["NYSIndividual2023V4.0.zip", "us_states", false],
     ]
   end
 


### PR DESCRIPTION
## Is PM acceptance required?
- No - merge after code review approval

## What was done?

For the tests for schema file loader for `setup:download_efile_schemas` and `setup:unzip_efile_schemas`, nj schema errors were ignored by adding an optional field for each state information in the StateInformationService. Errors were filtered by checking the optional value for each state.

Tests that were tagged required nj schema were altered to skip over nj files when checking for schema file loading.
Cfa staff would have to run the following command to utilize this tag until we receive the nj schemas: 
`cp .rspec-local.example .rspec-local`

## How to test?
Testing would be accomplished through running circle ci flow