### PR TITLE
NJ 170 - update checkboxes to better match designs

### DIFF
--- a/app/views/state_file/questions/nj_homeowner_eligibility/edit.html.erb
+++ b/app/views/state_file/questions/nj_homeowner_eligibility/edit.html.erb
@@ -8,18 +8,40 @@
     <h1 class="h2"><%= title %></h1>
     <p><%= t(".label") %></p>
 
-    <div class="tight-checkboxes spacing-above-0 question-with-follow-up">
-      <%= f.cfa_checkbox(:homeowner_home_subject_to_property_taxes, t(".homeowner_home_subject_to_property_taxes"), options: { checked_value: "yes", unchecked_value: "no" }) %>
-      <%= f.cfa_checkbox(:homeowner_more_than_one_main_home_in_nj, t(".homeowner_more_than_one_main_home_in_nj"), options: { checked_value: "yes", unchecked_value: "no" }) %>
-      <%= f.cfa_checkbox(:homeowner_shared_ownership_not_spouse, t(".homeowner_shared_ownership_not_spouse"), options: { checked_value: "yes", unchecked_value: "no" }) %>
-      <div class="question-with-follow-up__question">
+    <div class="spacing-above-0 question-with-follow-up">
+      <div class="white-group">
+        <div class="tight-checkboxes">
+          <%= f.cfa_checkbox(:homeowner_home_subject_to_property_taxes, t(".homeowner_home_subject_to_property_taxes"), options: { checked_value: "yes", unchecked_value: "no" }) %>
+        </div>
+      </div>
+      <div class="white-group">
+        <div class="tight-checkboxes">
+          <%= f.cfa_checkbox(:homeowner_more_than_one_main_home_in_nj, t(".homeowner_more_than_one_main_home_in_nj"), options: { checked_value: "yes", unchecked_value: "no" }) %>
+        </div>
+      </div>
+      <div class="white-group">
+        <div class="tight-checkboxes">
+          <%= f.cfa_checkbox(:homeowner_shared_ownership_not_spouse, t(".homeowner_shared_ownership_not_spouse"), options: { checked_value: "yes", unchecked_value: "no" }) %>
+        </div>
+      </div>
+      <div class="white-group question-with-follow-up__question">
+        <div class="tight-checkboxes">
         <%= f.cfa_checkbox(:homeowner_main_home_multi_unit, t(".homeowner_main_home_multi_unit"), options: { checked_value: "yes", unchecked_value: "no", "data-follow-up": "#homeowner_multi_unit_followup", "aria-controls": "homeowner_multi_unit_followup"}) %>
+        </div>
       </div>
       <div class="question-with-follow-up__follow-up" id="homeowner_multi_unit_followup">
-        <%= f.cfa_checkbox(:homeowner_main_home_multi_unit_max_four_one_commercial, t(".homeowner_main_home_multi_unit_max_four_one_commercial"), options: { checked_value: "yes", unchecked_value: "no" }) %>
+        <div class="white-group">
+          <div class="tight-checkboxes">
+            <%= f.cfa_checkbox(:homeowner_main_home_multi_unit_max_four_one_commercial, t(".homeowner_main_home_multi_unit_max_four_one_commercial"), options: { checked_value: "yes", unchecked_value: "no" }) %>
+          </div>
+        </div>
       </div>
       <% if current_intake.filing_status_mfs? %>
-        <%= f.cfa_checkbox(:homeowner_same_home_spouse, t(".homeowner_same_home_spouse"), options: { checked_value: "yes", unchecked_value: "no" }) %>
+        <div class="white-group">
+          <div class="tight-checkboxes">
+            <%= f.cfa_checkbox(:homeowner_same_home_spouse, t(".homeowner_same_home_spouse"), options: { checked_value: "yes", unchecked_value: "no" }) %>
+          </div>
+        </div>
       <% end %>
     </div>
 

--- a/app/views/state_file/questions/nj_homeowner_property_tax/edit.html.erb
+++ b/app/views/state_file/questions/nj_homeowner_property_tax/edit.html.erb
@@ -12,7 +12,7 @@
     </div>
 
     <div class="reveal">
-      <p><button class="reveal__button"><%= t('.helper_heading') %></button></p>
+      <button class="reveal__button"><%= t('.helper_heading') %></button>
       <div class="reveal__content">
         <p><%= t('.helper_description') %></p>
       </div>

--- a/app/views/state_file/questions/nj_municipality/edit.html.erb
+++ b/app/views/state_file/questions/nj_municipality/edit.html.erb
@@ -15,7 +15,7 @@
     </div>
 
     <div class="reveal">
-      <p><button class="reveal__button"><%= t('.helper_heading') %></button></p>
+      <button class="reveal__button"><%= t('.helper_heading') %></button>
       <div class="reveal__content">
         <p><%= t('.helper_description_html') %></p>
       </div>

