### PR TITLE
NJ 157 - add review screen for dependents attending college

### DIFF
--- a/app/views/state_file/questions/nj_review/edit.html.erb
+++ b/app/views/state_file/questions/nj_review/edit.html.erb
@@ -7,6 +7,26 @@
 
   <%= render "state_file/questions/shared/review_header" %>
 
+  <% if current_intake.dependents.count(&:under_22?).positive? %>
+    <div id="college-dependents" class="white-group">
+      <div class="spacing-below-5">
+        <h2 class="text--body text--bold spacing-below-5"><%=t(".college_dependents") %></h2>
+        <% current_intake.dependents.each do | dependent | %>
+          <% if dependent.nj_qualifies_for_college_exemption? %>
+            <p><%=dependent.full_name %></p>
+          <% end %>
+        <% end %>
+        <% if current_intake.dependents.all? { |dependent| !dependent.nj_qualifies_for_college_exemption? } %>
+          <p><%= t("general.none") %></p>
+        <% end %>
+        <%= link_to StateFile::Questions::NjCollegeDependentsExemptionController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
+          <%= t("general.edit") %>
+          <span class="sr-only"><%= t(".college_dependents") %></span>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+
   <div id="county" class="white-group">
     <div class="spacing-below-5">
       <h2 class="text--body text--bold spacing-below-5"><%=t(".county") %></h2>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2971,6 +2971,7 @@ en:
         edit:
           amount: Amount
           claimed_as_eitc_qualifying_child: I could be someone else's qualifying child for the Earned Income Tax Credit.
+          college_dependents: Dependents attending college
           county: County
           estimated_tax_payments: Payments already made to New Jersey taxes
           household_rent_own: Rent or own home

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2944,6 +2944,7 @@ es:
         edit:
           amount: Cantidad
           claimed_as_eitc_qualifying_child: I could be someone else's qualifying child for the Earned Income Tax Credit.
+          college_dependents: Dependents attending college
           county: Condado
           estimated_tax_payments: Payments already made to New Jersey taxes
           household_rent_own: Vivienda en alquiler o en propiedad propia


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/157

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
Fast-follow for college dependents work that was merged, add to review screen

## How to test?
- Use `zeus_many_deps` and select some but not all of them with all four checkboxes to see only the qualified dependents listed in review
- Use `zeus_many_deps` and no dependents fully to see the "None" state on review
- Use `minimal` to see that the section does not appear in review when no dependents under 22

## Screenshots (for visual changes)
![image](https://github.com/user-attachments/assets/287a8801-e635-49ed-836b-43aa3a61aeec)

