### PR TITLE
Fyst 484 add detailed return info to nc review page

### DIFF
--- a/app/lib/efile/line_data.yml
+++ b/app/lib/efile/line_data.yml
@@ -650,6 +650,8 @@ MD502_SU_LINE_V:
   label: "TBD"
 MD502_SU_LINE_1:
   label: "1 Add lines a. through yc. and enter this amount on line 13 of Form 502 with the appropriate code letters"
+NCD400_LINE_6:
+  label: '6 Federal Adjusted Gross Income'
 NCD400_LINE_9:
   label: '9 Deductions From Federal Adjusted Gross Income (From Form D-400 Schedule S, Part B, Line 41)'
 NCD400_LINE_10B:

--- a/app/lib/efile/nc/d400_calculator.rb
+++ b/app/lib/efile/nc/d400_calculator.rb
@@ -15,6 +15,7 @@ module Efile
 
       def calculate
         @d400_schedule_s.calculate
+        set_line(:NCD400_LINE_6, @direct_file_data, :fed_agi)
         set_line(:NCD400_LINE_9, :calculate_line_9)
         set_line(:NCD400_LINE_10B, :calculate_line_10b)
         set_line(:NCD400_LINE_11, :calculate_line_11)

--- a/app/lib/pdf_filler/nc_d400_pdf.rb
+++ b/app/lib/pdf_filler/nc_d400_pdf.rb
@@ -16,7 +16,6 @@ module PdfFiller
     end
 
     def hash_for_pdf
-
       mfs_spouse_first_name = @xml_document.at("MFSSpouseName FirstName")&.text || ""
       mfs_spouse_middle_initial = @xml_document.at("MFSSpouseName MiddleInitial")&.text || ""
       mfs_spouse_last_name = @xml_document.at("MFSSpouseName LastName")&.text || ""

--- a/app/lib/submission_builder/ty2024/states/nc/documents/d400.rb
+++ b/app/lib/submission_builder/ty2024/states/nc/documents/d400.rb
@@ -36,7 +36,7 @@ module SubmissionBuilder
                 if @submission.data_source.filing_status_qw? && @submission.data_source.direct_file_data.spouse_date_of_death.present?
                   xml.QWYearSpouseDied Date.parse(@submission.data_source.direct_file_data.spouse_date_of_death).year
                 end
-                xml.FAGI @submission.data_source.direct_file_data.fed_agi
+                xml.FAGI calculated_fields.fetch(:NCD400_LINE_6)
                 # line 7 AdditionsToFAGI is blank
                 xml.FAGIPlusAdditions @submission.data_source.direct_file_data.fed_agi
                 xml.DeductionsFromFAGI calculated_fields.fetch(:NCD400_LINE_9)

--- a/app/views/state_file/questions/az_review/edit.html.erb
+++ b/app/views/state_file/questions/az_review/edit.html.erb
@@ -73,10 +73,10 @@
   <% end %>
 
   <div id="details" class="reveal">
-    <p><button class="reveal__button"><%= t('.see_detailed_return') %></button></p>
+    <p><button class="reveal__button"><%= t('state_file.general.see_detailed_return') %></button></p>
     <div class="reveal__content">
       <div class="spacing-below-25 with-top-separator">
-        <p class="text--bold spacing-below-5"><%=t(".fed_agi") %></p>
+        <p class="text--bold spacing-below-5"><%=t("state_file.general.fed_agi") %></p>
         <p><%= number_to_currency(current_intake.calculator.line_or_zero(:AZ140_LINE_12)) %></p>
       </div>
 
@@ -96,7 +96,7 @@
       </div>
 
       <div class="spacing-below-25">
-        <p class="text--bold spacing-below-5"><%=t(".standard_deduction") %></p>
+        <p class="text--bold spacing-below-5"><%=t("state_file.general.standard_deduction") %></p>
         <p><%= number_to_currency(current_intake.calculator.line_or_zero(:AZ140_LINE_43)) %></p>
       </div>
 

--- a/app/views/state_file/questions/nc_review/edit.html.erb
+++ b/app/views/state_file/questions/nc_review/edit.html.erb
@@ -45,7 +45,7 @@
     <div class="reveal__content">
       <div class="spacing-below-25 with-top-separator">
         <p class="text--bold spacing-below-5"><%= t("state_file.general.fed_agi") %></p>
-        <p><%= number_to_currency(current_intake.direct_file_data.fed_agi) %></p>
+        <p><%= number_to_currency(current_intake.calculator.line_or_zero(:NCD400_LINE_6)) %></p>
       </div>
 
       <div class="spacing-below-25">

