### PR TITLE
NJ 131 - fix CTC bug, limit dependent count to 9

### DIFF
--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -4,6 +4,7 @@ module Efile
       attr_reader :lines
 
       RENT_CONVERSION = 0.18
+      MAX_NJ_CTC_DEPENDENTS = 9
 
       def initialize(year:, intake:, include_source: false)
         super
@@ -299,7 +300,9 @@ module Efile
 
       def number_of_dependents_age_5_younger
         # TODO: revise once we have lines 10 and 11
-        @intake.dependents.count { |dependent| age_on_last_day_of_tax_year(dependent.dob) <= 5 }
+
+        dep_age_5_younger_count = @intake.dependents.count { |dependent| age_on_last_day_of_tax_year(dependent.dob) <= 5 }
+        [dep_age_5_younger_count, MAX_NJ_CTC_DEPENDENTS].min
       end
 
       def is_over_65(birth_date)

--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -299,8 +299,6 @@ module Efile
       end
 
       def number_of_dependents_age_5_younger
-        # TODO: revise once we have lines 10 and 11
-
         dep_age_5_younger_count = @intake.dependents.count { |dependent| age_on_last_day_of_tax_year(dependent.dob) <= 5 }
         [dep_age_5_younger_count, MAX_NJ_CTC_DEPENDENTS].min
       end

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -1074,6 +1074,7 @@ describe Efile::Nj::Nj1040Calculator do
         instance.calculate
         expect(intake.dependents.count).to eq(1)
         expect(instance.lines[:NJ1040_LINE_65].value).to eq(nil)
+        expect(instance.lines[:NJ1040_LINE_65_DEPENDENTS].value).to eq(0)
       end
     end
 
@@ -1095,6 +1096,7 @@ describe Efile::Nj::Nj1040Calculator do
           instance.calculate
           expect(intake.dependents.count).to eq(11)
           expect(instance.lines[:NJ1040_LINE_65].value).to eq(1000)
+          expect(instance.lines[:NJ1040_LINE_65_DEPENDENTS].value).to eq(1)
         end
 
         it 'returns 800 for 1 eligible dependent and a taxable income of 40k' do
@@ -1102,6 +1104,7 @@ describe Efile::Nj::Nj1040Calculator do
           instance.calculate
           expect(intake.dependents.count).to eq(11)
           expect(instance.lines[:NJ1040_LINE_65].value).to eq(800)
+          expect(instance.lines[:NJ1040_LINE_65_DEPENDENTS].value).to eq(1)
         end
       end
 
@@ -1113,16 +1116,18 @@ describe Efile::Nj::Nj1040Calculator do
           intake.dependents.reload
         end
 
-        it 'returns 11000 for 11 eligible dependents and a taxable income of 10k' do
+        it 'returns $9000 ($1000*9) for 11 eligible dependents (reduced to max 9) and a taxable income of 10k' do
           allow(instance).to receive(:calculate_line_42).and_return 10_000
           instance.calculate
-          expect(instance.lines[:NJ1040_LINE_65].value).to eq(11_000)
+          expect(instance.lines[:NJ1040_LINE_65].value).to eq(9_000)
+          expect(instance.lines[:NJ1040_LINE_65_DEPENDENTS].value).to eq(9)
         end
 
-        it 'returns 8800 for 11 dependents and a taxable income of 40k' do
+        it 'returns $7200 ($800*9) for 11 dependents (reduced to max 9) and a taxable income of 40k' do
           allow(instance).to receive(:calculate_line_42).and_return 40_000
           instance.calculate
-          expect(instance.lines[:NJ1040_LINE_65].value).to eq(8800)
+          expect(instance.lines[:NJ1040_LINE_65].value).to eq(7_200)
+          expect(instance.lines[:NJ1040_LINE_65_DEPENDENTS].value).to eq(9)
         end
       end
     end

--- a/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
@@ -48,8 +48,16 @@ describe SubmissionBuilder::Ty2024::States::Nj::NjReturnXml, required_schema: "n
         end
       end
 
-      context "with many deps" do
+      context "with many deps all under 5 yrs old" do
         let(:intake) { create(:state_file_nj_intake, :df_data_many_deps, municipality_code: "0101") }
+
+        before do
+          five_years = Date.new(MultiTenantService.new(:statefile).current_tax_year - 5, 1, 1)
+          intake.synchronize_df_dependents_to_database
+          intake.dependents.each do |d| d.update(dob: five_years) end
+          intake.dependents.reload
+        end
+
         it "does not error" do
           builder_response = described_class.build(submission)
           expect(builder_response.errors).not_to be_present


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/131

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Add XML tests for case when more than 10 deps all under age of 5
- limit CTC dependent count to 9 max

## How to test?
- Use `zeus_many_deps`

## Screenshots (for visual changes)
Before:
```
189:0: ERROR: Element '{http://www.irs.gov/efile}NJChildTCNumOfDep': [facet 'totalDigits'] The value '10' has more digits than are allowed ('1').
189:0: ERROR: Element '{http://www.irs.gov/efile}NJChildTCNumOfDep': [facet 'maxInclusive'] The value '10' is greater than the maximum value allowed ('9').
```

After: No errors