### PR TITLE
NJ 140 - fix XML errors and add schema validation to all XML tests

### DIFF
--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -201,7 +201,7 @@ module Efile
 
         sum = 0
         @intake.state_file_w2s.each do |w2|
-          state_wage = w2.state_wages_amount
+          state_wage = w2.state_wages_amount.to_i
           sum += state_wage
         end
         sum

--- a/spec/factories/state_file_nj_intakes.rb
+++ b/spec/factories/state_file_nj_intakes.rb
@@ -110,6 +110,7 @@ FactoryBot.define do
     raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nj_zeus_one_dep') }
     
     after(:build) do |intake, evaluator|
+      intake.municipality_code = "0101"
       numeric_status = {
         single: 1,
         married_filing_jointly: 2,
@@ -133,14 +134,11 @@ FactoryBot.define do
       end
       intake.update(overrides)
 
+      intake.synchronize_df_w2s_to_database
       intake.synchronize_df_dependents_to_database
       intake.dependents.each_with_index do |dependent, i|
         dependent.update(dob: i.years.ago)
       end
-    end
-
-    trait :with_w2s_synced do
-      after(:create, &:synchronize_df_w2s_to_database)
     end
 
     trait :df_data_2_w2s do

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -366,25 +366,23 @@ describe Efile::Nj::Nj1040Calculator do
     let(:intake) { create(:state_file_nj_intake) }
 
     context 'when no state file w2s' do
+      let(:intake) { create(:state_file_nj_intake, :df_data_minimal) }
       it 'sets line 15 to -1 to indicate the sum does not exist' do
         expect(instance.lines[:NJ1040_LINE_15].value).to eq(-1)
       end
     end
 
     context 'when 2 state file w2s' do
+      let(:intake) { create(:state_file_nj_intake, :df_data_2_w2s) }
       it 'sets line 15 to the sum of all state wage amounts' do
-        create(:state_file_w2, state_file_intake: intake, state_wages_amount: 12345)
-        create(:state_file_w2, state_file_intake: intake, state_wages_amount: 50000)
-        instance.calculate
         expected_sum = 12345 + 50000
         expect(instance.lines[:NJ1040_LINE_15].value).to eq(expected_sum)
       end
     end
 
     context 'when many state file w2s' do
+      let(:intake) { create(:state_file_nj_intake, :df_data_many_w2s) }
       it 'sets line 15 to the sum of all state wage amounts' do
-        4.times { create(:state_file_w2, state_file_intake: intake, state_wages_amount: 50000) }
-        instance.calculate
         expected_sum = 50000 + 50000 + 50000 + 50000
         expect(instance.lines[:NJ1040_LINE_15].value).to eq(expected_sum)
       end

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -638,8 +638,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
         let(:submission) {
           create :efile_submission, tax_return: nil, data_source: create(
             :state_file_nj_intake,
-            :df_data_many_w2s,
-            :with_w2s_synced
+            :df_data_many_w2s
           )
         }
 
@@ -665,8 +664,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
         let(:submission) {
           create :efile_submission, tax_return: nil, data_source: create(
             :state_file_nj_intake,
-            :df_data_2_w2s,
-            :with_w2s_synced
+            :df_data_2_w2s
           )
         }
 
@@ -800,8 +798,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
         let(:submission) {
           create :efile_submission, tax_return: nil, data_source: create(
             :state_file_nj_intake,
-            :df_data_many_w2s,
-            :with_w2s_synced
+            :df_data_many_w2s
           )
         }
         it "fills in the total income boxes in the PDF on line 27 with the rounded value" do
@@ -855,8 +852,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
         let(:submission) {
           create :efile_submission, tax_return: nil, data_source: create(
             :state_file_nj_intake,
-            :df_data_many_w2s,
-            :with_w2s_synced
+            :df_data_many_w2s
           )
         }
         it "fills in the gross income boxes in the PDF on line 29 with the rounded value" do
@@ -911,7 +907,6 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           create :efile_submission, tax_return: nil, data_source: create(
             :state_file_nj_intake,
             :df_data_many_w2s,
-            :with_w2s_synced,
             medical_expenses: 567_890
           )
         }
@@ -935,7 +930,6 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           create :efile_submission, tax_return: nil, data_source: create(
             :state_file_nj_intake,
             :df_data_many_w2s,
-            :with_w2s_synced,
             medical_expenses: 4000
           )
         }
