### PR TITLE
Nj 90 external links

### DIFF
--- a/app/assets/images/icons/uswds-launch.svg
+++ b/app/assets/images/icons/uswds-launch.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"/></svg>

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -70,6 +70,7 @@
 @import "components/info-box";
 @import "components/form-cards";
 @import "components/offboarding";
+@import "components/external-link";
 @import "pages/form_13614c";
 @import "pages/provider-list";
 @import "pages/provider-details";
@@ -243,6 +244,10 @@ main {
   @include sr-only;
 }
 
+a[href^='http']:not([href*="fileyourstatetaxes.org" i]) {
+  @include external-link;
+}
+
 ul.with-bullets {
   margin-left: 20px;
   list-style-type: disc;
@@ -282,7 +287,7 @@ pre {
   position: fixed;
   transform: translateY(-100%);
   transition: transform 0.3s;
-  z-index: 3;
+  z-index: 1001;
 }
 
 .admin .skip-link {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -244,7 +244,7 @@ main {
   @include sr-only;
 }
 
-a[href^='http']:not([href*="fileyourstatetaxes.org" i]) {
+a[href^='http']:not([href*=request_domain i]) {
   @include external-link;
 }
 

--- a/app/assets/stylesheets/components/_external-link.scss
+++ b/app/assets/stylesheets/components/_external-link.scss
@@ -1,18 +1,8 @@
 // Taken from USWDS
 // https://github.com/uswds/uswds/blob/ae7129cafeeff2089e9ccfd4b286c50e8d7d0b5f/packages/uswds-core/src/styles/mixins/general/external-link.scss#L6
 
-$external-link-size: 1.75ex;
 $theme-external-link-sr-label-tab-same: "External.";
 $theme-external-link-sr-label-tab-new: "External, opens in a new tab";
-$icon-object: (
-  "name": "launch",
-  "color": currentColor,
-  "height": $external-link-size,
-  "svg-height": 24,
-  "svg-width": 24,
-  "position-x": center,
-  "position-y": center,
-);
 
 @mixin external-link($contrast-bg: "default") {
   display: inline-block;

--- a/app/assets/stylesheets/components/_external-link.scss
+++ b/app/assets/stylesheets/components/_external-link.scss
@@ -1,0 +1,49 @@
+// Taken from USWDS
+// https://github.com/uswds/uswds/blob/ae7129cafeeff2089e9ccfd4b286c50e8d7d0b5f/packages/uswds-core/src/styles/mixins/general/external-link.scss#L6
+
+$external-link-size: 1.75ex;
+$theme-external-link-sr-label-tab-same: "External.";
+$theme-external-link-sr-label-tab-new: "External, opens in a new tab";
+$icon-object: (
+  "name": "launch",
+  "color": currentColor,
+  "height": $external-link-size,
+  "svg-height": 24,
+  "svg-width": 24,
+  "position-x": center,
+  "position-y": center,
+);
+
+@mixin external-link($contrast-bg: "default") {
+  display: inline-block;
+
+  &::before {
+    @include sr-only;
+    content: $theme-external-link-sr-label-tab-same;
+  }
+
+  &[target="_blank"]::before {
+    @include sr-only;
+    content: $theme-external-link-sr-label-tab-new;
+  }
+
+  &::after {
+    background-image: url("icons/uswds-launch.svg");
+    color: currentColor;
+    content: "";
+    display: inline;
+    margin-top: 0.7ex;
+    margin-left: 2px;
+    padding-left: 1.75ex;
+    vertical-align: middle;
+
+    @supports (mask: url("")) {
+      background: none;
+      background-color: currentColor;
+      mask-image: url("icons/uswds-launch.svg"),
+        linear-gradient(transparent, transparent);
+      mask-repeat: no-repeat;
+    }
+  }
+
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,5 @@
 require "ordinalize_full/integer"
 module ApplicationHelper
-
   def number_in_words(number)
     number.ordinalize_in_full
   end
@@ -146,5 +145,9 @@ module ApplicationHelper
 
   def ctc_prior_tax_year
     MultiTenantService.new(:ctc).prior_tax_year
+  end
+
+  def request_domain
+    request.domain
   end
 end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/90

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
Copy the [USWDS external link indicator](https://designsystem.digital.gov/components/link/) pattern to visually show which links go to other sites and add sr-only text that indicates external links and links that open in new tabs, as recommended by USWDS, [W3C](https://www.w3.org/TR/WCAG20-TECHS/G201.html), and [Deque](https://dequeuniversity.com/checklists/web/links).

This PR marks any link that starts with http as external, excluding any link containing fileyourstatetaxes.org. We could add more urls to the exclusion list, or we could make this a class and manually apply it to every external link. The latter approach seems like it might be tedious and prone to being forgotten.

This PR also corrects the z index of the skip nav link to make it visible on top of the header.

## How to test?
Check out the footer links

## Screenshots (for visual changes)
<img width="642" alt="Screenshot 2024-10-18 at 5 26 10 PM" src="https://github.com/user-attachments/assets/0ae06448-6ff0-481b-b8b8-c88e368482e0">

