### PR TITLE
NJ 42 - add dependents name, birth year, SSN to XML and PDF

### DIFF
--- a/app/lib/pdf_filler/nj1040_pdf.rb
+++ b/app/lib/pdf_filler/nj1040_pdf.rb
@@ -59,88 +59,20 @@ module PdfFiller
       }
 
       dependents = get_dependents
-      if dependents[0]
-        dep0 = dependents[0]
-        name = format_name(dep0[:first_name], dep0[:last_name], dep0[:middle_initial], dep0[:suffix])
-        answers.merge!({
-          "Last Name First Name Middle Initial 1": name,
-          "undefined_18": dep0[:ssn][0],
-          "undefined_19": dep0[:ssn][1],
-          "undefined_20": dep0[:ssn][2],
-          "Text54": dep0[:ssn][3],
-          "Text55": dep0[:ssn][4],
-          "Text56": dep0[:ssn][5],
-          "Text57": dep0[:ssn][6],
-          "Text58": dep0[:ssn][7],
-          "Text59": dep0[:ssn][8],
-          "Birth Year": dep0[:birth_year][0],
-          "Text60": dep0[:birth_year][1],
-          "Text61": dep0[:birth_year][2],
-          "Text62": dep0[:birth_year][3]
-        })
-      end
+      dependents[0..3].each.with_index do |dependent, i|
+        name_field = dependent_pdf_keys[i][:name]
+        ssn_fields = dependent_pdf_keys[i][:ssn]
+        birth_year_fields = dependent_pdf_keys[i][:birth_year]
+        dependent_hash = {}
 
-      if dependents[1]
-        dep1 = dependents[1]
-        name = format_name(dep1[:first_name], dep1[:last_name], dep1[:middle_initial], dep1[:suffix])
-        answers.merge!({
-           "Last Name First Name Middle Initial 2": name,
-           "undefined_21": dep1[:ssn][0],
-           "undefined_22": dep1[:ssn][1],
-           "undefined_23": dep1[:ssn][2],
-           "undefined_24": dep1[:ssn][3],
-           "Text65": dep1[:ssn][4],
-           "Text66": dep1[:ssn][5],
-           "Text67": dep1[:ssn][6],
-           "Text68": dep1[:ssn][7],
-           "Text69": dep1[:ssn][8],
-           "Text70": dep1[:birth_year][0],
-           "Text71": dep1[:birth_year][1],
-           "Text72": dep1[:birth_year][2],
-           "Text73": dep1[:birth_year][3]
-         })
-      end
-
-      if dependents[2]
-        dep2 = dependents[2]
-        name = format_name(dep2[:first_name], dep2[:last_name], dep2[:middle_initial], dep2[:suffix])
-        answers.merge!({
-         "Last Name First Name Middle Initial 3": name,
-         "undefined_25": dep2[:ssn][0],
-         "undefined_26": dep2[:ssn][1],
-         "undefined_27": dep2[:ssn][2],
-         "undefined_28": dep2[:ssn][3],
-         "Text75": dep2[:ssn][4],
-         "Text76": dep2[:ssn][5],
-         "Text77": dep2[:ssn][6],
-         "Text78": dep2[:ssn][7],
-         "Text79": dep2[:ssn][8],
-         "Text80": dep2[:birth_year][0],
-         "Text81": dep2[:birth_year][1],
-         "Text82": dep2[:birth_year][2],
-         "Text83": dep2[:birth_year][3]
-       })
-      end
-
-      if dependents[3]
-        dep3 = dependents[3]
-        name = format_name(dep3[:first_name], dep3[:last_name], dep3[:middle_initial], dep3[:suffix])
-        answers.merge!({
-           "Last Name First Name Middle Initial 4": name,
-           "undefined_29": dep3[:ssn][0],
-           "undefined_30": dep3[:ssn][1],
-           "undefined_31": dep3[:ssn][2],
-           "undefined_32": dep3[:ssn][3],
-           "Text85": dep3[:ssn][4],
-           "Text86": dep3[:ssn][5],
-           "Text87": dep3[:ssn][6],
-           "Text88": dep3[:ssn][7],
-           "Text89": dep3[:ssn][8],
-           "Text90": dep3[:birth_year][0],
-           "Text91": dep3[:birth_year][1],
-           "Text92": dep3[:birth_year][2],
-           "Text93": dep3[:birth_year][3]
-         })
+        dependent_hash[name_field] = format_name(dependent[:first_name], dependent[:last_name], dependent[:middle_initial], dependent[:suffix])
+        ssn_fields.each.with_index do |field_name, i|
+          dependent_hash[field_name] = dependent[:ssn][i]
+        end
+        birth_year_fields.each.with_index do |field_name, i|
+          dependent_hash[field_name] = dependent[:birth_year][i]
+        end
+        answers.merge!(dependent_hash)
       end
 
       if spouse_ssn
@@ -241,5 +173,92 @@ module PdfFiller
     def get_spouse_ssn
       @xml_document.at("ReturnHeaderState Filer Secondary TaxpayerSSN")&.text
     end
+
+    def dependent_pdf_keys
+      [
+        {
+          name: "Last Name First Name Middle Initial 1",
+          ssn: [
+            "undefined_18",
+            "undefined_19",
+            "undefined_20",
+            "Text54",
+            "Text55",
+            "Text56",
+            "Text57",
+            "Text58",
+            "Text59"
+          ],
+          birth_year: [
+            "Birth Year",
+            "Text60",
+            "Text61",
+            "Text62"
+          ]
+        },
+        {
+          name: "Last Name First Name Middle Initial 2",
+          ssn: [
+            "undefined_21",
+            "undefined_22",
+            "undefined_23",
+            "undefined_24",
+            "Text65",
+            "Text66",
+            "Text67",
+            "Text68",
+            "Text69"
+          ],
+          birth_year: [
+            "Text70",
+            "Text71",
+            "Text72",
+            "Text73"
+          ]
+        },
+        {
+          name: "Last Name First Name Middle Initial 3",
+          ssn: [
+            "undefined_25",
+            "undefined_26",
+            "undefined_27",
+            "undefined_28",
+            "Text75",
+            "Text76",
+            "Text77",
+            "Text78",
+            "Text79"
+          ],
+          birth_year: [
+            "Text80",
+            "Text81",
+            "Text82",
+            "Text83"
+          ]
+        },
+        {
+          name: "Last Name First Name Middle Initial 4",
+          ssn: [
+            "undefined_29",
+            "undefined_30",
+            "undefined_31",
+            "undefined_32",
+            "Text85",
+            "Text86",
+            "Text87",
+            "Text88",
+            "Text89"
+          ],
+          birth_year: [
+            "Text90",
+            "Text91",
+            "Text92",
+            "Text93"
+          ]
+        }
+      ]
+    end
+
+
   end
 end

--- a/app/lib/pdf_filler/nj1040_pdf.rb
+++ b/app/lib/pdf_filler/nj1040_pdf.rb
@@ -196,14 +196,14 @@ module PdfFiller
     end
 
     def get_dependents
