### PR TITLE
Fyst 524 add MD, ID, and NJ FAQ

### DIFF
--- a/app/controllers/state_file/faq_controller.rb
+++ b/app/controllers/state_file/faq_controller.rb
@@ -2,32 +2,8 @@ class StateFile::FaqController < ApplicationController
   layout "state_file"
 
   def index
-    intake_start = Rails.configuration.state_file_start_of_open_intake
-    intake_end = Rails.configuration.state_file_end_of_in_progress_intakes
-    tax_year = Rails.configuration.statefile_current_tax_year
-
-    if Rails.env.production?
-      filter_years = if intake_start < app_time && app_time < intake_end # intake is open
-                       # show currently open states
-                       [tax_year]
-                     elsif app_time.year == intake_start.year && app_time < intake_start # before intake opens this year
-                       # show states that were open the previous year and will open this year
-                       [tax_year - 1, tax_year]
-                     else
-                       # intake is closed for the year
-                       # show states that were open this year and will open next year
-                       [tax_year, tax_year + 1]
-                     end
-    else
-      filter_years = if app_time > intake_end
-                       [tax_year + 1]
-                     else
-                       [tax_year]
-                     end
-    end
-
     visible_state_code_names = StateFile::StateInformationService.state_code_to_name_map.filter do |state_code, _|
-      filter_years.all? { |year| StateFile::StateInformationService.filing_years(state_code).include?(year) }
+      filing_years_to_show.all? { |year| StateFile::StateInformationService.filing_years(state_code).include?(year) }
     end
     @state_code_names = if params[:us_state] == 'us'
                           visible_state_code_names
@@ -41,5 +17,33 @@ class StateFile::FaqController < ApplicationController
     @faq_category = FaqCategory.find_by(slug: @section_key, product_type: FaqCategory.state_to_product_type(params[:us_state]))
 
     raise ActionController::RoutingError.new('Not found') unless @faq_category
+  end
+
+  private
+
+  def filing_years_to_show
+    intake_start = Rails.configuration.state_file_start_of_open_intake
+    intake_end = Rails.configuration.state_file_end_of_in_progress_intakes
+    tax_year = Rails.configuration.statefile_current_tax_year
+
+    if Rails.env.production?
+      if intake_start < app_time && app_time < intake_end # intake is open
+        # show currently open states
+        [tax_year]
+      elsif app_time.year == intake_start.year && app_time < intake_start # before intake opens this year
+        # show states that were open the previous year and will open this year
+        [tax_year - 1, tax_year]
+      else
+        # intake is closed for the year
+        # show states that were open this year and will open next year
+        [tax_year, tax_year + 1]
+      end
+    else
+      if app_time > intake_end
+        [tax_year + 1]
+      else
+        [tax_year]
+      end
+    end
   end
 end

--- a/app/controllers/state_file/faq_controller.rb
+++ b/app/controllers/state_file/faq_controller.rb
@@ -33,8 +33,7 @@ class StateFile::FaqController < ApplicationController
       elsif app_time.year == intake_start.year && app_time < intake_start # before intake opens this year
         # show states that were open the previous year and will open this year
         [tax_year - 1, tax_year]
-      else
-        # intake is closed for the year
+      else # intake is closed for the year
         # show states that were open this year and will open next year
         [tax_year, tax_year + 1]
       end

--- a/app/controllers/state_file/faq_controller.rb
+++ b/app/controllers/state_file/faq_controller.rb
@@ -3,13 +3,23 @@ class StateFile::FaqController < ApplicationController
 
   def index
     intake_start = Rails.configuration.state_file_start_of_open_intake
-    active_tax_year = if (app_time.year == intake_start.year) && app_time < intake_start
-                        # if the start of intake is set to this year and it is currently before that date, we should still show the previous year's states
-                        Rails.configuration.statefile_current_tax_year - 1
-                      else
-                        Rails.configuration.statefile_current_tax_year
-                      end
-    visible_state_code_names = StateFile::StateInformationService.state_code_to_name_map.filter { |code, name| StateFile::StateInformationService.filing_years(code).include?(active_tax_year) }
+    intake_end = Rails.configuration.state_file_end_of_in_progress_intakes
+    tax_year = Rails.configuration.statefile_current_tax_year
+
+    filter_years = if intake_start < app_time && app_time < intake_end # intake is open
+                     # show currently open states
+                     [tax_year]
+                   elsif app_time.year == intake_start.year && app_time < intake_start # before intake opens this year
+                     # show states that were open the previous year and will open this year
+                     [tax_year - 1, tax_year]
+                   else # intake is closed for the year
+                     # show states that were open this year and will open next year
+                     [tax_year, tax_year + 1]
+                   end
+
+    visible_state_code_names = StateFile::StateInformationService.state_code_to_name_map.filter do |state_code, _|
+      filter_years.all? { |year| StateFile::StateInformationService.filing_years(state_code).include?(year) }
+    end
     @state_code_names = if params[:us_state] == 'us'
                           visible_state_code_names
                         else

