### PR TITLE
add income review card to final review screen

### DIFF
--- a/app/controllers/state_file/questions/income_review_controller.rb
+++ b/app/controllers/state_file/questions/income_review_controller.rb
@@ -1,6 +1,7 @@
 module StateFile
   module Questions
     class IncomeReviewController < QuestionsController
+      include ReturnToReviewConcern
     end
   end
 end

--- a/app/views/state_file/questions/shared/_review_header.html.erb
+++ b/app/views/state_file/questions/shared/_review_header.html.erb
@@ -60,4 +60,16 @@
       <% end %>
     </div>
   </div>
+
+  <div id="income-info" class="white-group">
+    <div class="spacing-below-25">
+      <h2 class="text--body text--bold spacing-below-5"><%=t(".income_details") %></h2>
+    </div>
+    <div class="spacing-below-5">
+      <%= link_to StateFile::Questions::IncomeReviewController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
+        <%= t("general.edit") %>
+        <span class="sr-only"><%= t(".income_details") %></span>
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3148,6 +3148,7 @@ en:
           dependent_months_in_home: Number of months they lived with you
           dependent_name: Your dependent's name
           household_info: Household information
+          income_details: Income Details
           nth_dependent_name: Your %{ordinal} dependent's name
           spouse_name: Your spouse's name
           taxes_owed_header: Your refund or taxes owed

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3135,6 +3135,7 @@ es:
           dependent_months_in_home: Número de meses que vivieron contigo
           dependent_name: Nombre de tu dependiente
           household_info: Información del hogar
+          income_details: Detalles de ingresos
           nth_dependent_name: Nombre de tu %{ordinal} dependiente
           spouse_name: Nombre de tu cónyuge
           taxes_owed_header: Tu reembolso estimado o tus impuestos estimados a pagar


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1084
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Added a new card to the review header, which will show up for all states.
 - Note that this is not correct for NY, since the income review page was never added to the NY Question Navigation (flow), but I'm not addressing that since we aren't planning to ship with NY
## How to test?
- Go through the full flow for each state, and verify that the income details review card shows up, has an edit button that leads back to the income review page, and that clicking continue from that page leads back to the final review page
## Screenshots (for visual changes)
![image](https://github.com/user-attachments/assets/05b95962-c37d-415a-a006-966b95c6f033)