### PR TITLE
FYST-806 Add new 1099r DF field mappings

### DIFF
--- a/app/models/df_1099r_accessor.rb
+++ b/app/models/df_1099r_accessor.rb
@@ -18,7 +18,11 @@ class Df1099rAccessor < DfXmlAccessor
     StateAbbreviationCd: "F1099RStateLocalTaxGrp F1099RStateTaxGrp StateAbbreviationCd",
     PayerStateIdNumber: "F1099RStateLocalTaxGrp F1099RStateTaxGrp PayerStateIdNumber",
     StateDistributionAmt: "F1099RStateLocalTaxGrp F1099RStateTaxGrp StateDistributionAmt",
+    RecipientSSN: "RecipientSSN",
+    RecipientNm: "RecipientNm",
+    TxblAmountNotDeterminedInd: "TxblAmountNotDeterminedInd",
   }
+
 
   def self.selectors
     SELECTORS

--- a/app/models/df_1099r_accessor.rb
+++ b/app/models/df_1099r_accessor.rb
@@ -26,7 +26,6 @@ class Df1099rAccessor < DfXmlAccessor
     DesignatedROTHAcctFirstYr: "DesignatedROTHAcctFirstYr",
   }
 
-
   def self.selectors
     SELECTORS
   end

--- a/app/models/df_1099r_accessor.rb
+++ b/app/models/df_1099r_accessor.rb
@@ -21,6 +21,9 @@ class Df1099rAccessor < DfXmlAccessor
     RecipientSSN: "RecipientSSN",
     RecipientNm: "RecipientNm",
     TxblAmountNotDeterminedInd: "TxblAmountNotDeterminedInd",
+    TotalDistributionInd: "TotalDistributionInd",
+    CapitalGainAmt: "CapitalGainAmt",
+    DesignatedROTHAcctFirstYr: "DesignatedROTHAcctFirstYr",
   }
 
 

--- a/app/views/state_file/questions/federal_info/_df_1099r.html.erb
+++ b/app/views/state_file/questions/federal_info/_df_1099r.html.erb
@@ -20,6 +20,12 @@
       <%= f.state_file_nested_xml_field :StateAbbreviationCd %>
       <%= f.state_file_nested_xml_field :PayerStateIdNumber %>
       <%= f.state_file_nested_xml_field :StateDistributionAmt %>
+      <%= f.state_file_nested_xml_field :RecipientSSN %>
+      <%= f.state_file_nested_xml_field :RecipientNm %>
+      <%= f.state_file_nested_xml_field :TxblAmountNotDeterminedInd %>
+      <%= f.state_file_nested_xml_field :TotalDistributionInd %>
+      <%= f.state_file_nested_xml_field :CapitalGainAmt %>
+      <%= f.state_file_nested_xml_field :DesignatedROTHAcctFirstYr %>
     </table>
 
     <%= f.hidden_field :_destroy %>

