### PR TITLE
Nj 121 gubernatorial

### DIFF
--- a/app/controllers/state_file/questions/nj_gubernatorial_elections_controller.rb
+++ b/app/controllers/state_file/questions/nj_gubernatorial_elections_controller.rb
@@ -1,0 +1,7 @@
+module StateFile
+  module Questions
+    class NjGubernatorialElectionsController < QuestionsController
+      include ReturnToReviewConcern
+    end
+  end
+end

--- a/app/forms/state_file/nj_gubernatorial_elections_form.rb
+++ b/app/forms/state_file/nj_gubernatorial_elections_form.rb
@@ -1,0 +1,15 @@
+module StateFile
+  class NjGubernatorialElectionsForm < QuestionsForm
+    set_attributes_for :intake,
+                       :primary_contribution_gubernatorial_elections,
+                       :spouse_contribution_gubernatorial_elections
+    
+    validates :primary_contribution_gubernatorial_elections, presence: true
+    validates :spouse_contribution_gubernatorial_elections, presence: true, if: -> { intake.filing_status_mfj? }
+    
+    def save
+      @intake.update(attributes_for(:intake))
+    end
+
+  end
+end

--- a/app/lib/navigation/state_file_nj_question_navigation.rb
+++ b/app/lib/navigation/state_file_nj_question_navigation.rb
@@ -47,6 +47,7 @@ module Navigation
                                           Navigation::NavigationStep.new(StateFile::Questions::NjEitcQualifyingChildController),
                                           Navigation::NavigationStep.new(StateFile::Questions::NjEstimatedTaxPaymentsController),
                                           Navigation::NavigationStep.new(StateFile::Questions::NjSalesUseTaxController),
+                                          Navigation::NavigationStep.new(StateFile::Questions::NjGubernatorialElectionsController),
                                           Navigation::NavigationStep.new(StateFile::Questions::TaxesOwedController),
                                           Navigation::NavigationStep.new(StateFile::Questions::TaxRefundController),
                                           Navigation::NavigationStep.new(StateFile::Questions::NjReviewController),

--- a/app/lib/pdf_filler/nj1040_pdf.rb
+++ b/app/lib/pdf_filler/nj1040_pdf.rb
@@ -87,8 +87,10 @@ module PdfFiller
         '64': @xml_document.at("Body NJChildTCNumOfDep")&.text,
 
         # Gubernatorial elections fund
-        Group245: @xml_document.at("Body PrimGubernElectFund").nil? ? 'Choice2' : 'Choice1',
-        Group246: @xml_document.at("Body SpouCuPartPrimGubernElectFund").nil? ? 'Choice2' : 'Choice1',
+        Group245: @xml_document.at("Body PrimGubernElectFund").present? ? 'Choice1' : 'Choice2',
+        Group246: if get_mfj_spouse_ssn
+                    @xml_document.at("Body SpouCuPartPrimGubernElectFund").present? ? 'Choice1' : 'Choice2'
+                  end,
       }
 
       dependents = get_dependents

--- a/app/lib/pdf_filler/nj1040_pdf.rb
+++ b/app/lib/pdf_filler/nj1040_pdf.rb
@@ -85,6 +85,10 @@ module PdfFiller
 
         # line 65 nj child tax credit
         '64': @xml_document.at("Body NJChildTCNumOfDep")&.text,
+
+        # Gubernatorial elections fund
+        Group245: @xml_document.at("Body PrimGubernElectFund").nil? ? 'Choice2' : 'Choice1',
+        Group246: @xml_document.at("Body SpouCuPartPrimGubernElectFund").nil? ? 'Choice2' : 'Choice1',
       }
 
       dependents = get_dependents

--- a/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
+++ b/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
@@ -191,6 +191,14 @@ module SubmissionBuilder
                   line_65 = calculated_fields.fetch(:NJ1040_LINE_65)
                   xml.NJChildTCNumOfDep calculated_fields.fetch(:NJ1040_LINE_65_DEPENDENTS) if line_65
                   xml.NJChildTaxCredit line_65 if line_65
+
+                  if intake.primary_contribution_gubernatorial_elections_yes?
+                    xml.PrimGubernElectFund "X"
+                  end
+
+                  if intake.spouse_contribution_gubernatorial_elections_yes?
+                    xml.SpouCuPartPrimGubernElectFund "X"
+                  end
                 end
               end
             end

--- a/app/models/state_file_nj_intake.rb
+++ b/app/models/state_file_nj_intake.rb
@@ -52,6 +52,7 @@
 #  phone_number                                           :string
 #  phone_number_verified_at                               :datetime
 #  primary_birth_date                                     :date
+#  primary_contribution_gubernatorial_elections           :integer          default("unfilled"), not null
 #  primary_disabled                                       :integer          default("unfilled"), not null
 #  primary_esigned                                        :integer          default("unfilled"), not null
 #  primary_esigned_at                                     :datetime
@@ -74,6 +75,7 @@
 #  source                                                 :string
 #  spouse_birth_date                                      :date
 #  spouse_claimed_as_eitc_qualifying_child                :integer          default("unfilled"), not null
+#  spouse_contribution_gubernatorial_elections            :integer          default("unfilled"), not null
 #  spouse_disabled                                        :integer          default("unfilled"), not null
 #  spouse_esigned                                         :integer          default("unfilled"), not null
 #  spouse_esigned_at                                      :datetime
