### PR TITLE
Nj 98 rounding

### DIFF
--- a/app/assets/stylesheets/_state-file.scss
+++ b/app/assets/stylesheets/_state-file.scss
@@ -172,6 +172,11 @@
     }
   }
 
+  .anne-test {
+    background: $color-state-file-blue-box;
+    border: 2px solid $color-state-file-blue-box-border;
+  }
+
   .white-group {
     padding: 2rem;
     margin-bottom: 2rem;

--- a/app/assets/stylesheets/_state-file.scss
+++ b/app/assets/stylesheets/_state-file.scss
@@ -172,9 +172,11 @@
     }
   }
 
-  .anne-test {
-    background: $color-state-file-blue-box;
-    border: 2px solid $color-state-file-blue-box-border;
+  .beige-group {
+    background: $color-beige;
+    border: 2px solid $color-grey;
+    padding: 2rem;
+    margin-bottom: 2rem;
   }
 
   .white-group {

--- a/app/forms/state_file/nj_homeowner_property_tax_form.rb
+++ b/app/forms/state_file/nj_homeowner_property_tax_form.rb
@@ -4,8 +4,8 @@ module StateFile
                        :property_tax_paid
 
     validates :property_tax_paid, presence: true
-    validates_numericality_of :property_tax_paid, only_integer: true, message: :round_to_whole_number, if: -> { property_tax_paid.present? }
-    validates :property_tax_paid, presence: true, allow_blank: false, numericality: { greater_than_or_equal_to: 1 }, if: -> { property_tax_paid.present? }
+    validates_numericality_of :property_tax_paid, message: I18n.t("validators.not_a_number"), if: -> { property_tax_paid.present? }
+    validates :property_tax_paid, allow_blank: false, numericality: { greater_than_or_equal_to: 1 }, if: -> { property_tax_paid.present? }
 
     def save
       @intake.update(attributes_for(:intake))

--- a/app/forms/state_file/nj_medical_expenses_form.rb
+++ b/app/forms/state_file/nj_medical_expenses_form.rb
@@ -3,7 +3,7 @@ module StateFile
     set_attributes_for :intake,
                        :medical_expenses
 
-    validates_numericality_of :medical_expenses, message: I18n.t("validators.not_a_number")
+    validates_numericality_of :medical_expenses, message: I18n.t("validators.not_a_number"), if: -> { medical_expenses.present? }
     validates :medical_expenses, presence: true, allow_blank: false, numericality: { greater_than_or_equal_to: 0 }
                    
     def save

--- a/app/forms/state_file/nj_medical_expenses_form.rb
+++ b/app/forms/state_file/nj_medical_expenses_form.rb
@@ -3,7 +3,7 @@ module StateFile
     set_attributes_for :intake,
                        :medical_expenses
 
-    validates_numericality_of :medical_expenses, only_integer: true, message: :round_to_whole_number
+    validates_numericality_of :medical_expenses, message: I18n.t("validators.not_a_number")
     validates :medical_expenses, presence: true, allow_blank: false, numericality: { greater_than_or_equal_to: 0 }
                    
     def save

--- a/app/forms/state_file/nj_sales_use_tax_form.rb
+++ b/app/forms/state_file/nj_sales_use_tax_form.rb
@@ -11,9 +11,8 @@ module StateFile
       presence: true,
       numericality: {
         allow_blank: true,
-        only_integer: true,
         greater_than_or_equal_to: 0,
-        message: :round_to_whole_number
+        message: I18n.t("validators.not_a_number")
       },
       if: -> { sales_use_tax_calculation_method == "manual" }
 

--- a/app/forms/state_file/nj_tenant_rent_paid_form.rb
+++ b/app/forms/state_file/nj_tenant_rent_paid_form.rb
@@ -4,8 +4,8 @@ module StateFile
                        :rent_paid
 
     validates :rent_paid, presence: true
-    validates_numericality_of :rent_paid, only_integer: true, message: :round_to_whole_number, if: -> { rent_paid.present? }
-    validates :rent_paid, presence: true, allow_blank: false, numericality: { greater_than_or_equal_to: 1 }, if: -> { rent_paid.present? }
+    validates_numericality_of :rent_paid, message: I18n.t("validators.not_a_number"), if: -> { rent_paid.present? }
+    validates :rent_paid, presence: true, numericality: { greater_than_or_equal_to: 1 }, if: -> { rent_paid.present? }
 
     def save
       @intake.update(attributes_for(:intake))

--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -265,7 +265,7 @@ module Efile
       end
 
       def calculate_line_51
-        @intake.sales_use_tax ? @intake.sales_use_tax.round : 0
+        (@intake.sales_use_tax || 0).round
       end
 
       def calculate_line_56

--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -265,7 +265,7 @@ module Efile
       end
 
       def calculate_line_51
-        @intake.sales_use_tax || 0
+        @intake.sales_use_tax ? @intake.sales_use_tax.round : 0
       end
 
       def calculate_line_56

--- a/app/models/state_file_nj_intake.rb
+++ b/app/models/state_file_nj_intake.rb
@@ -36,7 +36,7 @@
 #  last_sign_in_ip                                        :inet
 #  locale                                                 :string           default("en")
 #  locked_at                                              :datetime
-#  medical_expenses                                       :integer          default(0), not null
+#  medical_expenses                                       :decimal(12, 2)   default(0.0), not null
 #  message_tracker                                        :jsonb
 #  municipality_code                                      :string
 #  municipality_name                                      :string
@@ -58,13 +58,13 @@
 #  primary_ssn                                            :string
 #  primary_suffix                                         :string
 #  primary_veteran                                        :integer          default("unfilled"), not null
-#  property_tax_paid                                      :integer
+#  property_tax_paid                                      :decimal(12, 2)
 #  raw_direct_file_data                                   :text
 #  raw_direct_file_intake_data                            :jsonb
 #  referrer                                               :string
-#  rent_paid                                              :integer
+#  rent_paid                                              :decimal(12, 2)
 #  routing_number                                         :string
-#  sales_use_tax                                          :integer
+#  sales_use_tax                                          :decimal(12, 2)
 #  sales_use_tax_calculation_method                       :integer          default("unfilled"), not null
 #  sign_in_count                                          :integer          default(0), not null
 #  source                                                 :string
@@ -127,7 +127,7 @@ class StateFileNjIntake < StateFileBaseIntake
   enum eligibility_out_of_state_income: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_out_of_state_income
   enum primary_disabled: { unfilled: 0, yes: 1, no: 2 }, _prefix: :primary_disabled
   enum spouse_disabled: { unfilled: 0, yes: 1, no: 2 }, _prefix: :spouse_disabled
-  
+
   enum primary_veteran: { unfilled: 0, yes: 1, no: 2 }, _prefix: :primary_veteran
   enum spouse_veteran: { unfilled: 0, yes: 1, no: 2 }, _prefix: :spouse_veteran
 

--- a/app/views/state_file/questions/nj_homeowner_property_tax/edit.html.erb
+++ b/app/views/state_file/questions/nj_homeowner_property_tax/edit.html.erb
@@ -8,7 +8,7 @@
 
   <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
     <div class="white-group">
-      <%= f.cfa_input_field(:property_tax_paid, t('.label',filing_year: @filing_year), classes: ["form-width--long"]) %>
+      <%= f.vita_min_money_field(:property_tax_paid, t('.label',filing_year: @filing_year), options: { placeholder: '0' }, classes: ["form-width--long"]) %>
     </div>
 
     <div class="reveal">

--- a/app/views/state_file/questions/nj_medical_expenses/edit.html.erb
+++ b/app/views/state_file/questions/nj_medical_expenses/edit.html.erb
@@ -14,7 +14,7 @@
         t('.label', filing_year: @filing_year),
         help_text: t('.help_text'),
         classes: ["form-width--long"],
-        options: { placeholder: "" }
+        options: { placeholder: "0" }
     ) %>
     </div>
 

--- a/app/views/state_file/questions/nj_review/edit.html.erb
+++ b/app/views/state_file/questions/nj_review/edit.html.erb
@@ -89,7 +89,7 @@
     <div id="rent_paid" class="white-group">
       <div class="spacing-below-5">
         <h2 class="text--body text--bold spacing-below-5"><%=t(".rent_paid") %></h2>
-        <p><%= number_to_currency(current_intake.rent_paid) %></p>
+        <p><%= number_to_currency(current_intake.rent_paid, precision: 0) %></p>
         <%= link_to StateFile::Questions::NjTenantRentPaidController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
           <%= t("general.edit") %>
           <span class="sr-only"><%= t(".rent_paid") %></span>

--- a/app/views/state_file/questions/nj_review/edit.html.erb
+++ b/app/views/state_file/questions/nj_review/edit.html.erb
@@ -120,7 +120,7 @@
   <div id="medical_expenses" class="white-group">
     <div class="spacing-below-5">
       <h2 class="text--body text--bold spacing-below-5"><%=t(".medical_expenses") %></h2>
-      <p><%= number_to_currency(current_intake.medical_expenses) %></p>
+      <p><%= number_to_currency(current_intake.medical_expenses, precision: 0) %></p>
       <%= link_to StateFile::Questions::NjMedicalExpensesController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
         <%= t("general.edit") %>
         <span class="sr-only"><%= t(".medical_expenses") %></span>

--- a/app/views/state_file/questions/nj_review/edit.html.erb
+++ b/app/views/state_file/questions/nj_review/edit.html.erb
@@ -1,5 +1,10 @@
 <% content_for :page_title, t("state_file.questions.shared.review_header.title") %>
 <% content_for :card do %>
+
+  <div class="white-group">
+    <p>Stuff has been rounded yo</p>
+  </div>
+
   <%= render "state_file/questions/shared/review_header" %>
 
   <div id="county" class="white-group">

--- a/app/views/state_file/questions/nj_review/edit.html.erb
+++ b/app/views/state_file/questions/nj_review/edit.html.erb
@@ -76,7 +76,7 @@
     <div id="property_tax_paid" class="white-group">
       <div class="spacing-below-5">
         <h2 class="text--body text--bold spacing-below-5"><%=t(".property_tax_paid") %></h2>
-        <p><%= number_to_currency(current_intake.property_tax_paid) %></p>
+        <p><%= number_to_currency(current_intake.property_tax_paid, precision: 0) %></p>
         <%= link_to StateFile::Questions::NjHomeownerPropertyTaxController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
           <%= t("general.edit") %>
           <span class="sr-only"><%= t(".property_tax_paid") %></span>

--- a/app/views/state_file/questions/nj_review/edit.html.erb
+++ b/app/views/state_file/questions/nj_review/edit.html.erb
@@ -1,8 +1,8 @@
 <% content_for :page_title, t("state_file.questions.shared.review_header.title") %>
 <% content_for :card do %>
 
-  <div class="white-group">
-    <p><%=t(".rounding_html") %></p>
+  <div class="beige-group">
+    <%=t(".rounding_html") %>
   </div>
 
   <%= render "state_file/questions/shared/review_header" %>

--- a/app/views/state_file/questions/nj_review/edit.html.erb
+++ b/app/views/state_file/questions/nj_review/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :card do %>
 
   <div class="white-group">
-    <p>Stuff has been rounded yo</p>
+    <p><%=t(".rounding_html") %></p>
   </div>
 
   <%= render "state_file/questions/shared/review_header" %>

--- a/app/views/state_file/questions/nj_tenant_rent_paid/edit.html.erb
+++ b/app/views/state_file/questions/nj_tenant_rent_paid/edit.html.erb
@@ -9,7 +9,7 @@
 
   <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
     <div class="white-group">
-      <%= f.cfa_input_field(:rent_paid, t('.label',filing_year: @filing_year), classes: ["form-width--long"]) %>
+      <%= f.vita_min_money_field(:rent_paid, t('.label',filing_year: @filing_year), options: { placeholder: '0' }, classes: ["form-width--long"]) %>
     </div>
 
     <% if params[:return_to_review].present? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2768,7 +2768,7 @@ en:
       nj_sales_use_tax:
         edit:
           followup_radio_label: Select one of the following
-          manual_use_tax_label: Enter calculated use tax. (Round to the nearest whole number)
+          manual_use_tax_label: Enter total calculated use tax
           subtitle: 'This includes:'
           subtitle_list_html: |
             <li>Items purchased or services performed out-of-state, where there was no sales tax or the sales tax rate was below the NJ rate of 6.625%.</li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -235,7 +235,6 @@ en:
       blank: Can't be blank.
       invalid: is invalid
       only_letters: Only letters are accepted
-      round_to_whole_number: Round to the nearest whole number
       whole_number: must be a whole number
   forms:
     errors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2762,6 +2762,7 @@ en:
           primary_veteran: I am a veteran
           property_tax_paid: Property taxes paid
           rent_paid: Rent paid
+          rounding_html: "<strong>We have automatically rounded all dollar amounts to the nearest whole number.</strong> New Jersey will only accept whole numbers on the final tax return."
           spouse_disabled: My spouse has a disability
           spouse_veteran: My spouse is a veteran
           use_tax_applied: Consumer Use Tax Applied

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -236,7 +236,6 @@ es:
       blank: No puede estar en blanco.
       invalid: es invalido
       only_letters: Sólo se aceptan cartas
-      round_to_whole_number: Redondea al número entero más próximo
       whole_number: Debe ser un número entero
   forms:
     errors:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2742,7 +2742,7 @@ es:
       nj_sales_use_tax:
         edit:
           followup_radio_label: Seleccione una de las siguientes
-          manual_use_tax_label: Ingrese el impuesto sobre el uso calculado. (Redondee al número entero más cercano)
+          manual_use_tax_label: Enter total calculated use tax
           subtitle: 'Esto incluye:'
           subtitle_list_html: |
             <li>Artículos adquiridos o servicios prestados fuera del estado, donde no hubo impuesto a las ventas o la tasa del impuesto a las ventas fue inferior a la tasa de New Jersey del 6,625 %.</li>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2736,6 +2736,7 @@ es:
           primary_veteran: Soy un veterano
           property_tax_paid: Impuestos sobre la propiedad pagados
           rent_paid: Alquiler pagado
+          rounding_html: "<strong>We have automatically rounded all dollar amounts to the nearest whole number.</strong> New Jersey will only accept whole numbers on the final tax return."
           spouse_disabled: Spouse disabled
           spouse_veteran: Mi cónyuge es un veterano
           use_tax_applied: Impuesto sobre el uso del consumidor aplicado

--- a/db/migrate/20241101161438_change_nj_intake_money_fields_to_decimal.rb
+++ b/db/migrate/20241101161438_change_nj_intake_money_fields_to_decimal.rb
@@ -1,0 +1,10 @@
+class ChangeNjIntakeMoneyFieldsToDecimal < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured {
+      change_column :state_file_nj_intakes, :sales_use_tax, :decimal, precision: 12, scale: 2
+      change_column :state_file_nj_intakes, :property_tax_paid, :decimal, precision: 12, scale: 2
+      change_column :state_file_nj_intakes, :rent_paid, :decimal, precision: 12, scale: 2
+      change_column :state_file_nj_intakes, :medical_expenses, :decimal, precision: 12, scale: 2
+    }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2071,7 +2071,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_30_144351) do
     t.inet "last_sign_in_ip"
     t.string "locale", default: "en"
     t.datetime "locked_at"
