### PR TITLE
Remove age method from person class and replace references in calculate_md502_cr_part_m_line_1

### DIFF
--- a/app/lib/efile/md/md502_calculator.rb
+++ b/app/lib/efile/md/md502_calculator.rb
@@ -148,13 +148,13 @@ module Efile
         agi = line_or_zero(:MD502_LINE_1)
         credit = 0
         if (filing_status_mfj? || filing_status_qw? || filing_status_hoh?) && agi <= 150_000
-          if @intake.primary.age >= 65 && @intake.spouse.age >= 65
+          if @intake.primary_senior? && @intake.spouse_senior?
             credit = 1750
-          elsif (@intake.primary.age >= 65) ^ (@intake.spouse.age >= 65)
+          elsif @intake.primary_senior? ^ @intake.spouse_senior?
             credit = 1000
           end
         elsif (filing_status_single? || filing_status_mfs?) && agi <= 100_000
-          if @intake.primary.age >= 65
+          if @intake.primary_senior?
             credit = 1000
           end
         end

--- a/app/models/state_file_base_intake.rb
+++ b/app/models/state_file_base_intake.rb
@@ -269,10 +269,6 @@ class StateFileBaseIntake < ApplicationRecord
       end
     end
 
-    def age
-      birth_date.present? ? MultiTenantService.statefile.current_tax_year - birth_date.year : 0
-    end
-
     def full_name
       [@first_name, @middle_initial, @last_name, @suffix].map(&:presence).compact.join(' ')
     end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. [link](https://codeforamerica.atlassian.net/browse/FYST-1040?atlOrigin=eyJpIjoiNzJmYWRlNmZiNzRjNDQzNmE0NTdlNzFmMzBmOTA2YjgiLCJwIjoiaiJ9)
## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- We changed how we calculate DOB in this [story](https://codeforamerica.atlassian.net/browse/FYST-1040?atlOrigin=eyJpIjoiNzJmYWRlNmZiNzRjNDQzNmE0NTdlNzFmMzBmOTA2YjgiLCJwIjoiaiJ9); this age method does not reflect the differences in guidelines across states and should be removed and references instead should use the calculate_age method or other methods that ultimately use it
## How to test?
- should function the same, current tests for this method still pass 

