### PR TITLE
Nj 37/38 add NJ1040 lines 6 and 7

### DIFF
--- a/app/lib/efile/line_data.yml
+++ b/app/lib/efile/line_data.yml
@@ -466,3 +466,13 @@ NCD400_LINE_20B:
   label: '20b For each W2, if EmployeeSSN = SpouseSSN, add StateIncomeTaxAmt to sum'
 NCD400_LINE_23:
   label: '23 Add lines 20a through 22'
+NJ1040_LINE_6_SPOUSE:
+  label: '6 Spouse Regular Exemption'
+NJ1040_LINE_6:
+  label: '6 Sum all regular exemptions, multiply by 1000'
+NJ1040_LINE_7_SELF:
+  label: '7 Primary Senior 65+ Exemption'
+NJ1040_LINE_7_SPOUSE:
+  label: '7 Spouse Senior 65+ Exemption'
+NJ1040_LINE_7:
+  label: '7 Sum all Senior 65+ Exemption, multiply by 1000'

--- a/app/lib/efile/nj/nj1040.rb
+++ b/app/lib/efile/nj/nj1040.rb
@@ -3,8 +3,58 @@ module Efile
     class Nj1040 < ::Efile::TaxCalculator
       attr_reader :lines
 
+      def initialize(year:, intake:, include_source: false)
+        super
+      end
+
       def calculate
+        set_line(:NJ1040_LINE_6_SPOUSE, :calculate_line_6_spouse_checkbox)
+        set_line(:NJ1040_LINE_6, :calculate_line_6)
+        set_line(:NJ1040_LINE_7_SELF, :calculate_line_7_self_checkbox)
+        set_line(:NJ1040_LINE_7_SPOUSE, :calculate_line_7_spouse_checkbox)
+        set_line(:NJ1040_LINE_7, :calculate_line_7)
         @lines.transform_values(&:value)
+      end
+
+      def calculate_line_6_spouse_checkbox
+        @intake.filing_status_mfj?
+      end
+
+      def calculate_line_6
+        number_of_line_6_exemptions = 1 # defaults to 1 since self checkbox is always true
+        if calculate_line_6_spouse_checkbox
+          number_of_line_6_exemptions += 1
+        end
+        # DF data does not contain Domestic Partner information, so we are not supporting the Domestic Partner exemption
+        number_of_line_6_exemptions * 1_000
+      end
+
+      def calculate_line_7_self_checkbox
+        over_65_birth_year = MultiTenantService.new(:statefile).current_tax_year - 65
+        return true if @intake.primary_birth_date <= Date.new(over_65_birth_year, 12, 31)
+        false
+      end
+
+      def calculate_line_7_spouse_checkbox
+        over_65_birth_year = MultiTenantService.new(:statefile).current_tax_year - 65
+        return false unless @intake.spouse_birth_date.present?
+        return true if @intake.spouse_birth_date <= Date.new(over_65_birth_year, 12, 31)
+        false
+      end
+
+      def calculate_line_7
+        number_of_line_7_exemptions = 0
+        if calculate_line_7_self_checkbox
+          number_of_line_7_exemptions += 1
+        end
+        if calculate_line_7_spouse_checkbox
+          number_of_line_7_exemptions += 1
+        end
+        number_of_line_7_exemptions * 1_000
+      end
+
+      def total_exemption_amount
+        0
       end
 
       def refund_or_owed_amount

--- a/app/lib/efile/nj/nj1040.rb
+++ b/app/lib/efile/nj/nj1040.rb
@@ -8,48 +8,35 @@ module Efile
       end
 
       def calculate
-        set_line(:NJ1040_LINE_6_SPOUSE, :calculate_line_6_spouse_checkbox)
+        set_line(:NJ1040_LINE_6_SPOUSE, :line_6_spouse_checkbox)
         set_line(:NJ1040_LINE_6, :calculate_line_6)
-        set_line(:NJ1040_LINE_7_SELF, :calculate_line_7_self_checkbox)
-        set_line(:NJ1040_LINE_7_SPOUSE, :calculate_line_7_spouse_checkbox)
+        set_line(:NJ1040_LINE_7_SELF, :line_7_self_checkbox)
+        set_line(:NJ1040_LINE_7_SPOUSE, :line_7_spouse_checkbox)
         set_line(:NJ1040_LINE_7, :calculate_line_7)
         @lines.transform_values(&:value)
       end
 
-      def calculate_line_6_spouse_checkbox
+      def line_6_spouse_checkbox
         @intake.filing_status_mfj?
       end
 
       def calculate_line_6
-        number_of_line_6_exemptions = 1 # defaults to 1 since self checkbox is always true
-        if calculate_line_6_spouse_checkbox
-          number_of_line_6_exemptions += 1
-        end
-        # DF data does not contain Domestic Partner information, so we are not supporting the Domestic Partner exemption
+        self_exemption = 1
+        number_of_line_6_exemptions = self_exemption + number_of_true_checkboxes([line_6_spouse_checkbox])
         number_of_line_6_exemptions * 1_000
       end
 
