### PR TITLE
Fyst 825 create state specific service types for efile error

### DIFF
--- a/app/controllers/hub/state_file/efile_errors_controller.rb
+++ b/app/controllers/hub/state_file/efile_errors_controller.rb
@@ -6,7 +6,7 @@ module Hub::StateFile
     def index
       order = [:source, :code]
       if params[:sort_by].present?
-        order = [params[:sort_by]] + order
+        order.prepend(params[:sort_by])
       end
 
       @efile_errors = @efile_errors.where.not(service_type: "ctc").order(*order)

--- a/app/controllers/hub/state_file/efile_errors_controller.rb
+++ b/app/controllers/hub/state_file/efile_errors_controller.rb
@@ -9,11 +9,11 @@ module Hub::StateFile
         order.prepend(params[:sort_by])
       end
 
-      @efile_errors = @efile_errors.where.not(service_type: "ctc").order(*order)
-
       if params[:filter_by_service_type].present?
-        @efile_errors = @efile_errors.where(service_type: params[:filter_by_service_type])
+        filter = { service_type: params[:filter_by_service_type] }
       end
+
+      @efile_errors = @efile_errors.where.not(service_type: "ctc").where(*filter).order(*order)
     end
 
     def edit

--- a/app/controllers/hub/state_file/efile_errors_controller.rb
+++ b/app/controllers/hub/state_file/efile_errors_controller.rb
@@ -4,7 +4,16 @@ module Hub::StateFile
     layout "hub"
 
     def index
-      @efile_errors = @efile_errors.where.not(service_type: "ctc").order(:source, :code)
+      order = [:source, :code]
+      if params[:sort_by].present?
+        order = [params[:sort_by]] + order
+      end
+
+      @efile_errors = @efile_errors.where.not(service_type: "ctc").order(*order)
+
+      if params[:filter_by_service_type].present?
+        @efile_errors = @efile_errors.where(service_type: params[:filter_by_service_type])
+      end
     end
 
     def edit

--- a/app/controllers/hub/state_file/efile_errors_controller.rb
+++ b/app/controllers/hub/state_file/efile_errors_controller.rb
@@ -9,11 +9,11 @@ module Hub::StateFile
         order.prepend(params[:sort_by])
       end
 
-      if params[:filter_by_service_type].present?
-        filter = { service_type: params[:filter_by_service_type] }
-      end
+      @efile_errors = @efile_errors.where.not(service_type: "ctc").order(*order)
 
-      @efile_errors = @efile_errors.where.not(service_type: "ctc").where(*filter).order(*order)
+      if params[:filter_by_service_type].present?
+        @efile_errors = @efile_errors.where(service_type: params[:filter_by_service_type])
+      end
     end
 
     def edit

--- a/app/jobs/update_efile_errors_job.rb
+++ b/app/jobs/update_efile_errors_job.rb
@@ -8,7 +8,6 @@ class UpdateEfileErrorsJob < ApplicationJob
     state_file_errors.update_all(service_type: :state_file)
     # state_file_errors.update_all(expose: false)
     DefaultErrorMessages.generate!(service_type: :state_file)
-
   end
 
   def priority

--- a/app/lib/default_error_messages.rb
+++ b/app/lib/default_error_messages.rb
@@ -1,5 +1,5 @@
 class DefaultErrorMessages
