### PR TITLE
NJ - lines 27, 29, 38, 39, 42

### DIFF
--- a/app/lib/efile/line_data.yml
+++ b/app/lib/efile/line_data.yml
@@ -532,5 +532,15 @@ NJ1040_LINE_13:
   label: '13 Total Exemption Amount (Add totals from the lines at 6 through 12)'
 NJ1040_LINE_15:
   label: '15 Wages, salaries, tips, and other employee compensation (State wages from Box 16 of enclosed W-2(s))'
+NJ1040_LINE_27:
+  label: '27 Total Income (Add lines 15, 16a, and 20a)'
+NJ1040_LINE_29:
+  label: "29 New Jersey Gross Income (Subtract line 28c from line 27) (See instructions)"
+NJ1040_LINE_38:
+  label: "38 Total Exemptions and Deductions (Add lines 30 through 37c)"
+NJ1040_LINE_39:
+  label: "39 Taxable Income (Subtract line 38 from line 29)"
 NJ1040_LINE_40A:
-  label: 'Total Property Taxes (18% of Rent) Paid (See instructions page 25)'
+  label: '40A Total Property Taxes (18% of Rent) Paid (See instructions page 25)'
+NJ1040_LINE_42:
+  label: '42 New Jersey Taxable Income (Subtract line 41 from line 39)'

--- a/app/lib/efile/nj/nj1040.rb
+++ b/app/lib/efile/nj/nj1040.rb
@@ -18,7 +18,12 @@ module Efile
         set_line(:NJ1040_LINE_8, :calculate_line_8)
         set_line(:NJ1040_LINE_13, :calculate_line_13)
         set_line(:NJ1040_LINE_15, :calculate_line_15)
+        set_line(:NJ1040_LINE_27, :calculate_line_27)
+        set_line(:NJ1040_LINE_29, :calculate_line_29)
+        set_line(:NJ1040_LINE_38, :calculate_line_38)
+        set_line(:NJ1040_LINE_39, :calculate_line_39)
         set_line(:NJ1040_LINE_40A, :calculate_line_40a)
+        set_line(:NJ1040_LINE_42, :calculate_line_42)
         @lines.transform_values(&:value)
       end
 
@@ -93,6 +98,26 @@ module Efile
           sum += state_wage
         end
         sum.round
+      end
+
+      def calculate_line_27
+        calculate_line_15
+      end
+
+      def calculate_line_29
+        calculate_line_27
+      end
+
+      def calculate_line_38
+        calculate_line_13
+      end
+
+      def calculate_line_39
+        calculate_line_29 - calculate_line_38
+      end
+
+      def calculate_line_42
+        calculate_line_39
       end
 
       def is_over_65(birth_date)

--- a/app/lib/pdf_filler/nj1040_pdf.rb
+++ b/app/lib/pdf_filler/nj1040_pdf.rb
@@ -121,6 +121,21 @@ module PdfFiller
         ]))
       end
 