@@ -125,6 +127,9 @@ class StateFileNjIntake < StateFileBaseIntake
 
   enum claimed_as_eitc_qualifying_child: { unfilled: 0, yes: 1, no: 2}, _prefix: :claimed_as_eitc_qualifying_child
   enum spouse_claimed_as_eitc_qualifying_child: { unfilled: 0, yes: 1, no: 2}, _prefix: :spouse_claimed_as_eitc_qualifying_child
+
+  enum primary_contribution_gubernatorial_elections: { unfilled: 0, yes: 1, no: 2}, _prefix: :primary_contribution_gubernatorial_elections
+  enum spouse_contribution_gubernatorial_elections: { unfilled: 0, yes: 1, no: 2}, _prefix: :spouse_contribution_gubernatorial_elections
 
   enum eligibility_all_members_health_insurance: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_all_members_health_insurance
 

--- a/app/views/state_file/questions/nj_gubernatorial_elections/edit.html.erb
+++ b/app/views/state_file/questions/nj_gubernatorial_elections/edit.html.erb
@@ -7,7 +7,7 @@
   <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder, html: { class: "form-card form-card--long" } do |f| %>
     <h1 class="h2"><%= title %></h1>
     <p><%= t(".details_1") %></p>
-    <p><%= t(".details_2_html", href: "https://elec.nj.gov/pdffiles/temporary/WebsitePlugForGubfinProgram.pdf") %></p>
+    <p><%= t(".details_2_html") %></p>
     <p><%= t(".details_3") %></p>
 
     <div class="white-group">

--- a/app/views/state_file/questions/nj_gubernatorial_elections/edit.html.erb
+++ b/app/views/state_file/questions/nj_gubernatorial_elections/edit.html.erb
@@ -1,0 +1,35 @@
+<%
+    title = t(".title")
+    content_for :page_title, title
+%>
+
+<% content_for :card do %>
+  <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder, html: { class: "form-card form-card--long" } do |f| %>
+    <h1 class="h2"><%= title %></h1>
+    <p><%= t(".details_1") %></p>
+    <p><%= t(".details_2_html", href: "https://elec.nj.gov/pdffiles/temporary/WebsitePlugForGubfinProgram.pdf") %></p>
+    <p><%= t(".details_3") %></p>
+
+    <div class="white-group">
+      <%= f.cfa_radio_set(:primary_contribution_gubernatorial_elections, label_text: t(".primary_contribute"), collection: [
+        { value: "yes", label: t("general.affirmative") },
+        { value: "no", label: t("general.negative") },
+      ]) %>
+    </div>
+
+    <% if current_intake.filing_status_mfj? %>
+      <div class="white-group">
+        <%= f.cfa_radio_set(:spouse_contribution_gubernatorial_elections, label_text: t(".spouse_contribute"), collection: [
+          { value: "yes", label: t("general.affirmative") },
+          { value: "no", label: t("general.negative") },
+        ]) %>
+      </div>
+    <% end %>
+
+    <% if params[:return_to_review].present? %>
+      <%= hidden_field_tag "return_to_review", params[:return_to_review] %>
+    <% end %>
+
+    <%= f.continue %>
+  <% end %>
+<% end %>

--- a/app/views/state_file/questions/nj_review/edit.html.erb
+++ b/app/views/state_file/questions/nj_review/edit.html.erb
@@ -33,14 +33,17 @@
     <div id="disabled_exemption" class="white-group">
       <div class="spacing-below-5">
         <% if !current_intake.primary_disabled_unfilled? %>
-          <p class="text--bold spacing-below-5"><%=t(".primary_disabled") %></p>
+          <h2 class="text--body text--bold spacing-below-5"><%=t(".primary_disabled") %></h2>
           <p><%= current_intake.primary_disabled %></p>
         <% end %>
         <% if !current_intake.spouse_disabled_unfilled? %>
-          <p class="text--bold spacing-below-5"><%=t(".spouse_disabled") %></p>
+          <h2 class="text--body text--bold spacing-below-5"><%=t(".spouse_disabled") %></h2>
           <p><%= current_intake.spouse_disabled  %></p>
         <% end %>
-        <%= link_to t("general.edit"), StateFile::Questions::NjDisabledExemptionController.to_path_helper(return_to_review: "y"), class: "button--small" %>
+        <%= link_to StateFile::Questions::NjDisabledExemptionController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
+          <%= t("general.edit") %>
+          <span class="sr-only"><%= t(".edit_disability")%></span>
+        <% end %>
       </div>
     </div>
   <% end %>
@@ -49,36 +52,33 @@
     <div id="veterans_exemption" class="white-group">
       <div class="spacing-below-5">
         <% if !current_intake.primary_veteran_unfilled? %>
-          <p class="text--bold spacing-below-5"><%=t(".primary_veteran") %></p>
+          <h2 class="text--body text--bold spacing-below-5"><%=t(".primary_veteran") %></h2>
           <p><%= current_intake.primary_veteran %></p>
         <% end %>
         <% if !current_intake.spouse_veteran_unfilled? %>
-          <p class="text--bold spacing-below-5"><%=t(".spouse_veteran") %></p>
+          <h2 class="text--body text--bold spacing-below-5"><%=t(".spouse_veteran") %></h2>
           <p><%= current_intake.spouse_veteran  %></p>
         <% end %>
-        <%= link_to t("general.edit"), StateFile::Questions::NjVeteransExemptionController.to_path_helper(return_to_review: "y"), class: "button--small" %>
+        <%= link_to StateFile::Questions::NjVeteransExemptionController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
+          <%= t("general.edit") %>
+          <span class="sr-only"><%= t(".edit_veteran") %></span>
+        <% end %>
       </div>
     </div>
   <% end %>
 