-  def self.generate!(service_type: "unfilled")
+  def self.generate!(service_type:)
     EfileError.find_or_create_by!(
       code: "USPS-2147219401",
       message: "Address Not Found.",

--- a/app/lib/default_error_messages.rb
+++ b/app/lib/default_error_messages.rb
@@ -1,46 +1,55 @@
 class DefaultErrorMessages
   def self.generate!(service_type: "unfilled")
     EfileError.find_or_create_by!(
-      code: "BUNDLE-FAIL",
-      message: "An error occurred while bundling the submission XML.",
-      source: :internal,
-      expose: false,
-      service_type: service_type
-    )
-    EfileError.find_or_create_by!(
       code: "USPS-2147219401",
       message: "Address Not Found.",
       source: :usps,
       expose: true
     )
-    EfileError.find_or_create_by!(
-      code: "PDF-1040-FAIL",
-      message: "Could not generate IRS Form 1040 PDF.",
-      source: :internal,
-      expose: false,
-      service_type: service_type
-    )
-    EfileError.find_or_create_by!(
-      code: "TRANSMISSION-SERVICE",
-      message: "Error communicating with GYR Efiler service.",
-      source: :internal,
-      expose: false,
-      service_type: service_type
-    )
-    EfileError.find_or_create_by!(
-      code: "TRANSMISSION-RESPONSE",
-      message: "Unexpected transmission response format from IRS.",
-      source: :internal,
-      expose: false,
-      service_type: service_type
-    )
-    EfileError.find_or_create_by!(
-      code: "BANK-DETAILS",
-      message: "Some of the provided bank account details are incorrect or absent.",
-      source: :intake,
-      expose: true,
-      auto_wait: true,
-      service_type: service_type
-    )
+
+    service_types = case service_type
+                    when :state_file
+                      StateFile::StateInformationService.active_state_codes.map { |state_code| "state_file_#{state_code}" }
+                    else
+                      [service_type]
+                    end
+    service_types.each do |service_type_name|
+      EfileError.find_or_create_by!(
+        code: "BUNDLE-FAIL",
+        message: "An error occurred while bundling the submission XML.",
+        source: :internal,
+        expose: false,
+        service_type: service_type_name
+      )
+      EfileError.find_or_create_by!(
+        code: "PDF-1040-FAIL",
+        message: "Could not generate IRS Form 1040 PDF.",
+        source: :internal,
+        expose: false,
+        service_type: service_type_name
+      )
+      EfileError.find_or_create_by!(
+        code: "TRANSMISSION-SERVICE",
+        message: "Error communicating with GYR Efiler service.",
+        source: :internal,
+        expose: false,
+        service_type: service_type_name
+      )
+      EfileError.find_or_create_by!(
+        code: "TRANSMISSION-RESPONSE",
+        message: "Unexpected transmission response format from IRS.",
+        source: :internal,
+        expose: false,
+        service_type: service_type_name
+      )
+      EfileError.find_or_create_by!(
+        code: "BANK-DETAILS",
+        message: "Some of the provided bank account details are incorrect or absent.",
+        source: :intake,
+        expose: true,
+        auto_wait: true,
+        service_type: service_type_name
+      )
+    end
   end
 end

--- a/app/lib/efile/submission_error_parser.rb
+++ b/app/lib/efile/submission_error_parser.rb
@@ -82,7 +82,7 @@ module Efile
     private
 
     def error_service_type(submission)
-      if submission.data_source
+      if submission.is_for_state_filing?
         state_code = submission.data_source.state_code
         "state_file_#{state_code}"
       else

--- a/app/lib/efile/submission_error_parser.rb
+++ b/app/lib/efile/submission_error_parser.rb
@@ -82,7 +82,12 @@ module Efile
     private
 
     def error_service_type(submission)
-      :state_file
+      if submission.data_source
+        state_code = submission.data_source.state_code
+        "state_file_#{state_code}"
+      else
+        "ctc"
+      end
     end
   end
 

--- a/app/models/efile_error.rb
+++ b/app/models/efile_error.rb
@@ -22,7 +22,11 @@ class EfileError < ApplicationRecord
   has_rich_text :resolution_en
   has_rich_text :resolution_es
 
-  enum service_type: { unfilled: 0, ctc: 1, state_file: 2 }, _prefix: :service_type
+  state_enum_options = StateFile::StateInformationService.active_state_codes.each.with_index.reduce({}) do |acc, (state_code, i)|
+    acc["state_file_#{state_code}"] = (i + 2)
+    acc
+  end
+  enum service_type: { unfilled: 0, ctc: 1 }.merge(state_enum_options), _prefix: :service_type
 
   def self.error_codes_to_retry_once
     # These error codes indicate that the IRS had trouble parsing our data. When we see this, it

--- a/app/models/efile_error.rb
+++ b/app/models/efile_error.rb
@@ -22,10 +22,9 @@ class EfileError < ApplicationRecord
   has_rich_text :resolution_en
   has_rich_text :resolution_es
 
-  state_enum_options = StateFile::StateInformationService.active_state_codes.reduce({}) do |acc, state_code|
-    int_value = state_code.bytes.map(&:to_s).join.to_i
-    acc["state_file_#{state_code}"] = int_value
-    acc
+  state_enum_options = StateFile::StateInformationService.active_state_codes.to_h do |state_code, _|
+    int_value = state_code.bytes.join.to_i
+    ["state_file_#{state_code}", int_value]
   end
   enum service_type: { unfilled: 0, ctc: 1, state_file: 2 }.merge(state_enum_options), _prefix: :service_type
 

--- a/app/models/efile_error.rb
+++ b/app/models/efile_error.rb
@@ -22,8 +22,9 @@ class EfileError < ApplicationRecord
   has_rich_text :resolution_en
   has_rich_text :resolution_es
 
-  state_enum_options = StateFile::StateInformationService.active_state_codes.each.with_index.reduce({}) do |acc, (state_code, i)|
-    acc["state_file_#{state_code}"] = (i + 3)
+  state_enum_options = StateFile::StateInformationService.active_state_codes.reduce({}) do |acc, state_code|
+    int_value = state_code.bytes.sum
+    acc["state_file_#{state_code}"] = int_value
     acc
   end
   enum service_type: { unfilled: 0, ctc: 1, state_file: 2 }.merge(state_enum_options), _prefix: :service_type

--- a/app/models/efile_error.rb
+++ b/app/models/efile_error.rb
@@ -23,10 +23,10 @@ class EfileError < ApplicationRecord
   has_rich_text :resolution_es
 
   state_enum_options = StateFile::StateInformationService.active_state_codes.each.with_index.reduce({}) do |acc, (state_code, i)|
-    acc["state_file_#{state_code}"] = (i + 2)
+    acc["state_file_#{state_code}"] = (i + 3)
     acc
   end
-  enum service_type: { unfilled: 0, ctc: 1 }.merge(state_enum_options), _prefix: :service_type
+  enum service_type: { unfilled: 0, ctc: 1, state_file: 2 }.merge(state_enum_options), _prefix: :service_type
 
   def self.error_codes_to_retry_once
     # These error codes indicate that the IRS had trouble parsing our data. When we see this, it

--- a/app/models/efile_error.rb
+++ b/app/models/efile_error.rb
@@ -23,7 +23,7 @@ class EfileError < ApplicationRecord
   has_rich_text :resolution_es
 
   state_enum_options = StateFile::StateInformationService.active_state_codes.reduce({}) do |acc, state_code|
-    int_value = state_code.bytes.sum
+    int_value = state_code.bytes.map(&:to_s).join.to_i
     acc["state_file_#{state_code}"] = int_value
     acc
   end

--- a/app/models/efile_submission.rb
+++ b/app/models/efile_submission.rb
@@ -274,8 +274,6 @@ class EfileSubmission < ApplicationRecord
     end
   end
 
-  private
-
   def is_for_federal_filing?
     tax_return.present?
   end

--- a/app/views/hub/state_file/efile_errors/index.html.erb
+++ b/app/views/hub/state_file/efile_errors/index.html.erb
@@ -12,8 +12,11 @@
         <th scope="col" width="100" class="index-table__header index-table__header--center">
           Auto-wait?
         </th>
-        <th scope="col" width="150" class="index-table__header">
+        <th scope="col" width="100" class="index-table__header">
           Source
+        </th>
+        <th scope="col" width="120" class="index-table__header">
+          Service type
         </th>
         <th scope="col" width="150" class="index-table__header">
           Error Code
@@ -51,6 +54,9 @@
           <td class="index-table__cell status">
             <% source = error.source.present? ? error.source : "none" %>
             <%= link_to source, hub_state_file_efile_error_path(id: error.id) %>
+          </td>
+          <td class="index-table__cell status">
+            <%= error.service_type %>
           </td>
           <td class="index-table__cell">
             <%= link_to error.code, hub_state_file_efile_error_path(id: error.id), class: "underline" %>

--- a/app/views/hub/state_file/efile_errors/index.html.erb
+++ b/app/views/hub/state_file/efile_errors/index.html.erb
@@ -56,7 +56,9 @@
             <%= source %>
           </td>
           <td class="index-table__cell">
-            <%= link_to error.service_type, hub_state_file_efile_errors_path(filter_by_service_type: error.service_type), class: "underline" %>
+            <% if error.service_type.present? %>
+              <%= link_to error.service_type, hub_state_file_efile_errors_path(filter_by_service_type: error.service_type), class: "underline" %>
+            <% end %>
           </td>
           <td class="index-table__cell status">
             <%= link_to error.code, hub_state_file_efile_error_path(id: error.id), class: "underline" %>

--- a/app/views/hub/state_file/efile_errors/index.html.erb
+++ b/app/views/hub/state_file/efile_errors/index.html.erb
@@ -16,7 +16,7 @@
           Source
         </th>
         <th scope="col" width="120" class="index-table__header">
-          Service type
+          <%= link_to "Service type", hub_state_file_efile_errors_path(sort_by: :service_type) %>
         </th>
         <th scope="col" width="150" class="index-table__header">
           Error Code
@@ -51,14 +51,14 @@
           <td class="index-table__cell index-table__cell--center">
             <%= image_tag error.auto_wait ? "icons/check.svg" : "icons/cancelled.svg", alt: error.auto_wait ? "yes" : "no" %>
           </td>
-          <td class="index-table__cell status">
+          <td class="index-table__cell">
             <% source = error.source.present? ? error.source : "none" %>
-            <%= link_to source, hub_state_file_efile_error_path(id: error.id) %>
-          </td>
-          <td class="index-table__cell status">
-            <%= error.service_type %>
+            <%= source %>
           </td>
           <td class="index-table__cell">
+            <%= link_to error.service_type, hub_state_file_efile_errors_path(filter_by_service_type: error.service_type), class: "underline" %>
+          </td>
+          <td class="index-table__cell status">
             <%= link_to error.code, hub_state_file_efile_error_path(id: error.id), class: "underline" %>
           </td>
           <td class="index-table__cell">

--- a/spec/controllers/hub/automated_messages_controller_spec.rb
+++ b/spec/controllers/hub/automated_messages_controller_spec.rb
@@ -2,9 +2,6 @@ require "rails_helper"
 
 describe Hub::AutomatedMessagesController do
   describe "#index" do
-    before do
-      DefaultErrorMessages.generate!
-    end
     it_behaves_like :a_get_action_for_admins_only, action: :index
 
     context "as an authenticated user" do

--- a/spec/controllers/state_file/questions/return_status_controller_spec.rb
+++ b/spec/controllers/state_file/questions/return_status_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe StateFile::Questions::ReturnStatusController do
         end
 
         context "client got accepted and then submitted another return which got reject 901" do
-          let(:efile_error) { create(:efile_error, code: "901", service_type: :state_file, expose: true) }
+          let(:efile_error) { create(:efile_error, code: "901", service_type: :state_file_az, expose: true) }
 
           it "shows the most recent accepted submission" do
             get :edit
@@ -58,7 +58,7 @@ RSpec.describe StateFile::Questions::ReturnStatusController do
         end
 
         context "client got accepted and then submitted another return which got a different rejection" do
-          let(:efile_error) { create(:efile_error, code: "A LEGIT REJECTION I GUESS", service_type: :state_file, expose: true) }
+          let(:efile_error) { create(:efile_error, code: "A LEGIT REJECTION I GUESS", service_type: :state_file_az, expose: true) }
 
           it "shows the most recent submission" do
             get :edit

--- a/spec/features/state_file/edit_return_spec.rb
+++ b/spec/features/state_file/edit_return_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Editing a rejected intake with an auto-wait error" do
            code: "STATE-901",
            severity: "Reject",
            source: "irs",
-           service_type: :state_file
+           service_type: :state_file_ny
   }
   let(:raw_response) do
     "<Acknowledgement>\n