--- a/app/controllers/state_file/faq_controller.rb
+++ b/app/controllers/state_file/faq_controller.rb
@@ -27,7 +27,7 @@ class StateFile::FaqController < ApplicationController
     tax_year = Rails.configuration.statefile_current_tax_year
 
     if Rails.env.production?
-      if intake_start < app_time && app_time < intake_end # intake is open
+      if app_time.between?(intake_start, intake_end) # intake is open
         # show currently open states
         [tax_year]
       elsif app_time.year == intake_start.year && app_time < intake_start # before intake opens this year

--- a/app/controllers/state_file/faq_controller.rb
+++ b/app/controllers/state_file/faq_controller.rb
@@ -6,16 +6,25 @@ class StateFile::FaqController < ApplicationController
     intake_end = Rails.configuration.state_file_end_of_in_progress_intakes
     tax_year = Rails.configuration.statefile_current_tax_year
 
-    filter_years = if intake_start < app_time && app_time < intake_end # intake is open
-                     # show currently open states
-                     [tax_year]
-                   elsif app_time.year == intake_start.year && app_time < intake_start # before intake opens this year
-                     # show states that were open the previous year and will open this year
-                     [tax_year - 1, tax_year]
-                   else # intake is closed for the year
-                     # show states that were open this year and will open next year
-                     [tax_year, tax_year + 1]
-                   end
+    if Rails.env.production?
+      filter_years = if intake_start < app_time && app_time < intake_end # intake is open
+                       # show currently open states
+                       [tax_year]
+                     elsif app_time.year == intake_start.year && app_time < intake_start # before intake opens this year
+                       # show states that were open the previous year and will open this year
+                       [tax_year - 1, tax_year]
+                     else
+                       # intake is closed for the year
+                       # show states that were open this year and will open next year
+                       [tax_year, tax_year + 1]
+                     end
+    else
+      filter_years = if app_time > intake_end
+                       [tax_year + 1]
+                     else
+                       [tax_year]
+                     end
+    end
 
     visible_state_code_names = StateFile::StateInformationService.state_code_to_name_map.filter do |state_code, _|
       filter_years.all? { |year| StateFile::StateInformationService.filing_years(state_code).include?(year) }

--- a/spec/controllers/state_file/faq_controller_spec.rb
+++ b/spec/controllers/state_file/faq_controller_spec.rb
@@ -5,8 +5,9 @@ RSpec.describe StateFile::FaqController do
 
   describe "#index" do
     let(:current_year) { Rails.configuration.state_file_start_of_open_intake.year }
+    let(:tax_year) { current_year - 1 }
     before do
-      allow(Rails.configuration).to receive(:statefile_current_tax_year).and_return(current_year - 1)
+      allow(Rails.configuration).to receive(:statefile_current_tax_year).and_return(tax_year)
     end
 
     it "renders the page" do
@@ -16,71 +17,89 @@ RSpec.describe StateFile::FaqController do
     end
 
     context "showing the right states" do
-      shared_examples :showing_only_states_that_were_open_and_will_reopen do
-        it "shows the right states" do
-          get :index, params: { us_state: "us" }
-
-          expect(response.body).to have_text I18n.t("state_file.faq.index.title", state: "state that was open last season and will reopen next season")
-          expect(response.body).not_to have_text I18n.t("state_file.faq.index.title", state: "new state that will be open this season but not yet")
-          expect(response.body).not_to have_text I18n.t("state_file.faq.index.title", state: "state that was open last season but will not reopen this season")
-        end
-      end
-
+      let(:last_year_state_name) { "state that was open last year but not this year" }
+      let(:continuing_state_name) { "state that was open last year and open this year" }
+      let(:new_this_year_state_name) { "new state that will open this year" }
+      let(:new_next_year_state_name) { "new state that will open next year" }
       before do
