### PR TITLE
Nj 75 medical

### DIFF
--- a/app/assets/stylesheets/components/_form-elements.scss
+++ b/app/assets/stylesheets/components/_form-elements.scss
@@ -101,3 +101,7 @@
 .textarea {
   margin-bottom: 0;
 }
+
+.form-group .form-question + .text--help{
+  margin-top: 0;
+}

--- a/app/controllers/state_file/questions/nj_medical_expenses_controller.rb
+++ b/app/controllers/state_file/questions/nj_medical_expenses_controller.rb
@@ -1,0 +1,9 @@
+module StateFile
+  module Questions
+    class NjMedicalExpensesController < QuestionsController
+      include ReturnToReviewConcern
+
+      before_action -> { @filing_year = Rails.configuration.statefile_current_tax_year }
+    end
+  end
+end

--- a/app/forms/state_file/nj_medical_expenses_form.rb
+++ b/app/forms/state_file/nj_medical_expenses_form.rb
@@ -1,0 +1,15 @@
+module StateFile
+  class NjMedicalExpensesForm < QuestionsForm
+    set_attributes_for :intake,
+                       :medical_expenses
+
+    validates_numericality_of :medical_expenses, only_integer: true, message: :round_to_whole_number, if: -> { medical_expenses.present? }
+    validates :medical_expenses, presence: true, allow_blank: false, numericality: { greater_than_or_equal_to: 0 }, if: -> { medical_expenses.present? }
+                   
+    def save
+      unless medical_expenses.nil?
+        @intake.update(attributes_for(:intake))
+      end
+    end
+  end
+end

--- a/app/forms/state_file/nj_medical_expenses_form.rb
+++ b/app/forms/state_file/nj_medical_expenses_form.rb
@@ -3,8 +3,8 @@ module StateFile
     set_attributes_for :intake,
                        :medical_expenses
 
-    validates_numericality_of :medical_expenses, only_integer: true, message: :round_to_whole_number, if: -> { medical_expenses.present? }
-    validates :medical_expenses, presence: true, allow_blank: false, numericality: { greater_than_or_equal_to: 0 }, if: -> { medical_expenses.present? }
+    validates_numericality_of :medical_expenses, only_integer: true, message: :round_to_whole_number
+    validates :medical_expenses, presence: true, allow_blank: false, numericality: { greater_than_or_equal_to: 0 }
                    
     def save
       unless medical_expenses.nil?

--- a/app/helpers/vita_min_form_builder.rb
+++ b/app/helpers/vita_min_form_builder.rb
@@ -71,14 +71,14 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
     html_options_with_errors = html_options.merge(error_attributes(method: method))
 
     html_output = <<~HTML
-          <div class="form-group#{error_state(object, method)}">
-            #{formatted_label}
-            <div class="select">
-              #{select(method, collection, options, html_options_with_errors, &block)}
-            </div>
-            #{errors_for(object, method)}
-          </div>
-        HTML
+      <div class="form-group#{error_state(object, method)}">
+        #{formatted_label}
+        <div class="select">
+          #{select(method, collection, options, html_options_with_errors, &block)}
+        </div>
+        #{errors_for(object, method)}
+      </div>
+    HTML
 
     html_output.html_safe
   end
@@ -282,11 +282,12 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
       method,
       label_text,
       options: {},
-      classes: []
+      classes: [],
+      help_text: nil
     )
     text_field_options = standard_options.merge(
       class: (classes + ["text-input money-input"]).join(" "),
-      ).merge(options).merge(error_attributes(method: method)).merge(placeholder: '0.00')
+      ).merge(error_attributes(method: method)).merge(placeholder: '0.00').merge(options)
 
     text_field_options[:id] ||= sanitized_id(method)
     options[:input_id] ||= sanitized_id(method)
@@ -301,6 +302,7 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
       prefix: '$',
       options: options,
       wrapper_classes: wrapper_classes,
+      help_text: help_text
       )
 
     html_output = <<~HTML
