### PR TITLE
NC D400 pdf: guard against nil values coming from xml

### DIFF
--- a/app/lib/pdf_filler/nc_d400_pdf.rb
+++ b/app/lib/pdf_filler/nc_d400_pdf.rb
@@ -16,21 +16,21 @@ module PdfFiller
 
     def hash_for_pdf
       {
-        y_d400wf_datebeg: formatted_date(@xml_document.at('ReturnHeaderState TaxPeriodBeginDt').text, "%m-%d"),
-        y_d400wf_dateend: formatted_date(@xml_document.at('ReturnHeaderState TaxPeriodEndDt').text, "%m-%d-%y"),
-        y_d400wf_ssn1: @xml_document.at('Primary TaxpayerSSN').text,
+        y_d400wf_datebeg: formatted_date(@xml_document.at('ReturnHeaderState TaxPeriodBeginDt')&.text, "%m-%d"),
+        y_d400wf_dateend: formatted_date(@xml_document.at('ReturnHeaderState TaxPeriodEndDt')&.text, "%m-%d-%y"),
+        y_d400wf_ssn1: @xml_document.at('Primary TaxpayerSSN')&.text,
         y_d400wf_ssn2: @xml_document.at('Secondary TaxpayerSSN')&.text,
-        y_d400wf_fname1: @xml_document.at('Primary TaxpayerName FirstName').text,
+        y_d400wf_fname1: @xml_document.at('Primary TaxpayerName FirstName')&.text,
         y_d400wf_mi1: @xml_document.at('Primary TaxpayerName MiddleInitial')&.text,
-        y_d400wf_lname1: @xml_document.at('Primary TaxpayerName LastName').text,
+        y_d400wf_lname1: @xml_document.at('Primary TaxpayerName LastName')&.text,
         y_d400wf_fname2: @xml_document.at('Secondary TaxpayerName FirstName')&.text,
         y_d400wf_mi2: @xml_document.at('Secondary TaxpayerName MiddleInitial')&.text,
         y_d400wf_lname2: @xml_document.at('Secondary TaxpayerName LastName')&.text,
-        y_d400wf_add: @xml_document.at('Filer USAddress AddressLine1Txt').text,
-        'y_d400wf_apartment number': @xml_document.at('Filer USAddress AddressLine2Txt').text,
-        y_d400wf_city: @xml_document.at('Filer USAddress CityNm').text,
-        y_d400wf_state: @xml_document.at('Filer USAddress StateAbbreviationCd').text,
-        y_d400wf_zip: @xml_document.at('Filer USAddress ZIPCd').text,
+        y_d400wf_add: @xml_document.at('Filer USAddress AddressLine1Txt')&.text,
+        'y_d400wf_apartment number': @xml_document.at('Filer USAddress AddressLine2Txt')&.text,
+        y_d400wf_city: @xml_document.at('Filer USAddress CityNm')&.text,
+        y_d400wf_state: @xml_document.at('Filer USAddress StateAbbreviationCd')&.text,
+        y_d400wf_zip: @xml_document.at('Filer USAddress ZIPCd')&.text,
         y_d400wf_dead2: formatted_date(@xml_document.at('Secondary DateOfDeath')&.text, "%m-%d-%y"),
         y_d400wf_rs1yes: 'Yes',
         y_d400wf_rs2yes: @submission.data_source.filing_status_mfj? ? 'Yes' : 'Off',
@@ -46,11 +46,11 @@ module PdfFiller
         y_d400wf_li8_good: @xml_document.at('FAGIPlusAdditions')&.text,
         y_d400wf_ncstandarddeduction: 'Yes',
         y_d400wf_li11_page1_good: @xml_document.at('NCStandardDeduction')&.text,
-        y_d400wf_lname2_PG2: @xml_document.at('Primary TaxpayerName LastName').text.slice(0,11),
-        y_d400wf_li20a_pg2_good: @xml_document.at('IncTaxWith').text,
-        y_d400wf_li20b_pg2_good: @xml_document.at('IncTaxWithSpouse').text,
-        y_d400wf_li23_pg2_good: @xml_document.at('NCTaxPaid').text,
-        y_d400wf_li25_pg2_good: @xml_document.at('RemainingPayment').text
+        y_d400wf_lname2_PG2: @xml_document.at('Primary TaxpayerName LastName')&.text.slice(0,11),
+        y_d400wf_li20a_pg2_good: @xml_document.at('IncTaxWith')&.text,
+        y_d400wf_li20b_pg2_good: @xml_document.at('IncTaxWithSpouse')&.text,
+        y_d400wf_li23_pg2_good: @xml_document.at('NCTaxPaid')&.text,
+        y_d400wf_li25_pg2_good: @xml_document.at('RemainingPayment')&.text
       }
     end
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-556
## Is PM acceptance required? (delete one)
- No - merge after code review approval
## What was done?
- We've started to get errors in sentry when these xml fields are nil so this adds a guard on `.text` to everything in the d400
## How to test?
- I *could* add tests that generate the pdf when each of these values are missing to make sure no error is thrown but that feels like overkill? Lmk what you think tho