### PR TITLE
NJ 89 - fix bug for app throwing error on Ineligible and Unsupported continue buttons

### DIFF
--- a/app/forms/state_file/nj_ineligible_property_tax_form.rb
+++ b/app/forms/state_file/nj_ineligible_property_tax_form.rb
@@ -1,4 +1,5 @@
 module StateFile
   class NjIneligiblePropertyTaxForm < QuestionsForm
+    def save; end
   end
 end

--- a/app/forms/state_file/nj_unsupported_property_tax_form.rb
+++ b/app/forms/state_file/nj_unsupported_property_tax_form.rb
@@ -1,4 +1,5 @@
 module StateFile
   class NjUnsupportedPropertyTaxForm < QuestionsForm
+    def save; end
   end
 end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://github.com/newjersey/affordability-pm/issues/89

## Is PM acceptance required? (delete one)
- No - merge after code review approval

## What was done?
- Add save methods to Unsupported and Ineligible forms so that they work

## How to test?

1. Go to rent/own page
2. Click "neither" or "both"
3. Receive the Unsupported or Ineligible screen
4. Click "continue"
5. App works and does not throw error

## Sceeenshots
![image](https://github.com/user-attachments/assets/5d1144f5-cbf0-4fa9-ba4a-7c44b40d9a9d)

