### PR TITLE
Partial refactor of direct_file_data class

### DIFF
--- a/app/lib/efile/ny/it213.rb
+++ b/app/lib/efile/ny/it213.rb
@@ -180,7 +180,7 @@ module Efile
       end
 
       def calculate_worksheet_a_line_9
-        @direct_file_data.fed_tax || 0
+        @direct_file_data.fed_tax_amt || 0
       end
 
       def calculate_worksheet_a_line_10

--- a/app/models/df_1099r_accessor.rb
+++ b/app/models/df_1099r_accessor.rb
@@ -23,5 +23,5 @@ class Df1099rAccessor < DfXmlAccessor
     Nokogiri::XML(StateFile::XmlReturnSampleService.new.read("az_richard_retirement_1099r")).at('IRS1099R')
   end
 
-  define_xml_methods
+  define_xml_accessors
 end

--- a/app/models/df_w2_accessor.rb
+++ b/app/models/df_w2_accessor.rb
@@ -31,5 +31,5 @@ class DfW2Accessor < DfXmlAccessor
     Nokogiri::XML(IrsApiService.df_return_sample).at('IRSW2')
   end
 
-  define_xml_methods
+  define_xml_accessors
 end

--- a/app/models/df_xml_accessor.rb
+++ b/app/models/df_xml_accessor.rb
@@ -14,7 +14,7 @@ class DfXmlAccessor
 
   def self.define_xml_readers
     self.selectors.keys.each do |key|
-      if key.ends_with?("Amt")
+      if key.ends_with?("Amt", "_amt")
         define_method(key) do
           df_xml_value(__method__)&.to_i || 0
         end

--- a/app/models/df_xml_accessor.rb
+++ b/app/models/df_xml_accessor.rb
@@ -12,13 +12,13 @@ class DfXmlAccessor
   end
   delegate :selectors, to: :class
 
-  def self.define_xml_methods
+  def self.define_xml_readers
     self.selectors.keys.each do |key|
       if key.ends_with?("Amt")
         define_method(key) do
           df_xml_value(__method__)&.to_i || 0
         end
-      elsif key.ends_with?("_year") || key.ends_with?("_status")
+      elsif key.ends_with?("_year", "_status")
         define_method(key) do
           df_xml_value(__method__)&.to_i
         end
@@ -27,11 +27,20 @@ class DfXmlAccessor
           df_xml_value(__method__)
         end
       end
+    end
+  end
 
+  def self.define_xml_writers
+    self.selectors.keys.each do |key|
       define_method("#{key}=") do |value|
         create_or_destroy_df_xml_node(__method__, value)
         write_df_xml_value(__method__, value)
       end
     end
+  end
+
+  def self.define_xml_accessors
+    define_xml_readers
+    define_xml_writers
   end
 end

--- a/app/models/df_xml_accessor.rb
+++ b/app/models/df_xml_accessor.rb
@@ -18,6 +18,10 @@ class DfXmlAccessor
         define_method(key) do
           df_xml_value(__method__)&.to_i || 0
         end
+      elsif key.ends_with?("_year")
+        define_method(key) do
+          df_xml_value(__method__)&.to_i
+        end
       else
         define_method(key) do
           df_xml_value(__method__)

--- a/app/models/df_xml_accessor.rb
+++ b/app/models/df_xml_accessor.rb
@@ -14,7 +14,7 @@ class DfXmlAccessor
 
   def self.define_xml_readers
     self.selectors.keys.each do |key|
-      if key.ends_with?("Amt", "_amt")
+      if key.ends_with?("Amt", "_amt", "_amount")
         define_method(key) do
           df_xml_value(__method__)&.to_i || 0
         end

--- a/app/models/df_xml_accessor.rb
+++ b/app/models/df_xml_accessor.rb
@@ -18,7 +18,7 @@ class DfXmlAccessor
         define_method(key) do
           df_xml_value(__method__)&.to_i || 0
         end
-      elsif key.ends_with?("_year")
+      elsif key.ends_with?("_year") || key.ends_with?("_status")
         define_method(key) do
           df_xml_value(__method__)&.to_i
         end

--- a/app/models/direct_file_data.rb
+++ b/app/models/direct_file_data.rb
@@ -16,7 +16,7 @@ class DirectFileData < DfXmlAccessor
     phone_number: 'ReturnHeader Filer PhoneNum',
     cell_phone_number: 'ReturnHeader AdditionalFilerInformation AtSubmissionFilingGrp CellPhoneNum',
     tax_payer_email: 'ReturnHeader AdditionalFilerInformation AtSubmissionFilingGrp EmailAddressTxt',
-    fed_tax: 'IRS1040 TotalTaxBeforeCrAndOthTaxesAmt',
+    fed_tax_amt: 'IRS1040 TotalTaxBeforeCrAndOthTaxesAmt',
     fed_agi: 'IRS1040 AdjustedGrossIncomeAmt',
     fed_wages: 'IRS1040 WagesAmt',
     fed_wages_salaries_tips: 'IRS1040 WagesSalariesAndTipsAmt',
@@ -168,11 +168,7 @@ class DirectFileData < DfXmlAccessor
     write_df_xml_value(__method__, value)
   end
 
-  def fed_tax
-    df_xml_value(__method__)&.to_i || 0
-  end
-
-  def fed_tax=(value)
+  def fed_tax_amt=(value)
     write_df_xml_value(__method__, value)
   end
 
@@ -792,7 +788,7 @@ class DirectFileData < DfXmlAccessor
       :cell_phone_number,
       :tax_payer_email,
       :total_state_tax_withheld,
-      :fed_tax,
+      :fed_tax_amt,
       :fed_agi,
       :fed_wages,
       :fed_wages_salaries_tips,