--- a/app/views/state_file/questions/nc_review/edit.html.erb
+++ b/app/views/state_file/questions/nc_review/edit.html.erb
@@ -40,5 +40,65 @@
     </div>
   </div>
 
+  <div id="details" class="reveal">
+    <p><button class="reveal__button"><%= t("state_file.general.see_detailed_return") %></button></p>
+    <div class="reveal__content">
+      <div class="spacing-below-25 with-top-separator">
+        <p class="text--bold spacing-below-5"><%= t("state_file.general.fed_agi") %></p>
+        <p><%= number_to_currency(current_intake.direct_file_data.fed_agi) %></p>
+      </div>
+
+      <div class="spacing-below-25">
+        <p class="text--bold spacing-below-5"><%= t(".social_security_benefits") %></p>
+        <p><%= number_to_currency(current_intake.calculator.line_or_zero(:NCD400_S_LINE_19)) %></p>
+      </div>
+
+      <div class="spacing-below-25">
+        <p class="text--bold spacing-below-5"><%= t(".interest_us_bonds") %></p>
+        <p><%= number_to_currency(current_intake.calculator.line_or_zero(:NCD400_S_LINE_18)) %></p>
+      </div>
+
+      <div class="spacing-below-25">
+        <p class="text--bold spacing-below-5"><%= t(".subtraction_indian_tribe") %></p>
+        <p><%= number_to_currency(current_intake.calculator.line_or_zero(:NCD400_S_LINE_27)) %></p>
+      </div>
+
+      <div class="spacing-below-25">
+        <p class="text--bold spacing-below-5"><%= t(".child_deduction") %></p>
+        <p><%= number_to_currency(current_intake.calculator.line_or_zero(:NCD400_LINE_10B)) %></p>
+      </div>
+
+      <div class="spacing-below-25">
+        <p class="text--bold spacing-below-5"><%= t("state_file.general.standard_deduction") %></p>
+        <p><%= number_to_currency(current_intake.calculator.line_or_zero(:NCD400_LINE_11)) %></p>
+      </div>
+
+      <div class="spacing-below-25">
+        <p class="text--bold spacing-below-5"><%= t("state_file.general.nc_taxable_income") %></p>
+        <p><%= number_to_currency(current_intake.calculator.line_or_zero(:NCD400_LINE_14)) %></p>
+      </div>
+
+      <div class="spacing-below-25">
+        <p class="text--bold spacing-below-5"><%= t("state_file.general.nc_income_tax") %></p>
+        <p><%= number_to_currency(current_intake.calculator.line_or_zero(:NCD400_LINE_15)) %></p>
+      </div>
+
+      <div class="spacing-below-25">
+        <p class="text--bold spacing-below-5"><%= t("state_file.general.nc_use_tax") %></p>
+        <p><%= number_to_currency(current_intake.calculator.line_or_zero(:NCD400_LINE_18)) %></p>
+      </div>
+
+      <div class="spacing-below-25">
+        <p class="text--bold spacing-below-5"><%= t("state_file.general.total_tax") %></p>
+        <p><%= number_to_currency(current_intake.calculator.line_or_zero(:NCD400_LINE_19)) %></p>
+      </div>
+
+      <div class="spacing-below-25">
+        <p class="text--bold spacing-below-5"><%= t("state_file.general.nc_tax_withheld") %></p>
+        <p><%= number_to_currency(current_intake.calculator.line_or_zero(:NCD400_LINE_20A) + current_intake.calculator.line_or_zero(:NCD400_LINE_20B)) %></p>
+      </div>
+    </div>
+  </div>
+
   <%= render "state_file/questions/shared/review_footer" %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2037,7 +2037,15 @@ en:
       index:
         title: Common questions from %{state} taxpayers
     general:
+      fed_agi: Federal adjusted gross income
+      nc_income_tax: North Carolina income tax
+      nc_tax_withheld: North Carolina tax withheld
+      nc_taxable_income: North Carolina taxable income
+      nc_use_tax: North Carolina use tax
+      see_detailed_return: See detailed return information
+      standard_deduction: Standard deduction
       title: Free AZ and NY state tax filing
+      total_tax: Total tax
     intake_logins:
       account_locked:
         body_html: This account has been locked due to too many failed login attempts. If you need help unlocking this account, please email us at <a href="mailto:help@fileyourstatetaxes.org">help@fileyourstatetaxes.org</a>.
