### PR TITLE
[FYST-1226] adds a mising filing_year param in the 529 screener

### DIFF
--- a/app/views/state_file/questions/az_eligibility_out_of_state_income/edit.html.erb
+++ b/app/views/state_file/questions/az_eligibility_out_of_state_income/edit.html.erb
@@ -18,7 +18,7 @@
     <div class="white-group">
       <%= f.cfa_radio_set(
             :eligibility_529_for_non_qual_expense,
-            label_text: t(".used_529_for_non_qual_expense_html"),
+            label_text: t(".used_529_for_non_qual_expense_html", filing_year: current_tax_year),
             collection: [
               { value: "yes", label: t("general.affirmative") },
               { value: "no", label: t("general.negative") },


### PR DESCRIPTION
## Link to pivotal/JIRA issue
[FYST-1226](https://codeforamerica.atlassian.net/browse/FYST-1226)

## Is PM acceptance required? (delete one)
Yes

## What was done?
Added a missing param to the view.

## How to test?
- Start a new intake (any state, any language)
- 529 screener is in the 2nd page of questions, ensure the filing year appears as 2024

## Screenshots (for visual changes)
### Before
![image](https://github.com/user-attachments/assets/052dd462-6beb-44d0-b992-faa119a6b135)

### After
![image](https://github.com/user-attachments/assets/a375de69-5bf8-46c0-8182-c64ecb77da14)