--- a/app/models/direct_file_data.rb
+++ b/app/models/direct_file_data.rb
@@ -1,4 +1,4 @@
-class DirectFileData
+class DirectFileData < DfXmlAccessor
   include DfXmlCrudMethods
 
   SELECTORS = {
@@ -71,9 +71,11 @@ class DirectFileData
     @raw_xml = raw_xml
   end
 
-  def selectors
+  def self.selectors
     SELECTORS
   end
+
+  define_xml_methods
 
   def parsed_xml
     @parsed_xml ||= Nokogiri::XML(@raw_xml)
@@ -85,14 +87,6 @@ class DirectFileData
 
   def to_s
     parsed_xml.to_s
-  end
-
-  def tax_return_year
-    df_xml_value(__method__)&.to_i
-  end
-
-  def tax_return_year=(value)
-    write_df_xml_value(__method__, value)
   end
 
   def filing_status

--- a/app/models/direct_file_data.rb
+++ b/app/models/direct_file_data.rb
@@ -89,30 +89,6 @@ class DirectFileData < DfXmlAccessor
     parsed_xml.to_s
   end
 
-  def tax_payer_email
-    df_xml_value(__method__)
-  end
-
-  def primary_ssn
-    df_xml_value(__method__)
-  end
-
-  def primary_ssn=(value)
-    write_df_xml_value(__method__, value)
-  end
-
-  def primary_occupation
-    df_xml_value(__method__)
-  end
-
-  def primary_occupation=(value)
-    write_df_xml_value(__method__, value)
-  end
-
-  def spouse_ssn
-    df_xml_value(__method__)
-  end
-
   def spouse_ssn=(value)
     create_or_destroy_df_xml_node(__method__, value, after="PrimarySSN")
 

--- a/app/models/direct_file_data.rb
+++ b/app/models/direct_file_data.rb
@@ -75,7 +75,7 @@ class DirectFileData < DfXmlAccessor
     SELECTORS
   end
 
-  define_xml_methods
+  define_xml_readers
 
   def parsed_xml
     @parsed_xml ||= Nokogiri::XML(@raw_xml)
@@ -89,6 +89,22 @@ class DirectFileData < DfXmlAccessor
     parsed_xml.to_s
   end
 
+  def tax_return_year=(value)
+    write_df_xml_value(__method__, value)
+  end
+
+  def filing_status=(value)
+    write_df_xml_value(__method__, value)
+  end
+
+  def primary_ssn=(value)
+    write_df_xml_value(__method__, value)
+  end
+
+  def primary_occupation=(value)
+    write_df_xml_value(__method__, value)
+  end
+
   def spouse_ssn=(value)
     create_or_destroy_df_xml_node(__method__, value, after="PrimarySSN")
 
@@ -97,20 +113,12 @@ class DirectFileData < DfXmlAccessor
     end
   end
 
-  def spouse_occupation
-    df_xml_value(__method__)
-  end
-
   def spouse_occupation=(value)
     create_or_destroy_df_xml_node(__method__, value, after="PrimaryOccupationTxt")
 
     if value.present?
       write_df_xml_value(__method__, value)
     end
-  end
-
-  def surviving_spouse
-    df_xml_value(__method__)
   end
 
   def spouse_deceased?
@@ -127,19 +135,11 @@ class DirectFileData < DfXmlAccessor
     end
   end
 
-  def spouse_date_of_death
-    df_xml_value(__method__)
-  end
-
   def spouse_date_of_death=(value)
     if value.present?
       create_or_destroy_df_xml_node(__method__, value, after="IndividualReturnFilingStatusCd")
       write_df_xml_value(__method__, value)
     end
-  end
-
-  def spouse_name
-    df_xml_value(__method__)
   end
 
   def spouse_name=(value)
@@ -148,40 +148,20 @@ class DirectFileData < DfXmlAccessor
     end
   end
 
-  def mailing_city
-    df_xml_value(__method__)
-  end
-
   def mailing_city=(value)
     write_df_xml_value(__method__, value)
-  end
-
-  def mailing_street
-    df_xml_value(__method__)
   end
 
   def mailing_street=(value)
     write_df_xml_value(__method__, value)
   end
 
-  def mailing_apartment
-    df_xml_value(__method__)
-  end
-
   def mailing_apartment=(value)
     write_df_xml_value(__method__, value)
   end
 
-  def mailing_state
-    df_xml_value(__method__)
-  end
-
   def mailing_state=(value)
     write_df_xml_value(__method__, value)
-  end
-
-  def mailing_zip
-    df_xml_value(__method__)
   end
 
   def mailing_zip=(value)

--- a/app/models/direct_file_data.rb
+++ b/app/models/direct_file_data.rb
@@ -89,14 +89,6 @@ class DirectFileData < DfXmlAccessor
     parsed_xml.to_s
   end
 
-  def phone_number
-    df_xml_value(__method__)
-  end
-
-  def cell_phone_number
-    df_xml_value(__method__)
-  end
-
   def tax_payer_email
     df_xml_value(__method__)
   end

--- a/app/models/direct_file_data.rb
+++ b/app/models/direct_file_data.rb
@@ -297,56 +297,28 @@ class DirectFileData < DfXmlAccessor
     write_df_xml_value(__method__, value)
   end
 
-  def fed_calculated_difference_amount
-    df_xml_value(__method__)&.to_i || 0
-  end
-
   def fed_calculated_difference_amount=(value)
     write_df_xml_value(__method__, value)
-  end
-
-  def fed_nontaxable_combat_pay_amount
-    df_xml_value(__method__)&.to_i || 0
   end
 
   def fed_nontaxable_combat_pay_amount=(value)
     write_df_xml_value(__method__, value)
   end
 
-  def fed_total_earned_income_amount
-    df_xml_value(__method__)&.to_i || 0
-  end
-
   def fed_total_earned_income_amount=(value)
     write_df_xml_value(__method__, value)
-  end
-
-  def fed_puerto_rico_income_exclusion_amount
-    df_xml_value(__method__)&.to_i || 0
   end
 
   def fed_puerto_rico_income_exclusion_amount=(value)
     write_df_xml_value(__method__, value)
   end
 
-  def fed_total_income_exclusion_amount
-    df_xml_value(__method__)&.to_i || 0
-  end
-
   def fed_total_income_exclusion_amount=(value)
     write_df_xml_value(__method__, value)
   end
 
-  def fed_housing_deduction_amount
-    df_xml_value(__method__)&.to_i || 0
-  end
-
   def fed_housing_deduction_amount=(value)
     write_df_xml_value(__method__, value)
-  end
-
-  def fed_gross_income_exclusion_amount
-    df_xml_value(__method__)&.to_i || 0
   end
 
   def fed_gross_income_exclusion_amount=(value)

--- a/app/models/direct_file_data.rb
+++ b/app/models/direct_file_data.rb
@@ -89,14 +89,6 @@ class DirectFileData < DfXmlAccessor
     parsed_xml.to_s
   end
 
-  def filing_status
-    df_xml_value(__method__)&.to_i
-  end
-
-  def filing_status=(value)
-    write_df_xml_value(__method__, value)
-  end
-
   def phone_number
     df_xml_value(__method__)
   end

--- a/spec/fixtures/state_file/fed_return_xmls/2023/az/df_complete_sample.xml
+++ b/spec/fixtures/state_file/fed_return_xmls/2023/az/df_complete_sample.xml
@@ -8,6 +8,7 @@
     <ReturnTypeCd>1040</ReturnTypeCd>
     <Filer>
       <PrimarySSN>400000003</PrimarySSN>
+      <SpouseSSN>500000003</SpouseSSN>
       <NameLine1Txt>ALEXIS&lt;ROSE</NameLine1Txt>
       <PrimaryNameControlTxt>ROSE</PrimaryNameControlTxt>
       <USAddress>

--- a/spec/fixtures/state_file/fed_return_xmls/2023/az/df_complete_sample.xml
+++ b/spec/fixtures/state_file/fed_return_xmls/2023/az/df_complete_sample.xml
@@ -13,6 +13,7 @@
       <PrimaryNameControlTxt>ROSE</PrimaryNameControlTxt>
       <USAddress>
         <AddressLine1Txt>321 Roland St</AddressLine1Txt>
+        <AddressLine2Txt>Apt B</AddressLine2Txt>
         <CityNm>Phoenix</CityNm>
         <StateAbbreviationCd>AZ</StateAbbreviationCd>
         <ZIPCd>85034</ZIPCd>
@@ -29,6 +30,8 @@
   <ReturnData documentCnt="5">
     <IRS1040 documentId="IRS10400001">
       <IndividualReturnFilingStatusCd>4</IndividualReturnFilingStatusCd>
+      <SpouseNm>Allen</SpouseNm>
+      <SpouseDeathDt>2024-07-06</SpouseDeathDt>
       <VirtualCurAcquiredDurTYInd>false</VirtualCurAcquiredDurTYInd>
       <TotalExemptPrimaryAndSpouseCnt>1</TotalExemptPrimaryAndSpouseCnt>
       <DependentDetail>
@@ -90,6 +93,8 @@
       <EsPenaltyAmt>0</EsPenaltyAmt>
       <ThirdPartyDesigneeInd>false</ThirdPartyDesigneeInd>
       <PrimaryOccupationTxt>Singer</PrimaryOccupationTxt>
+      <SpouseOccupationTxt>Actor</SpouseOccupationTxt>
+      <SurvivingSpouseInd>X</SurvivingSpouseInd>
       <RefundProductCd>NO FINANCIAL PRODUCT</RefundProductCd>
     </IRS1040>
     <IRS1040Schedule1 documentId="IRS1040S1001">

--- a/spec/fixtures/state_file/fed_return_xmls/2023/az/df_complete_sample.xml
+++ b/spec/fixtures/state_file/fed_return_xmls/2023/az/df_complete_sample.xml
@@ -66,6 +66,7 @@
       <TotalIncomeAmt>40000</TotalIncomeAmt>
       <TotalAdjustmentsAmt>0</TotalAdjustmentsAmt>
       <AdjustedGrossIncomeAmt>40000</AdjustedGrossIncomeAmt>
+      <ExcldSect933PuertoRicoIncmAmt>80</ExcldSect933PuertoRicoIncmAmt>
       <TotalItemizedOrStandardDedAmt>20800</TotalItemizedOrStandardDedAmt>
       <TotalDeductionsAmt>20800</TotalDeductionsAmt>
       <TaxableIncomeAmt>19200</TaxableIncomeAmt>
@@ -99,10 +100,13 @@
     </IRS1040>
     <IRS1040Schedule1 documentId="IRS1040S1001">
       <UnemploymentCompAmt>5000</UnemploymentCompAmt>
+      <TotalIncomeExclusionAmt>600</TotalIncomeExclusionAmt>
       <TotalAdditionalIncomeAmt>5000</TotalAdditionalIncomeAmt>
       <EducatorExpensesAmt>0</EducatorExpensesAmt>
       <StudentLoanInterestDedAmt>0</StudentLoanInterestDedAmt>
+      <HousingDeductionAmt>700</HousingDeductionAmt>
       <TotalAdjustmentsAmt>0</TotalAdjustmentsAmt>
+      <GrossIncomeExclusionAmt>900</GrossIncomeExclusionAmt>
     </IRS1040Schedule1>
     <IRS1040Schedule8812 documentId="IRS8812001" documentName="IRS1040Schedule8812">
       <AdjustedGrossIncomeAmt>40000</AdjustedGrossIncomeAmt>
@@ -125,7 +129,7 @@
         <QlfyChildUnderAgeSSNLimtAmt>1600</QlfyChildUnderAgeSSNLimtAmt>
         <ACTCAfterLimitAmt>7</ACTCAfterLimitAmt>
         <TotalEarnedIncomeAmt>35000</TotalEarnedIncomeAmt>
-        <NontaxableCombatPayAmt>0</NontaxableCombatPayAmt>
+        <NontaxableCombatPayAmt>10</NontaxableCombatPayAmt>
         <EarnedIncmMoreThanSpecifiedInd>true</EarnedIncmMoreThanSpecifiedInd>
         <NetTotalEarnedIncomeAmt>32500</NetTotalEarnedIncomeAmt>
         <NetEarnedIncomeCalculatedAmt>4875</NetEarnedIncomeCalculatedAmt>

--- a/spec/fixtures/state_file/fed_return_xmls/2023/az/df_complete_sample.xml
+++ b/spec/fixtures/state_file/fed_return_xmls/2023/az/df_complete_sample.xml
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Return xmlns="http://www.irs.gov/efile" xmlns:efile="http://www.irs.gov/efile" returnVersion="2023v5.0">
+  <ReturnHeader binaryAttachmentCnt="0">
+    <TaxYr>2023</TaxYr>
+    <TaxPeriodBeginDt>2023-01-01</TaxPeriodBeginDt>
+    <TaxPeriodEndDt>2023-12-31</TaxPeriodEndDt>
+    <SoftwareVersionNum>2022.2.100</SoftwareVersionNum>
+    <ReturnTypeCd>1040</ReturnTypeCd>
+    <Filer>
+      <PrimarySSN>400000003</PrimarySSN>
+      <NameLine1Txt>ALEXIS&lt;ROSE</NameLine1Txt>
+      <PrimaryNameControlTxt>ROSE</PrimaryNameControlTxt>
+      <USAddress>
+        <AddressLine1Txt>321 Roland St</AddressLine1Txt>
+        <CityNm>Phoenix</CityNm>
+        <StateAbbreviationCd>AZ</StateAbbreviationCd>
+        <ZIPCd>85034</ZIPCd>
+      </USAddress>
+      <PhoneNum>4805555555</PhoneNum>
+    </Filer>
+    <AdditionalFilerInformation>
+      <AtSubmissionFilingGrp>
+        <EmailAddressTxt>test011@test.com</EmailAddressTxt>
+        <CellPhoneNum>5551231234</CellPhoneNum>
+      </AtSubmissionFilingGrp>
+    </AdditionalFilerInformation>
+  </ReturnHeader>
+  <ReturnData documentCnt="5">
+    <IRS1040 documentId="IRS10400001">
+      <IndividualReturnFilingStatusCd>4</IndividualReturnFilingStatusCd>
+      <VirtualCurAcquiredDurTYInd>false</VirtualCurAcquiredDurTYInd>
+      <TotalExemptPrimaryAndSpouseCnt>1</TotalExemptPrimaryAndSpouseCnt>
+      <DependentDetail>
+        <DependentFirstNm>Axel</DependentFirstNm>
+        <DependentLastNm>Rose</DependentLastNm>
+        <DependentNameControlTxt>ROSE</DependentNameControlTxt>
+        <DependentSSN>300000009</DependentSSN>
+        <DependentRelationshipCd>SISTER</DependentRelationshipCd>
+        <EligibleForChildTaxCreditInd>X</EligibleForChildTaxCreditInd>
+      </DependentDetail>
+      <ChldWhoLivedWithYouCnt>0</ChldWhoLivedWithYouCnt>
+      <OtherDependentsListedCnt>0</OtherDependentsListedCnt>
+      <TotalExemptionsCnt>2</TotalExemptionsCnt>
+      <WagesAmt referenceDocumentId="W20001" referenceDocumentName="IRSW2">35000</WagesAmt>
+      <HouseholdEmployeeWagesAmt>0</HouseholdEmployeeWagesAmt>
+      <TipIncomeAmt>0</TipIncomeAmt>
+      <MedicaidWaiverPymtNotRptW2Amt>0</MedicaidWaiverPymtNotRptW2Amt>
+      <TaxableBenefitsAmt>0</TaxableBenefitsAmt>
+      <TaxableBenefitsForm8839Amt>0</TaxableBenefitsForm8839Amt>
+      <TotalWagesWithNoWithholdingAmt>0</TotalWagesWithNoWithholdingAmt>
+      <NontxCombatPayElectionAmt>0</NontxCombatPayElectionAmt>
+      <WagesSalariesAndTipsAmt>35000</WagesSalariesAndTipsAmt>
+      <TaxExemptInterestAmt>0</TaxExemptInterestAmt>
+      <TaxableInterestAmt>0</TaxableInterestAmt>
+      <QualifiedDividendsAmt>0</QualifiedDividendsAmt>
+      <OrdinaryDividendsAmt>0</OrdinaryDividendsAmt>
+      <TotalTaxablePensionsAmt>0</TotalTaxablePensionsAmt>
+      <SocSecBnftAmt socSecBnftCd="D">0</SocSecBnftAmt>
+      <TaxableSocSecAmt>0</TaxableSocSecAmt>
+      <CapitalGainLossAmt>0</CapitalGainLossAmt>
+      <TotalAdditionalIncomeAmt>5000</TotalAdditionalIncomeAmt>
+      <TotalIncomeAmt>40000</TotalIncomeAmt>
+      <TotalAdjustmentsAmt>0</TotalAdjustmentsAmt>
+      <AdjustedGrossIncomeAmt>40000</AdjustedGrossIncomeAmt>
+      <TotalItemizedOrStandardDedAmt>20800</TotalItemizedOrStandardDedAmt>
+      <TotalDeductionsAmt>20800</TotalDeductionsAmt>
+      <TaxableIncomeAmt>19200</TaxableIncomeAmt>
+      <TaxAmt>1993</TaxAmt>
+      <AdditionalTaxAmt>0</AdditionalTaxAmt>
+      <TotalTaxBeforeCrAndOthTaxesAmt>1993</TotalTaxBeforeCrAndOthTaxesAmt>
+      <CTCODCAmt>1993</CTCODCAmt>
+      <TotalNonrefundableCreditsAmt>0</TotalNonrefundableCreditsAmt>
+      <TotalCreditsAmt>1993</TotalCreditsAmt>
+      <TaxLessCreditsAmt>0</TaxLessCreditsAmt>
+      <TotalOtherTaxesAmt>0</TotalOtherTaxesAmt>
+      <TotalTaxAmt>0</TotalTaxAmt>
+      <FormW2WithheldTaxAmt>3000</FormW2WithheldTaxAmt>
+      <Form1099WithheldTaxAmt>0</Form1099WithheldTaxAmt>
+      <TaxWithheldOtherAmt>0</TaxWithheldOtherAmt>
+      <WithholdingTaxAmt>3500</WithholdingTaxAmt>
+      <EstimatedTaxPaymentsAmt>0</EstimatedTaxPaymentsAmt>
+      <EarnedIncomeCreditAmt referenceDocumentId="IRSEIC0001" referenceDocumentName="IRS1040ScheduleEIC">1044</EarnedIncomeCreditAmt>
+      <RefundableCreditsAmt>1051</RefundableCreditsAmt>
+      <TotalPaymentsAmt>4551</TotalPaymentsAmt>
+      <OverpaidAmt>4551</OverpaidAmt>
+      <RefundAmt>4551</RefundAmt>
+      <AppliedToEsTaxAmt>0</AppliedToEsTaxAmt>
+      <OwedAmt>0</OwedAmt>
+      <EsPenaltyAmt>0</EsPenaltyAmt>
+      <ThirdPartyDesigneeInd>false</ThirdPartyDesigneeInd>
+      <PrimaryOccupationTxt>Singer</PrimaryOccupationTxt>
+      <RefundProductCd>NO FINANCIAL PRODUCT</RefundProductCd>
+    </IRS1040>
+    <IRS1040Schedule1 documentId="IRS1040S1001">
+      <UnemploymentCompAmt>5000</UnemploymentCompAmt>
+      <TotalAdditionalIncomeAmt>5000</TotalAdditionalIncomeAmt>
+      <EducatorExpensesAmt>0</EducatorExpensesAmt>
+      <StudentLoanInterestDedAmt>0</StudentLoanInterestDedAmt>
+      <TotalAdjustmentsAmt>0</TotalAdjustmentsAmt>
+    </IRS1040Schedule1>
+    <IRS1040Schedule8812 documentId="IRS8812001" documentName="IRS1040Schedule8812">
+      <AdjustedGrossIncomeAmt>40000</AdjustedGrossIncomeAmt>
+      <ModifiedAGIAmt>40000</ModifiedAGIAmt>
+      <QlfyChildUnderAgeSSNCnt>1</QlfyChildUnderAgeSSNCnt>
+      <QlfyChildUnderAgeSSNLimtAmt>2000</QlfyChildUnderAgeSSNLimtAmt>
+      <OtherDependentCnt>0</OtherDependentCnt>
+      <OtherDependentCreditAmt>0</OtherDependentCreditAmt>
+      <InitialCTCODCAmt>2000</InitialCTCODCAmt>
+      <FilingStatusThresholdCd>200000</FilingStatusThresholdCd>
+      <ExcessAdjGrossIncomeAmt>0</ExcessAdjGrossIncomeAmt>
+      <ModifiedAGIPhaseOutAmt>0</ModifiedAGIPhaseOutAmt>
+      <CTCODCOverAGILimitInd>true</CTCODCOverAGILimitInd>
+      <CTCODCAfterAGILimitAmt>2000</CTCODCAfterAGILimitAmt>
+      <ACTCTaxLiabiltyLimitAmt>1993</ACTCTaxLiabiltyLimitAmt>
+      <CTCODCAmt>1993</CTCODCAmt>
+      <ClaimACTCAllFilersGrp>
+        <ACTCBeforeLimitAmt>7</ACTCBeforeLimitAmt>
+        <QlfyChildUnderAgeSSNCnt>1</QlfyChildUnderAgeSSNCnt>
+        <QlfyChildUnderAgeSSNLimtAmt>1600</QlfyChildUnderAgeSSNLimtAmt>
+        <ACTCAfterLimitAmt>7</ACTCAfterLimitAmt>
+        <TotalEarnedIncomeAmt>35000</TotalEarnedIncomeAmt>
+        <NontaxableCombatPayAmt>0</NontaxableCombatPayAmt>
+        <EarnedIncmMoreThanSpecifiedInd>true</EarnedIncmMoreThanSpecifiedInd>
+        <NetTotalEarnedIncomeAmt>32500</NetTotalEarnedIncomeAmt>
+        <NetEarnedIncomeCalculatedAmt>4875</NetEarnedIncomeCalculatedAmt>
+        <ThreeOrMoreQlfyChildrenInd>false</ThreeOrMoreQlfyChildrenInd>
+        <FromW2Amt>2678</FromW2Amt>
+        <CalcFromW2AndReturnAmt>2678</CalcFromW2AndReturnAmt>
+        <CalcAmtFromRetPlusTaxWhldAmt>1044</CalcAmtFromRetPlusTaxWhldAmt>
+        <CalculatedDifferenceAmt>1634</CalculatedDifferenceAmt>
+        <LargerCalcIncomeOrDiffAmt>4875</LargerCalcIncomeOrDiffAmt>
+      </ClaimACTCAllFilersGrp>
+      <AdditionalChildTaxCreditAmt>7</AdditionalChildTaxCreditAmt>
+    </IRS1040Schedule8812>
+    <IRS1040ScheduleEIC documentId="IRSEIC0001" documentName="IRS1040ScheduleEIC">
+      <QualifyingChildInformation>
+        <QualifyingChildNameControlTxt>ROSE</QualifyingChildNameControlTxt>
+        <ChildFirstAndLastName>
+          <PersonFirstNm>Axel</PersonFirstNm>
+          <PersonLastNm>Rose</PersonLastNm>
+        </ChildFirstAndLastName>
+        <QualifyingChildSSN>300000009</QualifyingChildSSN>
+        <ChildBirthYr>2010</ChildBirthYr>
+        <ChildIsAStudentUnder24Ind>false</ChildIsAStudentUnder24Ind>
+        <ChildPermanentlyDisabledInd>false</ChildPermanentlyDisabledInd>
+        <ChildRelationshipCd>SISTER</ChildRelationshipCd>
+        <MonthsChildLivedWithYouCnt>07</MonthsChildLivedWithYouCnt>
+      </QualifyingChildInformation>
+    </IRS1040ScheduleEIC>
+    <IRSW2 documentId="W20001" documentName="IRSW2">
+      <EmployeeSSN>400000003</EmployeeSSN>
+      <EmployerEIN>234567891</EmployerEIN>
+      <EmployerNameControlTxt>ROSE</EmployerNameControlTxt>
+      <EmployerName>
+        <BusinessNameLine1Txt>Rose Apothecary</BusinessNameLine1Txt>
+      </EmployerName>
+      <EmployerUSAddress>
+        <AddressLine1Txt>123 Twyla Road</AddressLine1Txt>
+        <CityNm>Phoenix</CityNm>
+        <StateAbbreviationCd>AZ</StateAbbreviationCd>
+        <ZIPCd>85034</ZIPCd>
+      </EmployerUSAddress>
+      <EmployeeNm>Alexis Rose</EmployeeNm>
+      <EmployeeUSAddress>
+        <AddressLine1Txt>321 Roland St</AddressLine1Txt>
+        <CityNm>Phoenix</CityNm>
+        <StateAbbreviationCd>AZ</StateAbbreviationCd>
+        <ZIPCd>85034</ZIPCd>
+      </EmployeeUSAddress>
+      <WagesAmt>35000</WagesAmt>
+      <WithholdingAmt>3000</WithholdingAmt>
+      <SocialSecurityWagesAmt>35000</SocialSecurityWagesAmt>
+      <SocialSecurityTaxAmt>2170</SocialSecurityTaxAmt>
+      <MedicareWagesAndTipsAmt>35000</MedicareWagesAndTipsAmt>
+      <MedicareTaxWithheldAmt>508</MedicareTaxWithheldAmt>
+      <SocialSecurityTipsAmt>0</SocialSecurityTipsAmt>
+      <AllocatedTipsAmt>50</AllocatedTipsAmt>
+      <DependentCareBenefitsAmt>70</DependentCareBenefitsAmt>
+      <NonqualifiedPlansAmt>10</NonqualifiedPlansAmt>
+      <EmployersUseGrp>
+        <EmployersUseCd>Q</EmployersUseCd>
+        <EmployersUseAmt>0</EmployersUseAmt>
+      </EmployersUseGrp>
+      <RetirementPlanInd>X</RetirementPlanInd>
+      <ThirdPartySickPayInd>X</ThirdPartySickPayInd>
+      <W2StateLocalTaxGrp>
+        <W2StateTaxGrp>
+          <StateAbbreviationCd>AZ</StateAbbreviationCd>
+          <EmployerStateIdNum>12345</EmployerStateIdNum>
+          <StateWagesAmt>35000</StateWagesAmt>
+          <StateIncomeTaxAmt>500</StateIncomeTaxAmt>
+          <W2LocalTaxGrp>
+            <LocalWagesAndTipsAmt>1350</LocalWagesAndTipsAmt>
+            <LocalIncomeTaxAmt>1000</LocalIncomeTaxAmt>
+            <LocalityNm>SomeCity</LocalityNm>
+          </W2LocalTaxGrp>
+        </W2StateTaxGrp>
+      </W2StateLocalTaxGrp>
+      <StandardOrNonStandardCd>S</StandardOrNonStandardCd>
+    </IRSW2>
+    <IRS1099R documentId="IRS1099R0001">
+      <PayerNameControlTxt>ALEXISPAYER</PayerNameControlTxt>
+      <PayerName>
+        <BusinessNameLine1Txt>Payer Name</BusinessNameLine1Txt>
+      </PayerName>
+      <PayerUSAddress>
+        <AddressLine1Txt>123 Walnut Street</AddressLine1Txt>
+        <CityNm>SomeTown</CityNm>
+        <StateAbbreviationCd>AZ</StateAbbreviationCd>
+        <ZIPCd>45502</ZIPCd>
+      </PayerUSAddress>
+      <PayerEIN>000000011</PayerEIN>
+      <PhoneNum>2225551111</PhoneNum>
+      <GrossDistributionAmt>2000</GrossDistributionAmt>
+      <TaxableAmt>10000</TaxableAmt>
+      <FederalIncomeTaxWithheldAmt>3000</FederalIncomeTaxWithheldAmt>
+      <F1099RDistributionCd>9</F1099RDistributionCd>
+      <StandardOrNonStandardCd>S</StandardOrNonStandardCd>
+    </IRS1099R>
+  </ReturnData>
+</Return>

--- a/spec/lib/efile/ny/it201_spec.rb
+++ b/spec/lib/efile/ny/it201_spec.rb
@@ -648,7 +648,7 @@ describe Efile::Ny::It201 do
         intake.dependents.create(dob: 5.years.ago, ctc_qualifying: true)
         intake.dependents.create(dob: 3.years.ago, ctc_qualifying: true)
         intake.direct_file_data.fed_ctc = 1_000
-        allow_any_instance_of(DirectFileData).to receive(:fed_tax).and_return(nil)
+        allow_any_instance_of(DirectFileData).to receive(:fed_tax_amt).and_return(nil)
       end
 
       it 'avoids getting undefined method `-` for nil:NilClass (NoMethodError)' do
@@ -705,7 +705,7 @@ describe Efile::Ny::It201 do
         intake.dependents.create(dob: 5.years.ago, ctc_qualifying: true)
         intake.dependents.create(dob: 3.years.ago, ctc_qualifying: true)
         intake.dependents.create(dob: 1.years.ago, ctc_qualifying: true)
-        intake.direct_file_data.fed_tax = 0
+        intake.direct_file_data.fed_tax_amt = 0
         intake.direct_file_data.fed_ctc = 1_000
       end
 

--- a/spec/models/direct_file_data_spec.rb
+++ b/spec/models/direct_file_data_spec.rb
@@ -9,6 +9,10 @@ describe DirectFileData do
     ["filing_status", 4, 3],
     ["phone_number", "4805555555"],
     ["cell_phone_number", "5551231234"],
+    ["tax_payer_email", "test011@test.com"],
+    ["primary_ssn", "400000003"],
+    ["spouse_ssn", "500000003"],
+    ["primary_occupation", "Singer"],
   ].each do |node_name, current_value, special_value=nil|
     describe "##{node_name}" do
       it "returns the value" do