@@ -2262,15 +2270,12 @@ en:
           charitable_noncash: Charitable contributions (Non-Cash)
           dependent_tax_credit: Dependent tax credit
           family_income_tax_credit: Family income tax credit
-          fed_agi: Federal adjusted gross income
           household_excise_credit_claimed: Other members in your household have claimed the Arizona Increased Excise Tax Credit
           incr_deduction_chrit_contributions: Increased deduction for charitable contributions
           increased_excise_tax_credit: Increased Excise Tax Credit
           last_names: Other last names in the last four years
           made_az321_contributions: Made contributions to qualifying charitable organizations
-          see_detailed_return: See detailed return information
           ssn_no_employment: "‘Not valid for employment’ is written on your Social Security Card"
-          standard_deduction: Standard deduction
           total_arizona_subtractions: Total Arizona subtractions
           total_exemptions: Total Exemptions
           total_payments: Total payments
@@ -2758,9 +2763,13 @@ en:
       nc_review:
         edit:
           amount: Amount
+          child_deduction: Child deduction
+          interest_us_bonds: Interest income from U.S. bonds (not taxable in North Carolina)
           primary_veteran: Veteran Info
+          social_security_benefits: Social Security benefits (not taxable in North Carolina)
           spouse_veteran: Spouse Veteran Info
           state_credit: Amount earned as member of a federally recognized Indian tribe
+          subtraction_indian_tribe: Subtraction for income of a member of an Indian tribe
           use_tax_applied: Consumer Use Tax Applied
       nc_sales_use_tax:
         edit:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2001,7 +2001,15 @@ es:
       index:
         title: 'Preguntas frecuentes de los contribuyentes de %{state}:'
     general:
+      fed_agi: Ingreso bruto ajustado federal
+      nc_income_tax: Impuesto sobre la renta de Carolina del Norte
+      nc_tax_withheld: Impuesto retenido en Carolina del Norte
+      nc_taxable_income: Ingresos imponibles de Carolina del Norte
+      nc_use_tax: Impuesto sobre el uso de Carolina del Norte
+      see_detailed_return: Consulta la información detallada de la declaración
+      standard_deduction: Deducción estándar
       title: Presentación de impuestos estatales de Arizona y Nueva York sin costo
+      total_tax: Impuesto total
     intake_logins:
       account_locked:
         body_html: Esta cuenta ha sido bloqueada debido a demasiados intentos fallidos de inicio de sesión. Si necesitas ayuda para desbloquear esta cuenta, por favor envíanos un correo electrónico a <a href="mailto:help@fileyourstatetaxes.org">help@fileyourstatetaxes.org</a>.
@@ -2231,15 +2239,12 @@ es:
           charitable_noncash: Donaciones caritativas (en especie)
           dependent_tax_credit: Crédito tributario por dependientes
           family_income_tax_credit: Crédito tributario por ingresos familiares
-          fed_agi: Ingreso bruto ajustado federal
           household_excise_credit_claimed: Otros miembros de tu hogar han reclamado el Crédito por Aumento de Impuestos Especiales de Arizona
           incr_deduction_chrit_contributions: Deducción aumentada por donaciones caritativas
           increased_excise_tax_credit: Crédito por Aumento de Impuestos Especiales
           last_names: Otros apellidos usados en los últimos cuatro años
           made_az321_contributions: Hizo contribuciones a organizaciones benéficas calificadas
-          see_detailed_return: Consulta la información detallada de la declaración
           ssn_no_employment: '"Not valid for employment" escrita en tu tarjeta de Seguro Social'
-          standard_deduction: Deducción estándar
           total_arizona_subtractions: Restas totales de Arizona
           total_exemptions: Exenciones Totales
           total_payments: Total de pagos
@@ -2730,9 +2735,13 @@ es:
       nc_review:
         edit:
           amount: Cantidad
+          child_deduction: Deducción por hijos
+          interest_us_bonds: Ingresos por intereses de bonos estadounidenses (no sujetos a impuestos en Carolina del Norte)
           primary_veteran: Información del Veterano
+          social_security_benefits: Beneficios del Seguro Social (no sujetos a impuestos en Carolina del Norte)
           spouse_veteran: Información del Cónyuge Veterano
           state_credit: Cantidad ganada como miembro de una tribu indígena reconocida federalmente
+          subtraction_indian_tribe: Resta de ingresos de un miembro de una tribu india
           use_tax_applied: Impuesto de Uso Aplicado
       nc_sales_use_tax:
         edit:

