### PR TITLE
Add negative case for NC sales use tax calculation

### DIFF
--- a/app/lib/efile/nc/d400_calculator.rb
+++ b/app/lib/efile/nc/d400_calculator.rb
@@ -41,10 +41,10 @@ module Efile
       end
 
       def calculate_use_tax(nc_taxable_income)
-        return 0 if nc_taxable_income < 0
+        return 0 if nc_taxable_income.nil?
 
         brackets = [
-          [0, 2200, 1], [2200, 3700, 2], [3700, 5200, 3], [5200, 6700, 4],
+          [-Float::INFINITY, 2200, 1], [2200, 3700, 2], [3700, 5200, 3], [5200, 6700, 4],
           [6700, 8100, 5], [8100, 9600, 6], [9600, 11100, 7], [11100, 12600, 8],
           [12600, 14100, 9], [14100, 15600, 10], [15600, 17000, 11], [17000, 18500, 12],
           [18500, 20000, 13], [20000, 21500, 14], [21500, 23000, 15], [23000, 24400, 16],
@@ -119,6 +119,7 @@ module Efile
         # Line 15 minus Line 16 (line 16 is 0/blank)
         line_or_zero(:NCD400_LINE_15)
       end
+
       def calculate_line_18
         # Consumer use tax
         if @intake.untaxed_out_of_state_purchases_yes?

--- a/spec/lib/efile/nc/d400_calculator_spec.rb
+++ b/spec/lib/efile/nc/d400_calculator_spec.rb
@@ -128,6 +128,15 @@ describe Efile::Nc::D400Calculator do
     context "they have untaxed out of state purchases and selected automated calculation" do
       let(:intake) { create(:state_file_nc_intake, untaxed_out_of_state_purchases: "yes", sales_use_tax_calculation_method: "automated") }
 
+      context "nc taxable income is negative" do
+        it "returns 1" do
+          allow(instance).to receive(:calculate_line_14).and_return -1_000
+          instance.calculate
+
+          expect(instance.lines[:NCD400_LINE_18].value).to eq 1
+        end
+      end
+
       context "nc taxable income is 2,100" do
         it "returns 1" do
           allow(instance).to receive(:calculate_line_14).and_return 2_100


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. [link](https://codeforamerica.atlassian.net/browse/FYST-1039?atlOrigin=eyJpIjoiZDU5OGViOWE0NDlhNDM4NWI0Y2RhOWE0ZGU0NDhlMDEiLCJwIjoiaiJ9)
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Instead of the NC sales use tax calculation returning 0 if the AGI is negative it should return 1; realized this was probably the case after reviewing NJ sales use tax story, here is the thread from that [story](https://github.com/codeforamerica/vita-min/pull/4899/files#diff-3851a4e7d18c585e8b47946e9886591879f7fc8586477297f5ccae0ea5f9a222) below:
<img width="545" alt="Screenshot 2024-10-28 at 5 13 26 PM" src="https://github.com/user-attachments/assets/e25c006e-236c-45d5-9155-7f438efb7252">
<img width="545" alt="Screenshot 2024-10-28 at 5 13 33 PM" src="https://github.com/user-attachments/assets/041aab97-736d-433c-9bca-66ea1e0ceb8b">

## How to test?
- If AGI is negative for a NC intake then the sales use tax should be 1
