### PR TITLE
Fix error on state file FAQ page by adding filing years to NJ

### DIFF
--- a/app/lib/schema_file_loader.rb
+++ b/app/lib/schema_file_loader.rb
@@ -5,14 +5,13 @@ class SchemaFileLoader
   EFILE_SCHEMAS_FILENAMES = (
     [
       # Format is schema name, directory, and whether the file is optional
-      ["efile1040x_2020v5.1.zip", "irs", false],
-      ["efile1040x_2021v5.2.zip", "irs", false],
-      ["efile1040x_2022v5.3.zip", "irs", false],
-      ["efile1040x_2023v5.0.zip", "irs", false]
+      ["efile1040x_2020v5.1.zip", "irs"],
+      ["efile1040x_2021v5.2.zip", "irs"],
+      ["efile1040x_2022v5.3.zip", "irs"],
+      ["efile1040x_2023v5.0.zip", "irs"]
     ] +
-      StateFile::StateInformationService::STATES_INFO.map do |key, values|
-        # TODO: If adding another member to this array, consider refactoring to a hash instead
-        [values[:schema_file_name], "us_states", values[:optional]]
+      StateFile::StateInformationService.active_state_codes.excluding("nj").map do |state_code|
+        [StateFile::StateInformationService.schema_file_name(state_code), "us_states"]
       end
   ).freeze
 
@@ -73,8 +72,8 @@ class SchemaFileLoader
     end
 
     def get_missing_downloads(dest_dir)
-      download_files = EFILE_SCHEMAS_FILENAMES.map do |(filename, download_folder, optional)|
-        [File.join(dest_dir, download_folder, filename), download_folder, optional]
+      download_files = EFILE_SCHEMAS_FILENAMES.map do |filename, download_folder|
+        [File.join(dest_dir, download_folder, filename), download_folder]
       end
       download_files.filter do |(download_file, _, _)|
         !File.exist?(download_file)

--- a/app/services/state_file/state_information_service.rb
+++ b/app/services/state_file/state_information_service.rb
@@ -47,10 +47,6 @@ module StateFile
       def state_intake_class_names
         @_state_intake_class_names ||= state_intake_classes.map(&:to_s).freeze
       end
-
-      def state_schema_file_names
-        @_state_schema_file_names ||= STATES_INFO.map { |_, attrs| attrs[:schema_file_name] }.freeze
-      end
     end
 
     private
@@ -76,7 +72,6 @@ module StateFile
         vita_link: "https://airtable.com/appnKuyQXMMCPSvVw/pag0hcyC6juDxamHo/form",
         voucher_form_name: "Form AZ-140V",
         voucher_path: "/pdfs/AZ-140V.pdf",
-        optional: false
       },
       nc: {
         intake_class: StateFileNcIntake,
@@ -98,7 +93,6 @@ module StateFile
         vita_link: "",
         voucher_form_name: "Form D-400V",
         voucher_path: "/pdfs/d400v-TY2023.pdf",
-        optional: false
       },
       nj: {
         intake_class: StateFileNjIntake,
@@ -109,7 +103,6 @@ module StateFile
         state_name: "New Jersey",
         return_type: "Resident",
         schema_file_name: "NJIndividual2023V0.4.zip",
-        optional: true,
         mail_voucher_address: "New Jersey Personal Income Tax<br/>" \
                               "Processing Center<br/>" \
                               "Trenton, NJ".html_safe,
@@ -143,7 +136,6 @@ module StateFile
         vita_link: "https://airtable.com/appQS3abRZGjT8wII/pagtpLaX0wokBqnuA/form",
         voucher_form_name: "Form IT-201-V",
         voucher_path: "/pdfs/it201v_1223.pdf",
-        optional: false
       }
     }.with_indifferent_access)
   end

--- a/app/services/state_file/state_information_service.rb
+++ b/app/services/state_file/state_information_service.rb
@@ -113,7 +113,7 @@ module StateFile
         tax_refund_url: "https://www.tax.ny.gov/pit/file/refund.htm",
         vita_link: "",
         voucher_form_name: "NJ Voucher Form",