--- a/spec/models/direct_file_data_spec.rb
+++ b/spec/models/direct_file_data_spec.rb
@@ -23,6 +23,13 @@ describe DirectFileData do
     ["mailing_state", "AZ"],
     ["mailing_zip", "85034"],
     ["fed_tax_amt", 1993],
+    ["fed_calculated_difference_amount", 1634],
+    ["fed_nontaxable_combat_pay_amount", 10],
+    ["fed_total_earned_income_amount", 35000],
+    ["fed_puerto_rico_income_exclusion_amount", 80],
+    ["fed_total_income_exclusion_amount", 600],
+    ["fed_housing_deduction_amount", 700],
+    ["fed_gross_income_exclusion_amount", 900],
   ].each do |node_name, current_value|
     describe "##{node_name}" do
       it "returns the value" do

--- a/spec/models/direct_file_data_spec.rb
+++ b/spec/models/direct_file_data_spec.rb
@@ -5,15 +5,16 @@ describe DirectFileData do
   let(:direct_file_data) { DirectFileData.new(xml.to_s) }
 
   [
-    ["tax_return_year", 2023, :year],
-  ].each do |node_name, current_value, type|
+    ["tax_return_year", 2023, 2024],
+    ["filing_status", 4, 3],
+  ].each do |node_name, current_value, special_value=nil|
     describe "##{node_name}" do
       it "returns the value" do
         expect(direct_file_data.send(node_name)).to eq current_value
       end
 
