### PR TITLE
nj 72 - add automated test for XML schema validation

### DIFF
--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -105,10 +105,10 @@ module Efile
 
         sum = 0
         @direct_file_data.w2s.each do |w2|
-          state_wage = w2.node.at("W2StateLocalTaxGrp StateWagesAmt").text.to_f
+          state_wage = w2.node.at("W2StateLocalTaxGrp StateWagesAmt").text.to_i
           sum += state_wage
         end
-        sum.round
+        sum
       end
 
       def calculate_line_27

--- a/app/lib/submission_builder/state_return.rb
+++ b/app/lib/submission_builder/state_return.rb
@@ -57,13 +57,17 @@ module SubmissionBuilder
       supported_documents.map { |item| OpenStruct.new(**item, kwargs: item[:kwargs] || {}) if item[:include] }.compact
     end
 
+    def w2_class
+      SubmissionBuilder::ReturnW2
+    end
+
     def combined_w2s
       @submission.data_source.direct_file_data.w2s.map.with_index do |w2, i|
         intake = @submission.data_source
         intake_w2 = intake.state_file_w2s.find { |w2| w2.w2_index == i } if intake.state_file_w2s.present?
 
         {
-          xml: SubmissionBuilder::ReturnW2,
+          xml: w2_class,
           pdf: w2_pdf,
           include: true,
           kwargs: { w2: w2, intake_w2: intake_w2 }

--- a/app/lib/submission_builder/ty2024/states/nj/documents/nj_w2.rb
+++ b/app/lib/submission_builder/ty2024/states/nj/documents/nj_w2.rb
@@ -3,28 +3,12 @@ module SubmissionBuilder
     module States
       module Nj
         module Documents
-          class NjW2 < SubmissionBuilder::Document
+          class NjW2 < SubmissionBuilder::ReturnW2
             def document
-              w2 = @kwargs[:w2]
-              intake_w2 = @kwargs[:intake_w2]
-              xml_node = Nokogiri::XML(w2.node.to_xml)
+              xml_node = super
+
               xml_node.at("IRSW2")["documentName"] = "NJW2"
               xml_node.at("IRSW2").name = "NJW2"
-
-              if intake_w2.present?
-                state_local_tax_grp_node = xml_node.at(:W2StateLocalTaxGrp)
-                state_tax_group_xml = intake_w2.state_tax_group_xml_node
-                if state_tax_group_xml.present?
-                  state_local_tax_grp_node.inner_html = state_tax_group_xml
-                else
-                  state_local_tax_grp_node.remove
-                end
-              end
-              locality_nm = xml_node.at(:LocalityNm)
-              if locality_nm.present?
-                locality_nm.inner_html = locality_nm.inner_html.upcase
-                locality_nm.name = "NameOfLocality"
-              end
 
               xml_node.at("EmployerNameControlTxt").name = "EmployerNameControl"
               xml_node.at("ControlNum").name = "ControlNumber" if xml_node.at("ControlNum").present?
@@ -32,10 +16,10 @@ module SubmissionBuilder
               xml_node.at("PriorUSERRAContributionYr").name = "PriorYearUserraContribution" if xml_node.at("PriorUSERRAContributionYr").present?
               xml_node.at("OtherDeductionsBenefitsGrp").name = "OtherDeductsBenefits"
               xml_node.at("EmployerStateIdNum").name = "EmployersStateIdNumber"
+              xml_node.at("LocalityNm").name = "NameOfLocality" if xml_node.at("LocalityNm").present?
 
               xml_node.at("AgentForEmployerInd").remove if xml_node.at("AgentForEmployerInd").present?
               xml_node.at("W2SecurityInformation").remove if xml_node.at("W2SecurityInformation").present?
-
               xml_node
             end
           end

--- a/app/lib/submission_builder/ty2024/states/nj/documents/nj_w2.rb
+++ b/app/lib/submission_builder/ty2024/states/nj/documents/nj_w2.rb
@@ -1,0 +1,46 @@
+module SubmissionBuilder
+  module Ty2024
+    module States
+      module Nj
+        module Documents
+          class NjW2 < SubmissionBuilder::Document
+            def document
+              w2 = @kwargs[:w2]
+              intake_w2 = @kwargs[:intake_w2]
+              xml_node = Nokogiri::XML(w2.node.to_xml)
+              xml_node.at("IRSW2")["documentName"] = "NJW2"
+              xml_node.at("IRSW2").name = "NJW2"
+
+              if intake_w2.present?
+                state_local_tax_grp_node = xml_node.at(:W2StateLocalTaxGrp)
+                state_tax_group_xml = intake_w2.state_tax_group_xml_node
+                if state_tax_group_xml.present?
+                  state_local_tax_grp_node.inner_html = state_tax_group_xml
+                else
+                  state_local_tax_grp_node.remove
+                end
+              end
+              locality_nm = xml_node.at(:LocalityNm)
+              if locality_nm.present?
+                locality_nm.inner_html = locality_nm.inner_html.upcase
+                locality_nm.name = "NameOfLocality"
+              end
+
+              xml_node.at("EmployerNameControlTxt").name = "EmployerNameControl"
+              xml_node.at("ControlNum").name = "ControlNumber" if xml_node.at("ControlNum").present?
+              xml_node.at("EmployeeNm").name = "EmployeeName"
+              xml_node.at("PriorUSERRAContributionYr").name = "PriorYearUserraContribution" if xml_node.at("PriorUSERRAContributionYr").present?
+              xml_node.at("OtherDeductionsBenefitsGrp").name = "OtherDeductsBenefits"
+              xml_node.at("EmployerStateIdNum").name = "EmployersStateIdNumber"
+
+              xml_node.at("AgentForEmployerInd").remove if xml_node.at("AgentForEmployerInd").present?
+              xml_node.at("W2SecurityInformation").remove if xml_node.at("W2SecurityInformation").present?
+
+              xml_node
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/submission_builder/ty2024/states/nj/nj_return_xml.rb
+++ b/app/lib/submission_builder/ty2024/states/nj/nj_return_xml.rb
@@ -6,6 +6,10 @@ module SubmissionBuilder
       module Nj
         class NjReturnXml < SubmissionBuilder::StateReturn
 
+          def w2_class
+            SubmissionBuilder::Ty2024::States::Nj::Documents::NjW2
+          end
+
           private
 
           def attached_documents_parent_tag

--- a/spec/fixtures/state_file/fed_return_xmls/2023/nj/zeus_many_w2s.xml
+++ b/spec/fixtures/state_file/fed_return_xmls/2023/nj/zeus_many_w2s.xml
@@ -199,11 +199,11 @@
         <StateAbbreviationCd>NJ</StateAbbreviationCd>
         <ZIPCd>08037</ZIPCd>
       </EmployeeUSAddress>
-      <WagesAmt>50000.33</WagesAmt>
+      <WagesAmt>50000</WagesAmt>
       <WithholdingAmt>1000</WithholdingAmt>
-      <SocialSecurityWagesAmt>50000.33</SocialSecurityWagesAmt>
+      <SocialSecurityWagesAmt>50000</SocialSecurityWagesAmt>
       <SocialSecurityTaxAmt>3100</SocialSecurityTaxAmt>
-      <MedicareWagesAndTipsAmt>50000.33</MedicareWagesAndTipsAmt>
+      <MedicareWagesAndTipsAmt>50000</MedicareWagesAndTipsAmt>
       <MedicareTaxWithheldAmt>725</MedicareTaxWithheldAmt>
       <OtherDeductionsBenefitsGrp>
         <Desc>414HSUB</Desc>
@@ -213,10 +213,10 @@
         <W2StateTaxGrp>
           <StateAbbreviationCd>NJ</StateAbbreviationCd>
           <EmployerStateIdNum>98765</EmployerStateIdNum>
-          <StateWagesAmt>50000.33</StateWagesAmt>
+          <StateWagesAmt>50000</StateWagesAmt>
           <StateIncomeTaxAmt>500</StateIncomeTaxAmt>
           <W2LocalTaxGrp>
-            <LocalWagesAndTipsAmt>50000.33</LocalWagesAndTipsAmt>
+            <LocalWagesAndTipsAmt>50000</LocalWagesAndTipsAmt>
             <LocalIncomeTaxAmt>250</LocalIncomeTaxAmt>
             <LocalityNm>Hammonton</LocalityNm>
           </W2LocalTaxGrp>
@@ -229,7 +229,7 @@
       <EmployerEIN>001245768</EmployerEIN>
       <EmployerNameControlTxt>BTB</EmployerNameControlTxt>
       <EmployerName>
-        <BusinessNameLine1Txt>Brendan T. Byrne State Forest</BusinessNameLine1Txt>
+        <BusinessNameLine1Txt>Brendan T Byrne State Forest</BusinessNameLine1Txt>
       </EmployerName>
       <EmployerUSAddress>
         <AddressLine1Txt>31 Batsto Road</AddressLine1Txt>
@@ -245,11 +245,11 @@
         <StateAbbreviationCd>NJ</StateAbbreviationCd>
         <ZIPCd>08037</ZIPCd>
       </EmployeeUSAddress>
-      <WagesAmt>50000.33</WagesAmt>
+      <WagesAmt>50000</WagesAmt>
       <WithholdingAmt>1000</WithholdingAmt>
-      <SocialSecurityWagesAmt>50000.33</SocialSecurityWagesAmt>
+      <SocialSecurityWagesAmt>50000</SocialSecurityWagesAmt>
       <SocialSecurityTaxAmt>3100</SocialSecurityTaxAmt>
-      <MedicareWagesAndTipsAmt>50000.33</MedicareWagesAndTipsAmt>
+      <MedicareWagesAndTipsAmt>50000</MedicareWagesAndTipsAmt>
       <MedicareTaxWithheldAmt>725</MedicareTaxWithheldAmt>
       <OtherDeductionsBenefitsGrp>
         <Desc>414HSUB</Desc>
@@ -259,10 +259,10 @@
         <W2StateTaxGrp>
           <StateAbbreviationCd>NJ</StateAbbreviationCd>
           <EmployerStateIdNum>12345</EmployerStateIdNum>
-          <StateWagesAmt>50000.33</StateWagesAmt>
+          <StateWagesAmt>50000</StateWagesAmt>
           <StateIncomeTaxAmt>500</StateIncomeTaxAmt>
           <W2LocalTaxGrp>
-            <LocalWagesAndTipsAmt>50000.33</LocalWagesAndTipsAmt>
+            <LocalWagesAndTipsAmt>50000</LocalWagesAndTipsAmt>
             <LocalIncomeTaxAmt>250</LocalIncomeTaxAmt>
             <LocalityNm>Hammonton</LocalityNm>
           </W2LocalTaxGrp>
@@ -291,11 +291,11 @@
         <StateAbbreviationCd>NJ</StateAbbreviationCd>
         <ZIPCd>08037</ZIPCd>
       </EmployeeUSAddress>
-      <WagesAmt>50000.33</WagesAmt>
+      <WagesAmt>50000</WagesAmt>
       <WithholdingAmt>1000</WithholdingAmt>
-      <SocialSecurityWagesAmt>50000.33</SocialSecurityWagesAmt>
+      <SocialSecurityWagesAmt>50000</SocialSecurityWagesAmt>
       <SocialSecurityTaxAmt>3100</SocialSecurityTaxAmt>
-      <MedicareWagesAndTipsAmt>50000.33</MedicareWagesAndTipsAmt>
+      <MedicareWagesAndTipsAmt>50000</MedicareWagesAndTipsAmt>
       <MedicareTaxWithheldAmt>725</MedicareTaxWithheldAmt>
       <OtherDeductionsBenefitsGrp>
         <Desc>414HSUB</Desc>
@@ -305,10 +305,10 @@
         <W2StateTaxGrp>
           <StateAbbreviationCd>NJ</StateAbbreviationCd>
           <EmployerStateIdNum>54321</EmployerStateIdNum>
-          <StateWagesAmt>50000.33</StateWagesAmt>
+          <StateWagesAmt>50000</StateWagesAmt>
           <StateIncomeTaxAmt>500</StateIncomeTaxAmt>
           <W2LocalTaxGrp>
-            <LocalWagesAndTipsAmt>50000.33</LocalWagesAndTipsAmt>
+            <LocalWagesAndTipsAmt>50000</LocalWagesAndTipsAmt>
             <LocalIncomeTaxAmt>250</LocalIncomeTaxAmt>
             <LocalityNm>Hammonton</LocalityNm>
           </W2LocalTaxGrp>
@@ -319,7 +319,7 @@
     <IRSW2 documentName="IRSW2" documentId="W20004">
       <EmployeeSSN>400000018</EmployeeSSN>
       <EmployerEIN>001245770</EmployerEIN>
-      <EmployerNameControlTxt>ATLCB</EmployerNameControlTxt>
+      <EmployerNameControlTxt>ATLC</EmployerNameControlTxt>
       <EmployerName>
         <BusinessNameLine1Txt>Atlantic City Beach</BusinessNameLine1Txt>
       </EmployerName>
@@ -337,11 +337,11 @@
         <StateAbbreviationCd>NJ</StateAbbreviationCd>
         <ZIPCd>08037</ZIPCd>
       </EmployeeUSAddress>
-      <WagesAmt>50000.33</WagesAmt>
+      <WagesAmt>50000</WagesAmt>
       <WithholdingAmt>1000</WithholdingAmt>
-      <SocialSecurityWagesAmt>50000.33</SocialSecurityWagesAmt>
+      <SocialSecurityWagesAmt>50000</SocialSecurityWagesAmt>
       <SocialSecurityTaxAmt>3100</SocialSecurityTaxAmt>
-      <MedicareWagesAndTipsAmt>50000.33</MedicareWagesAndTipsAmt>
+      <MedicareWagesAndTipsAmt>50000</MedicareWagesAndTipsAmt>
       <MedicareTaxWithheldAmt>725</MedicareTaxWithheldAmt>
       <OtherDeductionsBenefitsGrp>
         <Desc>414HSUB</Desc>
@@ -351,10 +351,10 @@
         <W2StateTaxGrp>
           <StateAbbreviationCd>NJ</StateAbbreviationCd>
           <EmployerStateIdNum>54321</EmployerStateIdNum>
-          <StateWagesAmt>50000.33</StateWagesAmt>
+          <StateWagesAmt>50000</StateWagesAmt>
           <StateIncomeTaxAmt>500</StateIncomeTaxAmt>
           <W2LocalTaxGrp>
-            <LocalWagesAndTipsAmt>50000.33</LocalWagesAndTipsAmt>
+            <LocalWagesAndTipsAmt>50000</LocalWagesAndTipsAmt>
             <LocalIncomeTaxAmt>250</LocalIncomeTaxAmt>
             <LocalityNm>Hammonton</LocalityNm>
           </W2LocalTaxGrp>

--- a/spec/fixtures/state_file/fed_return_xmls/2023/nj/zeus_two_w2s.xml
+++ b/spec/fixtures/state_file/fed_return_xmls/2023/nj/zeus_two_w2s.xml
@@ -198,11 +198,11 @@
         <StateAbbreviationCd>NJ</StateAbbreviationCd>
         <ZIPCd>08037</ZIPCd>
       </EmployeeUSAddress>
-      <WagesAmt>12345.67</WagesAmt>
+      <WagesAmt>12345</WagesAmt>
       <WithholdingAmt>1000</WithholdingAmt>
-      <SocialSecurityWagesAmt>12345.67</SocialSecurityWagesAmt>
+      <SocialSecurityWagesAmt>12345</SocialSecurityWagesAmt>
       <SocialSecurityTaxAmt>3100</SocialSecurityTaxAmt>
-      <MedicareWagesAndTipsAmt>12345.67</MedicareWagesAndTipsAmt>
+      <MedicareWagesAndTipsAmt>12345</MedicareWagesAndTipsAmt>
       <MedicareTaxWithheldAmt>725</MedicareTaxWithheldAmt>
       <OtherDeductionsBenefitsGrp>
         <Desc>414HSUB</Desc>
@@ -212,10 +212,10 @@
         <W2StateTaxGrp>
           <StateAbbreviationCd>NJ</StateAbbreviationCd>
           <EmployerStateIdNum>12345</EmployerStateIdNum>
-          <StateWagesAmt>12345.67</StateWagesAmt>
+          <StateWagesAmt>12345</StateWagesAmt>
           <StateIncomeTaxAmt>500</StateIncomeTaxAmt>
           <W2LocalTaxGrp>
-            <LocalWagesAndTipsAmt>12345.67</LocalWagesAndTipsAmt>
+            <LocalWagesAndTipsAmt>12345</LocalWagesAndTipsAmt>
             <LocalIncomeTaxAmt>250</LocalIncomeTaxAmt>
             <LocalityNm>Hammonton</LocalityNm>
           </W2LocalTaxGrp>
@@ -228,7 +228,7 @@
       <EmployerEIN>001245768</EmployerEIN>
       <EmployerNameControlTxt>BTB</EmployerNameControlTxt>
       <EmployerName>
-        <BusinessNameLine1Txt>Brendan T. Byrne State Forest</BusinessNameLine1Txt>
+        <BusinessNameLine1Txt>Brendan T Byrne State Forest</BusinessNameLine1Txt>
       </EmployerName>
       <EmployerUSAddress>
         <AddressLine1Txt>31 Batsto Road</AddressLine1Txt>

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -129,8 +129,8 @@ describe Efile::Nj::Nj1040Calculator do
     context 'when 2 federal w2s' do
       let(:intake) { create(:state_file_nj_intake, :df_data_2_w2s) }
 
-      it 'sets line 15 to the rounded sum of all state wage amounts' do
-        expected_sum = (12345.67 + 50000).round
+      it 'sets line 15 to the sum of all state wage amounts' do
+        expected_sum = 12345 + 50000
         expect(instance.lines[:NJ1040_LINE_15].value).to eq(expected_sum)
       end
     end
@@ -138,8 +138,8 @@ describe Efile::Nj::Nj1040Calculator do
     context 'when many federal w2s' do
       let(:intake) { create(:state_file_nj_intake, :df_data_many_w2s) }
 
-      it 'sets line 15 to the rounded sum of all state wage amounts' do
-        expected_sum = (50000.33 + 50000.33 + 50000.33 + 50000.33).round
+      it 'sets line 15 to the sum of all state wage amounts' do
+        expected_sum = 50000 + 50000 + 50000 + 50000
         expect(instance.lines[:NJ1040_LINE_15].value).to eq(expected_sum)
       end
     end
@@ -147,8 +147,8 @@ describe Efile::Nj::Nj1040Calculator do
 
   describe 'line 27 - total income' do
     let(:intake) { create(:state_file_nj_intake, :df_data_2_w2s) }
-    it 'sets line 27 to the rounded sum of all state wage amounts' do
-      line_15_w2_wages = (12345.67 + 50000).round
+    it 'sets line 27 to the sum of all state wage amounts' do
+      line_15_w2_wages = 12345 + 50000
       expect(instance.lines[:NJ1040_LINE_15].value).to eq(line_15_w2_wages)
       expect(instance.lines[:NJ1040_LINE_27].value).to eq(line_15_w2_wages)
     end
@@ -156,8 +156,8 @@ describe Efile::Nj::Nj1040Calculator do
 
   describe 'line 29 - gross income' do
     let(:intake) { create(:state_file_nj_intake, :df_data_2_w2s) }
-    it 'sets line 29 to the rounded sum of all state wage amounts' do
-      line_15_w2_wages = (12345.67 + 50000).round
+    it 'sets line 29 to the sum of all state wage amounts' do
+      line_15_w2_wages = 12345 + 50000
       expect(instance.lines[:NJ1040_LINE_15].value).to eq(line_15_w2_wages)
       expect(instance.lines[:NJ1040_LINE_29].value).to eq(line_15_w2_wages)
     end

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -640,7 +640,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           )
         }
 
