### PR TITLE
Move all logic to model instead of controller

### DIFF
--- a/app/controllers/state_file/questions/az_public_school_contributions_controller.rb
+++ b/app/controllers/state_file/questions/az_public_school_contributions_controller.rb
@@ -26,11 +26,10 @@ module StateFile
           return redirect_to next_path
         end
 
-        if @az322_contribution.valid? && has_valid_money_format?
+        if @az322_contribution.valid?
           @az322_contribution.save
           redirect_to action: :index, return_to_review: params[:return_to_review]
         else
-          @az322_contribution.errors.add(:amount, 'must be a valid dollar amount') unless has_valid_money_format?
           render :new
         end
       end
@@ -48,11 +47,10 @@ module StateFile
           return redirect_to action: :index, return_to_review: params[:return_to_review]
         end
 
-        if @az322_contribution.valid? && has_valid_money_format?
+        if @az322_contribution.valid?
           @az322_contribution.save
           redirect_to action: :index, return_to_review: params[:return_to_review]
         else
-          @az322_contribution.errors.add(:amount, 'must be a valid dollar amount') unless has_valid_money_format?
           render :edit
         end
       end

--- a/app/controllers/state_file/questions/az_public_school_contributions_controller.rb
+++ b/app/controllers/state_file/questions/az_public_school_contributions_controller.rb
@@ -65,11 +65,6 @@ module StateFile
 
       private
 
-      def has_valid_money_format?
-        amount = az322_contribution_params[:amount]
-        amount.to_s.match?(/^(\d+)?\.?\d{0,2}$/)
-      end
-
       def az322_contribution_params
         params.require(:az322_contribution).permit(
           :made_contribution,

--- a/app/models/az322_contribution.rb
+++ b/app/models/az322_contribution.rb
@@ -39,10 +39,7 @@ class Az322Contribution < ApplicationRecord
 
   # Custom validation for handling values before they are coerced into decimal(12, 2) type
   def amount=(value)
-    if value&.to_s&.match?(/^(\d+)?\.$/) # Remove trailing decimal. Ex: '10.'
-      value = value.chop
-    end
-    write_attribute :amount, value
+    write_attribute :amount, value&.to_s&.chomp('.') # Remove trailing decimal. Ex: '10.'
   end
 
   private

--- a/app/models/az322_contribution.rb
+++ b/app/models/az322_contribution.rb
@@ -29,6 +29,7 @@ class Az322Contribution < ApplicationRecord
   validates :ctds_code, presence: true, format: { with: /\A\d{9}\z/, message: -> (_object, _data) { I18n.t("validators.ctds_code") }}, if: -> { made_contribution == "yes" }
   validates :district_name, presence: true, if: -> { made_contribution == "yes" }
   validates :amount, presence: true, numericality: { greater_than: 0 }, if: -> { made_contribution == "yes" }
+  validate :amount_format
 
   validates :date_of_contribution,
             inclusion: {
@@ -45,4 +46,13 @@ class Az322Contribution < ApplicationRecord
   end
 
   private
+
+  VALID_MONEY_REGEXP = /\A(\d+)?\.?\d{0,2}\z/.freeze
+  def amount_format
+    return true if amount.blank?
+
+    unless VALID_MONEY_REGEXP.match?(read_attribute_before_type_cast(:amount).to_s)
+      errors.add(:amount, 'must be a valid dollar amount')
+    end
+  end
 end

--- a/spec/models/az322_contribution_spec.rb
+++ b/spec/models/az322_contribution_spec.rb
@@ -123,6 +123,12 @@ describe 'Az322Contribution' do
         az.valid?
         expect(az.errors[:amount]).to be_empty
       end
+
+      it "should invalidate amount with more than 2 decimals" do
+        az.amount = '1.123'
+        az.valid?
+        expect(az.errors[:amount]).to eq(['must be a valid dollar amount'])
+      end
     end
 
     describe '#date_of_contribution' do


### PR DESCRIPTION
Refactor to move all validations/clean up related to `amount`


Things I tried before arriving at this solution:
1. trying to add validation error in the writer `def amount=(value)`. This seems to get overwritten when validators run
2. using `validates_format_of`: the value has already been converted to a decimal(12, 2) value