-    t.integer "medical_expenses", default: 0, null: false
+    t.decimal "medical_expenses", precision: 12, scale: 2, default: "0.0", null: false
     t.jsonb "message_tracker", default: {}
     t.string "municipality_code"
     t.string "municipality_name"
@@ -2093,14 +2093,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_30_144351) do
     t.string "primary_ssn"
     t.bigint "primary_state_id_id"
     t.string "primary_suffix"
+    t.decimal "property_tax_paid", precision: 12, scale: 2
     t.integer "primary_veteran", default: 0, null: false
-    t.integer "property_tax_paid"
     t.text "raw_direct_file_data"
     t.jsonb "raw_direct_file_intake_data"
     t.string "referrer"
-    t.integer "rent_paid"
+    t.decimal "rent_paid", precision: 12, scale: 2
     t.string "routing_number"
-    t.integer "sales_use_tax"
+    t.decimal "sales_use_tax", precision: 12, scale: 2
     t.integer "sales_use_tax_calculation_method", default: 0, null: false
     t.integer "sign_in_count", default: 0, null: false
     t.string "source"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_30_144351) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_01_161438) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -2093,8 +2093,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_30_144351) do
     t.string "primary_ssn"
     t.bigint "primary_state_id_id"
     t.string "primary_suffix"
