### PR TITLE
Enable InsightAppSec security scans

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,7 @@
     <meta property="twitter:url" content="<%= canonical_url %>">
 
     <% # Site verification for InsightAppSec DAST vulnerability scanner %>
-    <% if not Rails.env.production? %>
+    <% unless Rails.env.production? %>
       <meta name="insight-app-sec-validation" content="a08ae307-c25f-4fc4-9dff-0c4ae0c7dff4">
     <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,6 +34,11 @@
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="<%= canonical_url %>">
 
+    <% # Site verification for InsightAppSec DAST vulnerability scanner %>
+    <% if not Rails.env.production? %>
+      <meta name="insight-app-sec-validation" content="a08ae307-c25f-4fc4-9dff-0c4ae0c7dff4">
+    <% end %>
+
     <link rel="canonical" href="<%= canonical_url %>" />
     <link rel="alternate" href="<%= canonical_url(:en) %>" hreflang="x-default" />
     <link rel="alternate" href="<%= canonical_url(:en) %>" hreflang="en" />


### PR DESCRIPTION
*Please forgive my lack of process here. This is my first pull request for this repo, so I do not know what I am doing.*
Please advise what I need to do. This is a minor change to allow us to scan the app with a security scanner we want to evaluate. 

## Link to pivotal/JIRA issue
- I do not have a JIRA issue for this change. Please let me know if I need to create one.
## Is PM acceptance required? 
- I only added a `meta` tag
## What was done?
- Added a small `meta` entry to enable the vendor to validate that we own the app. The logic is not environment agnostic, but it does not seem we are adopting that practice. Do let me know otherwise.
## How to test?
- This is such a small change I did not write a test for it and just tested it locally. Please let me know if I should do so.

