### PR TITLE
Update DOB handling between different guidelines w/raised error if missing DOB

### DIFF
--- a/app/lib/efile/az/az140_calculator.rb
+++ b/app/lib/efile/az/az140_calculator.rb
@@ -30,7 +30,7 @@ module Efile
         set_line(:AZ140_CCWS_LINE_5c, -> { 0 })
         set_line(:AZ140_CCWS_LINE_6c, :calculate_ccws_line_6c)
         set_line(:AZ140_CCWS_LINE_7c, :calculate_ccws_line_7c)
-        set_line(:AZ140_LINE_8, @direct_file_data, :fed_65_primary_spouse)
+        set_line(:AZ140_LINE_8, :calculate_line_8)
         set_line(:AZ140_LINE_9, @direct_file_data, :blind_primary_spouse)
         set_line(:AZ140_LINE_10A, @intake, :federal_dependent_count_under_17)
         set_line(:AZ140_LINE_10B, @intake, :federal_dependent_count_over_17_non_qualifying_senior)
@@ -100,6 +100,13 @@ module Efile
 
       def calculate_line_2c
         @intake.charitable_noncash_amount&.round
+      end
+
+      def calculate_line_8
+        # Age 65 or over (you and/or spouse) count
+        [@intake.primary_birth_date, @intake.spouse_birth_date].count do |dob|
+          dob && (@intake.calculate_age(inclusive_of_jan_1: true, dob: dob) >= 65)
+        end
       end
 
       def calculate_line_14

--- a/app/models/direct_file_data.rb
+++ b/app/models/direct_file_data.rb
@@ -510,18 +510,6 @@ class DirectFileData < DfXmlAccessor
     primary_ssn.start_with?("9")
   end
 
-  def fed_65_primary_spouse
-    elements_to_check = ['Primary65OrOlderInd', 'Spouse65OrOlderInd']
-    value = 0
-
-    elements_to_check.each do |element_name|
-      if parsed_xml.at(element_name)
-        value += 1
-      end
-    end
-    value
-  end
-
   def fed_w2_state
     df_xml_value(__method__)
   end

--- a/app/models/state_file_az_intake.rb
+++ b/app/models/state_file_az_intake.rb
@@ -109,11 +109,11 @@ class StateFileAzIntake < StateFileBaseIntake
 
   validates :az322_contributions, length: { maximum: 10 }, on: :az322
   def federal_dependent_count_under_17
-    self.dependents.select{ |dependent| dependent.age < 17 }.length
+    self.dependents.select{ |dependent| dependent.under_17? }.length
   end
 
   def federal_dependent_count_over_17_non_qualifying_senior
-    self.dependents.select{ |dependent| dependent.age >= 17 && !dependent.is_qualifying_parent_or_grandparent? }.length
+    self.dependents.select{ |dependent| !dependent.under_17? && !dependent.is_qualifying_parent_or_grandparent? }.length
   end
 
   def qualifying_parents_and_grandparents
