### PR TITLE
nj 35 - added lines 13 and 30 logic

### DIFF
--- a/app/lib/efile/line_data.yml
+++ b/app/lib/efile/line_data.yml
@@ -528,6 +528,8 @@ NJ1040_LINE_7:
   label: '7 Sum all Senior 65+ Exemption, multiply by 1000'
 NJ1040_LINE_8:
   label: '8 Sum all Blind/Disabled Exemption, multiply by 1000'
+NJ1040_LINE_13:
+  label: '13 Total Exemption Amount (Add totals from the lines at 6 through 12)'
 NJ1040_LINE_15:
   label: '15 Wages, salaries, tips, and other employee compensation (State wages from Box 16 of enclosed W-2(s))'
 NJ1040_LINE_40A:

--- a/app/lib/efile/nj/nj1040.rb
+++ b/app/lib/efile/nj/nj1040.rb
@@ -79,7 +79,7 @@ module Efile
       end
 
       def calculate_line_13
-        calculate_line_6 + calculate_line_7 + calculate_line_8
+        line_or_zero(:NJ1040_LINE_6) +  line_or_zero(:NJ1040_LINE_7) +  line_or_zero(:NJ1040_LINE_8) 
       end
 
       def calculate_line_15

--- a/app/lib/efile/nj/nj1040.rb
+++ b/app/lib/efile/nj/nj1040.rb
@@ -16,11 +16,22 @@ module Efile
         set_line(:NJ1040_LINE_7_SPOUSE, :line_7_spouse_checkbox)
         set_line(:NJ1040_LINE_7, :calculate_line_7)
         set_line(:NJ1040_LINE_8, :calculate_line_8)
+        set_line(:NJ1040_LINE_13, :calculate_line_13)
         set_line(:NJ1040_LINE_15, :calculate_line_15)
         set_line(:NJ1040_LINE_40A, :calculate_line_40a)
         @lines.transform_values(&:value)
       end
 
+      def refund_or_owed_amount
+        0
+      end
+
+      def analytics_attrs
+        {
+        }
+      end
+
+      private
       def line_6_spouse_checkbox
         @intake.filing_status_mfj?
       end
@@ -51,7 +62,7 @@ module Efile
                                                                  @direct_file_data.is_spouse_blind?])
         number_of_line_8_exemptions * 1_000
       end
-      
+
       def calculate_line_40a
         is_mfs = @intake.filing_status == :married_filing_separately
 
@@ -67,20 +78,9 @@ module Efile
         is_mfs ? (property_tax_paid / 2.0).round : property_tax_paid.round
       end
 
-      def total_exemption_amount
-        0
+      def calculate_line_13
+        calculate_line_6 + calculate_line_7 + calculate_line_8
       end
-
-      def refund_or_owed_amount
-        0
-      end
-
-      def analytics_attrs
-        {
-        }
-      end
-
-      private
 
       def calculate_line_15
         if @direct_file_data.w2s.empty?

--- a/app/lib/pdf_filler/nj1040_pdf.rb
+++ b/app/lib/pdf_filler/nj1040_pdf.rb
@@ -94,6 +94,33 @@ module PdfFiller
         answers.merge!(dependent_hash)
       end
 
