### PR TITLE
Nj 105 tax exempt interest income

### DIFF
--- a/app/lib/efile/line_data.yml
+++ b/app/lib/efile/line_data.yml
@@ -578,6 +578,8 @@ NJ1040_LINE_15:
   label: '15 Wages, salaries, tips, and other employee compensation (State wages from Box 16 of enclosed W-2(s))'
 NJ1040_LINE_16A:
   label: 'Taxable interest income (Enclose federal Schedule B if over $1,500) (See instructions)'
+NJ1040_LINE_16B:  
+  label: 'Tax-exempt interest income (Enclose schedule) (See instructions) Do not include on line 16a'
 NJ1040_LINE_27:
   label: '27 Total Income (Add lines 15, 16a, and 20a)'
 NJ1040_LINE_29:

--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -339,7 +339,7 @@ module Efile
       def interest_on_gov_bonds
         interest_reports = @intake.direct_file_json_data.interest_reports
         interests_on_gov_bonds = interest_reports&.map(&:interest_on_government_bonds)
-        interests_on_gov_bonds.sum.round
+        interests_on_gov_bonds&.sum&.round
       end
 
       def is_mfs_same_home

--- a/app/lib/pdf_filler/nj1040_pdf.rb
+++ b/app/lib/pdf_filler/nj1040_pdf.rb
@@ -97,22 +97,7 @@ module PdfFiller
         answers.merge!(dependent_hash)
       end
 
-      if @xml_document.at("TaxableInterestIncome")
-        taxable_interest_income = @xml_document.at("TaxableInterestIncome").text.to_i
-        answers.merge!(insert_digits_into_fields(taxable_interest_income, [
-                                                   "112",
-                                                   "111",
-                                                   "110",
-                                                   "109",
-                                                   "108",
-                                                   "Text107",
-                                                   "undefined_41",
-                                                   "undefined_40",
-                                                   "undefined_39",
-                                                   "undefined_43"
-                                                 ]))
-      end
-
+      # lines 13 and 30
       if @xml_document.at("Exemptions TotalExemptionAmountA")
         total_exemptions = @xml_document.at("Exemptions TotalExemptionAmountA").text.to_i
         answers.merge!(insert_digits_into_fields(total_exemptions, [
@@ -126,6 +111,7 @@ module PdfFiller
                                                  ]))
       end
 
+      # line 13
       if @xml_document.at("Body TotalExemptionAmountB")
         total_exemptions = @xml_document.at("Body TotalExemptionAmountB").text.to_i
         answers.merge!(insert_digits_into_fields(total_exemptions, [
@@ -169,6 +155,7 @@ module PdfFiller
                                                  ]))
       end
 
+      # line 15
       if @xml_document.at("WagesSalariesTips").present?
         wages = @xml_document.at("WagesSalariesTips").text.to_i
         answers.merge!(insert_digits_into_fields(wages, [
@@ -182,6 +169,39 @@ module PdfFiller
                                                    "undefined_37",
                                                    "undefined_36",
                                                    "15"
+                                                 ]))
+      end
+
+      # line 16a
+      if @xml_document.at("TaxableInterestIncome")
+        taxable_interest_income = @xml_document.at("TaxableInterestIncome").text.to_i
+        answers.merge!(insert_digits_into_fields(taxable_interest_income, [
+                                                   "112",
+                                                   "111",
+                                                   "110",
+                                                   "109",
+                                                   "108",
+                                                   "Text107",
+                                                   "undefined_41",
+                                                   "undefined_40",
+                                                   "undefined_39",
+                                                   "undefined_43"
+                                                 ]))
+      end
+
+      # line 16b
+      if @xml_document.at("TaxexemptInterestIncome")
+        tax_exempt_interest_income = @xml_document.at("TaxexemptInterestIncome").text.to_i
+        answers.merge!(insert_digits_into_fields(tax_exempt_interest_income, [
+                                                   "117",
+                                                   "116",
+                                                   "115",
+                                                   "114",
+                                                   "113",
+                                                   "undefined_44",
+                                                   "16a",
+                                                   "undefined_42",
+                                                   "16b"
                                                  ]))
       end
 