--- a/spec/fixtures/state_file/fed_return_xmls/2023/nc/miranda_1099r.xml
+++ b/spec/fixtures/state_file/fed_return_xmls/2023/nc/miranda_1099r.xml
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Return xmlns="http://www.irs.gov/efile" xmlns:efile="http://www.irs.gov/efile" returnVersion="2023v5.0">
+    <ReturnHeader binaryAttachmentCnt="0">
+        <TaxYr>2023</TaxYr>
+        <TaxPeriodBeginDt>2023-01-01</TaxPeriodBeginDt>
+        <TaxPeriodEndDt>2023-12-31</TaxPeriodEndDt>
+        <SoftwareVersionNum>2023.0.1</SoftwareVersionNum>
+        <Filer>
+            <PrimarySSN>400001032</PrimarySSN>
+            <NameLine1Txt>SUSAN&lt;MIRANDA</NameLine1Txt>
+            <PrimaryNameControlTxt>MIRA</PrimaryNameControlTxt>
+            <USAddress>
+                <AddressLine1Txt>2030 Pecan Street</AddressLine1Txt>
+                <CityNm>Monroe</CityNm>
+                <StateAbbreviationCd>NC</StateAbbreviationCd>
+                <ZIPCd>02301</ZIPCd>
+            </USAddress>
+            <PhoneNum>2025551212</PhoneNum>
+        </Filer>
+        <AdditionalFilerInformation>
+            <AtSubmissionFilingGrp>
+                <EmailAddressTxt>test.user.2@direct-file.local</EmailAddressTxt>
+            </AtSubmissionFilingGrp>
+        </AdditionalFilerInformation>
+    </ReturnHeader>
+    <ReturnData documentCnt="5">
+        <IRS1040 documentId="IRS10400001">
+            <IndividualReturnFilingStatusCd>1</IndividualReturnFilingStatusCd>
+            <VirtualCurAcquiredDurTYInd>false</VirtualCurAcquiredDurTYInd>
+            <TotalExemptPrimaryAndSpouseCnt>1</TotalExemptPrimaryAndSpouseCnt>
+            <ChldWhoLivedWithYouCnt>0</ChldWhoLivedWithYouCnt>
+            <OtherDependentsListedCnt>0</OtherDependentsListedCnt>
+            <TotalExemptionsCnt>1</TotalExemptionsCnt>
+            <WagesAmt referenceDocumentId="W20001 W20002" referenceDocumentName="IRSW2">39674</WagesAmt>
+            <WagesSalariesAndTipsAmt>39674</WagesSalariesAndTipsAmt>
+            <PensionsAnnuitiesAmt>4000</PensionsAnnuitiesAmt>
+            <TotalTaxablePensionsAmt>4200</TotalTaxablePensionsAmt>
+            <TotalIncomeAmt>43874</TotalIncomeAmt>
+            <AdjustedGrossIncomeAmt>43874</AdjustedGrossIncomeAmt>
+            <TotalItemizedOrStandardDedAmt>13850</TotalItemizedOrStandardDedAmt>
+            <TotalDeductionsAmt>13850</TotalDeductionsAmt>
+            <TaxableIncomeAmt>30024</TaxableIncomeAmt>
+            <TaxAmt>3383</TaxAmt>
+            <TotalTaxBeforeCrAndOthTaxesAmt>3383</TotalTaxBeforeCrAndOthTaxesAmt>
+            <TaxLessCreditsAmt>3383</TaxLessCreditsAmt>
+            <TotalTaxAmt>3383</TotalTaxAmt>
+            <FormW2WithheldTaxAmt>7274</FormW2WithheldTaxAmt>
+            <WithholdingTaxAmt>7574</WithholdingTaxAmt>
+            <TotalPaymentsAmt>7574</TotalPaymentsAmt>
+            <OverpaidAmt>4191</OverpaidAmt>
+            <RefundAmt>4191</RefundAmt>
+            <OwedAmt>0</OwedAmt>
+            <ThirdPartyDesigneeInd>false</ThirdPartyDesigneeInd>
+            <PrimaryOccupationTxt>Scenario Tester</PrimaryOccupationTxt>
+            <RefundProductCd>NO FINANCIAL PRODUCT</RefundProductCd>
+        </IRS1040>
+        <IRS1099R documentId="IRS1099R0001">
+            <PayerNameControlTxt>PAYE</PayerNameControlTxt>
+            <PayerName>
+                <BusinessNameLine1Txt>Payer Name</BusinessNameLine1Txt>
+            </PayerName>
+            <PayerUSAddress>
+                <AddressLine1Txt>2030 Pecan Street</AddressLine1Txt>
+                <CityNm>Monroe</CityNm>
+                <StateAbbreviationCd>NC</StateAbbreviationCd>
+                <ZIPCd>05502</ZIPCd>
+            </PayerUSAddress>
+            <PayerEIN>000000008</PayerEIN>
+            <PhoneNum>2025551212</PhoneNum>
+            <RecipientSSN>400001032</RecipientSSN>
+            <RecipientNm>Susan Miranda</RecipientNm>
+            <RecipientUSAddress>
+                <AddressLine1Txt>2030 Pecan Street</AddressLine1Txt>
+                <CityNm>Monroe</CityNm>
+                <StateAbbreviationCd>NC</StateAbbreviationCd>
+                <ZIPCd>02301</ZIPCd>
+            </RecipientUSAddress>
+            <GrossDistributionAmt>200</GrossDistributionAmt>
+            <TaxableAmt>1000</TaxableAmt>
+            <FederalIncomeTaxWithheldAmt>300</FederalIncomeTaxWithheldAmt>
+            <F1099RDistributionCd>7</F1099RDistributionCd>
+            <F1099RStateLocalTaxGrp>
+                <F1099RStateTaxGrp>
+                    <F1099RLocalTaxGrp/>
+                </F1099RStateTaxGrp>
+            </F1099RStateLocalTaxGrp>
+            <F1099RStateLocalTaxGrp>
+                <F1099RStateTaxGrp/>
+            </F1099RStateLocalTaxGrp>
+            <StandardOrNonStandardCd>S</StandardOrNonStandardCd>
+        </IRS1099R>
+        <IRS1099R documentId="IRS1099R0002">
+            <PayerNameControlTxt>PAYE</PayerNameControlTxt>
+            <PayerName>
+                <BusinessNameLine1Txt>Payer 2 Name</BusinessNameLine1Txt>
+                <BusinessNameLine2Txt>Line 2</BusinessNameLine2Txt>
+            </PayerName>
+            <PayerEIN>000000009</PayerEIN>
+            <RecipientSSN>400001032</RecipientSSN>
+            <RecipientNm>Susan Miranda</RecipientNm>
+            <RecipientUSAddress>
+                <AddressLine1Txt>20 Override Street</AddressLine1Txt>
+                <AddressLine2Txt>Line Two</AddressLine2Txt>
+                <CityNm>Monroe</CityNm>
+                <StateAbbreviationCd>NC</StateAbbreviationCd>
+                <ZIPCd>70201</ZIPCd>
+            </RecipientUSAddress>
+            <GrossDistributionAmt>4000</GrossDistributionAmt>
+            <TaxableAmt>3000</TaxableAmt>
+            <EmployeeContributionsAmt>500</EmployeeContributionsAmt>
+            <F1099RStateLocalTaxGrp>
+                <F1099RStateTaxGrp>
+                    <StateAbbreviationCd>NC</StateAbbreviationCd>
+                    <StateDistributionAmt>2000</StateDistributionAmt>
+                    <F1099RLocalTaxGrp>
+                        <LocalTaxWithheldAmt>2000</LocalTaxWithheldAmt>
+                        <LocalityNm>How Town</LocalityNm>
+                        <LocalDistributionAmt>2000</LocalDistributionAmt>
+                    </F1099RLocalTaxGrp>
+                </F1099RStateTaxGrp>
+            </F1099RStateLocalTaxGrp>
+            <F1099RStateLocalTaxGrp>
+                <F1099RStateTaxGrp/>
+            </F1099RStateLocalTaxGrp>
+            <StandardOrNonStandardCd>N</StandardOrNonStandardCd>
+        </IRS1099R>
+        <IRSW2 documentName="IRSW2" documentId="W20001">
+            <EmployeeSSN>400001032</EmployeeSSN>
+            <EmployerEIN>000000004</EmployerEIN>
+            <EmployerNameControlTxt>OURF</EmployerNameControlTxt>
+            <EmployerName>
+                <BusinessNameLine1Txt>Our Flower Shop</BusinessNameLine1Txt>
+            </EmployerName>
+            <EmployerUSAddress>
+                <AddressLine1Txt>2045 Pecan Street</AddressLine1Txt>
+                <CityNm>Monroe</CityNm>
+                <StateAbbreviationCd>NC</StateAbbreviationCd>
+                <ZIPCd>70201</ZIPCd>
+            </EmployerUSAddress>
+            <EmployeeNm>Susan Miranda</EmployeeNm>
+            <EmployeeUSAddress>
+                <AddressLine1Txt>2030 Pecan Street</AddressLine1Txt>
+                <CityNm>Monroe</CityNm>
+                <StateAbbreviationCd>NC</StateAbbreviationCd>
+                <ZIPCd>70201</ZIPCd>
+            </EmployeeUSAddress>
+            <WagesAmt>15205</WagesAmt>
+            <WithholdingAmt>1405</WithholdingAmt>
+            <SocialSecurityWagesAmt>15205</SocialSecurityWagesAmt>
+            <SocialSecurityTaxAmt>943</SocialSecurityTaxAmt>
+            <MedicareWagesAndTipsAmt>15205</MedicareWagesAndTipsAmt>
+            <MedicareTaxWithheldAmt>220</MedicareTaxWithheldAmt>
+            <W2StateLocalTaxGrp>
+                <W2StateTaxGrp>
+                    <StateAbbreviationCd>NC</StateAbbreviationCd>
+                    <EmployerStateIdNum>00-0000005</EmployerStateIdNum>
+                    <StateWagesAmt>15205</StateWagesAmt>
+                    <StateIncomeTaxAmt>507</StateIncomeTaxAmt>
+                    <W2LocalTaxGrp/>
+                </W2StateTaxGrp>
+            </W2StateLocalTaxGrp>
+            <StandardOrNonStandardCd>S</StandardOrNonStandardCd>
+        </IRSW2>
+        <IRSW2 documentName="IRSW2" documentId="W20002">
+            <EmployeeSSN>400001032</EmployeeSSN>
+            <EmployerEIN>000000007</EmployerEIN>
+            <EmployerNameControlTxt>MAGN</EmployerNameControlTxt>
+            <EmployerName>
+                <BusinessNameLine1Txt>Magnolia Floral Design</BusinessNameLine1Txt>
+            </EmployerName>
+            <EmployerUSAddress>
+                <AddressLine1Txt>1001 Main Street</AddressLine1Txt>
+                <CityNm>Monroe</CityNm>
+                <StateAbbreviationCd>NC</StateAbbreviationCd>
+                <ZIPCd>70201</ZIPCd>
+            </EmployerUSAddress>
+            <EmployeeNm>Susan Miranda</EmployeeNm>
+            <EmployeeUSAddress>
+                <AddressLine1Txt>2030 Pecan Street</AddressLine1Txt>
+                <CityNm>Monroe</CityNm>
+                <StateAbbreviationCd>NC</StateAbbreviationCd>
+                <ZIPCd>70201</ZIPCd>
+            </EmployeeUSAddress>
+            <WagesAmt>24469</WagesAmt>
+            <WithholdingAmt>5869</WithholdingAmt>
+            <SocialSecurityWagesAmt>24469</SocialSecurityWagesAmt>
+            <SocialSecurityTaxAmt>1517</SocialSecurityTaxAmt>
+            <MedicareWagesAndTipsAmt>24469</MedicareWagesAndTipsAmt>
+            <MedicareTaxWithheldAmt>355</MedicareTaxWithheldAmt>
+            <W2StateLocalTaxGrp>
+                <W2StateTaxGrp>
+                    <StateAbbreviationCd>NC</StateAbbreviationCd>
+                    <EmployerStateIdNum>00-0000008</EmployerStateIdNum>
+                    <StateWagesAmt>24469</StateWagesAmt>
+                    <StateIncomeTaxAmt>1502</StateIncomeTaxAmt>
+                    <W2LocalTaxGrp/>
+                </W2StateTaxGrp>
+            </W2StateLocalTaxGrp>
+            <StandardOrNonStandardCd>S</StandardOrNonStandardCd>
+        </IRSW2>
+    </ReturnData>
+</Return>