-    t.decimal "property_tax_paid", precision: 12, scale: 2
     t.integer "primary_veteran", default: 0, null: false
+    t.decimal "property_tax_paid", precision: 12, scale: 2
     t.text "raw_direct_file_data"
     t.jsonb "raw_direct_file_intake_data"
     t.string "referrer"

--- a/spec/factories/state_file_nj_intakes.rb
+++ b/spec/factories/state_file_nj_intakes.rb
@@ -36,7 +36,7 @@
 #  last_sign_in_ip                                        :inet
 #  locale                                                 :string           default("en")
 #  locked_at                                              :datetime
-#  medical_expenses                                       :integer          default(0), not null
+#  medical_expenses                                       :decimal(12, 2)   default(0.0), not null
 #  message_tracker                                        :jsonb
 #  municipality_code                                      :string
 #  municipality_name                                      :string
@@ -58,13 +58,13 @@
 #  primary_ssn                                            :string
 #  primary_suffix                                         :string
 #  primary_veteran                                        :integer          default("unfilled"), not null
-#  property_tax_paid                                      :integer
+#  property_tax_paid                                      :decimal(12, 2)
 #  raw_direct_file_data                                   :text
 #  raw_direct_file_intake_data                            :jsonb
 #  referrer                                               :string
-#  rent_paid                                              :integer
+#  rent_paid                                              :decimal(12, 2)
 #  routing_number                                         :string
