### PR TITLE
Fix signature date tests

### DIFF
--- a/spec/lib/pdf_filler/id40_pdf_spec.rb
+++ b/spec/lib/pdf_filler/id40_pdf_spec.rb
@@ -3,11 +3,12 @@ require 'rails_helper'
 RSpec.describe PdfFiller::Id40Pdf do
   include PdfSpecHelper
 
+  let(:tomorrow_midnight) { DateTime.tomorrow.beginning_of_day }
   let!(:intake) {
     create(:state_file_id_intake,
            :single_filer_with_json, # includes phone number data
            primary_esigned: "yes",
-           primary_esigned_at: DateTime.now)
+           primary_esigned_at: tomorrow_midnight)
   }
   let(:submission) { create :efile_submission, tax_return: nil, data_source: intake }
   let(:pdf) { described_class.new(submission) }
@@ -22,7 +23,7 @@ RSpec.describe PdfFiller::Id40Pdf do
 
     context "when filer signed submission agreement" do
       it 'sets signature date field to the correct value' do
-        expect(pdf_fields["DateSign 2"]).to eq DateTime.now.strftime("%m-%d-%Y")
+        expect(pdf_fields["DateSign 2"]).to eq tomorrow_midnight.in_time_zone("America/New_York").strftime("%m-%d-%Y")
         expect(pdf_fields["TaxpayerPhoneNo"]).to eq "2085551234"
       end
     end

--- a/spec/lib/pdf_filler/id40_pdf_spec.rb
+++ b/spec/lib/pdf_filler/id40_pdf_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe PdfFiller::Id40Pdf do
 
     context "when filer signed submission agreement" do
       it 'sets signature date field to the correct value' do
-        expect(pdf_fields["DateSign 2"]).to eq tomorrow_midnight.in_time_zone("America/New_York").strftime("%m-%d-%Y")
+        expect(pdf_fields["DateSign 2"]).to eq tomorrow_midnight.in_time_zone("America/Boise").strftime("%m-%d-%Y")
         expect(pdf_fields["TaxpayerPhoneNo"]).to eq "2085551234"
       end
     end

--- a/spec/lib/pdf_filler/nc_d400_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nc_d400_pdf_spec.rb
@@ -19,13 +19,14 @@ RSpec.describe PdfFiller::NcD400Pdf do
     end
 
     context "pulling fields from xml" do
+      let(:tomorrow_midnight) { DateTime.tomorrow.beginning_of_day }
       let(:intake) {
         create(:state_file_nc_intake,
                filing_status: "single",
                primary_last_name: "Carolinianian",
                untaxed_out_of_state_purchases: "no",
                primary_esigned: "yes",
-               primary_esigned_at: DateTime.now)
+               primary_esigned_at: tomorrow_midnight)
       }
 
       context "single filer" do
@@ -72,8 +73,8 @@ RSpec.describe PdfFiller::NcD400Pdf do
           expect(pdf_fields['y_d400wf_li27_pg2_good']).to eq '0'
           expect(pdf_fields['y_d400wf_li28_pg2_good']).to eq '15'
           expect(pdf_fields['y_d400wf_li34_pg2_good']).to eq '15'
-          expect(pdf_fields['y_d400wf_sigdate']). to eq DateTime.now.strftime('%Y-%m-%d')
-          expect(pdf_fields['y_d400wf_sigdate2']). to eq ""
+          expect(pdf_fields['y_d400wf_sigdate']).to eq tomorrow_midnight.in_time_zone("America/New_York").strftime("%Y-%m-%d")
+          expect(pdf_fields['y_d400wf_sigdate2']).to eq ""
         end
 
         context "CTC & cascading fields" do
@@ -103,7 +104,8 @@ RSpec.describe PdfFiller::NcD400Pdf do
       end
 
       context "mfj filers" do
-        let(:intake) { create(:state_file_nc_intake, :with_spouse, filing_status: "married_filing_jointly", primary_esigned: "yes", primary_esigned_at: DateTime.now, spouse_esigned: "yes", spouse_esigned_at: DateTime.now)}
+        let(:tomorrow_midnight) { DateTime.tomorrow.beginning_of_day }
+        let(:intake) { create(:state_file_nc_intake, :with_spouse, filing_status: "married_filing_jointly", primary_esigned: "yes", primary_esigned_at: tomorrow_midnight, spouse_esigned: "yes", spouse_esigned_at: tomorrow_midnight) }
 
         before do
           submission.data_source.direct_file_data.spouse_date_of_death = "2024-09-30"
@@ -131,8 +133,8 @@ RSpec.describe PdfFiller::NcD400Pdf do
           expect(pdf_fields['y_d400wf_fstat5']).to eq 'Off'
 
           expect(pdf_fields['y_d400wf_li20b_pg2_good']).to eq '15'
-          expect(pdf_fields['y_d400wf_sigdate']). to eq DateTime.now.strftime('%Y-%m-%d')
-          expect(pdf_fields['y_d400wf_sigdate2']). to eq DateTime.now.strftime('%Y-%m-%d')
+          expect(pdf_fields['y_d400wf_sigdate']).to eq tomorrow_midnight.in_time_zone("America/New_York").strftime("%Y-%m-%d")
+          expect(pdf_fields['y_d400wf_sigdate2']).to eq tomorrow_midnight.in_time_zone("America/New_York").strftime("%Y-%m-%d")
         end
       end
 


### PR DESCRIPTION
## Is PM acceptance required? (delete one)
- No - merge after code review approval

## What was done?
Refactored some tests for signature dates on pdfs so that it will pass no matter when it is run. Previously tests could not be run after midnight UTC because the signature date would be set on the date of the timezone. Now all signature dates set to specific time instead of time.now.

## How to test?
- Updated unit tests