--- a/spec/jobs/state_file/build_submission_bundle_job_spec.rb
+++ b/spec/jobs/state_file/build_submission_bundle_job_spec.rb
@@ -9,7 +9,6 @@ describe StateFile::BuildSubmissionBundleJob do
     before do
       address_service_double = instance_double(StandardizeAddressService, valid?: address_valid?, error_message: address_errors, error_code: address_errors)
       allow_any_instance_of(EfileSubmission).to receive(:generate_verified_address).and_return(address_service_double)
-      DefaultErrorMessages.generate!
     end
 
     context "when the address did not validate" do

--- a/spec/lib/default_error_messages_spec.rb
+++ b/spec/lib/default_error_messages_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+describe DefaultErrorMessages do
+  describe ".generate" do
+    context "service_type :ctc" do
+      it "creates one of each of the default e-file error types" do
+        described_class.generate!(service_type: :ctc)
+
+        expect(EfileError.count).to eq 6
+        [
+          "BUNDLE-FAIL",
+          "USPS-2147219401",
+          "PDF-1040-FAIL",
+          "TRANSMISSION-SERVICE",
+          "TRANSMISSION-RESPONSE",
+          "BANK-DETAILS",
+        ].each do |error_code|
+          expect(EfileError.where(code: error_code).count).to eq 1
+        end
+      end
+    end
+
+    context "service_type :state_file" do
+      it "creates one of each of the default e-file error types for each state" do
+        described_class.generate!(service_type: :state_file)
+
+        expect(EfileError.count).to eq (5 * StateFile::StateInformationService.active_state_codes.length) + 1
+
+        expect(EfileError.where(code: "USPS-2147219401").count).to eq 1
+        [
+          "BUNDLE-FAIL",
+          "PDF-1040-FAIL",
+          "TRANSMISSION-SERVICE",
+          "TRANSMISSION-RESPONSE",
+          "BANK-DETAILS",
+        ].each do |error_code|
+          expect(EfileError.where(code: error_code).count).to eq StateFile::StateInformationService.active_state_codes.length
+
+          StateFile::StateInformationService.active_state_codes.each do |state_code|
+            expect(EfileError.where(code: error_code, service_type: "state_file_#{state_code}").count).to eq 1
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/efile/submission_error_parser_spec.rb
+++ b/spec/lib/efile/submission_error_parser_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe Efile::SubmissionErrorParser do
   let(:raw_response) { file_fixture("irs_acknowledgement_rejection.xml").read }