--- a/spec/controllers/state_file/questions/nc_review_controller_spec.rb
+++ b/spec/controllers/state_file/questions/nc_review_controller_spec.rb
@@ -9,9 +9,59 @@ RSpec.describe StateFile::Questions::NcReviewController do
 
   describe "#edit" do
     render_views
-    it 'succeeds' do
+
+    it "renders" do
       get :edit
       expect(response).to be_successful
+    end
+
+    it "shows detailed return information" do
+      intake.direct_file_data.fed_agi = 20_000
+      intake.direct_file_data.fed_taxable_ssb = 1_000
+      intake.direct_file_data.fed_taxable_income = 3_000
+      allow_any_instance_of(Efile::Nc::D400ScheduleSCalculator).to receive(:calculate_line_27).and_return(150)
+      allow_any_instance_of(Efile::Nc::D400Calculator).to receive(:calculate_line_10b).and_return(550)
+      allow_any_instance_of(Efile::Nc::D400Calculator).to receive(:calculate_line_11).and_return(1_700)
+      allow_any_instance_of(Efile::Nc::D400Calculator).to receive(:calculate_line_14).and_return(19_000)
+      allow_any_instance_of(Efile::Nc::D400Calculator).to receive(:calculate_line_15).and_return(2_001)
+      allow_any_instance_of(Efile::Nc::D400Calculator).to receive(:calculate_line_18).and_return(2)
+      allow_any_instance_of(Efile::Nc::D400Calculator).to receive(:calculate_line_19).and_return(2_004)
+      allow_any_instance_of(Efile::Nc::D400Calculator).to receive(:calculate_line_20a).and_return(1_010)
+      allow_any_instance_of(Efile::Nc::D400Calculator).to receive(:calculate_line_20b).and_return(1_020)
+      intake.update!(raw_direct_file_data: intake.direct_file_data.to_s)
+
+      get :edit
+
+      page_content = response.body
+      expect(page_content).to include I18n.t("state_file.general.see_detailed_return")
+      expect(page_content).to include I18n.t("state_file.general.fed_agi")
+      expect(page_content).to include "$20,000"
+      expect(page_content).to include I18n.t("state_file.questions.nc_review.edit.social_security_benefits")
+      expect(page_content).to include "$1,000"
+      expect(page_content).to include I18n.t("state_file.questions.nc_review.edit.interest_us_bonds")
+      expect(page_content).to include "$3,000"
+      # TODO: add this once lines 20 & 21 are implemented
+      # Subtraction for retirement benefits by vested qualifying government pensions
+      # [schedule S, line 20]
+      # Subtraction for retirement benefits received by service members
+      # [schedule S, line 21]
+
+      expect(page_content).to include I18n.t("state_file.questions.nc_review.edit.subtraction_indian_tribe")
+      expect(page_content).to include "$150"
+      expect(page_content).to include I18n.t("state_file.questions.nc_review.edit.child_deduction")
+      expect(page_content).to include "$550"
+      expect(page_content).to include I18n.t("state_file.general.standard_deduction")
+      expect(page_content).to include "$1,700"
+      expect(page_content).to include I18n.t("state_file.general.nc_taxable_income")
+      expect(page_content).to include "$19,000"
+      expect(page_content).to include I18n.t("state_file.general.nc_income_tax")
+      expect(page_content).to include "$2,001"
+      expect(page_content).to include I18n.t("state_file.general.nc_use_tax")
+      expect(page_content).to include "$2"
+      expect(page_content).to include I18n.t("state_file.general.total_tax")
+      expect(page_content).to include "$2,004"
+      expect(page_content).to include I18n.t("state_file.general.nc_tax_withheld")
+      expect(page_content).to include "$2,030" # lines 20a + 20b
     end
   end
 end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-484
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- adds a detailed info section to NC review page
- a couple of incidental things:
  - moves some translations from az review page to general section for reuse
  - moves fed agi to calculator so we can get it from the calculator in the view like all the other lines
  - added a calculator spec to check that the tax withheld for spouse line (20b) returns 0 when there is no spouse
## How to test?
- Added a unit test to controller to test the correct values are being displayed (didn't want to overload feature spec)
## Screenshots (for visual changes)
- Before
  - no reveal
- After
<img width="1230" alt="image" src="https://github.com/user-attachments/assets/4e16d41c-1538-4980-96e3-b9c8cf607863">
<img width="666" alt="image" src="https://github.com/user-attachments/assets/1eeb8aad-8835-426b-8e75-749d407b29aa">