@@ -412,9 +414,9 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
   def warning_for_select(element_id, permitted_values, msg)
     @template.content_tag(:div, msg,
       class: "warning warning-for-select",
-      "data-warning-for-select": element_id,
+      'data-warning-for-select': element_id,
       style: "display:none",
-      "data-permitted": permitted_values.to_json
+      'data-permitted': permitted_values.to_json
     )
   end
 end

--- a/app/lib/efile/line_data.yml
+++ b/app/lib/efile/line_data.yml
@@ -578,6 +578,8 @@ NJ1040_LINE_27:
   label: '27 Total Income (Add lines 15, 16a, and 20a)'
 NJ1040_LINE_29:
   label: "29 New Jersey Gross Income (Subtract line 28c from line 27) (See instructions)"
+NJ1040_LINE_31:
+  label: "Medical Expenses (See Worksheet F and instructions)"
 NJ1040_LINE_38:
   label: "38 Total Exemptions and Deductions (Add lines 30 through 37c)"
 NJ1040_LINE_39:

--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -20,6 +20,7 @@ module Efile
         set_line(:NJ1040_LINE_15, :calculate_line_15)
         set_line(:NJ1040_LINE_27, :calculate_line_27)
         set_line(:NJ1040_LINE_29, :calculate_line_29)
+        set_line(:NJ1040_LINE_31, :calculate_line_31)
         set_line(:NJ1040_LINE_38, :calculate_line_38)
         set_line(:NJ1040_LINE_39, :calculate_line_39)
         set_line(:NJ1040_LINE_40A, :calculate_line_40a)
@@ -186,8 +187,16 @@ module Efile
         calculate_line_27
       end
 
+      def calculate_line_31
+        two_percent_gross = calculate_line_29 * 0.02
+        difference_with_med_expenses = @intake.medical_expenses - two_percent_gross
+        rounded_difference = difference_with_med_expenses.round
+        return rounded_difference if rounded_difference.positive?
+        nil
+      end
+
       def calculate_line_38
-        calculate_line_13
+        calculate_line_13 + line_or_zero(:NJ1040_LINE_31)
       end
 
       def calculate_line_39

--- a/app/lib/navigation/state_file_nj_question_navigation.rb
+++ b/app/lib/navigation/state_file_nj_question_navigation.rb
@@ -31,6 +31,7 @@ module Navigation
                                           Navigation::NavigationStep.new(StateFile::Questions::NameDobController),
                                           Navigation::NavigationStep.new(StateFile::Questions::NjCountyController),
                                           Navigation::NavigationStep.new(StateFile::Questions::NjMunicipalityController),
+                                          Navigation::NavigationStep.new(StateFile::Questions::NjMedicalExpensesController),
                                           Navigation::NavigationStep.new(StateFile::Questions::NjHouseholdRentOwnController),
                                           Navigation::NavigationStep.new(StateFile::Questions::NjHomeownerEligibilityController),
                                           Navigation::NavigationStep.new(StateFile::Questions::NjTenantEligibilityController),

--- a/app/lib/pdf_filler/nj1040_pdf.rb
+++ b/app/lib/pdf_filler/nj1040_pdf.rb
@@ -124,6 +124,20 @@ module PdfFiller
                                                  ]))
       end
 