-  let(:transition) { create :efile_submission_transition, :rejected, metadata: { raw_response: raw_response } }
+  let(:transition) { create :efile_submission_transition, :rejected, efile_submission: create(:efile_submission, :for_state), metadata: { raw_response: raw_response } }
 
   describe '#persist_errors' do
     context "when only an error code is provided" do
@@ -10,7 +10,7 @@ describe Efile::SubmissionErrorParser do
         let(:transition) { create :efile_submission_transition, :preparing, efile_submission: create(:efile_submission, :for_state), metadata: { error_code: "IRS-1040" } }
 
         it "creates a new EfileError object" do
-          expect{
+          expect {
             Efile::SubmissionErrorParser.new(transition).persist_errors
           }.to change(EfileError, :count).by(1)
           expect(transition.efile_errors.count).to eq 1
@@ -18,12 +18,11 @@ describe Efile::SubmissionErrorParser do
       end
 
       context "when a matching error already exists" do
-        let!(:existing_error) { create(:efile_error, code: "IRS-1040-PROBS", message: "You have a problem.", source: "irs", service_type: :state_file) }
-
+        let!(:existing_error) { create(:efile_error, code: "IRS-1040-PROBS", message: "You have a problem.", source: "irs", service_type: "state_file_#{transition.efile_submission.data_source.state_code}") }
         let(:transition) { create :efile_submission_transition, :preparing, efile_submission: create(:efile_submission, :for_state), metadata: { error_code: "IRS-1040-PROBS", message: "You have a different problem.", source: "irs" } }
 
         it "does not create a new EfileError object, but associates the existing one with the transition, and does not update the message" do
-          expect{
+          expect {
             Efile::SubmissionErrorParser.new(transition).persist_errors
           }.to change(EfileError, :count).by(0)
           expect(transition.efile_errors.count).to eq 1
@@ -39,7 +38,7 @@ describe Efile::SubmissionErrorParser do
                  code: "IRS-1040-PROBS",
                  message: "You have a problem.",
                  source: "irs",
-                 service_type: :state_file)
+                 service_type: "state_file_#{transition.efile_submission.data_source.state_code}")
         end
 
         let(:transition) do