--- a/spec/models/direct_file_data_spec.rb
+++ b/spec/models/direct_file_data_spec.rb
@@ -596,21 +596,22 @@ describe DirectFileData do
   end
 
   describe "Df1099R" do
-    let(:direct_file_data) { DirectFileData.new(Nokogiri::XML(StateFile::XmlReturnSampleService.new.read("az_richard_retirement_1099r")).to_s) }
+    let(:direct_file_data) { DirectFileData.new(Nokogiri::XML(StateFile::XmlReturnSampleService.new.read("nc_miranda_1099r")).to_s) }
+    # let(:direct_file_data) { DirectFileData.new(Nokogiri::XML(StateFile::XmlReturnSampleService.new.read("az_richard_retirement_1099r")).to_s) }
     let(:first_1099r) { direct_file_data.form1099rs[0] }
     let(:second_1099r) { direct_file_data.form1099rs[1] }
 
     describe "#PayerNameControlTxt" do
       it "returns the value" do
         expect(first_1099r.PayerNameControlTxt).to eq "PAYE"
-        expect(second_1099r.PayerNameControlTxt).to eq "PAYE DEUX"
+        expect(second_1099r.PayerNameControlTxt).to eq "PAYE"
       end
     end
 
     describe "#PayerName" do
       it "returns the value" do
         expect(first_1099r.PayerName).to eq "Payer Name"