-        it "includes the rounded sum 200,001.33 split into each box on line 15" do
+        it "includes the sum 200,000 split into each box on line 15" do
           # millions
           expect(pdf_fields["15"]).to eq ""
           expect(pdf_fields["undefined_36"]).to eq ""
@@ -651,7 +651,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           # hundreds
           expect(pdf_fields["Text101"]).to eq "0"
           expect(pdf_fields["Text103"]).to eq "0"
-          expect(pdf_fields["Text104"]).to eq "1"
+          expect(pdf_fields["Text104"]).to eq "0"
           # decimals
           expect(pdf_fields["Text105"]).to eq "0"
           expect(pdf_fields["Text106"]).to eq "0"
@@ -666,7 +666,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           )
         }
 
-        it "includes the rounded sum 62,345.67 split into each box on line 15" do
+        it "includes the sum 62,345 split into each box on line 15" do
           # millions
           expect(pdf_fields["15"]).to eq ""
           expect(pdf_fields["undefined_36"]).to eq ""
@@ -677,7 +677,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           # hundreds
           expect(pdf_fields["Text101"]).to eq "3"
           expect(pdf_fields["Text103"]).to eq "4"
-          expect(pdf_fields["Text104"]).to eq "6"
+          expect(pdf_fields["Text104"]).to eq "5"
           # decimals
           expect(pdf_fields["Text105"]).to eq "0"
           expect(pdf_fields["Text106"]).to eq "0"
