### PR TITLE
Fyst 394 do not allow greater than 10 contributions on public school contributions page

### DIFF
--- a/app/controllers/state_file/questions/az_public_school_contributions_controller.rb
+++ b/app/controllers/state_file/questions/az_public_school_contributions_controller.rb
@@ -26,7 +26,7 @@ module StateFile
           return redirect_to next_path
         end
 
-        if @az322_contribution.valid?
+        if current_intake.valid?(:az322) && @az322_contribution.valid?
           @az322_contribution.save
           redirect_to action: :index, return_to_review: params[:return_to_review]
         else

--- a/app/controllers/state_file/questions/az_public_school_contributions_controller.rb
+++ b/app/controllers/state_file/questions/az_public_school_contributions_controller.rb
@@ -11,7 +11,7 @@ module StateFile
       def index
         @az322_contributions = current_intake.az322_contributions
         unless @az322_contributions.present?
-          redirect_to action: :new
+          redirect_to action: :new, return_to_review: params[:return_to_review]
         end
       end
 

--- a/app/controllers/state_file/questions/az_qualifying_organization_contributions_controller.rb
+++ b/app/controllers/state_file/questions/az_qualifying_organization_contributions_controller.rb
@@ -33,7 +33,6 @@ module StateFile
         @contribution = contributions.build
         @contribution.assign_attributes(az321_contribution_params)
 
-
         if @contribution.save(context: :az321_form_create)
           redirect_to action: :index, return_to_review: params[:return_to_review]
         else

--- a/app/models/state_file_az_intake.rb
+++ b/app/models/state_file_az_intake.rb
@@ -119,6 +119,9 @@ class StateFileAzIntake < StateFileBaseIntake
 
   validates :made_az321_contributions, inclusion: { in: ["yes", "no"]}, on: :az321_form_create
   validates :az321_contributions, length: { maximum: 10 }
+
+  # validates :made_az322_contributions, inclusion: { in: ["yes", "no"]}, on: :az322_form_create
+  validates :az322_contributions, length: { maximum: 10 }
   def federal_dependent_count_under_17
     self.dependents.select{ |dependent| dependent.age < 17 }.length
   end

--- a/app/models/state_file_az_intake.rb
+++ b/app/models/state_file_az_intake.rb
@@ -120,8 +120,7 @@ class StateFileAzIntake < StateFileBaseIntake
   validates :made_az321_contributions, inclusion: { in: ["yes", "no"]}, on: :az321_form_create
   validates :az321_contributions, length: { maximum: 10 }
 
-  # validates :made_az322_contributions, inclusion: { in: ["yes", "no"]}, on: :az322_form_create
-  validates :az322_contributions, length: { maximum: 10 }
+  validates :az322_contributions, length: { maximum: 10 }, on: :az322
   def federal_dependent_count_under_17
     self.dependents.select{ |dependent| dependent.age < 17 }.length
   end

--- a/app/views/state_file/questions/az_public_school_contributions/index.html.erb
+++ b/app/views/state_file/questions/az_public_school_contributions/index.html.erb
@@ -26,8 +26,7 @@
   <%= link_to(next_path, class: "button button--primary button--wide spacing-below-10") do %>
     <%= t('general.continue') %>
   <% end %>
-  <%= @az322_contributions.count %>
-  <%= link_to(StateFile::Questions::AzPublicSchoolContributionsController.to_path_helper(action: :new, return_to_review: params[:return_to_review]), class: "button button--wide", method: :get, disabled: (@az322_contributions.count >= 10)) do %>
+  <%= button_to(StateFile::Questions::AzPublicSchoolContributionsController.to_path_helper(action: :new, return_to_review: params[:return_to_review]), class: "button button--wide", method: :get, disabled: (@az322_contributions.count >= 10)) do %>
     <%= t('.add_another') %>
   <% end %>
   <% if @az322_contributions.count >= 10 %>

--- a/app/views/state_file/questions/az_public_school_contributions/index.html.erb
+++ b/app/views/state_file/questions/az_public_school_contributions/index.html.erb
@@ -26,7 +26,8 @@
   <%= link_to(next_path, class: "button button--primary button--wide spacing-below-10") do %>
     <%= t('general.continue') %>
   <% end %>
-  <%= link_to(StateFile::Questions::AzPublicSchoolContributionsController.to_path_helper(action: :new, us_state: current_state_code, return_to_review: params[:return_to_review]), class: "button button--wide") do %>
+  <%= @az322_contributions.count %>
+  <%= link_to(StateFile::Questions::AzPublicSchoolContributionsController.to_path_helper(action: :new, return_to_review: params[:return_to_review]), class: "button button--wide", method: :get, disabled: (@az322_contributions.count >= 10)) do %>
     <%= t('.add_another') %>
   <% end %>
   <% if @az322_contributions.count >= 10 %>

--- a/app/views/state_file/questions/az_public_school_contributions/index.html.erb
+++ b/app/views/state_file/questions/az_public_school_contributions/index.html.erb
@@ -29,5 +29,8 @@
   <%= link_to(StateFile::Questions::AzPublicSchoolContributionsController.to_path_helper(action: :new, us_state: current_state_code, return_to_review: params[:return_to_review]), class: "button button--wide") do %>
     <%= t('.add_another') %>
   <% end %>
+  <% if @az322_contributions.count >= 10 %>
+    <p class="text--error text--centered spacing-above-5"><%= t('.maximum_records') %></p>
+  <% end %>
 <% end %>
 