@@ -48,10 +47,10 @@ describe Efile::SubmissionErrorParser do
                  metadata: { error_code: "IRS-1040-PROBS",
                              error_message: "You have a different problem now.",
                              error_source: "irs" }
-          end
+        end
 
         it "does not create a new EfileError object, but associates the existing one with the transition and updates its message" do
-          expect{
+          expect {
             Efile::SubmissionErrorParser.new(transition).persist_errors
           }.to change(EfileError, :count).by(0)
           expect(existing_error.reload.message).to eq "You have a different problem now."
@@ -59,7 +58,11 @@ describe Efile::SubmissionErrorParser do
       end
 
       context "when it does not match an existing code/message/source pair" do
-        let(:transition) { create :efile_submission_transition, :preparing, metadata: { error_code: "IRS-1040-PROBS", error_message: "You have a problem", error_source: "internal" } }
+        let(:transition) do
+          create :efile_submission_transition, :preparing,
+                 efile_submission: create(:efile_submission, :for_state),
+                 metadata: { error_code: "IRS-1040-PROBS", error_message: "You have a problem", error_source: "internal" }
+        end
 
         before do
           EfileError.create(code: "IRS-1040-PROBS", message: "You have a problem.", source: "irs")
@@ -72,7 +75,7 @@ describe Efile::SubmissionErrorParser do
           expect(transition.efile_errors.count).to eq 1
           expect(transition.efile_errors.first.message).to eq "You have a problem"
           expect(transition.efile_errors.first.source).to eq "internal"
-          expect(EfileError.last.service_type).to eq "state_file"
+          expect(EfileError.last.service_type).to eq "state_file_#{transition.efile_submission.data_source.state_code}"
         end
       end
 
@@ -81,18 +84,18 @@ describe Efile::SubmissionErrorParser do
           let(:efile_submission) { create :efile_submission, :for_state }
           let(:transition) { create :efile_submission_transition, :preparing, efile_submission: efile_submission, metadata: { error_code: "STATE-901", error_message: "Submission ID doesn't exist", error_source: "irs" } }
 
-          it "creates a new EfileError object with service_type state_file" do
+          it "creates a new EfileError object with service_type state_file_<state_code>" do
             Efile::SubmissionErrorParser.new(transition).persist_errors
             expect(EfileError.count).to eq 1
             expect(transition.efile_errors.count).to eq 1
-            expect(EfileError.last.service_type).to eq "state_file"
+            expect(EfileError.last.service_type).to eq "state_file_#{transition.efile_submission.data_source.state_code}"
           end
         end
       end
     end
 
     context "when there is raw_response metadata" do
-      let(:reject_transition) { create :efile_submission_transition, :rejected, metadata: { raw_response: raw_response } }
+      let(:reject_transition) { create :efile_submission_transition, :rejected, efile_submission: create(:efile_submission, :for_state), metadata: { raw_response: raw_response } }
 
       it "creates a new EfileError object" do
         expect {
@@ -108,13 +111,13 @@ describe Efile::SubmissionErrorParser do
           expect {
             Efile::SubmissionErrorParser.new(transition).persist_errors
           }.to change(transition.efile_errors, :count).by(2)
-                   .and change(EfileError, :count).by(2)
+                                                      .and change(EfileError, :count).by(2)
         end
       end
 
       context "when the rejection errors already exist in the db" do
         let(:raw_response) { file_fixture("irs_acknowledgement_rejection_with_new_error_message.xml").read }
-        let!(:other_transition) { create :efile_submission_transition, :rejected, metadata: { raw_response: file_fixture("irs_acknowledgement_rejection.xml").read } }
+        let!(:other_transition) { create :efile_submission_transition, :rejected, efile_submission: create(:efile_submission, :for_state), metadata: { raw_response: file_fixture("irs_acknowledgement_rejection.xml").read } }
 
         before do
           Efile::SubmissionErrorParser.new(other_transition).persist_errors
@@ -124,13 +127,14 @@ describe Efile::SubmissionErrorParser do
           expect {
             Efile::SubmissionErrorParser.new(transition).persist_errors
           }.to change(transition.efile_errors, :count).by(2)
-                   .and change(EfileError, :count).by(0)
+                                                      .and change(EfileError, :count).by(0)
           expect(EfileError.count).to eq 2
           expect(EfileError.find_by_code("IND-189").message).to eq "A very different error message than before."
           expect(EfileError.find_by_code("IND-190").message).to eq "'DeviceId' in 'AtSubmissionFilingGrp' in 'FilingSecurityInformation' in the Return Header must have a value."
         end
 
         context "with dependent association" do
+          let(:transition) { create :efile_submission_transition, :rejected, metadata: { raw_response: raw_response } }
           let(:dependent) { transition.efile_submission.intake.dependents.last }
 
           before do
@@ -158,7 +162,8 @@ describe Efile::SubmissionErrorParser do
     end
 
     context "persisting errors from bundle failure arrays" do
-      let(:transition) { create :efile_submission_transition, :failed, metadata: { raw_response: raw_response } }
+      let(:transition) { create :efile_submission_transition, :failed, efile_submission: create(:efile_submission, :for_state), metadata: { raw_response: raw_response } }
+
       context "when the raw response includes bank account issues" do
         let(:raw_response) { ["36:0: ERROR: Element '{http://www.irs.gov/efile}RoutingTransitNum': [facet 'pattern'] The value '' is not accepted by the pattern '(01|02|03|04|05|06|07|08|09|10|11|12|21|22|23|24|25|26|27|28|29|30|31|32)[0-9]{7}'.", "37:0: ERROR: Element '{http://www.irs.gov/efile}DepositorAccountNum': [facet 'pattern'] The value '' is not accepted by the pattern '[A-Za-z0-9\\-]+'.", "41:0: ERROR: Element '{http://www.irs.gov/efile}RoutingTransitNum': [facet 'pattern'] The value '' is not accepted by the pattern '(01|02|03|04|05|06|07|08|09|10|11|12|21|22|23|24|25|26|27|28|29|30|31|32)[0-9]{7}'.", "42:0: ERROR: Element '{http://www.irs.gov/efile}DepositorAccountNum': [facet 'pattern'] The value '' is not accepted by the pattern '[A-Za-z0-9\\-]+'.", "50:0: ERROR: Element '{http://www.irs.gov/efile}RoutingTransitNum': [facet 'pattern'] The value '' is not accepted by the pattern '(01|02|03|04|05|06|07|08|09|10|11|12|21|22|23|24|25|26|27|28|29|30|31|32)[0-9]{7}'.", "51:0: ERROR: Element '{http://www.irs.gov/efile}DepositorAccountNum': [facet 'pattern'] The value '' is not accepted by the pattern '[A-Za-z0-9\\-]+'.", "120:0: ERROR: Element '{http://www.irs.gov/efile}RoutingTransitNum': [facet 'pattern'] The value '' is not accepted by the pattern '(01|02|03|04|05|06|07|08|09|10|11|12|21|22|23|24|25|26|27|28|29|30|31|32)[0-9]{7}'.", "122:0: ERROR: Element '{http://www.irs.gov/efile}DepositorAccountNum': [facet 'pattern'] The value '' is not accepted by the pattern '[A-Za-z0-9\\-]+'."] }
 

--- a/spec/lib/efile/submission_error_parser_spec.rb
+++ b/spec/lib/efile/submission_error_parser_spec.rb
@@ -207,7 +207,7 @@ describe Efile::SubmissionErrorParser do
 
         context "when the BANK DETAIL error already exists" do
           before do
-            DefaultErrorMessages.generate!
+            DefaultErrorMessages.generate!(service_type: :state_file)
           end
 
           it "creates an efile submission transition error with associated error" do


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-825
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!
## What was done?
- added new enum values for `service_type` column; **something i want an opinion on: i'm dynamically generating these from `.active_state_codes` and have tried to make sure they always have the same value for each state by doing a weird thing where i turn state code letters into `.bytes` and then join them and then turn that into an integer? since state abbreviations are unique this should work? tell me if there is a better way!!**
- when default e-file errors are generated, make one for each state (for internal and irs sources)
- when new e-file errors are made, give them service type `state_code_<whatever state the submission is from>`
- added a new column to the e-file errors hub page
- 2 commits i'm willing to revert:
  - 9bfb5d5cf1a3f8271208cd742c6e9561326258e6 refactor of a test that i still think is super hard to read
  - 39a4e36721d66b356ecb7ce29e802695a99da971 i re-styled some of the e-file errors page and added a filtering and sorting option for service type because idk how long this page is gonna get now
## How to test?
- i updated the default error messages spec
- i updated some specs that were using the old `:state_file` service type to have a state suffix (to be more realistic)
- i did not test the efile errors page because it didn't have a test already and it's internal?
## Screenshots (for visual changes)
- Before
  <img width="1440" alt="image" src="https://github.com/user-attachments/assets/8ba93410-a1bf-43fc-bead-175f0fc464bd">

- After
  default:
  <img width="1440" alt="image" src="https://github.com/user-attachments/assets/ce06ea8d-2132-4b3d-9570-af551fcb9ff8">
  filtered:
  <img width="1440" alt="image" src="https://github.com/user-attachments/assets/f84d8c6c-e522-45fc-8b5b-f95c13770f0f">
  sorted:
  <img width="1440" alt="image" src="https://github.com/user-attachments/assets/bd5fe2bb-a394-4859-ba3b-953d33ef5735">


