### PR TITLE
Fix failing state_return_spec: use Nokogiri to pull expected value instead of DfW2 class method

### DIFF
--- a/spec/lib/submission_builder/state_return_spec.rb
+++ b/spec/lib/submission_builder/state_return_spec.rb
@@ -51,12 +51,12 @@ describe SubmissionBuilder::StateReturn do
 
               # w2 at index 0 remains the same
               w2_from_xml = xml.css('IRSW2')[0]
-              expect(w2_from_xml.at("EmployerStateIdNum").text).to eq intake.direct_file_data.w2s[0].EmployerStateIdNum
-              expect(w2_from_xml.at("LocalIncomeTaxAmt").text).to eq intake.direct_file_data.w2s[0].LocalIncomeTaxAmt.to_s
-              expect(w2_from_xml.at("LocalWagesAndTipsAmt").text).to eq intake.direct_file_data.w2s[0].LocalWagesAndTipsAmt.to_s
-              expect(w2_from_xml.at("LocalityNm").text).to eq intake.direct_file_data.w2s[0].LocalityNm.upcase
-              expect(w2_from_xml.at("StateIncomeTaxAmt").text).to eq intake.direct_file_data.w2s[0].StateIncomeTaxAmt.to_s
-              expect(w2_from_xml.at("StateWagesAmt").text).to eq intake.direct_file_data.w2s[0].StateWagesAmt.to_s
+              expect(w2_from_xml.at("EmployerStateIdNum").text).to eq intake.direct_file_data.w2s[0].node.at("W2StateLocalTaxGrp EmployerStateIdNum").text
+              expect(w2_from_xml.at("LocalIncomeTaxAmt").text).to eq intake.direct_file_data.w2s[0].node.at("W2StateLocalTaxGrp LocalIncomeTaxAmt").text
+              expect(w2_from_xml.at("LocalWagesAndTipsAmt").text).to eq intake.direct_file_data.w2s[0].node.at("W2StateLocalTaxGrp LocalWagesAndTipsAmt").text
+              expect(w2_from_xml.at("LocalityNm").text).to eq intake.direct_file_data.w2s[0].node.at("W2StateLocalTaxGrp LocalityNm").text.upcase
+              expect(w2_from_xml.at("StateIncomeTaxAmt").text).to eq intake.direct_file_data.w2s[0].node.at("W2StateLocalTaxGrp StateIncomeTaxAmt").text
+              expect(w2_from_xml.at("StateWagesAmt").text).to eq intake.direct_file_data.w2s[0].node.at("W2StateLocalTaxGrp StateWagesAmt").text
 
               # w2 at index 1 is filled in with info from client
               w2_from_db = xml.css('IRSW2')[1]


### PR DESCRIPTION
## Link to pivotal/JIRA issue
N/A
## Is PM acceptance required? (delete one)
- No - merge after code review approval
## What was done?
- A [PR from NJ](https://github.com/codeforamerica/vita-min/pull/4772) uncovered an issue with this spec: the methods defined by DfXmlAccessor convert nodes that end with _amt to integers but when we construct W2s we just copy over the whole chunk of xml from df without converting the values. The spec compares the constructed xml values with the values pulled using the accessor class, so one is rounded and the other is not. #4772 uncovered it by adding a fixture that included a decimal value as one of the amounts.
- This PR pulls the expected value from the DF fixture without rounding it
- There is a bigger conversation to be had I think about the fact that all of our df xml accessor methods call `.to_i` but this step is just to fix main