-      def calculate_line_7_self_checkbox
-        over_65_birth_year = MultiTenantService.new(:statefile).current_tax_year - 65
-        return true if @intake.primary_birth_date <= Date.new(over_65_birth_year, 12, 31)
-        false
+      def line_7_self_checkbox
+        is_over_65(@intake.primary_birth_date)
       end
 
-      def calculate_line_7_spouse_checkbox
-        over_65_birth_year = MultiTenantService.new(:statefile).current_tax_year - 65
+      def line_7_spouse_checkbox
         return false unless @intake.spouse_birth_date.present?
-        return true if @intake.spouse_birth_date <= Date.new(over_65_birth_year, 12, 31)
-        false
+        is_over_65(@intake.spouse_birth_date)
       end
 
       def calculate_line_7
-        number_of_line_7_exemptions = 0
-        if calculate_line_7_self_checkbox
-          number_of_line_7_exemptions += 1
-        end
-        if calculate_line_7_spouse_checkbox
-          number_of_line_7_exemptions += 1
-        end
+        number_of_line_7_exemptions = number_of_true_checkboxes([line_7_self_checkbox, line_7_spouse_checkbox])
         number_of_line_7_exemptions * 1_000
       end
 
@@ -64,6 +51,17 @@ module Efile
       def analytics_attrs
         {
         }
+      end
+
+      private
+
+      def is_over_65(birth_date)
+        over_65_birth_year = MultiTenantService.new(:statefile).current_tax_year - 65
+        birth_date <= Date.new(over_65_birth_year, 12, 31)
+      end
+
+      def number_of_true_checkboxes(checkbox_array_for_line)
+        checkbox_array_for_line.sum { |a| a == true ? 1 : 0 }
       end
     end
   end

--- a/app/lib/pdf_filler/nj1040_pdf.rb
+++ b/app/lib/pdf_filler/nj1040_pdf.rb
@@ -43,7 +43,19 @@ module PdfFiller
         "SpousesCU Partners SSN if filing jointly": get_address, # address text field
         "CountyMunicipality Code See Table page 50": @xml_document.at("ReturnHeaderState Filer USAddress CityNm")&.text,  # city / town text field
         "State": @xml_document.at("ReturnHeaderState Filer USAddress StateAbbreviationCd")&.text,
