### PR TITLE
add review page to md flow

### DIFF
--- a/app/controllers/state_file/questions/md_review_controller.rb
+++ b/app/controllers/state_file/questions/md_review_controller.rb
@@ -1,0 +1,6 @@
+module StateFile
+  module Questions
+    class MdReviewController < BaseReviewController
+    end
+  end
+end

--- a/app/lib/navigation/state_file_md_question_navigation.rb
+++ b/app/lib/navigation/state_file_md_question_navigation.rb
@@ -31,6 +31,7 @@ module Navigation
         Navigation::NavigationStep.new(StateFile::Questions::NameDobController),
         Navigation::NavigationStep.new(StateFile::Questions::W2Controller),
         Navigation::NavigationStep.new(StateFile::Questions::UnemploymentController),
+        Navigation::NavigationStep.new(StateFile::Questions::MdReviewController),
         Navigation::NavigationStep.new(StateFile::Questions::TaxesOwedController),
         Navigation::NavigationStep.new(StateFile::Questions::TaxRefundController),
         Navigation::NavigationStep.new(StateFile::Questions::EsignDeclarationController), # creates EfileSubmission and transitions to preparing

--- a/app/views/state_file/questions/md_review/edit.html.erb
+++ b/app/views/state_file/questions/md_review/edit.html.erb
@@ -1,0 +1,6 @@
+<% content_for :page_title, t("state_file.questions.shared.review_header.title") %>
+<% content_for :card do %>
+  <%= render "state_file/questions/shared/review_header" %>
+
+  <%= render "state_file/questions/shared/review_footer" %>
+<% end %>

--- a/spec/controllers/state_file/questions/md_review_controller_spec.rb
+++ b/spec/controllers/state_file/questions/md_review_controller_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe StateFile::Questions::MdReviewController do
+  let(:intake) { create :state_file_md_intake}
+
+  before do
+    sign_in intake
+  end
+
+  describe "#edit" do
+    render_views
+    it 'succeeds' do
+      get :edit
+      expect(response).to be_successful
+    end
+  end
+end

--- a/spec/models/efile_error_spec.rb
+++ b/spec/models/efile_error_spec.rb
@@ -60,6 +60,7 @@ describe 'EfileError' do
       "esign-declaration",
       "federal-info",
       "initiate-data-transfer",
+      "md-review",
       "name-dob",
       "nc-county",
       "nc-eligibility-out-of-state-income",


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-528
## Is PM acceptance required?
- Yes - don't merge until JIRA issue is accepted!
## What was done?
- Added a minimal review page to MD flow, showing only the basic template (amount owed/refund, househould info)
## How to test?
- Go through MD flow to see review page
- The refund amount is hardcoded to 0 currently, since none of the MD tax calculator has been implemented, so you will only see 0 on the review page, but the logic to show different amounts is entirely shared with other review pages. That said, if you want to see different amounts on this page, let me know and I can hardcode different amounts and push them to heroku for you!
## Screenshots (for visual changes)
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/7f2a7bae-a2ff-4f40-815f-290755253173">