-        expect(second_1099r.PayerName).to eq "Second Payer Name"
+        expect(second_1099r.PayerName).to eq "Payer 2 Name"
       end
     end
 
@@ -630,8 +631,8 @@ describe DirectFileData do
 
     describe "#PayerStateAbbreviationCd" do
       it "returns the value" do
-        expect(first_1099r.PayerStateAbbreviationCd).to eq "MA"
-        expect(second_1099r.PayerStateAbbreviationCd).to eq "NA"
+        expect(first_1099r.PayerStateAbbreviationCd).to eq "NC"
+        expect(second_1099r.PayerStateAbbreviationCd).to eq "NC"
       end
     end
 
@@ -644,8 +645,8 @@ describe DirectFileData do
 
     describe "#PayerEIN" do
       it "returns the value" do
-        expect(first_1099r.PayerEIN).to eq "000000001"
-        expect(second_1099r.PayerEIN).to eq "000000002"
+        expect(first_1099r.PayerEIN).to eq "000000008"
+        expect(second_1099r.PayerEIN).to eq "000000009"
       end
     end
 
@@ -659,21 +660,21 @@ describe DirectFileData do
     describe "#GrossDistributionAmt" do
       it "returns the value" do
         expect(first_1099r.GrossDistributionAmt).to eq 200
