### PR TITLE
[FYST-992] adds a card to the income review page for SSA-1099

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -264,6 +264,11 @@ ul.with-bullets {
   color: $color-red;
 }
 
+.text--grey-bold {
+  font-weight: bold;
+  color: $color-grey-medium;
+}
+
 pre {
   white-space: pre-wrap;
 }

--- a/app/views/state_file/questions/income_review/edit.html.erb
+++ b/app/views/state_file/questions/income_review/edit.html.erb
@@ -27,5 +27,14 @@
     </div>
   <% end %>
 
+  <% if current_intake.direct_file_data.fed_ssb > 0 || current_intake.direct_file_data.fed_taxable_ssb > 0 %>
+    <div class="white-group">
+      <p class="text--bold spacing-below-0"><%= t(".ssa_title") %></p>
+      <p class="text--grey-bold spacing-above-15 spacing-below-0">
+        <%= t(".no_info_needed") %>
+      </p>
+    </div>
+  <% end %>
+
   <%= link_to t("general.continue"), next_path, class: "button button--wide button--primary text--centered" %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2458,7 +2458,9 @@ en:
       income_review:
         edit:
           help_text: We will ask about any missing information.
+          no_info_needed: No additional state info needed
           review_and_edit_state_info: Review and edit state info
+          ssa_title: Social Security benefits (SSA-1099)
           state_info_to_be_collected: State info to be collected
           title: Here are the income forms we transferred from your federal tax return.
           unemployment_title: Unemployment benefits (1099-G)

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2431,7 +2431,9 @@ es:
       income_review:
         edit:
           help_text: Le preguntaremos sobre cualquier información faltante.
+          no_info_needed: No se necesita información estatal adicional
           review_and_edit_state_info: Revisar y editar información del estado
+          ssa_title: Beneficios del Seguro Social (SSA-1099)
           state_info_to_be_collected: Información estatal que se recopilará.
           title: Estos son los formularios de ingresos que transferimos de su declaración de impuestos federales.
           unemployment_title: Beneficios de desempleo (1099-G)

--- a/spec/controllers/state_file/questions/income_review_controller_spec.rb
+++ b/spec/controllers/state_file/questions/income_review_controller_spec.rb
@@ -65,4 +65,41 @@ RSpec.describe StateFile::Questions::IncomeReviewController do
       end
     end
   end
+
+  describe "SSA-1099 card" do
+    render_views
+    before do
+      intake.direct_file_data.fed_ssb = fed_ssb
+      intake.direct_file_data.fed_taxable_ssb = fed_taxable_ssb
+      intake.update!(raw_direct_file_data: intake.direct_file_data.to_s)
+    end
+
+    context "they have social security benefits greater than zero" do
+      let(:fed_ssb) { 10 }
+      let(:fed_taxable_ssb) { 0 }
+      it "shows the SSA card" do
+        get :edit
+        expect(response.body).to have_text "Social Security benefits (SSA-1099)"
+      end
+    end
+
+    context "they have _taxable_ social security benefit greater than zero" do
+      let(:fed_ssb) { 0 }
+      let(:fed_taxable_ssb) { 10 }
+      it "shows the SSA card" do
+        get :edit
+        expect(response.body).to have_text "Social Security benefits (SSA-1099)"
+      end
+    end
+
+    context "they have no social security benefit income" do
+      let(:fed_ssb) { 0 }
+      let(:fed_taxable_ssb) { 0 }
+
+      it "doesn't show the SSA card" do
+        get :edit
+        expect(response.body).not_to have_text "Social Security benefits (SSA-1099)"
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
[FYST-992](https://codeforamerica.atlassian.net/browse/FYST-992)

## Is PM acceptance required? (delete one)
Yes! - don't merge until JIRA issue is accepted!
**Reminder**: merge main into this branch and get green tests before merging to main

## What was done?
- Added a bit of logic to render a basic card when the filer has Social Security benefits (>0) reported in their federal data
- All states w/ income review have the same card and logic
- It's rather boolean; if there's positive values in _either_ `SocSecBnftAmt` or `TaxableSocSecAmt` on the filer's 1040, the card is rendered. Otherwise it isn't.

## How to test?
- [ ] Positive Test
  - Choose a persona that has positive Social Security benefits (like AZ leslie_qss_v2)
  - Navigate to income review 
  - Observe the SSA-1099 card is visible
- [ ] Negative Test
  - Choose a persona that doesn't have any reported SS benefits (like AZ Martha)
  - Navigate to income review
  - Observe the SSA-1099 card is _not_ visible

## Screenshots (for visual changes)

### Before
![image](https://github.com/user-attachments/assets/37306966-7160-4207-bcc5-0dc4903c4d16)

### After
![image](https://github.com/user-attachments/assets/fcdddc63-b27e-465e-b5eb-22635e3cf9fe)



[FYST-992]: https://codeforamerica.atlassian.net/browse/FYST-992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