-#  sales_use_tax                                          :integer
+#  sales_use_tax                                          :decimal(12, 2)
 #  sales_use_tax_calculation_method                       :integer          default("unfilled"), not null
 #  sign_in_count                                          :integer          default(0), not null
 #  source                                                 :string

--- a/spec/forms/state_file/nj_homeowner_property_tax_form_spec.rb
+++ b/spec/forms/state_file/nj_homeowner_property_tax_form_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe StateFile::NjHomeownerPropertyTaxForm do
   let(:intake) { create :state_file_nj_intake }
 
   describe "validations" do
-    let(:form) { described_class.new(intake, invalid_params) }
+    let(:form) { described_class.new(intake, params) }
 
     context "invalid params" do
       context "all fields are required" do
-        let(:invalid_params) do
+        let(:params) do
           { :property_tax_paid => nil }
         end
 
@@ -19,7 +19,7 @@ RSpec.describe StateFile::NjHomeownerPropertyTaxForm do
       end
 
       context "must be numeric" do
-        let(:invalid_params) do
+        let(:params) do
           { :property_tax_paid => "123A" }
         end
 
@@ -30,7 +30,7 @@ RSpec.describe StateFile::NjHomeownerPropertyTaxForm do
       end
 
       context "cannot be negative" do
-        let(:invalid_params) do
+        let(:params) do
           { :property_tax_paid => "-123" }
         end
 
