### PR TITLE
Nj 107 excess

### DIFF
--- a/app/controllers/state_file/questions/w2_controller.rb
+++ b/app/controllers/state_file/questions/w2_controller.rb
@@ -2,8 +2,10 @@ module StateFile
   module Questions
     class W2Controller < QuestionsController
       before_action :load_w2
-
-      def edit; end
+      
+      def edit
+        @state_code = current_state_code
+      end
 
       def update
         @w2.assign_attributes(form_params)

--- a/app/lib/efile/line_data.yml
+++ b/app/lib/efile/line_data.yml
@@ -702,6 +702,10 @@ NJ1040_LINE_57:
   label: '57 New Jersey Estimated Tax Payments/Credit from prior year tax return'
 NJ1040_LINE_58:
   label: '58 New Jersey Earned Income Tax Credit (See instructions)'
+NJ1040_LINE_59:
+  label: 'Excess New Jersey UI/WF/SWF Withheld (Enclose Form NJ-2450) (See instructions)'
+NJ1040_LINE_61:
+  label: 'Excess New Jersey Family Leave Insurance Withheld (Enclose Form NJ-2450) (See instructions)'
 NJ1040_LINE_64:
   label: '64 Child and Dependent Care Credit'
 NJ1040_LINE_65_DEPENDENTS:

--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -5,6 +5,8 @@ module Efile
 
       RENT_CONVERSION = 0.18
       MAX_NJ_CTC_DEPENDENTS = 9
+      EXCESS_UI_WF_SWF_UI_HC_WD_MAX = 179.78
+      EXCESS_FLI_MAX = 145.26
 
       def initialize(year:, intake:, include_source: false)
         super
@@ -300,14 +302,13 @@ module Efile
 
       def calculate_line_59
         total_excess = 0
-        excess_threshold = 179.78
 
-        total_excess += get_personal_excess(@intake.primary.ssn, :box14_ui_wf_swf, excess_threshold)
-        total_excess += get_personal_excess(@intake.primary.ssn, :box14_ui_hc_wd, excess_threshold)
+        total_excess += get_personal_excess(@intake.primary.ssn, :box14_ui_wf_swf, EXCESS_UI_WF_SWF_UI_HC_WD_MAX)
+        total_excess += get_personal_excess(@intake.primary.ssn, :box14_ui_hc_wd, EXCESS_UI_WF_SWF_UI_HC_WD_MAX)
 
         if @intake.filing_status_mfj?
-          total_excess += get_personal_excess(@intake.spouse.ssn, :box14_ui_wf_swf, excess_threshold)
-          total_excess += get_personal_excess(@intake.spouse.ssn, :box14_ui_hc_wd, excess_threshold)
+          total_excess += get_personal_excess(@intake.spouse.ssn, :box14_ui_wf_swf, EXCESS_UI_WF_SWF_UI_HC_WD_MAX)
+          total_excess += get_personal_excess(@intake.spouse.ssn, :box14_ui_hc_wd, EXCESS_UI_WF_SWF_UI_HC_WD_MAX)
         end
 
         total_excess.round if total_excess.positive?
@@ -315,12 +316,11 @@ module Efile
 
       def calculate_line_61
         total_excess = 0
-        excess_threshold = 145.26
 
-        total_excess += get_personal_excess(@intake.primary.ssn, :box14_fli, excess_threshold)
+        total_excess += get_personal_excess(@intake.primary.ssn, :box14_fli, EXCESS_FLI_MAX)
         
         if @intake.filing_status_mfj?
-          total_excess += get_personal_excess(@intake.spouse.ssn, :box14_fli, excess_threshold)
+          total_excess += get_personal_excess(@intake.spouse.ssn, :box14_fli, EXCESS_FLI_MAX)
         end
 
         total_excess.round if total_excess.positive?

--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -31,6 +31,8 @@ module Efile
         set_line(:NJ1040_LINE_56, :calculate_line_56)
         set_line(:NJ1040_LINE_57, :calculate_line_57)
         set_line(:NJ1040_LINE_58, :calculate_line_58)
+        set_line(:NJ1040_LINE_59, :calculate_line_59)
+        set_line(:NJ1040_LINE_61, :calculate_line_61)
         set_line(:NJ1040_LINE_64, :calculate_line_64)
         set_line(:NJ1040_LINE_65_DEPENDENTS, :number_of_dependents_age_5_younger)
         set_line(:NJ1040_LINE_65, :calculate_line_65)
@@ -274,6 +276,62 @@ module Efile
 
       def calculate_line_58
         (@direct_file_data.fed_eic * 0.4).round
+      end
+
+      def get_personal_excess(ssn, excess_type, threshold)
+        persons_w2s = @intake.state_file_w2s.all&.select { |w2| w2.employee_ssn == ssn }
+        has_multiple_w2s = persons_w2s.count > 1
+        excess_contribution_count = 0
+        total_contribution = 0
+
+        return 0 unless has_multiple_w2s
+
+        # TODO: what should happen when a w2 exceeds the limit by itself? see ticket conversation
+        persons_w2s.each do |w2|
+          contribution = w2[excess_type] || 0
+          total_contribution += contribution
+          excess_contribution_count += 1 if contribution.positive?
+        end
+
+        if excess_contribution_count > 1 && total_contribution > threshold
+          return total_contribution - threshold
+        end
+        0
+      end
+
+      def calculate_line_59
+        primary_excess = 0
+        spouse_excess = 0
+        total_excess = 0
+        excess_threshold = 179.78
+
+        primary_excess += get_personal_excess(@intake.primary.ssn, :box14_ui_wf_swf, excess_threshold)
+        primary_excess += get_personal_excess(@intake.primary.ssn, :box14_ui_hc_wd, excess_threshold)
+
+        if @intake.filing_status_mfj?
+          spouse_excess += get_personal_excess(@intake.spouse.ssn, :box14_ui_wf_swf, excess_threshold)
+          spouse_excess += get_personal_excess(@intake.spouse.ssn, :box14_ui_hc_wd, excess_threshold)
+        end
+
+        total_excess += primary_excess
+        total_excess += spouse_excess
+        total_excess if total_excess.positive?
+      end
+
+      def calculate_line_61
+        total_excess = 0
+        excess_threshold = 145.26
+        spouse_excess = 0
+
+        primary_excess = get_personal_excess(@intake.primary.ssn, :box14_fli, excess_threshold)
+        
+        if @intake.filing_status_mfj?
+          spouse_excess = get_personal_excess(@intake.spouse.ssn, :box14_fli, excess_threshold)
+        end
+
+        total_excess += primary_excess
+        total_excess += spouse_excess
+        total_excess if total_excess.positive?
       end
 
       def calculate_line_64

--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -285,19 +285,15 @@ module Efile
         return 0 unless persons_w2s.count > 1
         return 0 if persons_w2s.any? { |w2| w2[excess_type] && w2[excess_type] > threshold }
 
-        excess_contribution_count = 0
         total_contribution = 0
 
         persons_w2s.each do |w2|
           contribution = w2[excess_type] || 0
           total_contribution += contribution
-          excess_contribution_count += 1 if contribution.positive?
         end
 
-        if excess_contribution_count > 1 && total_contribution > threshold
-          return total_contribution - threshold
-        end
-        0
+        excess_contribution = total_contribution - threshold
+        excess_contribution.positive? ? excess_contribution : 0
       end
 
       def calculate_line_59

--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -5,7 +5,7 @@ module Efile
 
       RENT_CONVERSION = 0.18
       MAX_NJ_CTC_DEPENDENTS = 9
-      EXCESS_UI_WF_SWF_UI_HC_WD_MAX = 179.78
+      EXCESS_UI_WF_SWF_MAX = 179.78 # also applies to ui hc wd
       EXCESS_FLI_MAX = 145.26
 
       def initialize(year:, intake:, include_source: false)
@@ -299,12 +299,12 @@ module Efile
       def calculate_line_59
         total_excess = 0
 
-        total_excess += get_personal_excess(@intake.primary.ssn, :box14_ui_wf_swf, EXCESS_UI_WF_SWF_UI_HC_WD_MAX)
-        total_excess += get_personal_excess(@intake.primary.ssn, :box14_ui_hc_wd, EXCESS_UI_WF_SWF_UI_HC_WD_MAX)
+        total_excess += get_personal_excess(@intake.primary.ssn, :box14_ui_wf_swf, EXCESS_UI_WF_SWF_MAX)
+        total_excess += get_personal_excess(@intake.primary.ssn, :box14_ui_hc_wd, EXCESS_UI_WF_SWF_MAX)
 
         if @intake.filing_status_mfj?
-          total_excess += get_personal_excess(@intake.spouse.ssn, :box14_ui_wf_swf, EXCESS_UI_WF_SWF_UI_HC_WD_MAX)
-          total_excess += get_personal_excess(@intake.spouse.ssn, :box14_ui_hc_wd, EXCESS_UI_WF_SWF_UI_HC_WD_MAX)
+          total_excess += get_personal_excess(@intake.spouse.ssn, :box14_ui_wf_swf, EXCESS_UI_WF_SWF_MAX)
+          total_excess += get_personal_excess(@intake.spouse.ssn, :box14_ui_hc_wd, EXCESS_UI_WF_SWF_MAX)
         end
 
         total_excess.round if total_excess.positive?

--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -281,11 +281,11 @@ module Efile
       def get_personal_excess(ssn, excess_type, threshold)
         persons_w2s = @intake.state_file_w2s.all&.select { |w2| w2.employee_ssn == ssn }
         return 0 unless persons_w2s.count > 1
+        return 0 if persons_w2s.any? { |w2| w2[excess_type] && w2[excess_type] > threshold }
 
         excess_contribution_count = 0
         total_contribution = 0
 
-        # TODO: what should happen when a w2 exceeds the limit by itself? see ticket conversation
         persons_w2s.each do |w2|
           contribution = w2[excess_type] || 0
           total_contribution += contribution

--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -224,7 +224,7 @@ module Efile
 
       def is_ineligible_or_unsupported_for_property_tax_credit
         StateFile::NjHomeownerEligibilityHelper.determine_eligibility(@intake) != StateFile::NjHomeownerEligibilityHelper::ADVANCE ||
-        Efile::Nj::NjPropertyTaxEligibility.ineligible?(@intake)
+          Efile::Nj::NjPropertyTaxEligibility.ineligible?(@intake)
       end
 
       def calculate_line_40a
@@ -315,7 +315,7 @@ module Efile
 
         total_excess += primary_excess
         total_excess += spouse_excess
-        total_excess if total_excess.positive?
+        total_excess.round if total_excess.positive?
       end
 
       def calculate_line_61
@@ -331,7 +331,7 @@ module Efile
 
         total_excess += primary_excess
         total_excess += spouse_excess
-        total_excess if total_excess.positive?
+        total_excess.round if total_excess.positive?
       end
 
       def calculate_line_64

--- a/app/lib/navigation/state_file_nj_question_navigation.rb
+++ b/app/lib/navigation/state_file_nj_question_navigation.rb
@@ -28,6 +28,7 @@ module Navigation
                                           # Federal info does not show to users
                                           Navigation::NavigationStep.new(StateFile::Questions::FederalInfoController),
                                           Navigation::NavigationStep.new(StateFile::Questions::DataTransferOffboardingController, false),
+                                          Navigation::NavigationStep.new(StateFile::Questions::IncomeReviewController),
                                           Navigation::NavigationStep.new(StateFile::Questions::NjCountyController),
                                           Navigation::NavigationStep.new(StateFile::Questions::NjMunicipalityController),
                                           Navigation::NavigationStep.new(StateFile::Questions::NjDisabledExemptionController),

--- a/app/lib/pdf_filler/nj1040_pdf.rb
+++ b/app/lib/pdf_filler/nj1040_pdf.rb
@@ -385,6 +385,33 @@ module PdfFiller
         answers[:'Check Box168'] = pdf_checkbox_value(@xml_document.at("EarnedIncomeCredit EICFederalAmt"))
       end
 