-      if type == :amount
-        context "when the attribute is not present" do
+      if current_value.is_a?(Integer) && special_value.nil?
+        context "when the attribute is an amount and is not present" do
           before do
             selector = DirectFileData::SELECTORS[node_name.to_sym]
             xml.at(selector).remove
@@ -28,15 +29,15 @@ describe DirectFileData do
 
     describe "##{node_name}=" do
       context "when the node is present" do
-        if type == :amount
+        if special_value.present?
+          it "sets the value" do
+            direct_file_data.send("#{node_name}=", special_value.to_s)
+            expect(direct_file_data.send(node_name)).to eq special_value
+          end
+        elsif current_value.is_a?(Integer)
           it "sets the value" do
             direct_file_data.send("#{node_name}=", "500")
             expect(direct_file_data.send(node_name)).to eq 500
-          end
-        elsif type == :year
-          it "sets the value" do
-            direct_file_data.send("#{node_name}=", "2023")
-            expect(direct_file_data.send(node_name)).to eq 2023
           end
         else
           it "sets the value" do
@@ -52,15 +53,15 @@ describe DirectFileData do
           xml.at(selector).remove
         end
 
-        if type == :amount
+        if special_value.present?
+          it "sets the value" do
+            direct_file_data.send("#{node_name}=", special_value.to_s)
+            expect(direct_file_data.send(node_name)).to eq special_value
+          end
+        elsif current_value.is_a?(Integer)
           it "sets the value" do
             direct_file_data.send("#{node_name}=", "500")
             expect(direct_file_data.send(node_name)).to eq 500
