### PR TITLE
[FYST-1217] Tweak a default parameter so it renders as html

### DIFF
--- a/app/views/state_file/landing_page/edit.html.erb
+++ b/app/views/state_file/landing_page/edit.html.erb
@@ -65,7 +65,7 @@
               <% end %>
             <% else %>
               <div class="white-group spacing-below-60">
-                <% # i18n-tasks-use t('state_file.landing_page.edit.help_text_html') # hint for the i18n linter that, yes, we are using this key (sometime) %>
+                <% # i18n-tasks-use t('state_file.landing_page.edit.help_text_html') # hint for the i18n linter that, yes, we are using this key (sometimes) %>
                 <%= t(".#{@state_code}.help_text_html", default: :'.help_text_html', filing_year: current_tax_year) %>
               </div>
               <%= form_with model: @form, url: { action: :update }, local: true, method: :put, builder: VitaMinFormBuilder do |f| %>

--- a/app/views/state_file/landing_page/edit.html.erb
+++ b/app/views/state_file/landing_page/edit.html.erb
@@ -65,7 +65,7 @@
               <% end %>
             <% else %>
               <div class="white-group spacing-below-60">
-                <%= t(".#{@state_code}.help_text_html", default: t(".help_text_html"), filing_year: current_tax_year) %>
+                <%= t(".#{@state_code}.help_text_html", default: :'.help_text_html', filing_year: current_tax_year) %>
               </div>
               <%= form_with model: @form, url: { action: :update }, local: true, method: :put, builder: VitaMinFormBuilder do |f| %>
                 <%= f.submit t("general.get_started"), class: "button button--primary button--wide", id: "firstCta" %>

--- a/app/views/state_file/landing_page/edit.html.erb
+++ b/app/views/state_file/landing_page/edit.html.erb
@@ -65,6 +65,7 @@
               <% end %>
             <% else %>
               <div class="white-group spacing-below-60">
+                <% # i18n-tasks-use t('state_file.landing_page.edit.help_text_html') # hint for the i18n linter that, yes, we are using this key (sometime) %>
                 <%= t(".#{@state_code}.help_text_html", default: :'.help_text_html', filing_year: current_tax_year) %>
               </div>
               <%= form_with model: @form, url: { action: :update }, local: true, method: :put, builder: VitaMinFormBuilder do |f| %>


### PR DESCRIPTION
## Link to pivotal/JIRA issue
[FYST-1217](https://codeforamerica.atlassian.net/browse/FYST-1217)
## Is PM acceptance required? (delete one)
Yes - don't merge until JIRA issue is accepted!

## What was done?
when using the `:default` param in a `t` call, if you give it a plain string, that's what it'll render. pass a symbol to have it look up a translation instead.

## How to test?
Visit the landing page of all states; verify the "what you need" section is rendered as html

## Screenshots (for visual changes)
### Before
![image](https://github.com/user-attachments/assets/4e919cf1-d8dc-4538-bc5e-75ffa9767f82)

### After
![image](https://github.com/user-attachments/assets/426af90b-44d5-4d74-bebc-3243b2963ba6)


[FYST-1217]: https://codeforamerica.atlassian.net/browse/FYST-1217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