### PR TITLE
Remove old add_columns_to_state_file_w2, replace with one that doesn't have not-null constraint

### DIFF
--- a/app/models/state_file_w2.rb
+++ b/app/models/state_file_w2.rb
@@ -3,9 +3,9 @@
 # Table name: state_file_w2s
 #
 #  id                          :bigint           not null, primary key
-#  employee_name               :string           not null
+#  employee_name               :string
 #  employee_ssn                :string
-#  employer_name               :string           not null
+#  employer_name               :string
 #  employer_state_id_num       :string
 #  local_income_tax_amount     :decimal(12, 2)
 #  local_wages_and_tips_amount :decimal(12, 2)

--- a/db/migrate/20241017215227_add_columns_to_state_file_w2.rb
+++ b/db/migrate/20241017215227_add_columns_to_state_file_w2.rb
@@ -1,6 +1,0 @@
-class AddColumnsToStateFileW2 < ActiveRecord::Migration[7.1]
-  def change
-    add_column :state_file_w2s, :employer_name, :string, null: false
-    add_column :state_file_w2s, :employee_name, :string, null: false
-  end
-end

--- a/db/migrate/20241028231420_add_columns_to_state_file_w2.rb
+++ b/db/migrate/20241028231420_add_columns_to_state_file_w2.rb
@@ -1,0 +1,6 @@
+class AddColumnsToStateFileW2 < ActiveRecord::Migration[7.1]
+  def change
+    add_column :state_file_w2s, :employer_name, :string
+    add_column :state_file_w2s, :employee_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_21_190718) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_28_231420) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -2251,9 +2251,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_21_190718) do
 
   create_table "state_file_w2s", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.string "employee_name", null: false
+    t.string "employee_name"
     t.string "employee_ssn"
-    t.string "employer_name", null: false
+    t.string "employer_name"
     t.string "employer_state_id_num"
     t.decimal "local_income_tax_amount", precision: 12, scale: 2
     t.decimal "local_wages_and_tips_amount", precision: 12, scale: 2

--- a/spec/factories/state_file_w2s.rb
+++ b/spec/factories/state_file_w2s.rb
@@ -3,9 +3,9 @@
 # Table name: state_file_w2s
 #
 #  id                          :bigint           not null, primary key
-#  employee_name               :string           not null
+#  employee_name               :string
 #  employee_ssn                :string
-#  employer_name               :string           not null
+#  employer_name               :string
 #  employer_state_id_num       :string
 #  local_income_tax_amount     :decimal(12, 2)
 #  local_wages_and_tips_amount :decimal(12, 2)

--- a/spec/models/state_file_w2_spec.rb
+++ b/spec/models/state_file_w2_spec.rb
@@ -3,9 +3,9 @@
 # Table name: state_file_w2s
 #
 #  id                          :bigint           not null, primary key
-#  employee_name               :string           not null
+#  employee_name               :string
 #  employee_ssn                :string
-#  employer_name               :string           not null
+#  employer_name               :string
 #  employer_state_id_num       :string
 #  local_income_tax_amount     :decimal(12, 2)
 #  local_wages_and_tips_amount :decimal(12, 2)


### PR DESCRIPTION
a migration in https://github.com/codeforamerica/vita-min/pull/4886 included a not-null constraint on a new column for state file w2s. since we already have records in that table and didn't give it a default value, this ended up crashing on the deploy to demo. this PR removes that old migration and replaces it with one that doesn't have the not-null requirement. our thinking here is that this will not be an issue for demo (or any other shared environment) as it has failed to run the old migration. if anyone has run it locally they will have to reset their database.

slack conversation:
https://cfastaff.slack.com/archives/C0544ERAFQV/p1730155406015459