-      @xml_document.css("Dependents DependentsName").map.with_index do |dependent, i|
+      @xml_document.css("Dependents").map do |dependent|
         {
-          first_name: dependent.at("FirstName")&.text,
-          last_name: dependent.at("LastName")&.text,
-          middle_initial: dependent.at("MiddleInitial")&.text,
-          suffix: dependent.at("NameSuffix")&.text,
-          ssn: @xml_document.css("Dependents DependentsSSN")[i]&.text,
-          birth_year: @xml_document.css("Dependents BirthYear")[i]&.text,
+          first_name: dependent.at("DependentsName FirstName")&.text,
+          last_name: dependent.at("DependentsName LastName")&.text,
+          middle_initial: dependent.at("DependentsName MiddleInitial")&.text,
+          suffix: dependent.at("DependentsName NameSuffix")&.text,
+          ssn: dependent.at("DependentsSSN")&.text,
+          birth_year: dependent.at("BirthYear")&.text,
         }
       end
     end

--- a/app/lib/pdf_filler/nj1040_pdf.rb
+++ b/app/lib/pdf_filler/nj1040_pdf.rb
@@ -58,46 +58,89 @@ module PdfFiller
         "x  1000_2": get_line_7_exemption_count * 1000,
       }
 
-      undefined_field_counter = 17
-      get_dependents[0..3].map.with_index do |dependent, i|
-        index_starting_at_1 = i + 1
-        name = format_name(dependent[:first_name], dependent[:last_name], dependent[:middle_initial], dependent[:suffix])
+      dependents = get_dependents
+      if dependents[0]
+        dep0 = dependents[0]
+        name = format_name(dep0[:first_name], dep0[:last_name], dep0[:middle_initial], dep0[:suffix])
+        answers.merge!({
+          "Last Name First Name Middle Initial 1": name,
+          "undefined_18": dep0[:ssn][0],
+          "undefined_19": dep0[:ssn][1],
+          "undefined_20": dep0[:ssn][2],
+          "Text54": dep0[:ssn][3],
+          "Text55": dep0[:ssn][4],
+          "Text56": dep0[:ssn][5],
+          "Text57": dep0[:ssn][6],
+          "Text58": dep0[:ssn][7],
+          "Text59": dep0[:ssn][8],
+          "Birth Year": dep0[:birth_year][0],
+          "Text60": dep0[:birth_year][1],
+          "Text61": dep0[:birth_year][2],
+          "Text62": dep0[:birth_year][3]
+        })
+      end
 
-        name_hash = {
-          "Last Name First Name Middle Initial #{index_starting_at_1}": name
-        }
+      if dependents[1]
+        dep1 = dependents[1]
+        name = format_name(dep1[:first_name], dep1[:last_name], dep1[:middle_initial], dep1[:suffix])
+        answers.merge!({
+           "Last Name First Name Middle Initial 2": name,
+           "undefined_21": dep1[:ssn][0],
+           "undefined_22": dep1[:ssn][1],
+           "undefined_23": dep1[:ssn][2],
+           "undefined_24": dep1[:ssn][3],
+           "Text65": dep1[:ssn][4],
+           "Text66": dep1[:ssn][5],
+           "Text67": dep1[:ssn][6],
+           "Text68": dep1[:ssn][7],
+           "Text69": dep1[:ssn][8],
+           "Text70": dep1[:birth_year][0],
+           "Text71": dep1[:birth_year][1],
+           "Text72": dep1[:birth_year][2],
+           "Text73": dep1[:birth_year][3]
+         })
+      end
 
-        ssn_hash = {}
-        birth_year_hash = {}
-        text_field_start = 5
-        if i == 0
-          dependent[:ssn].chars.map.with_index do |char, j|
-            if j <= 2
-              ssn_hash["undefined_#{undefined_field_counter += 1}"] = char
-            else
-              ssn_hash["Text#{text_field_start}#{j + 1}"] = char
-            end
-            
-            birth_year_hash["Birth Year"] = dependent[:birth_year][0]
-            birth_year_hash["Text60"] = dependent[:birth_year][1]
-            birth_year_hash["Text61"] = dependent[:birth_year][2]
-            birth_year_hash["Text62"] = dependent[:birth_year][3]
-          end
-        else
-          dependent[:ssn].chars.map.with_index do |char, j|
-            if j <= 3
-              ssn_hash["undefined_#{undefined_field_counter += 1}"] = char
-            else
-              ssn_hash["Text#{text_field_start + i}#{j + 1}"] = char
-            end
-          end
+      if dependents[2]
+        dep2 = dependents[2]
+        name = format_name(dep2[:first_name], dep2[:last_name], dep2[:middle_initial], dep2[:suffix])
+        answers.merge!({
+         "Last Name First Name Middle Initial 3": name,
+         "undefined_25": dep2[:ssn][0],
+         "undefined_26": dep2[:ssn][1],
+         "undefined_27": dep2[:ssn][2],
+         "undefined_28": dep2[:ssn][3],
+         "Text75": dep2[:ssn][4],
+         "Text76": dep2[:ssn][5],
+         "Text77": dep2[:ssn][6],
+         "Text78": dep2[:ssn][7],
+         "Text79": dep2[:ssn][8],
+         "Text80": dep2[:birth_year][0],
+         "Text81": dep2[:birth_year][1],
+         "Text82": dep2[:birth_year][2],
+         "Text83": dep2[:birth_year][3]
+       })
+      end
 
-          dependent[:birth_year].chars.map.with_index do |char, j|
-            birth_year_hash["Text#{text_field_start + 1 + i}#{j}"] = char
-          end
-        end
-
-        answers.merge!(**name_hash, **ssn_hash, **birth_year_hash)
+      if dependents[3]
+        dep3 = dependents[3]
+        name = format_name(dep3[:first_name], dep3[:last_name], dep3[:middle_initial], dep3[:suffix])
+        answers.merge!({
+           "Last Name First Name Middle Initial 4": name,
+           "undefined_29": dep3[:ssn][0],
+           "undefined_30": dep3[:ssn][1],
+           "undefined_31": dep3[:ssn][2],
+           "undefined_32": dep3[:ssn][3],
+           "Text85": dep3[:ssn][4],
+           "Text86": dep3[:ssn][5],
+           "Text87": dep3[:ssn][6],
+           "Text88": dep3[:ssn][7],
+           "Text89": dep3[:ssn][8],
+           "Text90": dep3[:birth_year][0],
+           "Text91": dep3[:birth_year][1],
+           "Text92": dep3[:birth_year][2],
+           "Text93": dep3[:birth_year][3]
+         })
       end
 
       if spouse_ssn

--- a/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
+++ b/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
@@ -67,8 +67,8 @@ module SubmissionBuilder
                   end
 
                   unless intake.dependents.empty?
-                    xml.Dependents do
-                      intake.dependents.each do |dependent|
+                    intake.dependents[0..9].each do |dependent|
+                      xml.Dependents do
                         xml.DependentsName do
                           xml.FirstName sanitize_for_xml(dependent.first_name)
                           xml.MiddleInitial sanitize_for_xml(dependent.middle_initial) if dependent.middle_initial.present?
@@ -82,10 +82,11 @@ module SubmissionBuilder
                   end
 
                   xml.CountyCode "0#{intake.municipality_code}"
+                  xml.NactpCode "1234567890" # TODO - placeholder value
                 end
-                
+
                 xml.Body do
-                  xml.TaxableInterestIncome intake.fed_taxable_income
+
                 end
               end
             end