+      if @xml_document.at("Body MedicalExpenses")
+        medical_expenses = @xml_document.at("Body MedicalExpenses").text.to_i
+        answers.merge!(insert_digits_into_fields(medical_expenses, [
+                                                   "219",
+                                                   "undefined_93",
+                                                   "218",
+                                                   "217",
+                                                   "undefined_92",
+                                                   "216",
+                                                   "215",
+                                                   "31"
+                                                 ]))
+      end
+
       if @xml_document.at("TotalExemptDeductions")
         total_exemptions = @xml_document.at("TotalExemptDeductions").text.to_i
         answers.merge!(insert_digits_into_fields(total_exemptions, [

--- a/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
+++ b/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
@@ -109,6 +109,11 @@ module SubmissionBuilder
                   end
 
                   xml.TotalExemptionAmountB calculated_fields.fetch(:NJ1040_LINE_13)
+
+                  if calculated_fields.fetch(:NJ1040_LINE_31)
+                    xml.MedicalExpenses calculated_fields.fetch(:NJ1040_LINE_31)
+                  end
+
                   xml.TotalExemptDeductions calculated_fields.fetch(:NJ1040_LINE_38)
 
                   if calculated_fields.fetch(:NJ1040_LINE_39) > 0

--- a/app/models/state_file_nj_intake.rb
+++ b/app/models/state_file_nj_intake.rb
@@ -36,6 +36,7 @@
 #  last_sign_in_ip                                        :inet
 #  locale                                                 :string           default("en")
 #  locked_at                                              :datetime
+#  medical_expenses                                       :integer          default(0), not null
 #  message_tracker                                        :jsonb
 #  municipality_code                                      :string
 #  municipality_name                                      :string

--- a/app/views/state_file/questions/nj_medical_expenses/edit.html.erb
+++ b/app/views/state_file/questions/nj_medical_expenses/edit.html.erb
@@ -6,7 +6,7 @@
 <% content_for :card do %>
   <h1 class="h2"><%= t(".title") %></h1>
   <ul class="list--bulleted">
-    <%= t(".description") %>
+    <%= t(".description_html") %>
   </ul>
 
   <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>

--- a/app/views/state_file/questions/nj_medical_expenses/edit.html.erb
+++ b/app/views/state_file/questions/nj_medical_expenses/edit.html.erb
@@ -1,0 +1,41 @@
+<%
+  title = t(".title", filing_year: @filing_year)
+  content_for :page_title, title
+%>
+
+<% content_for :card do %>
+  <h1 class="h2"><%= t(".title") %></h1>
+  <ul class="list--bulleted">
+    <%= t(".description") %>
+  </ul>
+
+  <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
+    <div class="white-group">
+      <%= f.vita_min_money_field(
+        :medical_expenses,
+        t('.label', filing_year: @filing_year),
+        help_text: t('.help_text'),
+        classes: ["form-width--long"],
+        options: { placeholder: "" }
+    ) %>
+    </div>
+
+    <div class="reveal">
+        <h2 style="margin-bottom: 0">
+            <a class="reveal__link" aria-controls="nj-medical-details" aria-expanded="false">
+                <%= t('.learn_more_title') %>
+            </a>
+        </h2>
+        <div class="reveal__content" id="nj-medical-details">
+            <p><%= t('.learn_more_meaning') %>:</p>
+            <ul class="list--bulleted"><%= t('.learn_more_content_html') %></ul>
+            <p><%= t('.learn_more_note_html') %></p>
+        </div>
+    </div>
+
+    <% if params[:return_to_review].present? %>
+      <%= hidden_field_tag "return_to_review", params[:return_to_review] %>
+    <% end %>
+    <%= f.continue %>
+  <% end %>
+<% end %>

--- a/app/views/state_file/questions/nj_medical_expenses/edit.html.erb
+++ b/app/views/state_file/questions/nj_medical_expenses/edit.html.erb
@@ -5,9 +5,7 @@
 
 <% content_for :card do %>
   <h1 class="h2"><%= t(".title") %></h1>
-  <ul class="list--bulleted">
-    <%= t(".description_html") %>
-  </ul>
+  <%= t(".description_html") %>
 
   <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
     <div class="white-group">

--- a/app/views/state_file/questions/nj_medical_expenses/edit.html.erb
+++ b/app/views/state_file/questions/nj_medical_expenses/edit.html.erb
@@ -18,6 +18,8 @@
     ) %>
     </div>
 
+    <p><%= t(".do_not_claim") %></p>
+
     <div class="reveal">
         <h2 style="margin-bottom: 0">
             <a class="reveal__link" aria-controls="nj-medical-details" aria-expanded="false">

--- a/app/views/state_file/questions/nj_review/edit.html.erb
+++ b/app/views/state_file/questions/nj_review/edit.html.erb
@@ -61,6 +61,17 @@
       </div>
     </div>
   <% end %>
+  
+  <div id="medical_expenses" class="white-group">
+    <div class="spacing-below-5">
+      <p class="text--bold spacing-below-5"><%=t(".medical_expenses") %></p>
+      <p><%= number_to_currency(current_intake.medical_expenses) %></p>
+      <%= link_to StateFile::Questions::NjMedicalExpensesController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
+        <%= t("general.edit") %>
+        <span class="sr-only"><%= t(".medical_expenses") %></span>
+      <% end %>
+    </div>
+  </div>
 
   <%= render "state_file/questions/shared/review_footer" %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2641,12 +2641,12 @@ en:
           title: Looks like you’re not eligible for this credit.
       nj_medical_expenses:
         edit:
-          help_text: Estimates are ok. For example, $3000.
           description_html: |-
             <p>This includes expenses for yourself, your spouse, and your dependents.</p>
             <p>Only expenses that exceed 2% of your gross income may be deducted.</p>
             <p>You can’t deduct expenses for which you were reimbursed through your health insurance plan.</p>
           do_not_claim: If you do not want to claim this deduction, click “Continue”.
+          help_text: Estimates are ok. For example, $3000.
           label: Non-reimbursed medical expenses paid in %{filing_year}
           learn_more_content_html: |-
             <li>Physicians, dental, and other medical fees</li><li>Prescription eyeglasses and contact lenses</li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2641,11 +2641,12 @@ en:
           title: Looks like you’re not eligible for this credit.
       nj_medical_expenses:
         edit:
+          help_text: Estimates are ok. For example, $3000.
           description_html: |-
-            <li>This includes expenses for yourself, your spouse, and your dependents.</li>
-            <li>Only expenses that exceed 2% of your gross income may be deducted.</li>
-            <li>You can’t deduct expenses for which you were reimbursed through your health insurance plan.</li>
-          help_text: If you do not want to claim this deduction, click “Continue”.
+            <p>This includes expenses for yourself, your spouse, and your dependents.</p>
+            <p>Only expenses that exceed 2% of your gross income may be deducted.</p>
+            <p>You can’t deduct expenses for which you were reimbursed through your health insurance plan.</p>
+          do_not_claim: If you do not want to claim this deduction, click “Continue”.
           label: Non-reimbursed medical expenses paid in %{filing_year}
           learn_more_content_html: |-
             <li>Physicians, dental, and other medical fees</li><li>Prescription eyeglasses and contact lenses</li>
@@ -2660,7 +2661,7 @@ en:
             Note: In NJ, if you are paying for your adult child’s health insurance (ages 18 to 27), this can only be deducted as a medical expense <a href="https://www.nj.gov/treasury/taxation/pdf/pubs/tams/tam14.pdf" target="blank" rel=
             oopener noreferrer">if the child was your dependent.</a>
           learn_more_title: What are medical expenses?
-          title: You can deduct medical expenses
+          title: You can deduct medical expenses.
       nj_municipality:
         edit:
           helper_description_html: If the place where you live is not listed, use the <a href="https://www.nj.gov/nj/gov/county/localities.html" target="_blank" rel="noopener nofollow">NJ state locality tool</a> to get the name of your municipality.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2641,7 +2641,7 @@ en:
           title: Looks like you’re not eligible for this credit.
       nj_medical_expenses:
         edit:
-          description: |-
+          description_html: |-
             <li>This includes expenses for yourself, your spouse, and your dependents.</li>
             <li>Only expenses that exceed 2% of your gross income may be deducted.</li>
             <li>You can’t deduct expenses for which you were reimbursed through your health insurance plan.</li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2639,6 +2639,28 @@ en:
         edit:
           helper_description: Please continue to see what else we can guide you to qualify for.
           title: Looks like you’re not eligible for this credit.
+      nj_medical_expenses:
+        edit:
+          description: |-
+            <li>This includes expenses for yourself, your spouse, and your dependents.</li>
+            <li>Only expenses that exceed 2% of your gross income may be deducted.</li>
+            <li>You can’t deduct expenses for which you were reimbursed through your health insurance plan.</li>
+          help_text: If you do not want to claim this deduction, click “Continue”.
+          label: Non-reimbursed medical expenses paid in %{filing_year}
+          learn_more_content_html: |-
+            <li>Physicians, dental, and other medical fees</li><li>Prescription eyeglasses and contact lenses</li>
+            <li>Hospital care</li>
+            <li>Nursing care</li>
+            <li>Medicines and drugs</li><li>Prosthetic devices</li>
+            <li>X‑rays and other diagnostic services conducted by or directed by a physician or dentist</li>
+            <li>Amounts paid for transportation primarily for and essential to medical care</li>
+            <li>Insurance (including amounts paid as premiums under Part B of Title XVIII of the Social Security Act, relating to supplementary medical insurance for the aged) covering medical care</li>
+          learn_more_meaning: Medical expenses means non-reimbursed payments for costs such as
+          learn_more_note_html: |-
+            Note: In NJ, if you are paying for your adult child’s health insurance (ages 18 to 27), this can only be deducted as a medical expense <a href="https://www.nj.gov/treasury/taxation/pdf/pubs/tams/tam14.pdf" target="blank" rel=
+            oopener noreferrer">if the child was your dependent.</a>
+          learn_more_title: What are medical expenses?
+          title: You can deduct medical expenses
       nj_municipality:
         edit:
           helper_description_html: If the place where you live is not listed, use the <a href="https://www.nj.gov/nj/gov/county/localities.html" target="_blank" rel="noopener nofollow">NJ state locality tool</a> to get the name of your municipality.
@@ -2649,6 +2671,7 @@ en:
         edit:
           county: County
           household_rent_own: Rent or own home
+          medical_expenses: Medical expenses
           municipality: Municipality
           primary_disabled: I have a disability
           property_tax_paid: Property taxes paid

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2615,12 +2615,12 @@ es:
           title: Parece que no eres elegible para este crédito.
       nj_medical_expenses:
         edit:
-          help_text: Estimates are ok. For example, $3000.
           description_html: |-
             <p>This includes expenses for yourself, your spouse, and your dependents.</p>
             <p>Only expenses that exceed 2% of your gross income may be deducted.</p>
             <p>You can’t deduct expenses for which you were reimbursed through your health insurance plan.</p>
           do_not_claim: If you do not want to claim this deduction, click “Continue”.
+          help_text: Estimates are ok. For example, $3000.
           label: Non-reimbursed medical expenses paid in %{filing_year}
           learn_more_content_html: |-
             <li>Physicians, dental, and other medical fees</li><li>Prescription eyeglasses and contact lenses</li>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2613,6 +2613,28 @@ es:
         edit:
           helper_description: Continúe viendo para qué más podemos ayudarlo a calificar.
           title: Parece que no eres elegible para este crédito.
+      nj_medical_expenses:
+        edit:
+          description: |-
+            <li>This includes expenses for yourself, your spouse, and your dependents.</li>
+            <li>Only expenses that exceed 2% of your gross income may be deducted.</li>
+            <li>You can’t deduct expenses for which you were reimbursed through your health insurance plan.</li>
+          help_text: If you do not want to claim this deduction, click “Continue”.
+          label: Non-reimbursed medical expenses paid in %{filing_year}
+          learn_more_content_html: |-
+            <li>Physicians, dental, and other medical fees</li><li>Prescription eyeglasses and contact lenses</li>
+            <li>Hospital care</li>
+            <li>Nursing care</li>
+            <li>Medicines and drugs</li><li>Prosthetic devices</li>
+            <li>X‑rays and other diagnostic services conducted by or directed by a physician or dentist</li>
+            <li>Amounts paid for transportation primarily for and essential to medical care</li>
+            <li>Insurance (including amounts paid as premiums under Part B of Title XVIII of the Social Security Act, relating to supplementary medical insurance for the aged) covering medical care</li>
+          learn_more_meaning: Medical expenses means non-reimbursed payments for costs such as
+          learn_more_note_html: |-
+            Note: In NJ, if you are paying for your adult child’s health insurance (ages 18 to 27), this can only be deducted as a medical expense <a href="https://www.nj.gov/treasury/taxation/pdf/pubs/tams/tam14.pdf" target="blank" rel=
+            oopener noreferrer">if the child was your dependent.</a>
+          learn_more_title: What are medical expenses?
+          title: You can deduct medical expenses
       nj_municipality:
         edit:
           helper_description_html: Si el lugar donde usted vive no aparece en la lista, utilice la <a href="https://www.nj.gov/nj/gov/county/localities.html" target="_blank" rel="noopener nofollow">herramienta de localidad del estado de New Jersey</a> para obtener el nombre de su municipio.
@@ -2623,6 +2645,7 @@ es:
         edit:
           county: Condado
           household_rent_own: Vivienda en alquiler o en propiedad propia
+          medical_expenses: Gastos médicos
           municipality: Municipio
           primary_disabled: Primary disabled
           property_tax_paid: Impuestos sobre la propiedad pagados

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2615,11 +2615,12 @@ es:
           title: Parece que no eres elegible para este crédito.
       nj_medical_expenses:
         edit:
+          help_text: Estimates are ok. For example, $3000.
           description_html: |-
-            <li>This includes expenses for yourself, your spouse, and your dependents.</li>
-            <li>Only expenses that exceed 2% of your gross income may be deducted.</li>
-            <li>You can’t deduct expenses for which you were reimbursed through your health insurance plan.</li>
-          help_text: If you do not want to claim this deduction, click “Continue”.
+            <p>This includes expenses for yourself, your spouse, and your dependents.</p>
+            <p>Only expenses that exceed 2% of your gross income may be deducted.</p>
+            <p>You can’t deduct expenses for which you were reimbursed through your health insurance plan.</p>
+          do_not_claim: If you do not want to claim this deduction, click “Continue”.
           label: Non-reimbursed medical expenses paid in %{filing_year}
           learn_more_content_html: |-
             <li>Physicians, dental, and other medical fees</li><li>Prescription eyeglasses and contact lenses</li>
@@ -2634,7 +2635,7 @@ es:
             Note: In NJ, if you are paying for your adult child’s health insurance (ages 18 to 27), this can only be deducted as a medical expense <a href="https://www.nj.gov/treasury/taxation/pdf/pubs/tams/tam14.pdf" target="blank" rel=
             oopener noreferrer">if the child was your dependent.</a>
           learn_more_title: What are medical expenses?
-          title: You can deduct medical expenses
+          title: You can deduct medical expenses.
       nj_municipality:
         edit:
           helper_description_html: Si el lugar donde usted vive no aparece en la lista, utilice la <a href="https://www.nj.gov/nj/gov/county/localities.html" target="_blank" rel="noopener nofollow">herramienta de localidad del estado de New Jersey</a> para obtener el nombre de su municipio.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2615,7 +2615,7 @@ es:
           title: Parece que no eres elegible para este crédito.
       nj_medical_expenses:
         edit:
-          description: |-
+          description_html: |-
             <li>This includes expenses for yourself, your spouse, and your dependents.</li>
             <li>Only expenses that exceed 2% of your gross income may be deducted.</li>
             <li>You can’t deduct expenses for which you were reimbursed through your health insurance plan.</li>

--- a/db/migrate/20241007210254_add_medical_expenses_to_nj_intake.rb
+++ b/db/migrate/20241007210254_add_medical_expenses_to_nj_intake.rb
@@ -1,0 +1,5 @@
+class AddMedicalExpensesToNjIntake < ActiveRecord::Migration[7.1]
+  def change
+    add_column :state_file_nj_intakes, :medical_expenses, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2062,6 +2062,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_21_171609) do
     t.inet "last_sign_in_ip"
     t.string "locale", default: "en"
     t.datetime "locked_at"
+    t.integer "medical_expenses", default: 0, null: false
     t.jsonb "message_tracker", default: {}
     t.string "municipality_code"
     t.string "municipality_name"

--- a/spec/controllers/state_file/questions/nj_medical_expenses.rb
+++ b/spec/controllers/state_file/questions/nj_medical_expenses.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe StateFile::Questions::NjCountyController do
+  let(:intake) { create :state_file_nj_intake }
+  before do
+    sign_in intake
+  end
+
+  describe "#edit" do
+    render_views
+    it 'succeeds' do
+      get :edit
+      expect(response).to be_successful
+    end
+
+    describe "#update" do 
+      context "when a user has medical expenses" do
+        let(:form_params) {
+          {
+            state_file_nj_medical_expenses_form: {
+              medical_expenses: 1000,
+            }
+          }
+        }
+        
+        it "saves the correct value for renter" do
+          post :update, params: form_params
+          
+          intake.reload
+          expect(intake.medical_expenses).to eq 1000
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/state_file_nj_intakes.rb
+++ b/spec/factories/state_file_nj_intakes.rb
@@ -36,6 +36,7 @@
 #  last_sign_in_ip                                        :inet
 #  locale                                                 :string           default("en")
 #  locked_at                                              :datetime
+#  medical_expenses                                       :integer          default(0), not null
 #  message_tracker                                        :jsonb
 #  municipality_code                                      :string
 #  municipality_name                                      :string

--- a/spec/forms/state_file/nj_medical_expenses_form_spec.rb
+++ b/spec/forms/state_file/nj_medical_expenses_form_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe StateFile::NjMedicalExpensesForm do
+  let(:intake) { create :state_file_nj_intake }
+
+  describe "validations" do
+    let(:form) { described_class.new(intake, invalid_params) }
+
+    context "invalid params" do
+      context "must be numeric" do
+        let(:invalid_params) do
+          { medical_expenses: "awefwaefw" }
+        end
+
+        it "is invalid" do
+          expect(form.valid?).to eq false
+          expect(form.errors[:medical_expenses]).to include "Round to the nearest whole number"
+        end
+      end
+
+      context "must be an integer only" do
+        let(:invalid_params) do
+          { medical_expenses: 123.45 }
+        end
+
+        it "is invalid" do
+          expect(form.valid?).to eq false
+          expect(form.errors[:medical_expenses]).to include "Round to the nearest whole number"
+        end
+      end
+
+      context "cannot be negative" do
+        let(:invalid_params) do
+          { medical_expenses: "-123" }
+        end
+
+        it "is invalid" do
+          expect(form.valid?).to eq false
+          expect(form.errors[:medical_expenses]).to include "must be greater than or equal to 0"
+        end
+      end
+    end
+  end
+
+  describe ".save" do
+    let(:intake) {
+      create :state_file_nj_intake, medical_expenses: 0
+    }
+    let(:form) { described_class.new(intake, valid_params) }
+
+    context "when saving medical expenses" do
+      let(:valid_params) do
+        { medical_expenses: 12345 }
+      end
+
+      it "saves attributes" do
+        expect(form.valid?).to eq true
+        form.save
+
+        expect(intake.medical_expenses).to eq 12345
+      end
+    end
+  end
+end

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -899,6 +899,54 @@ RSpec.describe PdfFiller::Nj1040Pdf do
       end
     end
 
+    describe "line 31 medical expenses" do
+      context "with a gross income of 200k" do
+        let(:submission) {
+          create :efile_submission, tax_return: nil, data_source: create(
+            :state_file_nj_intake,
+            :df_data_many_w2s,
+            medical_expenses: 567_890
+          )
+        }
+        it "writes sum $563,890.00 to fill boxes on line 31" do
+          # thousands
+          expect(pdf_fields["31"]).to eq "5"
+          expect(pdf_fields["215"]).to eq "6"
+          expect(pdf_fields["216"]).to eq "3"
+          # hundreds
+          expect(pdf_fields["undefined_92"]).to eq "8"
+          expect(pdf_fields["217"]).to eq "9"
+          expect(pdf_fields["218"]).to eq "0"
+          # decimals
+          expect(pdf_fields["undefined_93"]).to eq "0"
+          expect(pdf_fields["219"]).to eq "0"
+        end
+      end
+
+      context "when medical expenses do not exceed 2% gross income" do
+        let(:submission) {
+          create :efile_submission, tax_return: nil, data_source: create(
+            :state_file_nj_intake,
+            :df_data_many_w2s,
+            medical_expenses: 4000
+          )
+        }
+        it "does not fill line 31" do
+          # thousands
+          expect(pdf_fields["31"]).to eq ""
+          expect(pdf_fields["215"]).to eq ""
+          expect(pdf_fields["216"]).to eq ""
+          # hundreds
+          expect(pdf_fields["undefined_92"]).to eq ""
+          expect(pdf_fields["217"]).to eq ""
+          expect(pdf_fields["218"]).to eq ""
+          # decimals
+          expect(pdf_fields["undefined_93"]).to eq ""
+          expect(pdf_fields["219"]).to eq ""
+        end
+      end
+    end
+
     describe "line 38 total exemptions and deductions" do
       let(:submission) {
         create :efile_submission, tax_return: nil, data_source: create(

--- a/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
@@ -331,6 +331,33 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
       end
     end
 
+    describe "line 31 medical expenses" do
+      context "with an income of 200k" do
+        let(:intake) { create(:state_file_nj_intake, :df_data_many_w2s, medical_expenses: 10_000) }
+        it "fills MedicalExpenses with medical expenses exceeding two percent gross income" do
+          expected_line_15_w2_wages = 200_000
+          two_percent_gross = expected_line_15_w2_wages * 0.02
+          expected_value = 10_000 - two_percent_gross
+          expect(xml.at("MedicalExpenses").text).to eq(expected_value.round.to_s)
+        end
+      end
+
+      context "with no income" do
+        let(:intake) { create(:state_file_nj_intake, :df_data_minimal, medical_expenses: 10_000) }
+        it "fills MedicalExpenses with full medical expesnse amount" do
+          expected_value = 10_000
+          expect(xml.at("MedicalExpenses").text).to eq(expected_value.round.to_s)
+        end
+      end
+
+      context "with no medical expenses" do
+        let(:intake) { create(:state_file_nj_intake, :df_data_minimal, medical_expenses: 0) }
+        it "does not fill MedicalExpenses" do
+          expect(xml.at("MedicalExpenses")).to eq(nil)
+        end
+      end
+    end
+
     describe "total exemptions and deductions - line 38" do
       let(:intake) { create(:state_file_nj_intake) }
       it "fills TotalExemptDeductions with total exemptions and deductions" do

--- a/spec/models/efile_error_spec.rb
+++ b/spec/models/efile_error_spec.rb
@@ -80,6 +80,7 @@ describe 'EfileError' do
       "nj-homeowner-property-tax",
       "nj-household-rent-own",
       "nj-ineligible-property-tax",
+      "nj-medical-expenses",
       "nj-municipality",
       "nj-review",
       "nj-tenant-eligibility",

--- a/spec/models/state_file_nj_intake_spec.rb
+++ b/spec/models/state_file_nj_intake_spec.rb
@@ -36,6 +36,7 @@
 #  last_sign_in_ip                                        :inet
 #  locale                                                 :string           default("en")
 #  locked_at                                              :datetime
+#  medical_expenses                                       :integer          default(0), not null
 #  message_tracker                                        :jsonb
 #  municipality_code                                      :string
 #  municipality_name                                      :string


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/75

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Add medical expenses column
- Add calculated medical expenses deduction
- Include medical expenses deduction in line 38

There are a few issues that need to be resolved in this PR or a subsequent one:
- ~The help text and label overlapping (we could do a quick fix with css obviously, but I would rather figure out why this is happening and fix that)~ Saw that this is also corrected in honeycrisp compact, so I corrected it for the whole application
- ~The placeholder text returning to 0.00 even though I gave an empty placeholder to the currency field~ should be fixed
- We need to update honeycrisp so we can use the accessible reveal component here and elsewhere

## How to test?
Select any directfile import and proceed to the medical expenses screen. Enter a value that is greater than 2% of gross income. When you get to the review screen, you should see medical expenses and be able to edit them.

A note for screen reader testing: one change I made here is on the review screen, where I included sr-only text to distinguish the medical expenses edit link from the others. We can use this pattern going forward and change it when we do the sundry a11y bugs ticket. The review screen should also use headers instead of styled text to indicate sections.

## Screenshots (for visual changes)
https://github.com/user-attachments/assets/51d9a3d5-b81d-43c4-99e9-543ff8b06566
<img width="536" alt="Screenshot 2024-10-17 at 11 35 56 AM" src="https://github.com/user-attachments/assets/01eebbd4-a61c-4fc8-986b-2ede80daccee">
