### PR TITLE
[TBE-129] set non-prod deployed environments to be 'open' by default

### DIFF
--- a/config/environments/demo.rb
+++ b/config/environments/demo.rb
@@ -39,4 +39,9 @@ Rails.application.configure do
 
   # StateFile
   config.state_file_start_of_open_intake = Time.find_zone('America/New_York').parse('2024-01-01 7:59:59')
+
+  # Keep GYR and FYST 'open' until the end of 2040 ^_^
+  # use the session toggles if you want to emulate/test 'closed' behaviors
+  config.end_of_intake = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
+  config.state_file_end_of_new_intakes = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
 end

--- a/config/environments/demo.rb
+++ b/config/environments/demo.rb
@@ -42,6 +42,8 @@ Rails.application.configure do
 
   # Keep GYR and FYST 'open' until the end of 2040 ^_^
   # use the session toggles if you want to emulate/test 'closed' behaviors
-  config.end_of_intake = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
-  config.state_file_end_of_new_intakes = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
+  the_future = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
+  config.end_of_intake = the_future
+  config.state_file_end_of_new_intakes = the_future
+  config.state_file_end_of_in_progress_intakes = the_future
 end

--- a/config/environments/heroku.rb
+++ b/config/environments/heroku.rb
@@ -44,6 +44,8 @@ Rails.application.configure do
 
   # Keep GYR and FYST 'open' until the end of 2040 ^_^
   # use the session toggles if you want to emulate/test 'closed' behaviors
-  config.end_of_intake = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
-  config.state_file_end_of_new_intakes = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
+  the_future = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
+  config.end_of_intake = the_future
+  config.state_file_end_of_new_intakes = the_future
+  config.state_file_end_of_in_progress_intakes = the_future
 end

--- a/config/environments/heroku.rb
+++ b/config/environments/heroku.rb
@@ -41,4 +41,9 @@ Rails.application.configure do
 
   # StateFile
   config.state_file_start_of_open_intake = Time.find_zone('America/New_York').parse('2024-01-01 7:59:59')
+
+  # Keep GYR and FYST 'open' until the end of 2040 ^_^
+  # use the session toggles if you want to emulate/test 'closed' behaviors
+  config.end_of_intake = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
+  config.state_file_end_of_new_intakes = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -35,4 +35,9 @@ Rails.application.configure do
 
   # StateFile
   config.state_file_start_of_open_intake = Time.find_zone('America/New_York').parse('2024-01-01 7:59:59')
+
+  # Keep GYR and FYST 'open' until the end of 2040 ^_^
+  # use the session toggles if you want to emulate/test 'closed' behaviors
+  config.end_of_intake = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
+  config.state_file_end_of_new_intakes = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -38,6 +38,8 @@ Rails.application.configure do
 
   # Keep GYR and FYST 'open' until the end of 2040 ^_^
   # use the session toggles if you want to emulate/test 'closed' behaviors
-  config.end_of_intake = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
-  config.state_file_end_of_new_intakes = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
+  the_future = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
+  config.end_of_intake = the_future
+  config.state_file_end_of_new_intakes = the_future
+  config.state_file_end_of_in_progress_intakes = the_future
 end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
[TBE-129](https://codeforamerica.atlassian.net/browse/TBE-129)
## Is PM acceptance required? (delete one)
Yes - don't merge until JIRA issue is accepted!

## What was done?
Set a far future date for intakes to close to enable easier/faster testing.

## How to test?
- Visit the heroku deploy for gyr and fyst; intakes should be open and active.
- Use the session toggles to set gyr and fyst closed; the products should then be, uh, closed.


[TBE-129]: https://codeforamerica.atlassian.net/browse/TBE-129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