### PR TITLE
Fyst 293/implement sms notification delivery

### DIFF
--- a/app/services/state_file/messaging_service.rb
+++ b/app/services/state_file/messaging_service.rb
@@ -87,11 +87,6 @@ module StateFile
       matching_intakes.present?
     end
 
-
-    # def send_sms
-    #   return unless Flipper.enabled?(:sms_notifications)
-    # end
-
     def base_args
       first_name = intake.primary_first_name ? intake.primary_first_name.split(/ |\_/).map(&:capitalize).join(" ") : ""
       {

--- a/app/services/state_file/messaging_service.rb
+++ b/app/services/state_file/messaging_service.rb
@@ -27,7 +27,8 @@ module StateFile
       if intake.unsubscribed_from_email?
         DatadogApi.increment("mailgun.state_file_notification_emails.not_sent_because_unsubscribed")
       end
-      # send_sms if @do_sms # TODO: Eventually send SMS when fixed
+
+      send_sms(require_verification:) if @do_sms
 
       message_tracker.record(sent_messages.last.created_at) if sent_messages.any? # will this be recorded correctly with what we have on line 40
 
@@ -52,6 +53,21 @@ module StateFile
         sent_messages << sent_message if sent_message.present?
       end
     end
+
+    def send_sms(require_verification: true)
+      phone_number_verified = intake.phone_number_verified_at.present? || matching_intakes_has_phone_number_verified_at?(intake)
+      return if intake.phone_number.nil?
+      return if require_verification && !phone_number_verified
+
+      if @message_instance.sms_body.present?
+        twilio = TwilioService.new(:statefile)
+
+        twilio.send_text_message(
+          to: intake.phone_number,
+          body: @message_instance.sms_body(locale: @locale, **sms_args)
+        )
+      end
+    end
     
     def matching_intakes_has_email_verified_at?(intake)
       return if intake.email_address.nil? || intake.hashed_ssn.nil?
@@ -59,6 +75,15 @@ module StateFile
       intake_class = StateFile::StateInformationService.intake_class(intake.state_code)
       matching_intakes = intake_class.where(email_address: intake.email_address, hashed_ssn: intake.hashed_ssn)
                                      .where.not(email_address_verified_at: nil)
+      matching_intakes.present?
+    end
+
+    def matching_intakes_has_phone_number_verified_at?(intake)
+      return if intake.phone_number.nil? || intake.hashed_ssn.nil?
+
+      intake_class = StateFile::StateInformationService.intake_class(intake.state_code)
+      matching_intakes = intake_class.where(phone_number: intake.phone_number, hashed_ssn: intake.hashed_ssn)
+                                     .where.not(phone_number_verified_at: nil)
       matching_intakes.present?
     end
 

--- a/scripts/send_message.rb
+++ b/scripts/send_message.rb
@@ -19,7 +19,7 @@ class SendMessage < Thor
         say "Creating disposable intake to test notification", :cyan
 
         intake = StateFileAzIntake.create(
-          primary_first_name: "Testa",
+          primary_first_name: "Test",
           primary_last_name: "Testerson",
           email_address: options.fetch(:email_address, nil),
           email_address_verified_at: 1.minute.ago,

--- a/scripts/send_message.rb
+++ b/scripts/send_message.rb
@@ -19,7 +19,7 @@ class SendMessage < Thor
         say "Creating disposable intake to test notification", :cyan
 
         intake = StateFileAzIntake.create(
-          primary_first_name: "Test",
+          primary_first_name: "Testa",
           primary_last_name: "Testerson",
           email_address: options.fetch(:email_address, nil),
           email_address_verified_at: 1.minute.ago,
@@ -51,6 +51,8 @@ class SendMessage < Thor
           sms: !!options[:sms_number],
           body_args: body_args
         ).send_message
+
+        raise ActiveRecord::Rollback
       end
     end
   end

--- a/scripts/send_message.rb
+++ b/scripts/send_message.rb
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+
+require_relative "../config/environment"
+
+# Quick and dirty script to run notifications from the command line to smoke test/copy-check them
+class SendMessage < Thor
+  all_message_classes = StateFile::AutomatedMessage.constants.select { |c| StateFile::AutomatedMessage.const_get(c).is_a? Class }
+
+  all_message_classes.each do |klass|
+    method_name = klass.to_s.underscore
+
+    desc method_name, "Sends the #{method_name} notification. Messages are created in a transaction due to intakes being required"
+    method_option :sms_number, aliases: '-s', desc: 'Number to send an sms to. Requires valid twilio credentials', type: :string
+    method_option :email_address, aliases: '-e', desc: 'Email address to send an email to. Requires the rails application to be configured to emit emails.', type: :string
+    method_option :body_args, aliases: '-b', desc: 'Body arguments. Pass multiple at once', type: :hash, default: {}
+
+    define_method(method_name) do
+      ActiveRecord::Base.transaction do
+        say "Creating disposable intake to test notification", :cyan
+
+        intake = StateFileAzIntake.create(
+          primary_first_name: "Test",
+          primary_last_name: "Testerson",
+          email_address: options.fetch(:email_address, nil),
+          email_address_verified_at: 1.minute.ago,
+          phone_number: options.fetch(:sms_number, nil),
+          phone_number_verified_at: 1.minute.ago,
+          message_tracker: {},
+          hashed_ssn: "nonsense"
+        )
+
+        # Horrible hack, but this enables us to avoid having to stub a submission
+        message = Class.new StateFile::AutomatedMessage.const_get(klass) do
+          def self.after_transition_notification?
+            false
+          end
+        end
+
+        body_args = {
+          intake_id: intake.id
+        }.merge(options[:body_args].symbolize_keys)
+
+        say "Sending message #{klass}", :cyan
+        say "Using email #{options[:email_address]}", :cyan if options[:email_address].present?
+        say "Using sms number #{options[:sms_number]}", :cyan if options[:sms_number].present?
+        say "Using body arguments #{body_args}", :cyan if options[:body_args].present?
+        StateFile::MessagingService.new(
+          message:,
+          intake:,
+          email: !!options[:email_address],
+          sms: !!options[:sms_number],
+          body_args: body_args
+        ).send_message
+      end
+    end
+  end
+end
+
+SendMessage.start

--- a/spec/services/state_file/messaging_service_spec.rb
+++ b/spec/services/state_file/messaging_service_spec.rb
@@ -1,7 +1,17 @@
 require "rails_helper"
 
 describe StateFile::MessagingService do
-  let(:intake) { create :state_file_az_intake, primary_first_name: "Mona", email_address: "mona@example.com", email_address_verified_at: 1.minute.ago, message_tracker: {}, hashed_ssn: "boopbedoop" }
+  include MockTwilio
+
+  let(:intake) do
+    create(
+      :state_file_az_intake,
+      primary_first_name: "Mona", phone_number: "+15555555555",
+      phone_number_verified_at: 1.minute.ago, email_address: "mona@example.com",
+      email_address_verified_at: 1.minute.ago, message_tracker: {}, hashed_ssn: "boopbedoop"
+    )
+  end
+
   let(:efile_submission) { create :efile_submission, :for_state, data_source: intake }
   let(:message) { StateFile::AutomatedMessage::Welcome }
   let(:body_args) { {intake_id: intake.id} }
@@ -45,6 +55,22 @@ describe StateFile::MessagingService do
           messaging_service.send_message
         end.to change(StateFileNotificationEmail, :count).by(1)
       end
+    end
+  end
+
+  context "when has a phone number" do
+    it "should send a message if the number is verified" do
+      expect {
+        messaging_service.send_message
+      }.to change { FakeTwilioClient.messages.count }
+    end
+
+    it "should not send a message if the number is unverified" do
+      intake.update(phone_number_verified_at: nil)
+
+      expect {
+        messaging_service.send_message
+      }.not_to change { FakeTwilioClient.messages.count }
     end
   end
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-293
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Hooks up send sms in the messaging service. Any message that uses the service should automatically pick up for SMS
- It also adds a test harness for smoke testing notifications for both email and SMS. It inspects the automated message namespace to automatically register new messages. It creates a temporary intake and accepts build args which can be used to populate content. For example:

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/7ee27a6e-dc58-476d-b68f-d4b5f41d10e3">

## How to test?
- Specs provided
- I'm a little unsure where all the triggers are. If acceptance has trouble I'll need a little guidance in testing in the application
- Smoke testing of SMS can be done with the new harness.

## Screenshots (for visual changes)
- Before
- After
