### PR TITLE
Do not allow greater than 10 contributions on Charitable Contributions page

### DIFF
--- a/app/controllers/state_file/questions/az_qualifying_organization_contributions_controller.rb
+++ b/app/controllers/state_file/questions/az_qualifying_organization_contributions_controller.rb
@@ -33,7 +33,6 @@ module StateFile
         @contribution = contributions.build
         @contribution.assign_attributes(az321_contribution_params)
 
-
         if @contribution.save(context: :az321_form_create)
           redirect_to action: :index, return_to_review: params[:return_to_review]
         else

--- a/app/views/state_file/questions/az_qualifying_organization_contributions/index.html.erb
+++ b/app/views/state_file/questions/az_qualifying_organization_contributions/index.html.erb
@@ -48,4 +48,7 @@
   <%= button_to(StateFile::Questions::AzQualifyingOrganizationContributionsController.to_path_helper(action: :new, return_to_review: params[:return_to_review]), class: "button button--wide", method: :get, disabled: (@contribution_count >= 10)) do %>
     <%= t('.add_another') %>
   <% end %>
+  <% if @contribution_count >= 10 %>
+    <p class="text--error text--centered spacing-above-5"><%= t('.maximum_records') %></p>
+  <% end %>
 <% end %>

--- a/app/views/state_file/questions/az_qualifying_organization_contributions/index.html.erb
+++ b/app/views/state_file/questions/az_qualifying_organization_contributions/index.html.erb
@@ -45,7 +45,7 @@
   <%= link_to(next_path, class: "button button--primary button--wide spacing-below-10") do %>
     <%= t('general.continue') %>
   <% end %>
-  <%= button_to(StateFile::Questions::AzQualifyingOrganizationContributionsController.to_path_helper(action: :new, return_to_review: params[:return_to_review]), class: "button button--wide", method: :get, disabled: (@contribution_count >= 3)) do %>
+  <%= button_to(StateFile::Questions::AzQualifyingOrganizationContributionsController.to_path_helper(action: :new, return_to_review: params[:return_to_review]), class: "button button--wide", method: :get, disabled: (@contribution_count >= 10)) do %>
     <%= t('.add_another') %>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2232,6 +2232,7 @@ en:
           contribution_name: Contribution to %{charity_name} with code %{charity_code}
           delete_confirmation: Are you sure you want to delete this contribution?
           lets_review: Great! Thanks for sharing that information. Let’s review.
+          maximum_records: You have provided the maximum amount of records.
       az_retirement_income:
         edit:
           amount_label: Enter amount earned

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2201,6 +2201,7 @@ es:
           contribution_name: Contribución a %{charity_name} con el código %{charity_code}
           delete_confirmation: "¿Estás seguro de que deseas eliminar esta contribución?"
           lets_review: "¡Genial! Gracias por compartir esa información. Repasemos."
+          maximum_records: Ha proporcionado la cantidad máxima de registros.
       az_retirement_income:
         edit:
           amount_label: Ingrese la cantidad ganada

--- a/spec/controllers/state_file/questions/az_qualifying_organization_contributions_controller_spec.rb
+++ b/spec/controllers/state_file/questions/az_qualifying_organization_contributions_controller_spec.rb
@@ -190,6 +190,17 @@ RSpec.describe StateFile::Questions::AzQualifyingOrganizationContributionsContro
 
       expect(response).to be_ok
     end
+
+    it 'should not create more than 10 contributions' do
+      10.times do
+        put :create, params: valid_params
+      end
+      expect(intake.az321_contributions.count).to eq 10
+
+      expect {
+        put :create, params: valid_params
+      }.not_to change(intake.az321_contributions, :count)
+    end
   end
 
   describe "destroy" do

--- a/spec/controllers/state_file/questions/az_qualifying_organization_contributions_controller_spec.rb
+++ b/spec/controllers/state_file/questions/az_qualifying_organization_contributions_controller_spec.rb
@@ -197,6 +197,9 @@ RSpec.describe StateFile::Questions::AzQualifyingOrganizationContributionsContro
       end
       expect(intake.az321_contributions.count).to eq 10
 
+      get :index
+      expect(response.body).to include(I18n.t('state_file.questions.az_qualifying_organization_contributions.index.maximum_records'))
+
       expect {
         put :create, params: valid_params
       }.not_to change(intake.az321_contributions, :count)

--- a/spec/controllers/state_file/questions/az_qualifying_organization_contributions_controller_spec.rb
+++ b/spec/controllers/state_file/questions/az_qualifying_organization_contributions_controller_spec.rb
@@ -192,6 +192,9 @@ RSpec.describe StateFile::Questions::AzQualifyingOrganizationContributionsContro
     end
 
     it 'should not create more than 10 contributions' do
+      get :index
+      expect(response.body).not_to include(I18n.t('state_file.questions.az_qualifying_organization_contributions.index.maximum_records'))
+
       10.times do
         put :create, params: valid_params
       end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-395
## Is PM acceptance required?
- Yes - don't merge until JIRA issue is accepted!
## What was done?
- Changed the 3 to a 10 in the disable logic for the "add" button in the index template for AZ321 contributions
## How to test?
- On heroku, create an AZ intake and navigate to the Qualifying Organization Contributions page, then try to add 10 contributions. You should be able to add 10, but no more.
## Screenshots (for visual changes)
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/682ee156-e8ca-4675-9cd9-e9fa79cfffab">