-        "ZIP Code": @xml_document.at("ReturnHeaderState Filer USAddress ZIPCd")&.text
+        "ZIP Code": @xml_document.at("ReturnHeaderState Filer USAddress ZIPCd")&.text,
+
+        # line 6 exemptions
+        "Check Box39": @xml_document.at("Exemptions SpouseCuRegular")&.text == "X" ? "Yes" : "Off",
+        "Check Box40": "Off",
+        "Domestic": get_line_6_exemption_count,
+        "x  1000": get_line_6_exemption_count * 1000,
+
+        # line 7 exemptions
+        "Check Box41": @xml_document.at("Exemptions YouOver65")&.text == "X" ? "Yes" : "Off",
+        "Check Box42": @xml_document.at("Exemptions SpouseCuPartner65OrOver")&.text == "X" ? "Yes" : "Off",
+        "undefined_9": get_line_7_exemption_count,
+        "x  1000_2": get_line_7_exemption_count * 1000,
       }
       if spouse_ssn
         answers.merge!({
@@ -70,6 +82,21 @@ module PdfFiller
 
     def get_taxpayer_ssn
       @xml_document.at("ReturnHeaderState Filer Primary TaxpayerSSN")&.text
+    end
+
+    def get_line_6_exemption_count
+      @xml_document.at("Exemptions SpouseCuRegular")&.text == "X" ? 2 : 1
+    end
+
+    def get_line_7_exemption_count
+      count = 0
+      if @xml_document.at("Exemptions YouOver65")&.text == "X"
+        count += 1
+      end
+      if @xml_document.at("Exemptions SpouseCuPartner65OrOver")&.text == "X"
+        count += 1
+      end
+      count
     end
 
     def get_address

--- a/app/lib/pdf_filler/nj1040_pdf.rb
+++ b/app/lib/pdf_filler/nj1040_pdf.rb
@@ -46,14 +46,14 @@ module PdfFiller
         "ZIP Code": @xml_document.at("ReturnHeaderState Filer USAddress ZIPCd")&.text,
 
         # line 6 exemptions
-        "Check Box39": @xml_document.at("Exemptions SpouseCuRegular")&.text == "X" ? "Yes" : "Off",
+        "Check Box39": pdf_checkbox_value(@xml_document.at("Exemptions SpouseCuRegular")),
         "Check Box40": "Off",
         "Domestic": get_line_6_exemption_count,
         "x  1000": get_line_6_exemption_count * 1000,
 
         # line 7 exemptions
-        "Check Box41": @xml_document.at("Exemptions YouOver65")&.text == "X" ? "Yes" : "Off",
-        "Check Box42": @xml_document.at("Exemptions SpouseCuPartner65OrOver")&.text == "X" ? "Yes" : "Off",
+        "Check Box41": pdf_checkbox_value(@xml_document.at("Exemptions YouOver65")),
+        "Check Box42": pdf_checkbox_value(@xml_document.at("Exemptions SpouseCuPartner65OrOver")),
         "undefined_9": get_line_7_exemption_count,
         "x  1000_2": get_line_7_exemption_count * 1000,
       }
@@ -75,6 +75,10 @@ module PdfFiller
     end
 
     private
+
+    def pdf_checkbox_value(checkbox_xml)
+      checkbox_xml&.text == "X" ? "Yes" : "Off"
+    end
 
     def get_county_code
       @xml_document.at("ReturnDataState FormNJ1040 Header CountyCode")&.text

--- a/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
+++ b/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
@@ -50,9 +50,13 @@ module SubmissionBuilder
                       raise "Filing status not found"
                     end
                   end
-                  
+
                   xml.Exemptions do
                     xml.YouRegular "X"
+                    xml.SpouseCuRegular calculated_fields.fetch(:NJ1040_LINE_6_SPOUSE) ? "X" : ""
+                    xml.DomesticPartnerRegular ""
+                    xml.YouOver65 calculated_fields.fetch(:NJ1040_LINE_7_SELF) ? "X" : ""
+                    xml.SpouseCuPartner65OrOver calculated_fields.fetch(:NJ1040_LINE_7_SPOUSE) ? "X" : ""
                     xml.NumOfQualiDependChild qualifying_dependents.count(&:qualifying_child?)
                     xml.NumOfOtherDepend qualifying_dependents.count(&:qualifying_relative?)
                   end

--- a/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
+++ b/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
@@ -53,10 +53,15 @@ module SubmissionBuilder
 
                   xml.Exemptions do
                     xml.YouRegular "X"
-                    xml.SpouseCuRegular calculated_fields.fetch(:NJ1040_LINE_6_SPOUSE) ? "X" : ""
-                    xml.DomesticPartnerRegular ""
-                    xml.YouOver65 calculated_fields.fetch(:NJ1040_LINE_7_SELF) ? "X" : ""
-                    xml.SpouseCuPartner65OrOver calculated_fields.fetch(:NJ1040_LINE_7_SPOUSE) ? "X" : ""
+                    if calculated_fields.fetch(:NJ1040_LINE_6_SPOUSE)
+                      xml.SpouseCuRegular "X"
+                    end
+                    if calculated_fields.fetch(:NJ1040_LINE_7_SELF)
+                      xml.YouOver65 "X"
+                    end
+                    if calculated_fields.fetch(:NJ1040_LINE_7_SPOUSE)
+                      xml.SpouseCuPartner65OrOver "X"
+                    end
                     xml.NumOfQualiDependChild qualifying_dependents.count(&:qualifying_child?)
                     xml.NumOfOtherDepend qualifying_dependents.count(&:qualifying_relative?)
                   end

--- a/spec/factories/state_file_nj_intakes.rb
+++ b/spec/factories/state_file_nj_intakes.rb
@@ -112,7 +112,7 @@ FactoryBot.define do
       raw_direct_file_data { StateFile::XmlReturnSampleService.new.read('nj_zeus_many_w2s') }
     end
 
-    trait :married do
+    trait :married_filing_jointly do
       filing_status { "married_filing_jointly" }
       spouse_birth_date { Date.new(1990, 1, 1) }
       spouse_ssn { "123456789" }
@@ -122,7 +122,7 @@ FactoryBot.define do
       primary_birth_date { Date.new(1900, 1, 1) }
     end
 
-    trait :married_spouse_over_65 do
+    trait :mfj_spouse_over_65 do
       filing_status { "married_filing_jointly" }
       spouse_birth_date { Date.new(1900, 1, 1) }
       spouse_ssn { "123456789" }

--- a/spec/factories/state_file_nj_intakes.rb
+++ b/spec/factories/state_file_nj_intakes.rb
@@ -88,6 +88,7 @@ FactoryBot.define do
     raw_direct_file_data { File.read(Rails.root.join('spec', 'fixtures', 'state_file', 'fed_return_xmls', '2023', 'nj', 'zeus_one_dep.xml')) }
     primary_first_name { "New" }
     primary_last_name { "Jerseyan" }
+    primary_birth_date { Date.new(1990, 1, 1) }
 
     after(:build) do |intake, evaluator|
       numeric_status = {
@@ -109,6 +110,22 @@ FactoryBot.define do
 
     trait :df_data_many_w2s do
       raw_direct_file_data { StateFile::XmlReturnSampleService.new.read('nj_zeus_many_w2s') }
+    end
+
+    trait :married do
+      filing_status { "married_filing_jointly" }
+      spouse_birth_date { Date.new(1990, 1, 1) }
+      spouse_ssn { "123456789" }
+    end
+
+    trait :primary_over_65 do
+      primary_birth_date { Date.new(1900, 1, 1) }
+    end
+
+    trait :married_spouse_over_65 do
+      filing_status { "married_filing_jointly" }
+      spouse_birth_date { Date.new(1900, 1, 1) }
+      spouse_ssn { "123456789" }
     end
   end
 end

--- a/spec/lib/efile/nj/nj1040_spec.rb
+++ b/spec/lib/efile/nj/nj1040_spec.rb
@@ -12,10 +12,12 @@ describe Efile::Nj::Nj1040 do
       intake: intake
     )
   end
+  before do
+    instance.calculate
+  end
 
   context 'when filing status is single' do
     it "sets line 6 to 1000" do
-      instance.calculate
       expect(instance.lines[:NJ1040_LINE_6].value).to eq(1000)
     end
 
@@ -24,9 +26,7 @@ describe Efile::Nj::Nj1040 do
         create(:state_file_nj_intake,
                primary_birth_date: Date.new(over_65_birth_year, 1, 1))
       end
-      before do
-        instance.calculate
-      end
+
       it 'checks the self 65+ checkbox and sets line 7 to 1000' do
         expect(instance.lines[:NJ1040_LINE_7_SELF].value).to eq(true)
         expect(instance.lines[:NJ1040_LINE_7_SPOUSE].value).to eq(false)
@@ -39,9 +39,7 @@ describe Efile::Nj::Nj1040 do
         create(:state_file_nj_intake,
                primary_birth_date: Date.new(over_65_birth_year + 1, 1, 1))
       end
-      before do
-        instance.calculate
-      end
+
       it 'does not check the self 65+ checkbox and sets line 7 to 0' do
         expect(instance.lines[:NJ1040_LINE_7_SELF].value).to eq(false)
         expect(instance.lines[:NJ1040_LINE_7_SPOUSE].value).to eq(false)
@@ -53,15 +51,12 @@ describe Efile::Nj::Nj1040 do
   context 'when filing status is married filing jointly' do
     let(:intake) { create(:state_file_nj_intake, :married_filing_jointly) }
     it "sets line 6 to 2000" do
-      instance.calculate
       expect(instance.lines[:NJ1040_LINE_6].value).to eq(2000)
     end
 
     context 'when filer is older than 65 and spouse is older than 65' do
       let(:intake) { create(:state_file_nj_intake, :mfj_spouse_over_65, :primary_over_65) }
-      before do
-        instance.calculate
-      end
+
       it 'checks both 65+ checkboxes and sets line 7 to 2000' do
         expect(instance.lines[:NJ1040_LINE_7_SELF].value).to eq(true)
         expect(instance.lines[:NJ1040_LINE_7_SPOUSE].value).to eq(true)
@@ -71,9 +66,7 @@ describe Efile::Nj::Nj1040 do
 
     context 'when filer is younger than 65 and spouse is older than 65' do
       let(:intake) { create(:state_file_nj_intake, :mfj_spouse_over_65) }
-      before do
-        instance.calculate
-      end
+
       it 'only checks the spouse 65+ checkbox and sets line 7 to 1000' do
         expect(instance.lines[:NJ1040_LINE_7_SELF].value).to eq(false)
         expect(instance.lines[:NJ1040_LINE_7_SPOUSE].value).to eq(true)
@@ -83,9 +76,7 @@ describe Efile::Nj::Nj1040 do
 
     context 'when filer is older than 65 and spouse is younger than 65' do
       let(:intake) { create(:state_file_nj_intake, :married_filing_jointly, :primary_over_65) }
-      before do
-        instance.calculate
-      end
+
       it 'only checks the self 65+ checkbox and sets line 7 to 1000' do
         expect(instance.lines[:NJ1040_LINE_7_SELF].value).to eq(true)
         expect(instance.lines[:NJ1040_LINE_7_SPOUSE].value).to eq(false)
@@ -95,9 +86,7 @@ describe Efile::Nj::Nj1040 do
 
     context 'when filer is younger than 65 and spouse is younger than 65' do
       let(:intake) { create(:state_file_nj_intake, :married_filing_jointly) }
-      before do
-        instance.calculate
-      end
+
       it 'checks neither checkbox and sets line 7 to 0' do
         expect(instance.lines[:NJ1040_LINE_7_SELF].value).to eq(false)
         expect(instance.lines[:NJ1040_LINE_7_SPOUSE].value).to eq(false)

--- a/spec/lib/efile/nj/nj1040_spec.rb
+++ b/spec/lib/efile/nj/nj1040_spec.rb
@@ -1,0 +1,97 @@
+require 'rails_helper'
+
+describe Efile::Nj::Nj1040 do
+  let(:intake) { create(:state_file_nj_intake) }
+  let(:instance) do
+    described_class.new(
+      year: MultiTenantService.statefile.current_tax_year,
+      intake: intake
+    )
+  end
+
+  context 'when filing status is single' do
+    it "sets line 6 to 1000" do
+      instance.calculate
+      expect(instance.lines[:NJ1040_LINE_6].value).to eq(1000)
+    end
+
+    context 'when filer is older than 65' do
+      before do
+        intake.primary_birth_date = Date.new(1900, 1, 1)
+        instance.calculate
+      end
+      it 'checks the self 65+ checkbox and sets line 7 to 1000' do
+        expect(instance.lines[:NJ1040_LINE_7_SELF].value).to eq(true)
+        expect(instance.lines[:NJ1040_LINE_7_SPOUSE].value).to eq(false)
+        expect(instance.lines[:NJ1040_LINE_7].value).to eq(1000)
+      end
+    end
+
+    context 'when filer is younger than 65' do
+      before do
+        intake.primary_birth_date = Date.new(2000, 1, 1)
+      end
+      it 'does not check the self 65+ checkbox and sets line 7 to 0' do
+        expect(instance.lines[:NJ1040_LINE_7_SELF].value).to eq(false)
+        expect(instance.lines[:NJ1040_LINE_7_SPOUSE].value).to eq(false)
+        expect(instance.lines[:NJ1040_LINE_7].value).to eq(0)
+      end
+    end
+  end
+
+  context 'when filing status is married filing jointly' do
+    let(:intake) { create(:state_file_nj_intake, :married) }
+    it "sets line 6 to 2000" do
+      instance.calculate
+      expect(instance.lines[:NJ1040_LINE_6].value).to eq(2000)
+    end
+
+    context 'when filer is older than 65 and spouse is older than 65' do
+      let(:intake) { create(:state_file_nj_intake, :married_spouse_over_65, :primary_over_65) }
+      before do
+        instance.calculate
+      end
+      it 'checks both 65+ checkboxes and sets line 7 to 2000' do
+        expect(instance.lines[:NJ1040_LINE_7_SELF].value).to eq(true)
+        expect(instance.lines[:NJ1040_LINE_7_SPOUSE].value).to eq(true)
+        expect(instance.lines[:NJ1040_LINE_7].value).to eq(2000)
+      end
+    end
+
+    context 'when filer is younger than 65 and spouse is older than 65' do
+      let(:intake) { create(:state_file_nj_intake, :married_spouse_over_65) }
+      before do
+        instance.calculate
+      end
+      it 'only checks the spouse 65+ checkbox and sets line 7 to 1000' do
+        expect(instance.lines[:NJ1040_LINE_7_SELF].value).to eq(false)
+        expect(instance.lines[:NJ1040_LINE_7_SPOUSE].value).to eq(true)
+        expect(instance.lines[:NJ1040_LINE_7].value).to eq(1000)
+      end
+    end
+
+    context 'when filer is older than 65 and spouse is younger than 65' do
+      let(:intake) { create(:state_file_nj_intake, :married, :primary_over_65) }
+      before do
+        instance.calculate
+      end
+      it 'only checks the self 65+ checkbox and sets line 7 to 1000' do
+        expect(instance.lines[:NJ1040_LINE_7_SELF].value).to eq(true)
+        expect(instance.lines[:NJ1040_LINE_7_SPOUSE].value).to eq(false)
+        expect(instance.lines[:NJ1040_LINE_7].value).to eq(1000)
+      end
+    end
+
+    context 'when filer is younger than 65 and spouse is younger than 65' do
+      let(:intake) { create(:state_file_nj_intake, :married) }
+      before do
+        instance.calculate
+      end
+      it 'checks neither checkbox and sets line 7 to 0' do
+        expect(instance.lines[:NJ1040_LINE_7_SELF].value).to eq(false)
+        expect(instance.lines[:NJ1040_LINE_7_SPOUSE].value).to eq(false)
+        expect(instance.lines[:NJ1040_LINE_7].value).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/lib/efile/nj/nj1040_spec.rb
+++ b/spec/lib/efile/nj/nj1040_spec.rb
@@ -30,6 +30,7 @@ describe Efile::Nj::Nj1040 do
     context 'when filer is younger than 65' do
       before do
         intake.primary_birth_date = Date.new(2000, 1, 1)
+        instance.calculate
       end
       it 'does not check the self 65+ checkbox and sets line 7 to 0' do
         expect(instance.lines[:NJ1040_LINE_7_SELF].value).to eq(false)

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -97,9 +97,6 @@ RSpec.describe PdfFiller::Nj1040Pdf do
         let(:submission) {
           create :efile_submission, tax_return: nil, data_source: create(
             :state_file_nj_intake,
-            primary_first_name: "Bert",
-            primary_last_name: "Muppet",
-            primary_middle_initial: "S",
           ) }
         it "fills pdf with correct Line 6 fields" do
           expect(pdf_fields["Check Box39"]).to eq "Off"
@@ -114,14 +111,12 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           expect(pdf_fields["x  1000_2"]).to eq "0"
           expect(pdf_fields["undefined_9"]).to eq "0"
         end
+
         context "primary over 65" do
           let(:submission) {
             create :efile_submission, tax_return: nil, data_source: create(
               :state_file_nj_intake,
               :primary_over_65,
-              primary_first_name: "Bert",
-              primary_last_name: "Muppet",
-              primary_middle_initial: "S",
             ) }
           it "fills pdf with Line 7 fields" do
             expect(pdf_fields["Check Box41"]).to eq "Yes"
@@ -135,13 +130,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
         let(:submission) {
           create :efile_submission, tax_return: nil, data_source: create(
             :state_file_nj_intake,
-            :married,
-            primary_first_name: "Bert",
-            primary_last_name: "Muppet",
-            primary_middle_initial: "S",
-            spouse_first_name: "Ernie",
-            spouse_last_name: "Muppet",
-            spouse_ssn: "123456789"
+            :married_filing_jointly,
           ) }
         it "fills pdf with correct Line 6 fields" do
           expect(pdf_fields["Check Box39"]).to eq "Yes"
@@ -149,6 +138,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           expect(pdf_fields["Domestic"]).to eq "2"
           expect(pdf_fields["x  1000"]).to eq "2000"
         end
+
         it "fills pdf with Line 7 fields" do
           expect(pdf_fields["Check Box41"]).to eq "Off"
           expect(pdf_fields["Check Box42"]).to eq "Off"
@@ -157,6 +147,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
         end
       end
     end
+
     describe "name field" do
       name_field = "Last Name First Name Initial Joint Filers enter first name and middle initial of each Enter spousesCU partners last name ONLY if different"
       context "single filer" do

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -92,6 +92,71 @@ RSpec.describe PdfFiller::Nj1040Pdf do
       end
     end
 
+    describe "exemptions" do
+      context "single filer" do
+        let(:submission) {
+          create :efile_submission, tax_return: nil, data_source: create(
+            :state_file_nj_intake,
+            primary_first_name: "Bert",
+            primary_last_name: "Muppet",
+            primary_middle_initial: "S",
+          ) }
+        it "fills pdf with correct Line 6 fields" do
+          expect(pdf_fields["Check Box39"]).to eq "Off"
+          expect(pdf_fields["Check Box40"]).to eq "Off"
+          expect(pdf_fields["Domestic"]).to eq "1"
+          expect(pdf_fields["x  1000"]).to eq "1000"
+        end
+
+        it "fills pdf with Line 7 fields" do
+          expect(pdf_fields["Check Box41"]).to eq "Off"
+          expect(pdf_fields["Check Box42"]).to eq "Off"
+          expect(pdf_fields["x  1000_2"]).to eq "0"
+          expect(pdf_fields["undefined_9"]).to eq "0"
+        end
+        context "primary over 65" do
+          let(:submission) {
+            create :efile_submission, tax_return: nil, data_source: create(
+              :state_file_nj_intake,
+              :primary_over_65,
+              primary_first_name: "Bert",
+              primary_last_name: "Muppet",
+              primary_middle_initial: "S",
+            ) }
+          it "fills pdf with Line 7 fields" do
+            expect(pdf_fields["Check Box41"]).to eq "Yes"
+            expect(pdf_fields["Check Box42"]).to eq "Off"
+            expect(pdf_fields["x  1000_2"]).to eq "1000"
+            expect(pdf_fields["undefined_9"]).to eq "1"
+          end
+        end
+      end
+      context "married filing jointly" do
+        let(:submission) {
+          create :efile_submission, tax_return: nil, data_source: create(
+            :state_file_nj_intake,
+            :married,
+            primary_first_name: "Bert",
+            primary_last_name: "Muppet",
+            primary_middle_initial: "S",
+            spouse_first_name: "Ernie",
+            spouse_last_name: "Muppet",
+            spouse_ssn: "123456789"
+          ) }
+        it "fills pdf with correct Line 6 fields" do
+          expect(pdf_fields["Check Box39"]).to eq "Yes"
+          expect(pdf_fields["Check Box40"]).to eq "Off"
+          expect(pdf_fields["Domestic"]).to eq "2"
+          expect(pdf_fields["x  1000"]).to eq "2000"
+        end
+        it "fills pdf with Line 7 fields" do
+          expect(pdf_fields["Check Box41"]).to eq "Off"
+          expect(pdf_fields["Check Box42"]).to eq "Off"
+          expect(pdf_fields["x  1000_2"]).to eq "0"
+          expect(pdf_fields["undefined_9"]).to eq "0"
+        end
+      end
+    end
     describe "name field" do
       name_field = "Last Name First Name Initial Joint Filers enter first name and middle initial of each Enter spousesCU partners last name ONLY if different"
       context "single filer" do
@@ -134,14 +199,14 @@ RSpec.describe PdfFiller::Nj1040Pdf do
         end
 
         context "with suffix and middle initial" do
-          let(:submission) { 
+          let(:submission) {
             create :efile_submission, tax_return: nil, data_source: create(
-            :state_file_nj_intake, 
-            primary_first_name: "Grace", 
-            primary_last_name: "Hopper", 
-            primary_middle_initial: "B", 
-            primary_suffix: "JR" 
-          ) }
+              :state_file_nj_intake,
+              primary_first_name: "Grace",
+              primary_last_name: "Hopper",
+              primary_middle_initial: "B",
+              primary_suffix: "JR"
+            ) }
           it 'fills pdf with LastName FirstName MI Suf' do
             expect(pdf_fields[name_field]).to eq "Hopper Grace B JR"
           end
