### PR TITLE
Reduce refresh window when waiting to load IRS data

### DIFF
--- a/app/views/state_file/questions/waiting_to_load_data/edit.html.erb
+++ b/app/views/state_file/questions/waiting_to_load_data/edit.html.erb
@@ -1,7 +1,7 @@
 <% title = t(".title_html") %>
 <% content_for :page_title, title %>
 <% content_for :meta_tags do %>
-  <meta http-equiv="refresh" content="20" />
+  <meta http-equiv="refresh" content="5" />
 <% end %>
 <% content_for :card do %>
   <div class="loading-container">


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- No story
## Is PM acceptance required?
- No - merge after code review approval
## What was done?
- I reduced the refresh on the page with the loading spinner from 20 seconds to 5
- Settled on 5 because it is lower than what we had, but not so low that it would result in spamming the refresh
- See the previous PR here for the previous change
   - https://github.com/codeforamerica/vita-min/pull/3896
   - We are seeing the second scenario happen a majority of the time, resulting in the 20 second wait to refresh happening regularly
## How to test?
- Go though a return, set a timer before the data loading screen, and see that it only takes 5 seconds instead of the previous 20
This is the spinner in question:
![image](https://github.com/user-attachments/assets/d6961180-6bed-4e29-85d0-b6e419c33609)