@@ -221,12 +221,12 @@ class StateFileAzIntake < StateFileBaseIntake
         dependent[:months_in_home] < 6
       }
       hoh_qualifying_dependent = six_plus_months_in_home.max_by { |dependent|
-        [dependent[:months_in_home], -dependent.age]
+        [dependent[:months_in_home], -dependent.calculate_age(inclusive_of_jan_1: false)]
       }
       if hoh_qualifying_dependent.nil?
         hoh_qualifying_dependent = hoh_qualifying_dependents.select { |dependent|
           dependent[:relationship] == "PARENT"
-        }.max_by(&:age)
+        }.max_by { |dependent| dependent.calculate_age(inclusive_of_jan_1: false) }
       end
       {
         :first_name => hoh_qualifying_dependent.first_name,

--- a/app/models/state_file_base_intake.rb
+++ b/app/models/state_file_base_intake.rb
@@ -364,6 +364,8 @@ class StateFileBaseIntake < ApplicationRecord
     # federal guidelines: you qualify for age related benefits the day before your birthday
     # that means for a given tax year those born on Jan 1st the following tax-year will be included
     # this does not apply for benefits you age out of or any age calculations for Maryland
+    raise StandardError, "Primary or spouse missing date-of-birth" if dob.nil?
+
     birth_year = dob.year
     if inclusive_of_jan_1
       birthday_is_jan_1 = dob.month == 1 && dob.day == 1

--- a/app/models/state_file_base_intake.rb
+++ b/app/models/state_file_base_intake.rb
@@ -359,4 +359,16 @@ class StateFileBaseIntake < ApplicationRecord
       self.date_electronic_withdrawal = nil
     end
   end
+
+  def calculate_age(inclusive_of_jan_1: true, dob: primary.birth_date)
+    # federal guidelines: you qualify for age related benefits the day before your birthday
+    # that means for a given tax year those born on Jan 1st the following tax-year will be included
+    # this does not apply for benefits you age out of or any age calculations for Maryland
+    birth_year = dob.year
+    if inclusive_of_jan_1
+      birthday_is_jan_1 = dob.month == 1 && dob.day == 1
+      birth_year -= 1 if birthday_is_jan_1
+    end
+    MultiTenantService.statefile.current_tax_year - birth_year
+  end
 end

--- a/app/models/state_file_dependent.rb
+++ b/app/models/state_file_dependent.rb
@@ -82,15 +82,23 @@ class StateFileDependent < ApplicationRecord
   end
 
   def under_17?
-    age < 17
+    calculate_age(inclusive_of_jan_1: false) < 17
   end
 
   def senior?
-    age >= 65
+    calculate_age(inclusive_of_jan_1: true) >= 65
   end
 
-  def age
-    MultiTenantService.statefile.current_tax_year - dob.year
+  def calculate_age(inclusive_of_jan_1: true)
+    # federal guidelines: you qualify for age related benefits the day before your birthday
+    # that means for a given tax year those born on Jan 1st the following tax-year will be included
+    # this does not apply for benefits you age out of or any age calculations for Maryland
+    birth_year = dob.year
+    if inclusive_of_jan_1 && intake&.state_code != 'md'
+      birthday_is_jan_1 = dob.month == 1 && dob.day == 1
+      birth_year -= 1 if birthday_is_jan_1
+    end
+    MultiTenantService.statefile.current_tax_year - birth_year
   end
 
   def eligible_for_child_tax_credit

--- a/app/models/state_file_dependent.rb
+++ b/app/models/state_file_dependent.rb
@@ -93,6 +93,8 @@ class StateFileDependent < ApplicationRecord
     # federal guidelines: you qualify for age related benefits the day before your birthday
     # that means for a given tax year those born on Jan 1st the following tax-year will be included
     # this does not apply for benefits you age out of or any age calculations for Maryland
+    raise StandardError, "Dependent ##{id} is missing date-of-birth" if dob.nil?
+
     birth_year = dob.year
     if inclusive_of_jan_1 && intake&.state_code != 'md'
       birthday_is_jan_1 = dob.month == 1 && dob.day == 1

--- a/app/models/state_file_md_intake.rb
+++ b/app/models/state_file_md_intake.rb
@@ -88,4 +88,10 @@ class StateFileMdIntake < StateFileBaseIntake
       eligibility_out_of_state_income: "yes",
     }
   end
+
+  def calculate_age(inclusive_of_jan_1: false, dob: primary.birth_date)
+    # overwriting the base intake method b/c
+    # MD always considers individuals to attain their age on their DOB
+    MultiTenantService.statefile.current_tax_year - dob.year
+  end
 end

--- a/app/models/state_file_md_intake.rb
+++ b/app/models/state_file_md_intake.rb
@@ -92,6 +92,8 @@ class StateFileMdIntake < StateFileBaseIntake
   def calculate_age(inclusive_of_jan_1: false, dob: primary.birth_date)
     # overwriting the base intake method b/c
     # MD always considers individuals to attain their age on their DOB
+    raise StandardError, "Primary or spouse missing date-of-birth" if dob.nil?
+
     MultiTenantService.statefile.current_tax_year - dob.year
   end
 end

--- a/spec/factories/state_file_az_intakes.rb
+++ b/spec/factories/state_file_az_intakes.rb
@@ -96,6 +96,7 @@ FactoryBot.define do
     raw_direct_file_data { File.read(Rails.root.join('app', 'controllers', 'state_file', 'questions', 'df_return_sample.xml')) }
     primary_first_name { "Ariz" }
     primary_last_name { "Onian" }
