### PR TITLE
fix error messages on sales use tax form

### DIFF
--- a/app/forms/state_file/sales_use_tax_form.rb
+++ b/app/forms/state_file/sales_use_tax_form.rb
@@ -10,6 +10,7 @@ module StateFile
     validates :sales_use_tax,
       presence: true,
       numericality: {
+        allow_blank: true,
         greater_than_or_equal_to: 0
       },
       if: -> { sales_use_tax_calculation_method == "manual" }

--- a/app/forms/state_file/sales_use_tax_form.rb
+++ b/app/forms/state_file/sales_use_tax_form.rb
@@ -11,7 +11,8 @@ module StateFile
       presence: true,
       numericality: {
         allow_blank: true,
-        greater_than_or_equal_to: 0
+        greater_than_or_equal_to: 0,
+        message: I18n.t("state_file.questions.sales_use_tax.edit.not_a_number")
       },
       if: -> { sales_use_tax_calculation_method == "manual" }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,8 +10,8 @@ en:
         state_file/sales_use_tax_form:
           attributes:
             sales_use_tax:
-              greater_than_or_equal_to: Please enter a positive dollar amount.
-              not_a_number: Please enter a dollar amount.
+              greater_than_or_equal_to: Please enter numbers only.
+              not_a_number: Please enter numbers only.
   activerecord:
     errors:
       models:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,11 +7,6 @@ en:
           attributes:
             ssn:
               blank: To claim family member as a dependent for benefits, an SSN or ATIN is required.
-        state_file/sales_use_tax_form:
-          attributes:
-            sales_use_tax:
-              greater_than_or_equal_to: Please enter numbers only.
-              not_a_number: Please enter numbers only.
   activerecord:
     errors:
       models:
@@ -2759,6 +2754,7 @@ en:
       sales_use_tax:
         edit:
           calculated_use_tax: Enter calculated use tax
+          not_a_number: Please enter numbers only.
           select_one: 'Select one of the following:'
           state_specific:
             nc:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -10,8 +10,8 @@ es:
         state_file/sales_use_tax_form:
           attributes:
             sales_use_tax:
-              greater_than_or_equal_to: Ingresa una cantidad en dólares.
-              not_a_number: Ingresa una cantidad en dólares.
+              greater_than_or_equal_to: Por favor ingresa únicamente números.
+              not_a_number: Por favor ingresa únicamente números.
   activerecord:
     errors:
       models:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -7,11 +7,6 @@ es:
           attributes:
             ssn:
               blank: Para reclamar a un miembro de su familia como dependiente para los beneficios, se requiere un SSN o ATIN.
-        state_file/sales_use_tax_form:
-          attributes:
-            sales_use_tax:
-              greater_than_or_equal_to: Por favor ingresa únicamente números.
-              not_a_number: Por favor ingresa únicamente números.
   activerecord:
     errors:
       models:
@@ -2746,6 +2741,7 @@ es:
       sales_use_tax:
         edit:
           calculated_use_tax: Ingresa el impuesto de uso calculado
+          not_a_number: Por favor ingresa únicamente números.
           select_one: 'Selecciona una de las siguientes opciones:'
           state_specific:
             nc:

--- a/spec/forms/state_file/sales_use_tax_form_spec.rb
+++ b/spec/forms/state_file/sales_use_tax_form_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe StateFile::SalesUseTaxForm do
 
           it "is valid" do
             expect(form.valid?).to eq false
-            expect(form.errors[:sales_use_tax]).to include "Please enter a dollar amount."
+            expect(form.errors[:sales_use_tax]).to include "Please enter numbers only."
           end
         end
 
@@ -127,7 +127,7 @@ RSpec.describe StateFile::SalesUseTaxForm do
 
           it "is invalid" do
             expect(form.valid?).to eq false
-            expect(form.errors[:sales_use_tax]).to include "Please enter a positive dollar amount."
+            expect(form.errors[:sales_use_tax]).to include "Please enter numbers only."
           end
         end
       end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-318
## Is PM acceptance required?
- Yes - don't merge until JIRA issue is accepted!
## What was done?
- Updated the error messages for the manually calculated sales & use tax form field to reflect design's specifications in conversation on the JIRA story after the original story was accepted & the PR was merged.
- Added `allow_blank: true` to the numericality validations so that they don't show up when the field is left blank (this will still get caught by the `presence: true` validation on the field), resulting in us only ever showing one error message at a time
## How to test?
1. Go through the NC flow til you get to the sale & use tax page.
1. Select "Yes" and "I kept a complete record..."
1. Submit the form without entering anything in the "Enter calculated use tax" field. _Verify that only "Can't be blank." is shown_
1. Submit the form with a non-number in that field. _Verify that "Please enter numbers only." is shown_
1. Submit the form with a negative number in that field. _Verify that "Please enter numbers only." is shown_
1. Change /en to /es in the url, and do the last two steps again, _verifying that we show "Por favor ingresa únicamente números." in those cases
## Screenshots (for visual changes)
**Before**
![image](https://github.com/user-attachments/assets/d65780f5-357c-439e-8225-33dc0b6ae7fe)
![image](https://github.com/user-attachments/assets/ba4b14dd-8f20-4296-a826-f8fe82aa5f98)
![image](https://github.com/user-attachments/assets/02fec823-ae9e-4052-a710-55b112621595)

**After**
![image](https://github.com/user-attachments/assets/3d202cd7-8a2b-46cd-882a-50f0e858ec7b)
![image](https://github.com/user-attachments/assets/e823d71b-e6e9-43bb-8016-f479a2923453)
![image](https://github.com/user-attachments/assets/1138a100-e3aa-4ca6-bd3a-56b8e91a89a4)
