### PR TITLE
[FYST-1180] AZ Increased Excise Credit should not result in a negative amount

### DIFF
--- a/app/lib/efile/az/az140_calculator.rb
+++ b/app/lib/efile/az/az140_calculator.rb
@@ -283,7 +283,9 @@ module Efile
           max_credit = 100
           max_credit -= @intake.household_excise_credit_claimed_amount&.round if @intake.household_excise_credit_claimed_yes?
 
-          [wrksht_line_4, max_credit].min
+          result = [wrksht_line_4, max_credit].min
+          result = 0 if result < 0
+          result
         end
       end
 

--- a/spec/lib/efile/az/az140_calculator_spec.rb
+++ b/spec/lib/efile/az/az140_calculator_spec.rb
@@ -413,6 +413,20 @@ describe Efile::Az::Az140Calculator do
       end
     end
 
+    context "single filer with four dependents with some credit claimed over total amount" do
+      it "sets the credit to 0" do
+        intake.direct_file_data.filing_status = 1 # single
+        intake.direct_file_data.fed_agi = 12_500 # qualifying agi
+        intake.dependents.create(dob: 7.years.ago)
+        intake.dependents.create(dob: 5.years.ago)
+        intake.dependents.create(dob: 3.years.ago)
+        intake.dependents.create(dob: 1.years.ago)
+        intake.update(household_excise_credit_claimed: "yes", household_excise_credit_claimed_amount: 110)
+        instance.calculate
+        expect(instance.lines[:AZ140_LINE_56].value).to eq(0) # (1 filer + 4 dependents) * 25 = 125 but max is 0
+      end
+    end
+
     # TODO: [JH] i don't....understand this test? was copied from commit a674f6f
     context "filing status is qualifying widow" do
       it "sets the family income tax credit and excise credit to 0" do


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1180

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Add line 9 to calculating nc d400 line 12a

## How to test?
- Go through AZ flow, say yes on `az-excise-credit`, and enter an amount greater than 100 to test negative values
- Verify the correct 12a value in the pdf export