--- a/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
+++ b/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
@@ -68,15 +68,15 @@ module SubmissionBuilder
 
                   unless intake.dependents.empty?
                     xml.Dependents do
-                      # TODO: Should this be qualifying dependents? Or all dependents?
                       intake.dependents.each do |dependent|
-                        xml.DependentsName do 
+                        xml.DependentsName do
                           xml.FirstName sanitize_for_xml(dependent.first_name)
                           xml.MiddleInitial sanitize_for_xml(dependent.middle_initial) if dependent.middle_initial.present?
                           xml.LastName sanitize_for_xml(dependent.last_name)
                           xml.NameSuffix dependent.suffix if dependent.suffix.present?
                         end
                         xml.DependentsSSN dependent.ssn
+                        xml.BirthYear dependent.dob.year
                       end
                     end
                   end

--- a/app/models/state_file_dependent.rb
+++ b/app/models/state_file_dependent.rb
@@ -49,7 +49,7 @@ class StateFileDependent < ApplicationRecord
   enum eic_disability: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eic_disability
   enum eic_student: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eic_student
 
-  # Create birth_date_* accessor methods for Honeycrisp's cfa_date_select
+  # Create dob_* accessor methods for Honeycrisp's cfa_date_select
   delegate :month, :day, :year, to: :dob, prefix: :dob, allow_nil: true
   validates_presence_of :first_name, :last_name, :dob, on: :dob_form
   validates_presence_of :months_in_home, on: :dob_form, if: -> { self.intake_type == 'StateFileAzIntake' }

--- a/spec/factories/state_file_nj_intakes.rb
+++ b/spec/factories/state_file_nj_intakes.rb
@@ -104,12 +104,24 @@ FactoryBot.define do
       intake.raw_direct_file_data = intake.direct_file_data.to_s
     end
 
+    after(:create) do |intake|
+      intake.synchronize_df_dependents_to_database
+    end
+
     trait :df_data_2_w2s do
       raw_direct_file_data { StateFile::XmlReturnSampleService.new.read('nj_zeus_two_w2s') }
     end
 
     trait :df_data_many_w2s do
       raw_direct_file_data { StateFile::XmlReturnSampleService.new.read('nj_zeus_many_w2s') }
+    end
+
+    trait :df_data_minimal do
+      raw_direct_file_data { StateFile::XmlReturnSampleService.new.read('nj_minimal') }
+    end
+
+    trait :df_data_many_deps do
+      raw_direct_file_data { StateFile::XmlReturnSampleService.new.read('nj_zeus_many_deps') }
     end
 
     trait :married_filing_jointly do

--- a/spec/factories/state_file_nj_intakes.rb
+++ b/spec/factories/state_file_nj_intakes.rb
@@ -106,6 +106,9 @@ FactoryBot.define do
 
     after(:create) do |intake|
       intake.synchronize_df_dependents_to_database
+      intake.dependents.each_with_index do |dependent, i|
+        dependent.update( dob: i.years.ago )
+      end
     end
 
     trait :df_data_2_w2s do

--- a/spec/factories/state_file_nj_intakes.rb
+++ b/spec/factories/state_file_nj_intakes.rb
@@ -127,6 +127,10 @@ FactoryBot.define do
       raw_direct_file_data { StateFile::XmlReturnSampleService.new.read('nj_zeus_many_deps') }
     end
 
+    trait :df_data_one_dep do
+      raw_direct_file_data { StateFile::XmlReturnSampleService.new.read('nj_zeus_one_dep') }
+    end
+
     trait :married_filing_jointly do
       filing_status { "married_filing_jointly" }
       spouse_birth_date { Date.new(1990, 1, 1) }