@@ -150,15 +215,15 @@ RSpec.describe PdfFiller::Nj1040Pdf do
 
       context "joint filer" do
         context "same last name" do
-          let(:submission) { 
+          let(:submission) {
             create :efile_submission, tax_return: nil, data_source: create(
-            :state_file_nj_intake, 
-            primary_first_name: "Bert", 
-            primary_last_name: "Muppet", 
-            primary_middle_initial: "S",
-            spouse_first_name: "Ernie",
-            spouse_last_name: "Muppet",
-            spouse_ssn: "123456789"
+              :state_file_nj_intake,
+              primary_first_name: "Bert",
+              primary_last_name: "Muppet",
+              primary_middle_initial: "S",
+              spouse_first_name: "Ernie",
+              spouse_last_name: "Muppet",
+              spouse_ssn: "123456789"
             ) }
           it 'fills pdf with LastName FirstName & FirstName' do
             expect(pdf_fields[name_field]).to eq "Muppet Bert S & Ernie"

--- a/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
@@ -25,22 +25,22 @@ describe SubmissionBuilder::Ty2024::States::Nj::NjReturnXml, required_schema: "n
 
       it "populates line 6 XML fields" do
         expect(xml.at("Exemptions YouRegular").text).to eq("X")
-        expect(xml.at("Exemptions SpouseCuRegular").text).to eq("")
-        expect(xml.at("Exemptions DomesticPartnerRegular").text).to eq("")
+        expect(xml.at("Exemptions SpouseCuRegular")).to eq(nil)
+        expect(xml.at("Exemptions DomesticPartnerRegular")).to eq(nil)
       end
 
       context "when filer is over 65" do
         let(:intake) { create(:state_file_nj_intake, :primary_over_65) }
         it "populates line 7 XML fields" do
           expect(xml.at("Exemptions YouOver65").text).to eq("X")
-          expect(xml.at("Exemptions SpouseCuPartner65OrOver").text).to eq("")
+          expect(xml.at("Exemptions SpouseCuPartner65OrOver")).to eq(nil)
         end
       end
       context "when filer is younger than 65" do
         let(:intake) { create(:state_file_nj_intake) }
         it "populates line 7 XML fields" do
-          expect(xml.at("Exemptions YouOver65").text).to eq("")
-          expect(xml.at("Exemptions SpouseCuPartner65OrOver").text).to eq("")
+          expect(xml.at("Exemptions YouOver65")).to eq(nil)
+          expect(xml.at("Exemptions SpouseCuPartner65OrOver")).to eq(nil)
         end
       end
     end
@@ -53,15 +53,15 @@ describe SubmissionBuilder::Ty2024::States::Nj::NjReturnXml, required_schema: "n
 
       it "populates line 6 XML fields" do
         expect(xml.at("Exemptions YouRegular").text).to eq("X")
-        expect(xml.at("Exemptions SpouseCURegular").text).to eq("X")
-        expect(xml.at("Exemptions DomesticPartnerRegular").text).to eq("")
+        expect(xml.at("Exemptions SpouseCuRegular").text).to eq("X")
+        expect(xml.at("Exemptions DomesticPartnerRegular")).to eq(nil)
       end
 
       context "when filer is over 65 and spouse is under 65" do
         let(:intake) { create(:state_file_nj_intake, :primary_over_65, :married) }
         it "populates line 7 XML fields" do
           expect(xml.at("Exemptions YouOver65").text).to eq("X")
-          expect(xml.at("Exemptions SpouseCuPartner65OrOver").text).to eq("")
+          expect(xml.at("Exemptions SpouseCuPartner65OrOver")).to eq(nil)
         end
       end
 
@@ -76,15 +76,15 @@ describe SubmissionBuilder::Ty2024::States::Nj::NjReturnXml, required_schema: "n
       context "when filer is under 65 and spouse is under 65" do
         let(:intake) { create(:state_file_nj_intake, :married) }
         it "populates line 7 XML fields" do
-          expect(xml.at("Exemptions YouOver65").text).to eq("")
-          expect(xml.at("Exemptions SpouseCuPartner65OrOver").text).to eq("")
+          expect(xml.at("Exemptions YouOver65")).to eq(nil)
+          expect(xml.at("Exemptions SpouseCuPartner65OrOver")).to eq(nil)
         end
       end
 
       context "when filer is under 65 and spouse is over 65" do
         let(:intake) { create(:state_file_nj_intake, :married_spouse_over_65) }
         it "populates line 7 XML fields" do
-          expect(xml.at("Exemptions YouOver65").text).to eq("")
+          expect(xml.at("Exemptions YouOver65")).to eq(nil)
           expect(xml.at("Exemptions SpouseCuPartner65OrOver").text).to eq("X")
         end
       end

--- a/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
@@ -37,7 +37,6 @@ describe SubmissionBuilder::Ty2024::States::Nj::NjReturnXml, required_schema: "n
         end
       end
       context "when filer is younger than 65" do
-        let(:intake) { create(:state_file_nj_intake) }
         it "populates line 7 XML fields" do
           expect(xml.at("Exemptions YouOver65")).to eq(nil)
           expect(xml.at("Exemptions SpouseCuPartner65OrOver")).to eq(nil)

--- a/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
@@ -46,7 +46,7 @@ describe SubmissionBuilder::Ty2024::States::Nj::NjReturnXml, required_schema: "n
     end
 
     context "when filer is married" do
-      let(:intake) { create(:state_file_nj_intake, :married) }
+      let(:intake) { create(:state_file_nj_intake, :married_filing_jointly) }
       it "Exemptions are populated" do
         expect(xml.css('Exemptions').count).to eq(1)
       end
@@ -58,7 +58,7 @@ describe SubmissionBuilder::Ty2024::States::Nj::NjReturnXml, required_schema: "n
       end
 
       context "when filer is over 65 and spouse is under 65" do
-        let(:intake) { create(:state_file_nj_intake, :primary_over_65, :married) }
+        let(:intake) { create(:state_file_nj_intake, :primary_over_65, :married_filing_jointly) }
         it "populates line 7 XML fields" do
           expect(xml.at("Exemptions YouOver65").text).to eq("X")
           expect(xml.at("Exemptions SpouseCuPartner65OrOver")).to eq(nil)
@@ -66,7 +66,7 @@ describe SubmissionBuilder::Ty2024::States::Nj::NjReturnXml, required_schema: "n
       end
 
       context "when filer is over 65 and spouse is over 65" do
-        let(:intake) { create(:state_file_nj_intake, :primary_over_65, :married_spouse_over_65) }
+        let(:intake) { create(:state_file_nj_intake, :primary_over_65, :mfj_spouse_over_65) }
         it "populates line 7 XML fields" do
           expect(xml.at("Exemptions YouOver65").text).to eq("X")
           expect(xml.at("Exemptions SpouseCuPartner65OrOver").text).to eq("X")
@@ -74,7 +74,7 @@ describe SubmissionBuilder::Ty2024::States::Nj::NjReturnXml, required_schema: "n
       end
 
       context "when filer is under 65 and spouse is under 65" do
-        let(:intake) { create(:state_file_nj_intake, :married) }
+        let(:intake) { create(:state_file_nj_intake, :married_filing_jointly) }
         it "populates line 7 XML fields" do
           expect(xml.at("Exemptions YouOver65")).to eq(nil)
           expect(xml.at("Exemptions SpouseCuPartner65OrOver")).to eq(nil)
@@ -82,7 +82,7 @@ describe SubmissionBuilder::Ty2024::States::Nj::NjReturnXml, required_schema: "n
       end
 
       context "when filer is under 65 and spouse is over 65" do
-        let(:intake) { create(:state_file_nj_intake, :married_spouse_over_65) }
+        let(:intake) { create(:state_file_nj_intake, :mfj_spouse_over_65) }
         it "populates line 7 XML fields" do
           expect(xml.at("Exemptions YouOver65")).to eq(nil)
           expect(xml.at("Exemptions SpouseCuPartner65OrOver").text).to eq("X")


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://github.com/newjersey/affordability-pm/issues/37
- https://github.com/newjersey/affordability-pm/issues/38

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Added logic to the calculator, the XML submission builder, and the PDF filler to populate fields related to lines 6 and 7.
- Rebased on top of @aloverso's PDF and County Code changes, for easier PR review, switch the commits to the latest 3 commits

## How to test?
- Describe the testing approach taken to verify the changes, including:
  - Ran unit tests for the NJ classes
  - Tested with the FYST local app, using both a single filer and the Zeus one dependent persona, verified the following:
    - XML showed correct values 
    - PDF generated correctly

## Screenshots (for visual changes)
https://github.com/user-attachments/assets/fde41d3a-268b-48ed-912b-3b4658c8d353


