### PR TITLE
use the 'keep it open forever' configs in dev like we do in other non-prod environments

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -136,4 +136,11 @@ Rails.application.configure do
 
   # StateFile
   config.state_file_start_of_open_intake = Time.find_zone('America/New_York').parse('2024-01-01 7:59:59')
+
+  # Keep GYR and FYST 'open' until the end of 2040 ^_^
+  # use the session toggles if you want to emulate/test 'closed' behaviors
+  the_future = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
+  config.end_of_intake = the_future
+  config.state_file_end_of_new_intakes = the_future
+  config.state_file_end_of_in_progress_intakes = the_future
 end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
n/a
## Is PM acceptance required? (delete one)
No - merge after code review approval

## What was done?
This adds the overrides to the dev environment so, by default, FYST and GYR are open for business. We've already done this in other non-prod environments, but hadn't brought it to dev. _until now_

## How to test?
Pull the branch, fire up local dev and rejoice that you don't have to use the session toggles to be able to start an intake.