+        allow(StateFile::StateInformationService).to receive(:filing_years).with(:last_year_state).and_return([tax_year - 1])
+        allow(StateFile::StateInformationService).to receive(:filing_years).with(:continuing_state).and_return([tax_year + 1, tax_year, tax_year - 1])
+        allow(StateFile::StateInformationService).to receive(:filing_years).with(:new_this_year_state).and_return([tax_year, tax_year + 1])
+        allow(StateFile::StateInformationService).to receive(:filing_years).with(:new_next_year_state).and_return([tax_year + 1])
+
         allow(StateFile::StateInformationService).to receive(:state_code_to_name_map).and_return(
           {
-            state_abbrev_1: "state that was open last season and will reopen next season",
-            state_abbrev_2: "new state that will be open this season but not yet",
-            state_abbrev_3: "state that was open last season but will not reopen this season"
+            last_year_state: last_year_state_name,
+            continuing_state: continuing_state_name,
+            new_this_year_state: new_this_year_state_name,
+            new_next_year_state: new_next_year_state_name,
           }
         )
       end
 
       context "when FYST has not opened yet for the year" do
-        before do
-          allow(StateFile::StateInformationService).to receive(:filing_years).with(:state_abbrev_1).and_return([current_year - 1, current_year - 2])
-          allow(StateFile::StateInformationService).to receive(:filing_years).with(:state_abbrev_2).and_return([current_year - 1])
-          allow(StateFile::StateInformationService).to receive(:filing_years).with(:state_abbrev_3).and_return([current_year - 2])
-        end
-
         around do |example|
           Timecop.freeze(Rails.configuration.state_file_start_of_open_intake - 1.hour) do
             example.run
           end
         end
 
-        it_behaves_like :showing_only_states_that_were_open_and_will_reopen
+        context "in production" do
+          before do
+            allow(Rails).to receive(:env).and_return("production".inquiry)
+          end
+
+          it "shows only states that were open before and will reopen" do
+            get :index, params: { us_state: "us" }
+
+            expect(response.body).not_to have_text I18n.t("state_file.faq.index.title", state: last_year_state_name)
+            expect(response.body).to have_text I18n.t("state_file.faq.index.title", state: continuing_state_name)
+            expect(response.body).not_to have_text I18n.t("state_file.faq.index.title", state: new_this_year_state_name)
+            expect(response.body).not_to have_text I18n.t("state_file.faq.index.title", state: new_next_year_state_name)
+          end
+        end
+
+        context "in any other environment" do
+          ["demo", "heroku", "development"].each do |environment|
+            before do
+              allow(Rails).to receive(:env).and_return(environment.inquiry)
+            end
+
+            it "shows states that will open this season" do
+              get :index, params: { us_state: "us" }
+
+              expect(response.body).not_to have_text I18n.t("state_file.faq.index.title", state: last_year_state_name)
+              expect(response.body).to have_text I18n.t("state_file.faq.index.title", state: continuing_state_name)
+              expect(response.body).to have_text I18n.t("state_file.faq.index.title", state: new_this_year_state_name)
+              expect(response.body).not_to have_text I18n.t("state_file.faq.index.title", state: new_next_year_state_name)
+            end
+          end
+        end
       end
 
       context "when FYST is either open or has closed for the year" do
-        before do
-          allow(StateFile::StateInformationService).to receive(:filing_years).with(:state_abbrev_1).and_return([current_year, current_year - 1, current_year - 2])
-          allow(StateFile::StateInformationService).to receive(:filing_years).with(:state_abbrev_2).and_return([current_year - 1])
-          allow(StateFile::StateInformationService).to receive(:filing_years).with(:state_abbrev_3).and_return([current_year - 2])
-        end
-
         context "open" do
-          before do
-            allow(StateFile::StateInformationService).to receive(:state_code_to_name_map).and_return(
-              {
-                state_abbrev_1: "state that is open this season",
-                state_abbrev_2: "new state that just opened this season",
-                state_abbrev_3: "state that was open last season but not this season"
-              }
-            )
-          end
           around do |example|
             Timecop.freeze(Rails.configuration.state_file_end_of_in_progress_intakes - 1.day) do
               example.run
             end
           end
 
-          it "shows states that are currently open" do
-            get :index, params: { us_state: "us" }
+          context "in any environment" do
+            ["production", "demo", "heroku", "development"].each do |environment|
+              before do
+                allow(Rails).to receive(:env).and_return(environment.inquiry)
+              end
 