-        expect(second_1099r.GrossDistributionAmt).to eq 300
+        expect(second_1099r.GrossDistributionAmt).to eq 4000
       end
     end
 
     describe "#TaxableAmt" do
       it "returns the value" do
         expect(first_1099r.TaxableAmt).to eq 1000
-        expect(second_1099r.TaxableAmt).to eq 500
+        expect(second_1099r.TaxableAmt).to eq 3000
       end
     end
 
     describe "#FederalIncomeTaxWithheldAmt" do
       it "returns the value" do
         expect(first_1099r.FederalIncomeTaxWithheldAmt).to eq 300
-        expect(second_1099r.FederalIncomeTaxWithheldAmt).to eq 200
+        expect(second_1099r.FederalIncomeTaxWithheldAmt).to eq 0
       end
     end
 
@@ -694,7 +695,7 @@ describe DirectFileData do
     describe "#StateTaxWithheldAmt" do
       it "returns the value" do
         expect(first_1099r.StateTaxWithheldAmt).to eq 11
-        expect(second_1099r.StateTaxWithheldAmt).to eq 22
+        expect(second_1099r.StateTaxWithheldAmt).to eq 0
       end
     end
     describe "#StateAbbreviationCd" do
@@ -712,7 +713,7 @@ describe DirectFileData do
     describe "#StateDistributionAmt" do
       it "returns the value" do
         expect(first_1099r.StateDistributionAmt).to eq 111
-        expect(second_1099r.StateDistributionAmt).to eq 222
+        expect(second_1099r.StateDistributionAmt).to eq 0
       end
     end
   end