@@ -792,7 +792,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
     end
 
     describe "line 27 - total income" do
-      context "when taxpayer provides total income with the sum 200,001.33" do
+      context "when taxpayer provides total income with the sum 200,000" do
         let(:submission) {
           create :efile_submission, tax_return: nil, data_source: create(
             :state_file_nj_intake,
@@ -811,7 +811,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           # hundreds
           expect(pdf_fields["undefined_79"]).to eq "0"
           expect(pdf_fields["186"]).to eq "0"
-          expect(pdf_fields["187"]).to eq "1"
+          expect(pdf_fields["187"]).to eq "0"
           # decimals
           expect(pdf_fields["undefined_80"]).to eq "0"
           expect(pdf_fields["188"]).to eq "0"
@@ -846,7 +846,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
     end
 
     describe "line 29 - gross income" do
-      context "when taxpayer provides gross income with the sum 200,001.33" do
+      context "when taxpayer provides gross income with the sum 200,000" do
         let(:submission) {
           create :efile_submission, tax_return: nil, data_source: create(
             :state_file_nj_intake,
@@ -865,7 +865,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           # hundreds
           expect(pdf_fields["undefined_88"]).to eq "0"
           expect(pdf_fields["207"]).to eq "0"
-          expect(pdf_fields["208"]).to eq "1"
+          expect(pdf_fields["208"]).to eq "0"
           # decimals
           expect(pdf_fields["undefined_89"]).to eq "0"
           expect(pdf_fields["209"]).to eq "0"
@@ -928,7 +928,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           :state_file_nj_intake, :df_data_many_w2s
         )
       }
-      it "writes taxable income $199,001 (200,001.33-1000) to fill boxes on line 39" do
+      it "writes taxable income $199,000 (200,000-1000) to fill boxes on line 39" do
         # millions
         expect(pdf_fields["279"]).to eq ""
         expect(pdf_fields["38a Total Property Taxes 18 of Rent Paid See instructions page 23 38a"]).to eq ""
@@ -940,7 +940,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
         # hundreds
         expect(pdf_fields["undefined_108"]).to eq "0"
         expect(pdf_fields["254"]).to eq "0"
-        expect(pdf_fields["255"]).to eq "1"
+        expect(pdf_fields["255"]).to eq "0"
         # decimals
         expect(pdf_fields["undefined_109"]).to eq "0"
         expect(pdf_fields["256"]).to eq "0"
@@ -1039,7 +1039,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           :state_file_nj_intake, :df_data_many_w2s
         )
       }