+    primary_birth_date { Date.new((MultiTenantService.statefile.current_tax_year - 65), 12, 1) }
     state_file_analytics { StateFileAnalytics.create }
 
     after(:build) do |intake, evaluator|

--- a/spec/factories/state_file_dependents.rb
+++ b/spec/factories/state_file_dependents.rb
@@ -29,7 +29,7 @@
 #
 FactoryBot.define do
   factory :state_file_dependent do
-    intake
+    intake { create :state_file_az_intake }
     first_name { "Ali" }
     middle_initial {"U"}
     last_name { "Poppyseed" }

--- a/spec/lib/efile/az/az140_calculator_spec.rb
+++ b/spec/lib/efile/az/az140_calculator_spec.rb
@@ -185,6 +185,8 @@ describe Efile::Az::Az140Calculator do
       intake.charitable_cash_amount = 50
       intake.charitable_noncash_amount = 50
       intake.charitable_contributions = 'yes'
+      allow(instance).to receive(:calculate_line_42).and_return 10_000
+      allow(instance).to receive(:calculate_line_43).and_return 2_000
     end
 
     # 31% of 100 (50+50)
@@ -192,29 +194,67 @@ describe Efile::Az::Az140Calculator do
       instance.calculate
       expect(instance.lines[:AZ140_CCWS_LINE_7c].value).to eq(31)
       expect(instance.lines[:AZ140_LINE_44].value).to eq(31)
-      expect(instance.lines[:AZ140_LINE_45].value).to eq(98392) # Charitable contribitions affect this; before was 98423
+      expect(instance.lines[:AZ140_LINE_45].value).to eq(7_969)
+    end
+  end
+
+  describe "Line 8" do
+    let(:senior_cutoff_date) { Date.new((MultiTenantService.statefile.current_tax_year - 65), 12, 31) }
+
+    context "when both primary and spouse are older than 65" do
+      let(:intake) { create(:state_file_az_intake, primary_birth_date: senior_cutoff_date, spouse_birth_date: senior_cutoff_date) }
+
+      it "returns 2" do
+        instance.calculate
+        expect(instance.lines[:AZ140_LINE_8].value).to eq(2)
+      end
+    end
+
+    context "when only the primary is over 65" do
+      let(:intake) { create(:state_file_az_intake, primary_birth_date: senior_cutoff_date, spouse_birth_date: senior_cutoff_date + 2.months) }
+
+      it "returns 1" do
+        instance.calculate
+        expect(instance.lines[:AZ140_LINE_8].value).to eq(1)
+      end
+    end
+
+    context "when born a day after the senior cutoff date" do
+      let(:intake) { create(:state_file_az_intake, primary_birth_date: senior_cutoff_date + 1.day, spouse_birth_date: senior_cutoff_date + 1.day) }
+
+      it "it counts them" do
+        instance.calculate
+        expect(instance.lines[:AZ140_LINE_8].value).to eq(2)
+      end
     end
   end
 
   describe 'the Az flat tax rate is 2.5%' do
     context 'when the filer has an income of $25,000' do
       before do
-        intake.direct_file_data.fed_agi = 25_000
+        allow(instance).to receive(:calculate_line_42).and_return 25_000
+        allow(instance).to receive(:calculate_line_43).and_return 2_000
+        allow(instance).to receive(:calculate_line_44).and_return 2_000
       end
+
       it 'the tax is 2.5%' do
         instance.calculate
-        expect(instance.lines[:AZ140_LINE_45].value).to eq(3423) # Deductions mean this is taxable
-        expect(instance.lines[:AZ140_LINE_46].value).to eq(86)
+        expect(instance.lines[:AZ140_LINE_45].value).to eq(21_000) # Deductions mean this is taxable
+        expect(instance.lines[:AZ140_LINE_46].value).to eq(525)
       end
     end
+
     context 'when the filer has an income of $150,000' do
       before do