-          end
-        elsif type == :year
-          it "sets the value" do
-            direct_file_data.send("#{node_name}=", "2023")
-            expect(direct_file_data.send(node_name)).to eq 2023
           end
         else
           it "sets the value" do

--- a/spec/models/direct_file_data_spec.rb
+++ b/spec/models/direct_file_data_spec.rb
@@ -1,12 +1,14 @@
 require 'rails_helper'
 
 describe DirectFileData do
-  let(:xml) { Nokogiri::XML(StateFile::XmlReturnSampleService.new.read("az_alexis_hoh_w2_and_1099")) }
+  let(:xml) { Nokogiri::XML(StateFile::XmlReturnSampleService.new.read("az_df_complete_sample")) }
   let(:direct_file_data) { DirectFileData.new(xml.to_s) }
 
   [
     ["tax_return_year", 2023, 2024],
     ["filing_status", 4, 3],
+    ["phone_number", "4805555555"],
+    ["cell_phone_number", "5551231234"],
   ].each do |node_name, current_value, special_value=nil|
     describe "##{node_name}" do
       it "returns the value" do

--- a/spec/models/direct_file_data_spec.rb
+++ b/spec/models/direct_file_data_spec.rb
@@ -5,21 +5,30 @@ describe DirectFileData do
   let(:direct_file_data) { DirectFileData.new(xml.to_s) }
 
   [
-    ["tax_return_year", 2023, 2024],
-    ["filing_status", 4, 3],
+    ["tax_return_year", 2023],
+    ["filing_status", 4],
     ["phone_number", "4805555555"],
     ["cell_phone_number", "5551231234"],
     ["tax_payer_email", "test011@test.com"],
     ["primary_ssn", "400000003"],
     ["spouse_ssn", "500000003"],
     ["primary_occupation", "Singer"],
-  ].each do |node_name, current_value, special_value=nil|
+    ["spouse_occupation", "Actor"],
+    ["surviving_spouse", "X"],
+    ["spouse_date_of_death", "2024-07-06"],
+    ["spouse_name", "Allen"],
+    ["mailing_city", "Phoenix"],
+    ["mailing_street", "321 Roland St"],
+    ["mailing_apartment", "Apt B"],
+    ["mailing_state", "AZ"],
+    ["mailing_zip", "85034"],
+  ].each do |node_name, current_value|
     describe "##{node_name}" do
       it "returns the value" do
         expect(direct_file_data.send(node_name)).to eq current_value
       end
 
