### PR TITLE
NJ 55 - Add taxpayer SSN and name to header

### DIFF
--- a/app/lib/pdf_filler/nj1040_pdf.rb
+++ b/app/lib/pdf_filler/nj1040_pdf.rb
@@ -20,6 +20,14 @@ module PdfFiller
       mfj_spouse_ssn = get_mfj_spouse_ssn
       mfs_spouse_ssn = get_mfs_spouse_ssn
       answers = {
+        # header
+        'Your Social Security Number': taxpayer_ssn.to_s,
+        'Your Social Security Number_2': taxpayer_ssn.to_s,
+        'Your Social Security Number_3': taxpayer_ssn.to_s,
+        'Names as shown on Form NJ1040': get_name,
+        'Names as shown on Form NJ1040_2': get_name,
+        'Names as shown on Form NJ1040_3': get_name,
+
         # county code
         CM4: county_code[1],
         CM3: county_code[2],

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -38,6 +38,12 @@ RSpec.describe PdfFiller::Nj1040Pdf do
         )
       }
 
+      it 'sets taxpayer SSN fields on header' do
+        expect(pdf_fields["Your Social Security Number"]).to eq "123456789"
+        expect(pdf_fields["Your Social Security Number_2"]).to eq "123456789"
+        expect(pdf_fields["Your Social Security Number_3"]).to eq "123456789"
+      end
+
       it 'sets taxpayer SSN fields' do
         expect(pdf_fields["undefined"]).to eq "1"
         expect(pdf_fields["undefined_2"]).to eq "2"
@@ -57,10 +63,17 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           create :efile_submission, tax_return: nil, data_source: create(
             :state_file_nj_intake,
             :married_filing_jointly,
+            primary_ssn: "222222222",
             spouse_ssn: "123456789",
             spouse_first_name: "Ada"
           )
         }
+
+        it 'sets taxpayer SSN fields on header to primary SSN' do
+          expect(pdf_fields["Your Social Security Number"]).to eq "222222222"
+          expect(pdf_fields["Your Social Security Number_2"]).to eq "222222222"
+          expect(pdf_fields["Your Social Security Number_3"]).to eq "222222222"
+        end
 
         it 'sets header spouse SSN fields' do
           expect(pdf_fields["undefined_3"]).to eq "1"
@@ -92,10 +105,17 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           create :efile_submission, tax_return: nil, data_source: create(
             :state_file_nj_intake,
             :married_filing_separately,
+            primary_ssn: "222222222",
             spouse_ssn: "123456789",
             spouse_first_name: "Ada"
           )
         }
+
+        it 'sets taxpayer SSN fields on header to primary SSN' do
+          expect(pdf_fields["Your Social Security Number"]).to eq "222222222"
+          expect(pdf_fields["Your Social Security Number_2"]).to eq "222222222"
+          expect(pdf_fields["Your Social Security Number_3"]).to eq "222222222"
+        end
 
         it 'fills married filing separately spouse SSN fields' do
           expect(pdf_fields["undefined_7"]).to eq "1"
@@ -196,6 +216,9 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           }
           it 'fills pdf with LastName FirstName' do
             expect(pdf_fields[name_field]).to eq "Hopper Grace"
+            expect(pdf_fields["Names as shown on Form NJ1040"]).to eq "Hopper Grace"
+            expect(pdf_fields["Names as shown on Form NJ1040_2"]).to eq "Hopper Grace"
+            expect(pdf_fields["Names as shown on Form NJ1040_3"]).to eq "Hopper Grace"
           end
         end
 
@@ -210,6 +233,9 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           }
           it 'fills pdf with LastName FirstName MI' do
             expect(pdf_fields[name_field]).to eq "Hopper Grace B"
+            expect(pdf_fields["Names as shown on Form NJ1040"]).to eq "Hopper Grace B"
+            expect(pdf_fields["Names as shown on Form NJ1040_2"]).to eq "Hopper Grace B"
+            expect(pdf_fields["Names as shown on Form NJ1040_3"]).to eq "Hopper Grace B"
           end
         end
 
@@ -224,6 +250,9 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           }
           it 'fills pdf with LastName FirstName Suf' do
             expect(pdf_fields[name_field]).to eq "Hopper Grace JR"
+            expect(pdf_fields["Names as shown on Form NJ1040"]).to eq "Hopper Grace JR"
+            expect(pdf_fields["Names as shown on Form NJ1040_2"]).to eq "Hopper Grace JR"
+            expect(pdf_fields["Names as shown on Form NJ1040_3"]).to eq "Hopper Grace JR"
           end
         end
 