--- a/spec/models/direct_file_data_spec.rb
+++ b/spec/models/direct_file_data_spec.rb
@@ -618,28 +618,28 @@ describe DirectFileData do
     describe "#PayerAddressLine1Txt" do
       it "returns the value" do
         expect(first_1099r.PayerAddressLine1Txt).to eq "2030 Pecan Street"
-        expect(second_1099r.PayerAddressLine1Txt).to eq "2031 Pecan Street"
+        expect(second_1099r.PayerAddressLine1Txt).to eq nil
       end
     end
 
     describe "#PayerCityNm" do
       it "returns the value" do
         expect(first_1099r.PayerCityNm).to eq "Monroe"
-        expect(second_1099r.PayerCityNm).to eq "Nonroe"
+        expect(second_1099r.PayerCityNm).to eq nil
       end
     end
 
     describe "#PayerStateAbbreviationCd" do
       it "returns the value" do
         expect(first_1099r.PayerStateAbbreviationCd).to eq "NC"
-        expect(second_1099r.PayerStateAbbreviationCd).to eq "NC"
+        expect(second_1099r.PayerStateAbbreviationCd).to eq nil
       end
     end
 
     describe "#PayerZIPCd" do
       it "returns the value" do
         expect(first_1099r.PayerZIPCd).to eq "05502"
-        expect(second_1099r.PayerZIPCd).to eq "05503"
+        expect(second_1099r.PayerZIPCd).to eq nil
       end
     end
 
@@ -653,7 +653,7 @@ describe DirectFileData do
     describe "#PhoneNum" do
       it "returns the value" do
         expect(first_1099r.PhoneNum).to eq "2025551212"
-        expect(second_1099r.PhoneNum).to eq "3025551212"
+        expect(second_1099r.PhoneNum).to eq nil
       end
     end
 
@@ -681,7 +681,7 @@ describe DirectFileData do
     describe "#F1099RDistributionCd" do
       it "returns the value" do
         expect(first_1099r.F1099RDistributionCd).to eq "7"
-        expect(second_1099r.F1099RDistributionCd).to eq "6"
+        expect(second_1099r.F1099RDistributionCd).to eq nil
       end
     end
 
@@ -694,26 +694,26 @@ describe DirectFileData do
 
     describe "#StateTaxWithheldAmt" do
       it "returns the value" do
-        expect(first_1099r.StateTaxWithheldAmt).to eq 11
+        expect(first_1099r.StateTaxWithheldAmt).to eq 0
         expect(second_1099r.StateTaxWithheldAmt).to eq 0
       end
     end
     describe "#StateAbbreviationCd" do
       it "returns the value" do
-        expect(first_1099r.StateAbbreviationCd).to eq "NC"
+        expect(first_1099r.StateAbbreviationCd).to eq nil
         expect(second_1099r.StateAbbreviationCd).to eq "NC"
       end
     end
     describe "#PayerStateIdNumber" do
       it "returns the value" do
-        expect(first_1099r.PayerStateIdNumber).to eq "111111111"
-        expect(second_1099r.PayerStateIdNumber).to eq "222222222"
+        expect(first_1099r.PayerStateIdNumber).to eq nil
+        expect(second_1099r.PayerStateIdNumber).to eq nil
       end
     end
     describe "#StateDistributionAmt" do
       it "returns the value" do
-        expect(first_1099r.StateDistributionAmt).to eq 111
-        expect(second_1099r.StateDistributionAmt).to eq 0
+        expect(first_1099r.StateDistributionAmt).to eq 0
+        expect(second_1099r.StateDistributionAmt).to eq 2000
       end
     end
   end

--- a/spec/models/direct_file_data_spec.rb
+++ b/spec/models/direct_file_data_spec.rb
@@ -731,10 +731,32 @@ describe DirectFileData do
       end
     end
 
+    # TODO: Once we have better 1099R example, replace with one that has values for these
     describe "#TxblAmountNotDeterminedInd" do
       it "returns the value" do
