### PR TITLE
remove digits-only validation on w2 employer state id num so that it matches the IRSW2 schema

### DIFF
--- a/app/models/state_file_base_intake.rb
+++ b/app/models/state_file_base_intake.rb
@@ -135,7 +135,7 @@ class StateFileBaseIntake < ApplicationRecord
         employer_name: direct_file_w2.EmployerName,
         employee_name: direct_file_w2.EmployeeNm,
         employee_ssn: direct_file_w2.EmployeeSSN,
-        employer_state_id_num: direct_file_w2.EmployerStateIdNum&.delete('-'),
+        employer_state_id_num: direct_file_w2.EmployerStateIdNum,
         local_income_tax_amount: direct_file_w2.LocalIncomeTaxAmt,
         local_wages_and_tips_amount: direct_file_w2.LocalWagesAndTipsAmt,
         locality_nm: direct_file_w2.LocalityNm,

--- a/app/models/state_file_w2.rb
+++ b/app/models/state_file_w2.rb
@@ -48,7 +48,7 @@ class StateFileW2 < ApplicationRecord
   encrypts :employee_ssn
 
   validates :w2_index, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
-  validates :employer_state_id_num, length: { maximum: 16, message: I18n.t('state_file.questions.w2.edit.employer_state_id_error') }
+  validates :employer_state_id_num, length: { maximum: 16, message: ->(_object, _data) { I18n.t('state_file.questions.w2.edit.employer_state_id_error') } }
   validates :state_wages_amount, numericality: { greater_than_or_equal_to: 0 }, if: -> { state_wages_amount.present? }
   validates :state_income_tax_amount, numericality: { greater_than_or_equal_to: 0 }, if: -> { state_income_tax_amount.present? }
   validates :local_wages_and_tips_amount, numericality: { greater_than_or_equal_to: 0 }, if: -> { local_wages_and_tips_amount.present? }

--- a/app/models/state_file_w2.rb
+++ b/app/models/state_file_w2.rb
@@ -48,7 +48,7 @@ class StateFileW2 < ApplicationRecord
   encrypts :employee_ssn
 
   validates :w2_index, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
-  validates :employer_state_id_num, length: { maximum: 16 }
+  validates :employer_state_id_num, length: { maximum: 16, message: I18n.t('state_file.questions.w2.edit.employer_state_id_error') }
   validates :state_wages_amount, numericality: { greater_than_or_equal_to: 0 }, if: -> { state_wages_amount.present? }
   validates :state_income_tax_amount, numericality: { greater_than_or_equal_to: 0 }, if: -> { state_income_tax_amount.present? }
   validates :local_wages_and_tips_amount, numericality: { greater_than_or_equal_to: 0 }, if: -> { local_wages_and_tips_amount.present? }

--- a/app/models/state_file_w2.rb
+++ b/app/models/state_file_w2.rb
@@ -48,7 +48,7 @@ class StateFileW2 < ApplicationRecord
   encrypts :employee_ssn
 
   validates :w2_index, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
-  validates :employer_state_id_num, format: { with: /\A(\d{0,17})\z/, message: ->(_object, _data) { I18n.t('state_file.questions.w2.edit.employer_state_id_error') } }
+  validates :employer_state_id_num, length: { maximum: 16 }
   validates :state_wages_amount, numericality: { greater_than_or_equal_to: 0 }, if: -> { state_wages_amount.present? }
   validates :state_income_tax_amount, numericality: { greater_than_or_equal_to: 0 }, if: -> { state_income_tax_amount.present? }
   validates :local_wages_and_tips_amount, numericality: { greater_than_or_equal_to: 0 }, if: -> { local_wages_and_tips_amount.present? }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3300,6 +3300,7 @@ en:
           box18_html: "<strong>Box 18,</strong> Local wages, tips, etc."
           box19_html: "<strong>Box 19,</strong> Local income tax"
           box20_locality_name: "<strong>Box 20,</strong> Locality name"
+          employer_state_id_error: EIN cannot be more than 16 characters.
           instructions_1_html: Please review your state income details for <strong>%{employer}</strong>
           local_income_tax_amt_error: Cannot be greater than local wages and tips.
           local_wages_and_tips_amt_error: Please enter local wages and tips

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3300,7 +3300,6 @@ en:
           box18_html: "<strong>Box 18,</strong> Local wages, tips, etc."
           box19_html: "<strong>Box 19,</strong> Local income tax"
           box20_locality_name: "<strong>Box 20,</strong> Locality name"
