### PR TITLE
FYST-1273 remove default selection from the correction path dropdown on the hub efile error edit page, since the default is now contextual based on the state of the currently-signed-in intake

### DIFF
--- a/app/controllers/hub/state_file/efile_errors_controller.rb
+++ b/app/controllers/hub/state_file/efile_errors_controller.rb
@@ -18,11 +18,6 @@ module Hub::StateFile
 
     def edit
       @correction_path_options_for_select = EfileError.paths
-      unless @efile_error.correction_path.present?
-        @efile_error.correction_path = EfileError.controller_to_path(
-          EfileError.default_controller(current_state_code)
-        )
-      end
     end
 
     def show; end

--- a/app/views/hub/state_file/efile_errors/edit.html.erb
+++ b/app/views/hub/state_file/efile_errors/edit.html.erb
@@ -26,7 +26,7 @@
       <div>
         <%= f.label "Correction Path", class: "h4"  %>
         <p class="help-text">directs clients to path when resubmitting</p>
-        <%= f.select :correction_path, @correction_path_options_for_select, selected: @efile_error.correction_path %>
+        <%= f.select :correction_path, @correction_path_options_for_select, include_blank: true, selected: @efile_error.correction_path %>
       </div>
 
       <div class="spacing-above-25">


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1273
- https://codeforamerica.sentry.io/issues/6108532532?project=1880321
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Since the default "correction path" for EfileError is now dependent on the currently-signed-in intake (it's always the final review page, but that's a different controller/path for each state), we can no longer select a single default path from the correction path dropdown on the efile error edit page. With this change, we now include a blank option in that dropdown that is selected by default, and if left selected the default logic (go to the currently-signed-in intake's state's final review page) will persist.
## How to test?
- This can be manually tested by going to the hub > state file admin > efile errors, choosing an efile error that doesn't have a correction path, then hitting edit & confirming that the page doesn't crash. If you want to go the extra mile, you could test that the default behavior (when no option is selected from the correction path dropdown) is to go to the state's final review page, and that selecting a controller from the correction path dropdown changes the redirect behavior to go to that path.