-    <% unless current_intake.claimed_as_eitc_qualifying_child_unfilled? && current_intake.spouse_claimed_as_eitc_qualifying_child_unfilled? %>
-    <div id="eitc_qualifying_child" class="white-group">
-      <div class="spacing-below-5">
-        <% unless current_intake.claimed_as_eitc_qualifying_child_unfilled? %>
-          <h2 class="text--body text--bold spacing-below-5"><%=t(".claimed_as_eitc_qualifying_child") %></h2>
-          <p><%= current_intake.claimed_as_eitc_qualifying_child %></p>
-        <% end %>
-        <% unless current_intake.spouse_claimed_as_eitc_qualifying_child_unfilled? %>
-        <h2 class="text--body text--bold spacing-below-5"><%=t(".spouse_claimed_as_eitc_qualifying_child") %></h2>
-          <p><%= current_intake.spouse_claimed_as_eitc_qualifying_child  %></p>
-        <% end %>
-        <%= link_to StateFile::Questions::NjEitcQualifyingChildController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
-          <%= t("general.edit") %>
-          <span class="sr-only"><%= t(".claimed_as_eitc_qualifying_child") %></span>
-        <% end %>
-      </div>
+  <%# Dependents %>
+
+  <div id="medical_expenses" class="white-group">
+    <div class="spacing-below-5">
+      <h2 class="text--body text--bold spacing-below-5"><%=t(".medical_expenses") %></h2>
+      <p><%= number_to_currency(current_intake.medical_expenses, precision: 0) %></p>
+      <%= link_to StateFile::Questions::NjMedicalExpensesController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
+        <%= t("general.edit") %>
+        <span class="sr-only"><%= t(".medical_expenses") %></span>
+      <% end %>
     </div>
-  <% end %>
+  </div>
 
   <div id="household_rent_own" class="white-group">
     <div class="spacing-below-5">
@@ -117,41 +117,33 @@
     </div>
   <% end %>
 
-  <% if !current_intake.primary_disabled_unfilled? || !current_intake.spouse_disabled_unfilled? %>
-    <div id="disabled_exemption" class="white-group">
+  <% unless current_intake.claimed_as_eitc_qualifying_child_unfilled? && current_intake.spouse_claimed_as_eitc_qualifying_child_unfilled? %>
+    <div id="eitc_qualifying_child" class="white-group">
       <div class="spacing-below-5">
-        <% if !current_intake.primary_disabled_unfilled? %>
-          <h2 class="text--body text--bold spacing-below-5"><%=t(".primary_disabled") %></h2>
-          <p><%= current_intake.primary_disabled %></p>
+        <% unless current_intake.claimed_as_eitc_qualifying_child_unfilled? %>
+          <h2 class="text--body text--bold spacing-below-5"><%=t(".claimed_as_eitc_qualifying_child") %></h2>
+          <p><%= current_intake.claimed_as_eitc_qualifying_child %></p>
         <% end %>
-        <% if !current_intake.spouse_disabled_unfilled? %>
-          <h2 class="text--body text--bold spacing-below-5"><%=t(".spouse_disabled") %></h2>
-          <p><%= current_intake.spouse_disabled  %></p>
+        <% unless current_intake.spouse_claimed_as_eitc_qualifying_child_unfilled? %>
+        <h2 class="text--body text--bold spacing-below-5"><%=t(".spouse_claimed_as_eitc_qualifying_child") %></h2>
+          <p><%= current_intake.spouse_claimed_as_eitc_qualifying_child  %></p>
         <% end %>
-        <%= link_to StateFile::Questions::NjDisabledExemptionController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
+        <%= link_to StateFile::Questions::NjEitcQualifyingChildController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
           <%= t("general.edit") %>
-          <span class="sr-only"><%= t(".primary_disabled") + " " + t("general.and") + " " +  t(".spouse_disabled") %></span>
+          <span class="sr-only"><%= t(".claimed_as_eitc_qualifying_child") %></span>
         <% end %>
       </div>
     </div>
   <% end %>
 
-  <div id="medical_expenses" class="white-group">
-    <div class="spacing-below-5">
-      <h2 class="text--body text--bold spacing-below-5"><%=t(".medical_expenses") %></h2>
-      <p><%= number_to_currency(current_intake.medical_expenses, precision: 0) %></p>
-      <%= link_to StateFile::Questions::NjMedicalExpensesController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
-        <%= t("general.edit") %>
-        <span class="sr-only"><%= t(".medical_expenses") %></span>
-      <% end %>
-    </div>
-  </div>
-
   <div id="estimated-tax-payments" class="white-group">
     <div class="spacing-below-5">
       <h2 class="text--body text--bold spacing-below-5"><%=t(".estimated_tax_payments") %></h2>
       <p><%= number_to_currency(current_intake.estimated_tax_payments || 0, precision: 0) %></p>
-      <%= link_to t("general.edit"), StateFile::Questions::NjEstimatedTaxPaymentsController.to_path_helper(return_to_review: "y"), class: "button--small" %>
+      <%= link_to StateFile::Questions::NjEstimatedTaxPaymentsController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
+          <%= t("general.edit") %>
+          <span class="sr-only"><%= t(".estimated_tax_payments") %></span>
+        <% end %>
     </div>
   </div>
 