--- a/spec/fixtures/state_file/fed_return_xmls/2023/nj/zeus_two_deps.xml
+++ b/spec/fixtures/state_file/fed_return_xmls/2023/nj/zeus_two_deps.xml
@@ -1,0 +1,279 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Return xmlns="http://www.irs.gov/efile" xmlns:efile="http://www.irs.gov/efile" returnVersion="2023v5.0">
+  <ReturnHeader binaryAttachmentCnt="0">
+    <ReturnTs>******</ReturnTs>
+    <TaxYr>2023</TaxYr>
+    <TaxPeriodBeginDt>2023-01-01</TaxPeriodBeginDt>
+    <TaxPeriodEndDt>2023-12-31</TaxPeriodEndDt>
+    <SoftwareId>******</SoftwareId>
+    <SoftwareVersionNum>******</SoftwareVersionNum>
+    <OriginatorGrp>
+      <EFIN>******</EFIN>
+      <OriginatorTypeCd>OnlineFiler</OriginatorTypeCd>
+    </OriginatorGrp>
+    <SelfSelectPINGrp>
+      <PrimaryBirthDt>1973-01-02</PrimaryBirthDt>
+      <SpouseBirthDt>1978-02-03</SpouseBirthDt>
+      <PrimaryPriorYearPIN>12345</PrimaryPriorYearPIN>
+      <SpousePriorYearPIN>54321</SpousePriorYearPIN>
+    </SelfSelectPINGrp>
+    <PINTypeCd>Self-Select On-Line</PINTypeCd>
+    <JuratDisclosureCd>Online Self Select PIN</JuratDisclosureCd>
+    <PrimaryPINEnteredByCd>Taxpayer</PrimaryPINEnteredByCd>
+    <SpousePINEnteredByCd>Taxpayer</SpousePINEnteredByCd>
+    <PrimarySignaturePIN>54321</PrimarySignaturePIN>
+    <SpouseSignaturePIN>12345</SpouseSignaturePIN>
+    <PrimarySignatureDt>2024-01-27</PrimarySignatureDt>
+    <SpouseSignatureDt>2024-01-27</SpouseSignatureDt>
+    <ReturnTypeCd>1040</ReturnTypeCd>
+    <Filer>
+      <PrimarySSN>400000015</PrimarySSN>
+      <SpouseSSN>600000013</SpouseSSN>
+      <NameLine1Txt>ZEUS L &amp; HERA&lt;THUNDER</NameLine1Txt>
+      <PrimaryNameControlTxt>THUN</PrimaryNameControlTxt>
+      <SpouseNameControlTxt>THUN</SpouseNameControlTxt>
+      <USAddress>
+        <AddressLine1Txt>391 US-206</AddressLine1Txt>
+        <CityNm>Hammonton</CityNm>
+        <StateAbbreviationCd>NJ</StateAbbreviationCd>
+        <ZIPCd>08037</ZIPCd>
+      </USAddress>
+      <PhoneNum>2125555555</PhoneNum>
+    </Filer>
+    <AdditionalFilerInformation>
+      <AtSubmissionCreationGrp/>
+      <AtSubmissionFilingGrp>
+        <RefundProductElectionInd>false</RefundProductElectionInd>
+        <RefundDisbursementGrp>
+          <RefundDisbursementCd>3</RefundDisbursementCd>
+        </RefundDisbursementGrp>
+        <EmailAddressTxt>zeus.thunder@aol.com</EmailAddressTxt>
+      </AtSubmissionFilingGrp>
+      <TrustedCustomerGrp>
+        <TrustedCustomerCd>0</TrustedCustomerCd>
+        <OOBSecurityVerificationCd>11</OOBSecurityVerificationCd>
+        <AuthenticationAssuranceLevelCd>AAL2</AuthenticationAssuranceLevelCd>
+        <IdentityAssuranceLevelCd>IAL2</IdentityAssuranceLevelCd>
+        <FederatedAssuranceLevelCd>FAL2</FederatedAssuranceLevelCd>
+      </TrustedCustomerGrp>
+    </AdditionalFilerInformation>
+    <FilingSecurityInformation>
+      <AtSubmissionCreationGrp>
+        <IPAddress>
+          <IPv4AddressTxt>76.122.220.120</IPv4AddressTxt>
+        </IPAddress>
+        <IPPortNum>57374</IPPortNum>
+        <DeviceId>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA</DeviceId>
+        <DeviceTypeCd>1</DeviceTypeCd>
+        <UserAgentTxt>curl/8.4.0</UserAgentTxt>
+        <BrowserLanguageTxt>en-us</BrowserLanguageTxt>
+        <PlatformTxt>iOS</PlatformTxt>
+        <TimeZoneOffsetNum>+240</TimeZoneOffsetNum>
+        <SystemTs>******</SystemTs>
+      </AtSubmissionCreationGrp>
+      <AtSubmissionFilingGrp>
+        <IPAddress>
+          <IPv4AddressTxt>76.122.220.120</IPv4AddressTxt>
+        </IPAddress>
+        <FinalIPPortNum>******</FinalIPPortNum>
+        <DeviceId>AEAEF1FED33281B55BDA9E1D6496D6A12D6085D7</DeviceId>
+        <DeviceTypeCd>1</DeviceTypeCd>
+        <UserAgentTxt>curl/8.4.0</UserAgentTxt>
+        <TimeZoneOffsetNum>-005</TimeZoneOffsetNum>
+        <SystemTs>******</SystemTs>
+      </AtSubmissionFilingGrp>
+      <FederalOriginalSubmissionId>******</FederalOriginalSubmissionId>
+      <FederalOriginalSubmissionIdDt>******</FederalOriginalSubmissionIdDt>
+      <FilingLicenseTypeCd>I</FilingLicenseTypeCd>
+      <TotalPreparationSubmissionTs>0</TotalPreparationSubmissionTs>
+      <TotActiveTimePrepSubmissionTs>0</TotActiveTimePrepSubmissionTs>
+      <AuthenticationReviewCd>5</AuthenticationReviewCd>
+      <VendorControlNum>******</VendorControlNum>
+    </FilingSecurityInformation>
+  </ReturnHeader>
+  <ReturnData documentCnt="6">
+    <IRS1040 documentId="IRS10400001">
+      <IndividualReturnFilingStatusCd>2</IndividualReturnFilingStatusCd>
+      <VirtualCurAcquiredDurTYInd>false</VirtualCurAcquiredDurTYInd>
+      <TotalExemptPrimaryAndSpouseCnt>2</TotalExemptPrimaryAndSpouseCnt>
+      <DependentDetail>
+        <DependentFirstNm>KRONOS</DependentFirstNm>
+        <DependentLastNm>ATHENS</DependentLastNm>
+        <DependentNameControlTxt>ATHE</DependentNameControlTxt>
+        <DependentSSN>300000029</DependentSSN>
+        <DependentRelationshipCd>PARENT</DependentRelationshipCd>
+        <EligibleForODCInd>X</EligibleForODCInd>
+      </DependentDetail>
+      <DependentDetail>
+        <DependentFirstNm>APHRODITE</DependentFirstNm>
+        <DependentLastNm>LOVE</DependentLastNm>
+        <DependentNameControlTxt>LOVE</DependentNameControlTxt>
+        <DependentSSN>900000067</DependentSSN>
+        <DependentRelationshipCd>GRANDCHILD</DependentRelationshipCd>
+        <EligibleForODCInd>X</EligibleForODCInd>
+      </DependentDetail>
+      <MoreDependentsInd>X</MoreDependentsInd>
+      <ChldWhoLivedWithYouCnt>2</ChldWhoLivedWithYouCnt>
+      <OtherDependentsListedCnt>0</OtherDependentsListedCnt>
+      <TotalExemptionsCnt>4</TotalExemptionsCnt>
+      <WagesAmt referenceDocumentId="W20001" referenceDocumentName="IRSW2">50000</WagesAmt>
+      <WagesSalariesAndTipsAmt>50000</WagesSalariesAndTipsAmt>
+      <TaxableInterestAmt>500</TaxableInterestAmt>
+      <SocSecBnftAmt>8000</SocSecBnftAmt>
+      <TaxableSocSecAmt>6800</TaxableSocSecAmt>
+      <TotalAdditionalIncomeAmt>500</TotalAdditionalIncomeAmt>
+      <TotalIncomeAmt>57800</TotalIncomeAmt>
+      <TotalAdjustmentsAmt>1500</TotalAdjustmentsAmt>
+      <AdjustedGrossIncomeAmt>56300</AdjustedGrossIncomeAmt>
+      <TotalItemizedOrStandardDedAmt>27700</TotalItemizedOrStandardDedAmt>
+      <TotalDeductionsAmt>27700</TotalDeductionsAmt>
+      <TaxableIncomeAmt>28600</TaxableIncomeAmt>
+      <TaxAmt>2995</TaxAmt>
+      <TotalTaxBeforeCrAndOthTaxesAmt>2995</TotalTaxBeforeCrAndOthTaxesAmt>
+      <CTCODCAmt>2995</CTCODCAmt>
+      <TotalCreditsAmt>2995</TotalCreditsAmt>
+      <FormW2WithheldTaxAmt>1000</FormW2WithheldTaxAmt>
+      <Form1099WithheldTaxAmt referenceDocumentId="OTHERWITHHOLDING0001" referenceDocumentName="OtherWithholdingStatement">5</Form1099WithheldTaxAmt>
+      <WithholdingTaxAmt>1005</WithholdingTaxAmt>
+      <EarnedIncomeCreditAmt referenceDocumentId="IRSEIC0001" referenceDocumentName="IRS1040ScheduleEIC">1490</EarnedIncomeCreditAmt>
+      <AdditionalChildTaxCreditAmt referenceDocumentId="IRS8812001" referenceDocumentName="IRS1040Schedule8812">6400</AdditionalChildTaxCreditAmt>
+      <RefundableCreditsAmt>7890</RefundableCreditsAmt>
+      <TotalPaymentsAmt>8895</TotalPaymentsAmt>
+      <OverpaidAmt>8895</OverpaidAmt>
+      <RefundAmt>8895</RefundAmt>
+      <OwedAmt>0</OwedAmt>
+      <ThirdPartyDesigneeInd>false</ThirdPartyDesigneeInd>
+      <PrimaryOccupationTxt>God of Thunder</PrimaryOccupationTxt>
+      <SpouseOccupationTxt>stay at home parent</SpouseOccupationTxt>
+      <RefundProductCd>NO FINANCIAL PRODUCT</RefundProductCd>
+    </IRS1040>
+    <IRS1040Schedule1 documentId="IRS1040S1001">
+      <UnemploymentCompAmt>500</UnemploymentCompAmt>
+      <TotalAdditionalIncomeAmt>500</TotalAdditionalIncomeAmt>
+      <EducatorExpensesAmt>200</EducatorExpensesAmt>
+      <StudentLoanInterestDedAmt>1300</StudentLoanInterestDedAmt>
+      <TotalAdjustmentsAmt>1500</TotalAdjustmentsAmt>
+    </IRS1040Schedule1>
+    <IRS1040Schedule8812 documentName="IRS1040Schedule8812" documentId="IRS8812001">
+      <AdjustedGrossIncomeAmt>56300</AdjustedGrossIncomeAmt>
+      <ModifiedAGIAmt>56300</ModifiedAGIAmt>
+      <QlfyChildUnderAgeSSNCnt>4</QlfyChildUnderAgeSSNCnt>
+      <QlfyChildUnderAgeSSNLimtAmt>8000</QlfyChildUnderAgeSSNLimtAmt>
+      <OtherDependentCnt>7</OtherDependentCnt>
+      <OtherDependentCreditAmt>3500</OtherDependentCreditAmt>
+      <InitialCTCODCAmt>11500</InitialCTCODCAmt>
+      <FilingStatusThresholdCd>400000</FilingStatusThresholdCd>
+      <CTCODCOverAGILimitInd>true</CTCODCOverAGILimitInd>
+      <CTCODCAfterAGILimitAmt>11500</CTCODCAfterAGILimitAmt>
+      <ACTCTaxLiabiltyLimitAmt>2995</ACTCTaxLiabiltyLimitAmt>
+      <CTCODCAmt>2995</CTCODCAmt>
+      <ClaimACTCAllFilersGrp>
+        <ACTCBeforeLimitAmt>8505</ACTCBeforeLimitAmt>
+        <QlfyChildUnderAgeSSNCnt>4</QlfyChildUnderAgeSSNCnt>
+        <QlfyChildUnderAgeSSNLimtAmt>6400</QlfyChildUnderAgeSSNLimtAmt>
+        <ACTCAfterLimitAmt>6400</ACTCAfterLimitAmt>
+        <TotalEarnedIncomeAmt>50000</TotalEarnedIncomeAmt>
+        <EarnedIncmMoreThanSpecifiedInd>true</EarnedIncmMoreThanSpecifiedInd>
+        <NetTotalEarnedIncomeAmt>47500</NetTotalEarnedIncomeAmt>
+        <NetEarnedIncomeCalculatedAmt>7125</NetEarnedIncomeCalculatedAmt>
+        <ThreeOrMoreQlfyChildrenInd>true</ThreeOrMoreQlfyChildrenInd>
+        <FromW2Amt>3825</FromW2Amt>
+        <CalcFromW2AndReturnAmt>3825</CalcFromW2AndReturnAmt>
+        <CalcAmtFromRetPlusTaxWhldAmt>1490</CalcAmtFromRetPlusTaxWhldAmt>
+        <CalculatedDifferenceAmt>2335</CalculatedDifferenceAmt>
+        <LargerCalcIncomeOrDiffAmt>7125</LargerCalcIncomeOrDiffAmt>
+      </ClaimACTCAllFilersGrp>
+      <AdditionalChildTaxCreditAmt>6400</AdditionalChildTaxCreditAmt>
+    </IRS1040Schedule8812>
+    <IRS1040ScheduleEIC documentName="IRS1040ScheduleEIC" documentId="IRSEIC0001">
+      <QualifyingChildInformation>
+        <QualifyingChildNameControlTxt>TROY</QualifyingChildNameControlTxt>
+        <ChildFirstAndLastName>
+          <PersonFirstNm>HELEN</PersonFirstNm>
+          <PersonLastNm>TROY</PersonLastNm>
+        </ChildFirstAndLastName>
+        <QualifyingChildSSN>900000025</QualifyingChildSSN>
+        <ChildBirthYr>2012</ChildBirthYr>
+        <ChildRelationshipCd>NEPHEW</ChildRelationshipCd>
+        <MonthsChildLivedWithYouCnt>12</MonthsChildLivedWithYouCnt>
+      </QualifyingChildInformation>
+      <QualifyingChildInformation>
+        <QualifyingChildNameControlTxt>THUN</QualifyingChildNameControlTxt>
+        <ChildFirstAndLastName>
+          <PersonFirstNm>ARES</PersonFirstNm>
+          <PersonLastNm>THUNDER</PersonLastNm>
+        </ChildFirstAndLastName>
+        <QualifyingChildSSN>300000022</QualifyingChildSSN>
+        <ChildBirthYr>2009</ChildBirthYr>
+        <ChildRelationshipCd>DAUGHTER</ChildRelationshipCd>
+        <MonthsChildLivedWithYouCnt>12</MonthsChildLivedWithYouCnt>
+      </QualifyingChildInformation>
+      <QualifyingChildInformation>
+        <QualifyingChildNameControlTxt>STOR</QualifyingChildNameControlTxt>
+        <ChildFirstAndLastName>
+          <PersonFirstNm>POSEIDON</PersonFirstNm>
+          <PersonLastNm>STORM</PersonLastNm>
+        </ChildFirstAndLastName>
+        <QualifyingChildSSN>900000028</QualifyingChildSSN>
+        <ChildBirthYr>2000</ChildBirthYr>
+        <ChildIsAStudentUnder24Ind>true</ChildIsAStudentUnder24Ind>
+        <ChildRelationshipCd>NEPHEW</ChildRelationshipCd>
+        <MonthsChildLivedWithYouCnt>07</MonthsChildLivedWithYouCnt>
+      </QualifyingChildInformation>
+    </IRS1040ScheduleEIC>
+    <!-- TODO -->
+    <IRSW2 documentName="IRSW2" documentId="W20001">
+      <EmployeeSSN>400000015</EmployeeSSN>
+      <EmployerEIN>001245767</EmployerEIN>
+      <EmployerNameControlTxt>WSF</EmployerNameControlTxt>
+      <EmployerName>
+        <BusinessNameLine1Txt>Wharton State Forest</BusinessNameLine1Txt>
+      </EmployerName>
+      <EmployerUSAddress>
+        <AddressLine1Txt>31 Batsto Road</AddressLine1Txt>
+        <CityNm>Hammonton</CityNm>
+        <StateAbbreviationCd>NJ</StateAbbreviationCd>
+        <ZIPCd>08037</ZIPCd>
+      </EmployerUSAddress>
+      <EmployeeNm>ZEUS L THUNDER</EmployeeNm>
+      <EmployeeUSAddress>
+        <AddressLine1Txt>391 US-206</AddressLine1Txt>
+        <AddressLine2Txt>Unit 73</AddressLine2Txt>
+        <CityNm>Hammonton</CityNm>
+        <StateAbbreviationCd>NJ</StateAbbreviationCd>
+        <ZIPCd>08037</ZIPCd>
+      </EmployeeUSAddress>
+      <WagesAmt>50000</WagesAmt>
+      <WithholdingAmt>1000</WithholdingAmt>
+      <SocialSecurityWagesAmt>50000</SocialSecurityWagesAmt>
+      <SocialSecurityTaxAmt>3100</SocialSecurityTaxAmt>
+      <MedicareWagesAndTipsAmt>50000</MedicareWagesAndTipsAmt>
+      <MedicareTaxWithheldAmt>725</MedicareTaxWithheldAmt>
+      <OtherDeductionsBenefitsGrp>
+        <Desc>414HSUB</Desc>
+        <Amt>250</Amt>
+      </OtherDeductionsBenefitsGrp>
+      <W2StateLocalTaxGrp>
+        <W2StateTaxGrp>
+          <StateAbbreviationCd>NJ</StateAbbreviationCd>
+          <EmployerStateIdNum>12345</EmployerStateIdNum>
+          <StateWagesAmt>50000</StateWagesAmt>
+          <StateIncomeTaxAmt>500</StateIncomeTaxAmt>
+          <W2LocalTaxGrp>
+            <LocalWagesAndTipsAmt>50000</LocalWagesAndTipsAmt>
+            <LocalIncomeTaxAmt>250</LocalIncomeTaxAmt>
+            <LocalityNm>Hammonton</LocalityNm>
+          </W2LocalTaxGrp>
+        </W2StateTaxGrp>
+      </W2StateLocalTaxGrp>
+      <StandardOrNonStandardCd>S</StandardOrNonStandardCd>
+    </IRSW2>
+    <OtherWithholdingStatement documentName="OtherWithholdingStatement" documentId="OTHERWITHHOLDING0001">
+      <OtherWithholdingStmt>
+        <WithholdingCd>FORM 1099</WithholdingCd>
+        <EIN>000293117</EIN>
+        <WithholdingAmt>5</WithholdingAmt>
+      </OtherWithholdingStmt>
+    </OtherWithholdingStatement>
+  </ReturnData>
+</Return>

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -253,5 +253,102 @@ RSpec.describe PdfFiller::Nj1040Pdf do
         expect(pdf_fields["ZIP Code"]).to eq "08037"
       end
     end