@@ -981,7 +975,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
     describe "line 39 taxable income" do
       let(:submission) {
         create :efile_submission, tax_return: nil, data_source: create(
-          :state_file_nj_intake, :df_data_many_w2s, :with_w2s_synced
+          :state_file_nj_intake, :df_data_many_w2s
         )
       }
       it "writes taxable income $199,000 (200,000-1000) to fill boxes on line 39" do
@@ -1038,7 +1032,6 @@ RSpec.describe PdfFiller::Nj1040Pdf do
         let(:submission) {
           create :efile_submission, tax_return: nil, data_source: create(
             :state_file_nj_intake,
-            :with_w2s_synced,
             household_rent_own: 'own',
             property_tax_paid: 12345678
           )
@@ -1096,7 +1089,6 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           create :efile_submission, tax_return: nil, data_source: create(
              :state_file_nj_intake,
              :df_data_many_w2s,
-             :with_w2s_synced,
              household_rent_own: 'own',
              property_tax_paid: 15_000,
           )
@@ -1144,7 +1136,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
     describe "line 42 new jersey taxable income" do
       let(:submission) {
         create :efile_submission, tax_return: nil, data_source: create(
-          :state_file_nj_intake, :df_data_many_w2s, :with_w2s_synced
+          :state_file_nj_intake, :df_data_many_w2s
         )
       }
       it "writes new jersey taxable income $199,000 (200,000-1000) to fill boxes on line 39" do
@@ -1171,7 +1163,6 @@ RSpec.describe PdfFiller::Nj1040Pdf do
         create :efile_submission, tax_return: nil, data_source: create(
           :state_file_nj_intake,
           :df_data_many_w2s,
-          :with_w2s_synced,
           :married_filing_jointly,
           household_rent_own: 'own',
           property_tax_paid: 15_000,
@@ -1240,7 +1231,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
 
     describe "line 64 child and dependent care credit" do
       let(:intake) {
-        create(:state_file_nj_intake, :df_data_one_dep, :with_w2s_synced, :fed_credit_for_child_and_dependent_care)
+        create(:state_file_nj_intake, :df_data_one_dep, :fed_credit_for_child_and_dependent_care)
       }
       let(:submission) {
         create :efile_submission, tax_return: nil, data_source: intake
@@ -1268,8 +1259,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
       let(:intake) {
         create(
           :state_file_nj_intake,
-          :df_data_one_dep,
-          :with_w2s_synced
+          :df_data_one_dep
         )
       }
       let(:submission) {

--- a/spec/lib/submission_builder/state_return_spec.rb
+++ b/spec/lib/submission_builder/state_return_spec.rb
@@ -18,89 +18,29 @@ describe SubmissionBuilder::StateReturn do
   states_requiring_w2s.each do |state_code|
     describe "#combined_w2s", required_schema: state_code do
       let(:builder_class) { StateFile::StateInformationService.submission_builder_class(state_code) }
-      let(:intake) { create("state_file_#{state_code}_intake".to_sym, filing_status: filing_status) }
+      let(:intake) { create("state_file_#{state_code}_intake".to_sym) }
       let(:submission) { create(:efile_submission, data_source: intake) }
       let(:vars) { spec_vars[state_code.to_sym] || spec_vars[:default] }
+      before do
+        intake.synchronize_df_w2s_to_database
+      end
 
       context "#{state_code}: when there are w2s present" do
-        let(:filing_status) { 'single' }
-
-        context "when the intake does not have any state_file_w2s" do
-          it "copies all w2s from the direct file xml field" do
-            xml = Nokogiri::XML::Document.parse(builder_class.build(submission).document.to_xml)
-            expect(xml.css(vars[:w2_node_name]).count).to eq intake.direct_file_data.w2s.length
-          end
-        end
-
         context "when the intake has state_file_w2s" do
           context "create, update, delete nodes" do
             let(:intake) { create "state_file_#{state_code}_intake".to_sym, :df_data_2_w2s }
-            let!(:state_file_w2) {
-              create(
-                :state_file_w2,
-                state_file_intake: intake,
-                w2_index: 1,
-                employer_state_id_num: "00123",
-                local_income_tax_amount: "0",
-                local_wages_and_tips_amount: "2000",
-                locality_nm: intake.direct_file_data.w2s[0].LocalityNm,
-                state_income_tax_amount: "700",
-                state_wages_amount: "2000",
-                )
-            }
-            before do
-              xml = Nokogiri::XML(intake.raw_direct_file_data)
-              xml.search(vars[:w2_node_name]).each_with_index do |w2, i|
-                if i == 1
-                  w2.at("StateWagesAmt").remove
-                end
-              end
-              intake.update(raw_direct_file_data: xml.to_xml)
-            end
 
-            it "prioritises state_file_w2s over w2s from the direct file xml, correctly updates & creates & deletes nodes" do
+            it "copies the state and local tags from the state_file_w2s table into the state return xml" do
               xml = Nokogiri::XML::Document.parse(builder_class.build(submission).document.to_xml)
 
-              # w2 at index 0 remains the same
-              w2_from_xml = xml.css(vars[:w2_node_name])[0]
-              expect(w2_from_xml.at(vars[:employer_state_id_num_name]).text).to eq intake.direct_file_data.w2s[0].node.at("W2StateLocalTaxGrp EmployerStateIdNum").text
-              expect(w2_from_xml.at("LocalIncomeTaxAmt").text).to eq intake.direct_file_data.w2s[0].node.at("W2StateLocalTaxGrp LocalIncomeTaxAmt").text
-              expect(w2_from_xml.at("LocalWagesAndTipsAmt").text).to eq intake.direct_file_data.w2s[0].node.at("W2StateLocalTaxGrp LocalWagesAndTipsAmt").text
-              expect(w2_from_xml.at(vars[:locality_name]).text).to eq intake.direct_file_data.w2s[0].node.at("W2StateLocalTaxGrp LocalityNm").text.upcase
-              expect(w2_from_xml.at("StateIncomeTaxAmt").text).to eq intake.direct_file_data.w2s[0].node.at("W2StateLocalTaxGrp StateIncomeTaxAmt").text
-              expect(w2_from_xml.at("StateWagesAmt").text).to eq intake.direct_file_data.w2s[0].node.at("W2StateLocalTaxGrp StateWagesAmt").text
-
-              # w2 at index 1 is filled in with info from client
-              w2_from_db = xml.css(vars[:w2_node_name])[1]
-              expect(w2_from_db.at(vars[:employer_state_id_num_name]).text).to eq state_file_w2.employer_state_id_num
-              expect(w2_from_db.at("LocalIncomeTaxAmt").text).to eq state_file_w2.local_income_tax_amount.round.to_s
-              expect(w2_from_db.at("LocalWagesAndTipsAmt").text).to eq state_file_w2.local_wages_and_tips_amount.round.to_s
-              expect(w2_from_db.at(vars[:locality_name]).text).to eq state_file_w2.locality_nm
-              expect(w2_from_db.at("StateIncomeTaxAmt").text).to eq state_file_w2.state_income_tax_amount.round.to_s
-              expect(w2_from_db.at("StateWagesAmt").text).to eq state_file_w2.state_wages_amount.round.to_s
-            end
-          end
-
-          context "updating multiple w2s" do
-            let(:intake) { create "state_file_#{state_code}_intake".to_sym, :df_data_many_w2s }
-            let!(:original_w2_count) { intake.direct_file_data.w2s.length }
-            let!(:w2_1) { create(:state_file_w2, state_file_intake: intake, w2_index: 0) }
-            let!(:w2_2) { create(:state_file_w2, state_file_intake: intake, w2_index: 1) }
-            let!(:w2_3) { create(:state_file_w2, state_file_intake: intake, w2_index: 2) }
-            let!(:w2_4) { create(:state_file_w2, state_file_intake: intake, w2_index: 3) }
-
-            it "updates the correct tags" do
-              w2 = vars[:w2_node_name]
-              generated_document = Nokogiri::XML::Document.parse(builder_class.build(submission).document.to_xml, &:noblanks)
-
-              expect(generated_document.css(w2).count).to eq original_w2_count
-              (0..3).each do |i|
-                expect(generated_document.css(w2)[i].at(vars[:employer_state_id_num_name]).text).to eq send("w2_#{i+1}").employer_state_id_num
-                expect(generated_document.css(w2)[i].at("LocalIncomeTaxAmt").text).to eq send("w2_#{i+1}").local_income_tax_amount.round.to_s
-                expect(generated_document.css(w2)[i].at("LocalWagesAndTipsAmt").text).to eq send("w2_#{i+1}").local_wages_and_tips_amount.round.to_s
-                expect(generated_document.css(w2)[i].at(vars[:locality_name]).text).to eq send("w2_#{i+1}").locality_nm
-                expect(generated_document.css(w2)[i].at("StateIncomeTaxAmt").text).to eq send("w2_#{i+1}").state_income_tax_amount.round.to_s
-                expect(generated_document.css(w2)[i].at("StateWagesAmt").text).to eq send("w2_#{i+1}").state_wages_amount.round.to_s
+              intake.state_file_w2s.each_with_index do |state_file_w2, index|
+                w2_xml = xml.css(vars[:w2_node_name])[index]
+                expect(w2_xml.at(vars[:employer_state_id_num_name]).text).to eq state_file_w2.employer_state_id_num
+                expect(w2_xml.at("LocalIncomeTaxAmt").text).to eq state_file_w2.local_income_tax_amount.round.to_s
+                expect(w2_xml.at("LocalWagesAndTipsAmt").text).to eq state_file_w2.local_wages_and_tips_amount.round.to_s
+                expect(w2_xml.at(vars[:locality_name]).text).to eq state_file_w2.locality_nm
+                expect(w2_xml.at("StateIncomeTaxAmt").text).to eq state_file_w2.state_income_tax_amount.round.to_s
+                expect(w2_xml.at("StateWagesAmt").text).to eq state_file_w2.state_wages_amount.round.to_s
               end
             end
           end

--- a/spec/lib/submission_builder/state_return_spec.rb
+++ b/spec/lib/submission_builder/state_return_spec.rb
@@ -38,7 +38,7 @@ describe SubmissionBuilder::StateReturn do
                 expect(w2_xml.at(vars[:employer_state_id_num_name]).text).to eq state_file_w2.employer_state_id_num
                 expect(w2_xml.at("LocalIncomeTaxAmt").text).to eq state_file_w2.local_income_tax_amount.round.to_s
                 expect(w2_xml.at("LocalWagesAndTipsAmt").text).to eq state_file_w2.local_wages_and_tips_amount.round.to_s
-                expect(w2_xml.at(vars[:locality_name]).text).to eq state_file_w2.locality_nm
+                expect(w2_xml.at(vars[:locality_name]).text).to eq state_file_w2.locality_nm if state_file_w2.locality_nm.present?
                 expect(w2_xml.at("StateIncomeTaxAmt").text).to eq state_file_w2.state_income_tax_amount.round.to_s
                 expect(w2_xml.at("StateWagesAmt").text).to eq state_file_w2.state_wages_amount.round.to_s
               end

--- a/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
@@ -2,14 +2,22 @@ require 'rails_helper'
 
 describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_schema: "nj" do
   describe ".document" do
-    let(:intake) { create(:state_file_nj_intake, filing_status: "single", municipality_code: "0101") }
+    let(:intake) { create(:state_file_nj_intake, filing_status: "single") }
     let(:submission) { create(:efile_submission, data_source: intake) }
-    let(:build_response) { described_class.build(submission, validate: false) }
+    let(:build_response) { described_class.build(submission, validate: true) }
     let(:xml) { Nokogiri::XML::Document.parse(build_response.document.to_xml) }
 
-    it "includes municipality code with a prepending 0" do
-      xml = described_class.build(submission).document
-      expect(xml.document.at("CountyCode").to_s).to include("00101")
+    after(:each) do
+      expect(build_response.errors).not_to be_present
+    end
+
+    context "with municipality code" do
+      let(:intake) { create(:state_file_nj_intake, municipality_code: "0304") }
+
+      it "includes municipality code with a prepending 0" do
+        xml = described_class.build(submission).document
+        expect(xml.document.at("CountyCode").to_s).to include("00304")
+      end
     end
 
     context "when filer has no spouse" do
@@ -333,7 +341,7 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
 
     describe "line 31 medical expenses" do
       context "with an income of 200k" do
-        let(:intake) { create(:state_file_nj_intake, :df_data_many_w2s, :with_w2s_synced, medical_expenses: 10_000) }
+        let(:intake) { create(:state_file_nj_intake, :df_data_many_w2s, medical_expenses: 10_000) }
         it "fills MedicalExpenses with medical expenses exceeding two percent gross income" do
           expected_line_15_w2_wages = 200_000
           two_percent_gross = expected_line_15_w2_wages * 0.02
@@ -425,7 +433,8 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
     describe "property tax deduction - line 41" do
       context 'when taking property tax deduction' do
         it "fills PropertyTaxDeduction with property tax deduction amount" do
-          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_41).and_return 15000
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_property_tax_deduction).and_return 15000
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:should_use_property_tax_deduction).and_return true
           expect(xml.at("PropertyTaxDeduction").text).to eq(15000.to_s)
         end
       end

--- a/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
@@ -47,8 +47,6 @@ describe SubmissionBuilder::Ty2024::States::Nj::NjReturnXml, required_schema: "n
         it "does not error" do
           builder_response = described_class.build(submission)
           expect(builder_response.errors).not_to be_present
-          expect(builder_response.document.at("WagesSalariesTips").text).not_to eq(nil)
-          expect(builder_response.document.at("NewJerseyTaxableIncome").text).not_to eq(nil)
         end
       end
 
@@ -65,8 +63,6 @@ describe SubmissionBuilder::Ty2024::States::Nj::NjReturnXml, required_schema: "n
         it "does not error" do
           builder_response = described_class.build(submission)
           expect(builder_response.errors).not_to be_present
-          expect(builder_response.document.at("WagesSalariesTips").text).not_to eq(nil)
-          expect(builder_response.document.at("NewJerseyTaxableIncome").text).not_to eq(nil)
         end
       end
 
@@ -75,8 +71,6 @@ describe SubmissionBuilder::Ty2024::States::Nj::NjReturnXml, required_schema: "n
         it "does not error" do
           builder_response = described_class.build(submission)
           expect(builder_response.errors).not_to be_present
-          expect(builder_response.document.at("WagesSalariesTips").text).not_to eq(nil)
-          expect(builder_response.document.at("NewJerseyTaxableIncome").text).not_to eq(nil)
         end
       end
 
@@ -85,8 +79,6 @@ describe SubmissionBuilder::Ty2024::States::Nj::NjReturnXml, required_schema: "n
         it "does not error" do
           builder_response = described_class.build(submission)
           expect(builder_response.errors).not_to be_present
-          expect(builder_response.document.at("WagesSalariesTips").text).not_to eq(nil)
-          expect(builder_response.document.at("NewJerseyTaxableIncome").text).not_to eq(nil)
         end
       end
 

--- a/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
@@ -71,7 +71,7 @@ describe SubmissionBuilder::Ty2024::States::Nj::NjReturnXml, required_schema: "n
       end
 
       context "with many w2s" do
-        let(:intake) { create(:state_file_nj_intake, raw_direct_file_data: StateFile::DirectFileApiResponseSampleService.new.read_xml('nj_zeus_many_w2s')) }
+        let(:intake) { create(:state_file_nj_intake, :df_data_many_w2s) }
         it "does not error" do
           builder_response = described_class.build(submission)
           expect(builder_response.errors).not_to be_present
@@ -81,7 +81,7 @@ describe SubmissionBuilder::Ty2024::States::Nj::NjReturnXml, required_schema: "n
       end
 
       context "with two w2s" do
-        let(:intake) { create(:state_file_nj_intake, raw_direct_file_data: StateFile::DirectFileApiResponseSampleService.new.read_xml('nj_zeus_two_w2s')) }
+        let(:intake) { create(:state_file_nj_intake, :df_data_2_w2s) }
         it "does not error" do
           builder_response = described_class.build(submission)
           expect(builder_response.errors).not_to be_present

--- a/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
@@ -26,10 +26,12 @@ describe SubmissionBuilder::Ty2024::States::Nj::NjReturnXml, required_schema: "n
       end
 
       context "with one dep" do
-        let(:intake) { create(:state_file_nj_intake, :df_data_one_dep, municipality_code: "0101") }
+        let(:intake) { create(:state_file_nj_intake, :df_data_one_dep) }
         it "does not error" do
           builder_response = described_class.build(submission)
           expect(builder_response.errors).not_to be_present
+          expect(builder_response.document.at("WagesSalariesTips").text).not_to eq(nil)
+          expect(builder_response.document.at("NewJerseyTaxableIncome").text).not_to eq(nil)
         end
 
         it "fills details from json" do
@@ -41,15 +43,17 @@ describe SubmissionBuilder::Ty2024::States::Nj::NjReturnXml, required_schema: "n
       end
 
       context "with two deps" do
-        let(:intake) { create(:state_file_nj_intake, :df_data_two_deps, municipality_code: "0101") }
+        let(:intake) { create(:state_file_nj_intake, :df_data_two_deps) }
         it "does not error" do
           builder_response = described_class.build(submission)
           expect(builder_response.errors).not_to be_present
+          expect(builder_response.document.at("WagesSalariesTips").text).not_to eq(nil)
+          expect(builder_response.document.at("NewJerseyTaxableIncome").text).not_to eq(nil)
         end
       end
 
       context "with many deps all under 5 yrs old" do
-        let(:intake) { create(:state_file_nj_intake, :df_data_many_deps, municipality_code: "0101") }
+        let(:intake) { create(:state_file_nj_intake, :df_data_many_deps) }
 
         before do
           five_years = Date.new(MultiTenantService.new(:statefile).current_tax_year - 5, 1, 1)
@@ -61,22 +65,28 @@ describe SubmissionBuilder::Ty2024::States::Nj::NjReturnXml, required_schema: "n
         it "does not error" do
           builder_response = described_class.build(submission)
           expect(builder_response.errors).not_to be_present
+          expect(builder_response.document.at("WagesSalariesTips").text).not_to eq(nil)
+          expect(builder_response.document.at("NewJerseyTaxableIncome").text).not_to eq(nil)
         end
       end
 
       context "with many w2s" do
-        let(:intake) { create(:state_file_nj_intake, municipality_code: "0101", raw_direct_file_data: StateFile::DirectFileApiResponseSampleService.new.read_xml('nj_zeus_many_w2s')) }
+        let(:intake) { create(:state_file_nj_intake, raw_direct_file_data: StateFile::DirectFileApiResponseSampleService.new.read_xml('nj_zeus_many_w2s')) }
         it "does not error" do
           builder_response = described_class.build(submission)
           expect(builder_response.errors).not_to be_present
+          expect(builder_response.document.at("WagesSalariesTips").text).not_to eq(nil)
+          expect(builder_response.document.at("NewJerseyTaxableIncome").text).not_to eq(nil)
         end
       end
 
       context "with two w2s" do
-        let(:intake) { create(:state_file_nj_intake, municipality_code: "0101", raw_direct_file_data: StateFile::DirectFileApiResponseSampleService.new.read_xml('nj_zeus_two_w2s')) }
+        let(:intake) { create(:state_file_nj_intake, raw_direct_file_data: StateFile::DirectFileApiResponseSampleService.new.read_xml('nj_zeus_two_w2s')) }
         it "does not error" do
           builder_response = described_class.build(submission)
           expect(builder_response.errors).not_to be_present
+          expect(builder_response.document.at("WagesSalariesTips").text).not_to eq(nil)
+          expect(builder_response.document.at("NewJerseyTaxableIncome").text).not_to eq(nil)
         end
       end
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/140

## Is PM acceptance required? (delete one)
- No - merge after code review approval

## What was done?
- Fix error introduced by W2 changes (need for `to_i`)
- Add tests that would have caught this error to `nj_return_xml_spec`, automatically sync W2s in NJ intake
- Add tests that will catch future issues in XML including client questions by adding XML validation to all nj1040 specs

## How to test?
n/a

## Screenshots (for visual changes)
Before:
```
113:0: ERROR: Element '{http://www.irs.gov/efile}WagesSalariesTips': '50000.0' is not a valid value of the atomic type '{http://www.irs.gov/efile}NJAmountNNType'.
115:0: ERROR: Element '{http://www.irs.gov/efile}TotalIncome': '50000.0' is not a valid value of the atomic type '{http://www.irs.gov/efile}NJAmountNNType'.
116:0: ERROR: Element '{http://www.irs.gov/efile}GrossIncome': '50000.0' is not a valid value of the atomic type '{http://www.irs.gov/efile}NJAmountNNType'.
120:0: ERROR: Element '{http://www.irs.gov/efile}TaxableIncome': '45000.0' is not a valid value of the atomic type '{http://www.irs.gov/efile}NJAmountNNType'.
124:0: ERROR: Element '{http://www.irs.gov/efile}NewJerseyTaxableIncome': '45000.0' is not a valid value of the atomic type '{http://www.irs.gov/efile}NJAmountNNType'.
```
