### PR TITLE
Remove unemployment from NJ navigation

### DIFF
--- a/app/lib/navigation/state_file_nj_question_navigation.rb
+++ b/app/lib/navigation/state_file_nj_question_navigation.rb
@@ -39,7 +39,6 @@ module Navigation
                                           Navigation::NavigationStep.new(StateFile::Questions::NjHomeownerPropertyTaxController),
                                           Navigation::NavigationStep.new(StateFile::Questions::NjTenantRentPaidController),
                                           Navigation::NavigationStep.new(StateFile::Questions::NjSalesUseTaxController),
-                                          Navigation::NavigationStep.new(StateFile::Questions::UnemploymentController),
                                           Navigation::NavigationStep.new(StateFile::Questions::NjDisabledExemptionController),
                                           Navigation::NavigationStep.new(StateFile::Questions::TaxesOwedController),
                                           Navigation::NavigationStep.new(StateFile::Questions::TaxRefundController),

--- a/app/views/state_file/landing_page/edit.html.erb
+++ b/app/views/state_file/landing_page/edit.html.erb
@@ -65,7 +65,7 @@
               <% end %>
             <% else %>
               <div class="white-group spacing-below-60">
-                <%= t(".help_text_html") %>
+                <%= t(".#{@state_code}.help_text_html", default: t(".help_text_html")) %>
               </div>
               <%= form_with model: @form, url: { action: :update }, local: true, method: :put, builder: VitaMinFormBuilder do |f| %>
                 <%= f.submit t("general.get_started"), class: "button button--primary button--wide", id: "firstCta" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2110,6 +2110,15 @@ en:
         nj:
           built_with_html: "<strong>FileYourStateTaxes</strong> is built in partnership with the <strong>New Jersey Office of Innovation</strong> to integrate with the IRS Direct File tool. It takes about 10 to 15 minutes to complete <strong>once your federal return is accepted</strong>. Get started by setting up your account."
           closed_html: "<strong>FileYourStateTaxes</strong> is built in partnership with the New Jersey Office of Innovation to integrate with the IRS Direct File tool.<br /><br />\nWe're closed for the tax season. Unfortunately you can no longer file your state return with us this year.              \n"
+          help_text_html: |
+            <strong>What you’ll need:</strong>
+            <br />
+            <ul class="list--bulleted">
+              <li>An <strong>accepted</strong> 2023 federal return using <a href="https://directfile.irs.gov/">IRS Direct File</a>. (You don’t need a copy of this return; you’ll transfer your return here.)
+              <li>Email address or phone number</li>
+              <li>Driver’s license or state-issued ID</li>
+              <li>Bank routing and account numbers (if you want to receive your refund or make a tax payment electronically)</li>
+            </ul>
           supported_by: Supported by the New Jersey Office of Innovation
           title: File your New Jersey taxes for free
         not_you: Not %{user_name}?

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2076,6 +2076,15 @@ es:
           closed_html: |
             <strong>FileYourStateTaxes</strong> se creó en asociación con el New Jersey Office of Innovation para integrarse con la herramienta Direct File del IRS.<br /><br />
             Estamos cerrados por la temporada de impuestos. Desafortunadamente no puede presentar su declaración estatal con nosotros este año.
+          help_text_html: |
+            <strong>Lo que necesitarás para comenzar</strong>
+            <br />
+            <ul class="list--bulleted">
+              <li>Una declaración federal de 2023 <strong>aceptada</strong> mediante <a href="https://directfile.irs.gov/">IRS Direct File</a>. (No necesitas una copia de esta declaración; transferirás tu declaración aquí).</li>
+              <li>Dirección de correo electrónico o número de teléfono.</li>
+              <li>Licencia de conducir o identificación emitida por el estado.</li>
+              <li>Números de ruta bancaria y de cuenta (si deseas recibir tu reembolso o hacer un pago de impuestos electrónicamente).</li>
+            </ul>
           supported_by: Respaldada por el New Jersey Office of Innovation
           title: Presenta tus impuestos estatales de New Jersey sin costo
         not_you: "¿No es %{user_name}?"


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/99

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
Remove unemployment from NJ navigation controller

## How to test?
Go through the flow, observe the lack of unemployment question