+
+    describe "dependents" do
+      let(:intake) {
+        create(
+        :state_file_nj_intake,
+        :df_data_many_deps
+      )}
+      let(:submission) {
+        create :efile_submission, tax_return: nil, data_source: intake }
+
+      before do
+        intake.dependents.each_with_index do |dependent, i|
+          dependent.update(
+            dob: i.years.ago(Date.new(2020, 1, 1)),
+            first_name: "Firstname#{i}",
+            last_name: "Lastname#{i}",
+            middle_initial: 'ABCDEFGHIJK'[i],
+            suffix: 'JR',
+            ssn: "1234567#{"%02d" % i}"
+          )
+        end
+      end
+
+      it 'enters first four dependents into PDF' do
+        # dependent 1
+        expect(pdf_fields["Last Name First Name Middle Initial 1"]).to eq "Lastname0 Firstname0 A JR"
+
+        expect(pdf_fields["undefined_18"]).to eq "1"
+        expect(pdf_fields["undefined_19"]).to eq "2"
+        expect(pdf_fields["undefined_20"]).to eq "3"
+        expect(pdf_fields["Text54"]).to eq "4"
+        expect(pdf_fields["Text55"]).to eq "5"
+        expect(pdf_fields["Text56"]).to eq "6"
+        expect(pdf_fields["Text57"]).to eq "7"
+        expect(pdf_fields["Text58"]).to eq "0"
+        expect(pdf_fields["Text59"]).to eq "0"
+
+        expect(pdf_fields["Birth Year"]).to eq "2"
+        expect(pdf_fields["Text60"]).to eq "0"
+        expect(pdf_fields["Text61"]).to eq "2"
+        expect(pdf_fields["Text62"]).to eq "0"
+
+        # dependent 2
+        expect(pdf_fields["Last Name First Name Middle Initial 2"]).to eq "Lastname1 Firstname1 B JR"
+
+        expect(pdf_fields["undefined_21"]).to eq "1"
+        expect(pdf_fields["undefined_22"]).to eq "2"
+        expect(pdf_fields["undefined_23"]).to eq "3"
+        expect(pdf_fields["undefined_24"]).to eq "4"
+        expect(pdf_fields["Text65"]).to eq "5"
+        expect(pdf_fields["Text66"]).to eq "6"
+        expect(pdf_fields["Text67"]).to eq "7"
+        expect(pdf_fields["Text68"]).to eq "0"
+        expect(pdf_fields["Text69"]).to eq "1"
+
+        expect(pdf_fields["Text70"]).to eq "2"
+        expect(pdf_fields["Text71"]).to eq "0"
+        expect(pdf_fields["Text72"]).to eq "1"
+        expect(pdf_fields["Text73"]).to eq "9"
+
+        # dependent 3
+        expect(pdf_fields["Last Name First Name Middle Initial 3"]).to eq "Lastname2 Firstname2 C JR"
+
+        expect(pdf_fields["undefined_25"]).to eq "1"
+        expect(pdf_fields["undefined_26"]).to eq "2"
+        expect(pdf_fields["undefined_27"]).to eq "3"
+        expect(pdf_fields["undefined_28"]).to eq "4"
+        expect(pdf_fields["Text75"]).to eq "5"
+        expect(pdf_fields["Text76"]).to eq "6"
+        expect(pdf_fields["Text77"]).to eq "7"
+        expect(pdf_fields["Text78"]).to eq "0"
+        expect(pdf_fields["Text79"]).to eq "2"
+
+        expect(pdf_fields["Text80"]).to eq "2"
+        expect(pdf_fields["Text81"]).to eq "0"
+        expect(pdf_fields["Text82"]).to eq "1"
+        expect(pdf_fields["Text83"]).to eq "8"
+
+        # dependent 4
+        expect(pdf_fields["Last Name First Name Middle Initial 4"]).to eq "Lastname3 Firstname3 D JR"
+
+        expect(pdf_fields["undefined_29"]).to eq "1"
+        expect(pdf_fields["undefined_30"]).to eq "2"
+        expect(pdf_fields["undefined_31"]).to eq "3"
+        expect(pdf_fields["undefined_32"]).to eq "4"
+        expect(pdf_fields["Text85"]).to eq "5"
+        expect(pdf_fields["Text86"]).to eq "6"
+        expect(pdf_fields["Text87"]).to eq "7"
+        expect(pdf_fields["Text88"]).to eq "0"
+        expect(pdf_fields["Text89"]).to eq "3"
+
+        expect(pdf_fields["Text90"]).to eq "2"
+        expect(pdf_fields["Text91"]).to eq "0"
+        expect(pdf_fields["Text92"]).to eq "1"
+        expect(pdf_fields["Text93"]).to eq "7"
+      end
+    end
   end
 end

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -255,99 +255,151 @@ RSpec.describe PdfFiller::Nj1040Pdf do
     end
 
     describe "dependents" do