-      it "writes new jersey taxable income $199,001 (200,001.33-1000) to fill boxes on line 39" do
+      it "writes new jersey taxable income $199,000 (200,000-1000) to fill boxes on line 39" do
         # millions
         expect(pdf_fields["Enter Code4332"]).to eq ""
         expect(pdf_fields["40"]).to eq ""
@@ -1051,7 +1051,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
         # hundreds
         expect(pdf_fields["Text37"]).to eq "0"
         expect(pdf_fields["Text38"]).to eq "0"
-        expect(pdf_fields["Text39"]).to eq "1"
+        expect(pdf_fields["Text39"]).to eq "0"
         # decimals
         expect(pdf_fields["Text40"]).to eq "0"
         expect(pdf_fields["Text41"]).to eq "0"

--- a/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
@@ -261,7 +261,7 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
         let(:intake) { create(:state_file_nj_intake, :df_data_many_w2s) }
 
         it "includes the sum in WagesSalariesTips item" do
-          expected_sum = (50000.33 + 50000.33 + 50000.33 + 50000.33).round
+          expected_sum = 50000 + 50000 + 50000 + 50000
           expect(xml.at("WagesSalariesTips").text).to eq(expected_sum.to_s)
         end
       end
@@ -283,7 +283,7 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
       context "when filer submits w2 wages" do
         let(:intake) { create(:state_file_nj_intake, :df_data_many_w2s) }
         it "fills TotalIncome with the value from Line 15" do
