### PR TITLE
add #analytics_attrs to nc d400 calculator

### DIFF
--- a/app/lib/efile/nc/d400_calculator.rb
+++ b/app/lib/efile/nc/d400_calculator.rb
@@ -60,6 +60,10 @@ module Efile
         end
       end
 
+      def analytics_attrs
+        {}
+      end
+
       private
 
       def calculate_line_9

--- a/spec/models/state_file_analytics_spec.rb
+++ b/spec/models/state_file_analytics_spec.rb
@@ -51,6 +51,17 @@ describe StateFileAnalytics do
       }
     }
 
+    StateFile::StateInformationService.active_state_codes.each do |state_code|
+      context "#{state_code}  calculator implements #analytics_attrs" do
+        let(:intake) { create "state_file_#{state_code}_intake".to_sym }
+
+        it "returns some analytics attributes" do
+          analytics = StateFileAnalytics.create(record: intake)
+          expect(analytics.calculated_attrs.symbolize_keys).to be_present
+        end
+      end
+    end
+
     context "AZ intake" do
       let(:intake) { create :state_file_az_intake }
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1244
## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- We were getting a [crash on demo](https://codeforamerica.sentry.io/issues/6106195127?project=1880321) because the NC D400 calculator didn't implement `#analytics_attrs`, which is called by `StateFileAnalytics`. I added an implementation that just returns an empty Hash, and added a test that verifies that all active states' calculators implement this method. 
## How to test?
- Submit an NC return and validate that its submission doesn't fail to transition to the `transmitted` state