-        voucher_path: "/pdfs/it201v_1223.pdf", # TODO
+        voucher_path: "",
       },
       ny: {
         intake_class: StateFileNyIntake,

--- a/app/services/state_file/state_information_service.rb
+++ b/app/services/state_file/state_information_service.rb
@@ -1,26 +1,28 @@
 # frozen_string_literal: true
 module StateFile
   class StateInformationService
+    GETTER_METHODS = [
+      :intake_class,
+      :calculator_class,
+      :filing_years,
+      :mail_voucher_address,
+      :navigation_class,
+      :pay_taxes_link,
+      :return_type,
+      :schema_file_name,
+      :state_name,
+      :submission_builder_class,
+      :survey_link,
+      :tax_payment_info_url,
+      :tax_payment_url,
+      :tax_refund_url,
+      :vita_link,
+      :voucher_form_name,
+      :voucher_path,
+    ].freeze
+
     class << self
-      [
-        :intake_class,
-        :calculator_class,
-        :filing_years,
-        :mail_voucher_address,
-        :navigation_class,
-        :pay_taxes_link,
-        :return_type,
-        :schema_file_name,
-        :state_name,
-        :submission_builder_class,
-        :survey_link,
-        :tax_payment_info_url,
-        :tax_payment_url,
-        :tax_refund_url,
-        :vita_link,
-        :voucher_form_name,
-        :voucher_path,
-      ].each do |attribute|
+      GETTER_METHODS.each do |attribute|
         define_method(attribute) do |state_code|
           unless STATES_INFO.key?(state_code)
             raise InvalidStateCodeError, state_code
@@ -34,6 +36,10 @@ module StateFile
         @_active_state_codes ||= STATES_INFO.keys.map(&:to_s).freeze
       end
 
+      def state_code_to_name_map
+        @_state_code_to_name_map ||= active_state_codes.to_h { |state_code, _| [state_code, state_name(state_code)] }.freeze
+      end
+
       def state_intake_classes
         @_state_intake_classes ||= STATES_INFO.map { |_, attrs| attrs[:intake_class] }.freeze
       end
@@ -44,10 +50,6 @@ module StateFile
 
       def state_schema_file_names
         @_state_schema_file_names ||= STATES_INFO.map { |_, attrs| attrs[:schema_file_name] }.freeze
-      end
-
-      def state_code_to_name_map
-        @_state_code_to_name_map ||= active_state_codes.to_h { |state_code, _| [state_code, state_name(state_code)] }.freeze
       end
     end
 
@@ -101,23 +103,24 @@ module StateFile
       nj: {
         intake_class: StateFileNjIntake,
         calculator_class: Efile::Nj::Nj1040,
+        filing_years: [2024],
         navigation_class: Navigation::StateFileNjQuestionNavigation,
         submission_builder_class: SubmissionBuilder::Ty2024::States::Nj::NjReturnXml,
         state_name: "New Jersey",
         return_type: "Resident",
         schema_file_name: "NJIndividual2023V0.4.zip",
-        optional: true
-        # mail_voucher_address: "New Jersey Personal Income Tax<br/>" \
-        #                       "Processing Center<br/>" \
-        #                       "Trenton, NJ".html_safe,
-        # pay_taxes_link: "https://www.nj.gov/treasury/taxation/payments-notices.shtml",
-        # survey_link: "",
-        # tax_payment_info_url: "https://www.nj.gov/treasury/taxation/payments-notices.shtml",
-        # tax_payment_url: "https://www.nj.gov/treasury/taxation/payments-notices.shtml",
-        # tax_refund_url: "https://www.tax.ny.gov/pit/file/refund.htm",
-        # vita_link: "",
-        # voucher_form_name: "NJ Voucher Form",
-        # voucher_path: "/pdfs/it201v_1223.pdf", # TODO
+        optional: true,
+        mail_voucher_address: "New Jersey Personal Income Tax<br/>" \
+                              "Processing Center<br/>" \
+                              "Trenton, NJ".html_safe,
+        pay_taxes_link: "https://www.nj.gov/treasury/taxation/payments-notices.shtml",
+        survey_link: "",
+        tax_payment_info_url: "https://www.nj.gov/treasury/taxation/payments-notices.shtml",
+        tax_payment_url: "https://www.nj.gov/treasury/taxation/payments-notices.shtml",
+        tax_refund_url: "https://www.tax.ny.gov/pit/file/refund.htm",
+        vita_link: "",
+        voucher_form_name: "NJ Voucher Form",
+        voucher_path: "/pdfs/it201v_1223.pdf", # TODO
       },
       ny: {
         intake_class: StateFileNyIntake,

--- a/spec/controllers/state_file/faq_controller_spec.rb
+++ b/spec/controllers/state_file/faq_controller_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe StateFile::FaqController do
       allow(Rails.configuration).to receive(:statefile_current_tax_year).and_return(current_year - 1)
     end
 
+    it "renders the page" do
+      get :index, params: { us_state: "us" }
+
+      expect(response).to be_ok
+    end
+
     context "showing the right states" do
       context "when FYST has not opened yet for the year" do
         before do

--- a/spec/lib/schema_file_loader_spec.rb
+++ b/spec/lib/schema_file_loader_spec.rb
@@ -1,22 +1,19 @@
 require "rails_helper"
 
 describe SchemaFileLoader do
-
   it "all required schema files are present" do
     expect(SchemaFileLoader::EFILE_SCHEMAS_FILENAMES).to eq [
-      ["efile1040x_2020v5.1.zip", "irs", false],
-      ["efile1040x_2021v5.2.zip", "irs", false],
-      ["efile1040x_2022v5.3.zip", "irs", false],
-      ["efile1040x_2023v5.0.zip", "irs", false],
-      ["AZIndividual2023v1.0.zip", "us_states", false],
-      ["NCIndividual2023v1.0.zip", "us_states", false],
-      ["NJIndividual2023V0.4.zip", "us_states", true],
-      ["NYSIndividual2023V4.0.zip", "us_states", false],
+      ["efile1040x_2020v5.1.zip", "irs"],
+      ["efile1040x_2021v5.2.zip", "irs"],
+      ["efile1040x_2022v5.3.zip", "irs"],
+      ["efile1040x_2023v5.0.zip", "irs"],
+      ["AZIndividual2023v1.0.zip", "us_states"],
+      ["NCIndividual2023v1.0.zip", "us_states"],
+      ["NYSIndividual2023V4.0.zip", "us_states"],
     ]
   end
 
   describe "#s3_credentials" do
-
     context "AWS_ACCESS_KEY_ID in ENV" do
       it "uses the environment variables" do
         stub_const("ENV", {
@@ -86,14 +83,13 @@ describe SchemaFileLoader do
     it "gets missing downloads" do
       expect(SchemaFileLoader.get_missing_downloads("testy")).to eq(
         [
-          ["testy/irs/efile1040x_2020v5.1.zip", 'irs', false],
-          ["testy/irs/efile1040x_2021v5.2.zip", 'irs', false],
-          ["testy/irs/efile1040x_2022v5.3.zip", 'irs', false],
-          ["testy/irs/efile1040x_2023v5.0.zip", 'irs', false],
-          ["testy/us_states/AZIndividual2023v1.0.zip", 'us_states', false],
-          ["testy/us_states/NCIndividual2023v1.0.zip", 'us_states', false],
-          ["testy/us_states/NJIndividual2023V0.4.zip", 'us_states', true],
-          ["testy/us_states/NYSIndividual2023V4.0.zip", 'us_states', false]
+          ["testy/irs/efile1040x_2020v5.1.zip", 'irs'],
+          ["testy/irs/efile1040x_2021v5.2.zip", 'irs'],
+          ["testy/irs/efile1040x_2022v5.3.zip", 'irs'],
+          ["testy/irs/efile1040x_2023v5.0.zip", 'irs'],
+          ["testy/us_states/AZIndividual2023v1.0.zip", 'us_states'],
+          ["testy/us_states/NCIndividual2023v1.0.zip", 'us_states'],
+          ["testy/us_states/NYSIndividual2023V4.0.zip", 'us_states']
         ]
       )
     end

--- a/spec/services/state_file/state_information_service_spec.rb
+++ b/spec/services/state_file/state_information_service_spec.rb
@@ -7,24 +7,6 @@ describe StateFile::StateInformationService do
     end
   end
 
-  describe ".calculator_class" do
-    it "returns the tax calculator class" do
-      expect(described_class.calculator_class("az")).to eq Efile::Az::Az140Calculator
-    end
-  end
-
-  describe ".state_name" do
-    it "returns the name of the state" do
-      expect(described_class.state_name("az")).to eq "Arizona"
-    end
-
-    it "throws an error for an invalid state code" do
-      expect do
-        described_class.state_name("boop")
-      end.to raise_error(InvalidStateCodeError, "Invalid state code: boop")
-    end
-  end
-
   describe ".state_code_to_name_map" do
     it "returns a map of all the state codes to state names" do
       result = {
@@ -37,77 +19,31 @@ describe StateFile::StateInformationService do
     end
   end
 
-  describe ".tax_refund_url" do
-    it "returns the refund url" do
-      expect(described_class.tax_refund_url("az")).to eq 'https://aztaxes.gov/home/checkrefund'
+  describe ".state_intake_classes" do
+    it "returns an array of the intake classes" do
+      expect(described_class.state_intake_classes).to match_array [StateFileAzIntake, StateFileNcIntake, StateFileNjIntake, StateFileNyIntake]
     end
   end
 
-  describe ".tax_payment_url" do
-    it "returns the tax payment url" do
-      expect(described_class.tax_payment_url("az")).to eq 'AZTaxes.gov'
+  describe ".state_intake_class_names" do
+    it "returns an array of the intake classes as strings" do
+      expect(described_class.state_intake_class_names).to match_array ["StateFileAzIntake", "StateFileNcIntake", "StateFileNjIntake", "StateFileNyIntake"]
     end
   end
 
-  describe ".voucher_form_name" do
-    it "returns the name of the voucher form" do
-      expect(described_class.voucher_form_name("az")).to eq 'Form AZ-140V'
-    end
-  end
+  described_class::GETTER_METHODS.each do |getter_method|
+    describe ".#{getter_method}" do
+      described_class.active_state_codes.each do |state_code|
+        it "defines the method for #{state_code}" do
+          expect(described_class.send(getter_method, state_code)).not_to be_nil
+        end
 
-  describe ".mail_voucher_address" do
-    it "returns the mail voucher address" do
-      expect(described_class.mail_voucher_address("az")).to eq "Arizona Department of Revenue<br/>"\
-          "PO Box 29085<br/>"\
-          "Phoenix, AZ 85038-9085".html_safe
-    end
-  end
-
-  describe ".voucher_path" do
-    it "returns the voucher path" do
-      expect(described_class.voucher_path("az")).to eq '/pdfs/AZ-140V.pdf'
-    end
-  end
-
-  describe ".tax_payment_info_url" do
-    it "returns the link" do
-      expect(described_class.tax_payment_info_url("az")).to eq 'https://azdor.gov/making-payments-late-payments-and-filing-extensions'
-    end
-  end
-
-  describe ".vita_link" do
-    it "returns the link to the airtable" do
-      expect(described_class.vita_link("az")).to eq 'https://airtable.com/appnKuyQXMMCPSvVw/pag0hcyC6juDxamHo/form'
-    end
-  end
-
-  describe ".survey_link" do
-    it "returns the survey link" do
-      expect(described_class.survey_link("az")).to eq 'https://codeforamerica.co1.qualtrics.com/jfe/form/SV_7UTycCvS3UEokey'
-    end
-  end
-
-  describe ".intake_class" do
-    it "returns the intake class" do
-      expect(described_class.intake_class("az")).to eq StateFileAzIntake
-    end
-  end
-
-  describe ".return_type" do
-    it "returns the string that goes in ReturnType in the return header and StateSubmissionTyp in the state manifest" do
-      expect(described_class.return_type("az")).to eq "Form140"
-    end
-  end
-
-  describe ".pay_taxes_link" do
-    it "returns the pay taxes link" do
-      expect(described_class.pay_taxes_link("az")).to eq "https://www.aztaxes.gov/"
-    end
-  end
-
-  describe ".filing_years" do
-    it "returns the filing years for a state" do
-      expect(described_class.filing_years("az")).to eq [2024, 2023]
+        it "throws an error for an invalid state code" do
+          expect do
+            described_class.send(getter_method, "boop")
+          end.to raise_error(InvalidStateCodeError, "Invalid state code: boop")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Link to Sentry issue
- https://codeforamerica.sentry.io/issues/5827535300/?alert_rule_id=1046555&alert_type=issue&notification_uuid=a00e7a97-90ae-469c-9b42-8a110921010c&project=1880327&referrer=slack
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!
## What was done?
- like the title says
- also:
  - refactored state info service and specs so that they test all the states
  - refactored the schema file loader because it doesn't seem like we need an attribute on the info service just for that but maybe i'm missing something?
## How to test?
- one reservation about the info service tests: it doesn't feel like we *need* to require all the methods be defined but it also felt like overkill to separate them into required and not required. open to suggestions!
## Screenshots (for visual changes)
- Before
![image](https://github.com/user-attachments/assets/5ca1abef-3774-4e32-a61d-8ba4d227426b)

- After
![image](https://github.com/user-attachments/assets/daab6691-bf31-4d69-b92f-43b787b6f620)