+
+      # line 59 excess ui etc contributions
+      if @xml_document.at("ExcessNjUiWfSwf").present?
+        tax = @xml_document.at("ExcessNjUiWfSwf").text.to_i
+        answers.merge!(insert_digits_into_fields(tax, [
+                                                   "Text175",
+                                                   "Text174",
+                                                   "Text173",
+                                                   "undefined_155",
+                                                   "undefined_154",
+                                                   "59"
+                                                 ]))
+      end
+      
+      # line 61 excess fli contributions
+      if @xml_document.at("ExcesNjFamiInsur").present?
+        tax = @xml_document.at("ExcesNjFamiInsur").text.to_i
+        answers.merge!(insert_digits_into_fields(tax, [
+                                                   "Text178",
+                                                   "Text177",
+                                                   "Text176",
+                                                   "undefined_157",
+                                                   "undefined_156",
+                                                   "60"
+                                                 ]))
+      end
+
       if mfj_spouse_ssn && xml_filing_status == 'MarriedCuPartFilingJoint'
         answers.merge!({
           undefined_3: mfj_spouse_ssn[0],

--- a/app/lib/pdf_filler/nj1040_pdf.rb
+++ b/app/lib/pdf_filler/nj1040_pdf.rb
@@ -386,7 +386,7 @@ module PdfFiller
       end
 
 
-      # line 59 excess ui etc contributions
+      # line 59
       if @xml_document.at("ExcessNjUiWfSwf").present?
         tax = @xml_document.at("ExcessNjUiWfSwf").text.to_i
         answers.merge!(insert_digits_into_fields(tax, [
@@ -399,7 +399,7 @@ module PdfFiller
                                                  ]))
       end
       
-      # line 61 excess fli contributions
+      # line 61
       if @xml_document.at("ExcesNjFamiInsur").present?
         tax = @xml_document.at("ExcesNjFamiInsur").text.to_i
         answers.merge!(insert_digits_into_fields(tax, [

--- a/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
+++ b/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
@@ -175,6 +175,14 @@ module SubmissionBuilder
                     end
                   end
 
+                  if calculated_fields.fetch(:NJ1040_LINE_59)&.positive?
+                    xml.ExcessNjUiWfSwf calculated_fields.fetch(:NJ1040_LINE_59)
+                  end
+
+                  if calculated_fields.fetch(:NJ1040_LINE_61)&.positive?
+                    xml.ExcesNjFamiInsur calculated_fields.fetch(:NJ1040_LINE_61)
+                  end
+
                   xml.ChildDependentCareCredit calculated_fields.fetch(:NJ1040_LINE_64).to_i if calculated_fields.fetch(:NJ1040_LINE_64)
 
                   line_65 = calculated_fields.fetch(:NJ1040_LINE_65)

--- a/app/models/state_file_base_intake.rb
+++ b/app/models/state_file_base_intake.rb
@@ -38,7 +38,7 @@ class StateFileBaseIntake < ApplicationRecord
   before_save :sanitize_bank_details
 
   def self.state_code
-    state_code, _ = StateFile::StateInformationService::STATES_INFO.find do |_, state_info|
+    state_code, = StateFile::StateInformationService::STATES_INFO.find do |_, state_info|
       state_info[:intake_class] == self
     end
     state_code.to_s
@@ -120,7 +120,15 @@ class StateFileBaseIntake < ApplicationRecord
   def synchronize_df_w2s_to_database
     direct_file_data.w2s.each_with_index do |direct_file_w2, i|
       state_file_w2 = state_file_w2s.where(w2_index: i).first || state_file_w2s.build
+      box_14_values = {}
+      direct_file_w2.w2_box14.each do |deduction|
+        box_14_values[deduction[:other_description]] = deduction[:other_amount]
+      end
       state_file_w2.assign_attributes(
+        box14_ui_wf_swf: box_14_values['UI/WF/SWF'],
+        box14_ui_hc_wd: box_14_values['UI/HC/WD'],
+        box14_fli: box_14_values['FLI'],
+        box14_stpickup: box_14_values['STPICKUP'],
         employer_name: direct_file_w2.EmployerName,
         employee_name: direct_file_w2.EmployeeNm,
         employee_ssn: direct_file_w2.EmployeeSSN,
@@ -131,7 +139,7 @@ class StateFileBaseIntake < ApplicationRecord
         state_income_tax_amount: direct_file_w2.StateIncomeTaxAmt,
         state_wages_amount: direct_file_w2.StateWagesAmt,
         state_file_intake: self,
-        w2_index: i
+        w2_index: i,
       )
       state_file_w2.save!
     end
@@ -241,18 +249,13 @@ class StateFileBaseIntake < ApplicationRecord
   def validate_state_specific_w2_requirements(w2); end
 
   def validate_state_specific_1099_g_requirements(state_file1099_g)
-    unless /\A\d{9}\z/.match(state_file1099_g.payer_tin)
+    unless /\A\d{9}\z/.match?(state_file1099_g.payer_tin)
       state_file1099_g.errors.add(:payer_tin, I18n.t("errors.attributes.payer_tin.invalid"))
     end
   end
 
   class Person
-    attr_reader :first_name
-    attr_reader :middle_initial
-    attr_reader :last_name
-    attr_reader :suffix
-    attr_reader :birth_date
-    attr_reader :ssn
+    attr_reader :first_name, :middle_initial, :last_name, :suffix, :birth_date, :ssn
 
     def initialize(intake, primary_or_spouse)
       @primary_or_spouse = primary_or_spouse
@@ -319,7 +322,7 @@ class StateFileBaseIntake < ApplicationRecord
   def save_nil_enums_with_unfilled
     keys_with_unfilled = self.defined_enums.map { |e| e.first if e.last.include?("unfilled") }
     keys_with_unfilled.each do |key|
-      if self.send(key) == nil
+      if self.send(key).nil?
         self.send("#{key}=", "unfilled")
       end
     end
@@ -331,27 +334,27 @@ class StateFileBaseIntake < ApplicationRecord
 
   def increment_failed_attempts
     super
-    if attempts_exceeded?
-      lock_access! unless access_locked?
+    if attempts_exceeded? && !access_locked?
+      lock_access!
     end
   end
 
   def controller_for_current_step
-    begin
-      if efile_submissions.present?
-        StateFile::Questions::ReturnStatusController
-      else
-        step_name = current_step.split('/').last
-        controller_name = "StateFile::Questions::#{step_name.underscore.camelize}Controller"
-        controller_name.constantize
-      end
-    rescue
-      if hashed_ssn.present?
-        StateFile::Questions::DataReviewController
-      else
-        StateFile::Questions::TermsAndConditionsController
-      end
+    
+    if efile_submissions.present?
+      StateFile::Questions::ReturnStatusController
+    else
+      step_name = current_step.split('/').last
+      controller_name = "StateFile::Questions::#{step_name.underscore.camelize}Controller"
+      controller_name.constantize
     end
+  rescue StandardError
+    if hashed_ssn.present?
+      StateFile::Questions::DataReviewController
+    else
+      StateFile::Questions::TermsAndConditionsController
+    end
+    
   end
 
   def self.opted_out_state_file_intakes(email)

--- a/app/models/state_file_w2.rb
+++ b/app/models/state_file_w2.rb
@@ -3,7 +3,10 @@
 # Table name: state_file_w2s
 #
 #  id                          :bigint           not null, primary key
+#  box14_fli                   :decimal(12, 2)
 #  box14_stpickup              :decimal(12, 2)
+#  box14_ui_hc_wd              :decimal(12, 2)
+#  box14_ui_wf_swf             :decimal(12, 2)
 #  employee_name               :string
 #  employee_ssn                :string
 #  employer_name               :string

--- a/app/models/state_file_w2.rb
+++ b/app/models/state_file_w2.rb
@@ -31,17 +31,17 @@ class StateFileW2 < ApplicationRecord
 
   include XmlMethods
   STATE_TAX_GRP_TEMPLATE = <<~XML
-  <W2StateTaxGrp>
-    <StateAbbreviationCd></StateAbbreviationCd>
-    <EmployerStateIdNum></EmployerStateIdNum>
-    <StateWagesAmt></StateWagesAmt>
-    <StateIncomeTaxAmt></StateIncomeTaxAmt>
-    <W2LocalTaxGrp>
-      <LocalWagesAndTipsAmt></LocalWagesAndTipsAmt>
-      <LocalIncomeTaxAmt></LocalIncomeTaxAmt>
-      <LocalityNm></LocalityNm>
-    </W2LocalTaxGrp>
-  </W2StateTaxGrp>
+    <W2StateTaxGrp>
+      <StateAbbreviationCd></StateAbbreviationCd>
+      <EmployerStateIdNum></EmployerStateIdNum>
+      <StateWagesAmt></StateWagesAmt>
+      <StateIncomeTaxAmt></StateIncomeTaxAmt>
+      <W2LocalTaxGrp>
+        <LocalWagesAndTipsAmt></LocalWagesAndTipsAmt>
+        <LocalIncomeTaxAmt></LocalIncomeTaxAmt>
+        <LocalityNm></LocalityNm>
+      </W2LocalTaxGrp>
+    </W2StateTaxGrp>
   XML
 
   belongs_to :state_file_intake, polymorphic: true
@@ -53,6 +53,10 @@ class StateFileW2 < ApplicationRecord
   validates :state_income_tax_amount, numericality: { greater_than_or_equal_to: 0 }, if: -> { state_income_tax_amount.present? }
   validates :local_wages_and_tips_amount, numericality: { greater_than_or_equal_to: 0 }, if: -> { local_wages_and_tips_amount.present? }
   validates :local_income_tax_amount, numericality: { greater_than_or_equal_to: 0 }, if: -> { local_income_tax_amount.present? }
+  validates :box14_fli, numericality: { greater_than_or_equal_to: 0 }, if: -> { box14_fli.present? }
+  validates :box14_stpickup, numericality: { greater_than_or_equal_to: 0 }, if: -> { box14_stpickup.present? }
+  validates :box14_ui_hc_wd, numericality: { greater_than_or_equal_to: 0 }, if: -> { box14_ui_hc_wd.present? }
+  validates :box14_ui_wf_swf, numericality: { greater_than_or_equal_to: 0 }, if: -> { box14_ui_wf_swf.present? }
   validates :locality_nm, presence: { message: ->(_object, _data) { I18n.t('state_file.questions.w2.edit.locality_nm_missing_error') } }, if: -> { local_wages_and_tips_amount.present? && local_wages_and_tips_amount.positive? }
   validates :employer_state_id_num, presence: true, if: -> { state_wages_amount.present? && state_wages_amount.positive? }
   validates :locality_nm, format: { with: /\A[a-zA-Z]{1}([A-Za-z\-\s']{0,19})\z/, message: :only_letters }, if: -> { locality_nm.present? }

--- a/app/services/state_file/state_information_service.rb
+++ b/app/services/state_file/state_information_service.rb
@@ -167,7 +167,7 @@ module StateFile
         vita_link: "",
         voucher_form_name: "NJ Voucher Form",
         voucher_path: "",
-        w2_supported_box14_codes: [],
+        w2_supported_box14_codes: ["UI_WF_SWF", "UI_HC_WD", "FLI"],
         w2_include_local_income_boxes: false
       },
       ny: {

--- a/app/views/state_file/questions/w2/edit.html.erb
+++ b/app/views/state_file/questions/w2/edit.html.erb
@@ -46,15 +46,13 @@
       <% end %>
     </div>
 
-    <% if @box14_codes.present? && current_state_code != 'nj' %>
+    <% if t(".box14_explanation.#{@state_code}_html", default: nil) %>
       <div class="reveal spacing-above-35">
         <p><button href="#" class="reveal__button"><%= t(".what_is_box14") %></button></p>
         <div class="reveal__content">
-          <% @box14_codes.each do |code| %>
             <p class="spacing-below-15">
-              <%= t(".box14_#{code.downcase}_explanation_html", year: MultiTenantService.statefile.current_tax_year) %>
+              <%= t(".box14_explanation.#{@state_code}_html", year: MultiTenantService.statefile.current_tax_year) %>
             </p>
-          <% end %>
         </div>
       </div>
     <% end %>

--- a/app/views/state_file/questions/w2/edit.html.erb
+++ b/app/views/state_file/questions/w2/edit.html.erb
@@ -9,17 +9,19 @@
       <p class="spacing-below-25"><%= @w2.employer_name %></p>
 
       <% if @box14_codes.present? %>
-        <p class="spacing-below-5"><%= t(".box14_html") %></p>
-        <% @box14_codes.each do |code| %>
-          <div class="form-question spacing-below-25">
-            <% field_name = "box14_#{code.downcase}" %>
-            <%= f.vita_min_money_field(
-                  field_name.to_sym,
-                  t(".box14_#{code.downcase}_html"),
-                  classes: ["form-width--long"]
-                ) %>
-              <%= t(".box14_#{code.downcase}_help_text", year: MultiTenantService.statefile.current_tax_year) %>
-          </div>
+        <fieldset>
+          <legend class="spacing-below-5"><%= t(".box14_html") %></legend>
+          <% @box14_codes.each do |code| %>
+            <div class="form-question spacing-below-25">
+              <% field_name = "box14_#{code.downcase}" %>
+              <%= f.vita_min_money_field(
+                    field_name.to_sym,
+                    t(".box14_#{code.downcase}_html"),
+                    classes: ["form-width--long"]
+                  ) %>
+                  <%= t(".box14_#{code.downcase}_help_text", year: MultiTenantService.statefile.current_tax_year, default: nil) %>
+            </div>
+          </fieldset>
         <% end %>
       <% end %>
       <div class="form-question spacing-below-25">
@@ -44,7 +46,7 @@
       <% end %>
     </div>
 
-    <% if @box14_codes.present? %>
+    <% if @box14_codes.present? && current_state_code != 'nj' %>
       <div class="reveal spacing-above-35">
         <p><button href="#" class="reveal__button"><%= t(".what_is_box14") %></button></p>
         <div class="reveal__content">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3219,10 +3219,13 @@ en:
           verification_code_label: Enter the 6-digit code
       w2:
         edit:
+          box14_fli_html: "<strong>FLI</strong>"
           box14_html: "<strong>Box 14,</strong> Other"
           box14_stpickup_explanation_html: For tax year %{year}, we will only process the <strong>STPICKUP</strong> code, which represents any contributions you made to the state retirement system.
           box14_stpickup_help_text: For tax year %{year}, we will only process the STPICKUP code. If you do not see this code or have other codes in Box 14, please leave it blank.
           box14_stpickup_html: "<strong>STPICKUP</strong>"
+          box14_ui_hc_wd_html: "<strong>UI/HC/WD</strong>"
+          box14_ui_wf_swf_html: "<strong>UI/WF/SWF</strong>"
           box15_html: "<strong>Box 15,</strong> Employer’s State ID number"
           box16_html: "<strong>Box 16,</strong> State wages, tips, etc."
           box17_html: "<strong>Box 17,</strong> State income tax"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3219,9 +3219,10 @@ en:
           verification_code_label: Enter the 6-digit code
       w2:
         edit:
+          box14_explanation:
+            md_html: For tax year %{year}, we will only process the <strong>STPICKUP</strong> code, which represents any contributions you made to the state retirement system.
           box14_fli_html: "<strong>FLI</strong>"
           box14_html: "<strong>Box 14,</strong> Other"
-          box14_stpickup_explanation_html: For tax year %{year}, we will only process the <strong>STPICKUP</strong> code, which represents any contributions you made to the state retirement system.
           box14_stpickup_help_text: For tax year %{year}, we will only process the STPICKUP code. If you do not see this code or have other codes in Box 14, please leave it blank.
           box14_stpickup_html: "<strong>STPICKUP</strong>"
           box14_ui_hc_wd_html: "<strong>UI/HC/WD</strong>"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3207,10 +3207,13 @@ es:
           verification_code_label: Ingresa el código de 6 dígitos
       w2:
         edit:
+          box14_fli_html: "<strong>FLI</strong>"
           box14_html: "<strong>Casilla 14,</strong> Otros"
           box14_stpickup_explanation_html: Para el año fiscal %{year}, solo procesaremos el código <strong>STPICKUP</strong>, que representa cualquier contribución que hayas hecho al sistema de jubilación estatal.
           box14_stpickup_help_text: Para el año fiscal %{year}, solo procesaremos el código STPICKUP. Si no ves este código o tienes otros códigos en la Casilla 14, déjala en blanco.
           box14_stpickup_html: "<strong>STPICKUP</strong>"
+          box14_ui_hc_wd_html: "<strong>UI/HC/WD</strong>"
+          box14_ui_wf_swf_html: "<strong>UI/WF/SWF</strong>"
           box15_html: "<strong>Box 15</strong>: Número de identificación del estado del empleador"
           box16_html: "<strong>Box 16</strong>: Salarios estatales, propinas, etc."
           box17_html: "<strong>Box 17</strong>: Impuesto sobre la renta estatal"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3207,9 +3207,10 @@ es:
           verification_code_label: Ingresa el código de 6 dígitos
       w2:
         edit:
+          box14_explanation:
+            md_html: Para el año fiscal %{year}, solo procesaremos el código <strong>STPICKUP</strong>, que representa cualquier contribución que hayas hecho al sistema de jubilación estatal.
           box14_fli_html: "<strong>FLI</strong>"
           box14_html: "<strong>Casilla 14,</strong> Otros"
-          box14_stpickup_explanation_html: Para el año fiscal %{year}, solo procesaremos el código <strong>STPICKUP</strong>, que representa cualquier contribución que hayas hecho al sistema de jubilación estatal.
           box14_stpickup_help_text: Para el año fiscal %{year}, solo procesaremos el código STPICKUP. Si no ves este código o tienes otros códigos en la Casilla 14, déjala en blanco.
           box14_stpickup_html: "<strong>STPICKUP</strong>"
           box14_ui_hc_wd_html: "<strong>UI/HC/WD</strong>"

--- a/db/migrate/20241106195606_add_nj_box14_codes_to_state_file_w2.rb
+++ b/db/migrate/20241106195606_add_nj_box14_codes_to_state_file_w2.rb
@@ -1,0 +1,7 @@
+class AddNjBox14CodesToStateFileW2 < ActiveRecord::Migration[7.1]
+  def change
+    add_column :state_file_w2s, :box14_ui_wf_swf, :decimal, precision: 12, scale: 2
+    add_column :state_file_w2s, :box14_ui_hc_wd, :decimal, precision: 12, scale: 2
+    add_column :state_file_w2s, :box14_fli, :decimal, precision: 12, scale: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2274,7 +2274,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_07_014709) do
   end
 
   create_table "state_file_w2s", force: :cascade do |t|
+    t.decimal "box14_fli", precision: 12, scale: 2
     t.decimal "box14_stpickup", precision: 12, scale: 2
+    t.decimal "box14_ui_hc_wd", precision: 12, scale: 2
+    t.decimal "box14_ui_wf_swf", precision: 12, scale: 2
     t.datetime "created_at", null: false
     t.string "employee_name"
     t.string "employee_ssn"

--- a/spec/controllers/state_file/questions/w2_controller_spec.rb
+++ b/spec/controllers/state_file/questions/w2_controller_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe StateFile::Questions::W2Controller do
         expect(response).to redirect_to(StateFile::Questions::IncomeReviewController.to_path_helper)
       end
 
-      context "with Box 14 fields" do
+      context "with MD Box 14 fields" do
         let(:intake) { create :state_file_md_intake }
         let(:params) do
           {
@@ -111,10 +111,35 @@ RSpec.describe StateFile::Questions::W2Controller do
           }
         end
 
-        it "updates Box 14 fields" do
+        it "updates MD Box 14 fields" do
           post :update, params: params
           state_file_w2.reload
           expect(state_file_w2.box14_stpickup).to eq 230
+        end
+      end
+
+      context "with NJ Box 14 fields" do
+        let(:intake) { create :state_file_nj_intake }
+        let(:params) do
+          {
+            id: state_file_w2.id,
+            state_file_w2: {
+              employer_state_id_num: "12345",
+              state_wages_amount: 10000,
+              state_income_tax_amount: 500,
+              box14_ui_wf_swf: 230,
+              box14_ui_hc_wd: 340,
+              box14_fli: 450,
+            }
+          }
+        end
+
+        it "updates NJ Box 14 fields" do
+          post :update, params: params
+          state_file_w2.reload
+          expect(state_file_w2.box14_ui_wf_swf).to eq 230
+          expect(state_file_w2.box14_ui_hc_wd).to eq 340
+          expect(state_file_w2.box14_fli).to eq 450
         end
       end
 

--- a/spec/factories/state_file_nj_intakes.rb
+++ b/spec/factories/state_file_nj_intakes.rb
@@ -191,6 +191,11 @@ FactoryBot.define do
       raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nj_exempt_interest_over_10k') }
     end
 
+    trait :df_data_box_14 do
+      raw_direct_file_data { StateFile::DirectFileApiResponseSampleService.new.read_xml('nj_zeus_box_14') }
+      raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nj_zeus_box_14') }
+    end
+
     trait :married_filing_jointly do
       filing_status { "married_filing_jointly" }
       spouse_birth_date { Date.new(1990, 1, 1) }

--- a/spec/factories/state_file_w2s.rb
+++ b/spec/factories/state_file_w2s.rb
@@ -3,7 +3,10 @@
 # Table name: state_file_w2s
 #
 #  id                          :bigint           not null, primary key
+#  box14_fli                   :decimal(12, 2)
 #  box14_stpickup              :decimal(12, 2)
+#  box14_ui_hc_wd              :decimal(12, 2)
+#  box14_ui_wf_swf             :decimal(12, 2)
 #  employee_name               :string
 #  employee_ssn                :string
 #  employer_name               :string

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -645,6 +645,9 @@ RSpec.feature "Completing a state file intake", active_job: true do
       expect(page).to have_text I18n.t("state_file.questions.data_review.edit.title")
       click_on I18n.t("general.continue")
 
+      expect(page).to have_text I18n.t("state_file.questions.income_review.edit.title")
+      click_on I18n.t("general.continue")
+
       select "Atlantic"
       click_on I18n.t("general.continue")
 

--- a/spec/fixtures/state_file/fed_return_jsons/2023/nj/zeus_box_14.json
+++ b/spec/fixtures/state_file/fed_return_jsons/2023/nj/zeus_box_14.json
@@ -1,0 +1,32 @@
+{
+  "familyAndHousehold": [
+    {
+      "firstName": "Kronos",
+      "middleInitial": "T",
+      "lastName": "Athens",
+      "dateOfBirth": "1920-01-01",
+      "relationship": "parent",
+      "eligibleDependent": true,
+      "isClaimedDependent": true,
+      "tin": "300-00-0029"
+    }
+  ],
+  "filers": [
+    {
+      "firstName": "Zeus",
+      "middleInitial": "L",
+      "lastName": "Thunder",
+      "dateOfBirth": "1980-01-01",
+      "isPrimaryFiler": true,
+      "tin": "400-00-0015"
+    },
+    {
+      "firstName": "Hera",
+      "middleInitial": null,
+      "lastName": "Thunder",
+      "dateOfBirth": "1980-01-01",
+      "isPrimaryFiler": false,
+      "tin": "600-00-0013"
+    }
+  ]
+}

--- a/spec/fixtures/state_file/fed_return_xmls/2023/nj/zeus_box_14.xml
+++ b/spec/fixtures/state_file/fed_return_xmls/2023/nj/zeus_box_14.xml
@@ -205,8 +205,20 @@
       <MedicareWagesAndTipsAmt>12345</MedicareWagesAndTipsAmt>
       <MedicareTaxWithheldAmt>725</MedicareTaxWithheldAmt>
       <OtherDeductionsBenefitsGrp>
-        <Desc>414HSUB</Desc>
+        <Desc>STPICKUP</Desc>
         <Amt>250</Amt>
+      </OtherDeductionsBenefitsGrp>
+      <OtherDeductionsBenefitsGrp>
+        <Desc>UI/WF/SWF</Desc>
+        <Amt>350</Amt>
+      </OtherDeductionsBenefitsGrp>
+      <OtherDeductionsBenefitsGrp>
+        <Desc>UI/HC/WD</Desc>
+        <Amt>450</Amt>
+      </OtherDeductionsBenefitsGrp>
+      <OtherDeductionsBenefitsGrp>
+        <Desc>FLI</Desc>
+        <Amt>550</Amt>
       </OtherDeductionsBenefitsGrp>
       <W2StateLocalTaxGrp>
         <W2StateTaxGrp>
@@ -216,52 +228,6 @@
           <StateIncomeTaxAmt>500</StateIncomeTaxAmt>
           <W2LocalTaxGrp>
             <LocalWagesAndTipsAmt>12345</LocalWagesAndTipsAmt>
-            <LocalIncomeTaxAmt>250</LocalIncomeTaxAmt>
-            <LocalityNm>Hammonton</LocalityNm>
-          </W2LocalTaxGrp>
-        </W2StateTaxGrp>
-      </W2StateLocalTaxGrp>
-      <StandardOrNonStandardCd>S</StandardOrNonStandardCd>
-    </IRSW2>
-    <IRSW2 documentName="IRSW2" documentId="W20002">
-      <EmployeeSSN>400000015</EmployeeSSN>
-      <EmployerEIN>001245768</EmployerEIN>
-      <EmployerNameControlTxt>BTB</EmployerNameControlTxt>
-      <EmployerName>
-        <BusinessNameLine1Txt>Brendan T Byrne State Forest</BusinessNameLine1Txt>
-      </EmployerName>
-      <EmployerUSAddress>
-        <AddressLine1Txt>31 Batsto Road</AddressLine1Txt>
-        <CityNm>Hammonton</CityNm>
-        <StateAbbreviationCd>NJ</StateAbbreviationCd>
-        <ZIPCd>08037</ZIPCd>
-      </EmployerUSAddress>
-      <EmployeeNm>ZEUS L THUNDER</EmployeeNm>
-      <EmployeeUSAddress>
-        <AddressLine1Txt>391 US-206</AddressLine1Txt>
-        <AddressLine2Txt>Unit 73</AddressLine2Txt>
-        <CityNm>Hammonton</CityNm>
-        <StateAbbreviationCd>NJ</StateAbbreviationCd>
-        <ZIPCd>08037</ZIPCd>
-      </EmployeeUSAddress>
-      <WagesAmt>50000</WagesAmt>
-      <WithholdingAmt>1000</WithholdingAmt>
-      <SocialSecurityWagesAmt>50000</SocialSecurityWagesAmt>
-      <SocialSecurityTaxAmt>3100</SocialSecurityTaxAmt>
-      <MedicareWagesAndTipsAmt>50000</MedicareWagesAndTipsAmt>
-      <MedicareTaxWithheldAmt>725</MedicareTaxWithheldAmt>
-      <OtherDeductionsBenefitsGrp>
-        <Desc>414HSUB</Desc>
-        <Amt>250</Amt>
-      </OtherDeductionsBenefitsGrp>
-      <W2StateLocalTaxGrp>
-        <W2StateTaxGrp>
-          <StateAbbreviationCd>NJ</StateAbbreviationCd>
-          <EmployerStateIdNum>54321</EmployerStateIdNum>
-          <StateWagesAmt>50000</StateWagesAmt>
-          <StateIncomeTaxAmt>500</StateIncomeTaxAmt>
-          <W2LocalTaxGrp>
-            <LocalWagesAndTipsAmt>50000</LocalWagesAndTipsAmt>
             <LocalIncomeTaxAmt>250</LocalIncomeTaxAmt>
             <LocalityNm>Hammonton</LocalityNm>
           </W2LocalTaxGrp>

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -1081,16 +1081,9 @@ describe Efile::Nj::Nj1040Calculator do
       end
 
       it 'does not fill line 59' do
-        expect(intake.state_file_w2s.count).to eq(2)
         first_w2 = intake.state_file_w2s.first 
-        second_w2 = intake.state_file_w2s.all[1]
         first_w2.update_attribute(:box14_ui_wf_swf, 0)
         first_w2.update_attribute(:box14_ui_hc_wd, described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX + 1)
-
-        expect(first_w2.box14_ui_wf_swf).to eq(0)
-        expect(first_w2.box14_ui_hc_wd).to eq(described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX + 1)
-        expect(second_w2.box14_ui_wf_swf).to eq(nil)
-        expect(second_w2.box14_ui_hc_wd).to eq(nil)
         expect(instance.lines[:NJ1040_LINE_59].value).to eq(nil)
       end
     end
@@ -1099,15 +1092,11 @@ describe Efile::Nj::Nj1040Calculator do
       let(:intake) { create(:state_file_nj_intake, :df_data_2_w2s) }
 
       it 'does not fill line 59' do
-        expect(intake.state_file_w2s.count).to eq(2)
         first_w2 = intake.state_file_w2s.first 
         second_w2 = intake.state_file_w2s.all[1]
         first_w2.update_attribute(:box14_fli, 40)
         second_w2.update_attribute(:box14_fli, 50)
         instance.calculate
-
-        expect(first_w2.box14_fli).to eq(40.00)
-        expect(second_w2.box14_fli).to eq(50.00)
         expect(instance.lines[:NJ1040_LINE_59].value).to eq(nil)
       end
     end
@@ -1115,15 +1104,11 @@ describe Efile::Nj::Nj1040Calculator do
     context "with multiple w2s, one of which has an excess contribution of more than #{described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX}" do 
       let(:intake) { create(:state_file_nj_intake, :df_data_2_w2s) }
       it 'does not fill line 59' do
-        expect(intake.state_file_w2s.count).to eq(2)
         first_w2 = intake.state_file_w2s.first 
         second_w2 = intake.state_file_w2s.all[1]
         first_w2.update_attribute(:box14_ui_wf_swf, described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX + 1)
         second_w2.update_attribute(:box14_ui_wf_swf, 1)
         instance.calculate
-
-        expect(first_w2.box14_ui_wf_swf).to eq(described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX + 1)
-        expect(second_w2.box14_ui_wf_swf).to eq(1.00)
         expect(instance.lines[:NJ1040_LINE_59].value).to eq(nil)
       end
     end
@@ -1131,7 +1116,6 @@ describe Efile::Nj::Nj1040Calculator do
     context "with multiple w2s that do not individually exceed #{described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX}, but have a total excess contribution of more than #{described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX}" do 
       let(:intake) { create(:state_file_nj_intake, :df_data_2_w2s) }
       it 'fills line 59 with the sum of the contributions less the excess threshold' do
-        expect(intake.state_file_w2s.count).to eq(2)
         first_w2 = intake.state_file_w2s.first 
         second_w2 = intake.state_file_w2s.all[1]
         contribution_1 = described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX - 1
@@ -1141,8 +1125,6 @@ describe Efile::Nj::Nj1040Calculator do
         second_w2.update_attribute(:box14_ui_wf_swf, contribution_2)
         instance.calculate
 
-        expect(first_w2.box14_ui_wf_swf).to eq(contribution_1)
-        expect(second_w2.box14_ui_wf_swf).to eq(contribution_2)
         expected_sum = (contribution_1 + contribution_2 - described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX).round
         expect(instance.lines[:NJ1040_LINE_59].value).to eq(expected_sum)
       end
@@ -1159,11 +1141,7 @@ describe Efile::Nj::Nj1040Calculator do
 
       context "mfj with multiple w2s per spouse that are each less than the max, total more than #{described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX} altogether, but total less than #{described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX} for each spouse" do 
         it 'does not fill line 59' do
-          expect(intake.state_file_w2s.count).to eq(5) # the mfj xml has 1 w2 already
           instance.calculate
-          [w2_1, w2_2, w2_3, w2_4].each do |w2|
-            expect(w2.box14_ui_hc_wd).to eq(10.00)
-          end
           expect(instance.lines[:NJ1040_LINE_59].value).to eq(nil)
         end
       end
@@ -1175,9 +1153,6 @@ describe Efile::Nj::Nj1040Calculator do
           w2_3.update_attribute(:box14_ui_wf_swf, contribution_1)
           w2_4.update_attribute(:box14_ui_wf_swf, contribution_2)
           instance.calculate
-
-          expect(w2_3.box14_ui_wf_swf).to eq(contribution_1)
-          expect(w2_4.box14_ui_wf_swf).to eq(contribution_2)
           expected_sum = (contribution_1 + contribution_2 - described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX).round
           expect(instance.lines[:NJ1040_LINE_59].value).to eq(expected_sum)
         end
@@ -1194,11 +1169,6 @@ describe Efile::Nj::Nj1040Calculator do
           w2_3.update_attribute(:box14_ui_wf_swf, contribution_3)
           w2_4.update_attribute(:box14_ui_wf_swf, contribution_4)
           instance.calculate
-
-          expect(w2_1.box14_ui_wf_swf).to eq(contribution_1)
-          expect(w2_2.box14_ui_wf_swf).to eq(contribution_2)
-          expect(w2_3.box14_ui_wf_swf).to eq(contribution_3)
-          expect(w2_4.box14_ui_wf_swf).to eq(contribution_4)
           expected_sum = (contribution_1 + contribution_2 + contribution_3 + contribution_4 - (described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX * 2)).round
           expect(instance.lines[:NJ1040_LINE_59].value).to eq(expected_sum)
         end
@@ -1224,15 +1194,11 @@ describe Efile::Nj::Nj1040Calculator do
       end
 
       it 'does not fill line 61' do
-        expect(intake.state_file_w2s.count).to eq(2)
         first_w2 = intake.state_file_w2s.all[0]
         second_w2 = intake.state_file_w2s.all[1]
         first_w2.update_attribute(:box14_fli, described_class::EXCESS_FLI_MAX + 1)
         second_w2.update_attribute(:box14_fli, nil)
         instance.calculate
-
-        expect(first_w2.box14_fli).to eq(described_class::EXCESS_FLI_MAX + 1)
-        expect(second_w2.box14_fli).to eq(nil)
         expect(instance.lines[:NJ1040_LINE_61].value).to eq(nil)
       end
     end
@@ -1241,15 +1207,11 @@ describe Efile::Nj::Nj1040Calculator do
       let(:intake) { create(:state_file_nj_intake, :df_data_2_w2s) }
 
       it 'does not fill line 61' do
-        expect(intake.state_file_w2s.count).to eq(2)
         first_w2 = intake.state_file_w2s.first 
         second_w2 = intake.state_file_w2s.all[1]
         first_w2.update_attribute(:box14_ui_wf_swf, 40)
         second_w2.update_attribute(:box14_ui_wf_swf, 50)
         instance.calculate
-
-        expect(first_w2.box14_ui_wf_swf).to eq(40.00)
-        expect(second_w2.box14_ui_wf_swf).to eq(50.00)
         expect(instance.lines[:NJ1040_LINE_61].value).to eq(nil)
       end
     end
@@ -1257,15 +1219,11 @@ describe Efile::Nj::Nj1040Calculator do
     context "with multiple w2s, one of which has an excess contribution of more than #{described_class::EXCESS_FLI_MAX}" do 
       let(:intake) { create(:state_file_nj_intake, :df_data_2_w2s) }
       it 'does not fill line 61' do
-        expect(intake.state_file_w2s.count).to eq(2)
         first_w2 = intake.state_file_w2s.first 
         second_w2 = intake.state_file_w2s.all[1]
         first_w2.update_attribute(:box14_fli, described_class::EXCESS_FLI_MAX + 1)
         second_w2.update_attribute(:box14_fli, 1)
         instance.calculate
-
-        expect(first_w2.box14_fli).to eq(described_class::EXCESS_FLI_MAX + 1)
-        expect(second_w2.box14_fli).to eq(1.00)
         expect(instance.lines[:NJ1040_LINE_61].value).to eq(nil)
       end
     end
@@ -1273,7 +1231,6 @@ describe Efile::Nj::Nj1040Calculator do
     context "with multiple w2s that do not individually exceed #{described_class::EXCESS_FLI_MAX}, but have a total excess contribution of more than #{described_class::EXCESS_FLI_MAX}" do 
       let(:intake) { create(:state_file_nj_intake, :df_data_2_w2s) }
       it 'fills line 61 with the sum of the contributions less the excess threshold' do
-        expect(intake.state_file_w2s.count).to eq(2)
         first_w2 = intake.state_file_w2s.first 
         second_w2 = intake.state_file_w2s.all[1]
         contribution_1 = described_class::EXCESS_FLI_MAX - 1
@@ -1283,8 +1240,6 @@ describe Efile::Nj::Nj1040Calculator do
         second_w2.update_attribute(:box14_fli, contribution_2)
         instance.calculate
 
-        expect(first_w2.box14_fli).to eq(contribution_1)
-        expect(second_w2.box14_fli).to eq(contribution_2)
         expected_sum = (contribution_1 + contribution_2 - described_class::EXCESS_FLI_MAX).round
         expect(instance.lines[:NJ1040_LINE_61].value).to eq(expected_sum)
       end
@@ -1301,11 +1256,7 @@ describe Efile::Nj::Nj1040Calculator do
 
       context "mfj with multiple w2s per spouse, each under #{described_class::EXCESS_FLI_MAX}, that total more than #{described_class::EXCESS_FLI_MAX} altogether, but total less than #{described_class::EXCESS_FLI_MAX} for each spouse" do 
         it 'does not fill line 61' do
-          expect(intake.state_file_w2s.count).to eq(5) # the mfj xml has 1 w2 already
           instance.calculate
-          [w2_1, w2_2, w2_3, w2_4].each do |w2|
-            expect(w2.box14_fli).to eq(10.00)
-          end
           expect(instance.lines[:NJ1040_LINE_61].value).to eq(nil)
         end
       end
@@ -1318,8 +1269,6 @@ describe Efile::Nj::Nj1040Calculator do
           w2_4.update_attribute(:box14_fli, contribution_2)
           instance.calculate
 
-          expect(w2_3.box14_fli).to eq(contribution_1)
-          expect(w2_4.box14_fli).to eq(contribution_2)
           expected_sum = (contribution_1 + contribution_2 - described_class::EXCESS_FLI_MAX).round
           expect(instance.lines[:NJ1040_LINE_61].value).to eq(expected_sum)
         end
@@ -1337,10 +1286,6 @@ describe Efile::Nj::Nj1040Calculator do
           w2_4.update_attribute(:box14_fli, contribution_4)
           instance.calculate
 
-          expect(w2_1.box14_fli).to eq(contribution_1)
-          expect(w2_2.box14_fli).to eq(contribution_2)
-          expect(w2_3.box14_fli).to eq(contribution_3)
-          expect(w2_4.box14_fli).to eq(contribution_4)
           expected_sum = (contribution_1 + contribution_2 + contribution_3 + contribution_4 - (described_class::EXCESS_FLI_MAX * 2)).round
           expect(instance.lines[:NJ1040_LINE_61].value).to eq(expected_sum)
         end

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -1160,7 +1160,7 @@ describe Efile::Nj::Nj1040Calculator do
 
         expect(first_w2.box14_ui_wf_swf).to eq(contribution_1)
         expect(second_w2.box14_ui_wf_swf).to eq(contribution_2)
-        expected_sum = contribution_1 + contribution_2 - EXCESS_UI_WF_SWF_UI_HC_WD_MAX
+        expected_sum = (contribution_1 + contribution_2 - EXCESS_UI_WF_SWF_UI_HC_WD_MAX).round
         expect(instance.lines[:NJ1040_LINE_59].value).to eq(expected_sum)
       end
     end
@@ -1196,7 +1196,7 @@ describe Efile::Nj::Nj1040Calculator do
 
           expect(w2_3.box14_ui_wf_swf).to eq(contribution_1)
           expect(w2_4.box14_ui_wf_swf).to eq(contribution_2)
-          expected_sum = contribution_1 + contribution_2 - EXCESS_UI_WF_SWF_UI_HC_WD_MAX
+          expected_sum = (contribution_1 + contribution_2 - EXCESS_UI_WF_SWF_UI_HC_WD_MAX).round
           expect(instance.lines[:NJ1040_LINE_59].value).to eq(expected_sum)
         end
       end
@@ -1217,7 +1217,7 @@ describe Efile::Nj::Nj1040Calculator do
           expect(w2_2.box14_ui_wf_swf).to eq(contribution_2)
           expect(w2_3.box14_ui_wf_swf).to eq(contribution_3)
           expect(w2_4.box14_ui_wf_swf).to eq(contribution_4)
-          expected_sum = contribution_1 + contribution_2 + contribution_3 + contribution_4 - (EXCESS_UI_WF_SWF_UI_HC_WD_MAX * 2)
+          expected_sum = (contribution_1 + contribution_2 + contribution_3 + contribution_4 - (EXCESS_UI_WF_SWF_UI_HC_WD_MAX * 2)).round
           expect(instance.lines[:NJ1040_LINE_59].value).to eq(expected_sum)
         end
       end
@@ -1238,14 +1238,16 @@ describe Efile::Nj::Nj1040Calculator do
     context 'with multiple w2s but excess contribution only from one employer' do
       let(:intake) { create(:state_file_nj_intake, :df_data_box_14) }
       before do
-        create :state_file_w2, state_file_intake: intake 
+        create :state_file_w2, state_file_intake: intake, box14_fli: 0
       end
 
       it 'does not fill line 61' do
         expect(intake.state_file_w2s.count).to eq(2)
-        first_w2 = intake.state_file_w2s.first 
+        first_w2 = intake.state_file_w2s.all[0]
         second_w2 = intake.state_file_w2s.all[1]
         first_w2.update_attribute(:box14_fli, EXCESS_FLI_MAX + 1)
+        second_w2.update_attribute(:box14_fli, nil)
+        instance.calculate
 
         expect(first_w2.box14_fli).to eq(EXCESS_FLI_MAX + 1)
         expect(second_w2.box14_fli).to eq(nil)
@@ -1302,7 +1304,7 @@ describe Efile::Nj::Nj1040Calculator do
 
         expect(first_w2.box14_fli).to eq(contribution_1)
         expect(second_w2.box14_fli).to eq(contribution_2)
-        expected_sum = contribution_1 + contribution_2 - EXCESS_FLI_MAX
+        expected_sum = (contribution_1 + contribution_2 - EXCESS_FLI_MAX).round
         expect(instance.lines[:NJ1040_LINE_61].value).to eq(expected_sum)
       end
     end
@@ -1338,7 +1340,7 @@ describe Efile::Nj::Nj1040Calculator do
 
           expect(w2_3.box14_fli).to eq(contribution_1)
           expect(w2_4.box14_fli).to eq(contribution_2)
-          expected_sum = contribution_1 + contribution_2 - EXCESS_FLI_MAX
+          expected_sum = (contribution_1 + contribution_2 - EXCESS_FLI_MAX).round
           expect(instance.lines[:NJ1040_LINE_61].value).to eq(expected_sum)
         end
       end
@@ -1359,7 +1361,7 @@ describe Efile::Nj::Nj1040Calculator do
           expect(w2_2.box14_fli).to eq(contribution_2)
           expect(w2_3.box14_fli).to eq(contribution_3)
           expect(w2_4.box14_fli).to eq(contribution_4)
-          expected_sum = contribution_1 + contribution_2 + contribution_3 + contribution_4 - (EXCESS_FLI_MAX * 2)
+          expected_sum = (contribution_1 + contribution_2 + contribution_3 + contribution_4 - (EXCESS_FLI_MAX * 2)).round
           expect(instance.lines[:NJ1040_LINE_61].value).to eq(expected_sum)
         end
       end

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -1115,35 +1115,21 @@ describe Efile::Nj::Nj1040Calculator do
       end
     end
 
-    # TODO: figure out how to handle the case of multiple w2s and one having a contribution greater than the max
-    # context "with multiple w2s that have an excess contribution of more than #{EXCESS_UI_WF_SWF_UI_HC_WD_MAX}" do 
-    #   let(:intake) { create(:state_file_nj_intake, :df_data_2_w2s) }
-    #   it 'fills line 59' do
-    #     expect(intake.state_file_w2s.count).to eq(2)
-    #     first_w2 = intake.state_file_w2s.first 
-    #     second_w2 = intake.state_file_w2s.all[1]
-    #     first_w2.update_attribute(:box14_ui_wf_swf, EXCESS_UI_WF_SWF_UI_HC_WD_MAX + 1)
-    #     second_w2.update_attribute(:box14_ui_wf_swf, 1)
-    #     instance.calculate
+    context "with multiple w2s, one of which has an excess contribution of more than #{EXCESS_UI_WF_SWF_UI_HC_WD_MAX}" do 
+      let(:intake) { create(:state_file_nj_intake, :df_data_2_w2s) }
+      it 'does not fill line 59' do
+        expect(intake.state_file_w2s.count).to eq(2)
+        first_w2 = intake.state_file_w2s.first 
+        second_w2 = intake.state_file_w2s.all[1]
+        first_w2.update_attribute(:box14_ui_wf_swf, EXCESS_UI_WF_SWF_UI_HC_WD_MAX + 1)
+        second_w2.update_attribute(:box14_ui_wf_swf, 1)
+        instance.calculate
 
-    #     expect(first_w2.box14_ui_wf_swf).to eq(1111.00)
-    #     expect(second_w2.box14_ui_wf_swf).to eq(2222.00)
-    #     expect(instance.lines[:NJ1040_LINE_59].value).to eq(1111 + 2222 - EXCESS_UI_WF_SWF_UI_HC_WD_MAX)
-    #   end
-
-    #   it 'fills line 59 for ui hc wd' do
-    #     expect(intake.state_file_w2s.count).to eq(2)
-    #     first_w2 = intake.state_file_w2s.first 
-    #     second_w2 = intake.state_file_w2s.all[1]
-    #     first_w2.update_attribute(:box14_ui_hc_wd, 1111)
-    #     second_w2.update_attribute(:box14_ui_hc_wd, 2222)
-    #     instance.calculate
-
-    #     expect(first_w2.box14_ui_hc_wd).to eq(1111.00)
-    #     expect(second_w2.box14_ui_hc_wd).to eq(2222.00)
-    #     expect(instance.lines[:NJ1040_LINE_59].value).to eq(1111 + 2222 - EXCESS_UI_WF_SWF_UI_HC_WD_MAX)
-    #   end
-    # end
+        expect(first_w2.box14_ui_wf_swf).to eq(EXCESS_UI_WF_SWF_UI_HC_WD_MAX + 1)
+        expect(second_w2.box14_ui_wf_swf).to eq(1.00)
+        expect(instance.lines[:NJ1040_LINE_59].value).to eq(nil)
+      end
+    end
 
     context "with multiple w2s that do not individually exceed #{EXCESS_UI_WF_SWF_UI_HC_WD_MAX}, but have a total excess contribution of more than #{EXCESS_UI_WF_SWF_UI_HC_WD_MAX}" do 
       let(:intake) { create(:state_file_nj_intake, :df_data_2_w2s) }
@@ -1272,22 +1258,21 @@ describe Efile::Nj::Nj1040Calculator do
       end
     end
 
-    # TODO: figure out how to handle the case of multiple w2s and one having a contribution greater than the max - see line 59
-    # context "with multiple w2s that have an excess contribution of more than #{EXCESS_FLI_MAX}" do 
-    #   let(:intake) { create(:state_file_nj_intake, :df_data_2_w2s) }
-    #   it 'fills line 61' do
-    #     expect(intake.state_file_w2s.count).to eq(2)
-    #     first_w2 = intake.state_file_w2s.first 
-    #     second_w2 = intake.state_file_w2s.all[1]
-    #     first_w2.update_attribute(:box14_fli, EXCESS_FLI_MAX + 1)
-    #     second_w2.update_attribute(:box14_fli, 1)
-    #     instance.calculate
+    context "with multiple w2s, one of which has an excess contribution of more than #{EXCESS_FLI_MAX}" do 
+      let(:intake) { create(:state_file_nj_intake, :df_data_2_w2s) }
+      it 'does not fill line 61' do
+        expect(intake.state_file_w2s.count).to eq(2)
+        first_w2 = intake.state_file_w2s.first 
+        second_w2 = intake.state_file_w2s.all[1]
+        first_w2.update_attribute(:box14_fli, EXCESS_FLI_MAX + 1)
+        second_w2.update_attribute(:box14_fli, 1)
+        instance.calculate
 
-    #     expect(first_w2.box14_fli).to eq(1111.00)
-    #     expect(second_w2.box14_fli).to eq(2222.00)
-    #     expect(instance.lines[:NJ1040_LINE_61].value).to eq(1111 + 2222 - EXCESS_FLI_MAX)
-    #   end
-    # end
+        expect(first_w2.box14_fli).to eq(EXCESS_FLI_MAX + 1)
+        expect(second_w2.box14_fli).to eq(1.00)
+        expect(instance.lines[:NJ1040_LINE_61].value).to eq(nil)
+      end
+    end
 
     context "with multiple w2s that do not individually exceed #{EXCESS_FLI_MAX}, but have a total excess contribution of more than #{EXCESS_FLI_MAX}" do 
       let(:intake) { create(:state_file_nj_intake, :df_data_2_w2s) }

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -1068,7 +1068,7 @@ describe Efile::Nj::Nj1040Calculator do
       it 'does not fill line 59' do
         w2 = intake.state_file_w2s.first 
         w2.update_attribute(:box14_ui_wf_swf, 0)
-        w2.update_attribute(:box14_ui_hc_wd, described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX + 1)
+        w2.update_attribute(:box14_ui_hc_wd, described_class::EXCESS_UI_WF_SWF_MAX + 1)
         instance.calculate
         expect(instance.lines[:NJ1040_LINE_59].value).to eq(nil)
       end
@@ -1083,7 +1083,7 @@ describe Efile::Nj::Nj1040Calculator do
       it 'does not fill line 59' do
         first_w2 = intake.state_file_w2s.first 
         first_w2.update_attribute(:box14_ui_wf_swf, 0)
-        first_w2.update_attribute(:box14_ui_hc_wd, described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX + 1)
+        first_w2.update_attribute(:box14_ui_hc_wd, described_class::EXCESS_UI_WF_SWF_MAX + 1)
         expect(instance.lines[:NJ1040_LINE_59].value).to eq(nil)
       end
     end
@@ -1101,31 +1101,31 @@ describe Efile::Nj::Nj1040Calculator do
       end
     end
 
-    context "with multiple w2s, one of which has an excess contribution of more than #{described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX}" do 
+    context "with multiple w2s, one of which has an excess contribution of more than #{described_class::EXCESS_UI_WF_SWF_MAX}" do 
       let(:intake) { create(:state_file_nj_intake, :df_data_2_w2s) }
       it 'does not fill line 59' do
         first_w2 = intake.state_file_w2s.first 
         second_w2 = intake.state_file_w2s.all[1]
-        first_w2.update_attribute(:box14_ui_wf_swf, described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX + 1)
+        first_w2.update_attribute(:box14_ui_wf_swf, described_class::EXCESS_UI_WF_SWF_MAX + 1)
         second_w2.update_attribute(:box14_ui_wf_swf, 1)
         instance.calculate
         expect(instance.lines[:NJ1040_LINE_59].value).to eq(nil)
       end
     end
 
-    context "with multiple w2s that do not individually exceed #{described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX}, but have a total excess contribution of more than #{described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX}" do 
+    context "with multiple w2s that do not individually exceed #{described_class::EXCESS_UI_WF_SWF_MAX}, but have a total excess contribution of more than #{described_class::EXCESS_UI_WF_SWF_MAX}" do 
       let(:intake) { create(:state_file_nj_intake, :df_data_2_w2s) }
       it 'fills line 59 with the sum of the contributions less the excess threshold' do
         first_w2 = intake.state_file_w2s.first 
         second_w2 = intake.state_file_w2s.all[1]
-        contribution_1 = described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX - 1
-        contribution_2 = described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX - 2
+        contribution_1 = described_class::EXCESS_UI_WF_SWF_MAX - 1
+        contribution_2 = described_class::EXCESS_UI_WF_SWF_MAX - 2
 
         first_w2.update_attribute(:box14_ui_wf_swf, contribution_1)
         second_w2.update_attribute(:box14_ui_wf_swf, contribution_2)
         instance.calculate
 
-        expected_sum = (contribution_1 + contribution_2 - described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX).round
+        expected_sum = (contribution_1 + contribution_2 - described_class::EXCESS_UI_WF_SWF_MAX).round
         expect(instance.lines[:NJ1040_LINE_59].value).to eq(expected_sum)
       end
     end
@@ -1139,36 +1139,36 @@ describe Efile::Nj::Nj1040Calculator do
       let!(:w2_3) { create(:state_file_w2, state_file_intake: intake, employee_ssn: spouse_ssn_from_fixture, box14_ui_hc_wd: 10) }
       let!(:w2_4) { create(:state_file_w2, state_file_intake: intake, employee_ssn: spouse_ssn_from_fixture, box14_ui_hc_wd: 10) }
 
-      context "mfj with multiple w2s per spouse that are each less than the max, total more than #{described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX} altogether, but total less than #{described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX} for each spouse" do 
+      context "mfj with multiple w2s per spouse that are each less than the max, total more than #{described_class::EXCESS_UI_WF_SWF_MAX} altogether, but total less than #{described_class::EXCESS_UI_WF_SWF_MAX} for each spouse" do 
         it 'does not fill line 59' do
           expect(instance.lines[:NJ1040_LINE_59].value).to eq(nil)
         end
       end
       
-      context "mfj with multiple w2s per person that individually do not exceed #{described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX}, total more than #{described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX} for spouse, but total less than #{described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX} for primary" do 
+      context "mfj with multiple w2s per person that individually do not exceed #{described_class::EXCESS_UI_WF_SWF_MAX}, total more than #{described_class::EXCESS_UI_WF_SWF_MAX} for spouse, but total less than #{described_class::EXCESS_UI_WF_SWF_MAX} for primary" do 
         it 'fills line 59 for the partner with multiple w2s' do
-          contribution_1 = described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX - 1
-          contribution_2 = described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX - 2
+          contribution_1 = described_class::EXCESS_UI_WF_SWF_MAX - 1
+          contribution_2 = described_class::EXCESS_UI_WF_SWF_MAX - 2
           w2_3.update_attribute(:box14_ui_wf_swf, contribution_1)
           w2_4.update_attribute(:box14_ui_wf_swf, contribution_2)
           instance.calculate
-          expected_sum = (contribution_1 + contribution_2 - described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX).round
+          expected_sum = (contribution_1 + contribution_2 - described_class::EXCESS_UI_WF_SWF_MAX).round
           expect(instance.lines[:NJ1040_LINE_59].value).to eq(expected_sum)
         end
       end
       
-      context "mfj with multiple w2s per spouse that individually do not exceed #{described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX} and total more than #{described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX} for each spouse" do 
+      context "mfj with multiple w2s per spouse that individually do not exceed #{described_class::EXCESS_UI_WF_SWF_MAX} and total more than #{described_class::EXCESS_UI_WF_SWF_MAX} for each spouse" do 
         it 'adds the sum for both spouses to line 59' do
-          contribution_1 = described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX - 1
-          contribution_2 = described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX - 2
-          contribution_3 = described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX - 3
-          contribution_4 = described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX - 4
+          contribution_1 = described_class::EXCESS_UI_WF_SWF_MAX - 1
+          contribution_2 = described_class::EXCESS_UI_WF_SWF_MAX - 2
+          contribution_3 = described_class::EXCESS_UI_WF_SWF_MAX - 3
+          contribution_4 = described_class::EXCESS_UI_WF_SWF_MAX - 4
           w2_1.update_attribute(:box14_ui_wf_swf, contribution_1)
           w2_2.update_attribute(:box14_ui_wf_swf, contribution_2)
           w2_3.update_attribute(:box14_ui_wf_swf, contribution_3)
           w2_4.update_attribute(:box14_ui_wf_swf, contribution_4)
           instance.calculate
-          expected_sum = (contribution_1 + contribution_2 + contribution_3 + contribution_4 - (described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX * 2)).round
+          expected_sum = (contribution_1 + contribution_2 + contribution_3 + contribution_4 - (described_class::EXCESS_UI_WF_SWF_MAX * 2)).round
           expect(instance.lines[:NJ1040_LINE_59].value).to eq(expected_sum)
         end
       end

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -1168,7 +1168,7 @@ describe Efile::Nj::Nj1040Calculator do
           w2_3.update_attribute(:box14_ui_wf_swf, contribution_3)
           w2_4.update_attribute(:box14_ui_wf_swf, contribution_4)
           instance.calculate
-          expected_sum = (contribution_1 + contribution_2 + contribution_3 + contribution_4 - (described_class::EXCESS_UI_WF_SWF_MAX * 2)).round
+          expected_sum = 350
           expect(instance.lines[:NJ1040_LINE_59].value).to eq(expected_sum)
         end
       end
@@ -1284,7 +1284,7 @@ describe Efile::Nj::Nj1040Calculator do
           w2_4.update_attribute(:box14_fli, contribution_4)
           instance.calculate
 
-          expected_sum = (contribution_1 + contribution_2 + contribution_3 + contribution_4 - (described_class::EXCESS_FLI_MAX * 2)).round
+          expected_sum = 281
           expect(instance.lines[:NJ1040_LINE_61].value).to eq(expected_sum)
         end
       end

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -4,9 +4,6 @@ def over_65_birth_year
   MultiTenantService.statefile.current_tax_year - 65
 end
 
-EXCESS_UI_WF_SWF_UI_HC_WD_MAX = 179.78
-EXCESS_FLI_MAX = 145.26
-
 describe Efile::Nj::Nj1040Calculator do
   let(:intake) { create(:state_file_nj_intake) }
   let(:instance) do
@@ -1071,7 +1068,7 @@ describe Efile::Nj::Nj1040Calculator do
       it 'does not fill line 59' do
         w2 = intake.state_file_w2s.first 
         w2.update_attribute(:box14_ui_wf_swf, 0)
-        w2.update_attribute(:box14_ui_hc_wd, EXCESS_UI_WF_SWF_UI_HC_WD_MAX + 1)
+        w2.update_attribute(:box14_ui_hc_wd, described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX + 1)
         instance.calculate
         expect(instance.lines[:NJ1040_LINE_59].value).to eq(nil)
       end
@@ -1088,10 +1085,10 @@ describe Efile::Nj::Nj1040Calculator do
         first_w2 = intake.state_file_w2s.first 
         second_w2 = intake.state_file_w2s.all[1]
         first_w2.update_attribute(:box14_ui_wf_swf, 0)
-        first_w2.update_attribute(:box14_ui_hc_wd, EXCESS_UI_WF_SWF_UI_HC_WD_MAX + 1)
+        first_w2.update_attribute(:box14_ui_hc_wd, described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX + 1)
 
         expect(first_w2.box14_ui_wf_swf).to eq(0)
-        expect(first_w2.box14_ui_hc_wd).to eq(EXCESS_UI_WF_SWF_UI_HC_WD_MAX + 1)
+        expect(first_w2.box14_ui_hc_wd).to eq(described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX + 1)
         expect(second_w2.box14_ui_wf_swf).to eq(nil)
         expect(second_w2.box14_ui_hc_wd).to eq(nil)
         expect(instance.lines[:NJ1040_LINE_59].value).to eq(nil)
@@ -1115,30 +1112,30 @@ describe Efile::Nj::Nj1040Calculator do
       end
     end
 
-    context "with multiple w2s, one of which has an excess contribution of more than #{EXCESS_UI_WF_SWF_UI_HC_WD_MAX}" do 
+    context "with multiple w2s, one of which has an excess contribution of more than #{described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX}" do 
       let(:intake) { create(:state_file_nj_intake, :df_data_2_w2s) }
       it 'does not fill line 59' do
         expect(intake.state_file_w2s.count).to eq(2)
         first_w2 = intake.state_file_w2s.first 
         second_w2 = intake.state_file_w2s.all[1]
-        first_w2.update_attribute(:box14_ui_wf_swf, EXCESS_UI_WF_SWF_UI_HC_WD_MAX + 1)
+        first_w2.update_attribute(:box14_ui_wf_swf, described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX + 1)
         second_w2.update_attribute(:box14_ui_wf_swf, 1)
         instance.calculate
 
-        expect(first_w2.box14_ui_wf_swf).to eq(EXCESS_UI_WF_SWF_UI_HC_WD_MAX + 1)
+        expect(first_w2.box14_ui_wf_swf).to eq(described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX + 1)
         expect(second_w2.box14_ui_wf_swf).to eq(1.00)
         expect(instance.lines[:NJ1040_LINE_59].value).to eq(nil)
       end
     end
 
-    context "with multiple w2s that do not individually exceed #{EXCESS_UI_WF_SWF_UI_HC_WD_MAX}, but have a total excess contribution of more than #{EXCESS_UI_WF_SWF_UI_HC_WD_MAX}" do 
+    context "with multiple w2s that do not individually exceed #{described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX}, but have a total excess contribution of more than #{described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX}" do 
       let(:intake) { create(:state_file_nj_intake, :df_data_2_w2s) }
       it 'fills line 59 with the sum of the contributions less the excess threshold' do
         expect(intake.state_file_w2s.count).to eq(2)
         first_w2 = intake.state_file_w2s.first 
         second_w2 = intake.state_file_w2s.all[1]
-        contribution_1 = EXCESS_UI_WF_SWF_UI_HC_WD_MAX - 1
-        contribution_2 = EXCESS_UI_WF_SWF_UI_HC_WD_MAX - 2
+        contribution_1 = described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX - 1
+        contribution_2 = described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX - 2
 
         first_w2.update_attribute(:box14_ui_wf_swf, contribution_1)
         second_w2.update_attribute(:box14_ui_wf_swf, contribution_2)
@@ -1146,7 +1143,7 @@ describe Efile::Nj::Nj1040Calculator do
 
         expect(first_w2.box14_ui_wf_swf).to eq(contribution_1)
         expect(second_w2.box14_ui_wf_swf).to eq(contribution_2)
-        expected_sum = (contribution_1 + contribution_2 - EXCESS_UI_WF_SWF_UI_HC_WD_MAX).round
+        expected_sum = (contribution_1 + contribution_2 - described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX).round
         expect(instance.lines[:NJ1040_LINE_59].value).to eq(expected_sum)
       end
     end
@@ -1160,39 +1157,38 @@ describe Efile::Nj::Nj1040Calculator do
       let!(:w2_3) { create(:state_file_w2, state_file_intake: intake, employee_ssn: spouse_ssn_from_fixture, box14_ui_hc_wd: 10) }
       let!(:w2_4) { create(:state_file_w2, state_file_intake: intake, employee_ssn: spouse_ssn_from_fixture, box14_ui_hc_wd: 10) }
 
-      context "mfj with multiple w2s per spouse that are each less than the max, total more than #{EXCESS_UI_WF_SWF_UI_HC_WD_MAX} altogether, but total less than #{EXCESS_UI_WF_SWF_UI_HC_WD_MAX} for each spouse" do 
+      context "mfj with multiple w2s per spouse that are each less than the max, total more than #{described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX} altogether, but total less than #{described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX} for each spouse" do 
         it 'does not fill line 59' do
           expect(intake.state_file_w2s.count).to eq(5) # the mfj xml has 1 w2 already
           instance.calculate
-          w2s = intake.state_file_w2s.all
-          (1..4).each do |n|
-            expect(w2s[n].box14_ui_hc_wd).to eq(10.00)
+          [w2_1, w2_2, w2_3, w2_4].each do |w2|
+            expect(w2.box14_ui_hc_wd).to eq(10.00)
           end
           expect(instance.lines[:NJ1040_LINE_59].value).to eq(nil)
         end
       end
       
-      context "mfj with multiple w2s per person that individually do not exceed #{EXCESS_UI_WF_SWF_UI_HC_WD_MAX}, total more than #{EXCESS_UI_WF_SWF_UI_HC_WD_MAX} for spouse, but total less than #{EXCESS_UI_WF_SWF_UI_HC_WD_MAX} for primary" do 
+      context "mfj with multiple w2s per person that individually do not exceed #{described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX}, total more than #{described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX} for spouse, but total less than #{described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX} for primary" do 
         it 'fills line 59 for the partner with multiple w2s' do
-          contribution_1 = EXCESS_UI_WF_SWF_UI_HC_WD_MAX - 1
-          contribution_2 = EXCESS_UI_WF_SWF_UI_HC_WD_MAX - 2
+          contribution_1 = described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX - 1
+          contribution_2 = described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX - 2
           w2_3.update_attribute(:box14_ui_wf_swf, contribution_1)
           w2_4.update_attribute(:box14_ui_wf_swf, contribution_2)
           instance.calculate
 
           expect(w2_3.box14_ui_wf_swf).to eq(contribution_1)
           expect(w2_4.box14_ui_wf_swf).to eq(contribution_2)
-          expected_sum = (contribution_1 + contribution_2 - EXCESS_UI_WF_SWF_UI_HC_WD_MAX).round
+          expected_sum = (contribution_1 + contribution_2 - described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX).round
           expect(instance.lines[:NJ1040_LINE_59].value).to eq(expected_sum)
         end
       end
       
-      context "mfj with multiple w2s per spouse that individually do not exceed #{EXCESS_UI_WF_SWF_UI_HC_WD_MAX} and total more than #{EXCESS_UI_WF_SWF_UI_HC_WD_MAX} for each spouse" do 
+      context "mfj with multiple w2s per spouse that individually do not exceed #{described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX} and total more than #{described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX} for each spouse" do 
         it 'adds the sum to line 59' do
-          contribution_1 = EXCESS_UI_WF_SWF_UI_HC_WD_MAX - 1
-          contribution_2 = EXCESS_UI_WF_SWF_UI_HC_WD_MAX - 2
-          contribution_3 = EXCESS_UI_WF_SWF_UI_HC_WD_MAX - 3
-          contribution_4 = EXCESS_UI_WF_SWF_UI_HC_WD_MAX - 4
+          contribution_1 = described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX - 1
+          contribution_2 = described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX - 2
+          contribution_3 = described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX - 3
+          contribution_4 = described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX - 4
           w2_1.update_attribute(:box14_ui_wf_swf, contribution_1)
           w2_2.update_attribute(:box14_ui_wf_swf, contribution_2)
           w2_3.update_attribute(:box14_ui_wf_swf, contribution_3)
@@ -1203,7 +1199,7 @@ describe Efile::Nj::Nj1040Calculator do
           expect(w2_2.box14_ui_wf_swf).to eq(contribution_2)
           expect(w2_3.box14_ui_wf_swf).to eq(contribution_3)
           expect(w2_4.box14_ui_wf_swf).to eq(contribution_4)
-          expected_sum = (contribution_1 + contribution_2 + contribution_3 + contribution_4 - (EXCESS_UI_WF_SWF_UI_HC_WD_MAX * 2)).round
+          expected_sum = (contribution_1 + contribution_2 + contribution_3 + contribution_4 - (described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX * 2)).round
           expect(instance.lines[:NJ1040_LINE_59].value).to eq(expected_sum)
         end
       end
@@ -1215,7 +1211,7 @@ describe Efile::Nj::Nj1040Calculator do
       let(:intake) { create(:state_file_nj_intake, :df_data_box_14) }
       it 'does not fill line 61' do
         w2 = intake.state_file_w2s.first 
-        w2.update_attribute(:box14_fli, EXCESS_FLI_MAX + 1)
+        w2.update_attribute(:box14_fli, described_class::EXCESS_FLI_MAX + 1)
         instance.calculate
         expect(instance.lines[:NJ1040_LINE_61].value).to eq(nil)
       end
@@ -1231,11 +1227,11 @@ describe Efile::Nj::Nj1040Calculator do
         expect(intake.state_file_w2s.count).to eq(2)
         first_w2 = intake.state_file_w2s.all[0]
         second_w2 = intake.state_file_w2s.all[1]
-        first_w2.update_attribute(:box14_fli, EXCESS_FLI_MAX + 1)
+        first_w2.update_attribute(:box14_fli, described_class::EXCESS_FLI_MAX + 1)
         second_w2.update_attribute(:box14_fli, nil)
         instance.calculate
 
-        expect(first_w2.box14_fli).to eq(EXCESS_FLI_MAX + 1)
+        expect(first_w2.box14_fli).to eq(described_class::EXCESS_FLI_MAX + 1)
         expect(second_w2.box14_fli).to eq(nil)
         expect(instance.lines[:NJ1040_LINE_61].value).to eq(nil)
       end
@@ -1258,30 +1254,30 @@ describe Efile::Nj::Nj1040Calculator do
       end
     end
 
-    context "with multiple w2s, one of which has an excess contribution of more than #{EXCESS_FLI_MAX}" do 
+    context "with multiple w2s, one of which has an excess contribution of more than #{described_class::EXCESS_FLI_MAX}" do 
       let(:intake) { create(:state_file_nj_intake, :df_data_2_w2s) }
       it 'does not fill line 61' do
         expect(intake.state_file_w2s.count).to eq(2)
         first_w2 = intake.state_file_w2s.first 
         second_w2 = intake.state_file_w2s.all[1]
-        first_w2.update_attribute(:box14_fli, EXCESS_FLI_MAX + 1)
+        first_w2.update_attribute(:box14_fli, described_class::EXCESS_FLI_MAX + 1)
         second_w2.update_attribute(:box14_fli, 1)
         instance.calculate
 
-        expect(first_w2.box14_fli).to eq(EXCESS_FLI_MAX + 1)
+        expect(first_w2.box14_fli).to eq(described_class::EXCESS_FLI_MAX + 1)
         expect(second_w2.box14_fli).to eq(1.00)
         expect(instance.lines[:NJ1040_LINE_61].value).to eq(nil)
       end
     end
 
-    context "with multiple w2s that do not individually exceed #{EXCESS_FLI_MAX}, but have a total excess contribution of more than #{EXCESS_FLI_MAX}" do 
+    context "with multiple w2s that do not individually exceed #{described_class::EXCESS_FLI_MAX}, but have a total excess contribution of more than #{described_class::EXCESS_FLI_MAX}" do 
       let(:intake) { create(:state_file_nj_intake, :df_data_2_w2s) }
       it 'fills line 61 with the sum of the contributions less the excess threshold' do
         expect(intake.state_file_w2s.count).to eq(2)
         first_w2 = intake.state_file_w2s.first 
         second_w2 = intake.state_file_w2s.all[1]
-        contribution_1 = EXCESS_FLI_MAX - 1
-        contribution_2 = EXCESS_FLI_MAX - 2
+        contribution_1 = described_class::EXCESS_FLI_MAX - 1
+        contribution_2 = described_class::EXCESS_FLI_MAX - 2
 
         first_w2.update_attribute(:box14_fli, contribution_1)
         second_w2.update_attribute(:box14_fli, contribution_2)
@@ -1289,7 +1285,7 @@ describe Efile::Nj::Nj1040Calculator do
 
         expect(first_w2.box14_fli).to eq(contribution_1)
         expect(second_w2.box14_fli).to eq(contribution_2)
-        expected_sum = (contribution_1 + contribution_2 - EXCESS_FLI_MAX).round
+        expected_sum = (contribution_1 + contribution_2 - described_class::EXCESS_FLI_MAX).round
         expect(instance.lines[:NJ1040_LINE_61].value).to eq(expected_sum)
       end
     end
@@ -1303,39 +1299,38 @@ describe Efile::Nj::Nj1040Calculator do
       let!(:w2_3) { create(:state_file_w2, state_file_intake: intake, employee_ssn: spouse_ssn_from_fixture, box14_fli: 10) }
       let!(:w2_4) { create(:state_file_w2, state_file_intake: intake, employee_ssn: spouse_ssn_from_fixture, box14_fli: 10) }
 
-      context "mfj with multiple w2s per spouse, each under #{EXCESS_FLI_MAX}, that total more than #{EXCESS_FLI_MAX} altogether, but total less than #{EXCESS_FLI_MAX} for each spouse" do 
+      context "mfj with multiple w2s per spouse, each under #{described_class::EXCESS_FLI_MAX}, that total more than #{described_class::EXCESS_FLI_MAX} altogether, but total less than #{described_class::EXCESS_FLI_MAX} for each spouse" do 
         it 'does not fill line 61' do
           expect(intake.state_file_w2s.count).to eq(5) # the mfj xml has 1 w2 already
           instance.calculate
-          w2s = intake.state_file_w2s.all
-          (1..4).each do |n|
-            expect(w2s[n].box14_fli).to eq(10.00)
+          [w2_1, w2_2, w2_3, w2_4].each do |w2|
+            expect(w2.box14_fli).to eq(10.00)
           end
           expect(instance.lines[:NJ1040_LINE_61].value).to eq(nil)
         end
       end
       
-      context "mfj with multiple w2s per person that individually do not exceed #{EXCESS_FLI_MAX}, total more than #{EXCESS_FLI_MAX} for spouse, but total less than #{EXCESS_FLI_MAX} for primary" do 
+      context "mfj with multiple w2s per person that individually do not exceed #{described_class::EXCESS_FLI_MAX}, total more than #{described_class::EXCESS_FLI_MAX} for spouse, but total less than #{described_class::EXCESS_FLI_MAX} for primary" do 
         it 'fills line 61 for the partner with multiple w2s' do
-          contribution_1 = EXCESS_FLI_MAX - 1
-          contribution_2 = EXCESS_FLI_MAX - 2
+          contribution_1 = described_class::EXCESS_FLI_MAX - 1
+          contribution_2 = described_class::EXCESS_FLI_MAX - 2
           w2_3.update_attribute(:box14_fli, contribution_1)
           w2_4.update_attribute(:box14_fli, contribution_2)
           instance.calculate
 
           expect(w2_3.box14_fli).to eq(contribution_1)
           expect(w2_4.box14_fli).to eq(contribution_2)
-          expected_sum = (contribution_1 + contribution_2 - EXCESS_FLI_MAX).round
+          expected_sum = (contribution_1 + contribution_2 - described_class::EXCESS_FLI_MAX).round
           expect(instance.lines[:NJ1040_LINE_61].value).to eq(expected_sum)
         end
       end
       
-      context "mfj with multiple w2s per spouse that individually do not exceed #{EXCESS_FLI_MAX} and total more than #{EXCESS_FLI_MAX} for each spouse" do 
+      context "mfj with multiple w2s per spouse that individually do not exceed #{described_class::EXCESS_FLI_MAX} and total more than #{described_class::EXCESS_FLI_MAX} for each spouse" do 
         it 'adds the sum to line 61' do
-          contribution_1 = EXCESS_FLI_MAX - 1
-          contribution_2 = EXCESS_FLI_MAX - 2
-          contribution_3 = EXCESS_FLI_MAX - 3
-          contribution_4 = EXCESS_FLI_MAX - 4
+          contribution_1 = described_class::EXCESS_FLI_MAX - 1
+          contribution_2 = described_class::EXCESS_FLI_MAX - 2
+          contribution_3 = described_class::EXCESS_FLI_MAX - 3
+          contribution_4 = described_class::EXCESS_FLI_MAX - 4
           w2_1.update_attribute(:box14_fli, contribution_1)
           w2_2.update_attribute(:box14_fli, contribution_2)
           w2_3.update_attribute(:box14_fli, contribution_3)
@@ -1346,7 +1341,7 @@ describe Efile::Nj::Nj1040Calculator do
           expect(w2_2.box14_fli).to eq(contribution_2)
           expect(w2_3.box14_fli).to eq(contribution_3)
           expect(w2_4.box14_fli).to eq(contribution_4)
-          expected_sum = (contribution_1 + contribution_2 + contribution_3 + contribution_4 - (EXCESS_FLI_MAX * 2)).round
+          expected_sum = (contribution_1 + contribution_2 + contribution_3 + contribution_4 - (described_class::EXCESS_FLI_MAX * 2)).round
           expect(instance.lines[:NJ1040_LINE_61].value).to eq(expected_sum)
         end
       end

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -1088,7 +1088,7 @@ describe Efile::Nj::Nj1040Calculator do
       end
     end
     
-    context 'with only other types of excess contribution' do 
+    context 'with only non ui/wf/swf and non ui/hc/wd types of excess contribution' do 
       let(:intake) { create(:state_file_nj_intake, :df_data_2_w2s) }
 
       it 'does not fill line 59' do
@@ -1141,7 +1141,6 @@ describe Efile::Nj::Nj1040Calculator do
 
       context "mfj with multiple w2s per spouse that are each less than the max, total more than #{described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX} altogether, but total less than #{described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX} for each spouse" do 
         it 'does not fill line 59' do
-          instance.calculate
           expect(instance.lines[:NJ1040_LINE_59].value).to eq(nil)
         end
       end
@@ -1159,7 +1158,7 @@ describe Efile::Nj::Nj1040Calculator do
       end
       
       context "mfj with multiple w2s per spouse that individually do not exceed #{described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX} and total more than #{described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX} for each spouse" do 
-        it 'adds the sum to line 59' do
+        it 'adds the sum for both spouses to line 59' do
           contribution_1 = described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX - 1
           contribution_2 = described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX - 2
           contribution_3 = described_class::EXCESS_UI_WF_SWF_UI_HC_WD_MAX - 3
@@ -1203,7 +1202,7 @@ describe Efile::Nj::Nj1040Calculator do
       end
     end
     
-    context 'with only other types of excess contribution' do 
+    context 'with only non fli types of excess contribution' do 
       let(:intake) { create(:state_file_nj_intake, :df_data_2_w2s) }
 
       it 'does not fill line 61' do
@@ -1256,7 +1255,6 @@ describe Efile::Nj::Nj1040Calculator do
 
       context "mfj with multiple w2s per spouse, each under #{described_class::EXCESS_FLI_MAX}, that total more than #{described_class::EXCESS_FLI_MAX} altogether, but total less than #{described_class::EXCESS_FLI_MAX} for each spouse" do 
         it 'does not fill line 61' do
-          instance.calculate
           expect(instance.lines[:NJ1040_LINE_61].value).to eq(nil)
         end
       end
@@ -1275,7 +1273,7 @@ describe Efile::Nj::Nj1040Calculator do
       end
       
       context "mfj with multiple w2s per spouse that individually do not exceed #{described_class::EXCESS_FLI_MAX} and total more than #{described_class::EXCESS_FLI_MAX} for each spouse" do 
-        it 'adds the sum to line 61' do
+        it 'adds the sum for both spouses to line 61' do
           contribution_1 = described_class::EXCESS_FLI_MAX - 1
           contribution_2 = described_class::EXCESS_FLI_MAX - 2
           contribution_3 = described_class::EXCESS_FLI_MAX - 3

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -1562,20 +1562,16 @@ RSpec.describe PdfFiller::Nj1040Pdf do
       end
 
       context "with excess contributions" do 
-        let(:primary_ssn_from_fixture) { intake.primary.ssn }
-        let(:spouse_ssn_from_fixture) { intake.spouse.ssn }
-        let!(:w2_1) { create(:state_file_w2, state_file_intake: intake, employee_ssn: primary_ssn_from_fixture, box14_ui_hc_wd: 100) }
-        let!(:w2_2) { create(:state_file_w2, state_file_intake: intake, employee_ssn: primary_ssn_from_fixture, box14_ui_hc_wd: 101) }
-        let!(:w2_3) { create(:state_file_w2, state_file_intake: intake, employee_ssn: spouse_ssn_from_fixture, box14_ui_hc_wd: 102) }
-        let!(:w2_4) { create(:state_file_w2, state_file_intake: intake, employee_ssn: spouse_ssn_from_fixture, box14_ui_hc_wd: 103) }
-
-        it "fills line 59 with 46" do 
+        before do
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_59).and_return 123
+        end
+        it "fills line 59 with 123.00" do 
           # thousands
           expect(pdf_fields["59"]).to eq ""
           # hundreds
-          expect(pdf_fields["undefined_154"]).to eq ""
-          expect(pdf_fields["undefined_155"]).to eq "4"
-          expect(pdf_fields["Text173"]).to eq "6"
+          expect(pdf_fields["undefined_154"]).to eq "1"
+          expect(pdf_fields["undefined_155"]).to eq "2"
+          expect(pdf_fields["Text173"]).to eq "3"
           # decimals
           expect(pdf_fields["Text174"]).to eq "0"
           expect(pdf_fields["Text175"]).to eq "0"
@@ -1601,20 +1597,16 @@ RSpec.describe PdfFiller::Nj1040Pdf do
       end
 
       context "with excess contributions" do 
-        let(:primary_ssn_from_fixture) { intake.primary.ssn }
-        let(:spouse_ssn_from_fixture) { intake.spouse.ssn }
-        let!(:w2_1) { create(:state_file_w2, state_file_intake: intake, employee_ssn: primary_ssn_from_fixture, box14_fli: 100) }
-        let!(:w2_2) { create(:state_file_w2, state_file_intake: intake, employee_ssn: primary_ssn_from_fixture, box14_fli: 101) }
-        let!(:w2_3) { create(:state_file_w2, state_file_intake: intake, employee_ssn: spouse_ssn_from_fixture, box14_fli: 102) }
-        let!(:w2_4) { create(:state_file_w2, state_file_intake: intake, employee_ssn: spouse_ssn_from_fixture, box14_fli: 103) }
-
-        it "fills line 61 with 115" do 
+        before do
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_61).and_return 123
+        end
+        it "fills line 61 with 123" do 
           # thousands
           expect(pdf_fields["60"]).to eq ""
           # hundreds
           expect(pdf_fields["undefined_156"]).to eq "1"
-          expect(pdf_fields["undefined_157"]).to eq "1"
-          expect(pdf_fields["Text176"]).to eq "5"
+          expect(pdf_fields["undefined_157"]).to eq "2"
+          expect(pdf_fields["Text176"]).to eq "3"
           # decimals
           expect(pdf_fields["Text177"]).to eq "0"
           expect(pdf_fields["Text178"]).to eq "0"

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -1545,6 +1545,83 @@ RSpec.describe PdfFiller::Nj1040Pdf do
       end
     end
 
+    describe "line 59 - excess UI/WF/SWF or UI/HC/WD" do
+      let(:intake) { create(:state_file_nj_intake, :df_data_mfj) }
+
+      context "without excess contributions" do 
+        it "does not fill line 59" do 
+          [
+            "Text175",
+            "Text174",
+            "Text173",
+            "undefined_155",
+            "undefined_154",
+            "59"
+          ].each { |pdf_field| expect(pdf_fields[pdf_field]).to eq "" }
+        end
+      end
+
+      context "with excess contributions" do 
+        let(:primary_ssn_from_fixture) { intake.primary.ssn }
+        let(:spouse_ssn_from_fixture) { intake.spouse.ssn }
+        let!(:w2_1) { create(:state_file_w2, state_file_intake: intake, employee_ssn: primary_ssn_from_fixture, box14_ui_hc_wd: 100) }
+        let!(:w2_2) { create(:state_file_w2, state_file_intake: intake, employee_ssn: primary_ssn_from_fixture, box14_ui_hc_wd: 101) }
+        let!(:w2_3) { create(:state_file_w2, state_file_intake: intake, employee_ssn: spouse_ssn_from_fixture, box14_ui_hc_wd: 102) }
+        let!(:w2_4) { create(:state_file_w2, state_file_intake: intake, employee_ssn: spouse_ssn_from_fixture, box14_ui_hc_wd: 103) }
+
+        it "fills line 59 with 46" do 
+          # thousands
+          expect(pdf_fields["59"]).to eq ""
+          # hundreds
+          expect(pdf_fields["undefined_154"]).to eq ""
+          expect(pdf_fields["undefined_155"]).to eq "4"
+          expect(pdf_fields["Text173"]).to eq "6"
+          # decimals
+          expect(pdf_fields["Text174"]).to eq "0"
+          expect(pdf_fields["Text175"]).to eq "0"
+          
+        end
+      end
+    end
+
+    describe "line 61 - excess FLI" do
+      let(:intake) { create(:state_file_nj_intake, :df_data_mfj) }
+
+      context "without excess contributions" do 
+        it "does not fill line 61" do 
+          [
+            "Text178",
+            "Text177",
+            "Text176",
+            "undefined_157",
+            "undefined_156",
+            "60"
+          ].each { |pdf_field| expect(pdf_fields[pdf_field]).to eq "" }
+        end
+      end
+
+      context "with excess contributions" do 
+        let(:primary_ssn_from_fixture) { intake.primary.ssn }
+        let(:spouse_ssn_from_fixture) { intake.spouse.ssn }
+        let!(:w2_1) { create(:state_file_w2, state_file_intake: intake, employee_ssn: primary_ssn_from_fixture, box14_fli: 100) }
+        let!(:w2_2) { create(:state_file_w2, state_file_intake: intake, employee_ssn: primary_ssn_from_fixture, box14_fli: 101) }
+        let!(:w2_3) { create(:state_file_w2, state_file_intake: intake, employee_ssn: spouse_ssn_from_fixture, box14_fli: 102) }
+        let!(:w2_4) { create(:state_file_w2, state_file_intake: intake, employee_ssn: spouse_ssn_from_fixture, box14_fli: 103) }
+
+        it "fills line 61 with 115" do 
+          # thousands
+          expect(pdf_fields["60"]).to eq ""
+          # hundreds
+          expect(pdf_fields["undefined_156"]).to eq "1"
+          expect(pdf_fields["undefined_157"]).to eq "1"
+          expect(pdf_fields["Text176"]).to eq "5"
+          # decimals
+          expect(pdf_fields["Text177"]).to eq "0"
+          expect(pdf_fields["Text178"]).to eq "0"
+          
+        end
+      end
+    end
 
     describe "line 64 child and dependent care credit" do
       let(:intake) {

--- a/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
@@ -684,34 +684,22 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
 
     describe "line 59 - excess UI/WF/SWF or UI/HC/WD" do
       context "mfj with multiple w2s per spouse that individually do not exceed the max and total more than the max for each spouse" do 
-        let(:intake) { create(:state_file_nj_intake, :df_data_mfj) }
-        let(:primary_ssn_from_fixture) { intake.primary.ssn }
-        let(:spouse_ssn_from_fixture) { intake.spouse.ssn }
-        let!(:w2_1) { create(:state_file_w2, state_file_intake: intake, employee_ssn: primary_ssn_from_fixture, box14_ui_hc_wd: 100) }
-        let!(:w2_2) { create(:state_file_w2, state_file_intake: intake, employee_ssn: primary_ssn_from_fixture, box14_ui_hc_wd: 101) }
-        let!(:w2_3) { create(:state_file_w2, state_file_intake: intake, employee_ssn: spouse_ssn_from_fixture, box14_ui_hc_wd: 102) }
-        let!(:w2_4) { create(:state_file_w2, state_file_intake: intake, employee_ssn: spouse_ssn_from_fixture, box14_ui_hc_wd: 103) }
-
+        before do
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_59).and_return 123
+        end
         it 'adds the sum to line 59' do
-          expected_sum = (100 + 101 + 102 + 103 - (179.78 * 2)).round
-          expect(xml.at("ExcessNjUiWfSwf").text).to eq(expected_sum.to_s)
+          expect(xml.at("ExcessNjUiWfSwf").text).to eq('123')
         end
       end
     end
 
     describe "line 61 - excess FLI" do
       context "mfj with multiple w2s per spouse that individually do not exceed max and total more than max for each spouse" do 
-        let(:intake) { create(:state_file_nj_intake, :df_data_mfj) }
-        let(:primary_ssn_from_fixture) { intake.primary.ssn }
-        let(:spouse_ssn_from_fixture) { intake.spouse.ssn }
-        let!(:w2_1) { create(:state_file_w2, state_file_intake: intake, employee_ssn: primary_ssn_from_fixture, box14_fli: 100) }
-        let!(:w2_2) { create(:state_file_w2, state_file_intake: intake, employee_ssn: primary_ssn_from_fixture, box14_fli: 101) }
-        let!(:w2_3) { create(:state_file_w2, state_file_intake: intake, employee_ssn: spouse_ssn_from_fixture, box14_fli: 102) }
-        let!(:w2_4) { create(:state_file_w2, state_file_intake: intake, employee_ssn: spouse_ssn_from_fixture, box14_fli: 103) }
-
+        before do
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_61).and_return 123
+        end
         it 'adds the sum to line 61' do
-          expected_sum = (100 + 101 + 102 + 103 - (145.26 * 2)).round
-          expect(xml.at("ExcesNjFamiInsur").text).to eq(expected_sum.to_s)
+          expect(xml.at("ExcesNjFamiInsur").text).to eq('123')
         end
       end
     end

--- a/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
@@ -700,7 +700,20 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
     end
 
     describe "line 61 - excess FLI" do
-      
+      context "mfj with multiple w2s per spouse that individually do not exceed max and total more than max for each spouse" do 
+        let(:intake) { create(:state_file_nj_intake, :df_data_mfj) }
+        let(:primary_ssn_from_fixture) { intake.primary.ssn }
+        let(:spouse_ssn_from_fixture) { intake.spouse.ssn }
+        let!(:w2_1) { create(:state_file_w2, state_file_intake: intake, employee_ssn: primary_ssn_from_fixture, box14_fli: 100) }
+        let!(:w2_2) { create(:state_file_w2, state_file_intake: intake, employee_ssn: primary_ssn_from_fixture, box14_fli: 101) }
+        let!(:w2_3) { create(:state_file_w2, state_file_intake: intake, employee_ssn: spouse_ssn_from_fixture, box14_fli: 102) }
+        let!(:w2_4) { create(:state_file_w2, state_file_intake: intake, employee_ssn: spouse_ssn_from_fixture, box14_fli: 103) }
+
+        it 'adds the sum to line 61' do
+          expected_sum = (100 + 101 + 102 + 103 - (145.26 * 2)).round
+          expect(xml.at("ExcesNjFamiInsur").text).to eq(expected_sum.to_s)
+        end
+      end
     end
 
     describe "child and dependent care credit - line 64" do

--- a/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
@@ -682,6 +682,27 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
       end
     end
 
+    describe "line 59 - excess UI/WF/SWF or UI/HC/WD" do
+      context "mfj with multiple w2s per spouse that individually do not exceed the max and total more than the max for each spouse" do 
+        let(:intake) { create(:state_file_nj_intake, :df_data_mfj) }
+        let(:primary_ssn_from_fixture) { intake.primary.ssn }
+        let(:spouse_ssn_from_fixture) { intake.spouse.ssn }
+        let!(:w2_1) { create(:state_file_w2, state_file_intake: intake, employee_ssn: primary_ssn_from_fixture, box14_ui_hc_wd: 100) }
+        let!(:w2_2) { create(:state_file_w2, state_file_intake: intake, employee_ssn: primary_ssn_from_fixture, box14_ui_hc_wd: 101) }
+        let!(:w2_3) { create(:state_file_w2, state_file_intake: intake, employee_ssn: spouse_ssn_from_fixture, box14_ui_hc_wd: 102) }
+        let!(:w2_4) { create(:state_file_w2, state_file_intake: intake, employee_ssn: spouse_ssn_from_fixture, box14_ui_hc_wd: 103) }
+
+        it 'adds the sum to line 59' do
+          expected_sum = (100 + 101 + 102 + 103 - (179.78 * 2)).round
+          expect(xml.at("ExcessNjUiWfSwf").text).to eq(expected_sum.to_s)
+        end
+      end
+    end
+
+    describe "line 61 - excess FLI" do
+      
+    end
+
     describe "child and dependent care credit - line 64" do
       it "adds 40% of federal credit for an income of 60k or less" do
         allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_64).and_return 400

--- a/spec/models/state_file_base_intake_spec.rb
+++ b/spec/models/state_file_base_intake_spec.rb
@@ -105,6 +105,18 @@ describe StateFileBaseIntake do
 
       expect(w2.employer_state_id_num).to eq "000000005"
     end
+
+    it "adds box 14 fields" do
+      intake = create(:state_file_nj_intake, :df_data_box_14)
+      intake.synchronize_df_w2s_to_database
+      expect(intake.state_file_w2s.count).to eq 1
+      w2 = intake.state_file_w2s.first
+
+      expect(w2.box14_fli).to eq 550.00
+      expect(w2.box14_stpickup).to eq 250.00
+      expect(w2.box14_ui_hc_wd).to eq 450.00
+      expect(w2.box14_ui_wf_swf).to eq 350.00
+    end
   end
 
   describe "#timedout?" do

--- a/spec/models/state_file_w2_spec.rb
+++ b/spec/models/state_file_w2_spec.rb
@@ -3,7 +3,10 @@
 # Table name: state_file_w2s
 #
 #  id                          :bigint           not null, primary key
+#  box14_fli                   :decimal(12, 2)
 #  box14_stpickup              :decimal(12, 2)
+#  box14_ui_hc_wd              :decimal(12, 2)
+#  box14_ui_wf_swf             :decimal(12, 2)
 #  employee_name               :string
 #  employee_ssn                :string
 #  employer_name               :string

--- a/spec/models/state_file_w2_spec.rb
+++ b/spec/models/state_file_w2_spec.rb
@@ -50,7 +50,7 @@ describe StateFileW2 do
       expect(w2).to be_valid
     end
 
-    [:w2_index, :state_wages_amount, :state_income_tax_amount, :local_wages_and_tips_amount, :local_income_tax_amount].each do |field|
+    [:w2_index, :state_wages_amount, :state_income_tax_amount, :local_wages_and_tips_amount, :local_income_tax_amount, :box14_fli, :box14_stpickup, :box14_ui_hc_wd, :box14_ui_wf_swf].each do |field|
       context field do
 
         it "does not permit strings" do


### PR DESCRIPTION
## Link to pivotal/JIRA issue
This PR only makes the NJ 1040 modifications specified in this ticket. There will be a follow-up PR to add the NJ 2450.
https://github.com/newjersey/affordability-pm/issues/107

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Add the existing w2 edit controller made by the CfA team to the nav flow
- Add box 14 fields to the state file w2 model
- Add NJ box 14 sample data to test the box 14 import (note: this one only has one w2, so it's not useful to test lines 59 and 61)
- Add lines 59 and 61 to NJ 1040 calculator, XML, and PDF

## How to test?
To test lines 59 and 61, select one of the profiles with multiple w2s. Edit the w2 and enter box 14 values that each fall under the threshold, but add up to be greater.

## Screenshots (for visual changes)
The only visual change is to add the existing view made by CfA to the navigation

MD before
![Screenshot 2024-11-13 at 11-21-47 Free AZ and NY state tax filing FileYourStateTaxes](https://github.com/user-attachments/assets/e02c43a3-2d9b-4116-9e84-057aba5cf205)

MD after
![Screenshot 2024-11-13 at 11-27-30 Free AZ and NY state tax filing FileYourStateTaxes](https://github.com/user-attachments/assets/e0cf09af-a083-4a7c-8682-16ad997e03d8)

NJ after
![Screenshot 2024-11-13 at 11-24-52 Free AZ and NY state tax filing FileYourStateTaxes](https://github.com/user-attachments/assets/63cda7a4-e06a-4f99-ae85-7db1aff06dd3)