-          expected_line_15_w2_wages = 200_001
+          expected_line_15_w2_wages = 200_000
           expect(xml.at("WagesSalariesTips").text).to eq(expected_line_15_w2_wages.to_s)
           expect(xml.at("TotalIncome").text).to eq(expected_line_15_w2_wages.to_s)
         end
@@ -301,7 +301,7 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
       context "when filer submits w2 wages" do
         let(:intake) { create(:state_file_nj_intake, :df_data_many_w2s) }
         it "fills TotalIncome with the value from Line 15" do
-          expected_line_15_w2_wages = 200_001
+          expected_line_15_w2_wages = 200_000
           expect(xml.at("WagesSalariesTips").text).to eq(expected_line_15_w2_wages.to_s)
           expect(xml.at("GrossIncome").text).to eq(expected_line_15_w2_wages.to_s)
         end
@@ -329,7 +329,7 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
     describe "taxable income - line 39" do
       let(:intake) { create(:state_file_nj_intake, :df_data_many_w2s) }
       it "fills TaxableIncome with gross income minus total exemptions/deductions" do
-        expected_line_15_w2_wages = 200_001
+        expected_line_15_w2_wages = 200_000
         line_6_single_filer = 1_000
         line_7_not_over_65 = 0
         line_8_not_blind = 0