-      let(:intake) {
-        create(
-        :state_file_nj_intake,
-        :df_data_many_deps
-      )}
-      let(:submission) {
-        create :efile_submission, tax_return: nil, data_source: intake }
 
-      before do
-        intake.dependents.each_with_index do |dependent, i|
-          dependent.update(
-            dob: i.years.ago(Date.new(2020, 1, 1)),
-            first_name: "Firstname#{i}",
-            last_name: "Lastname#{i}",
-            middle_initial: 'ABCDEFGHIJK'[i],
-            suffix: 'JR',
-            ssn: "1234567#{"%02d" % i}"
-          )
+      context 'one dependent' do
+        let(:intake) {
+          create(
+            :state_file_nj_intake,
+            :df_data_one_dep
+          )}
+        let(:submission) {
+          create :efile_submission, tax_return: nil, data_source: intake }
+
+        before do
+          intake.dependents[0].update(dob: Date.new(2023, 1, 1))
+        end
+
+        it 'enters single dependent into PDF' do
+          # dependent 1
+          expect(pdf_fields["Last Name First Name Middle Initial 1"]).to eq "ATHENS KRONOS"
+          expect(pdf_fields["undefined_18"]).to eq "3"
+          expect(pdf_fields["undefined_19"]).to eq "0"
+          expect(pdf_fields["undefined_20"]).to eq "0"
+          expect(pdf_fields["Text54"]).to eq "0"
+          expect(pdf_fields["Text55"]).to eq "0"
+          expect(pdf_fields["Text56"]).to eq "0"
+          expect(pdf_fields["Text57"]).to eq "0"
+          expect(pdf_fields["Text58"]).to eq "2"
+          expect(pdf_fields["Text59"]).to eq "9"
+
+          expect(pdf_fields["Birth Year"]).to eq "2"
+          expect(pdf_fields["Text60"]).to eq "0"
+          expect(pdf_fields["Text61"]).to eq "2"
+          expect(pdf_fields["Text62"]).to eq "3"
+
+          # dependent 2
+          expect(pdf_fields["Last Name First Name Middle Initial 2"]).to eq ""
+          expect(pdf_fields["undefined_21"]).to eq ""
+          expect(pdf_fields["undefined_22"]).to eq ""
+          expect(pdf_fields["undefined_23"]).to eq ""
+          expect(pdf_fields["undefined_24"]).to eq ""
+          expect(pdf_fields["Text65"]).to eq ""
+          expect(pdf_fields["Text66"]).to eq ""
+          expect(pdf_fields["Text67"]).to eq ""
+          expect(pdf_fields["Text68"]).to eq ""
+          expect(pdf_fields["Text69"]).to eq ""
+          expect(pdf_fields["Text70"]).to eq ""
+          expect(pdf_fields["Text71"]).to eq ""
+          expect(pdf_fields["Text72"]).to eq ""
+          expect(pdf_fields["Text73"]).to eq ""
         end
       end
 
