### PR TITLE
Updated references to 2023 schema to 2024 schema

### DIFF
--- a/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
+++ b/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
@@ -17,7 +17,7 @@ module SubmissionBuilder
             }.freeze
 
             def schema_file
-              SchemaFileLoader.load_file("us_states", "unpacked", "NJIndividual2023V0.4", "NJIndividual", "NJForms", "FormNJ1040.xsd")
+              SchemaFileLoader.load_file("us_states", "unpacked", "NJIndividual2024V0.1", "NJIndividual", "NJForms", "FormNJ1040.xsd")
             end
 
             def document

--- a/app/lib/submission_builder/ty2024/states/nj/nj_return_xml.rb
+++ b/app/lib/submission_builder/ty2024/states/nj/nj_return_xml.rb
@@ -23,7 +23,7 @@ module SubmissionBuilder
           end
 
           def state_schema_version
-            "NJIndividual2023V0.4"
+            "NJIndividual2024V0.1"
           end
 
           def documents_wrapper
@@ -31,7 +31,7 @@ module SubmissionBuilder
           end
 
           def schema_file
-            SchemaFileLoader.load_file("us_states", "unpacked", "NJIndividual2023V0.4", "NJIndividual", "IndividualReturnNJ1040.xsd")
+            SchemaFileLoader.load_file("us_states", "unpacked", "NJIndividual2024V0.1", "NJIndividual", "IndividualReturnNJ1040.xsd")
           end
 
           def supported_documents

--- a/app/services/state_file/state_information_service.rb
+++ b/app/services/state_file/state_information_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module StateFile
   class StateInformationService
     GETTER_METHODS = [
@@ -48,8 +49,6 @@ module StateFile
         @_state_intake_class_names ||= state_intake_classes.map(&:to_s).freeze
       end
     end
-
-    private
 
     STATES_INFO = IceNine.deep_freeze!({
       az: {
@@ -140,7 +139,7 @@ module StateFile
         submission_builder_class: SubmissionBuilder::Ty2024::States::Nj::NjReturnXml,
         state_name: "New Jersey",
         return_type: "Resident",
-        schema_file_name: "NJIndividual2023V0.4.zip",
+        schema_file_name: "NJIndividual2024V0.1.zip",
         mail_voucher_address: "New Jersey Personal Income Tax<br/>" \
                               "Processing Center<br/>" \
                               "Trenton, NJ".html_safe,

--- a/spec/lib/schema_file_loader_spec.rb
+++ b/spec/lib/schema_file_loader_spec.rb
@@ -10,7 +10,7 @@ describe SchemaFileLoader do
       ["AZIndividual2023v1.0.zip", "us_states"],
       ["MDIndividual2023v1.0.zip", "us_states"],
       ["NCIndividual2023v1.0.zip", "us_states"],
-      ["NJIndividual2023V0.4.zip", "us_states"],
+      ["NJIndividual2024V0.1.zip", "us_states"],
       ["NYSIndividual2023V4.0.zip", "us_states"],
       ["ID.MeF2023V1.0.zip", "us_states"],
     ]
@@ -86,7 +86,7 @@ describe SchemaFileLoader do
           ["testy/us_states/AZIndividual2023v1.0.zip", 'us_states'],
           ["testy/us_states/MDIndividual2023v1.0.zip", 'us_states'],
           ["testy/us_states/NCIndividual2023v1.0.zip", 'us_states'],
-          ["testy/us_states/NJIndividual2023V0.4.zip", 'us_states'],
+          ["testy/us_states/NJIndividual2024V0.1.zip", 'us_states'],
           ["testy/us_states/NYSIndividual2023V4.0.zip", 'us_states'],
           ["testy/us_states/ID.MeF2023V1.0.zip", "us_states"]
         ]


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://github.com/newjersey/affordability-pm/issues/93

## Is PM acceptance required? (delete one)
- No

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Updated schemas from 2023 to 2024

## How to test?
- Installed 2024 NJ schemas locally and ran `rspec` locally
- Risk Assessment
  - Tests may fail until NJ 2024 schemas are installed on the test environment

## Screenshots (for visual changes)
N/A