### PR TITLE
Correct blinking disabled for nested question-with-follow-up

### DIFF
--- a/app/javascript/lib/honeycrisp.js
+++ b/app/javascript/lib/honeycrisp.js
@@ -121,7 +121,7 @@ var followUpQuestion = (function () {
             });
         },
         update: function ($container) {
-            $container.find('> .question-with-follow-up__follow-up input, .question-with-follow-up__follow-up select').attr('disabled', true);
+            $container.find('> .question-with-follow-up__follow-up input, > .question-with-follow-up__follow-up select').attr('disabled', true);
             $container.find('> .question-with-follow-up__follow-up').hide();
 
             $container.find('.question-with-follow-up__question input').each(function (index, input) {

--- a/app/javascript/lib/honeycrisp.js
+++ b/app/javascript/lib/honeycrisp.js
@@ -121,8 +121,8 @@ var followUpQuestion = (function () {
             });
         },
         update: function ($container) {
-            $container.find('.question-with-follow-up__follow-up input, .question-with-follow-up__follow-up select').attr('disabled', true);
-            $container.find('.question-with-follow-up__follow-up').hide();
+            $container.find('> .question-with-follow-up__follow-up input, .question-with-follow-up__follow-up select').attr('disabled', true);
+            $container.find('> .question-with-follow-up__follow-up').hide();
 
             $container.find('.question-with-follow-up__question input').each(function (index, input) {
                 // if any of the inputs with a data-follow-up is checked then show the follow-up


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1075

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- This changes the nested follow up normalization code to only work on direct descendants. This stops the issue of nested question with follow up boxes from being picked up
- 🚨 This feature is not unit tested. It may be that there are places where this will break existing functionality. I went through and checked as much as I could think of but it's something to be vigilant for.

## How to test?
- Navigate through NC flow
- Transfer any persona
- Select `yes` on `nc-sales-use-tax` page
- Select second option `I kept a complete
- Click money field input box
