### PR TITLE
Refactor refund_or_owed_amount to be defined on parent class and use constants on child classes

### DIFF
--- a/app/lib/efile/az/az140_calculator.rb
+++ b/app/lib/efile/az/az140_calculator.rb
@@ -2,6 +2,8 @@ module Efile
   module Az
     class Az140Calculator < ::Efile::TaxCalculator
       attr_reader :lines
+      REFUND_LINE_NUM = :AZ140_LINE_79
+      OWED_LINE_NUM = :AZ140_LINE_80
 
       def initialize(year:, intake:, include_source: false)
         super
@@ -79,10 +81,6 @@ module Efile
         set_line(:AZ140_LINE_79, :calculate_line_79)
         set_line(:AZ140_LINE_80, :calculate_line_80)
         @lines.transform_values(&:value)
-      end
-
-      def refund_or_owed_amount
-        calculate_line_79 - calculate_line_80
       end
 
       def analytics_attrs

--- a/app/lib/efile/az/az140_calculator.rb
+++ b/app/lib/efile/az/az140_calculator.rb
@@ -2,8 +2,7 @@ module Efile
   module Az
     class Az140Calculator < ::Efile::TaxCalculator
       attr_reader :lines
-      REFUND_LINE_NUM = :AZ140_LINE_79
-      OWED_LINE_NUM = :AZ140_LINE_80
+      set_refund_lines refund: :AZ140_LINE_79, owed: :AZ140_LINE_80
 
       def initialize(year:, intake:, include_source: false)
         super

--- a/app/lib/efile/az/az140_calculator.rb
+++ b/app/lib/efile/az/az140_calculator.rb
@@ -2,7 +2,7 @@ module Efile
   module Az
     class Az140Calculator < ::Efile::TaxCalculator
       attr_reader :lines
-      set_refund_lines refund: :AZ140_LINE_79, owed: :AZ140_LINE_80
+      set_refund_owed_lines refund: :AZ140_LINE_79, owed: :AZ140_LINE_80
 
       def initialize(year:, intake:, include_source: false)
         super

--- a/app/lib/efile/id/id40_calculator.rb
+++ b/app/lib/efile/id/id40_calculator.rb
@@ -35,10 +35,6 @@ module Efile
         @lines.transform_values(&:value)
       end
 
-      def refund_or_owed_amount
-        0
-      end
-
       def grocery_credit_amount
         line_or_zero(:ID40_LINE_43_WORKSHEET)
       end

--- a/app/lib/efile/md/md502_calculator.rb
+++ b/app/lib/efile/md/md502_calculator.rb
@@ -78,10 +78,6 @@ module Efile
         @lines.transform_values(&:value)
       end
 
-      def refund_or_owed_amount
-        0
-      end
-
       def analytics_attrs
         {}
       end

--- a/app/lib/efile/nc/d400_calculator.rb
+++ b/app/lib/efile/nc/d400_calculator.rb
@@ -2,7 +2,7 @@ module Efile
   module Nc
     class D400Calculator < ::Efile::TaxCalculator
       attr_reader :lines
-      set_refund_lines refund: :NCD400_LINE_25, owed: :NCD400_LINE_19
+      set_refund_owed_lines refund: :NCD400_LINE_25, owed: :NCD400_LINE_19
 
       def initialize(year:, intake:, include_source: false)
         super

--- a/app/lib/efile/nc/d400_calculator.rb
+++ b/app/lib/efile/nc/d400_calculator.rb
@@ -2,6 +2,8 @@ module Efile
   module Nc
     class D400Calculator < ::Efile::TaxCalculator
       attr_reader :lines
+      REFUND_LINE_NUM = :NCD400_LINE_25
+      OWED_LINE_NUM = :NCD400_LINE_19
 
       def initialize(year:, intake:, include_source: false)
         super
@@ -33,11 +35,6 @@ module Efile
         set_line(:NCD400_LINE_28, :calculate_line_28)
         set_line(:NCD400_LINE_34, :calculate_line_34)
         @lines.transform_values(&:value)
-      end
-
-      def refund_or_owed_amount
-        # refund if amount is positive, owed if amount is negative
-        line_or_zero(:NCD400_LINE_25) - line_or_zero(:NCD400_LINE_19)
       end
 
       def calculate_use_tax(nc_taxable_income)