-        expect(first_1099r.TxblAmountNotDeterminedInd).to eq 'Susan Miranda'
-        expect(second_1099r.TxblAmountNotDeterminedInd).to eq 'Susan Miranda'
+        expect(first_1099r.TxblAmountNotDeterminedInd).to eq nil
+        expect(second_1099r.TxblAmountNotDeterminedInd).to eq nil
+      end
+    end
+
+    describe "#TotalDistributionInd" do
+      it "returns the value" do
+        expect(first_1099r.TotalDistributionInd).to eq nil
+        expect(second_1099r.TotalDistributionInd).to eq nil
+      end
+    end
+
+    describe "#CapitalGainAmt" do
+      it "returns the value" do
+        expect(first_1099r.CapitalGainAmt).to eq 0
+        expect(second_1099r.CapitalGainAmt).to eq 0
+      end
+    end
+
+    describe "#DesignatedROTHAcctFirstYr" do
+      it "returns the value" do
+        expect(first_1099r.DesignatedROTHAcctFirstYr).to eq nil
+        expect(second_1099r.DesignatedROTHAcctFirstYr).to eq nil
       end
     end
   end

--- a/spec/models/direct_file_data_spec.rb
+++ b/spec/models/direct_file_data_spec.rb
@@ -716,5 +716,26 @@ describe DirectFileData do
         expect(second_1099r.StateDistributionAmt).to eq 2000
       end
     end
+
+    describe "#RecipientSSN" do
+      it "returns the value" do
+        expect(first_1099r.RecipientSSN).to eq '400001032'
+        expect(second_1099r.RecipientSSN).to eq '400001032'
+      end
+    end
+
+    describe "#RecipientNm" do
+      it "returns the value" do
+        expect(first_1099r.RecipientNm).to eq 'Susan Miranda'
+        expect(second_1099r.RecipientNm).to eq 'Susan Miranda'
+      end
+    end
+
+    describe "#TxblAmountNotDeterminedInd" do
+      it "returns the value" do
+        expect(first_1099r.TxblAmountNotDeterminedInd).to eq 'Susan Miranda'
+        expect(second_1099r.TxblAmountNotDeterminedInd).to eq 'Susan Miranda'
+      end
+    end
   end
 end

--- a/spec/models/direct_file_data_spec.rb
+++ b/spec/models/direct_file_data_spec.rb
@@ -597,7 +597,6 @@ describe DirectFileData do
 
   describe "Df1099R" do
     let(:direct_file_data) { DirectFileData.new(Nokogiri::XML(StateFile::XmlReturnSampleService.new.read("nc_miranda_1099r")).to_s) }
-    # let(:direct_file_data) { DirectFileData.new(Nokogiri::XML(StateFile::XmlReturnSampleService.new.read("az_richard_retirement_1099r")).to_s) }
     let(:first_1099r) { direct_file_data.form1099rs[0] }
     let(:second_1099r) { direct_file_data.form1099rs[1] }
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/FYST-806
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!
## What was done?
- Added new fields RecipientSSN, RecipientNm, TxblAmountNotDeterminedInd, TotalDistributionInd, CapitalGainAmt, DesignatedROTHAcctFirstYr
- Added a new fixture `mirada_1099r.xml` to North Carolina
- Allowed editing xml in dev mode
- Updated existing 1099r specs to match new fixture

## How to test?
- Describe the testing approach taken to verify the changes, including:
  - Unit tests
  - Go through the NC flow with `miranda_1099r` df example
  - Try editing/save new values
- Risk Assessment
  - We don't have any real examples of TxblAmountNotDeterminedInd, TotalDistributionInd, CapitalGainAmt, DesignatedROTHAcctFirstYr but hopefully these won't deviate from schema `xsd` examples we have

## Screenshots (for visual changes)
- After
![Screenshot 2024-10-02 at 1 53 22 PM](https://github.com/user-attachments/assets/5aae173a-bbca-4bcc-9e95-3d17c649e6d8)
