### PR TITLE
TBE-114 Stop submitting mixpanel events in dev

### DIFF
--- a/app/services/mixpanel_service.rb
+++ b/app/services/mixpanel_service.rb
@@ -39,7 +39,7 @@ class MixpanelService
   #
   def run(distinct_id:, event_name:, data: {})
     unless Rails.env.production?
-      Rails.logger.error "You are currently on non-prod environment. if You want to track mixpanel events in non-prod environments, please uncomment this check in Mixpanel Service"
+      Rails.logger.error "You are currently on non-prod environment. If you want to track mixpanel events in non-prod environments, please uncomment this check in Mixpanel Service"
       return
     end
 

--- a/app/services/mixpanel_service.rb
+++ b/app/services/mixpanel_service.rb
@@ -18,23 +18,25 @@ class MixpanelService
 
     @buffer = []
     @mutex = Mutex.new
+
     @tracker =
       if Rails.env.production?
         Mixpanel::Tracker.new(mixpanel_key) do |type, message|
           buffer_event_for_send(type, message)
         end
-      elsif Rails.env.development? # for debugging purposes
-        Struct.new(:track) do
+      elsif Rails.env.development?
+        Struct.new("DummyTracker") do
           def track(distinct_id, event_name, data)
+            # for debugging purposes
             Rails.logger.info("Sending Mixpanel event: id #{distinct_id}, event_name #{event_name}, data #{data}")
           end
-        end
+        end.new
       else # demo, staging, heroku
-        Struct.new(:track) do
+        Struct.new("DummyTracker") do
           def track(_distinct_id, _event_name, _data)
             # do nothing
           end
-        end
+        end.new
       end
 
     # silence local SSL errors

--- a/app/services/mixpanel_service.rb
+++ b/app/services/mixpanel_service.rb
@@ -31,7 +31,7 @@ class MixpanelService
         end
       else # demo, staging, heroku
         Struct.new(:track) do
-          def track(distinct_id, event_name, data)
+          def track(_distinct_id, _event_name, _data)
             # do nothing
           end
         end

--- a/app/services/mixpanel_service.rb
+++ b/app/services/mixpanel_service.rb
@@ -38,6 +38,11 @@ class MixpanelService
   # @param [Hash] data: (optional, defaults to {}) data to be sent to mixpanel
   #
   def run(distinct_id:, event_name:, data: {})
+    unless Rails.env.production?
+      Rails.logger.error "You are currently on non-prod environment. if You want to track mixpanel events in non-prod environments, please uncomment this check in Mixpanel Service"
+      return
+    end
+
     @tracker.track(distinct_id, event_name, data)
   rescue StandardError => err
     Rails.logger.error "Error tracking analytics event #{err}"


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/TBE-114
## Is PM acceptance required? (delete one)
- No - merge after code review approval
## What was done?
- Currently, all events fired from dev, demo, staging, heroku environments will all be received at the GetYourRefund.dev mixpanel. ~~I am disabling the `run` command which appears to actually send the tracking events to mixpanel.~~ Trying to mock out a `@tracker` by using a Struct per Jey's suggestion
- Alternatives considered: 
   - I thought about just removing the config variables `mixpanel_token` from the rails credentials files and storing that in LastPass. This would minimize any code changes but would be less transparent about why/how mixpanel is being disabled for the non-prod environments.
   - I also tried to see if there was a way to conveniently disable the Dev environment on mixpanel's end, but alas I didn't find anything :( 
- Risks:
   - It'll be harder to do acceptance testing for mixpanel events on staging/demo/heroku environments once we turn these off. I think the best course of option would be to locally manipulate the code in MixpanelService & pair with a prod person to show what the events will look like in mixpanel. We can also turn on the mixpanel events via a commit (adding certain environments to the `Rails.env.production?` block as needed on a temporary basis).
## How to test?
- Describe the testing approach taken to verify the changes, including:
  - Unit tests
  - Try navigating to a page on a demo page & see that reflected on the Dev Mixpanel & switch over to this branch, go to the same page & see that the event does not come through.