-      if current_value.is_a?(Integer) && special_value.nil?
+      if current_value.is_a?(Integer) && !node_name.ends_with?("_year", "_status")
         context "when the attribute is an amount and is not present" do
           before do
             selector = DirectFileData::SELECTORS[node_name.to_sym]
@@ -28,51 +37,6 @@ describe DirectFileData do
 
           it "defaults to 0" do
             expect(direct_file_data.send(node_name)).to eq 0
-          end
-        end
-      end
-    end
-
-    describe "##{node_name}=" do
-      context "when the node is present" do
-        if special_value.present?
-          it "sets the value" do
-            direct_file_data.send("#{node_name}=", special_value.to_s)
-            expect(direct_file_data.send(node_name)).to eq special_value
-          end
-        elsif current_value.is_a?(Integer)
-          it "sets the value" do
-            direct_file_data.send("#{node_name}=", "500")
-            expect(direct_file_data.send(node_name)).to eq 500
-          end
-        else
-          it "sets the value" do
-            direct_file_data.send("#{node_name}=", "New Value")
-            expect(direct_file_data.send(node_name)).to eq "New Value"
-          end
-        end
-      end
-
-      context "when the node is not present" do
-        before do
-          selector = DirectFileData::SELECTORS[node_name.to_sym]
-          xml.at(selector).remove
-        end
-
-        if special_value.present?
-          it "sets the value" do
-            direct_file_data.send("#{node_name}=", special_value.to_s)
-            expect(direct_file_data.send(node_name)).to eq special_value
-          end
-        elsif current_value.is_a?(Integer)
-          it "sets the value" do
-            direct_file_data.send("#{node_name}=", "500")
-            expect(direct_file_data.send(node_name)).to eq 500
-          end
-        else
-          it "sets the value" do
-            direct_file_data.send("#{node_name}=", "New Value")
-            expect(direct_file_data.send(node_name)).to eq "New Value"
           end
         end
       end

