### PR TITLE
NJ 128 - only show rent paid screen if tenant is eligible

### DIFF
--- a/app/controllers/state_file/questions/nj_tenant_rent_paid_controller.rb
+++ b/app/controllers/state_file/questions/nj_tenant_rent_paid_controller.rb
@@ -6,7 +6,7 @@ module StateFile
       before_action -> { @filing_year = Rails.configuration.statefile_current_tax_year }
 
       def self.show?(intake)
-        intake.household_rent_own == 'rent'
+        intake.household_rent_own == 'rent' && StateFile::NjTenantEligibilityHelper.determine_eligibility(intake) == StateFile::NjTenantEligibilityHelper::ADVANCE
       end
     end
   end

--- a/spec/controllers/state_file/questions/nj_tenant_rent_paid_controller_spec.rb
+++ b/spec/controllers/state_file/questions/nj_tenant_rent_paid_controller_spec.rb
@@ -34,6 +34,27 @@ RSpec.describe StateFile::Questions::NjTenantRentPaidController do
         expect(described_class.show?(intake)).to eq false
       end
     end
+
+    context "when ineligible hard no" do
+      let(:intake) { create :state_file_nj_intake, household_rent_own: "rent", tenant_home_subject_to_property_taxes: "no" }
+      it "does not show" do
+        expect(described_class.show?(intake)).to eq false
+      end
+    end
+
+    context "when unsupported soft no" do
+      let(:intake) { create :state_file_nj_intake, household_rent_own: "rent", tenant_more_than_one_main_home_in_nj: "yes" }
+      it "does not show" do
+        expect(described_class.show?(intake)).to eq false
+      end
+    end
+
+    context "when advance state" do
+      let(:intake) { create :state_file_nj_intake, household_rent_own: "rent", tenant_home_subject_to_property_taxes: "yes" }
+      it "shows" do
+        expect(described_class.show?(intake)).to eq true
+      end
+    end
   end
 
   describe "#edit" do


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/128

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
Test for eligibility when showing rent_paid controller (missed functionality for tenant that already exists for homeowner)

## How to test?
import Zeus w/ 1 dep
progress through to tenant question
mark a scenario that isn't supported (ex. do not check the first box)
hit continue after the ineligible screen
no longer see the rent paid screen

## Screenshots (for visual changes)

Before: https://github.com/user-attachments/assets/04c28087-d749-4fb1-9a3b-99feab50f06d

After:


https://github.com/user-attachments/assets/0837bf5a-c8aa-43e9-b02d-4e756f6f295f



