### PR TITLE
Fyst 455 add 1099 g review edit screen to nc flow

### DIFF
--- a/app/models/state_file_base_intake.rb
+++ b/app/models/state_file_base_intake.rb
@@ -371,6 +371,10 @@ class StateFileBaseIntake < ApplicationRecord
     end
   end
 
+  def total_unemployment_compensation_amount(recipient)
+    self.state_file1099_gs.sum {|g| g.recipient == recipient ? g.unemployment_compensation_amount : 0 }
+  end
+
   def primary_senior?
     calculate_age(primary_birth_date, inclusive_of_jan_1: true) >= 65
   end

--- a/app/views/state_file/questions/nc_review/edit.html.erb
+++ b/app/views/state_file/questions/nc_review/edit.html.erb
@@ -40,5 +40,25 @@
     </div>
   </div>
 
+  <% if current_intake.state_file1099_gs.present? %>
+    <div id="unemployment" class="white-group">
+      <div class="spacing-below-5">
+        <p class="text--bold spacing-below-5"><%=t(".primary_unemployment") %></p>
+        <p><%= number_to_currency(current_intake.total_unemployment_compensation_amount("primary").abs) %></p>
+        <%= link_to t("general.edit"), StateFile::Questions::UnemploymentController.to_path_helper(action: :index, return_to_review: "y"), class: "button--small" %>
+      </div>
+    </div>
+
+    <% if current_intake.filing_status_mfj? %>
+      <div id="spouse-unemployment" class="white-group">
+        <div class="spacing-below-5">
+          <p class="text--bold spacing-below-5"><%=t(".spouse_unemployment") %></p>
+          <p><%= number_to_currency(current_intake.total_unemployment_compensation_amount("spouse").abs) %></p>
+          <%= link_to t("general.edit"), StateFile::Questions::UnemploymentController.to_path_helper(action: :index, return_to_review: "y"), class: "button--small" %>
+        </div>
+      </div>
+    <% end %>
+  <%end %>
+
   <%= render "state_file/questions/shared/review_footer" %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2699,7 +2699,9 @@ en:
       nc_review:
         edit:
           amount: Amount
+          primary_unemployment: Unemployment compensation
           primary_veteran: Veteran Info
+          spouse_unemployment: Spouse's unemployment compensation
           spouse_veteran: Spouse Veteran Info
           state_credit: Amount earned as member of a federally recognized Indian tribe
           use_tax_applied: Consumer Use Tax Applied

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2671,7 +2671,9 @@ es:
       nc_review:
         edit:
           amount: Cantidad
+          primary_unemployment: Compensación por desempleo
           primary_veteran: Información del Veterano
+          spouse_unemployment: Compensación por desempleo del cónyuge
           spouse_veteran: Información del Cónyuge Veterano
           state_credit: Cantidad ganada como miembro de una tribu indígena reconocida federalmente
           use_tax_applied: Impuesto de Uso Aplicado

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -409,6 +409,10 @@ RSpec.feature "Completing a state file intake", active_job: true do
       click_on I18n.t("general.continue")
 
       expect(page).to have_text I18n.t("state_file.questions.shared.review_header.title")
+      expect(page).to have_text(I18n.t("state_file.questions.nc_review.edit.primary_unemployment"))
+      within '#unemployment' do
+        expect(page).to have_text('123')
+      end
       click_on I18n.t("general.continue")
 
       expect(strip_html_tags(page.body)).to include strip_html_tags(I18n.t("state_file.questions.tax_refund.edit.title_html", refund_amount: 1000, state_name: "North Carolina"))

--- a/spec/models/state_file_base_intake_spec.rb
+++ b/spec/models/state_file_base_intake_spec.rb
@@ -170,4 +170,34 @@ describe StateFileBaseIntake do
       end
     end
   end
+
+  describe "#total_unemployment_compensation_amount" do
+    let(:intake) { create :state_file_az_intake }
+
+    context "when there are 1099gs" do
+      let!(:primary_1099g) { create :state_file1099_g, recipient: 'primary', intake: intake, unemployment_compensation_amount: 20 }
+      let!(:primary_1099g_2) { create :state_file1099_g, recipient: 'primary', intake: intake, unemployment_compensation_amount: 15 }
+      let!(:spouse_1099g) { create :state_file1099_g, recipient: 'spouse', intake: intake, unemployment_compensation_amount: 200 }
+      let!(:spouse_1099g_2) { create :state_file1099_g, recipient: 'spouse', intake: intake, unemployment_compensation_amount: 150 }
+
+      context "when calculating the recipient's unemployment" do
+        it 'calculates' do
+          expect(intake.total_unemployment_compensation_amount('primary')).to eq 35
+        end
+      end
+
+      context "when calculating the spouse's unemployment" do
+        it 'calculates' do
+          expect(intake.total_unemployment_compensation_amount('spouse')).to eq 350
+        end
+      end
+    end
+
+    context "when there are no 1099gs" do
+      it 'returns 0' do
+        expect(intake.total_unemployment_compensation_amount('primary')).to eq 0
+        expect(intake.total_unemployment_compensation_amount('spouse')).to eq 0
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/FYST-455
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
The 1099G workflow already exists. This adds the unemployment total to the final page for the primary and spouse. If there are no 1099gs, the content will not appear on the page. 

## How to test?
Add 1099G data to the intake for the primary and spouse and see if the content shows up on the review page. If there are no 1099gs, the content will not appear on the page. 

## Screenshots (for visual changes)
<img width="778" alt="Screenshot 2024-11-08 at 2 35 31 PM" src="https://github.com/user-attachments/assets/6a54c531-4d48-4dfa-bff8-5d33778abe6a">

