### PR TITLE
Stub out that we are before end_of_in_progress_intake for Diy control…

### DIFF
--- a/spec/controllers/diy/continue_to_fsa_controller_spec.rb
+++ b/spec/controllers/diy/continue_to_fsa_controller_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Diy::ContinueToFsaController do
+  before do
+    allow_any_instance_of(Diy::BaseController).to receive(:open_for_diy?).and_return(true)
+  end
+
   describe "#edit" do
     let(:diy_intake) { create(:diy_intake, :filled_out) }
     let(:experiments_enabled) { true }

--- a/spec/controllers/diy/file_yourself_controller_spec.rb
+++ b/spec/controllers/diy/file_yourself_controller_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe Diy::FileYourselfController do
   end
 
   describe "#update" do
+    before do
+      allow(controller).to receive(:open_for_diy?).and_return(true)
+    end
+
     context "with valid params" do
       let(:params) do
         {

--- a/spec/support/shared_examples/offseason.rb
+++ b/spec/support/shared_examples/offseason.rb
@@ -4,6 +4,7 @@ shared_examples :a_normal_page_when_intake_is_open do |controller, action: :edit
       allow(Rails.configuration).to receive(:start_of_unique_links_only_intake).and_return(1.minute.ago)
       allow(Rails.configuration).to receive(:start_of_open_intake).and_return(1.minute.ago)
       allow(Rails.configuration).to receive(:end_of_intake).and_return(1.minute.from_now)
+      allow(Rails.configuration).to receive(:end_of_in_progress_intake).and_return(1.minute.from_now)
     end
 
     it "renders normally" do


### PR DESCRIPTION
Tests started failing b/c our `Rails.configuration.end_of_in_progress_intake` was yesterday and we depend on being `:open_for_diy?` for these specs.

Failing specs:
https://app.circleci.com/pipelines/github/codeforamerica/vita-min/24770/workflows/3c482e81-d553-4a04-bf4b-4d0b7f03da8a/jobs/67110/tests
 
<img width="875" alt="Screenshot 2024-10-16 at 9 50 51 AM" src="https://github.com/user-attachments/assets/551901b0-8ff3-48e4-9775-c41663662e03">