-            expect(response.body).to have_text I18n.t("state_file.faq.index.title", state: "state that is open this season")
-            expect(response.body).to have_text I18n.t("state_file.faq.index.title", state: "new state that just opened this season")
-            expect(response.body).not_to have_text I18n.t("state_file.faq.index.title", state: "state that was open last season but not this season")
+              it "shows states that are currently open" do
+                get :index, params: { us_state: "us" }
+
+                expect(response.body).not_to have_text I18n.t("state_file.faq.index.title", state: last_year_state_name)
+                expect(response.body).to have_text I18n.t("state_file.faq.index.title", state: continuing_state_name)
+                expect(response.body).to have_text I18n.t("state_file.faq.index.title", state: new_this_year_state_name)
+                expect(response.body).not_to have_text I18n.t("state_file.faq.index.title", state: new_next_year_state_name)
+              end
+            end
           end
         end
 
@@ -91,7 +110,37 @@ RSpec.describe StateFile::FaqController do
             end
           end
 
-          it_behaves_like :showing_only_states_that_were_open_and_will_reopen
+          context "in production" do
+            before do
+              allow(Rails).to receive(:env).and_return("production".inquiry)
+            end
+
+            it "shows only states that were open before and will reopen" do
+              get :index, params: { us_state: "us" }
+
+              expect(response.body).not_to have_text I18n.t("state_file.faq.index.title", state: last_year_state_name)
+              expect(response.body).to have_text I18n.t("state_file.faq.index.title", state: continuing_state_name)
+              expect(response.body).to have_text I18n.t("state_file.faq.index.title", state: new_this_year_state_name)
+              expect(response.body).not_to have_text I18n.t("state_file.faq.index.title", state: new_next_year_state_name)
+            end
+          end
+
+          context "in any other environment" do
+            ["demo", "heroku", "development"].each do |environment|
+              before do
+                allow(Rails).to receive(:env).and_return(environment.inquiry)
+              end
+
+              it "shows states that will open next season" do
+                get :index, params: { us_state: "us" }
+
+                expect(response.body).not_to have_text I18n.t("state_file.faq.index.title", state: last_year_state_name)
+                expect(response.body).to have_text I18n.t("state_file.faq.index.title", state: continuing_state_name)
+                expect(response.body).to have_text I18n.t("state_file.faq.index.title", state: new_this_year_state_name)
+                expect(response.body).to have_text I18n.t("state_file.faq.index.title", state: new_next_year_state_name)
+              end
+            end
+          end
         end
       end
     end

--- a/spec/controllers/state_file/faq_controller_spec.rb
+++ b/spec/controllers/state_file/faq_controller_spec.rb
@@ -16,11 +16,31 @@ RSpec.describe StateFile::FaqController do
     end
 
     context "showing the right states" do
+      shared_examples :showing_only_states_that_were_open_and_will_reopen do
+        it "shows the right states" do
+          get :index, params: { us_state: "us" }
+
+          expect(response.body).to have_text I18n.t("state_file.faq.index.title", state: "state that was open last season and will reopen next season")
+          expect(response.body).not_to have_text I18n.t("state_file.faq.index.title", state: "new state that will be open this season but not yet")
+          expect(response.body).not_to have_text I18n.t("state_file.faq.index.title", state: "state that was open last season but will not reopen this season")
+        end
+      end
+
+      before do
+        allow(StateFile::StateInformationService).to receive(:state_code_to_name_map).and_return(
+          {
+            state_abbrev_1: "state that was open last season and will reopen next season",
+            state_abbrev_2: "new state that will be open this season but not yet",
+            state_abbrev_3: "state that was open last season but will not reopen this season"
+          }
+        )
+      end
+
       context "when FYST has not opened yet for the year" do
         before do
           allow(StateFile::StateInformationService).to receive(:filing_years).with(:state_abbrev_1).and_return([current_year - 1, current_year - 2])
           allow(StateFile::StateInformationService).to receive(:filing_years).with(:state_abbrev_2).and_return([current_year - 1])
-          allow(StateFile::StateInformationService).to receive(:state_code_to_name_map).and_return({ state_abbrev_1: "state that was open last year", state_abbrev_2: "state that will be open this year but not yet" })
+          allow(StateFile::StateInformationService).to receive(:filing_years).with(:state_abbrev_3).and_return([current_year - 2])
         end
 
         around do |example|
@@ -29,23 +49,25 @@ RSpec.describe StateFile::FaqController do
           end
         end
 
