### PR TITLE
NJ 108 - line 58 basic EITC calculation from federal

### DIFF
--- a/app/lib/efile/line_data.yml
+++ b/app/lib/efile/line_data.yml
@@ -600,6 +600,8 @@ NJ1040_LINE_51:
   label: '51 Use Tax Due on Internet, Mail-Order, or Other Out-of-State Purchases (See instructions) If no Use Tax, enter 0.00'
 NJ1040_LINE_56:
   label: '56 Property Tax Credit (See instructions page 25)'
+NJ1040_LINE_58:
+  label: '58 New Jersey Earned Income Tax Credit (See instructions)'
 NJ1040_LINE_64:
   label: '64 Child and Dependent Care Credit'
 NJ1040_LINE_65_DEPENDENTS:

--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -248,7 +248,7 @@ module Efile
         should_use_property_tax_deduction ? calculate_property_tax_deduction : nil
       end
 
-      def calculate_line_42 
+      def calculate_line_42
         should_use_property_tax_deduction ? calculate_line_39 - calculate_property_tax_deduction : calculate_line_39
       end
 

--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -31,6 +31,7 @@ module Efile
         set_line(:NJ1040_LINE_43, :calculate_line_43)
         set_line(:NJ1040_LINE_51, :calculate_line_51)
         set_line(:NJ1040_LINE_56, :calculate_line_56)
+        set_line(:NJ1040_LINE_58, :calculate_line_58)
         set_line(:NJ1040_LINE_64, :calculate_line_64)
         set_line(:NJ1040_LINE_65_DEPENDENTS, :number_of_dependents_age_5_younger)
         set_line(:NJ1040_LINE_65, :calculate_line_65)
@@ -247,7 +248,7 @@ module Efile
         should_use_property_tax_deduction ? calculate_property_tax_deduction : nil
       end
 
-      def calculate_line_42
+      def calculate_line_42 
         should_use_property_tax_deduction ? calculate_line_39 - calculate_property_tax_deduction : calculate_line_39
       end
 
@@ -265,6 +266,10 @@ module Efile
         else
           is_mfs_same_home ? 25 : 50
         end
+      end
+
+      def calculate_line_58
+        (@direct_file_data.fed_eic * 0.4).round
       end
 
       def calculate_line_64

--- a/app/lib/pdf_filler/nj1040_pdf.rb
+++ b/app/lib/pdf_filler/nj1040_pdf.rb
@@ -71,7 +71,7 @@ module PdfFiller
         'Check Box44': pdf_checkbox_value(@xml_document.at("Exemptions SpouseCuPartnerBlindOrDisabled")),
         undefined_10: get_line_8_exemption_count,
         'x  1000_3': get_line_8_exemption_count * 1000,
-        
+
         Group1: filing_status,
         Group1qualwi5ab: spouse_death_year,
         Group182: household_rent_own,
@@ -327,6 +327,21 @@ module PdfFiller
                                                  ]))
       end
 