@@ -382,7 +382,7 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
     describe "new jersey taxable income - line 42" do
       let(:intake) { create(:state_file_nj_intake, :df_data_many_w2s) }
       it "fills NewJerseyTaxableIncome with taxable income" do
-        expected_line_15_w2_wages = 200_001
+        expected_line_15_w2_wages = 200_000
         line_6_single_filer = 1_000
         line_7_not_over_65 = 0
         line_8_not_blind = 0

--- a/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
@@ -8,6 +8,50 @@ describe SubmissionBuilder::Ty2024::States::Nj::NjReturnXml, required_schema: "n
     let!(:submission_efile_device_info) { create :state_file_efile_device_info, :submission, :filled, intake: intake }
     let(:xml) { Nokogiri::XML::Document.parse(described_class.build(submission).document.to_xml) }
 
+    describe "XML schema" do
+
+      context "with one dep" do
+        let(:intake) { create(:state_file_nj_intake, municipality_code: "0101", raw_direct_file_data: StateFile::XmlReturnSampleService.new.read('nj_zeus_one_dep')) }
+        it "does not error" do
+          builder_response = described_class.build(submission)
+          expect(builder_response.errors).not_to be_present
+        end
+      end
+
+      context "with two deps" do
+        let(:intake) { create(:state_file_nj_intake, municipality_code: "0101", raw_direct_file_data: StateFile::XmlReturnSampleService.new.read('nj_zeus_two_deps')) }
+        it "does not error" do
+          builder_response = described_class.build(submission)
+          expect(builder_response.errors).not_to be_present
+        end
+      end
+
+      context "with many deps" do
+        let(:intake) { create(:state_file_nj_intake, municipality_code: "0101", raw_direct_file_data: StateFile::XmlReturnSampleService.new.read('nj_zeus_many_deps')) }
+        it "does not error" do
+          builder_response = described_class.build(submission)
+          expect(builder_response.errors).not_to be_present
+        end
+      end
+
+      context "with many w2s" do
+        let(:intake) { create(:state_file_nj_intake, municipality_code: "0101", raw_direct_file_data: StateFile::XmlReturnSampleService.new.read('nj_zeus_many_w2s')) }
+        it "does not error" do
+          builder_response = described_class.build(submission)
+          expect(builder_response.errors).not_to be_present
+        end
+      end
+
+      context "with two w2s" do
+        let(:intake) { create(:state_file_nj_intake, municipality_code: "0101", raw_direct_file_data: StateFile::XmlReturnSampleService.new.read('nj_zeus_two_w2s')) }
+        it "does not error" do
+          builder_response = described_class.build(submission)
+          expect(builder_response.errors).not_to be_present
+        end
+      end
+
+    end
+
     it "generates basic components of return" do
       expect(xml.document.root.namespaces).to include({ "xmlns:efile" => "http://www.irs.gov/efile", "xmlns" => "http://www.irs.gov/efile" })
       expect(xml.document.at('AuthenticationHeader').to_s).to include('xmlns="http://www.irs.gov/efile"')


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/72

## Is PM acceptance required? (delete one)
- No - merge after code review approval

## What was done?
- Add automated test for asserting no NJ XML errors
- Fix existing NJ XML errors by introducing `NJW2` document and mapping to replace `IRSW2` and update specs to match
- Fix existing NJ fake IRS DF data that does not conform to schema (w2 wages must be integers) and associated tests

## How to test?
n/a

## Screenshots (for visual changes)
n/a