-          employer_state_id_error: EIN must be a number. Do not include a dash.
           instructions_1_html: Please review your state income details for <strong>%{employer}</strong>
           local_income_tax_amt_error: Cannot be greater than local wages and tips.
           local_wages_and_tips_amt_error: Please enter local wages and tips

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3288,7 +3288,6 @@ es:
           box18_html: "<strong>Box 18</strong>: Salarios locales, propinas, etc."
           box19_html: "<strong>Box 19</strong>: Impuesto sobre la renta local"
           box20_locality_name: "<strong>Box 20</strong>: Nombre de la localidad"
-          employer_state_id_error: El EIN debe ser un número. No incluya un guión.
           instructions_1_html: Revisa los detalles de tus ingresos estatales para <strong>%{employer}</strong>
           local_income_tax_amt_error: No puede ser mayor que los salarios y propinas locales.
           local_wages_and_tips_amt_error: Ingresa los salarios y propinas locales

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3288,6 +3288,7 @@ es:
           box18_html: "<strong>Box 18</strong>: Salarios locales, propinas, etc."
           box19_html: "<strong>Box 19</strong>: Impuesto sobre la renta local"
           box20_locality_name: "<strong>Box 20</strong>: Nombre de la localidad"
+          employer_state_id_error: El EIN no puede tener más de 16 caracteres.
           instructions_1_html: Revisa los detalles de tus ingresos estatales para <strong>%{employer}</strong>
           local_income_tax_amt_error: No puede ser mayor que los salarios y propinas locales.
           local_wages_and_tips_amt_error: Ingresa los salarios y propinas locales

--- a/spec/fixtures/state_file/fed_return_xmls/2023/id/miranda_1099r_with_df_w2_error.xml
+++ b/spec/fixtures/state_file/fed_return_xmls/2023/id/miranda_1099r_with_df_w2_error.xml
@@ -153,7 +153,7 @@
             <W2StateLocalTaxGrp>
                 <W2StateTaxGrp>
                     <StateAbbreviationCd>ID</StateAbbreviationCd>
-                    <EmployerStateIdNum>00-000%0005</EmployerStateIdNum>
+                    <EmployerStateIdNum>abcdefghijklmnopq</EmployerStateIdNum>
                     <StateWagesAmt>15205</StateWagesAmt>
                     <StateIncomeTaxAmt>507</StateIncomeTaxAmt>
                     <W2LocalTaxGrp/>

--- a/spec/jobs/state_file/import_from_direct_file_job_spec.rb
+++ b/spec/jobs/state_file/import_from_direct_file_job_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe StateFile::ImportFromDirectFileJob, type: :job do
 
         expect(intake.df_data_import_succeeded_at).to be_nil
         expect(intake.df_data_import_errors.count).to eq(1)
-        expect(intake.df_data_import_errors.first.message).to eq("Validation failed: Employer state id num is too long (maximum is 16 characters)")
+        expect(intake.df_data_import_errors.first.message).to eq("Validation failed: Employer state id num EIN cannot be more than 16 characters.")
       end
     end
 

--- a/spec/jobs/state_file/import_from_direct_file_job_spec.rb
+++ b/spec/jobs/state_file/import_from_direct_file_job_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe StateFile::ImportFromDirectFileJob, type: :job do
 
         expect(intake.df_data_import_succeeded_at).to be_nil
         expect(intake.df_data_import_errors.count).to eq(1)
-        expect(intake.df_data_import_errors.first.message).to eq("Validation failed: Employer state id num EIN must be a number. Do not include a dash.")
+        expect(intake.df_data_import_errors.first.message).to eq("Validation failed: Employer state id num is too long (maximum is 16 characters)")
       end
     end
 

--- a/spec/models/state_file_base_intake_spec.rb
+++ b/spec/models/state_file_base_intake_spec.rb
@@ -113,7 +113,7 @@ describe StateFileBaseIntake do
       expect(intake.state_file_w2s.count).to eq 2
       w2 = intake.state_file_w2s.first
 
-      expect(w2.employer_state_id_num).to eq "000000005"
+      expect(w2.employer_state_id_num).to eq "00-0000005"
     end
 
     it "adds box 14 fields" do


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1202
- https://codeforamerica.atlassian.net/browse/FYST-1203
## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Removed the digits-only restriction from EmployerStateIDNum validation
- Removed the hyphen-deletion code we had added to work around this overly-stringent validation
## How to test?
- Once this is on demo, we can verify that it correctly handles Employer State ID Nums on DF W2s that have non-digit characters in them