### PR TITLE
change dependent dob formatting in md502b pdf

### DIFF
--- a/app/lib/pdf_filler/md_502b_pdf.rb
+++ b/app/lib/pdf_filler/md_502b_pdf.rb
@@ -39,7 +39,7 @@ module PdfFiller
         answers["REGULAR #{i + 1}"] = "Yes"
         answers["65 OR OLDER #{i + 1}"] = dependent.senior? ? "2" : "Off"
         dob_field_name = i.zero? ? "DOB date 1_af_date" : "DOB date 1_af_date #{i + 1}"
-        answers[dob_field_name] = dependent.dob
+        answers[dob_field_name] = dependent.dob.strftime("%m/%d/%Y")
         answers[HEALTH_INSURANCE_CHECKBOX_LABELS[i]] = dependent.md_did_not_have_health_insurance_yes? ? "Yes" : "Off"
       end
       answers

--- a/spec/lib/pdf_filler/md_502b_pdf_spec.rb
+++ b/spec/lib/pdf_filler/md_502b_pdf_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe PdfFiller::Md502bPdf do
         expect(pdf_fields["RELATIONSHIP 1"]).to eq "Daughter"
         expect(pdf_fields["REGULAR 1"]).to eq "Yes"
         expect(pdf_fields["65 OR OLDER 1"]).to eq "Off"
-        expect(pdf_fields["DOB date 1_af_date"]).to eq young_dob.strftime("%Y-%m-%d")
+        expect(pdf_fields["DOB date 1_af_date"]).to eq young_dob.strftime("%m/%d/%Y")
         expect(pdf_fields["Check Box 1"]).to eq "Yes"
 
         expect(pdf_fields["First Name 2"]).to eq "Jeanie"
@@ -92,7 +92,7 @@ RSpec.describe PdfFiller::Md502bPdf do
         expect(pdf_fields["RELATIONSHIP 2"]).to eq "Grandparent"
         expect(pdf_fields["REGULAR 2"]).to eq "Yes"
         expect(pdf_fields["65 OR OLDER 2"]).to eq "2"
-        expect(pdf_fields["DOB date 1_af_date 2"]).to eq old_dob.strftime("%Y-%m-%d")
+        expect(pdf_fields["DOB date 1_af_date 2"]).to eq old_dob.strftime("%m/%d/%Y")
         expect(pdf_fields["Check Box 2"]).to eq "Off"
       end
     end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1299
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Changed date formatting for dependent dob on MD 502B PDF to match instructions
## How to test?
- Go through the MD flow with a federal return that includes at least one dependent, and verify that the dependent dob is displayed in MM/DD/YYYY format on the 502B pdf
## Screenshots (for visual changes)
- Before
See story
- After
<img width="737" alt="image" src="https://github.com/user-attachments/assets/66448fc7-a953-461f-9213-1dc154ca86b5">