@@ -41,7 +41,7 @@ RSpec.describe StateFile::NjHomeownerPropertyTaxForm do
       end
 
       context "cannot be zero" do
-        let(:invalid_params) do
+        let(:params) do
           { :property_tax_paid => "0" }
         end
 
@@ -54,7 +54,7 @@ RSpec.describe StateFile::NjHomeownerPropertyTaxForm do
 
     context "valid params" do
       context "can be a decimal" do
-        let(:invalid_params) do
+        let(:params) do
           { :property_tax_paid => "123.45" }
         end
 
@@ -64,7 +64,7 @@ RSpec.describe StateFile::NjHomeownerPropertyTaxForm do
       end
 
       context "can be an integer" do
-        let(:invalid_params) do
+        let(:params) do
           { :property_tax_paid => "123" }
         end
 

--- a/spec/forms/state_file/nj_homeowner_property_tax_form_spec.rb
+++ b/spec/forms/state_file/nj_homeowner_property_tax_form_spec.rb
@@ -25,18 +25,7 @@ RSpec.describe StateFile::NjHomeownerPropertyTaxForm do
 
         it "is invalid" do
           expect(form.valid?).to eq false
-          expect(form.errors[:property_tax_paid]).to include "Round to the nearest whole number"
-        end
-      end
-
-      context "must be an integer only" do
-        let(:invalid_params) do
-          { :property_tax_paid => "123.45" }
-        end
-
-        it "is invalid" do
-          expect(form.valid?).to eq false
-          expect(form.errors[:property_tax_paid]).to include "Round to the nearest whole number"
+          expect(form.errors[:property_tax_paid]).to include "Please enter numbers only."
         end
       end
 