--- a/app/lib/efile/nc/d400_calculator.rb
+++ b/app/lib/efile/nc/d400_calculator.rb
@@ -2,8 +2,7 @@ module Efile
   module Nc
     class D400Calculator < ::Efile::TaxCalculator
       attr_reader :lines
-      REFUND_LINE_NUM = :NCD400_LINE_25
-      OWED_LINE_NUM = :NCD400_LINE_19
+      set_refund_lines refund: :NCD400_LINE_25, owed: :NCD400_LINE_19
 
       def initialize(year:, intake:, include_source: false)
         super

--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -46,10 +46,6 @@ module Efile
         }
       end
 
-      def refund_or_owed_amount
-        0
-      end
-
       def get_tax_rate_and_subtraction_amount(income)
         if @intake.filing_status_mfs? || @intake.filing_status_single?
           case income

--- a/app/lib/efile/tax_calculator.rb
+++ b/app/lib/efile/tax_calculator.rb
@@ -16,6 +16,17 @@ module Efile
       @lines[line.to_sym]&.value.to_i
     end
 
+    def refund_or_owed_amount
+      # TEMP: we will stub the amount and allow these to be undefined for now but when the calculators are complete we should raise
+      # an error along the lines of "child classes must define these"
+      return 0 unless defined?(self.class::REFUND_LINE_NUM) && defined?(self.class::OWED_LINE_NUM)
+
+      # if amount is positive they get a refund
+      # if amount is negative they owe taxes
+      # so we subtract owed from refund since one of them should always be 0
+      line_or_zero(self.class::REFUND_LINE_NUM) - line_or_zero(self.class::OWED_LINE_NUM)
+    end
+
     private
 
     def set_line(line_id, value_fn_or_data_source, field = nil)

--- a/app/lib/efile/tax_calculator.rb
+++ b/app/lib/efile/tax_calculator.rb
@@ -16,15 +16,25 @@ module Efile
       @lines[line.to_sym]&.value.to_i
     end
 
+    delegate :refund_line, :owed_line, to: :class
+    class << self
+      attr_accessor :refund_line, :owed_line
+
+      def set_refund_lines(refund:, owed:)
+        self.refund_line = refund
+        self.owed_line = owed
+      end
+    end
+
+    # if amount is positive they get a refund
+    # if amount is negative they owe taxes
+    # so we subtract owed from refund since one of them should always be 0
     def refund_or_owed_amount
       # TEMP: we will stub the amount and allow these to be undefined for now but when the calculators are complete we should raise
       # an error along the lines of "child classes must define these"
-      return 0 unless defined?(self.class::REFUND_LINE_NUM) && defined?(self.class::OWED_LINE_NUM)
+      return 0 unless refund_line.present? && owed_line.present?
 
-      # if amount is positive they get a refund
-      # if amount is negative they owe taxes
-      # so we subtract owed from refund since one of them should always be 0
-      line_or_zero(self.class::REFUND_LINE_NUM) - line_or_zero(self.class::OWED_LINE_NUM)
+      line_or_zero(refund_line) - line_or_zero(owed_line)
     end
 
     private

--- a/app/lib/efile/tax_calculator.rb
+++ b/app/lib/efile/tax_calculator.rb
@@ -20,7 +20,7 @@ module Efile
     class << self
       attr_accessor :refund_line, :owed_line
 
-      def set_refund_lines(refund:, owed:)
+      def set_refund_owed_lines(refund:, owed:)
         self.refund_line = refund
         self.owed_line = owed
       end

--- a/spec/lib/efile/az/az140_calculator_spec.rb
+++ b/spec/lib/efile/az/az140_calculator_spec.rb
@@ -387,4 +387,13 @@ describe Efile::Az::Az140Calculator do
       end
     end
   end
+
+  describe "refund_or_owed_amount" do
+    it "subtracts owed amount from refund amount" do
+      allow(instance).to receive(:calculate_line_79).and_return 20
+      allow(instance).to receive(:calculate_line_80).and_return 0
+      instance.calculate
+      expect(instance.refund_or_owed_amount).to eq(20)
+    end
+  end
 end

--- a/spec/lib/efile/id/id40_calculator_spec.rb
+++ b/spec/lib/efile/id/id40_calculator_spec.rb
@@ -194,7 +194,6 @@ describe Efile::Id::Id40Calculator do
     end
   end
 
