### PR TITLE
Add back jdk to Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,8 @@
 brew "gh"
 brew "ghostscript"
 brew "imagemagick"
+tap "AdoptOpenJDK/openjdk"
+cask "adoptopenjdk"
 brew "poppler"
 brew "postgresql@14"
 brew "postgis"


### PR DESCRIPTION
https://cfastaff.slack.com/archives/C0544ERAFQV/p1728410484526749

although I used `asdf` using install instructions in the readme, I kept seeing:
```
pdftk executable /Users/[achoi@codeforamerica.org](mailto:achoi@codeforamerica.org)/Documents/workspace/vita-min/vendor/pdftk/pdftk not found
```

when I ran specs locally.

I used `brew install --cask adoptopenjdk` instead to resolve; with this addition we shouldn't have to 