-      it 'enters first four dependents into PDF' do
-        # dependent 1
-        expect(pdf_fields["Last Name First Name Middle Initial 1"]).to eq "Lastname0 Firstname0 A JR"
+      context 'many dependents' do
+        let(:intake) {
+          create(
+            :state_file_nj_intake,
+            :df_data_many_deps
+          )}
+        let(:submission) {
+          create :efile_submission, tax_return: nil, data_source: intake }
 
-        expect(pdf_fields["undefined_18"]).to eq "1"
-        expect(pdf_fields["undefined_19"]).to eq "2"
-        expect(pdf_fields["undefined_20"]).to eq "3"
-        expect(pdf_fields["Text54"]).to eq "4"
-        expect(pdf_fields["Text55"]).to eq "5"
-        expect(pdf_fields["Text56"]).to eq "6"
-        expect(pdf_fields["Text57"]).to eq "7"
-        expect(pdf_fields["Text58"]).to eq "0"
-        expect(pdf_fields["Text59"]).to eq "0"
+        before do
+          intake.dependents.each_with_index do |dependent, i|
+            dependent.update(
+              dob: i.years.ago(Date.new(2020, 1, 1)),
+              first_name: "Firstname#{i}",
+              last_name: "Lastname#{i}",
+              middle_initial: 'ABCDEFGHIJK'[i],
+              suffix: 'JR',
+              ssn: "1234567#{"%02d" % i}"
+            )
+          end
+        end
 
-        expect(pdf_fields["Birth Year"]).to eq "2"
-        expect(pdf_fields["Text60"]).to eq "0"
-        expect(pdf_fields["Text61"]).to eq "2"
-        expect(pdf_fields["Text62"]).to eq "0"
+        it 'enters first four dependents into PDF' do
+          # dependent 1
+          expect(pdf_fields["Last Name First Name Middle Initial 1"]).to eq "Lastname0 Firstname0 A JR"
 
-        # dependent 2
-        expect(pdf_fields["Last Name First Name Middle Initial 2"]).to eq "Lastname1 Firstname1 B JR"
+          expect(pdf_fields["undefined_18"]).to eq "1"
+          expect(pdf_fields["undefined_19"]).to eq "2"
+          expect(pdf_fields["undefined_20"]).to eq "3"
+          expect(pdf_fields["Text54"]).to eq "4"
+          expect(pdf_fields["Text55"]).to eq "5"
+          expect(pdf_fields["Text56"]).to eq "6"
+          expect(pdf_fields["Text57"]).to eq "7"
+          expect(pdf_fields["Text58"]).to eq "0"
+          expect(pdf_fields["Text59"]).to eq "0"
 
-        expect(pdf_fields["undefined_21"]).to eq "1"
-        expect(pdf_fields["undefined_22"]).to eq "2"
-        expect(pdf_fields["undefined_23"]).to eq "3"
-        expect(pdf_fields["undefined_24"]).to eq "4"
-        expect(pdf_fields["Text65"]).to eq "5"
-        expect(pdf_fields["Text66"]).to eq "6"
-        expect(pdf_fields["Text67"]).to eq "7"
-        expect(pdf_fields["Text68"]).to eq "0"
-        expect(pdf_fields["Text69"]).to eq "1"
+          expect(pdf_fields["Birth Year"]).to eq "2"
+          expect(pdf_fields["Text60"]).to eq "0"
+          expect(pdf_fields["Text61"]).to eq "2"
+          expect(pdf_fields["Text62"]).to eq "0"
 
-        expect(pdf_fields["Text70"]).to eq "2"
-        expect(pdf_fields["Text71"]).to eq "0"
-        expect(pdf_fields["Text72"]).to eq "1"
-        expect(pdf_fields["Text73"]).to eq "9"
+          # dependent 2
+          expect(pdf_fields["Last Name First Name Middle Initial 2"]).to eq "Lastname1 Firstname1 B JR"
 
-        # dependent 3
-        expect(pdf_fields["Last Name First Name Middle Initial 3"]).to eq "Lastname2 Firstname2 C JR"
+          expect(pdf_fields["undefined_21"]).to eq "1"
+          expect(pdf_fields["undefined_22"]).to eq "2"
+          expect(pdf_fields["undefined_23"]).to eq "3"
+          expect(pdf_fields["undefined_24"]).to eq "4"
+          expect(pdf_fields["Text65"]).to eq "5"
+          expect(pdf_fields["Text66"]).to eq "6"
+          expect(pdf_fields["Text67"]).to eq "7"
+          expect(pdf_fields["Text68"]).to eq "0"
+          expect(pdf_fields["Text69"]).to eq "1"
 
-        expect(pdf_fields["undefined_25"]).to eq "1"
-        expect(pdf_fields["undefined_26"]).to eq "2"
-        expect(pdf_fields["undefined_27"]).to eq "3"
-        expect(pdf_fields["undefined_28"]).to eq "4"
-        expect(pdf_fields["Text75"]).to eq "5"
-        expect(pdf_fields["Text76"]).to eq "6"
-        expect(pdf_fields["Text77"]).to eq "7"
-        expect(pdf_fields["Text78"]).to eq "0"
-        expect(pdf_fields["Text79"]).to eq "2"
+          expect(pdf_fields["Text70"]).to eq "2"
+          expect(pdf_fields["Text71"]).to eq "0"
+          expect(pdf_fields["Text72"]).to eq "1"
+          expect(pdf_fields["Text73"]).to eq "9"
 