-
   describe "Line 43: Grocery Credit" do
     context "primary is claimed as dependent" do
       let(:intake) { create(:state_file_id_intake, :single_filer_with_json) }
@@ -377,6 +376,13 @@ describe Efile::Id::Id40Calculator do
           expect(instance.lines[:ID40_LINE_46].value).to eq(10 + 25 + 507 + 1502)
         end
       end
+    end
+  end
+
+  describe "refund_or_owed_amount" do
+    it "subtracts owed amount from refund amount" do
+      # TEMP: stub calculator lines once implemented
+      expect(instance.refund_or_owed_amount).to eq(0)
     end
   end
 end

--- a/spec/lib/efile/id/id40_calculator_spec.rb
+++ b/spec/lib/efile/id/id40_calculator_spec.rb
@@ -381,7 +381,7 @@ describe Efile::Id::Id40Calculator do
 
   describe "refund_or_owed_amount" do
     it "subtracts owed amount from refund amount" do
-      # TEMP: stub calculator lines once implemented
+      # TEMP: stub calculator lines and test outcome of method once implemented
       expect(instance.refund_or_owed_amount).to eq(0)
     end
   end

--- a/spec/lib/efile/md/md502_calculator_spec.rb
+++ b/spec/lib/efile/md/md502_calculator_spec.rb
@@ -1191,7 +1191,7 @@ describe Efile::Md::Md502Calculator do
 
   describe "refund_or_owed_amount" do
     it "subtracts owed amount from refund amount" do
-      # TEMP: stub calculator lines once implemented
+      # TEMP: stub calculator lines and test outcome of method once implemented
       expect(instance.refund_or_owed_amount).to eq(0)
     end
   end

--- a/spec/lib/efile/md/md502_calculator_spec.rb
+++ b/spec/lib/efile/md/md502_calculator_spec.rb
@@ -1188,4 +1188,11 @@ describe Efile::Md::Md502Calculator do
       expect(instance.lines[:MD502_LINE_40].value).to eq(1610)
     end
   end
+
+  describe "refund_or_owed_amount" do
+    it "subtracts owed amount from refund amount" do
+      # TEMP: stub calculator lines once implemented
+      expect(instance.refund_or_owed_amount).to eq(0)
+    end
+  end
 end

--- a/spec/lib/efile/nc/d400_calculator_spec.rb
+++ b/spec/lib/efile/nc/d400_calculator_spec.rb
@@ -334,4 +334,13 @@ describe Efile::Nc::D400Calculator do
       expect(instance.lines[:NCD400_LINE_34].value).to eq 250
     end
   end
+
+  describe "refund_or_owed_amount" do
+    it "subtracts owed amount from refund amount" do
+      allow(instance).to receive(:calculate_line_25).and_return 0
+      allow(instance).to receive(:calculate_line_19).and_return 10
+      instance.calculate
+      expect(instance.refund_or_owed_amount).to eq(-10)
+    end
+  end
 end

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -1487,7 +1487,7 @@ describe Efile::Nj::Nj1040Calculator do
 
   describe "refund_or_owed_amount" do
     it "subtracts owed amount from refund amount" do
-      # TEMP: stub calculator lines once implemented
+      # TEMP: stub calculator lines and test outcome of method once implemented
       expect(instance.refund_or_owed_amount).to eq(0)
     end
   end

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -1484,4 +1484,11 @@ describe Efile::Nj::Nj1040Calculator do
       end
     end
   end
+
+  describe "refund_or_owed_amount" do
+    it "subtracts owed amount from refund amount" do
+      # TEMP: stub calculator lines once implemented
+      expect(instance.refund_or_owed_amount).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
This is some preliminary work for FYST-799. It doesn't contain any functional changes so I'd like to merge it in.

## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- The `refund_or_owed_amount` method, as far as I can tell, should be the same everywhere. It is used to determine whether clients see the refund or owed page in the flow, and to display an amount on the review page. It should subtract the owed amount from the refund amount, one of which should always be 0 because you can't owe and get a refund at the same time, so that you get a positive amount if refund and negative if owed.
- Open to other approaches to this, e.g. not using constants. I figure this is pretty flexible because child classes can just overwrite the method if it works differently for a state.
## How to test?
- I added tests for all states even the ones that are stubbed for now. Hopefully they can be a guide so that when this calc is added for states that don't have it yet, people remember to actually test it. I think it makes sense to have one test per state just to check that the correct lines are defined for refund/owed.