--- a/app/views/state_file/questions/nj_tenant_eligibility/edit.html.erb
+++ b/app/views/state_file/questions/nj_tenant_eligibility/edit.html.erb
@@ -9,27 +9,51 @@
     <fieldset>
       <legend style="margin-bottom: 2.5rem"><%= t(".label") %></legend>
 
-      <div class="tight-checkboxes spacing-above-0 question-with-follow-up">
-        <%= f.cfa_checkbox(:tenant_home_subject_to_property_taxes, t(".tenant_home_subject_to_property_taxes"), options: { checked_value: "yes", unchecked_value: "no" }) %>
-
-        <div class="question-with-follow-up__question">
-          <%= f.cfa_checkbox(:tenant_building_multi_unit, t(".tenant_building_multi_unit"), options: { checked_value: "yes", unchecked_value: "no", "data-follow-up": "#tenant_access_kitchen_bath_followup", "aria-controls": "tenant_access_kitchen_bath_followup" }) %>
+      <div class="spacing-above-0 question-with-follow-up">
+        <div class="white-group">
+          <div class="tight-checkboxes">
+            <%= f.cfa_checkbox(:tenant_home_subject_to_property_taxes, t(".tenant_home_subject_to_property_taxes"), options: { checked_value: "yes", unchecked_value: "no" }) %>
+          </div>
         </div>
+
+        <div class="white-group question-with-follow-up__question">
+          <div class="tight-checkboxes">
+            <%= f.cfa_checkbox(:tenant_building_multi_unit, t(".tenant_building_multi_unit"), options: { checked_value: "yes", unchecked_value: "no", "data-follow-up": "#tenant_access_kitchen_bath_followup", "aria-controls": "tenant_access_kitchen_bath_followup" }) %>
+          </div>
+        </div>
+
         <div class="question-with-follow-up__follow-up" id="tenant_access_kitchen_bath_followup">
-          <%= f.cfa_checkbox(:tenant_access_kitchen_bath, t(".tenant_access_kitchen_bath"), options: { checked_value: "yes", unchecked_value: "no" }) %>
+          <div class="white-group">
+            <div class="tight-checkboxes">
+              <%= f.cfa_checkbox(:tenant_access_kitchen_bath, t(".tenant_access_kitchen_bath"), options: { checked_value: "yes", unchecked_value: "no" }) %>
+            </div>
+          </div>
         </div>
 
-        <%= f.cfa_checkbox(:tenant_more_than_one_main_home_in_nj, t(".tenant_more_than_one_main_home_in_nj"), options: { checked_value: "yes", unchecked_value: "no" }) %>
-        <%= f.cfa_checkbox(:tenant_shared_rent_not_spouse, t(".tenant_shared_rent_not_spouse"), options: { checked_value: "yes", unchecked_value: "no" }) %>
+        <div class="white-group">
+          <div class="tight-checkboxes">
+            <%= f.cfa_checkbox(:tenant_more_than_one_main_home_in_nj, t(".tenant_more_than_one_main_home_in_nj"), options: { checked_value: "yes", unchecked_value: "no" }) %>
+          </div>
+        </div>
+
+        <div class="white-group">
+          <div class="tight-checkboxes">
+            <%= f.cfa_checkbox(:tenant_shared_rent_not_spouse, t(".tenant_shared_rent_not_spouse"), options: { checked_value: "yes", unchecked_value: "no" }) %>
+          </div>
+        </div>
 
         <% if current_intake.filing_status_mfs? %>
-          <%= f.cfa_checkbox(:tenant_same_home_spouse, t(".tenant_same_home_spouse"), options: { checked_value: "yes", unchecked_value: "no" }) %>
+          <div class="white-group">
+            <div class="tight-checkboxes">
+              <%= f.cfa_checkbox(:tenant_same_home_spouse, t(".tenant_same_home_spouse"), options: { checked_value: "yes", unchecked_value: "no" }) %>
+            </div>
+          </div>
         <% end %>
       </div>
     </fieldset>
 
     <div class="reveal">
-      <p><button class="reveal__button"><%= t('.helper_heading') %></button></p>
+      <button class="reveal__button"><%= t('.helper_heading') %></button>
       <div class="reveal__content">
         <p><%= t('.helper_description') %></p>
       </div>


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/170

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Update checkbox design to use newer style
- Also I fixed the remaining `<p><button>` accessibility issues while I was there

## How to test?
- Go to homeowner and tenant eligibility screens

## Screenshots (for visual changes)

### Before:
![image](https://github.com/user-attachments/assets/e3c07e18-ccf1-4d27-b13f-3985370224f3)


---

### After: homeowner
<img width="974" alt="image" src="https://github.com/user-attachments/assets/46853342-dbaa-4415-842f-bcdc87552100">

---


### After: tenant
<img width="1009" alt="image" src="https://github.com/user-attachments/assets/f0689c74-a571-4133-a6f4-5c3e0d446320">