@@ -163,7 +155,27 @@
         <p class="text--bold spacing-below-5"><%=t(".amount") %></p>
         <p><%=number_to_currency(current_intake.sales_use_tax, precision: 0)%></p>
       <% end %>
-      <%= link_to t("general.edit"), StateFile::Questions::NjSalesUseTaxController.to_path_helper(return_to_review: "y"), class: "button--small" %>
+      <%= link_to StateFile::Questions::NjSalesUseTaxController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
+          <%= t("general.edit") %>
+          <span class="sr-only"><%= t(".use_tax_applied") %></span>
+        <% end %>
+    </div>
+  </div>
+
+  <div class="white-group">
+    <div class="spacing-below-5">
+      <h2 class="text--body text--bold spacing-below-5"><%=t(".primary_gubernatorial") %></h2>
+      <p><%=current_intake.primary_contribution_gubernatorial_elections %></p>
+
+      <% if current_intake.filing_status_mfj? %>
+        <h2 class="text--body text--bold spacing-below-5"><%=t(".spouse_gubernatorial") %></h2>
+        <p><%=current_intake.spouse_contribution_gubernatorial_elections %></p>
+      <% end %>
+
+      <%= link_to StateFile::Questions::NjGubernatorialElectionsController.to_path_helper(return_to_review: "y"), class: "button--small"  do%>
+        <%= t("general.edit") %>
+        <span class="sr-only"><%= t(".edit_gubernatorial") %></span>
+      <% end %>
     </div>
   </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2913,7 +2913,7 @@ en:
       nj_gubernatorial_elections:
         edit:
           details_1: You may have heard this referred to as “public financing” of campaigns.
-          details_2_html: You can contribute $1 of where your taxes go to the <a href="%{href}" target="_blank" rel="noopener noreferrer">Gubernatorial Elections Fund.</a>
+          details_2_html: You can contribute $1 of where your taxes go to the <a href="https://elec.nj.gov/pdffiles/temporary/WebsitePlugForGubfinProgram.pdf" target="_blank" rel="noopener noreferrer">Gubernatorial Elections Fund.</a>
           details_3: 'FYI: Your taxes won’t increase and your refund won’t be reduced. This just gives New Jersey permission to use $1 of your tax dollars for this fund.'
           primary_contribute: Would you like to contribute $1 to the fund?
           spouse_contribute: Would your spouse like to contribute $1 to the fund?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2910,6 +2910,14 @@ en:
           subtitle_list_2: Overpayments on your %{prior_year} return that you chose to apply to your %{filing_year} New Jersey taxes
           subtitle_list_2_sub: 'Note: you would have selected this option when filing your %{prior_year} return'
           title: Please tell us if you already made any payments toward your %{filing_year} New Jersey taxes
+      nj_gubernatorial_elections:
+        edit:
+          details_1: You may have heard this referred to as “public financing” of campaigns.
+          details_2_html: You can contribute $1 of where your taxes go to the <a href="%{href}" target="_blank" rel="noopener noreferrer">Gubernatorial Elections Fund.</a>
+          details_3: 'FYI: Your taxes won’t increase and your refund won’t be reduced. This just gives New Jersey permission to use $1 of your tax dollars for this fund.'
+          primary_contribute: Would you like to contribute $1 to the fund?
+          spouse_contribute: Would your spouse like to contribute $1 to the fund?
+          title: The Gubernatorial Elections Fund helps qualified New Jersey governor candidates who need financial help.
       nj_homeowner_eligibility:
         edit:
           homeowner_home_subject_to_property_taxes: My main home, whether owned or rented, was subject to property taxes that were paid either as actual property taxes or through rent.
@@ -2972,17 +2980,22 @@ en:
           amount: Amount
           claimed_as_eitc_qualifying_child: I could be someone else's qualifying child for the Earned Income Tax Credit.
           county: County
+          edit_disability: disability status
+          edit_gubernatorial: gubernatorial fund contributions
+          edit_veteran: veteran status
           estimated_tax_payments: Payments already made to New Jersey taxes
           household_rent_own: Rent or own home
           medical_expenses: Medical expenses
           municipality: Municipality
           primary_disabled: I have a disability
+          primary_gubernatorial: I want $1 of my taxes to go to the gubernatorial elections fund
           primary_veteran: I am a veteran
           property_tax_paid: Property taxes paid
           rent_paid: Rent paid
           rounding_html: "<strong>We have automatically rounded all dollar amounts to the nearest whole number.</strong> New Jersey will only accept whole numbers on the final tax return."
           spouse_claimed_as_eitc_qualifying_child: My spouse could be someone else's qualifying child for the Earned Income Tax Credit.
           spouse_disabled: My spouse has a disability
+          spouse_gubernatorial: My spouse wants $1 of their taxes to go to the gubernatorial elections fund
           spouse_veteran: My spouse is a veteran
           use_tax_applied: Consumer Use Tax Applied
       nj_sales_use_tax:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2886,7 +2886,7 @@ es:
       nj_gubernatorial_elections:
         edit:
           details_1: You may have heard this referred to as “public financing” of campaigns.
