### PR TITLE
NJ 123 - health insurance indicators / 53c checkbox

### DIFF
--- a/app/lib/efile/line_data.yml
+++ b/app/lib/efile/line_data.yml
@@ -864,6 +864,8 @@ NJ1040_LINE_50:
   label: '50 Balance of Tax After Credits (Subtract line 49 from line 45) If zero or less, make no entry'
 NJ1040_LINE_51:
   label: '51 Use Tax Due on Internet, Mail-Order, or Other Out-of-State Purchases (See instructions) If no Use Tax, enter 0.00'
+NJ1040_LINE_53C_CHECKBOX:
+  label: '53C Enclose Schedule NJ-HCC and fill in'
 NJ1040_LINE_54:
   label: '54 Total Tax Due (Add lines 50 through 53c)'
 NJ1040_LINE_55:

--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -50,6 +50,7 @@ module Efile
         set_line(:NJ1040_LINE_49, :calculate_line_49)
         set_line(:NJ1040_LINE_50, :calculate_line_50)
         set_line(:NJ1040_LINE_51, :calculate_line_51)
+        set_line(:NJ1040_LINE_53C_CHECKBOX, :calculate_line_53c_checkbox)
         set_line(:NJ1040_LINE_54, :calculate_line_54)
         set_line(:NJ1040_LINE_55, :calculate_line_55)
         set_line(:NJ1040_LINE_56, :calculate_line_56)
@@ -352,6 +353,10 @@ module Efile
 
       def calculate_line_51
         (@intake.sales_use_tax || 0).round
+      end
+
+      def calculate_line_53c_checkbox
+        @intake.eligibility_all_members_health_insurance_yes?
       end
 
       def calculate_line_54

--- a/app/lib/pdf_filler/nj1040_pdf.rb
+++ b/app/lib/pdf_filler/nj1040_pdf.rb
@@ -83,6 +83,9 @@ module PdfFiller
         Group1qualwi5ab: spouse_death_year,
         Group182: household_rent_own,
 
+        # line 53c checkbox
+        'Check Box147': pdf_checkbox_value(@xml_document.at("HCCEnclosed")),
+
         # line 65 nj child tax credit
         '64': @xml_document.at("Body NJChildTCNumOfDep")&.text,
 

--- a/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
+++ b/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
@@ -175,6 +175,10 @@ module SubmissionBuilder
 
                   xml.SalesAndUseTax calculated_fields.fetch(:NJ1040_LINE_51)
 
+                  if calculated_fields.fetch(:NJ1040_LINE_53C_CHECKBOX)
+                    xml.HCCEnclosed "X"
+                  end
+
                   xml.TotalTaxAndPenalty calculated_fields.fetch(:NJ1040_LINE_54)
 
                   if calculated_fields.fetch(:NJ1040_LINE_55)

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -1583,6 +1583,79 @@ RSpec.describe PdfFiller::Nj1040Pdf do
       end
     end
 
+    describe "line 53c checkbox" do
+      context "when taxpayer indicated all members of household have health insurance" do
+        let(:submission) {
+          create :efile_submission, tax_return: nil, data_source: create(
+            :state_file_nj_intake,
+            eligibility_all_members_health_insurance: "yes",
+            )
+        }
+
+        it "checks 53c Schedule NJ-HCC checkbox and leaves 53a, 53b, and 53c amount blank" do
+          # 53c checkbox
+          expect(pdf_fields["Check Box147"]).to eq "Yes"
+
+          # 53a
+          expect(pdf_fields["Check Box146aabb"]).to eq "Off"
+
+          # 53b
+          expect(pdf_fields["Check Box146aabbffdd"]).to eq "Off"
+
+          # 53c amount
+          # thousands
+          expect(pdf_fields["52"]).to eq ""
+          expect(pdf_fields["undefined_139"]).to eq ""
+          expect(pdf_fields["undefined_140"]).to eq ""
+          # hundreds
+          expect(pdf_fields["Text141"]).to eq ""
+          expect(pdf_fields["Text142"]).to eq ""
+          expect(pdf_fields["Text143"]).to eq ""
+          # decimals
+          expect(pdf_fields["Text144"]).to eq ""
+          expect(pdf_fields["Text145"]).to eq ""
+        end
+      end
+
+      context "when taxpayer indicated all members of household do NOT have health insurance but qualifies for exemption" do
+        let(:submission) {
+          create :efile_submission, tax_return: nil, data_source: create(
+            :state_file_nj_intake,
+            eligibility_all_members_health_insurance: "no",
+            )
+        }
+
+        before do
+          single_income_threshold = 10_000
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_54).and_return single_income_threshold
+        end
+
+        it "does not check 53c Schedule NJ-HCC checkbox and leaves 53a, 53b, and 53c amount blank" do
+          # 53c checkbox
+          expect(pdf_fields["Check Box147"]).to eq "Off"
+
+          # 53a
+          expect(pdf_fields["Check Box146aabb"]).to eq "Off"
+
+          # 53b
+          expect(pdf_fields["Check Box146aabbffdd"]).to eq "Off"
+
+          # 53c amount
+          # thousands
+          expect(pdf_fields["52"]).to eq ""
+          expect(pdf_fields["undefined_139"]).to eq ""
+          expect(pdf_fields["undefined_140"]).to eq ""
+          # hundreds
+          expect(pdf_fields["Text141"]).to eq ""
+          expect(pdf_fields["Text142"]).to eq ""
+          expect(pdf_fields["Text143"]).to eq ""
+          # decimals
+          expect(pdf_fields["Text144"]).to eq ""
+          expect(pdf_fields["Text145"]).to eq ""
+        end
+      end
+    end
+
     describe "line 54 - total tax and penalty" do
       let(:submission) {
         create :efile_submission, tax_return: nil, data_source: create(

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -1585,12 +1585,9 @@ RSpec.describe PdfFiller::Nj1040Pdf do
 
     describe "line 53c checkbox" do
       context "when taxpayer indicated all members of household have health insurance" do
-        let(:submission) {
-          create :efile_submission, tax_return: nil, data_source: create(
-            :state_file_nj_intake,
-            eligibility_all_members_health_insurance: "yes",
-            )
-        }
+        before do
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_53c_checkbox).and_return true
+        end
 
         it "checks 53c Schedule NJ-HCC checkbox and leaves 53a, 53b, and 53c amount blank" do
           # 53c checkbox
@@ -1618,16 +1615,10 @@ RSpec.describe PdfFiller::Nj1040Pdf do
       end
 
       context "when taxpayer indicated all members of household do NOT have health insurance but qualifies for exemption" do
-        let(:submission) {
-          create :efile_submission, tax_return: nil, data_source: create(
-            :state_file_nj_intake,
-            eligibility_all_members_health_insurance: "no",
-            )
-        }
-
         before do
           single_income_threshold = 10_000
           allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_54).and_return single_income_threshold
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_53c_checkbox).and_return false
         end
 
         it "does not check 53c Schedule NJ-HCC checkbox and leaves 53a, 53b, and 53c amount blank" do