@@ -59,6 +48,28 @@ RSpec.describe StateFile::NjHomeownerPropertyTaxForm do
         it "is invalid" do
           expect(form.valid?).to eq false
           expect(form.errors[:property_tax_paid]).to include "must be greater than or equal to 1"
+        end
+      end
+    end
+
+    context "valid params" do
+      context "can be a decimal" do
+        let(:invalid_params) do
+          { :property_tax_paid => "123.45" }
+        end
+
+        it "is valid" do
+          expect(form.valid?).to eq true
+        end
+      end
+
+      context "can be an integer" do
+        let(:invalid_params) do
+          { :property_tax_paid => "123" }
+        end
+
+        it "is valid" do
+          expect(form.valid?).to eq true
         end
       end
     end

--- a/spec/forms/state_file/nj_medical_expenses_form_spec.rb
+++ b/spec/forms/state_file/nj_medical_expenses_form_spec.rb
@@ -4,39 +4,50 @@ RSpec.describe StateFile::NjMedicalExpensesForm do
   let(:intake) { create :state_file_nj_intake }
 
   describe "validations" do
-    let(:form) { described_class.new(intake, invalid_params) }
+    let(:form) { described_class.new(intake, params) }
 
     context "invalid params" do
       context "must be numeric" do
-        let(:invalid_params) do
+        let(:params) do
           { medical_expenses: "awefwaefw" }
         end
 
         it "is invalid" do
           expect(form.valid?).to eq false
-          expect(form.errors[:medical_expenses]).to include "Round to the nearest whole number"
-        end
-      end
-
-      context "must be an integer only" do
-        let(:invalid_params) do
-          { medical_expenses: 123.45 }
-        end
-
-        it "is invalid" do
-          expect(form.valid?).to eq false
-          expect(form.errors[:medical_expenses]).to include "Round to the nearest whole number"
+          expect(form.errors[:medical_expenses]).to include "Please enter numbers only."
         end
       end
 
       context "cannot be negative" do
-        let(:invalid_params) do
+        let(:params) do
           { medical_expenses: "-123" }
         end
 
         it "is invalid" do
           expect(form.valid?).to eq false
           expect(form.errors[:medical_expenses]).to include "must be greater than or equal to 0"
+        end
+      end
+    end
+
+    context "valid params" do
+      context "can be a decimal" do
+        let(:params) do
+          { medical_expenses: 123.45 }
+        end
+
+        it "is valid" do
+          expect(form.valid?).to eq true
+        end
+      end
+
+      context "can be an integer" do
+        let(:params) do
+          { medical_expenses: 123 }
+        end
+
+        it "is valid" do
+          expect(form.valid?).to eq true
         end
       end
     end

--- a/spec/forms/state_file/nj_sales_use_tax_form_spec.rb
+++ b/spec/forms/state_file/nj_sales_use_tax_form_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe StateFile::NjSalesUseTaxForm do
 
         it "is invalid" do
           expect(form.valid?).to eq false
-          expect(form.errors[:sales_use_tax]).to include "Round to the nearest whole number"
+          expect(form.errors[:sales_use_tax]).to include "Please enter numbers only."
         end
       end
 
@@ -120,11 +120,14 @@ RSpec.describe StateFile::NjSalesUseTaxForm do
 
         it "is invalid" do
           expect(form.valid?).to eq false
-          expect(form.errors[:sales_use_tax]).to include "Round to the nearest whole number"
+          expect(form.errors[:sales_use_tax]).to include "Please enter numbers only."
         end
       end