-          details_2_html: You can contribute $1 of where your taxes go to the <a href="%{href}" target="_blank" rel="noopener noreferrer">Gubernatorial Elections Fund.</a>
+          details_2_html: You can contribute $1 of where your taxes go to the <a href="https://elec.nj.gov/pdffiles/temporary/WebsitePlugForGubfinProgram.pdf" target="_blank" rel="noopener noreferrer">Gubernatorial Elections Fund.</a>
           details_3: 'FYI: Your taxes won’t increase and your refund won’t be reduced. This just gives New Jersey permission to use $1 of your tax dollars for this fund.'
           primary_contribute: Would you like to contribute $1 to the fund?
           spouse_contribute: Would your spouse like to contribute $1 to the fund?

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2883,6 +2883,14 @@ es:
           subtitle_list_2: Overpayments on your %{prior_year} return that you chose to apply to your %{filing_year} New Jersey taxes
           subtitle_list_2_sub: 'Note: you would have selected this option when filing your %{prior_year} return'
           title: Please tell us if you already made any payments toward your %{filing_year} New Jersey taxes
+      nj_gubernatorial_elections:
+        edit:
+          details_1: You may have heard this referred to as “public financing” of campaigns.
+          details_2_html: You can contribute $1 of where your taxes go to the <a href="%{href}" target="_blank" rel="noopener noreferrer">Gubernatorial Elections Fund.</a>
+          details_3: 'FYI: Your taxes won’t increase and your refund won’t be reduced. This just gives New Jersey permission to use $1 of your tax dollars for this fund.'
+          primary_contribute: Would you like to contribute $1 to the fund?
+          spouse_contribute: Would your spouse like to contribute $1 to the fund?
+          title: The Gubernatorial Elections Fund helps qualified New Jersey governor candidates who need financial help.
       nj_homeowner_eligibility:
         edit:
           homeowner_home_subject_to_property_taxes: Mi vivienda principal, ya sea propia o alquilada, estaba sujeta a impuestos sobre la propiedad que se pagaban como impuestos sobre la propiedad reales o a través del alquiler.
@@ -2945,17 +2953,22 @@ es:
           amount: Cantidad
           claimed_as_eitc_qualifying_child: I could be someone else's qualifying child for the Earned Income Tax Credit.
           county: Condado
+          edit_disability: disability status
+          edit_gubernatorial: gubernatorial fund contributions
+          edit_veteran: veteran status
           estimated_tax_payments: Payments already made to New Jersey taxes
           household_rent_own: Vivienda en alquiler o en propiedad propia
           medical_expenses: Gastos médicos
           municipality: Municipio
           primary_disabled: Primary disabled
+          primary_gubernatorial: I want $1 of my taxes to go to the gubernatorial elections fund
           primary_veteran: Soy un veterano
           property_tax_paid: Impuestos sobre la propiedad pagados
           rent_paid: Alquiler pagado
           rounding_html: "<strong>We have automatically rounded all dollar amounts to the nearest whole number.</strong> New Jersey will only accept whole numbers on the final tax return."
           spouse_claimed_as_eitc_qualifying_child: My spouse could be someone else's qualifying child for the Earned Income Tax Credit.
           spouse_disabled: Spouse disabled
+          spouse_gubernatorial: My spouse wants $1 of their taxes to go to the gubernatorial elections fund
           spouse_veteran: Mi cónyuge es un veterano
           use_tax_applied: Impuesto sobre el uso del consumidor aplicado
       nj_sales_use_tax:

--- a/db/migrate/20241121162009_add_gubernatorial_elections_fund_fields_to_nj_intake.rb
+++ b/db/migrate/20241121162009_add_gubernatorial_elections_fund_fields_to_nj_intake.rb
@@ -1,0 +1,6 @@
+class AddGubernatorialElectionsFundFieldsToNjIntake < ActiveRecord::Migration[7.1]
+  def change
+    add_column :state_file_nj_intakes, :primary_contribution_gubernatorial_elections, :integer, default: 0, null: false
+    add_column :state_file_nj_intakes, :spouse_contribution_gubernatorial_elections, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_11_19_203800) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_21_162009) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -2121,6 +2121,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_19_203800) do
     t.string "phone_number"
     t.datetime "phone_number_verified_at"
     t.date "primary_birth_date"
+    t.integer "primary_contribution_gubernatorial_elections", default: 0, null: false
     t.integer "primary_disabled", default: 0, null: false
     t.integer "primary_esigned", default: 0, null: false
     t.datetime "primary_esigned_at"
@@ -2144,6 +2145,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_19_203800) do
     t.string "source"
     t.date "spouse_birth_date"
     t.integer "spouse_claimed_as_eitc_qualifying_child", default: 0, null: false
+    t.integer "spouse_contribution_gubernatorial_elections", default: 0, null: false
     t.integer "spouse_disabled", default: 0, null: false
     t.integer "spouse_esigned", default: 0, null: false
     t.datetime "spouse_esigned_at"

--- a/spec/controllers/state_file/questions/nj_gubernatorial_elections_controller_spec.rb
+++ b/spec/controllers/state_file/questions/nj_gubernatorial_elections_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe StateFile::Questions::NjGubernatorialElectionsController do
-  let(:intake) { create :state_file_nj_intake }
+  let(:intake) { create :state_file_nj_intake, primary_contribution_gubernatorial_elections: :yes, spouse_contribution_gubernatorial_elections: :yes}
   before do
     sign_in intake
   end
@@ -11,6 +11,37 @@ RSpec.describe StateFile::Questions::NjGubernatorialElectionsController do
     it 'succeeds' do
       get :edit
       expect(response).to be_successful