@@ -219,6 +239,7 @@ module PdfFiller
                                                  ]))
       end
 
+      # line 39
       if @xml_document.at("TaxableIncome").present?
         taxable_income = @xml_document.at("TaxableIncome").text.to_i
         answers.merge!(insert_digits_into_fields(taxable_income, [

--- a/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
+++ b/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
@@ -106,6 +106,10 @@ module SubmissionBuilder
                     xml.TaxableInterestIncome calculated_fields.fetch(:NJ1040_LINE_16A)
                   end
 
+                  if calculated_fields.fetch(:NJ1040_LINE_16B)&.positive?
+                    xml.TaxexemptInterestIncome calculated_fields.fetch(:NJ1040_LINE_16B)
+                  end
+                  
                   if calculated_fields.fetch(:NJ1040_LINE_27).positive?
                     xml.TotalIncome calculated_fields.fetch(:NJ1040_LINE_27)
                   end

--- a/app/models/state_file_nj_intake.rb
+++ b/app/models/state_file_nj_intake.rb
@@ -139,6 +139,9 @@ class StateFileNjIntake < StateFileBaseIntake
     return :has_out_of_state_w2 if w2_states.any? do |state|
       !(state.text || '').casecmp(state_code).zero?
     end
+
+    tax_exempt_interest_income = calculator.calculate_tax_exempt_interest_income
+    return :exempt_interest_exceeds_10k if tax_exempt_interest_income > 10_000
   end
 
   def disqualifying_eligibility_rules

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2341,6 +2341,7 @@ en:
       data_transfer_offboarding:
         edit:
           ineligible_reason:
+            exempt_interest_exceeds_10k: your tax exempt interest income exceeds $10,000.
             has_irc_125_code: W2 lists IRC 125 benefit plan amounts.
             has_out_of_state_w2: you earned income in another state in 2023.
             has_yonkers_income: lived, earned income, or maintained a home in Yonkers in 2023.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2315,6 +2315,7 @@ es:
       data_transfer_offboarding:
         edit:
           ineligible_reason:
+            exempt_interest_exceeds_10k: your tax exempt interest income exceeds $10,000.
             has_irc_125_code: tu formulario W-2 incluye cantidades del plan de beneficios del Código de Rentas Internas (IRC 125).
             has_out_of_state_w2: recibiste ingresos en otro estado en el 2023
             has_yonkers_income: viviste, recibiste ingresos o mantuviste un hogar en Yonkers en 2023.

--- a/spec/factories/state_file_nj_intakes.rb
+++ b/spec/factories/state_file_nj_intakes.rb
@@ -185,6 +185,11 @@ FactoryBot.define do
       raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nj_married_filing_separately') }
     end
 
+    trait :df_data_exempt_interest do
+      raw_direct_file_data { StateFile::DirectFileApiResponseSampleService.new.read_xml('nj_exempt_interest_over_10k') }
+      raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nj_exempt_interest_over_10k') }
+    end
+
     trait :married_filing_jointly do
       filing_status { "married_filing_jointly" }
       spouse_birth_date { Date.new(1990, 1, 1) }

--- a/spec/fixtures/state_file/fed_return_jsons/2023/nj/exempt_interest_over_10k.json
+++ b/spec/fixtures/state_file/fed_return_jsons/2023/nj/exempt_interest_over_10k.json
@@ -1,0 +1,46 @@
+{
+  "familyAndHousehold": [],
+  "filers": [
+    {
+      "firstName": "Ernie",
+      "middleInitial": null,
+      "lastName": "Muppet",
+      "dateOfBirth": "1980-01-01",
+      "isPrimaryFiler": true,
+      "tin": "400-00-0039"
+    },
+    {
+      "firstName": "Bert",
+      "middleInitial": "K",
+      "lastName": "Muppet",
+      "dateOfBirth": "1990-01-01",
+      "isPrimaryFiler": false,
+      "tin": "600-00-0039"
+    }
+  ],
+  "interestReports": [
+    {
+      "1099Amount": "0.00",
+      "has1099": false,
+      "interestOnGovernmentBonds": "5000.00",
+      "no1099Amount": "800.00",
+      "recipientTin": "400-00-0039",
+      "taxExemptInterest": "0.00",
+      "payer": "The payer name",
+      "payerTin": "101-23-4567",
+      "taxWithheld": "0.00",
+      "taxExemptAndTaxCreditBondCusipNo": "123456789"
+    },
+    {
+      "1099Amount": "0.00",
+      "has1099": false,
+      "interestOnGovernmentBonds": "5000.00",
+      "no1099Amount": "800.00",
+      "recipientTin": "400-00-0039",
+      "taxExemptInterest": "0.00",
+      "payer": "The payer name",
+      "payerTin": "101-23-4567",
+      "taxWithheld": "0.00",
+      "taxExemptAndTaxCreditBondCusipNo": "123456789"
+    }]
+}

--- a/spec/fixtures/state_file/fed_return_xmls/2023/nj/exempt_interest_over_10k.xml
+++ b/spec/fixtures/state_file/fed_return_xmls/2023/nj/exempt_interest_over_10k.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Return xmlns="http://www.irs.gov/efile" xmlns:efile="http://www.irs.gov/efile" returnVersion="2023v5.0">
+  <ReturnHeader binaryAttachmentCnt="0">
+    <TaxYr>2023</TaxYr>
+    <TaxPeriodBeginDt>2023-01-01</TaxPeriodBeginDt>
+    <TaxPeriodEndDt>2023-12-31</TaxPeriodEndDt>
+    <SoftwareVersionNum>2023.0.1</SoftwareVersionNum>
+    <ReturnTypeCd>1040</ReturnTypeCd>
+    <Filer>
+      <PrimarySSN>400000039</PrimarySSN>
+      <SpouseSSN>600000039</SpouseSSN>
+      <NameLine1Txt>BERT &amp; ERNIE&lt;MUPPET</NameLine1Txt>
+      <PrimaryNameControlTxt>MUPP</PrimaryNameControlTxt>
+      <SpouseNameControlTxt>BERT</SpouseNameControlTxt>
+      <USAddress>
+        <AddressLine1Txt>123 Sesame St Apt 1</AddressLine1Txt>
+        <CityNm>Hammonton</CityNm>
+        <StateAbbreviationCd>NJ</StateAbbreviationCd>
+        <ZIPCd>85034</ZIPCd>
+      </USAddress>
+      <PhoneNum>4805559876</PhoneNum>
+    </Filer>
+    <AdditionalFilerInformation>
+      <AtSubmissionFilingGrp>
+        <EmailAddressTxt>bert@sesame.com</EmailAddressTxt>
+      </AtSubmissionFilingGrp>
+    </AdditionalFilerInformation>
+  </ReturnHeader>
+  <ReturnData documentCnt="2">
+    <IRS1040 documentId="IRS10400001">
+      <IndividualReturnFilingStatusCd>2</IndividualReturnFilingStatusCd>
+      <SpouseNm>Ernie Muppet</SpouseNm>
+      <VirtualCurAcquiredDurTYInd>false</VirtualCurAcquiredDurTYInd>
+      <SpouseClaimAsDependentInd>X</SpouseClaimAsDependentInd>
+      <TotalBoxesCheckedCnt>1</TotalBoxesCheckedCnt>
+      <TotalExemptPrimaryAndSpouseCnt>2</TotalExemptPrimaryAndSpouseCnt>
+      <ChldWhoLivedWithYouCnt>0</ChldWhoLivedWithYouCnt>
+      <OtherDependentsListedCnt>0</OtherDependentsListedCnt>
+      <TotalExemptionsCnt>2</TotalExemptionsCnt>
+      <WagesAmt referenceDocumentId="W20001" referenceDocumentName="IRSW2">9000</WagesAmt>
+      <HouseholdEmployeeWagesAmt>0</HouseholdEmployeeWagesAmt>
+      <TipIncomeAmt>0</TipIncomeAmt>
+      <MedicaidWaiverPymtNotRptW2Amt>0</MedicaidWaiverPymtNotRptW2Amt>
+      <TaxableBenefitsAmt>0</TaxableBenefitsAmt>
+      <TaxableBenefitsForm8839Amt>0</TaxableBenefitsForm8839Amt>
+      <TotalWagesWithNoWithholdingAmt>0</TotalWagesWithNoWithholdingAmt>
+      <NontxCombatPayElectionAmt>0</NontxCombatPayElectionAmt>
+      <WagesSalariesAndTipsAmt>9000</WagesSalariesAndTipsAmt>
+      <TaxExemptInterestAmt>1</TaxExemptInterestAmt>
+      <TaxableInterestAmt>0</TaxableInterestAmt>
+      <QualifiedDividendsAmt>0</QualifiedDividendsAmt>
+      <OrdinaryDividendsAmt>0</OrdinaryDividendsAmt>
+      <TotalTaxablePensionsAmt>0</TotalTaxablePensionsAmt>
+      <SocSecBnftAmt>0</SocSecBnftAmt>
+      <TaxableSocSecAmt>0</TaxableSocSecAmt>
+      <CapitalGainLossAmt>0</CapitalGainLossAmt>
+      <TotalAdditionalIncomeAmt>0</TotalAdditionalIncomeAmt>
+      <TotalIncomeAmt>9000</TotalIncomeAmt>
+      <TotalAdjustmentsAmt>0</TotalAdjustmentsAmt>
+      <AdjustedGrossIncomeAmt>9000</AdjustedGrossIncomeAmt>
+      <TotalItemizedOrStandardDedAmt>29200</TotalItemizedOrStandardDedAmt>
+      <TotalDeductionsAmt>29200</TotalDeductionsAmt>
+      <TaxableIncomeAmt>0</TaxableIncomeAmt>
+      <TaxAmt>0</TaxAmt>
+      <AdditionalTaxAmt>0</AdditionalTaxAmt>
+      <TotalTaxBeforeCrAndOthTaxesAmt>0</TotalTaxBeforeCrAndOthTaxesAmt>
+      <CTCODCAmt>0</CTCODCAmt>
+      <TotalNonrefundableCreditsAmt>0</TotalNonrefundableCreditsAmt>
+      <TotalCreditsAmt>0</TotalCreditsAmt>
+      <TaxLessCreditsAmt>0</TaxLessCreditsAmt>
+      <TotalOtherTaxesAmt>0</TotalOtherTaxesAmt>
+      <TotalTaxAmt>0</TotalTaxAmt>
+      <FormW2WithheldTaxAmt>900</FormW2WithheldTaxAmt>
+      <Form1099WithheldTaxAmt>0</Form1099WithheldTaxAmt>
+      <TaxWithheldOtherAmt>0</TaxWithheldOtherAmt>
+      <WithholdingTaxAmt>900</WithholdingTaxAmt>
+      <EstimatedTaxPaymentsAmt>0</EstimatedTaxPaymentsAmt>
+      <RefundableCreditsAmt>0</RefundableCreditsAmt>
+      <TotalPaymentsAmt>900</TotalPaymentsAmt>
+      <OverpaidAmt>900</OverpaidAmt>
+      <RefundAmt>900</RefundAmt>
+      <AppliedToEsTaxAmt>0</AppliedToEsTaxAmt>
+      <OwedAmt>0</OwedAmt>
+      <EsPenaltyAmt>0</EsPenaltyAmt>
+      <ThirdPartyDesigneeInd>false</ThirdPartyDesigneeInd>
+      <PrimaryOccupationTxt>Eyebrow technician</PrimaryOccupationTxt>
+      <SpouseOccupationTxt>Rubber ducky manufacturer</SpouseOccupationTxt>
+      <RefundProductCd>NO FINANCIAL PRODUCT</RefundProductCd>
+    </IRS1040>
+    <IRSW2 documentId="W20001" documentName="IRSW2">
+      <EmployeeSSN>400000039</EmployeeSSN>
+      <EmployerEIN>678912345</EmployerEIN>
+      <EmployerNameControlTxt>SESA</EmployerNameControlTxt>
+      <EmployerName>
+        <BusinessNameLine1Txt>Sesame Street Eye Lip and Hair Removal</BusinessNameLine1Txt>
+      </EmployerName>
+      <EmployerUSAddress>
+        <AddressLine1Txt>300 Josephine St</AddressLine1Txt>
+        <CityNm>Hammonton</CityNm>
+        <StateAbbreviationCd>NJ</StateAbbreviationCd>
+        <ZIPCd>80212</ZIPCd>
+      </EmployerUSAddress>
+      <EmployeeNm>Bert Muppet</EmployeeNm>
+      <EmployeeUSAddress>
+        <AddressLine1Txt>123 Sesame St Apt 1</AddressLine1Txt>
+        <CityNm>Hammonton</CityNm>
+        <StateAbbreviationCd>NJ</StateAbbreviationCd>
+        <ZIPCd>85034</ZIPCd>
+      </EmployeeUSAddress>
+      <WagesAmt>9000</WagesAmt>
+      <WithholdingAmt>900</WithholdingAmt>
+      <SocialSecurityWagesAmt>9000</SocialSecurityWagesAmt>
+      <SocialSecurityTaxAmt>558</SocialSecurityTaxAmt>
+      <MedicareWagesAndTipsAmt>9000</MedicareWagesAndTipsAmt>
+      <MedicareTaxWithheldAmt>131</MedicareTaxWithheldAmt>
+      <SocialSecurityTipsAmt>0</SocialSecurityTipsAmt>
+      <AllocatedTipsAmt>0</AllocatedTipsAmt>
+      <NonqualifiedPlansAmt>0</NonqualifiedPlansAmt>
+      <W2StateLocalTaxGrp>
+        <W2StateTaxGrp>
+          <StateAbbreviationCd>NJ</StateAbbreviationCd>
+          <EmployerStateIdNum>12345</EmployerStateIdNum>
+          <StateWagesAmt>9000</StateWagesAmt>
+          <StateIncomeTaxAmt>15</StateIncomeTaxAmt>
+          <W2LocalTaxGrp>
+            <LocalWagesAndTipsAmt>0</LocalWagesAndTipsAmt>
+            <LocalIncomeTaxAmt>0</LocalIncomeTaxAmt>
+          </W2LocalTaxGrp>
+        </W2StateTaxGrp>
+      </W2StateLocalTaxGrp>
+      <StandardOrNonStandardCd>S</StandardOrNonStandardCd>
+    </IRSW2>
+  </ReturnData>
+</Return>

--- a/spec/fixtures/state_file/fed_return_xmls/2023/nj/zeus_two_deps.xml
+++ b/spec/fixtures/state_file/fed_return_xmls/2023/nj/zeus_two_deps.xml
@@ -118,6 +118,7 @@
       <TotalExemptionsCnt>4</TotalExemptionsCnt>
       <WagesAmt referenceDocumentId="W20001" referenceDocumentName="IRSW2">50000</WagesAmt>
       <WagesSalariesAndTipsAmt>50000</WagesSalariesAndTipsAmt>
+      <TaxExemptInterestAmt>1</TaxExemptInterestAmt>
       <TaxableInterestAmt>500</TaxableInterestAmt>
       <SocSecBnftAmt>8000</SocSecBnftAmt>
       <TaxableSocSecAmt>6800</TaxableSocSecAmt>

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -414,6 +414,29 @@ describe Efile::Nj::Nj1040Calculator do
     end
   end
 
+  describe 'line 16b tax exempt interest income' do
+    context 'with federal tax exempt interest income and interest on government bonds' do
+      let(:intake) { create(:state_file_nj_intake, :df_data_exempt_interest) }
+      it 'calculates the sum' do
+        expect(instance.calculate_tax_exempt_interest_income).to eq(10_001)
+      end
+    end
+
+    context 'with no tax exempt interest income' do
+      let(:intake) { create(:state_file_nj_intake, :df_data_minimal) }
+      it 'does not set line 16b' do
+        expect(instance.lines[:NJ1040_LINE_16B].value).to eq(nil)
+      end
+    end
+
+    context 'with tax exempt interest income and interest on government bonds less than 10k' do
+      let(:intake) { create(:state_file_nj_intake, :df_data_two_deps) }
+      it 'sets line 1b to the sum' do
+        expect(instance.lines[:NJ1040_LINE_16B].value).to eq(201)
+      end
+    end
+  end
+
   describe 'line 27 - total income' do
     let(:intake) { create(:state_file_nj_intake) }
 

--- a/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
@@ -318,6 +318,22 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
       end
     end
 
+    describe 'line 16b tax exempt interest income' do
+      context 'with no tax exempt interest income' do
+        let(:intake) { create(:state_file_nj_intake, :df_data_minimal) }
+        it 'does not set line 16b' do
+          expect(xml.at("Body TaxexemptInterestIncome")).to eq(nil)
+        end
+      end
+  
+      context 'with tax exempt interest income and interest on government bonds less than 10k' do
+        let(:intake) { create(:state_file_nj_intake, :df_data_two_deps) }
+        it 'sets line 16b to the sum' do
+          expect(xml.at("Body TaxexemptInterestIncome").text).to eq('201')
+        end
+      end
+    end
+
     describe "total income - line 27" do
       context "when filer submits w2 wages" do
         it "fills TotalIncome with the value from Line 15" do

--- a/spec/models/state_file_nj_intake_spec.rb
+++ b/spec/models/state_file_nj_intake_spec.rb
@@ -103,5 +103,30 @@
 require 'rails_helper'
 
 RSpec.describe StateFileNjIntake, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "#disqualifying_df_data_reason" do
+    context "when federal non taxable interest income exceeds 10k" do
+      let(:intake) { create :state_file_nj_intake, :df_data_minimal }
+      before do
+        intake.direct_file_data.fed_tax_exempt_interest = 10_001
+      end
+
+      it "returns exempt_interest_exceeds_10k" do
+        expect(intake.disqualifying_df_data_reason).to eq :exempt_interest_exceeds_10k
+      end
+    end
+
+    context "when gov bonds are 10k and federal tax exempt interest amt is 1" do
+      let(:intake) { create :state_file_nj_intake, :df_data_exempt_interest }
+      it "returns exempt_interest_exceeds_10k" do
+        expect(intake.disqualifying_df_data_reason).to eq :exempt_interest_exceeds_10k
+      end
+    end
+
+    context "when there are no disqualifying reasons" do
+      let(:intake) { create :state_file_nj_intake, :df_data_two_deps }
+      it "returns nil" do
+        expect(intake.disqualifying_df_data_reason).to eq nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/105

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
Add tax exempt interest income. Add df data eligibility check.

Do some tidying: in the pdf tests to remove unnecessary code; move some code around to vaguely follow the order in which it appears on the NJ 1040; add some comments in the pdf builder to make it easier to figure out where to put new code.

## How to test?
Use the "exempt interest over 10k" profile to see post-df-import rejection.

Use "Zeus two deps" to see line 16b filled.

## Screenshots (for visual changes)
The only visual change should be the value filled on the pdf. The page that a user sees after they are deemed ineligible is just the common ineligibiltiy page.