+    end
 
-      context "with a non integer sales-use-tax" do
+    context "valid params" do
+
+      context "with a non-integer sales-use-tax" do
         let(:params) do
           {
             untaxed_out_of_state_purchases: "yes",
@@ -133,14 +136,10 @@ RSpec.describe StateFile::NjSalesUseTaxForm do
           }
         end
 
-        it "is invalid" do
-          expect(form.valid?).to eq false
-          expect(form.errors[:sales_use_tax]).to include "Round to the nearest whole number"
+        it "is valid" do
+          expect(form.valid?).to eq true
         end
       end
-    end
-
-    context "valid params" do
 
       context "with an integer sales-use-tax" do
         let(:params) do

--- a/spec/forms/state_file/nj_tenant_rent_paid_form_spec.rb
+++ b/spec/forms/state_file/nj_tenant_rent_paid_form_spec.rb
@@ -25,18 +25,7 @@ RSpec.describe StateFile::NjTenantRentPaidForm do
 
         it "is invalid" do
           expect(form.valid?).to eq false
-          expect(form.errors[:rent_paid]).to include "Round to the nearest whole number"
-        end
-      end
-
-      context "must be an integer only" do
-        let(:invalid_params) do
-          { :rent_paid => "123.45" }
-        end
-
-        it "is invalid" do
-          expect(form.valid?).to eq false
-          expect(form.errors[:rent_paid]).to include "Round to the nearest whole number"
+          expect(form.errors[:rent_paid]).to include "Please enter numbers only."
         end
       end
 
@@ -59,6 +48,28 @@ RSpec.describe StateFile::NjTenantRentPaidForm do
         it "is invalid" do
           expect(form.valid?).to eq false
           expect(form.errors[:rent_paid]).to include "must be greater than or equal to 1"
+        end
+      end
+    end
+
+    context "valid params" do
+      context "can be a decimal" do
+        let(:invalid_params) do
+          { :rent_paid => "123.45" }
+        end
+
+        it "is valid" do
+          expect(form.valid?).to eq true
+        end
+      end
+
+      context "can be an integer" do
+        let(:invalid_params) do
+          { :rent_paid => "123" }
+        end
+
+        it "is valid" do
+          expect(form.valid?).to eq true
         end
       end
     end

--- a/spec/forms/state_file/nj_tenant_rent_paid_form_spec.rb
+++ b/spec/forms/state_file/nj_tenant_rent_paid_form_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe StateFile::NjTenantRentPaidForm do
   let(:intake) { create :state_file_nj_intake }
 
   describe "validations" do
-    let(:form) { described_class.new(intake, invalid_params) }
+    let(:form) { described_class.new(intake, params) }
 
     context "invalid params" do
       context "all fields are required" do
-        let(:invalid_params) do
+        let(:params) do
           { :rent_paid => nil }
         end
 
@@ -19,7 +19,7 @@ RSpec.describe StateFile::NjTenantRentPaidForm do
       end
 
       context "must be numeric" do
-        let(:invalid_params) do
+        let(:params) do
           { :rent_paid => "123A" }
         end
 
@@ -30,7 +30,7 @@ RSpec.describe StateFile::NjTenantRentPaidForm do
       end
 
       context "cannot be negative" do
-        let(:invalid_params) do
+        let(:params) do
           { :rent_paid => "-123" }
         end
 
@@ -41,7 +41,7 @@ RSpec.describe StateFile::NjTenantRentPaidForm do
       end
 
       context "cannot be zero" do
-        let(:invalid_params) do
+        let(:params) do
           { :rent_paid => "0" }
         end
 
@@ -54,7 +54,7 @@ RSpec.describe StateFile::NjTenantRentPaidForm do
 
     context "valid params" do
       context "can be a decimal" do
-        let(:invalid_params) do
+        let(:params) do
           { :rent_paid => "123.45" }
         end
 
@@ -64,7 +64,7 @@ RSpec.describe StateFile::NjTenantRentPaidForm do
       end
 
       context "can be an integer" do