+      if @xml_document.at("Exemptions TotalExemptionAmountA")
+        total_exemptions = @xml_document.at("Exemptions TotalExemptionAmountA").text.to_i
+        answers.merge!(insert_digits_into_fields(total_exemptions, [
+          "Text53",
+          "Text52",
+          "Text51",
+          "Text50",
+          "undefined_17",
+          "undefined_16",
+          "undefined_15"
+        ]))
+      end
+
+      if @xml_document.at("Body TotalExemptionAmountB")
+        total_exemptions = @xml_document.at("Body TotalExemptionAmountB").text.to_i
+        answers.merge!(insert_digits_into_fields(total_exemptions, [
+          "214",
+          "undefined_91",
+          "213",
+          "212",
+          "undefined_90",
+          "211",
+          "210",
+          "30"
+        ]))
+      end
+
       if @xml_document.at("WagesSalariesTips").present?
         wages = @xml_document.at("WagesSalariesTips").text.to_i
         answers.merge!(insert_digits_into_fields(wages, [

--- a/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
+++ b/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
@@ -73,6 +73,7 @@ module SubmissionBuilder
                     if @submission.data_source.direct_file_data.is_spouse_blind?
                       xml.SpouseCuPartnerBlindOrDisabled "X"
                     end
+                    xml.TotalExemptionAmountA calculated_fields.fetch(:NJ1040_LINE_13)
                     xml.NumOfQualiDependChild qualifying_dependents.count(&:qualifying_child?)
                     xml.NumOfOtherDepend qualifying_dependents.count(&:qualifying_relative?)
                   end
@@ -100,6 +101,8 @@ module SubmissionBuilder
                   if calculated_fields.fetch(:NJ1040_LINE_15) >= 0
                     xml.WagesSalariesTips calculated_fields.fetch(:NJ1040_LINE_15)
                   end
+
+                  xml.TotalExemptionAmountB calculated_fields.fetch(:NJ1040_LINE_13)
 
                   xml.PropertyTaxDeductOrCredit do
                     if calculated_fields.fetch(:NJ1040_LINE_40A)

--- a/spec/lib/efile/nj/nj1040_spec.rb
+++ b/spec/lib/efile/nj/nj1040_spec.rb
@@ -105,15 +105,15 @@ describe Efile::Nj::Nj1040 do
   end
 
   describe 'line 13 - total exemptions' do
-    let(:intake) { create(:state_file_nj_intake) }
-    it 'sets line 13 to the sum of lines 6-12' do
-      self_exemption = 1000
+    let(:intake) { create(:state_file_nj_intake, :primary_over_65, :primary_blind) }
+    it 'sets line 13 to the sum of lines 6-8' do
+      self_exemption = 1_000
       expect(instance.lines[:NJ1040_LINE_6].value).to eq(self_exemption)
-      not_over_65 = 0
-      expect(instance.lines[:NJ1040_LINE_7].value).to eq(not_over_65)
-      not_blind = 0
-      expect(instance.lines[:NJ1040_LINE_8].value).to eq(not_blind)
-      expect(instance.lines[:NJ1040_LINE_13].value).to eq(self_exemption + not_over_65 + not_blind)
+      self_over_65 = 1_000
+      expect(instance.lines[:NJ1040_LINE_7].value).to eq(self_over_65)
+      self_blind = 1_000
+      expect(instance.lines[:NJ1040_LINE_8].value).to eq(self_blind)
+      expect(instance.lines[:NJ1040_LINE_13].value).to eq(self_exemption + self_over_65 + self_blind)
     end
   end
 

--- a/spec/lib/efile/nj/nj1040_spec.rb
+++ b/spec/lib/efile/nj/nj1040_spec.rb
@@ -104,6 +104,19 @@ describe Efile::Nj::Nj1040 do
     end
   end
 
+  describe 'line 13 - total exemptions' do
+    let(:intake) { create(:state_file_nj_intake) }
+    it 'sets line 13 to the sum of lines 6-12' do
+      self_exemption = 1000
+      expect(instance.lines[:NJ1040_LINE_6].value).to eq(self_exemption)
+      not_over_65 = 0
+      expect(instance.lines[:NJ1040_LINE_7].value).to eq(not_over_65)
+      not_blind = 0
+      expect(instance.lines[:NJ1040_LINE_8].value).to eq(not_blind)
+      expect(instance.lines[:NJ1040_LINE_13].value).to eq(self_exemption + not_over_65 + not_blind)
+    end
+  end
+
   describe 'line 15 - state wages' do
     context 'when no federal w2s' do
       let(:intake) { create(:state_file_nj_intake, :df_data_minimal) }

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -682,7 +682,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           :state_file_nj_intake
         )
       }
-      it "totals line 6-12 and writes it to line 13" do
+      it "totals line 6-8 and writes it to line 13" do
         # thousands
         expect(pdf_fields["undefined_15"]).to eq ""
         expect(pdf_fields["undefined_16"]).to eq "1"
@@ -694,7 +694,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
         expect(pdf_fields["Text52"]).to eq "0"
         expect(pdf_fields["Text53"]).to eq "0"
       end
-      it "totals line 6-12 and writes it to line 30" do
+      it "totals line 6-8 and writes it to line 30" do
         # thousands
         expect(pdf_fields["30"]).to eq ""
         expect(pdf_fields["210"]).to eq ""

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -676,6 +676,39 @@ RSpec.describe PdfFiller::Nj1040Pdf do
       end
     end
 
+    describe "line 13/30 total exemptions" do
+      let(:submission) {
+        create :efile_submission, tax_return: nil, data_source: create(
+          :state_file_nj_intake
+        )
+      }
+      it "totals line 6-12 and writes it to line 13" do
+        # thousands
+        expect(pdf_fields["undefined_15"]).to eq ""
+        expect(pdf_fields["undefined_16"]).to eq "1"
+        # hundreds
+        expect(pdf_fields["undefined_17"]).to eq "0"
+        expect(pdf_fields["Text50"]).to eq "0"
+        expect(pdf_fields["Text51"]).to eq "0"
+        # decimals
+        expect(pdf_fields["Text52"]).to eq "0"
+        expect(pdf_fields["Text53"]).to eq "0"
+      end
+      it "totals line 6-12 and writes it to line 30" do
+        # thousands
+        expect(pdf_fields["30"]).to eq ""
+        expect(pdf_fields["210"]).to eq ""
+        expect(pdf_fields["211"]).to eq "1"
+        # hundreds
+        expect(pdf_fields["undefined_90"]).to eq "0"
+        expect(pdf_fields["212"]).to eq "0"
+        expect(pdf_fields["213"]).to eq "0"
+        # decimals
+        expect(pdf_fields["undefined_91"]).to eq "0"
+        expect(pdf_fields["214"]).to eq "0"
+      end
+    end
+
     describe "filing status" do
       context "single" do
         before do

--- a/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
@@ -269,7 +269,7 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
 
     describe "total exemption - lines 13 and 30" do
       let(:intake) { create(:state_file_nj_intake) }
-      it "totals lines 6-12 and stores the result" do
+      it "totals lines 6-8 and stores the result in both TotalExemptionAmountA and TotalExemptionAmountB" do
         line_6_single_filer = 1_000
         line_7_not_over_65 = 0
         line_8_not_blind = 0

--- a/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
@@ -267,6 +267,18 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
       end
     end
 
+    describe "total exemption - lines 13 and 30" do
+      let(:intake) { create(:state_file_nj_intake) }
+      it "totals lines 6-12 and stores the result" do
+        line_6_single_filer = 1_000
+        line_7_not_over_65 = 0
+        line_8_not_blind = 0
+        expected_sum = line_6_single_filer + line_7_not_over_65 + line_8_not_blind
+        expect(xml.at("Exemptions TotalExemptionAmountA").text).to eq(expected_sum.to_s)
+        expect(xml.at("Body TotalExemptionAmountB").text).to eq(expected_sum.to_s)
+      end
+    end
+
     describe "property tax - lines 40a and 40b" do
       context "when taxpayer is a renter" do
         let(:intake) { create(:state_file_nj_intake, :df_data_minimal, household_rent_own: 'rent', rent_paid: 54321) }


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://github.com/newjersey/affordability-pm/issues/35#issue-2503540877

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Sum lines 6-8 and store value in `calculated_fields`, XML fields for 13/30, and the PDF

## How to test?
- Manual Testing in Heroku, selected a variety of filing situations from Minimal to Blind Primary and Spouse, validated that PDF and XML were populated with the right values.
- 

## Screenshots (for visual changes)
<img width="966" alt="image" src="https://github.com/user-attachments/assets/cc14fa1e-3e21-417e-8659-0fad070dd7b2">
<img width="994" alt="image" src="https://github.com/user-attachments/assets/9b6bc5e0-3cb0-4b41-b45e-cb9d689aad6f">

<img width="786" alt="image" src="https://github.com/user-attachments/assets/083b7a99-3b4b-40bd-9cc3-de662eab5579">
<img width="794" alt="image" src="https://github.com/user-attachments/assets/e3a85bcd-5e58-4b56-a91a-6a850989b80e">