+      if @xml_document.at("TotalExemptDeductions")
+        total_exemptions = @xml_document.at("TotalExemptDeductions").text.to_i
+        answers.merge!(insert_digits_into_fields(total_exemptions, [
+          "250",
+          "undefined_106",
+          "249",
+          "248",
+          "undefined_105",
+          "247",
+          "246",
+          "undefined_104",
+          "278",
+        ]))
+      end
+
       if @xml_document.at("WagesSalariesTips").present?
         wages = @xml_document.at("WagesSalariesTips").text.to_i
         answers.merge!(insert_digits_into_fields(wages, [
@@ -134,6 +149,74 @@ module PdfFiller
           "undefined_37",
           "undefined_36",
           "15"
+        ]))
+      end
+
+      if @xml_document.at("TotalIncome").present?
+        total_income = @xml_document.at("TotalIncome").text.to_i
+        answers.merge!(insert_digits_into_fields(total_income, [
+          "188",
+          "undefined_80",
+          "187",
+          "186",
+          "undefined_79",
+          "185",
+          "184",
+          "undefined_78",
+          "183",
+          "27",
+          "263"
+        ]))
+      end
+
+      if @xml_document.at("GrossIncome").present?
+        gross_income = @xml_document.at("GrossIncome").text.to_i
+        answers.merge!(insert_digits_into_fields(gross_income, [
+          "209",
+          "undefined_89",
+          "208",
+          "207",
+          "undefined_88",
+          "206",
+          "205",
+          "undefined_87",
+          "204",
+          "29",
+          "270",
+        ]))
+      end
+
+      if @xml_document.at("TaxableIncome").present?
+        taxable_income = @xml_document.at("TaxableIncome").text.to_i
+        answers.merge!(insert_digits_into_fields(taxable_income, [
+          "256",
+          "undefined_109",
+          "255",
+          "254",
+          "undefined_108",
+          "253",
+          "252",
+          "undefined_107",
+          "251",
+          "38a Total Property Taxes 18 of Rent Paid See instructions page 23 38a",
+          "279",
+        ]))
+      end
+
+      if @xml_document.at("NewJerseyTaxableIncome").present?
+        nj_taxable_income = @xml_document.at("NewJerseyTaxableIncome").text.to_i
+        answers.merge!(insert_digits_into_fields(nj_taxable_income, [
+          "Text41",
+          "Text40",
+          "Text39",
+          "Text38",
+          "Text37",
+          "Text30",
+          "Text20",
+          "Text19",
+          "undefined_114",
+          "40",
+          "Enter Code4332",
         ]))
       end
 

--- a/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
+++ b/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
@@ -73,9 +73,9 @@ module SubmissionBuilder
                     if @submission.data_source.direct_file_data.is_spouse_blind?
                       xml.SpouseCuPartnerBlindOrDisabled "X"
                     end
-                    xml.TotalExemptionAmountA calculated_fields.fetch(:NJ1040_LINE_13)
                     xml.NumOfQualiDependChild qualifying_dependents.count(&:qualifying_child?)
                     xml.NumOfOtherDepend qualifying_dependents.count(&:qualifying_relative?)
+                    xml.TotalExemptionAmountA calculated_fields.fetch(:NJ1040_LINE_13)
                   end
 
                   unless intake.dependents.empty?
@@ -101,8 +101,19 @@ module SubmissionBuilder
                   if calculated_fields.fetch(:NJ1040_LINE_15) >= 0
                     xml.WagesSalariesTips calculated_fields.fetch(:NJ1040_LINE_15)
                   end
+                  if calculated_fields.fetch(:NJ1040_LINE_27) > 0
+                    xml.TotalIncome calculated_fields.fetch(:NJ1040_LINE_27)
+                  end
+                  if calculated_fields.fetch(:NJ1040_LINE_29) > 0
+                    xml.GrossIncome calculated_fields.fetch(:NJ1040_LINE_29)
+                  end
 
                   xml.TotalExemptionAmountB calculated_fields.fetch(:NJ1040_LINE_13)
+                  xml.TotalExemptDeductions calculated_fields.fetch(:NJ1040_LINE_38)
+
+                  if calculated_fields.fetch(:NJ1040_LINE_39) > 0
+                    xml.TaxableIncome calculated_fields.fetch(:NJ1040_LINE_39)
+                  end
 
                   xml.PropertyTaxDeductOrCredit do
                     if calculated_fields.fetch(:NJ1040_LINE_40A)
@@ -114,6 +125,10 @@ module SubmissionBuilder
                     elsif intake.household_rent_own_own?
                       xml.Homeowner "X"
                     end
+                  end
+
+                  if calculated_fields.fetch(:NJ1040_LINE_42) > 0
+                    xml.NewJerseyTaxableIncome calculated_fields.fetch(:NJ1040_LINE_42)
                   end
                 end
               end

--- a/spec/lib/efile/nj/nj1040_spec.rb
+++ b/spec/lib/efile/nj/nj1040_spec.rb
@@ -145,6 +145,43 @@ describe Efile::Nj::Nj1040 do
     end
   end
 