-        expect(pdf_fields["Text80"]).to eq "2"
-        expect(pdf_fields["Text81"]).to eq "0"
-        expect(pdf_fields["Text82"]).to eq "1"
-        expect(pdf_fields["Text83"]).to eq "8"
+          # dependent 3
+          expect(pdf_fields["Last Name First Name Middle Initial 3"]).to eq "Lastname2 Firstname2 C JR"
 
-        # dependent 4
-        expect(pdf_fields["Last Name First Name Middle Initial 4"]).to eq "Lastname3 Firstname3 D JR"
+          expect(pdf_fields["undefined_25"]).to eq "1"
+          expect(pdf_fields["undefined_26"]).to eq "2"
+          expect(pdf_fields["undefined_27"]).to eq "3"
+          expect(pdf_fields["undefined_28"]).to eq "4"
+          expect(pdf_fields["Text75"]).to eq "5"
+          expect(pdf_fields["Text76"]).to eq "6"
+          expect(pdf_fields["Text77"]).to eq "7"
+          expect(pdf_fields["Text78"]).to eq "0"
+          expect(pdf_fields["Text79"]).to eq "2"
 
-        expect(pdf_fields["undefined_29"]).to eq "1"
-        expect(pdf_fields["undefined_30"]).to eq "2"
-        expect(pdf_fields["undefined_31"]).to eq "3"
-        expect(pdf_fields["undefined_32"]).to eq "4"
-        expect(pdf_fields["Text85"]).to eq "5"
-        expect(pdf_fields["Text86"]).to eq "6"
-        expect(pdf_fields["Text87"]).to eq "7"
-        expect(pdf_fields["Text88"]).to eq "0"
-        expect(pdf_fields["Text89"]).to eq "3"
+          expect(pdf_fields["Text80"]).to eq "2"
+          expect(pdf_fields["Text81"]).to eq "0"
+          expect(pdf_fields["Text82"]).to eq "1"
+          expect(pdf_fields["Text83"]).to eq "8"
 
-        expect(pdf_fields["Text90"]).to eq "2"
-        expect(pdf_fields["Text91"]).to eq "0"
-        expect(pdf_fields["Text92"]).to eq "1"
-        expect(pdf_fields["Text93"]).to eq "7"
+          # dependent 4
+          expect(pdf_fields["Last Name First Name Middle Initial 4"]).to eq "Lastname3 Firstname3 D JR"
+
+          expect(pdf_fields["undefined_29"]).to eq "1"
+          expect(pdf_fields["undefined_30"]).to eq "2"
+          expect(pdf_fields["undefined_31"]).to eq "3"
+          expect(pdf_fields["undefined_32"]).to eq "4"
+          expect(pdf_fields["Text85"]).to eq "5"
+          expect(pdf_fields["Text86"]).to eq "6"
+          expect(pdf_fields["Text87"]).to eq "7"
+          expect(pdf_fields["Text88"]).to eq "0"
+          expect(pdf_fields["Text89"]).to eq "3"
+
+          expect(pdf_fields["Text90"]).to eq "2"
+          expect(pdf_fields["Text91"]).to eq "0"
+          expect(pdf_fields["Text92"]).to eq "1"
+          expect(pdf_fields["Text93"]).to eq "7"
+        end
       end
     end
   end

--- a/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
@@ -114,28 +114,30 @@ describe SubmissionBuilder::Ty2024::States::Nj::NjReturnXml, required_schema: "n
           end
         end
 
-        it 'includes each dependent names, SSN, and year of birth' do
-          expect(xml.css("Dependents DependentsName").count).to eq(11)
+        it 'includes each dependent names, SSN, and year of birth to a maximum of 10' do
+          expect(xml.css("Dependents").count).to eq(10)
 
-          last_dep_name = xml.css("Dependents DependentsName")[0]
-          last_dep_ssn = xml.css("Dependents DependentsSSN")[0]
-          last_dep_birth_year = xml.css("Dependents BirthYear")[0]
-          expect(last_dep_name.at("FirstName").text).to eq("Firstname0")
-          expect(last_dep_name.at("LastName").text).to eq("Lastname0")
-          expect(last_dep_name.at("MiddleInitial").text).to eq("A")
-          expect(last_dep_name.at("NameSuffix").text).to eq("JR")
-          expect(last_dep_ssn.text).to eq("000000000")
-          expect(last_dep_birth_year.text).to eq("2020")
+          first_dep = xml.css("Dependents")[0]
+          first_dep_name = first_dep.at("DependentsName")
+          first_dep_ssn = first_dep.at("DependentsSSN")
+          first_dep_birth_year = first_dep.at("BirthYear")
+          expect(first_dep_name.at("FirstName").text).to eq("Firstname0")
+          expect(first_dep_name.at("LastName").text).to eq("Lastname0")
+          expect(first_dep_name.at("MiddleInitial").text).to eq("A")
+          expect(first_dep_name.at("NameSuffix").text).to eq("JR")
+          expect(first_dep_ssn.text).to eq("000000000")
+          expect(first_dep_birth_year.text).to eq("2020")
 
-          last_dep_name = xml.css("Dependents DependentsName")[10]
-          last_dep_ssn = xml.css("Dependents DependentsSSN")[10]
-          last_dep_birth_year = xml.css("Dependents BirthYear")[10]
-          expect(last_dep_name.at("FirstName").text).to eq("Firstname10")
-          expect(last_dep_name.at("LastName").text).to eq("Lastname10")
-          expect(last_dep_name.at("MiddleInitial").text).to eq("K")
+          last_dep = xml.css("Dependents")[9]
+          last_dep_name = last_dep.at("DependentsName")
+          last_dep_ssn = last_dep.at("DependentsSSN")
+          last_dep_birth_year = last_dep.at("BirthYear")
+          expect(last_dep_name.at("FirstName").text).to eq("Firstname9")
+          expect(last_dep_name.at("LastName").text).to eq("Lastname9")
+          expect(last_dep_name.at("MiddleInitial").text).to eq("J")
           expect(last_dep_name.at("NameSuffix").text).to eq("JR")
-          expect(last_dep_ssn.text).to eq("000000010")
-          expect(last_dep_birth_year.text).to eq("2010")
+          expect(last_dep_ssn.text).to eq("000000009")
+          expect(last_dep_birth_year.text).to eq("2011")
         end
       end
     end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://github.com/newjersey/affordability-pm/issues/42

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- [Code] Add zeus_two_deps so that we can test multiple without going through 11 dependents
- Include `BirthYear` in XML output for each dependent
- Fill in first 4 dependents with name, SSN, and birth year in PDF

## How to test?
- Use `zeus_one_dep` to test output with 1 dependent
- Use `zeus_two_deps` to test output with 2 dependents
- Use `zeus_many_deps` to test output with 11 dependents (validates all 11 show on XML, only first 4 show on PDF) 
  
## Screenshots (for visual changes)
![image](https://github.com/user-attachments/assets/91357998-2e6f-4b50-b133-b5ee21959260)