@@ -239,6 +268,9 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           }
           it 'fills pdf with LastName FirstName MI Suf' do
             expect(pdf_fields[name_field]).to eq "Hopper Grace B JR"
+            expect(pdf_fields["Names as shown on Form NJ1040"]).to eq "Hopper Grace B JR"
+            expect(pdf_fields["Names as shown on Form NJ1040_2"]).to eq "Hopper Grace B JR"
+            expect(pdf_fields["Names as shown on Form NJ1040_3"]).to eq "Hopper Grace B JR"
           end
         end
       end
@@ -258,6 +290,9 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           }
           it 'fills pdf with LastName FirstName & FirstName' do
             expect(pdf_fields[name_field]).to eq "Muppet Bert S & Ernie"
+            expect(pdf_fields["Names as shown on Form NJ1040"]).to eq "Muppet Bert S & Ernie"
+            expect(pdf_fields["Names as shown on Form NJ1040_2"]).to eq "Muppet Bert S & Ernie"
+            expect(pdf_fields["Names as shown on Form NJ1040_3"]).to eq "Muppet Bert S & Ernie"
           end
         end
 
@@ -273,8 +308,12 @@ RSpec.describe PdfFiller::Nj1040Pdf do
               spouse_ssn: "123456789"
             )
           }
+
           it 'fills pdf with LastName FirstName & LastName FirstName' do
             expect(pdf_fields[name_field]).to eq "Lively Blake E & Reynolds Ryan"
+            expect(pdf_fields["Names as shown on Form NJ1040"]).to eq "Lively Blake E & Reynolds Ryan"
+            expect(pdf_fields["Names as shown on Form NJ1040_2"]).to eq "Lively Blake E & Reynolds Ryan"
+            expect(pdf_fields["Names as shown on Form NJ1040_3"]).to eq "Lively Blake E & Reynolds Ryan"
           end
         end
       end

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -215,10 +215,11 @@ RSpec.describe PdfFiller::Nj1040Pdf do
             )
           }
           it 'fills pdf with LastName FirstName' do
-            expect(pdf_fields[name_field]).to eq "Hopper Grace"
-            expect(pdf_fields["Names as shown on Form NJ1040"]).to eq "Hopper Grace"
-            expect(pdf_fields["Names as shown on Form NJ1040_2"]).to eq "Hopper Grace"
-            expect(pdf_fields["Names as shown on Form NJ1040_3"]).to eq "Hopper Grace"
+            expected_name = "Hopper Grace"
+            expect(pdf_fields[name_field]).to eq expected_name
+            expect(pdf_fields["Names as shown on Form NJ1040"]).to eq expected_name
+            expect(pdf_fields["Names as shown on Form NJ1040_2"]).to eq expected_name
+            expect(pdf_fields["Names as shown on Form NJ1040_3"]).to eq expected_name
           end
         end
 
@@ -232,10 +233,11 @@ RSpec.describe PdfFiller::Nj1040Pdf do
             )
           }
           it 'fills pdf with LastName FirstName MI' do
-            expect(pdf_fields[name_field]).to eq "Hopper Grace B"
-            expect(pdf_fields["Names as shown on Form NJ1040"]).to eq "Hopper Grace B"
-            expect(pdf_fields["Names as shown on Form NJ1040_2"]).to eq "Hopper Grace B"
-            expect(pdf_fields["Names as shown on Form NJ1040_3"]).to eq "Hopper Grace B"
+            expected_name = "Hopper Grace B"
+            expect(pdf_fields[name_field]).to eq expected_name
+            expect(pdf_fields["Names as shown on Form NJ1040"]).to eq expected_name
+            expect(pdf_fields["Names as shown on Form NJ1040_2"]).to eq expected_name
+            expect(pdf_fields["Names as shown on Form NJ1040_3"]).to eq expected_name
           end
         end
 
@@ -249,10 +251,11 @@ RSpec.describe PdfFiller::Nj1040Pdf do
             )
           }
           it 'fills pdf with LastName FirstName Suf' do
-            expect(pdf_fields[name_field]).to eq "Hopper Grace JR"
-            expect(pdf_fields["Names as shown on Form NJ1040"]).to eq "Hopper Grace JR"
-            expect(pdf_fields["Names as shown on Form NJ1040_2"]).to eq "Hopper Grace JR"
-            expect(pdf_fields["Names as shown on Form NJ1040_3"]).to eq "Hopper Grace JR"
+            expected_name = "Hopper Grace JR"
+            expect(pdf_fields[name_field]).to eq expected_name
+            expect(pdf_fields["Names as shown on Form NJ1040"]).to eq expected_name
+            expect(pdf_fields["Names as shown on Form NJ1040_2"]).to eq expected_name
+            expect(pdf_fields["Names as shown on Form NJ1040_3"]).to eq expected_name
           end
         end
 