-        let(:invalid_params) do
+        let(:params) do
           { :rent_paid => "123" }
         end
 

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -565,13 +565,13 @@ describe Efile::Nj::Nj1040Calculator do
             :state_file_nj_intake,
             :married_filing_separately,
             household_rent_own: 'own',
-            property_tax_paid: 12345,
+            property_tax_paid: 12345.77,
             homeowner_same_home_spouse: 'no'
           )
         }
 
-        it 'sets line 40a to property_tax_paid' do
-          expect(instance.lines[:NJ1040_LINE_40A].value).to eq(12345)
+        it 'sets line 40a to property_tax_paid rounded' do
+          expect(instance.lines[:NJ1040_LINE_40A].value).to eq(12346)
         end
       end
 

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -497,9 +497,9 @@ describe Efile::Nj::Nj1040Calculator do
 
     context 'when medical expenses exceed 2% of gross income' do
       let(:gross_income) { 10_000 }
-      let(:medical_expenses) { 201 }
+      let(:medical_expenses) { 201.11 }
 
-      it 'sets line 31 to medical expenses minus $200' do
+      it 'sets line 31 to medical expenses minus $200, rounded' do
         expect(instance.lines[:NJ1040_LINE_31].value).to eq(1)
       end
 

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -420,7 +420,7 @@ describe Efile::Nj::Nj1040Calculator do
       it 'does not set line 16a' do
         expect(instance.lines[:NJ1040_LINE_16A].value).to eq(nil)
       end
-    end 
+    end
 
     context 'with interest on government bonds' do
       let(:intake) { create(:state_file_nj_intake, :df_data_two_deps) }
@@ -987,9 +987,9 @@ describe Efile::Nj::Nj1040Calculator do
   describe 'line 51 - sales and use tax' do
     
     context 'when sales_use_tax exists (already calculated automated or manual)' do
-      let(:intake) { create(:state_file_nj_intake, sales_use_tax: 400)}
-      it 'sets line 51 to the sales_use_tax' do
-        expect(instance.lines[:NJ1040_LINE_51].value).to eq 400
+      let(:intake) { create(:state_file_nj_intake, sales_use_tax: 400.77 )}
+      it 'sets line 51 to the rounded sales_use_tax' do
+        expect(instance.lines[:NJ1040_LINE_51].value).to eq 401
       end
     end
 

--- a/spec/models/state_file_nj_intake_spec.rb
+++ b/spec/models/state_file_nj_intake_spec.rb
@@ -36,7 +36,7 @@
 #  last_sign_in_ip                                        :inet
 #  locale                                                 :string           default("en")
 #  locked_at                                              :datetime
-#  medical_expenses                                       :integer          default(0), not null
+#  medical_expenses                                       :decimal(12, 2)   default(0.0), not null
 #  message_tracker                                        :jsonb
 #  municipality_code                                      :string
 #  municipality_name                                      :string
@@ -58,13 +58,13 @@
 #  primary_ssn                                            :string
 #  primary_suffix                                         :string
 #  primary_veteran                                        :integer          default("unfilled"), not null
-#  property_tax_paid                                      :integer
+#  property_tax_paid                                      :decimal(12, 2)
 #  raw_direct_file_data                                   :text
 #  raw_direct_file_intake_data                            :jsonb
 #  referrer                                               :string
-#  rent_paid                                              :integer
+#  rent_paid                                              :decimal(12, 2)
 #  routing_number                                         :string
-#  sales_use_tax                                          :integer
+#  sales_use_tax                                          :decimal(12, 2)
 #  sales_use_tax_calculation_method                       :integer          default("unfilled"), not null
 #  sign_in_count                                          :integer          default(0), not null
 #  source                                                 :string


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/98

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
For each of the following fields:
- property tax paid
- rent paid
- medical expenses
- use tax

do the following:
- update to use money field with `$0` placeholder
- update validation to accept decimals in the field
- update review page to display as rounded integers & use rounded for tax return
- when returning to the text box using review->edit flow or back button, display value in field as decimal (as originally entered)

## How to test?
Visit the fields using `minimal` profile

## Screenshots
![image](https://github.com/user-attachments/assets/392afa1a-e24c-487c-9520-e8bf5392d4d9)