+    end
+  end
+
+  describe "#update" do
+    context "when a mfj primary and spouse update their choice" do
+      let(:form_params) {
+        {
+          state_file_nj_gubernatorial_elections_form: {
+            primary_contribution_gubernatorial_elections: 'no',
+            spouse_contribution_gubernatorial_elections: 'no'
+          }
+        }
+      }
+
+      it "saves the updated values" do
+        post :update, params: form_params
+        intake.reload
+        expect(intake.primary_contribution_gubernatorial_elections).to eq 'no'
+        expect(intake.spouse_contribution_gubernatorial_elections).to eq 'no'
+      end
+    end
+
+    it_behaves_like :return_to_review_concern do
+      let(:form_params) do
+        {
+          state_file_nj_gubernatorial_elections_form: {
+            primary_contribution_gubernatorial_elections: 'no',
+            spouse_contribution_gubernatorial_elections: 'no'
+          }
+        }
+      end
     end
   end
 end

--- a/spec/controllers/state_file/questions/nj_gubernatorial_elections_controller_spec.rb
+++ b/spec/controllers/state_file/questions/nj_gubernatorial_elections_controller_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe StateFile::Questions::NjGubernatorialElectionsController do
+  let(:intake) { create :state_file_nj_intake }
+  before do
+    sign_in intake
+  end
+
+  describe "#edit" do
+    render_views
+    it 'succeeds' do
+      get :edit
+      expect(response).to be_successful
+    end
+  end
+end

--- a/spec/factories/state_file_nj_intakes.rb
+++ b/spec/factories/state_file_nj_intakes.rb
@@ -52,6 +52,7 @@
 #  phone_number                                           :string
 #  phone_number_verified_at                               :datetime
 #  primary_birth_date                                     :date
+#  primary_contribution_gubernatorial_elections           :integer          default("unfilled"), not null
 #  primary_disabled                                       :integer          default("unfilled"), not null
 #  primary_esigned                                        :integer          default("unfilled"), not null
 #  primary_esigned_at                                     :datetime
@@ -74,6 +75,7 @@
 #  source                                                 :string
 #  spouse_birth_date                                      :date
 #  spouse_claimed_as_eitc_qualifying_child                :integer          default("unfilled"), not null
+#  spouse_contribution_gubernatorial_elections            :integer          default("unfilled"), not null
 #  spouse_disabled                                        :integer          default("unfilled"), not null
 #  spouse_esigned                                         :integer          default("unfilled"), not null
 #  spouse_esigned_at                                      :datetime

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -514,7 +514,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
       fill_in 'state_file_id_sales_use_tax_form_total_purchase_amount', with: "290"
       click_on I18n.t("general.continue")
 
-      #Permanent Building Fund
+      # Permanent Building Fund
       expect(page).to have_text I18n.t('state_file.questions.id_permanent_building_fund.edit.title')
       choose I18n.t("general.negative")
       click_on I18n.t("general.continue")
@@ -691,8 +691,35 @@ RSpec.feature "Completing a state file intake", active_job: true do
       choose I18n.t('state_file.questions.nj_household_rent_own.edit.neither')
       click_on I18n.t("general.continue")
 
+      click_on I18n.t("general.continue")
+
+      fill_in I18n.t('state_file.questions.nj_estimated_tax_payments.edit.label', filing_year: MultiTenantService.statefile.current_tax_year), with: 1000
+      click_on I18n.t("general.continue")
+
+      choose I18n.t('general.negative')
+      click_on I18n.t("general.continue")
+
+      # Gubernatorial elections fund
+      choose I18n.t('general.affirmative')
       expect(page).to be_axe_clean.within "main"
       click_on I18n.t("general.continue")
+
+      # Review
+      expect(page).to have_text I18n.t("state_file.questions.shared.review_header.title")
+      expect(page).to be_axe_clean.within "main"
+
+      groups = page.all(:css, '.white-group').count
+      has_h2 = page.all(:css, '.white-group:has(h2)').count
+      expect(groups).to eq(has_h2)
+
+      edit_buttons = page.all(:css, '.white-group a')
+      edit_buttons_count = edit_buttons.count
+      edit_buttons_with_sr_only_text = page.all(:css, '.white-group a span.sr-only').count
+      expect(edit_buttons_count).to eq(edit_buttons_with_sr_only_text)
+
+      edit_buttons_text = edit_buttons.map(&:text)
+      edit_buttons_unique_text_count = edit_buttons_text.uniq.count
+      expect(edit_buttons_unique_text_count).to eq(edit_buttons_count)
     end
   end
 end

--- a/spec/forms/state_file/nj_gubernatorial_elections_form_spec.rb
+++ b/spec/forms/state_file/nj_gubernatorial_elections_form_spec.rb
@@ -6,13 +6,38 @@ RSpec.describe StateFile::NjGubernatorialElectionsForm do
   describe "validations" do
     let(:form) { described_class.new(intake, invalid_params) }
 
-    context "invalid params" do
+    context "single invalid params" do
       context "all fields are required" do
-        let(:invalid_params) { :primary_contribution_gubernatorial_elections => nil }
+        let(:invalid_params) do
+          {
+            :primary_contribution_gubernatorial_elections => nil,
+            :spouse_contribution_gubernatorial_elections => nil, 
+          }
+        end
 
         it "is invalid" do
           expect(form.valid?).to eq false
           expect(form.errors[:primary_contribution_gubernatorial_elections]).to include "Can't be blank."