@@ -267,10 +270,11 @@ RSpec.describe PdfFiller::Nj1040Pdf do
             )
           }
           it 'fills pdf with LastName FirstName MI Suf' do
-            expect(pdf_fields[name_field]).to eq "Hopper Grace B JR"
-            expect(pdf_fields["Names as shown on Form NJ1040"]).to eq "Hopper Grace B JR"
-            expect(pdf_fields["Names as shown on Form NJ1040_2"]).to eq "Hopper Grace B JR"
-            expect(pdf_fields["Names as shown on Form NJ1040_3"]).to eq "Hopper Grace B JR"
+            expected_name = "Hopper Grace B JR"
+            expect(pdf_fields[name_field]).to eq expected_name
+            expect(pdf_fields["Names as shown on Form NJ1040"]).to eq expected_name
+            expect(pdf_fields["Names as shown on Form NJ1040_2"]).to eq expected_name
+            expect(pdf_fields["Names as shown on Form NJ1040_3"]).to eq expected_name
           end
         end
       end
@@ -289,10 +293,11 @@ RSpec.describe PdfFiller::Nj1040Pdf do
             )
           }
           it 'fills pdf with LastName FirstName & FirstName' do
-            expect(pdf_fields[name_field]).to eq "Muppet Bert S & Ernie"
-            expect(pdf_fields["Names as shown on Form NJ1040"]).to eq "Muppet Bert S & Ernie"
-            expect(pdf_fields["Names as shown on Form NJ1040_2"]).to eq "Muppet Bert S & Ernie"
-            expect(pdf_fields["Names as shown on Form NJ1040_3"]).to eq "Muppet Bert S & Ernie"
+            expected_name = "Muppet Bert S & Ernie"
+            expect(pdf_fields[name_field]).to eq expected_name
+            expect(pdf_fields["Names as shown on Form NJ1040"]).to eq expected_name
+            expect(pdf_fields["Names as shown on Form NJ1040_2"]).to eq expected_name
+            expect(pdf_fields["Names as shown on Form NJ1040_3"]).to eq expected_name
           end
         end
 
@@ -310,10 +315,11 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           }
 
           it 'fills pdf with LastName FirstName & LastName FirstName' do
-            expect(pdf_fields[name_field]).to eq "Lively Blake E & Reynolds Ryan"
-            expect(pdf_fields["Names as shown on Form NJ1040"]).to eq "Lively Blake E & Reynolds Ryan"
-            expect(pdf_fields["Names as shown on Form NJ1040_2"]).to eq "Lively Blake E & Reynolds Ryan"
-            expect(pdf_fields["Names as shown on Form NJ1040_3"]).to eq "Lively Blake E & Reynolds Ryan"
+            expected_name = "Lively Blake E & Reynolds Ryan"
+            expect(pdf_fields[name_field]).to eq expected_name
+            expect(pdf_fields["Names as shown on Form NJ1040"]).to eq expected_name
+            expect(pdf_fields["Names as shown on Form NJ1040_2"]).to eq expected_name
+            expect(pdf_fields["Names as shown on Form NJ1040_3"]).to eq expected_name
           end
         end
       end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://github.com/newjersey/affordability-pm/issues/55
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Update PDF filler to take name and SSN and put in the header

## How to test?
- Describe the testing approach taken to verify the changes, including:
  - Unit tests
  - Testing locally through the statefile app using the `married_filing_jointly` persona

## Screenshots (for visual changes)
- Before
![image](https://github.com/user-attachments/assets/99447f60-3304-45de-88d8-fd12c554fced)


- After
<img width="989" alt="image" src="https://github.com/user-attachments/assets/c2a11093-70fc-4ab2-84b9-b3bf92cea843">
<img width="977" alt="image" src="https://github.com/user-attachments/assets/b1db6d08-d57a-4866-a110-ec9e7824d457">
<img width="967" alt="image" src="https://github.com/user-attachments/assets/5881bb7d-862b-439d-994d-8a068fa6ae7f">
<img width="961" alt="image" src="https://github.com/user-attachments/assets/e6ecae8a-d1c3-45de-b88c-6e41d4440fd2">


