### PR TITLE
round D400 Schedule S line 18

### DIFF
--- a/app/lib/efile/nc/d400_schedule_s_calculator.rb
+++ b/app/lib/efile/nc/d400_schedule_s_calculator.rb
@@ -20,7 +20,7 @@ module Efile
       private
 
       def calculate_line_18
-        @intake.direct_file_json_data.interest_reports.sum(&:interest_on_government_bonds)
+        @intake.direct_file_json_data.interest_reports.sum(&:interest_on_government_bonds).round
       end
 
       def calculate_line_27

--- a/spec/lib/submission_builder/ty2024/states/nc/documents/d400_schedule_s_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nc/documents/d400_schedule_s_spec.rb
@@ -8,9 +8,10 @@ describe SubmissionBuilder::Ty2024::States::Nc::Documents::D400ScheduleS, requir
     let(:xml) { Nokogiri::XML::Document.parse(build_response.document.to_xml) }
 
     context "calculating DedFedAGI" do
+
       before do
         interest_report = instance_double(DirectFileJsonData::DfJsonInterestReport)
-        allow(interest_report).to receive(:interest_on_government_bonds).and_return 323
+        allow(interest_report).to receive(:interest_on_government_bonds).and_return 323.00
         allow(intake.direct_file_json_data).to receive(:interest_reports).and_return [interest_report]
 
         intake.direct_file_data.fed_taxable_ssb = 123


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1327
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- The recent change to D400 Sched S line 18 introduced a bug where we were outputting decimal places into the PDF and XML, because we weren't rounding off the decimal places present in the input JSON. This change rounds the value returned by `calculate_line_18`, and tests that the rounding has the desired effect
## How to test?
- Go through the flow with NC Clara hoh and verify that the XML doesn't produce a validation error, and that the PDF D400 Schedule S Line 18 doesn't have a decimal place.
## Screenshots (for visual changes)
- Before (see story)
- After
<img width="746" alt="image" src="https://github.com/user-attachments/assets/26bbcc66-7898-4acd-8703-cbf9b2d00933">
<img width="486" alt="image" src="https://github.com/user-attachments/assets/5b67930e-f92a-461b-ad8a-7b18ecbc05e3">
