### PR TITLE
Fyst 328 Remove W2s from NC xml

### DIFF
--- a/app/lib/submission_builder/ty2024/states/nc/nc_return_xml.rb
+++ b/app/lib/submission_builder/ty2024/states/nc/nc_return_xml.rb
@@ -23,17 +23,13 @@ module SubmissionBuilder
           end
 
           def supported_documents
-            supported_docs = [
+            [
               {
                 xml: SubmissionBuilder::Ty2024::States::Nc::Documents::D400,
                 pdf: PdfFiller::NcD400Pdf,
                 include: true
               },
             ]
-
-            supported_docs += combined_w2s
-
-            supported_docs
           end
         end
       end

--- a/spec/lib/submission_builder/state_return_spec.rb
+++ b/spec/lib/submission_builder/state_return_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe SubmissionBuilder::StateReturn do
-  # NC does not include W2s in the state return xml
-  StateFile::StateInformationService.active_state_codes.excluding("nc").each do |state_code|
+  states_requiring_w2s = StateFile::StateInformationService.active_state_codes.excluding("nc")
+  states_requiring_w2s.each do |state_code|
     describe '#combined_w2s', required_schema: state_code do
       let(:builder_class) { StateFile::StateInformationService.submission_builder_class(state_code) }
       let(:intake) { create("state_file_#{state_code}_intake".to_sym, filing_status: filing_status) }

--- a/spec/lib/submission_builder/state_return_spec.rb
+++ b/spec/lib/submission_builder/state_return_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
 describe SubmissionBuilder::StateReturn do
-  StateFile::StateInformationService.active_state_codes.each do |state_code|
-    describe '.build', required_schema: state_code do
+  # NC does not include W2s in the state return xml
+  StateFile::StateInformationService.active_state_codes.excluding("nc").each do |state_code|
+    describe '#combined_w2s', required_schema: state_code do
       let(:builder_class) { StateFile::StateInformationService.submission_builder_class(state_code) }
       let(:intake) { create("state_file_#{state_code}_intake".to_sym, filing_status: filing_status) }
       let(:submission) { create(:efile_submission, data_source: intake) }


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-328 kind of
## Is PM acceptance required? (delete one)
- No - merge after code review approval
## What was done?
- Realized during acceptance testing that W2s are actually not in the documents list in the NC schema, removing them for that reason
- Had to fix a failing spec: state_return_spec checks for the presence of W2s so I excluded NC from the list. Would appreciate any input on how that affects the readability of the test
## How to test?
- Acceptance test: fill out NC intake, see that xml contains no W2s
