### PR TITLE
Removed erroneous paragraph causing weird margins

### DIFF
--- a/app/views/state_file/questions/name_dob/edit.html.erb
+++ b/app/views/state_file/questions/name_dob/edit.html.erb
@@ -98,7 +98,7 @@
 
       <% if asked_months %>
         <div class="reveal">
-          <p><button class="reveal__button"><%= t('.months_helper_heading') %></button></p>
+          <button class="reveal__button"><%= t('.months_helper_heading') %></button>
           <div class="reveal__content">
             <p><%= t('.months_helper_description') %></p>
             <p><%= t('.months_helper_born_died') %></p>


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- No jira ticket

## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- An erroneous wrapping paragraph was causing some weird margins on reveals on the `name-dob` page. This corrects that.

## How to test?
- Navigate through AZ intake until you reach the `name-dob` page. Note the reveal boxes have correctly spaced chevrons.

## Screenshots (for visual changes)
- Before
![image](https://github.com/user-attachments/assets/010e574b-0f3e-4530-8d79-3e5c8540728f)

- After
![image](https://github.com/user-attachments/assets/34d1c264-ab73-4b91-842c-87ff0e4bf39a)