--- a/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
@@ -704,6 +704,50 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
       end
     end
 
+    describe "lines 53a, 53b, 53c: health insurance indicators" do
+      context "when taxpayer indicated all members of household have health insurance" do
+        let(:intake) { create(:state_file_nj_intake, eligibility_all_members_health_insurance: "yes" ) }
+
+        it "checks 53c Schedule NJ-HCC checkbox and leaves 53a, 53b, and 53c amount blank" do
+          expect(xml.at("NoHealthInsurance")).to eq(nil) # 53a
+          expect(xml.at("NJAssistObtainingHC")).to eq(nil) # 53b
+          expect(xml.at("SharedResPay")).to eq(nil) # 53c amount
+          expect(xml.at("HCCEnclosed").text).to eq("X") # 53c checkbox
+        end
+      end
+
+      context "when taxpayer indicated all members of household do NOT have health insurance" do
+        context "when qualifies for income exemption" do
+          let(:intake) { create(:state_file_nj_intake,
+                                eligibility_all_members_health_insurance: "no",
+          ) }
+
+          it "does not check 53c Schedule NJ-HCC checkbox and leaves 53a, 53b, and 53c amount blank" do
+            single_income_threshold = 10_000
+            allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_54).and_return single_income_threshold
+            expect(xml.at("NoHealthInsurance")).to eq(nil) # 53a
+            expect(xml.at("NJAssistObtainingHC")).to eq(nil) # 53b
+            expect(xml.at("SharedResPay")).to eq(nil) # 53c amount
+            expect(xml.at("HCCEnclosed")).to eq(nil) # 53c checkbox
+          end
+        end
+
+        context "when qualifies for claimed as dependent exemption" do
+          let(:intake) { create(:state_file_nj_intake,
+                                :df_data_mfj_primary_claimed_dep,
+                                eligibility_all_members_health_insurance: "no"
+          ) }
+
+          it "does not check 53c Schedule NJ-HCC checkbox and leaves 53a, 53b, and 53c amount blank" do
+            expect(xml.at("NoHealthInsurance")).to eq(nil) # 53a
+            expect(xml.at("NJAssistObtainingHC")).to eq(nil) # 53b
+            expect(xml.at("SharedResPay")).to eq(nil) # 53c amount
+            expect(xml.at("HCCEnclosed")).to eq(nil) # 53c checkbox
+          end
+        end
+      end
+    end
+
     describe 'line 54 - total tax due' do
       let(:intake) { create(:state_file_nj_intake) }
       it 'sets line 54 to calculated value' do


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/123

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Check line 53c checkbox if user answered "yes" to health insurance question
- Do not check line 53c checkbox if user answered "no" to health insurance question (but is still eligible due to exemption)
- Ensure lines 53a, 53b, and 53c amount are always blank

## How to test?
- Select "yes" to health insurance question to see checkbox
- Use an exemption persona (ie `married filing jointly both claimed dep` for claimed-as-dependent exemption, or any persona and edit W2 to be less than 10K for income exemption) and select "no" to health insurance to see checkbox unchecked

## Screenshots (for visual changes)
![image](https://github.com/user-attachments/assets/af4a8977-ab2e-4ab7-b7b1-5623748ae706)
![image](https://github.com/user-attachments/assets/229e71bd-96f4-4711-8435-8e2780b7565e)

