### PR TITLE
NJ sales use tax - fix bug preventing field input

### DIFF
--- a/app/views/state_file/questions/nj_sales_use_tax/edit.html.erb
+++ b/app/views/state_file/questions/nj_sales_use_tax/edit.html.erb
@@ -25,8 +25,8 @@
       </div>
       <div class="question-with-follow-up__follow-up" id="sut-method-field">
         <div class="question-with-follow-up">
-          <div class="question-with-follow-up__question">
-            <div class="white-group">
+          <div class="white-group">
+            <div class="question-with-follow-up__question">
               <%=
                 f.cfa_radio_set(
                   :sales_use_tax_calculation_method,
@@ -37,9 +37,9 @@
                   ]
                 )
               %>
-              <div class="question-with-follow-up__follow-up" id="sut-field">
+            </div>
+            <div class="question-with-follow-up__follow-up" id="sut-field">
                 <%= f.vita_min_money_field(:sales_use_tax, t(".manual_use_tax_label"), options: { placeholder: '0' }, classes: ["form-width--long"]) %>
-              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Link to pivotal/JIRA issue
?

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Fix field so that you can type in it

## How to test?
- Go to sales use tax screen, select yes/manual, type in field

## Screenshots (for visual changes)
Before:

https://github.com/user-attachments/assets/231aedb4-5282-4255-ab42-3e794677acc4