-        intake.direct_file_data.fed_agi = 150_000
+        allow(instance).to receive(:calculate_line_42).and_return 150_000
+        allow(instance).to receive(:calculate_line_43).and_return 2_000
+        allow(instance).to receive(:calculate_line_44).and_return 2_000
       end
+
       it 'the tax is 2.5%' do
         instance.calculate
-        expect(instance.lines[:AZ140_LINE_45].value).to eq(128423) # Deductions mean this is taxable
-        expect(instance.lines[:AZ140_LINE_46].value).to eq(3211)
+        expect(instance.lines[:AZ140_LINE_45].value).to eq(146000) # Deductions mean this is taxable
+        expect(instance.lines[:AZ140_LINE_46].value).to eq(3650)
       end
     end
   end

--- a/spec/models/state_file_base_intake_spec.rb
+++ b/spec/models/state_file_base_intake_spec.rb
@@ -119,4 +119,23 @@ describe StateFileBaseIntake do
       expect(intake.tax_calculator).to be_an_instance_of(Efile::Az::Az140Calculator)
     end
   end
+
+  describe "#calculate_age" do
+    let(:intake) { create :state_file_az_intake, primary_birth_date: dob }
+    let(:dob) { Date.new((MultiTenantService.statefile.end_of_current_tax_year.year - 10), 1, 1) }
+
+    context "when following federal guidelines" do
+      context "when calculating age for benefit one ages into" do
+        it "includes Jan 1st b-days for the past tax year" do
+          expect(intake.calculate_age(inclusive_of_jan_1: true, dob: dob)).to eq 11
+        end
+      end
+
+      context "when calculating age for benefits one ages out of" do
+        it "doesn't include Jan 1st for the past tax year" do
+          expect(intake.calculate_age(inclusive_of_jan_1: false, dob: dob)).to eq 10
+        end
+      end
+    end
+  end
 end

--- a/spec/models/state_file_md_intake_spec.rb
+++ b/spec/models/state_file_md_intake_spec.rb
@@ -76,4 +76,14 @@ require 'rails_helper'
 
 RSpec.describe StateFileMdIntake, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"
+
+  describe "#calculate_age" do
+    let(:intake) { create :state_file_md_intake, primary_birth_date: dob }
+    let(:dob) { Date.new((MultiTenantService.statefile.end_of_current_tax_year.year - 10), 1, 1) }
+
+    it "doesn't include Jan 1st in the past tax year" do
+      expect(intake.calculate_age(inclusive_of_jan_1: true, dob: dob)).to eq 10
+      expect(intake.calculate_age(inclusive_of_jan_1: false, dob: dob)).to eq 10
+    end
+  end
 end


### PR DESCRIPTION
Reverts codeforamerica/vita-min#4877
Same as #4840 but adds error messages:
![Screenshot 2024-10-17 at 4 05 50 PM](https://github.com/user-attachments/assets/455ecf53-952d-4542-bc00-d9923cd364d5)
## Link to pivotal/JIRA issue
- e.g. [JIRA link](https://codeforamerica.atlassian.net/browse/FYST-828?atlOrigin=eyJpIjoiMGZlZDBjNzJkYTFjNDFiZjg0M2ZmMmUxNGI0MTkzOGIiLCJwIjoiaiJ9)
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!
## What was done?
- there are different age calculations depending on the state or what benefits you're calculating the age for
  - most states follow federal guidelines which consider individuals to attain their age the day before their birthday for benefits that need you to be a certain age (for example, senior benefits) but **not** for benefits you age out (for example some dependent benefits)
  - Maryland is an outlier and always considers an individual to attain their age on the day of their birthday
  - this means that when calculating folks' age at the end of the tax year sometimes we have to include people with Jan 1st birthdays and sometimes we don't
  - I added a `calculate_age(inclusive_of_jan_1: true)` method to make it clear that this is a calculation that changes based on whether or not you want to include Jan 1st birthdays in the previous year
  - In the story description it said there were some options to use DF indicators instead of calculating it but I decided against this after talking to Courtney who said we can't reliably count on these always being provided in the DF xml and since Maryland calculates things differently we would have to calculate it anyways (except for <17 benefits)
## How to test?
- unit tests for state-file-dependent, state-file-az-intake and az-140 calculator specs
