### PR TITLE
FYST-1264 Add federal submission ids for new personas to @submission_id_lookup

### DIFF
--- a/app/services/state_file/direct_file_api_response_sample_service.rb
+++ b/app/services/state_file/direct_file_api_response_sample_service.rb
@@ -12,7 +12,23 @@ module StateFile
         'az_leslie_qss_v2' => '1016422024026atw001h',
         'az_donald_v2' => '1016422024027atw0020',
         'az_robin_v2' => '1016422024028ate001q',
-        'az_superman_v2' => '1016422024025ate000b'
+        'az_superman_v2' => '1016422024025ate000b',
+        'nc_nala_hoh' => '1016422024326jt6oz0h',
+        'nc_mickey_mfj' => '1016422024327qqldslz',
+        'nc_wylie_mfs' => '10164220243274vip4ag',
+        'nc_zeus_mfjdeps' => '1016422024327ahu7xl7',
+        'nc_daffy_single' => '1016422024327xmcxxwy',
+        'md_annabelle_single' => '1016422024326lssbe1f',
+        'nc_clara_hoh' => '10164220243303quinwv',
+        'az_johnny_mfj' => '101642202433073zlynk',
+        'az_alexis_hoh' => '10164220243273drvnwu',
+        'az_shell_hoh' => '1016422024330uizbsmb',
+        'az_Tycho_Single_No_1099R' => '1016422024332rjtkoti',
+        'az_Tycho_Single_With_1099R' => '1016422024332hyykc8y',
+        'az_Martha_MFJ_Owe' => '1016422024332t6d92qn',
+        'az_Rory_claimed_as_dep' => '1016422024334wutmbb9',
+        'id_Smith_Claimed_as_Dep' => '1016422024332a3erp1m',
+        'id_Grey_no_1099r' => '1016422024337kkb3get'
       }
       @old_xml_sample = "app/controllers/state_file/questions/df_return_sample.xml"
       @old_json_sample = "app/controllers/state_file/questions/df_return_sample.json"


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1264
## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- In order for state returns to be processed in MeF, a federal return must exist for the filer
- The return is looked up using the federal submission id, which we include in our submission
- In the testing environment, we can submit an unlimited number of state returns connected to the same federal return, so each persona needs a `federal_submission_id` that MeF will recognize
## How to test?
- Only testable in demo
## Screenshots
The mef error in the hub:
![image](https://github.com/user-attachments/assets/eb201665-8702-4f58-b286-4162581fb49d)