+      # line 58
+      if @xml_document.at("EarnedIncomeCredit EarnedIncomeCreditAmount").present?
+        tax = @xml_document.at("EarnedIncomeCredit EarnedIncomeCreditAmount").text.to_i
+        answers.merge!(insert_digits_into_fields(tax, [
+          "Text172",
+          "Text171",
+          "Text170",
+          "undefined_153",
+          "undefined_152",
+          "58",
+        ]))
+        answers.merge!({
+          'Check Box168': pdf_checkbox_value(@xml_document.at("EarnedIncomeCredit EICFederalAmt")),
+        })
+      end
 
       if mfj_spouse_ssn && xml_filing_status == 'MarriedCuPartFilingJoint'
         answers.merge!({
@@ -599,10 +614,10 @@ module PdfFiller
     def get_line_64_nj_child_dependent_care
       @xml_document.at('ChildDependentCareCredit')&.text.to_i
     end
-    
+
     def get_line_65_nj_ctc
       @xml_document.at("Body NJChildTaxCredit")&.text.to_i
     end
-    
+
   end
 end

--- a/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
+++ b/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
@@ -106,10 +106,11 @@ module SubmissionBuilder
                     xml.TaxableInterestIncome calculated_fields.fetch(:NJ1040_LINE_16A)
                   end
 
-                  if calculated_fields.fetch(:NJ1040_LINE_27) > 0
+                  if calculated_fields.fetch(:NJ1040_LINE_27).positive?
                     xml.TotalIncome calculated_fields.fetch(:NJ1040_LINE_27)
                   end
-                  if calculated_fields.fetch(:NJ1040_LINE_29) > 0
+
+                  if calculated_fields.fetch(:NJ1040_LINE_29).positive?
                     xml.GrossIncome calculated_fields.fetch(:NJ1040_LINE_29)
                   end
 
@@ -121,7 +122,7 @@ module SubmissionBuilder
 
                   xml.TotalExemptDeductions calculated_fields.fetch(:NJ1040_LINE_38)
 
-                  if calculated_fields.fetch(:NJ1040_LINE_39) > 0
+                  if calculated_fields.fetch(:NJ1040_LINE_39).positive?
                     xml.TaxableIncome calculated_fields.fetch(:NJ1040_LINE_39)
                   end
 
@@ -145,13 +146,20 @@ module SubmissionBuilder
                     end
                   end
 
-                  if calculated_fields.fetch(:NJ1040_LINE_42) > 0
+                  if calculated_fields.fetch(:NJ1040_LINE_42).positive?
                     xml.NewJerseyTaxableIncome calculated_fields.fetch(:NJ1040_LINE_42)
                   end
 
                   xml.Tax calculated_fields.fetch(:NJ1040_LINE_43)
 
                   xml.SalesAndUseTax calculated_fields.fetch(:NJ1040_LINE_51)
+
+                  if calculated_fields.fetch(:NJ1040_LINE_58).positive?
+                    xml.EarnedIncomeCredit do
+                      xml.EarnedIncomeCreditAmount calculated_fields.fetch(:NJ1040_LINE_58)
+                      xml.EICFederalAmt 'X'
+                    end
+                  end
 
                   xml.ChildDependentCareCredit calculated_fields.fetch(:NJ1040_LINE_64).to_i if calculated_fields.fetch(:NJ1040_LINE_64)
 

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -962,6 +962,24 @@ describe Efile::Nj::Nj1040Calculator do
     end
   end
 
+  describe 'line 58 - earned income tax credit' do
+    context 'when there is EarnedIncomeCreditAmt on the federal 1040' do
+      let(:intake) { create(:state_file_nj_intake) }
+
+      it 'sets line 58 to 40% of federal EITC (40% of $1490)' do
+        expect(instance.lines[:NJ1040_LINE_58].value).to eq(596)
+      end
+    end
+
+    context 'when there is no EarnedIncomeCreditAmt on the federal 1040' do
+      let(:intake) { create(:state_file_nj_intake, :df_data_minimal) }
+
+      it 'sets line 58 to 0' do
+        expect(instance.lines[:NJ1040_LINE_58].value).to eq(0)
+      end
+    end
+  end
+
   describe 'line 64 - child and dependent care credit' do
     let(:intake) { 
       create(

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -1281,6 +1281,61 @@ RSpec.describe PdfFiller::Nj1040Pdf do
       end
     end
 
+    describe "line 58 - earned income tax credit" do
+      context 'when there is EarnedIncomeCreditAmt on the federal 1040' do
+        let(:submission) {
+          create :efile_submission, tax_return: nil, data_source: create(
+            :state_file_nj_intake
+          )
+        }
+
+        it "fills line 58 with $596 for 40% of federal tax credit and checks federal checkbox" do
+          # thousands
+          expect(pdf_fields["58"]).to eq ""
+          # hundreds
+          expect(pdf_fields["undefined_152"]).to eq "5"
+          expect(pdf_fields["undefined_153"]).to eq "9"
+          expect(pdf_fields["Text170"]).to eq "6"
+          # decimals
+          expect(pdf_fields["Text171"]).to eq "0"
+          expect(pdf_fields["Text172"]).to eq "0"
+
+          # federal checkbox
+          expect(pdf_fields["Check Box168"]).to eq "Yes"
+
+          # NJ CU checkbox
+          expect(pdf_fields["Check Box169"]).to eq "Off"
+        end
+      end
+
+      context 'when there is no EarnedIncomeCreditAmt on the federal 1040' do
+        let(:submission) {
+          create :efile_submission, tax_return: nil, data_source: create(
+            :state_file_nj_intake, :df_data_minimal
+          )
+        }
+
+        it "does not fill line 58 and does not check any checkboxes" do
+          # thousands
+          expect(pdf_fields["58"]).to eq ""
+          # hundreds
+          expect(pdf_fields["undefined_152"]).to eq ""
+          expect(pdf_fields["undefined_153"]).to eq ""
+          expect(pdf_fields["Text170"]).to eq ""
+          # decimals
+          expect(pdf_fields["Text171"]).to eq ""
+          expect(pdf_fields["Text172"]).to eq ""
+
+          # federal checkbox
+          expect(pdf_fields["Check Box168"]).to eq "Off"
+
+          # NJ CU checkbox
+          expect(pdf_fields["Check Box169"]).to eq "Off"
+        end
+      end
+    end
+
+
     describe "line 64 child and dependent care credit" do
       let(:intake) {
         create(:state_file_nj_intake, :df_data_one_dep, :with_w2s_synced, :fed_credit_for_child_and_dependent_care)

--- a/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
@@ -508,7 +508,28 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
         expect(xml.at("PropertyTaxCredit").text).to eq(50.to_s)
       end
     end
-    
+
+    describe "earned income tax credit - line 58" do
+      context 'when there is EarnedIncomeCreditAmt on the federal 1040' do
+        let(:intake) { create(:state_file_nj_intake) }
+
+        it "fills EarnedIncomeCreditAmount with $596 for 40% of federal tax credit and checks EICFederalAmt" do
+          expect(xml.at("EarnedIncomeCredit EarnedIncomeCreditAmount").text).to eq(596.to_s)
+          expect(xml.at("EarnedIncomeCredit EICFederalAmt").text).to eq('X')
+        end
+      end
+
+      context 'when there is no EarnedIncomeCreditAmt on the federal 1040' do
+        let(:intake) { create(:state_file_nj_intake, :df_data_minimal) }
+
+        it "does not fill EarnedIncomeCreditAmount and does not check EICFederalAmt" do
+          expect(xml.at("EarnedIncomeCredit")).to eq(nil)
+          expect(xml.at("EarnedIncomeCredit EarnedIncomeCreditAmount")).to eq(nil)
+          expect(xml.at("EarnedIncomeCredit EICFederalAmt")).to eq(nil)
+        end
+      end
+    end
+
     describe "child and dependent care credit - line 64" do
       it "adds 40% of federal credit for an income of 60k or less" do
         allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_64).and_return 400


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/108

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Basic case for EITC - calculate as 40% of federal when it exists

## How to test?
- `minimal` for no federal EITC
- `two_w2s` has federal amount $1490

## Screenshots (for visual changes)
![image](https://github.com/user-attachments/assets/6c4e7024-2307-4b40-812f-84384bc53a00)
---
![image](https://github.com/user-attachments/assets/1906d6d2-77c0-4907-a379-bf62c890eb71)