-        it "shows states that were active the last time the app was open" do
-          get :index, params: { us_state: "us" }
-
-          expect(response.body).to have_text I18n.t("state_file.faq.index.title", state: "state that was open last year")
-          expect(response.body).not_to have_text I18n.t("state_file.faq.index.title", state: "state that will be open this year but not yet")
-        end
+        it_behaves_like :showing_only_states_that_were_open_and_will_reopen
       end
 
       context "when FYST is either open or has closed for the year" do
         before do
-          allow(StateFile::StateInformationService).to receive(:filing_years).with(:state_abbrev_1).and_return([current_year - 1, current_year - 2])
-          allow(StateFile::StateInformationService).to receive(:filing_years).with(:state_abbrev_2).and_return([current_year - 2])
+          allow(StateFile::StateInformationService).to receive(:filing_years).with(:state_abbrev_1).and_return([current_year, current_year - 1, current_year - 2])
+          allow(StateFile::StateInformationService).to receive(:filing_years).with(:state_abbrev_2).and_return([current_year - 1])
+          allow(StateFile::StateInformationService).to receive(:filing_years).with(:state_abbrev_3).and_return([current_year - 2])
         end
 
         context "open" do
           before do
-            allow(StateFile::StateInformationService).to receive(:state_code_to_name_map).and_return({ state_abbrev_1: "state that is open this year", state_abbrev_2: "state that was open last year but not this year" })
+            allow(StateFile::StateInformationService).to receive(:state_code_to_name_map).and_return(
+              {
+                state_abbrev_1: "state that is open this season",
+                state_abbrev_2: "new state that just opened this season",
+                state_abbrev_3: "state that was open last season but not this season"
+              }
+            )
           end
           around do |example|
             Timecop.freeze(Rails.configuration.state_file_end_of_in_progress_intakes - 1.day) do
@@ -53,30 +75,23 @@ RSpec.describe StateFile::FaqController do
             end
           end
 
-          it "shows states that are currently active" do
+          it "shows states that are currently open" do
             get :index, params: { us_state: "us" }
 
-            expect(response.body).to have_text I18n.t("state_file.faq.index.title", state: "state that is open this year")
-            expect(response.body).not_to have_text I18n.t("state_file.faq.index.title", state: "state that was open last year but not this year")
+            expect(response.body).to have_text I18n.t("state_file.faq.index.title", state: "state that is open this season")
+            expect(response.body).to have_text I18n.t("state_file.faq.index.title", state: "new state that just opened this season")
+            expect(response.body).not_to have_text I18n.t("state_file.faq.index.title", state: "state that was open last season but not this season")
           end
         end
 
         context "after close" do
-          before do
-            allow(StateFile::StateInformationService).to receive(:state_code_to_name_map).and_return({ state_abbrev_1: "state that was open this year", state_abbrev_2: "state that was open last year but was not this year" })
-          end
           around do |example|
             Timecop.freeze(Rails.configuration.state_file_end_of_in_progress_intakes + 1.day) do
               example.run
             end
           end
 
-          it "shows states that were active during the season" do
-            get :index, params: { us_state: "us" }
-
-            expect(response.body).to have_text I18n.t("state_file.faq.index.title", state: "state that was open this year")
-            expect(response.body).not_to have_text I18n.t("state_file.faq.index.title", state: "state that was open last year but was not this year")
-          end
+          it_behaves_like :showing_only_states_that_were_open_and_will_reopen
         end
       end
     end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-524
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!
## What was done?
- in production, modified visible FAQ states to include *only* those that have been open before AND will be open in the coming season (the upshot is that in production only AZ should be visible, not NY because it is not reopening)
- in non-prod envs, visible FAQ states include all that will be open in the coming season, regardless of whether they were open before (so this will now include MD, ID, NJ, NC in addition to AZ)
## How to test?
- tried to test all scenarios in a way that is not too completely unreadable and confusing. "all scenarios" = 
  - before, during, and after filing season in a given year
  - prod and non-prod
  - states that are open 2 years in a row, closing, opening for the first time
- acceptance testing will be weird because A) behavior is specific to environment and B) session toggles can't change the year apparently
## Screenshots (for visual changes)
- Before
  <img width="1264" alt="image" src="https://github.com/user-attachments/assets/90f8da2f-bf84-4b73-a985-c5a51fd5d3ac">
- After
  <img width="1275" alt="image" src="https://github.com/user-attachments/assets/4c18eec9-a175-4ca4-8d13-2626e18f23a2">