+          expect(form.errors[:spouse_contribution_gubernatorial_elections].length).to be 0 
+        end
+      end
+    end
+
+    context "mfj invalid params" do
+      let(:intake) { create :state_file_nj_intake, :married_filing_jointly }
+
+      context "all fields are required" do
+        let(:invalid_params) do
+          {
+            :primary_contribution_gubernatorial_elections => nil,
+            :spouse_contribution_gubernatorial_elections => nil, 
+          }
+        end
+
+        it "is invalid" do
+          expect(form.valid?).to eq false
+          expect(form.errors[:primary_contribution_gubernatorial_elections]).to include "Can't be blank."
+          expect(form.errors[:spouse_contribution_gubernatorial_elections]).to include "Can't be blank."
         end
       end
     end
@@ -23,7 +48,7 @@ RSpec.describe StateFile::NjGubernatorialElectionsForm do
       create :state_file_nj_intake,
       :married_filing_jointly,
       primary_contribution_gubernatorial_elections: 'no',
-      spouse_contribution_gubernatorial_elections: 'yes'
+      spouse_contribution_gubernatorial_elections: 'no'
     }
     let(:form) { described_class.new(intake, valid_params) }
 

--- a/spec/forms/state_file/nj_gubernatorial_elections_form_spec.rb
+++ b/spec/forms/state_file/nj_gubernatorial_elections_form_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe StateFile::NjGubernatorialElectionsForm do
+  let(:intake) { create :state_file_nj_intake }
+
+  describe "validations" do
+    let(:form) { described_class.new(intake, invalid_params) }
+
+    context "invalid params" do
+      context "all fields are required" do
+        let(:invalid_params) do
+          {
+            :primary_contribution_gubernatorial_elections => nil,
+          }
+        end
+
+        it "is invalid" do
+          expect(form.valid?).to eq false
+          expect(form.errors[:primary_contribution_gubernatorial_elections]).to include "Can't be blank."
+        end
+      end
+    end
+  end
+
+  describe ".save" do
+    let(:intake) {
+      create :state_file_nj_intake,
+      :married_filing_jointly,
+      primary_contribution_gubernatorial_elections: 'no',
+      spouse_contribution_gubernatorial_elections: 'yes'
+    }
+    let(:form) { described_class.new(intake, valid_params) }
+
+    context "when saving a new selection" do
+      let(:valid_params) do
+        { primary_contribution_gubernatorial_elections: "yes", spouse_contribution_gubernatorial_elections: "yes" }
+      end
+
+      it "saves attributes" do
+        expect(form.valid?).to eq true
+        form.save
+
+        expect(intake.primary_contribution_gubernatorial_elections).to eq "yes"
+        expect(intake.spouse_contribution_gubernatorial_elections).to eq "yes"
+      end
+    end
+  end
+end

--- a/spec/forms/state_file/nj_gubernatorial_elections_form_spec.rb
+++ b/spec/forms/state_file/nj_gubernatorial_elections_form_spec.rb
@@ -8,11 +8,7 @@ RSpec.describe StateFile::NjGubernatorialElectionsForm do
 
     context "invalid params" do
       context "all fields are required" do
-        let(:invalid_params) do
-          {
-            :primary_contribution_gubernatorial_elections => nil,
-          }
-        end
+        let(:invalid_params) { :primary_contribution_gubernatorial_elections => nil }
 
         it "is invalid" do
           expect(form.valid?).to eq false

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -1739,5 +1739,50 @@ RSpec.describe PdfFiller::Nj1040Pdf do
         expect(tax_credit).to eq 600
       end
     end
+
+    describe "gubernatorial elections fund" do
+      context "not mfj" do 
+        let(:intake) { 
+          create(:state_file_nj_intake)
+        }
+        it "does not fill the field when the answer is no" do 
+          expect(pdf_fields["Group245"]).to eq "Choice2"
+          expect(pdf_fields["Group246"]).to eq "Choice2"
+        end
+
+        it "checks yes when the answer is yes" do
+          intake.primary_contribution_gubernatorial_elections = :yes
+          expect(pdf_fields["Group245"]).to eq "Choice1"
+        end
+      end
+
+      context "mfj" do 
+        context "when primary does not contribtue and spouse does" do 
+          let(:intake) { 
+            create(:state_file_nj_intake, 
+            :married_filing_jointly,
+            primary_contribution_gubernatorial_elections: :no, spouse_contribution_gubernatorial_elections: :yes,
+            )
+          }
+          it "leaves primary blank and marks an X for spouse" do 
+            expect(pdf_fields["Group245"]).to eq "Choice2"
+            expect(pdf_fields["Group246"]).to eq "Choice1"
+          end
+        end
+
+        context "when primary wants to contribute and spouse does not" do 
+          let(:intake) { 
+            create(:state_file_nj_intake, 
+            :married_filing_jointly,
+            primary_contribution_gubernatorial_elections: :yes, spouse_contribution_gubernatorial_elections: :no,
+            )
+          }
+          it "checks yes for primary and no for spouse" do 
+            expect(pdf_fields["Group245"]).to eq "Choice1"
+            expect(pdf_fields["Group246"]).to eq "Choice2"
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -1765,7 +1765,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
             primary_contribution_gubernatorial_elections: :no, spouse_contribution_gubernatorial_elections: :yes,
             )
           }
-          it "checks no for primary and marks an X for spouse" do 
+          it "checks no for primary and marks yes for spouse" do 
             expect(pdf_fields["Group245"]).to eq "Choice2"
             expect(pdf_fields["Group246"]).to eq "Choice1"
           end

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -1745,26 +1745,27 @@ RSpec.describe PdfFiller::Nj1040Pdf do
         let(:intake) { 
           create(:state_file_nj_intake)
         }
