### PR TITLE
Send auto response on join keyword

### DIFF
--- a/app/models/automated_message/join_response.rb
+++ b/app/models/automated_message/join_response.rb
@@ -1,0 +1,11 @@
+module AutomatedMessage
+  class JoinResponse < AutomatedMessage
+    def self.name
+      'messages.join_keyword_response'.freeze
+    end
+
+    def sms_body
+      I18n.t("messages.join_keyword_response.sms.body")
+    end
+  end
+end

--- a/app/models/automated_message/join_response.rb
+++ b/app/models/automated_message/join_response.rb
@@ -7,5 +7,13 @@ module AutomatedMessage
     def sms_body
       I18n.t("messages.join_keyword_response.sms.body")
     end
+
+    def email_subject
+      "Join"
+    end
+
+    def email_body
+      I18n.t("messages.join_keyword_response.sms.body")
+    end
   end
 end

--- a/app/services/incoming_text_message_service.rb
+++ b/app/services/incoming_text_message_service.rb
@@ -10,6 +10,12 @@ class IncomingTextMessageService
       consenting_clients.where(intakes: { sms_phone_number: phone_number })
     )
 
+    # "minimal" join keyword support, to be expanded in the future
+    if params["Body"].downcase == "join" || params["Body"].downcase == "start"
+      body = AutomatedMessage::JoinResponse.new.sms_body
+      SendOutgoingTextMessageWithoutClientJob.perform_later(phone_number: phone_number, body: body)
+    end
+
     client_count = clients.count
     if client_count.zero?
       body = AutomatedMessage::UnmonitoredReplies.new.sms_body(support_email: Rails.configuration.email_from[:support][:gyr])

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1404,6 +1404,9 @@ en:
     document_upload:
       id_type: ID Type
   messages:
+    join_keyword_response:
+      sms:
+        body: Welcome to FileYourStateTaxes messages. Msg&data rates may apply.  Msg frequency varies. Reply "HELP" for help, "STOP" to unsubscribe.
     closing_soon:
       email:
         body: We are closing GetYourRefund for the tax season on {end_of_in_progress_intake_date}. We will need all required documentation by {end_of_docs_date}; otherwise, we will not be able to prepare your taxes. Please login and respond by {end_of_docs_date}. <<Client.LoginLink>> If we do not hear from you by then, we will close out your case and you can file with us next year.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1404,9 +1404,6 @@ en:
     document_upload:
       id_type: ID Type
   messages:
-    join_keyword_response:
-      sms:
-        body: Welcome to FileYourStateTaxes messages. Msg&data rates may apply.  Msg frequency varies. Reply "HELP" for help, "STOP" to unsubscribe.
     closing_soon:
       email:
         body: We are closing GetYourRefund for the tax season on {end_of_in_progress_intake_date}. We will need all required documentation by {end_of_docs_date}; otherwise, we will not be able to prepare your taxes. Please login and respond by {end_of_docs_date}. <<Client.LoginLink>> If we do not hear from you by then, we will close out your case and you can file with us next year.
@@ -1486,6 +1483,9 @@ en:
         subject: Your message has been forwarded to GetYourRefund customer support
       sms:
         body: This conversation is being forwarded to our customer service specialists. You should expect to see a message from them at a different email shortly.
+    join_keyword_response:
+      sms:
+        body: Welcome to FileYourStateTaxes messages. Msg&data rates may apply.  Msg frequency varies. Reply "HELP" for help, "STOP" to unsubscribe.
     new_photos_requested:
       admin_note: requested new photos
       email:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1402,9 +1402,6 @@ es:
     document_upload:
       id_type: Tipo de Identificación
   messages:
-    join_keyword_response:
-      sms:
-        body: Bienvenido a los mensajes de FileYourStateTaxes. Pueden aplicarse tarifas por mensajes y datos. La frecuencia de los mensajes varía. Responda "HELP" para obtener ayuda, "STOP" para cancelar la suscripción.
     closing_soon:
       email:
         body: 'Cerramos la temporada de impuestos de GetYourRefund el {end_of_in_progress_intake_date}. Necesitamos todos los documentos requeridos antes del {end_of_docs_date} de lo contrario, no podremos preparar su declaración de impuestos. Por favor inicie sesión y responda antes del {end_of_docs_date}.  <<Client.LoginLink>> Si no tenemos noticias suyas para entonces, cerraremos su caso y podrá presentar su declaración de impuestos con nosotros el próximo año. '
@@ -1472,6 +1469,9 @@ es:
         subject: Esta conversación ha sido enviada a los especialistas del servicio al cliente de GetYourRefund
       sms:
         body: Esta conversación ha sido enviada a los especialistas del servicio al cliente de getyourrefund.org. Espere  recibir un mensaje de ellos por correo electrónico en breve.
+    join_keyword_response:
+      sms:
+        body: Bienvenido a los mensajes de FileYourStateTaxes. Pueden aplicarse tarifas por mensajes y datos. La frecuencia de los mensajes varía. Responda "HELP" para obtener ayuda, "STOP" para cancelar la suscripción.
     new_photos_requested:
       admin_note: Se solicitaron nuevas fotos
       email:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1402,6 +1402,9 @@ es:
     document_upload:
       id_type: Tipo de Identificación
   messages:
+    join_keyword_response:
+      sms:
+        body: Bienvenido a los mensajes de FileYourStateTaxes. Pueden aplicarse tarifas por mensajes y datos. La frecuencia de los mensajes varía. Responda "HELP" para obtener ayuda, "STOP" para cancelar la suscripción.
     closing_soon:
       email:
         body: 'Cerramos la temporada de impuestos de GetYourRefund el {end_of_in_progress_intake_date}. Necesitamos todos los documentos requeridos antes del {end_of_docs_date} de lo contrario, no podremos preparar su declaración de impuestos. Por favor inicie sesión y responda antes del {end_of_docs_date}.  <<Client.LoginLink>> Si no tenemos noticias suyas para entonces, cerraremos su caso y podrá presentar su declaración de impuestos con nosotros el próximo año. '


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1006

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Adds a condition in `IncomingTextMessageService` so that incoming messages that are just the text "join" or "start" receive an automated reply
- The ticket mentions just sending the message, with follow up for actual "join" logic to follow up
## How to test?
- Unsure, but if there are numbers registered to the same credentials that our heroku pr apps use, we can test by texting one of their registered numbers the keyword "JOIN" or "START" and verify the response.
