### PR TITLE
FYST 558 - XML Editor bug for W2s

### DIFF
--- a/app/forms/state_file/federal_info_form.rb
+++ b/app/forms/state_file/federal_info_form.rb
@@ -114,19 +114,19 @@ module StateFile
     end
 
     def w2s_attributes=(attributes)
+      index = 0
       attributes.each do |_form_number, w2_attributes|
-        w2 = w2s.find { |w| w.id == w2_attributes['id'] }
-        if w2
-          w2_attributes.except('id', '_destroy').each do |field, value|
-            w2.send("#{field}=", value) if w2.respond_to?("#{field}=")
-          end
-        else
-          new_w2_node = @intake.direct_file_data.build_new_w2_node
-          new_w2 = DfIrsW2Form.new(new_w2_node)
-          w2_attributes.except('id', '_destroy').each do |field, value|
-            new_w2.send("#{field}=", value) if new_w2.respond_to?("#{field}=")
+        if index == w2s.length
+          @intake.direct_file_data.build_new_w2_node
+        end
+        w2 = w2s[index.to_i]
+        DfIrsW2Form.selectors.each_key do |field|
+          new_value = w2_attributes[field.to_s]
+          if new_value.present? && w2.send(field) != new_value
+            w2.send(:"#{field}=", new_value)
           end
         end
+        index += 1
       end
     end
 

--- a/app/forms/state_file/federal_info_form.rb
+++ b/app/forms/state_file/federal_info_form.rb
@@ -114,16 +114,19 @@ module StateFile
     end
 
     def w2s_attributes=(attributes)
-      index = 0
       attributes.each do |_form_number, w2_attributes|
-        if index == w2s.length
-          @intake.direct_file_data.build_new_w2_node
+        w2 = w2s.find { |w| w.id == w2_attributes['id'] }
+        if w2
+          w2_attributes.except('id', '_destroy').each do |field, value|
+            w2.send("#{field}=", value) if w2.respond_to?("#{field}=")
+          end
+        else
+          new_w2_node = @intake.direct_file_data.build_new_w2_node
+          new_w2 = DfIrsW2Form.new(new_w2_node)
+          w2_attributes.except('id', '_destroy').each do |field, value|
+            new_w2.send("#{field}=", value) if new_w2.respond_to?("#{field}=")
+          end
         end
-        w2 = w2s[index.to_i]
-        DfIrsW2Form.selectors.each_key do |field|
-          w2.send(:"#{field}=", w2_attributes[field.to_s])
-        end
-        index += 1
       end
     end
 

--- a/spec/features/state_file/editing_df_xml_spec.rb
+++ b/spec/features/state_file/editing_df_xml_spec.rb
@@ -127,7 +127,7 @@ RSpec.feature "editing direct file XML with the FederalInfoController", active_j
     expect(StateFileAzIntake.last.direct_file_data.form1099rs[0].StateDistributionAmt).to eq 200
   end
 
-  it "preserves W2 EmployeeSSN when XML Editor is opened without changes" do
+  it "preserves W2 when XML Editor is opened without changes" do
     visit "/"
     click_on "Start Test NC"
 
@@ -146,6 +146,18 @@ RSpec.feature "editing direct file XML with the FederalInfoController", active_j
     expect(page).to have_text I18n.t('state_file.questions.data_review.edit.title')
 
     xml_before = StateFileNcIntake.last.direct_file_data
+    raw_xml_before = StateFileNcIntake.last.raw_direct_file_data.strip
     expect(xml_before.w2s[0].EmployeeSSN).to eq "400000030"
+
+    find("#visit_federal_info_controller").click
+    expect(page).to have_text "‍💻🛠️ Direct File Data Overrides 🛠️💻"
+
+    click_on "Continue"
+    expect(page).to have_text I18n.t('state_file.questions.name_dob.edit.title1')
+    xml_after = StateFileNcIntake.last.direct_file_data
+    raw_xml_after = StateFileNcIntake.last.raw_direct_file_data.strip
+    expect(raw_xml_before).to eq(raw_xml_after)
+
+    expect(xml_after.w2s[0].EmployeeSSN).to eq "400000030"
   end
 end

--- a/spec/features/state_file/editing_df_xml_spec.rb
+++ b/spec/features/state_file/editing_df_xml_spec.rb
@@ -126,4 +126,26 @@ RSpec.feature "editing direct file XML with the FederalInfoController", active_j
     expect(StateFileAzIntake.last.direct_file_data.form1099rs[0].PayerStateIdNumber).to eq "987654321"
     expect(StateFileAzIntake.last.direct_file_data.form1099rs[0].StateDistributionAmt).to eq 200
   end
+
+  it "preserves W2 EmployeeSSN when XML Editor is opened without changes" do
+    visit "/"
+    click_on "Start Test NC"
+
+    expect(page).to have_text I18n.t("state_file.landing_page.edit.nc.title")
+    click_on "Get Started", id: "firstCta"
+
+    step_through_eligibility_screener(us_state: "nc")
+
+    step_through_initial_authentication(contact_preference: :text_message)
+
+    expect(page).to have_text I18n.t('state_file.questions.terms_and_conditions.edit.title')
+    click_on I18n.t("state_file.questions.terms_and_conditions.edit.accept")
+
+    step_through_df_data_transfer("Transfer Nick")
+
+    expect(page).to have_text I18n.t('state_file.questions.data_review.edit.title')
+
+    xml_before = StateFileNcIntake.last.direct_file_data
+    expect(xml_before.w2s[0].EmployeeSSN).to eq "400000030"
+  end
 end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/FYST-558

## Is PM acceptance required?
- Yes - don't merge until JIRA issue is accepted!

## What was done?
The form was accidentally erasing important tax nodes, like EmployeeSSN, whenever someone opened the editor to look at the data. This happened even if they didn't change anything.
This was fixed by editing the w2 attributes method to only update a field if it has changed and the new value is present. This prevents overwriting existing data with blank or unchanged values.

## How to test?
Use the heroku link to do the following: 

1- Transfer fake DF data from [Nick](https://github.com/codeforamerica/vita-min/blob/main/spec/fixtures/state_file/fed_return_xmls/2023/nc/nick.xml)

2- Click on the “I’m on a demo environment, let me edit the response XML” and press “Continue” (without editing anything)

3 - Continue through the flow without changing anything - submit & download the pdf

4 - In the NC XML  <IncTaxWith> should be equal to “15”

5 - In the PDF Line 20a (Primary NC Income tax withheld) should also be qual to “15”
