### PR TITLE
remove nj schema skips now that it's available in s3 and drive

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
           key: parallel-runtime-{{ checksum "/tmp/today" }}
       - run: RAILS_ENV=test bin/shakapacker
       - run:
-          command: bundle exec parallel_rspec -n 12 -o "--tag ~required_schema:nj" || touch /tmp/re-run
+          command: bundle exec parallel_rspec -n 12 || touch /tmp/re-run
           environment:
             EAGER_LOAD: 1
             RAILS_CACHE_CLASSES: 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ commands:
     steps:
       - restore_cache:
           key: bundle-{{ checksum "lib/tasks/setup.rake" }}-v2
-      - run: if [ ! -d vendor/irs/unpacked ] ; then bundle exec rails setup:download_efile_schemas setup:unzip_efile_schemas ; fi && find vendor/irs
+      - run: if [ ! -d vendor/irs/unpacked ] ; then bundle exec rails setup:download_efile_schemas setup:unzip_efile_schemas ; fi && find vendor/irs && find vendor/us_states
       - save_cache:
           key: bundle-{{ checksum "lib/tasks/setup.rake" }}-v2
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,10 +66,10 @@ commands:
     description: "Install IRS e-File schemas"
     steps:
       - restore_cache:
-          key: bundle-{{ checksum "lib/tasks/setup.rake" }}-v2
+          key: bundle-{{ checksum "app/lib/schema_file_loader.rb" }}-v2
       - run: if [ ! -d vendor/irs/unpacked ] ; then bundle exec rails setup:download_efile_schemas setup:unzip_efile_schemas ; fi && find vendor/irs && find vendor/us_states
       - save_cache:
-          key: bundle-{{ checksum "lib/tasks/setup.rake" }}-v2
+          key: bundle-{{ checksum "app/lib/schema_file_loader.rb" }}-v2
           paths:
             - /mnt/ramdisk/vendor/irs
             - /mnt/ramdisk/vendor/us_states

--- a/.rspec-local.example
+++ b/.rspec-local.example
@@ -1,1 +1,0 @@
---tag ~required_schema:nj

--- a/app/lib/schema_file_loader.rb
+++ b/app/lib/schema_file_loader.rb
@@ -10,7 +10,7 @@ class SchemaFileLoader
       ["efile1040x_2022v5.3.zip", "irs"],
       ["efile1040x_2023v5.0.zip", "irs"]
     ] +
-      StateFile::StateInformationService.active_state_codes.excluding("nj").map do |state_code|
+      StateFile::StateInformationService.active_state_codes.map do |state_code|
         [StateFile::StateInformationService.schema_file_name(state_code), "us_states"]
       end
   ).freeze

--- a/app/lib/submission_builder/ty2024/states/nj/nj_return_xml.rb
+++ b/app/lib/submission_builder/ty2024/states/nj/nj_return_xml.rb
@@ -6,12 +6,6 @@ module SubmissionBuilder
       module Nj
         class NjReturnXml < SubmissionBuilder::StateReturn
 
-          # TEMPORARY: remove this override when the NJ schema is added
-          def initialize(submission, validate: true, kwargs: {})
-            super
-            @validate = false
-          end
-
           private
 
           def attached_documents_parent_tag

--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -15,7 +15,6 @@ namespace :setup do
   task download_efile_schemas: :environment do |_task|
     SchemaFileLoader.prepare_directories(vendor_dir)
     SchemaFileLoader.download_schemas_from_s3(vendor_dir)
-    puts "heck"
   end
 
   task unzip_efile_schemas: :environment do |_task|

--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -15,6 +15,7 @@ namespace :setup do
   task download_efile_schemas: :environment do |_task|
     SchemaFileLoader.prepare_directories(vendor_dir)
     SchemaFileLoader.download_schemas_from_s3(vendor_dir)
+    puts "heck"
   end
 
   task unzip_efile_schemas: :environment do |_task|

--- a/spec/lib/schema_file_loader_spec.rb
+++ b/spec/lib/schema_file_loader_spec.rb
@@ -9,6 +9,7 @@ describe SchemaFileLoader do
       ["efile1040x_2023v5.0.zip", "irs"],
       ["AZIndividual2023v1.0.zip", "us_states"],
       ["NCIndividual2023v1.0.zip", "us_states"],
+      ["NJIndividual2023V0.4.zip", "us_states"],
       ["NYSIndividual2023V4.0.zip", "us_states"],
     ]
   end
@@ -82,6 +83,7 @@ describe SchemaFileLoader do
           ["testy/irs/efile1040x_2023v5.0.zip", 'irs'],
           ["testy/us_states/AZIndividual2023v1.0.zip", 'us_states'],
           ["testy/us_states/NCIndividual2023v1.0.zip", 'us_states'],
+          ["testy/us_states/NJIndividual2023V0.4.zip", 'us_states'],
           ["testy/us_states/NYSIndividual2023V4.0.zip", 'us_states']
         ]
       )


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-567
## Is PM acceptance required?
- No - merge after code review approval
## What was done?
- NJ schema zip added to s3 and google drive
- Places where we skipped over or didn't use the NJ schema are removed
- did NOT remove the required_schemas tag or ALLOWED_SCHEMAS env variable on test runs that allows NJ team to skip schema-dependent tests that require non-NJ schemas
- Made a few improvements to the circleci step where we download schemas: changed the cache key for schema contents to the checksum of the schema_file_loader.rb file, and print out the contents of vendor/us_states along with vendor/irs for debugging
## How to test?
- All test should pass, without the NJ schemas being skipped, indicating that this PR works