-        it "does not fill the field when the answer is no" do 
+        it "marks no for primary when answer is no and does not fill spouse field" do 
           expect(pdf_fields["Group245"]).to eq "Choice2"
-          expect(pdf_fields["Group246"]).to eq "Choice2"
+          expect(pdf_fields["Group246"]).to eq ""
         end
 
-        it "checks yes when the answer is yes" do
+        it "checks yes when the answer is yes and does not fill spouse field" do
           intake.primary_contribution_gubernatorial_elections = :yes
           expect(pdf_fields["Group245"]).to eq "Choice1"
+          expect(pdf_fields["Group246"]).to eq ""
         end
       end
 
       context "mfj" do 
-        context "when primary does not contribtue and spouse does" do 
+        context "when primary does not contribute and spouse does" do 
           let(:intake) { 
             create(:state_file_nj_intake, 
             :married_filing_jointly,
             primary_contribution_gubernatorial_elections: :no, spouse_contribution_gubernatorial_elections: :yes,
             )
           }
-          it "leaves primary blank and marks an X for spouse" do 
+          it "checks no for primary and marks an X for spouse" do 
             expect(pdf_fields["Group245"]).to eq "Choice2"
             expect(pdf_fields["Group246"]).to eq "Choice1"
           end

--- a/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
@@ -787,7 +787,7 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
       end
 
       context "mfj" do 
-        context "when primary does not contribtue and spouse does" do 
+        context "when primary does not contribute and spouse does" do 
           let(:intake) { 
             create(:state_file_nj_intake, 
             :married_filing_jointly,

--- a/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
@@ -769,5 +769,50 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
         end
       end
     end
+
+    describe "gubernatorial elections fund" do
+      context "not mfj" do 
+        let(:intake) { 
+          create(:state_file_nj_intake)
+        }
+        it "does not fill the field when the answer is no" do 
+          expect(xml.at("Body PrimGubernElectFund")).to eq(nil)
+          expect(xml.at("Body SpouCuPartPrimGubernElectFund")).to eq(nil)
+        end
+
+        it "checks yes when the answer is yes" do
+          intake.primary_contribution_gubernatorial_elections = :yes
+          expect(xml.at("Body PrimGubernElectFund").text).to eq('X')
+        end
+      end
+
+      context "mfj" do 
+        context "when primary does not contribtue and spouse does" do 
+          let(:intake) { 
+            create(:state_file_nj_intake, 
+            :married_filing_jointly,
+            primary_contribution_gubernatorial_elections: :no, spouse_contribution_gubernatorial_elections: :yes,
+            )
+          }
+          it "leaves primary blank and marks an X for spouse" do 
+            expect(xml.at("Body PrimGubernElectFund")).to eq(nil)
+            expect(xml.at("Body SpouCuPartPrimGubernElectFund").text).to eq('X')
+          end
+        end
+
+        context "when primary wants to contribute and spouse does not" do 
+          let(:intake) { 
+            create(:state_file_nj_intake, 
+            :married_filing_jointly,
+            primary_contribution_gubernatorial_elections: :yes, spouse_contribution_gubernatorial_elections: :no,
+            )
+          }
+          it "checks yes for primary and no for spouse" do 
+            expect(xml.at("Body PrimGubernElectFund").text).to eq('X')
+            expect(xml.at("Body SpouCuPartPrimGubernElectFund")).to eq(nil)
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/models/efile_error_spec.rb
+++ b/spec/models/efile_error_spec.rb
@@ -86,6 +86,7 @@ describe 'EfileError' do
       "nj-eitc-qualifying-child",
       "nj-eligibility-health-insurance",
       "nj-estimated-tax-payments",
+      "nj-gubernatorial-elections",
       "nj-homeowner-eligibility",
       "nj-homeowner-property-tax",
       "nj-household-rent-own",

--- a/spec/models/state_file_nj_intake_spec.rb
+++ b/spec/models/state_file_nj_intake_spec.rb
@@ -52,6 +52,7 @@
 #  phone_number                                           :string
 #  phone_number_verified_at                               :datetime
 #  primary_birth_date                                     :date
+#  primary_contribution_gubernatorial_elections           :integer          default("unfilled"), not null
 #  primary_disabled                                       :integer          default("unfilled"), not null
 #  primary_esigned                                        :integer          default("unfilled"), not null
 #  primary_esigned_at                                     :datetime
@@ -74,6 +75,7 @@
 #  source                                                 :string
 #  spouse_birth_date                                      :date
 #  spouse_claimed_as_eitc_qualifying_child                :integer          default("unfilled"), not null
+#  spouse_contribution_gubernatorial_elections            :integer          default("unfilled"), not null
 #  spouse_disabled                                        :integer          default("unfilled"), not null
 #  spouse_esigned                                         :integer          default("unfilled"), not null
 #  spouse_esigned_at                                      :datetime


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/121

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Just before review, add gubernatorial elections fund contribution for self and, if mfj, spouse. Add to review, xml, pdf.
- Fix accessibility of review screen and update end to end test to go all the way through the minimal intake. Add some a11y checks for the review screen itself

## How to test?
- Choose mfj
- Answer yes or no to gubernatorial elections fund questions
- Go back and edit from review screen to test that that works
- See that answers are reflected in PDF and xml

## Screenshots (for visual changes)
![Screenshot 2024-11-22 at 13-34-22 The Gubernatorial Elections Fund helps qualified New Jersey governor candidates who need financial help  FileYourStateTaxes](https://github.com/user-attachments/assets/02ea82ad-339a-4121-8f30-2698cd2af272)
