### PR TITLE
remove name_dob lines from MD feature spec

### DIFF
--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -475,13 +475,6 @@ RSpec.feature "Completing a state file intake", active_job: true do
       expect(page).to have_text I18n.t("state_file.questions.data_review.edit.title")
       click_on I18n.t("general.continue")
 
-      expect(page).to have_text I18n.t("state_file.questions.name_dob.edit.title2")
-      expect(page).to have_text "Your responses are saved. If you need a break, you can come back and log in to your account at fileyourstatetaxes.org."
-      fill_in "state_file_name_dob_form_primary_first_name", with: "Titus"
-      fill_in "state_file_name_dob_form_primary_last_name", with: "Testerson"
-      select_cfa_date "state_file_name_dob_form_primary_birth_date", Date.new(1978, 6, 21)
-      click_on I18n.t("general.continue")
-
       expect(page).to have_text I18n.t('state_file.questions.unemployment.edit.title.one', year: MultiTenantService.statefile.current_tax_year)
       choose I18n.t("general.affirmative")
       fill_in I18n.t('state_file.questions.unemployment.edit.payer_name'), with: "Business Name"


### PR DESCRIPTION
tests were failing on main. order of events that led there:
- arin made a branch for the MD502 story and as part of her work, removed the NameDobController from MD navigation
- i added a feature spec for MD intake, which included lines for name-dob because it was still present on main; that got merged in
- when i merged arin's PR to main, it failed that feature spec at the name-dob part because it had been removed