### PR TITLE
Fix 1099-INT XML output crash

### DIFF
--- a/app/lib/submission_builder/state1099_int.rb
+++ b/app/lib/submission_builder/state1099_int.rb
@@ -13,7 +13,7 @@ module SubmissionBuilder
             xml.BusinessNameLine1Txt sanitize_for_xml(form1099int.payer.tr('-', ' '), 75)
           end
         end
-        xml.PayerEIN form1099int.payer_tin.tr('-', '')
+        xml.PayerEIN form1099int.payer_tin&.tr('-', '')
         xml.RecipientSSN form1099int.recipient_tin.tr('-', '')
         recipient = if form1099int.recipient_tin.tr('-', '') == intake.primary.ssn
                       intake.primary

--- a/spec/factories/state_file_id_intakes.rb
+++ b/spec/factories/state_file_id_intakes.rb
@@ -184,10 +184,8 @@ FactoryBot.define do
     end
 
     trait :df_data_1099_int do
-      primary_first_name { "Tim" }
-      primary_last_name { "Interest" }
-      raw_direct_file_data { StateFile::DirectFileApiResponseSampleService.new.read_xml('id_tim_1099_int') }
-      raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('id_tim_1099_int') }
+      raw_direct_file_data { StateFile::DirectFileApiResponseSampleService.new.read_xml('id_Estrada_donations') }
+      raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('id_Estrada_donations') }
     end
 
     trait :primary_blind do

--- a/spec/lib/efile/id/id39_r_calculator_spec.rb
+++ b/spec/lib/efile/id/id39_r_calculator_spec.rb
@@ -17,7 +17,7 @@ describe Efile::Id::Id39RCalculator do
       }
       it "sums the interest from government bonds across all reports" do
         instance.calculate
-        expect(instance.lines[:ID39R_B_LINE_3].value).to eq(2)
+        expect(instance.lines[:ID39R_B_LINE_3].value).to eq(50)
       end
     end
 

--- a/spec/lib/pdf_filler/id39r_pdf_spec.rb
+++ b/spec/lib/pdf_filler/id39r_pdf_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe PdfFiller::Id39rPdf do
     context "fills out Interest Income from Obligations of the US" do
       let(:intake) { create(:state_file_id_intake, :df_data_1099_int) }
       it "correctly fills answers" do
-        expect(pdf_fields["BL3"]).to eq "2"
+        expect(pdf_fields["BL3"]).to eq "50"
       end
     end
 

--- a/spec/lib/submission_builder/state1099_int_spec.rb
+++ b/spec/lib/submission_builder/state1099_int_spec.rb
@@ -7,19 +7,20 @@ describe SubmissionBuilder::State1099Int do
   let(:index) { 0 }
   let(:doc) { described_class.new(submission, kwargs: { form1099int: form1099int, index: index, intake: intake }).document }
 
-  describe "Maryland" do
-    let(:intake) { create(:state_file_md_intake, :df_data_1099_int) }
+  describe "Idaho" do
+    let(:intake) { create(:state_file_id_intake, :df_data_1099_int) }
 
     it "generates xml with the right values" do
-      expect(doc.at("PayerName")['payerNameControl']).to eq "THEP"
-      expect(doc.at("PayerName/BusinessNameLine1Txt").text).to eq "The payer name"
-      expect(doc.at("RecipientSSN").text).to eq "123456789"
-      expect(doc.at("RecipientName").text).to eq "Mary A Lando"
-      expect(doc.at("InterestIncome").text).to eq "1.0"
-      expect(doc.at("InterestOnBondsAndTreasury").text).to eq "2.0"
-      expect(doc.at("FederalTaxWithheld").text).to eq "5.0"
-      expect(doc.at("TaxExemptInterest").text).to eq "4.0"
-      expect(doc.at("TaxExemptCUSIP").text).to eq "123456789"
+      expect(doc.at("PayerName")['payerNameControl']).to eq "BANK"
+      expect(doc.at("PayerName/BusinessNameLine1Txt").text).to eq "Bank of Potatoes"
+      expect(doc.at("PayerEIN").text).to eq ""
+      expect(doc.at("RecipientSSN").text).to eq "400005957"
+      expect(doc.at("RecipientName").text).to eq "Miguel Estrada"
+      expect(doc.at("InterestIncome").text).to eq "550.0"
+      expect(doc.at("InterestOnBondsAndTreasury").text).to eq "50.0"
+      expect(doc.at("FederalTaxWithheld").text).to eq "0.0"
+      expect(doc.at("TaxExemptInterest").text).to eq "0"
+      expect(doc.at("TaxExemptCUSIP").text).to eq ""
     end
   end
 

--- a/spec/lib/submission_builder/ty2024/states/id/documents/id39_r_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/id/documents/id39_r_spec.rb
@@ -11,10 +11,10 @@ describe SubmissionBuilder::Ty2024::States::Id::Documents::Id39R, required_schem
       let(:intake) { create(:state_file_id_intake, :df_data_1099_int) }
       it "correctly fills answers" do
         expect(xml.at("TotalAdditions")&.text).to eq "0"
-        expect(xml.at("IncomeUSObligations")&.text).to eq "2"
+        expect(xml.at("IncomeUSObligations")&.text).to eq "50"
         expect(xml.at("RetirementBenefitsDeduction")&.text).to eq "0"
         expect(xml.at("HealthInsurancePaid")&.text).to eq "0"
-        expect(xml.at("TotalSubtractions")&.text).to eq "2"
+        expect(xml.at("TotalSubtractions")&.text).to eq "50"
         expect(xml.at("TotalSupplementalCredits")&.text).to eq "0"
       end
     end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1281
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Make our 1099-int xml output not crash when Payer TIN is missing. 
- Update ID 1099 int intake factory to use new (real) DF return, which does not include Payer TIN
- Fix tests that break due to new factory
## How to test?
- Go through the app with a DF return that includes real, current 1099-INT in the JSON (such as Idaho > Estrada) and confirm that you don't get a crash when viewing our output XML