+  describe 'line 27 - total income' do
+    let(:intake) { create(:state_file_nj_intake, :df_data_2_w2s) }
+    it 'sets line 27 to the rounded sum of all state wage amounts' do
+      line_15_w2_wages = (12345.67 + 50000).round
+      expect(instance.lines[:NJ1040_LINE_15].value).to eq(line_15_w2_wages)
+      expect(instance.lines[:NJ1040_LINE_27].value).to eq(line_15_w2_wages)
+    end
+  end
+
+  describe 'line 29 - gross income' do
+    let(:intake) { create(:state_file_nj_intake, :df_data_2_w2s) }
+    it 'sets line 29 to the rounded sum of all state wage amounts' do
+      line_15_w2_wages = (12345.67 + 50000).round
+      expect(instance.lines[:NJ1040_LINE_15].value).to eq(line_15_w2_wages)
+      expect(instance.lines[:NJ1040_LINE_29].value).to eq(line_15_w2_wages)
+    end
+  end
+
+  describe 'line 38 - total exemptions/deductions' do
+    let(:intake) { create(:state_file_nj_intake, :primary_over_65, :primary_blind) }
+    it 'sets line 38 to the total exemption amount' do
+      self_exemption = 1_000
+      self_over_65 = 1_000
+      self_blind = 1_000
+      total_exemptions = self_exemption + self_over_65 + self_blind
+      expect(instance.lines[:NJ1040_LINE_38].value).to eq(total_exemptions)
+    end
+  end
+
+  describe 'line 39 - taxable income' do
+    let(:intake) { create(:state_file_nj_intake, :df_data_2_w2s, :primary_over_65, :primary_blind) }
+    it 'sets line 39 to line 29 gross income minus line 38 total exemptions/deductions' do
+      expected_total = instance.lines[:NJ1040_LINE_29].value - instance.lines[:NJ1040_LINE_38].value
+      expect(instance.lines[:NJ1040_LINE_39].value).to eq(expected_total)
+    end
+  end
+
   describe 'line 40a - total property taxes paid' do
     context 'when homeowner' do
       context 'when married filing separately' do
@@ -219,6 +256,13 @@ describe Efile::Nj::Nj1040 do
       it 'sets line 40a to nil' do
         expect(instance.lines[:NJ1040_LINE_40A].value).to eq(nil)
       end
+    end
+  end
+
+  describe 'line 42 - new jersey taxable income' do
+    let(:intake) { create(:state_file_nj_intake, :df_data_2_w2s, :primary_over_65, :primary_blind) }
+    it 'sets line 42 to line 39 (taxable income)' do
+      expect(instance.lines[:NJ1040_LINE_42].value).to eq(instance.lines[:NJ1040_LINE_39].value)
     end
   end
 end

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -781,6 +781,162 @@ RSpec.describe PdfFiller::Nj1040Pdf do
       end
     end
 