--- a/spec/models/direct_file_data_spec.rb
+++ b/spec/models/direct_file_data_spec.rb
@@ -22,6 +22,7 @@ describe DirectFileData do
     ["mailing_apartment", "Apt B"],
     ["mailing_state", "AZ"],
     ["mailing_zip", "85034"],
+    ["fed_tax_amt", 1993],
   ].each do |node_name, current_value|
     describe "##{node_name}" do
       it "returns the value" do

--- a/spec/models/direct_file_data_spec.rb
+++ b/spec/models/direct_file_data_spec.rb
@@ -1,6 +1,77 @@
 require 'rails_helper'
 
 describe DirectFileData do
+  let(:xml) { Nokogiri::XML(StateFile::XmlReturnSampleService.new.read("az_alexis_hoh_w2_and_1099")) }
+  let(:direct_file_data) { DirectFileData.new(xml.to_s) }
+
+  [
+    ["tax_return_year", 2023, :year],
+  ].each do |node_name, current_value, type|
+    describe "##{node_name}" do
+      it "returns the value" do
+        expect(direct_file_data.send(node_name)).to eq current_value
+      end
+
+      if type == :amount
+        context "when the attribute is not present" do
+          before do
+            selector = DirectFileData::SELECTORS[node_name.to_sym]
+            xml.at(selector).remove
+          end
+
+          it "defaults to 0" do
+            expect(direct_file_data.send(node_name)).to eq 0
+          end
+        end
+      end
+    end
+
+    describe "##{node_name}=" do
+      context "when the node is present" do
+        if type == :amount
+          it "sets the value" do
+            direct_file_data.send("#{node_name}=", "500")
+            expect(direct_file_data.send(node_name)).to eq 500
+          end
+        elsif type == :year
+          it "sets the value" do
+            direct_file_data.send("#{node_name}=", "2023")
+            expect(direct_file_data.send(node_name)).to eq 2023
+          end
+        else
+          it "sets the value" do
+            direct_file_data.send("#{node_name}=", "New Value")
+            expect(direct_file_data.send(node_name)).to eq "New Value"
+          end
+        end
+      end
+
+      context "when the node is not present" do
+        before do
+          selector = DirectFileData::SELECTORS[node_name.to_sym]
+          xml.at(selector).remove
+        end
+
+        if type == :amount
+          it "sets the value" do
+            direct_file_data.send("#{node_name}=", "500")
+            expect(direct_file_data.send(node_name)).to eq 500
+          end
+        elsif type == :year
+          it "sets the value" do
+            direct_file_data.send("#{node_name}=", "2023")
+            expect(direct_file_data.send(node_name)).to eq 2023
+          end
+        else
+          it "sets the value" do
+            direct_file_data.send("#{node_name}=", "New Value")
+            expect(direct_file_data.send(node_name)).to eq "New Value"
+          end
+        end
+      end
+    end
+  end
+
   describe '#ny_public_employee_retirement_contributions' do
     let(:desc1) { '414H' }
     let(:desc2) { '414 (H)' }


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- N/A, did this mostly with some spare minutes
## Is PM acceptance required? (delete one)
- No - merge after code review approval
## What was done?
- Chatted recently with Martha and Mike about how it would be nice to apply the DfXmlAccessor dynamic method creation to the df data class because it has so many repetitive xml readers and writers
- Started down a path of defining both readers/writers and quickly realized that our xml writing code is not that robust (esp if tag order matters) so this PR just turns some of the _readers_ into dynamically defined methods
- This required a small refactor of the DfXmlAccessor class so the reader and writer definitions are separate
## How to test?
- I added tests for all of the methods I "deleted". Unclear if they were actually tested anywhere—could be implicitly in the xml builders or something, but having it in the df data spec seems nice to me
- Risk Assessment
  - The main thing this could affect is building the state xml but we've got plenty of time to test that before the season begins
