### PR TITLE
Remove old integer columns

### DIFF
--- a/db/migrate/20240930194429_remove_old_integer_monetary_values.rb
+++ b/db/migrate/20240930194429_remove_old_integer_monetary_values.rb
@@ -1,0 +1,20 @@
+class RemoveOldIntegerMonetaryValues < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      remove_column :state_file_az_intakes, :armed_forces_wages, :integer
+      remove_column :state_file_az_intakes, :charitable_cash, :integer
+      remove_column :state_file_az_intakes, :charitable_noncash, :integer
+      remove_column :state_file_az_intakes, :household_excise_credit_claimed_amt, :integer
+      remove_column :state_file_az_intakes, :tribal_wages, :integer
+
+      remove_column :state_file_w2s, :local_income_tax_amt, :integer
+      remove_column :state_file_w2s, :local_wages_and_tips_amt, :integer
+      remove_column :state_file_w2s, :state_income_tax_amt, :integer
+      remove_column :state_file_w2s, :state_wages_amt, :integer
+
+      remove_column :state_file1099_gs, :federal_income_tax_withheld, :integer
+      remove_column :state_file1099_gs, :state_income_tax_withheld, :integer
+      remove_column :state_file1099_gs, :unemployment_compensation, :integer
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_26_172957) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_30_194429) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -1600,7 +1600,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_26_172957) do
   create_table "state_file1099_gs", force: :cascade do |t|
     t.integer "address_confirmation", default: 0, null: false
     t.datetime "created_at", null: false
-    t.integer "federal_income_tax_withheld"
     t.decimal "federal_income_tax_withheld_amount", precision: 12, scale: 2
     t.integer "had_box_11", default: 0, null: false
     t.bigint "intake_id", null: false
@@ -1616,9 +1615,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_26_172957) do
     t.string "recipient_street_address_apartment"
     t.string "recipient_zip"
     t.string "state_identification_number"
-    t.integer "state_income_tax_withheld"
     t.decimal "state_income_tax_withheld_amount", precision: 12, scale: 2
-    t.integer "unemployment_compensation"
     t.decimal "unemployment_compensation_amount", precision: 12, scale: 2
     t.datetime "updated_at", null: false
     t.index ["intake_type", "intake_id"], name: "index_state_file1099_gs_on_intake"
@@ -1655,13 +1652,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_26_172957) do
     t.string "account_number"
     t.integer "account_type"
     t.integer "armed_forces_member", default: 0, null: false
-    t.integer "armed_forces_wages"
     t.decimal "armed_forces_wages_amount", precision: 12, scale: 2
     t.string "bank_name"
-    t.integer "charitable_cash", default: 0
     t.decimal "charitable_cash_amount", precision: 12, scale: 2
     t.integer "charitable_contributions", default: 0, null: false
-    t.integer "charitable_noncash", default: 0
     t.decimal "charitable_noncash_amount", precision: 12, scale: 2
     t.integer "consented_to_terms_and_conditions", default: 0, null: false
     t.integer "contact_preference", default: 0, null: false
@@ -1685,7 +1679,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_26_172957) do
     t.string "hashed_ssn"
     t.integer "household_excise_credit_claimed", default: 0, null: false
     t.decimal "household_excise_credit_claimed_amount", precision: 12, scale: 2
-    t.integer "household_excise_credit_claimed_amt"
     t.datetime "last_sign_in_at"
     t.inet "last_sign_in_ip"
     t.string "locale", default: "en"
@@ -1728,7 +1721,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_26_172957) do
     t.integer "spouse_was_incarcerated", default: 0, null: false
     t.integer "ssn_no_employment", default: 0, null: false
     t.integer "tribal_member", default: 0, null: false
-    t.integer "tribal_wages"
     t.decimal "tribal_wages_amount", precision: 12, scale: 2
     t.text "unfinished_intake_ids", default: [], array: true
     t.boolean "unsubscribed_from_email", default: false, null: false
@@ -2169,16 +2161,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_26_172957) do
     t.datetime "created_at", null: false
     t.string "employer_state_id_num"
     t.decimal "local_income_tax_amount", precision: 12, scale: 2
-    t.integer "local_income_tax_amt"
     t.decimal "local_wages_and_tips_amount", precision: 12, scale: 2
-    t.integer "local_wages_and_tips_amt"
     t.string "locality_nm"
     t.bigint "state_file_intake_id"
     t.string "state_file_intake_type"
     t.decimal "state_income_tax_amount", precision: 12, scale: 2
-    t.integer "state_income_tax_amt"
     t.decimal "state_wages_amount", precision: 12, scale: 2
-    t.integer "state_wages_amt"
     t.datetime "updated_at", null: false
     t.integer "w2_index"
     t.index ["state_file_intake_type", "state_file_intake_id"], name: "index_state_file_w2s_on_state_file_intake"


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/FYST-162

## Is PM acceptance required?
- No - merge after code review approval

## What was done?
Dropped all the old monetary columns that were integers that are now decimals from [this PR](https://github.com/codeforamerica/vita-min/pull/4797):  with safety_assured.

## How to test?
The unit/integration tests should pass