+    describe "line 27 - total income" do
+      context "when taxpayer provides total income with the sum 200,001.33" do
+        let(:submission) {
+          create :efile_submission, tax_return: nil, data_source: create(
+            :state_file_nj_intake,
+            :df_data_many_w2s
+          )
+        }
+        it "fills in the total income boxes in the PDF on line 27 with the rounded value" do
+          # millions
+          expect(pdf_fields["263"]).to eq ""
+          expect(pdf_fields["27"]).to eq ""
+          expect(pdf_fields["183"]).to eq ""
+          # thousands
+          expect(pdf_fields["undefined_78"]).to eq "2"
+          expect(pdf_fields["184"]).to eq "0"
+          expect(pdf_fields["185"]).to eq "0"
+          # hundreds
+          expect(pdf_fields["undefined_79"]).to eq "0"
+          expect(pdf_fields["186"]).to eq "0"
+          expect(pdf_fields["187"]).to eq "1"
+          # decimals
+          expect(pdf_fields["undefined_80"]).to eq "0"
+          expect(pdf_fields["188"]).to eq "0"
+        end
+      end
+
+      context "when taxpayer provides total income of 0" do
+        let(:submission) {
+          create :efile_submission, tax_return: nil, data_source: create(
+            :state_file_nj_intake,
+            :df_data_minimal
+          )
+        }
+        it "does not fill in any of the boxes on line 27" do
+          # millions
+          expect(pdf_fields["263"]).to eq ""
+          expect(pdf_fields["27"]).to eq ""
+          expect(pdf_fields["183"]).to eq ""
+          # thousands
+          expect(pdf_fields["undefined_78"]).to eq ""
+          expect(pdf_fields["184"]).to eq ""
+          expect(pdf_fields["185"]).to eq ""
+          # hundreds
+          expect(pdf_fields["undefined_79"]).to eq ""
+          expect(pdf_fields["186"]).to eq ""
+          expect(pdf_fields["187"]).to eq ""
+          # decimals
+          expect(pdf_fields["undefined_80"]).to eq ""
+          expect(pdf_fields["188"]).to eq ""
+        end
+      end
+    end
+
+    describe "line 29 - gross income" do
+      context "when taxpayer provides gross income with the sum 200,001.33" do
+        let(:submission) {
+          create :efile_submission, tax_return: nil, data_source: create(
+            :state_file_nj_intake,
+            :df_data_many_w2s
+          )
+        }
+        it "fills in the gross income boxes in the PDF on line 29 with the rounded value" do
+          # millions
+          expect(pdf_fields["270"]).to eq ""
+          expect(pdf_fields["29"]).to eq ""
+          expect(pdf_fields["204"]).to eq ""
+          # thousands
+          expect(pdf_fields["undefined_87"]).to eq "2"
+          expect(pdf_fields["205"]).to eq "0"
+          expect(pdf_fields["206"]).to eq "0"
+          # hundreds
+          expect(pdf_fields["undefined_88"]).to eq "0"
+          expect(pdf_fields["207"]).to eq "0"
+          expect(pdf_fields["208"]).to eq "1"
+          # decimals
+          expect(pdf_fields["undefined_89"]).to eq "0"
+          expect(pdf_fields["209"]).to eq "0"
+        end
+      end
+
+      context "when taxpayer provides total income of 0" do
+        let(:submission) {
+          create :efile_submission, tax_return: nil, data_source: create(
+            :state_file_nj_intake,
+            :df_data_minimal
+          )
+        }
+        it "does not fill in any of the boxes on line 29" do
+          # millions
+          expect(pdf_fields["270"]).to eq ""
+          expect(pdf_fields["29"]).to eq ""
+          expect(pdf_fields["204"]).to eq ""
+          # thousands
+          expect(pdf_fields["undefined_87"]).to eq ""
+          expect(pdf_fields["205"]).to eq ""
+          expect(pdf_fields["206"]).to eq ""
+          # hundreds
+          expect(pdf_fields["undefined_88"]).to eq ""
+          expect(pdf_fields["207"]).to eq ""
+          expect(pdf_fields["208"]).to eq ""
+          # decimals
+          expect(pdf_fields["undefined_89"]).to eq ""
+          expect(pdf_fields["209"]).to eq ""
+        end
+      end
+    end
+
+    describe "line 38 total exemptions and deductions" do
+      let(:submission) {
+        create :efile_submission, tax_return: nil, data_source: create(
+          :state_file_nj_intake
+        )
+      }
+      it "writes sum $1,000.00 to fill boxes on line 38" do
+        # millions
+        expect(pdf_fields["278"]).to eq ""
+        # thousands
+        expect(pdf_fields["undefined_104"]).to eq ""
+        expect(pdf_fields["246"]).to eq ""
+        expect(pdf_fields["247"]).to eq "1"
+        # hundreds
+        expect(pdf_fields["undefined_105"]).to eq "0"
+        expect(pdf_fields["248"]).to eq "0"
+        expect(pdf_fields["249"]).to eq "0"
+        # decimals
+        expect(pdf_fields["undefined_106"]).to eq "0"
+        expect(pdf_fields["250"]).to eq "0"
+      end
+    end
+
+    describe "line 39 taxable income" do
+      let(:submission) {
+        create :efile_submission, tax_return: nil, data_source: create(
+          :state_file_nj_intake, :df_data_many_w2s
+        )
+      }
+      it "writes taxable income $199,001 (200,001.33-1000) to fill boxes on line 39" do
+        # millions
+        expect(pdf_fields["279"]).to eq ""
+        expect(pdf_fields["38a Total Property Taxes 18 of Rent Paid See instructions page 23 38a"]).to eq ""
+        expect(pdf_fields["251"]).to eq ""
+        # thousands
+        expect(pdf_fields["undefined_107"]).to eq "1"
+        expect(pdf_fields["252"]).to eq "9"
+        expect(pdf_fields["253"]).to eq "9"
+        # hundreds
+        expect(pdf_fields["undefined_108"]).to eq "0"
+        expect(pdf_fields["254"]).to eq "0"
+        expect(pdf_fields["255"]).to eq "1"
+        # decimals
+        expect(pdf_fields["undefined_109"]).to eq "0"
+        expect(pdf_fields["256"]).to eq "0"
+      end
+    end
+
     describe "lines 40a and 40b" do
       context "when taxpayer is a renter" do
         let(:submission) {
@@ -864,6 +1020,31 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           expect(pdf_fields["245"]).to eq ""
           expect(pdf_fields["24539a#2"]).to eq ""
         end
+      end
+    end
+
+    describe "line 42 new jersey taxable income" do
+      let(:submission) {
+        create :efile_submission, tax_return: nil, data_source: create(
+          :state_file_nj_intake, :df_data_many_w2s
+        )
+      }
+      it "writes new jersey taxable income $199,001 (200,001.33-1000) to fill boxes on line 39" do
+        # millions
+        expect(pdf_fields["Enter Code4332"]).to eq ""
+        expect(pdf_fields["40"]).to eq ""
+        expect(pdf_fields["undefined_114"]).to eq ""
+        # thousands
+        expect(pdf_fields["Text19"]).to eq "1"
+        expect(pdf_fields["Text20"]).to eq "9"
+        expect(pdf_fields["Text30"]).to eq "9"
+        # hundreds
+        expect(pdf_fields["Text37"]).to eq "0"
+        expect(pdf_fields["Text38"]).to eq "0"
+        expect(pdf_fields["Text39"]).to eq "1"
+        # decimals
+        expect(pdf_fields["Text40"]).to eq "0"
+        expect(pdf_fields["Text41"]).to eq "0"
       end
     end
   end

--- a/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
@@ -279,6 +279,63 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
       end
     end
 
+    describe "total income - line 27" do
+      context "when filer submits w2 wages" do
+        let(:intake) { create(:state_file_nj_intake, :df_data_many_w2s) }
+        it "fills TotalIncome with the value from Line 15" do
+          expected_line_15_w2_wages = 200_001
+          expect(xml.at("WagesSalariesTips").text).to eq(expected_line_15_w2_wages.to_s)
+          expect(xml.at("TotalIncome").text).to eq(expected_line_15_w2_wages.to_s)
+        end
+      end
+      context "when filer does not submit w2 wages" do
+        let(:intake) { create(:state_file_nj_intake, :df_data_minimal) }
+        it "does not include TotalIncome in the XML" do
+          expect(xml.at("TotalIncome")).to eq(nil)
+        end
+      end
+    end
+
+    describe "gross income - line 29" do
+      context "when filer submits w2 wages" do
+        let(:intake) { create(:state_file_nj_intake, :df_data_many_w2s) }
+        it "fills TotalIncome with the value from Line 15" do
+          expected_line_15_w2_wages = 200_001
+          expect(xml.at("WagesSalariesTips").text).to eq(expected_line_15_w2_wages.to_s)
+          expect(xml.at("GrossIncome").text).to eq(expected_line_15_w2_wages.to_s)
+        end
+      end
+      context "when filer does not submit w2 wages" do
+        let(:intake) { create(:state_file_nj_intake, :df_data_minimal) }
+        it "does not include TotalIncome in the XML" do
+          expect(xml.at("GrossIncome")).to eq(nil)
+        end
+      end
+    end
+
+    describe "total exemptions and deductions - line 38" do
+      let(:intake) { create(:state_file_nj_intake) }
+      it "fills TotalExemptDeductions with total exemptions and deductions" do
+        line_6_single_filer = 1_000
+        line_7_not_over_65 = 0
+        line_8_not_blind = 0
+        expected_sum = line_6_single_filer + line_7_not_over_65 + line_8_not_blind
+        expect(xml.at("TotalExemptDeductions").text).to eq(expected_sum.to_s)
+      end
+    end
+
+    describe "taxable income - line 39" do
+      let(:intake) { create(:state_file_nj_intake, :df_data_many_w2s) }
+      it "fills TaxableIncome with gross income minus total exemptions/deductions" do
+        expected_line_15_w2_wages = 200_001
+        line_6_single_filer = 1_000
+        line_7_not_over_65 = 0
+        line_8_not_blind = 0
+        expected_total = expected_line_15_w2_wages - (line_6_single_filer + line_7_not_over_65 + line_8_not_blind)
+        expect(xml.at("TaxableIncome").text).to eq(expected_total.to_s)
+      end
+    end
+
     describe "property tax - lines 40a and 40b" do
       context "when taxpayer is a renter" do
         let(:intake) { create(:state_file_nj_intake, :df_data_minimal, household_rent_own: 'rent', rent_paid: 54321) }
@@ -288,7 +345,7 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
           expect(xml.at("PropertyTaxDeductOrCredit Homeowner")).to eq(nil)
         end
 
-        it 'inserts property tax rent calculation on line 40a' do
+        it "inserts property tax rent calculation on line 40a" do
           expect(xml.at("PropertyTaxDeductOrCredit TotalPropertyTaxPaid").text).to eq("9778")
         end
       end
@@ -317,6 +374,18 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
         it 'does not add property tax on line 40a' do
           expect(xml.at("PropertyTaxDeductOrCredit TotalPropertyTaxPaid")).to eq(nil)
         end
+      end
+    end
+
+    describe "new jersey taxable income - line 42" do
+      let(:intake) { create(:state_file_nj_intake, :df_data_many_w2s) }
+      it "fills NewJerseyTaxableIncome with taxable income" do
+        expected_line_15_w2_wages = 200_001
+        line_6_single_filer = 1_000
+        line_7_not_over_65 = 0
+        line_8_not_blind = 0
+        expected_total = expected_line_15_w2_wages - (line_6_single_filer + line_7_not_over_65 + line_8_not_blind)
+        expect(xml.at("NewJerseyTaxableIncome").text).to eq(expected_total.to_s)
       end
     end
   end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- Line 27: total income https://github.com/newjersey/affordability-pm/issues/61
- Line 29: gross income https://github.com/newjersey/affordability-pm/issues/60
- Line 38: total exemptions and deductions https://github.com/newjersey/affordability-pm/issues/59
- Line 39: taxable income https://github.com/newjersey/affordability-pm/issues/65
- Line 42: new jersey taxable income https://github.com/newjersey/affordability-pm/issues/62


## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
Add basic calculations for income/exemptions lines, add to XML and PDF

## How to test?
- use `minimal` for no W2 income, or zeus with W2 income for testing taxable income
- use blind or others to test exemptions

## Screenshots (for visual changes)
![image](https://github.com/user-attachments/assets/fcc148b3-c9c0-4074-83c1-0b86c16d8003)
![image](https://github.com/user-attachments/assets/89116e26-a4f8-431e-83b1-98056553d14f)