--- a/app/views/state_file/questions/az_qualifying_organization_contributions/index.html.erb
+++ b/app/views/state_file/questions/az_qualifying_organization_contributions/index.html.erb
@@ -45,7 +45,7 @@
   <%= link_to(next_path, class: "button button--primary button--wide spacing-below-10") do %>
     <%= t('general.continue') %>
   <% end %>
-  <%= button_to(StateFile::Questions::AzQualifyingOrganizationContributionsController.to_path_helper(action: :new, return_to_review: params[:return_to_review]), class: "button button--wide", method: :get, disabled: (@contribution_count >= 3)) do %>
+  <%= link_to(StateFile::Questions::AzQualifyingOrganizationContributionsController.to_path_helper(action: :new, return_to_review: params[:return_to_review]), class: "button button--wide", method: :get, disabled: (@contribution_count >= 3)) do %>
     <%= t('.add_another') %>
   <% end %>
 <% end %>

--- a/app/views/state_file/questions/az_qualifying_organization_contributions/index.html.erb
+++ b/app/views/state_file/questions/az_qualifying_organization_contributions/index.html.erb
@@ -45,7 +45,7 @@
   <%= link_to(next_path, class: "button button--primary button--wide spacing-below-10") do %>
     <%= t('general.continue') %>
   <% end %>
-  <%= link_to(StateFile::Questions::AzQualifyingOrganizationContributionsController.to_path_helper(action: :new, return_to_review: params[:return_to_review]), class: "button button--wide", method: :get, disabled: (@contribution_count >= 3)) do %>
+  <%= button_to(StateFile::Questions::AzQualifyingOrganizationContributionsController.to_path_helper(action: :new, return_to_review: params[:return_to_review]), class: "button button--wide", method: :get, disabled: (@contribution_count >= 3)) do %>
     <%= t('.add_another') %>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2222,6 +2222,7 @@ en:
           contribution_label: Contribution to %{school_name}
           delete_confirmation: Are you sure you want to delete this contribution?
           lets_review: Lets review your public school cash contributions and fees
+          maximum_records: You have provided the maximum amount of records.
       az_qualifying_organization_contributions:
         destroy:
           removed: Removed AZ 321 for %{charity_name}

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2191,6 +2191,7 @@ es:
           contribution_label: Contribución a %{school_name}
           delete_confirmation: "¿Estás seguro de que quieres eliminar esta contribución?"
           lets_review: Revisión de tus hiciste contribuciones y tarifas a la escuela pública
+          maximum_records: Ha proporcionado la cantidad máxima de registros.
       az_qualifying_organization_contributions:
         destroy:
           removed: Se eliminó AZ 321 para %{charity_name}

--- a/spec/controllers/state_file/questions/az_public_school_contributions_controller_spec.rb
+++ b/spec/controllers/state_file/questions/az_public_school_contributions_controller_spec.rb
@@ -65,16 +65,17 @@ RSpec.describe StateFile::Questions::AzPublicSchoolContributionsController do
     end
 
     it 'should not create more than 10 contributions' do
-      get :index
-      expect(response.body).not_to include(I18n.t('state_file.questions.az_public_school_contributions.index.maximum_records'))
-
       10.times do
         put :create, params: params
       end
       expect(intake.az322_contributions.count).to eq 10
 
       get :index
+      expect(response).to be_ok
       expect(response.body).to include(I18n.t('state_file.questions.az_public_school_contributions.index.maximum_records'))
+      html = Nokogiri::HTML.parse(response.body)
+      add_contribution_button = html.xpath("//button[contains(., 'Add another contribution')]")[0]
+      expect(add_contribution_button.attr("disabled")).to eq("disabled")
 
       expect {
         put :create, params: params

--- a/spec/controllers/state_file/questions/az_public_school_contributions_controller_spec.rb
+++ b/spec/controllers/state_file/questions/az_public_school_contributions_controller_spec.rb
@@ -34,6 +34,8 @@ RSpec.describe StateFile::Questions::AzPublicSchoolContributionsController do
   end
 
   describe "#create" do
+    render_views
+
     let(:params) do
       {
         az322_contribution: {
@@ -60,6 +62,23 @@ RSpec.describe StateFile::Questions::AzPublicSchoolContributionsController do
       expect(contribution.state_file_az_intake).to eq intake
       expect(contribution.school_name).to eq 'School A'
       expect(contribution.amount).to eq 100
+    end
+
+    it 'should not create more than 10 contributions' do
+      get :index
+      expect(response.body).not_to include(I18n.t('state_file.questions.az_public_school_contributions.index.maximum_records'))
+
+      10.times do
+        put :create, params: params
+      end
+      expect(intake.az322_contributions.count).to eq 10
+
+      get :index
+      expect(response.body).to include(I18n.t('state_file.questions.az_public_school_contributions.index.maximum_records'))
+
+      expect {
+        put :create, params: params
+      }.not_to change(intake.az322_contributions, :count)
     end
 
     context "when 'no' was selected for made_contribution" do


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-394
## Is PM acceptance required?
- Yes - don't merge until JIRA issue is accepted!
## What was done?
- Added logic to the add button that disables it if there are already 10 contributions, and also shows a warning below it
## How to test?
- Add 10 public school contributions & verify that the button is disabled and the warning is shown
- There are also automated tests verifying this
## Screenshots (for visual changes)
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/6ee76783-51ee-4dbe-ac59-8dec8efcabf8">

