### PR TITLE
Flipper: turn off :prevent_duplicate_accepted_statefile_submissions in demo and heroku

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -10,7 +10,11 @@ end
 begin
   Flipper.disable :sms_notifications unless Flipper.exist?(:sms_notifications)
   Flipper.disable :hub_dashboard unless Flipper.exist?(:hub_dashboard)
-  Flipper.enable :prevent_duplicate_accepted_statefile_submissions unless Flipper.exist?(:prevent_duplicate_accepted_statefile_submissions)
+  if Rails.env.heroku? || Rails.env.demo?
+    Flipper.disable :prevent_duplicate_accepted_statefile_submissions unless Flipper.exist?(:prevent_duplicate_accepted_statefile_submissions)
+  else
+    Flipper.enable :prevent_duplicate_accepted_statefile_submissions unless Flipper.exist?(:prevent_duplicate_accepted_statefile_submissions)
+  end
 rescue
   # make sure we can still run rake tasks before table has been created
   nil


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-500?atlOrigin=eyJpIjoiMzE1ZmY0OWJjYjRjNDNjMTg4MzE4MTFhYTA4MmRhYjAiLCJwIjoiaiJ9
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!
## What was done?
- the story just says "Set Duplicate Submissions flipper to "off" for heroku and demo"—normally i would say we should manually turn feature flags on/off through the UI but i guess because the heroku apps are generated constantly we have to do it in the code
- not sure if i went about it the right way???
## How to test?
- no tests. not sure if that is bad!!?