### PR TITLE
Fyst 1291 add sms terms page

### DIFF
--- a/app/assets/stylesheets/_state-file.scss
+++ b/app/assets/stylesheets/_state-file.scss
@@ -3,61 +3,60 @@
   font-family: "Public Sans";
   font-style: normal;
   font-weight: 400;
-  src: url(https://fonts.gstatic.com/s/publicsans/v15/ijwRs572Xtc6ZYQws9YVwnNJfJ7QwOk1Fig.woff2)
-    format("woff2");
+  src: url(https://fonts.gstatic.com/s/publicsans/v15/ijwRs572Xtc6ZYQws9YVwnNJfJ7QwOk1Fig.woff2) format("woff2");
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1,
     U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329,
     U+1EA0-1EF9, U+20AB;
 }
+
 // latin-ext
 @font-face {
   font-family: "Public Sans";
   font-style: normal;
   font-weight: 400;
-  src: url(https://fonts.gstatic.com/s/publicsans/v15/ijwRs572Xtc6ZYQws9YVwnNIfJ7QwOk1Fig.woff2)
-    format("woff2");
+  src: url(https://fonts.gstatic.com/s/publicsans/v15/ijwRs572Xtc6ZYQws9YVwnNIfJ7QwOk1Fig.woff2) format("woff2");
   unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF,
     U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
+
 // latin
 @font-face {
   font-family: "Public Sans";
   font-style: normal;
   font-weight: 400;
-  src: url(https://fonts.gstatic.com/s/publicsans/v15/ijwRs572Xtc6ZYQws9YVwnNGfJ7QwOk1.woff2)
-    format("woff2");
+  src: url(https://fonts.gstatic.com/s/publicsans/v15/ijwRs572Xtc6ZYQws9YVwnNGfJ7QwOk1.woff2) format("woff2");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
     U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191,
     U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
+
 // vietnamese
 @font-face {
   font-family: "Public Sans";
   font-style: normal;
   font-weight: 700;
-  src: url(https://fonts.gstatic.com/s/publicsans/v15/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymu8Z6JywcofVotfzbj9m4.woff2)
-    format("woff2");
+  src: url(https://fonts.gstatic.com/s/publicsans/v15/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymu8Z6JywcofVotfzbj9m4.woff2) format("woff2");
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1,
     U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329,
     U+1EA0-1EF9, U+20AB;
 }
+
 // latin-ext
 @font-face {
   font-family: "Public Sans";
   font-style: normal;
   font-weight: 700;
-  src: url(https://fonts.gstatic.com/s/publicsans/v15/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymu8Z6JygcofVotfzbj9m4.woff2)
-    format("woff2");
+  src: url(https://fonts.gstatic.com/s/publicsans/v15/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymu8Z6JygcofVotfzbj9m4.woff2) format("woff2");
   unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF,
     U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
+
 // latin
 @font-face {
   font-family: "Public Sans";
   font-style: normal;
   font-weight: 700;
-  src: url(https://fonts.gstatic.com/s/publicsans/v15/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymu8Z6JxAcofVotfzbj.woff2)
-    format("woff2");
+  src: url(https://fonts.gstatic.com/s/publicsans/v15/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymu8Z6JxAcofVotfzbj.woff2) format("woff2");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
     U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191,
     U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
@@ -118,6 +117,7 @@
 
     .client-menu-item {
       border-bottom: none;
+
       a {
         color: white;
         text-decoration: underline;
@@ -331,6 +331,7 @@
         margin-bottom: 2rem;
         border: 1px solid $color-state-file-input-border;
         box-shadow: none;
+
         &:focus-within {
           box-shadow: $focus-box-shadow;
         }
@@ -340,9 +341,11 @@
         box-shadow: none;
         background-color: white;
       }
+
       .money-input {
         margin-bottom: 0;
         border: none;
+
         &:focus {
           box-shadow: none;
         }
@@ -500,6 +503,12 @@
     }
   }
 
+  #joint-account-holder-questions {
+    .form-group {
+      margin-bottom: 2rem;
+    }
+  }
+
   .partner-logo-wrapper {
     display: flex;
     align-items: center;
@@ -546,6 +555,7 @@
     p {
       text-align: center;
     }
+
     img {
       height: 80px;
       width: 80px;
@@ -744,9 +754,11 @@
       main {
         display: flex;
         justify-content: space-between;
+
         .landing-page-content {
           max-width: 570px;
         }
+
         .fyst-home-image {
           width: 273px;
           height: 250px;
@@ -777,6 +789,7 @@
       text-align: center;
     }
   }
+
   @media screen and (max-width: $tablet-up) {
     .landing-page-container .fyst-home-image {
       display: none;
@@ -855,13 +868,16 @@ $state-colors: (
 
   .state-file-html-bg--#{$state_key} {
     background-color: $state-color;
+
     .state-file {
       .main-header {
         background-color: $state-color;
       }
+
       .client-menu-closer {
         background-color: $state-color;
       }
+
       .client-menu {
         background-color: $state-color;
       }
@@ -870,13 +886,16 @@ $state-colors: (
 
   .state-file-html-bg--nj {
     background-color: $color-nj-blue-darker;
+
     .state-file {
       .main-header {
         background-color: $color-nj-blue-darker;
       }
+
       .client-menu-closer {
         background-color: $color-nj-blue-darker;
       }
+
       .client-menu {
         background-color: $color-nj-blue-darker;
       }
@@ -924,9 +943,10 @@ $state-colors: (
   .pagination-wrapper {
     align-items: center;
   }
+
   .search-container {
     padding-bottom: 2rem;
-    .hub-searchbar__input {
-    }
+
+    .hub-searchbar__input {}
   }
 }

--- a/app/controllers/flows_controller.rb
+++ b/app/controllers/flows_controller.rb
@@ -581,7 +581,8 @@ class FlowsController < ApplicationController
         last_sign_in_ip: nil,
         sign_in_count: 0,
         df_data_import_succeeded_at: 30.seconds.ago,
-        hashed_ssn: SsnHashingService.hash("555002222") # hash PrimarySSN from raw_direct_file_data
+        hashed_ssn: SsnHashingService.hash("555002222"), # hash PrimarySSN from raw_direct_file_data
+        consented_to_sms_terms: "yes",
       }
     end
 

--- a/app/controllers/state_file/questions/declined_terms_and_conditions_controller.rb
+++ b/app/controllers/state_file/questions/declined_terms_and_conditions_controller.rb
@@ -3,7 +3,17 @@ module StateFile
     class DeclinedTermsAndConditionsController < QuestionsController
 
       def self.show?(intake)
-        intake.consented_to_terms_and_conditions_no?
+        intake.consented_to_terms_and_conditions_no? || intake.consented_to_sms_terms_no?
+      end
+
+      private
+
+      def prev_path
+        if current_intake.consented_to_sms_terms_yes?
+          super
+        else
+          StateFile::Questions::SmsTermsController.to_path_helper
+        end
       end
     end
   end

--- a/app/controllers/state_file/questions/sms_terms_controller.rb
+++ b/app/controllers/state_file/questions/sms_terms_controller.rb
@@ -1,0 +1,6 @@
+module StateFile
+  module Questions
+    class SmsTermsController < QuestionsController
+    end
+  end
+end

--- a/app/controllers/state_file/questions/terms_and_conditions_controller.rb
+++ b/app/controllers/state_file/questions/terms_and_conditions_controller.rb
@@ -2,6 +2,10 @@ module StateFile
   module Questions
     class TermsAndConditionsController < QuestionsController
 
+      def self.show?(intake)
+        intake.consented_to_sms_terms_yes?
+      end
+
       def edit
         @li_items = I18n.t('state_file.questions.terms_and_conditions.edit.list_items_html', privacy_policy_link: state_file_privacy_policy_path).split('</li>')
         unless Flipper.enabled?(:sms_notifications)

--- a/app/forms/state_file/sms_terms_form.rb
+++ b/app/forms/state_file/sms_terms_form.rb
@@ -1,0 +1,10 @@
+module StateFile
+  class SmsTermsForm < QuestionsForm
+    set_attributes_for :intake, :consented_to_sms_terms
+    validates :consented_to_sms_terms, inclusion: { in: ['yes', 'no'] }
+
+    def save
+      @intake.update(attributes_for(:intake))
+    end
+  end
+end

--- a/app/lib/navigation/state_file_az_question_navigation.rb
+++ b/app/lib/navigation/state_file_az_question_navigation.rb
@@ -13,6 +13,7 @@ module Navigation
         Navigation::NavigationStep.new(StateFile::Questions::VerificationCodeController),
         Navigation::NavigationStep.new(StateFile::Questions::CodeVerifiedController),
         Navigation::NavigationStep.new(StateFile::Questions::NotificationPreferencesController),
+        Navigation::NavigationStep.new(StateFile::Questions::SmsTermsController),
       ]),
       Navigation::NavigationSection.new("state_file.navigation.section_3", [
         Navigation::NavigationStep.new(StateFile::Questions::TermsAndConditionsController),

--- a/app/lib/navigation/state_file_id_question_navigation.rb
+++ b/app/lib/navigation/state_file_id_question_navigation.rb
@@ -15,6 +15,7 @@ module Navigation
         Navigation::NavigationStep.new(StateFile::Questions::VerificationCodeController),
         Navigation::NavigationStep.new(StateFile::Questions::CodeVerifiedController),
         Navigation::NavigationStep.new(StateFile::Questions::NotificationPreferencesController),
+        Navigation::NavigationStep.new(StateFile::Questions::SmsTermsController),
       ]),
       Navigation::NavigationSection.new("state_file.navigation.section_3", [
         Navigation::NavigationStep.new(StateFile::Questions::TermsAndConditionsController),

--- a/app/lib/navigation/state_file_md_question_navigation.rb
+++ b/app/lib/navigation/state_file_md_question_navigation.rb
@@ -15,6 +15,7 @@ module Navigation
         Navigation::NavigationStep.new(StateFile::Questions::VerificationCodeController),
         Navigation::NavigationStep.new(StateFile::Questions::CodeVerifiedController),
         Navigation::NavigationStep.new(StateFile::Questions::NotificationPreferencesController),
+        Navigation::NavigationStep.new(StateFile::Questions::SmsTermsController),
       ]),
       Navigation::NavigationSection.new("state_file.navigation.section_3", [
         Navigation::NavigationStep.new(StateFile::Questions::TermsAndConditionsController),

--- a/app/lib/navigation/state_file_nc_question_navigation.rb
+++ b/app/lib/navigation/state_file_nc_question_navigation.rb
@@ -15,6 +15,7 @@ module Navigation
         Navigation::NavigationStep.new(StateFile::Questions::VerificationCodeController),
         Navigation::NavigationStep.new(StateFile::Questions::CodeVerifiedController),
         Navigation::NavigationStep.new(StateFile::Questions::NotificationPreferencesController),
+        Navigation::NavigationStep.new(StateFile::Questions::SmsTermsController),
       ]),
       Navigation::NavigationSection.new("state_file.navigation.section_3", [
         Navigation::NavigationStep.new(StateFile::Questions::TermsAndConditionsController),

--- a/app/lib/navigation/state_file_nj_question_navigation.rb
+++ b/app/lib/navigation/state_file_nj_question_navigation.rb
@@ -14,6 +14,7 @@ module Navigation
                                           Navigation::NavigationStep.new(StateFile::Questions::VerificationCodeController),
                                           Navigation::NavigationStep.new(StateFile::Questions::CodeVerifiedController),
                                           Navigation::NavigationStep.new(StateFile::Questions::NotificationPreferencesController),
+                                          Navigation::NavigationStep.new(StateFile::Questions::SmsTermsController),
                                         ]),
       Navigation::NavigationSection.new("state_file.navigation.section_3", [
                                           Navigation::NavigationStep.new(StateFile::Questions::TermsAndConditionsController),

--- a/app/lib/navigation/state_file_ny_question_navigation.rb
+++ b/app/lib/navigation/state_file_ny_question_navigation.rb
@@ -17,6 +17,7 @@ module Navigation
         Navigation::NavigationStep.new(StateFile::Questions::VerificationCodeController),
         Navigation::NavigationStep.new(StateFile::Questions::CodeVerifiedController),
         Navigation::NavigationStep.new(StateFile::Questions::NotificationPreferencesController),
+        Navigation::NavigationStep.new(StateFile::Questions::SmsTermsController),
       ]),
       Navigation::NavigationSection.new("state_file.navigation.section_3", [
         Navigation::NavigationStep.new(StateFile::Questions::TermsAndConditionsController),

--- a/app/models/state_file_az_intake.rb
+++ b/app/models/state_file_az_intake.rb
@@ -10,6 +10,7 @@
 #  charitable_cash_amount                 :decimal(12, 2)
 #  charitable_contributions               :integer          default("unfilled"), not null
 #  charitable_noncash_amount              :decimal(12, 2)
+#  consented_to_sms_terms                 :integer          default("unfilled"), not null
 #  consented_to_terms_and_conditions      :integer          default("unfilled"), not null
 #  contact_preference                     :integer          default("unfilled"), not null
 #  current_sign_in_at                     :datetime
@@ -108,6 +109,7 @@ class StateFileAzIntake < StateFileBaseIntake
   enum eligibility_out_of_state_income: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_out_of_state_income
   enum email_notification_opt_in: { unfilled: 0, yes: 1, no: 2 }, _prefix: :email_notification_opt_in
   enum sms_notification_opt_in: { unfilled: 0, yes: 1, no: 2 }, _prefix: :sms_notification_opt_in
+  enum consented_to_sms_terms: { unfilled: 0, yes: 1, no: 2 }, _prefix: :consented_to_sms_terms
 
   validates :made_az321_contributions, inclusion: { in: ["yes", "no"]}, on: :az321_form_create
   validates :az321_contributions, length: { maximum: 10 }

--- a/app/models/state_file_base_intake.rb
+++ b/app/models/state_file_base_intake.rb
@@ -32,6 +32,7 @@ class StateFileBaseIntake < ApplicationRecord
   enum account_type: { unfilled: 0, checking: 1, savings: 2 }, _prefix: :account_type
   enum payment_or_deposit_type: { unfilled: 0, direct_deposit: 1, mail: 2 }, _prefix: :payment_or_deposit_type
   enum consented_to_terms_and_conditions: { unfilled: 0, yes: 1, no: 2 }, _prefix: :consented_to_terms_and_conditions
+  enum consented_to_sms_terms: { unfilled: 0, yes: 1, no: 2 }, _prefix: :consented_to_sms_terms
   scope :with_df_data_and_no_federal_submission, lambda {
     where.not(raw_direct_file_data: nil)
          .where(federal_submission_id: nil)

--- a/app/models/state_file_id_intake.rb
+++ b/app/models/state_file_id_intake.rb
@@ -7,6 +7,7 @@
 #  account_type                                   :integer          default("unfilled"), not null
 #  american_red_cross_fund_donation               :decimal(12, 2)
 #  childrens_trust_fund_donation                  :decimal(12, 2)
+#  consented_to_sms_terms                         :integer          default("unfilled"), not null
 #  consented_to_terms_and_conditions              :integer          default("unfilled"), not null
 #  contact_preference                             :integer          default("unfilled"), not null
 #  current_sign_in_at                             :datetime
@@ -97,6 +98,7 @@ class StateFileIdIntake < StateFileBaseIntake
   enum received_id_public_assistance: { unfilled: 0, yes: 1, no: 2 }, _prefix: :received_id_public_assistance
   enum email_notification_opt_in: { unfilled: 0, yes: 1, no: 2 }, _prefix: :email_notification_opt_in
   enum sms_notification_opt_in: { unfilled: 0, yes: 1, no: 2 }, _prefix: :sms_notification_opt_in
+  enum consented_to_sms_terms: { unfilled: 0, yes: 1, no: 2 }, _prefix: :consented_to_sms_terms
 
   def disqualifying_df_data_reason; end
 

--- a/app/models/state_file_md_intake.rb
+++ b/app/models/state_file_md_intake.rb
@@ -192,4 +192,16 @@ class StateFileMdIntake < StateFileBaseIntake
   def filing_status_dependent?
     filing_status == :dependent
   end
+
+  def address
+    if confirmed_permanent_address_yes?
+      result = "#{self.direct_file_data.mailing_street}"
+      result += " #{self.direct_file_data.mailing_apartment}" if self.direct_file_data.mailing_apartment.present?
+      result += ", #{self.direct_file_data.mailing_city}, #{self.direct_file_data.mailing_state} #{self.direct_file_data.mailing_zip}"
+      result
+    else
+      apt = self.permanent_apartment.present? ? " #{self.permanent_apartment}" : ""
+      "#{self.permanent_street}#{apt}, #{self.permanent_city} MD, #{self.permanent_zip}"
+    end
+  end
 end

--- a/app/models/state_file_md_intake.rb
+++ b/app/models/state_file_md_intake.rb
@@ -13,6 +13,7 @@
 #  bank_authorization_confirmed               :integer          default("unfilled"), not null
 #  city                                       :string
 #  confirmed_permanent_address                :integer          default("unfilled"), not null
+#  consented_to_sms_terms                     :integer          default("unfilled"), not null
 #  consented_to_terms_and_conditions          :integer          default("unfilled"), not null
 #  contact_preference                         :integer          default("unfilled"), not null
 #  current_sign_in_at                         :datetime
@@ -124,6 +125,7 @@ class StateFileMdIntake < StateFileBaseIntake
   enum sms_notification_opt_in: { unfilled: 0, yes: 1, no: 2 }, _prefix: :sms_notification_opt_in
   enum bank_authorization_confirmed: { unfilled: 0, yes: 1, no: 2 }, _prefix: :bank_authorization_confirmed
   enum has_joint_account_holder: { unfilled: 0, yes: 1, no: 2 }, _prefix: :has_joint_account_holder
+  enum consented_to_sms_terms: { unfilled: 0, yes: 1, no: 2 }, _prefix: :consented_to_sms_terms
 
   def disqualifying_df_data_reason
     w2_states = direct_file_data.parsed_xml.css('W2StateLocalTaxGrp W2StateTaxGrp StateAbbreviationCd')

--- a/app/models/state_file_nc_intake.rb
+++ b/app/models/state_file_nc_intake.rb
@@ -6,6 +6,7 @@
 #  account_number                    :string
 #  account_type                      :integer          default("unfilled"), not null
 #  city                              :string
+#  consented_to_sms_terms            :integer          default("unfilled"), not null
 #  consented_to_terms_and_conditions :integer          default("unfilled"), not null
 #  contact_preference                :integer          default("unfilled"), not null
 #  current_sign_in_at                :datetime
@@ -98,6 +99,7 @@ class StateFileNcIntake < StateFileBaseIntake
 
   enum eligibility_ed_loan_cancelled: { no: 0, yes: 1 }, _prefix: :eligibility_ed_loan_cancelled
   enum eligibility_ed_loan_emp_payment: { no: 0, yes: 1 }, _prefix: :eligibility_ed_loan_emp_payment
+  enum consented_to_sms_terms: { unfilled: 0, yes: 1, no: 2 }, _prefix: :consented_to_sms_terms
 
   attr_accessor :nc_eligiblity_none
 

--- a/app/models/state_file_nj_intake.rb
+++ b/app/models/state_file_nj_intake.rb
@@ -7,6 +7,7 @@
 #  account_type                                           :integer          default("unfilled"), not null
 #  claimed_as_dep                                         :integer
 #  claimed_as_eitc_qualifying_child                       :integer          default("unfilled"), not null
+#  consented_to_sms_terms                                 :integer          default("unfilled"), not null
 #  consented_to_terms_and_conditions                      :integer          default("unfilled"), not null
 #  contact_preference                                     :integer          default("unfilled"), not null
 #  county                                                 :string
@@ -150,6 +151,7 @@ class StateFileNjIntake < StateFileBaseIntake
 
   enum email_notification_opt_in: { unfilled: 0, yes: 1, no: 2 }, _prefix: :email_notification_opt_in
   enum sms_notification_opt_in: { unfilled: 0, yes: 1, no: 2 }, _prefix: :sms_notification_opt_in
+  enum consented_to_sms_terms: { unfilled: 0, yes: 1, no: 2 }, _prefix: :consented_to_sms_terms
 
   def calculate_sales_use_tax
     nj_gross_income = calculator.lines[:NJ1040_LINE_29].value

--- a/app/models/state_file_ny_intake.rb
+++ b/app/models/state_file_ny_intake.rb
@@ -7,6 +7,7 @@
 #  account_type                       :integer          default("unfilled"), not null
 #  confirmed_permanent_address        :integer          default("unfilled"), not null
 #  confirmed_third_party_designee     :integer          default("unfilled"), not null
+#  consented_to_sms_terms             :integer          default("unfilled"), not null
 #  consented_to_terms_and_conditions  :integer          default("unfilled"), not null
 #  contact_preference                 :integer          default("unfilled"), not null
 #  current_sign_in_at                 :datetime
@@ -157,6 +158,7 @@ class StateFileNyIntake < StateFileBaseIntake
   enum eligibility_out_of_state_income: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_out_of_state_income
   enum email_notification_opt_in: { unfilled: 0, yes: 1, no: 2 }, _prefix: :email_notification_opt_in
   enum sms_notification_opt_in: { unfilled: 0, yes: 1, no: 2 }, _prefix: :sms_notification_opt_in
+  enum consented_to_sms_terms: { unfilled: 0, yes: 1, no: 2 }, _prefix: :consented_to_sms_terms
 
   before_save do
 

--- a/app/views/state_file/questions/md_primary_state_id/_md_primary.html.erb
+++ b/app/views/state_file/questions/md_primary_state_id/_md_primary.html.erb
@@ -20,5 +20,6 @@
 
 <% content_for :card do %>
   <h1 class="h2"><%= title %></h1>
-  <%= render 'state_file/questions/primary_state_id/state_id', options: {} %>
+  <p class="spacing spacing-above-10 spacing-below-15"><%= t('.subtitle') %></p>
+  <%= render 'state_file/questions/primary_state_id/state_id', options: { dmv_bmv_label: t('.dmv_bmv_label'), info_link: 'https://www.e-verify.gov/sites/default/files/everify/factsheets/factsheetsArchive/MarylandRIDEFactSheet.pdf' } %>
 <% end %>

--- a/app/views/state_file/questions/md_review/edit.html.erb
+++ b/app/views/state_file/questions/md_review/edit.html.erb
@@ -1,4 +1,13 @@
 <% content_for :page_title, t("state_file.questions.shared.abstract_review_header.title") %>
+
+<% content_for :additional_household_box_content do %>
+  <div class="spacing-below-5">
+    <h3 class="text--body text--bold spacing-below-5"><%=t(".your_address", filing_year: current_tax_year) %></h3>
+    <p><%=current_intake.address %></p>
+    <%= link_to t("general.edit"), StateFile::Questions::MdPermanentAddressController.to_path_helper(return_to_review: "y"), class: "button--small" %>
+  </div>
+<% end %>
+
 <% content_for :card do %>
   <%= render "state_file/questions/shared/review_header" %>
 

--- a/app/views/state_file/questions/md_spouse_state_id/_md_spouse.html.erb
+++ b/app/views/state_file/questions/md_spouse_state_id/_md_spouse.html.erb
@@ -20,5 +20,6 @@
 
 <% content_for :card do %>
   <h1 class="h2"><%= title %></h1>
-  <%= render 'state_file/questions/ny_primary_state_id/state_id', options: {} %>
+  <p class="spacing spacing-above-10 spacing-below-15"><%= t('.subtitle') %></p>
+  <%= render 'state_file/questions/ny_primary_state_id/state_id', options: { dmv_bmv_label: t('.dmv_bmv_label'), info_link: 'https://www.e-verify.gov/sites/default/files/everify/factsheets/factsheetsArchive/MarylandRIDEFactSheet.pdf' } %>
 <% end %>

--- a/app/views/state_file/questions/md_tax_refund/_md_bank_details.html.erb
+++ b/app/views/state_file/questions/md_tax_refund/_md_bank_details.html.erb
@@ -46,7 +46,7 @@
             t(".suffix"),
             suffix_options_for_state_select,
             prompt: t('general.select_prompt'), include_blank: true) %>
-      <div class="question-with-follow-up__follow-up not-centered" id="joint-account-holder-questions">
+      <div class="form-group-tight question-with-follow-up__follow-up" id="joint-account-holder-questions">
         <p class="text--bold spacing-below-0"><%= t('.joint_account_holder_name') %></p>
         <%= form.cfa_input_field :joint_account_holder_first_name, t("general.first_name"), classes: ["form-width--long"] %>
         <%= form.cfa_input_field :joint_account_holder_middle_initial, t(".middle_initial"), classes: ["form-width--long"] %>

--- a/app/views/state_file/questions/md_tax_refund/_md_bank_details.html.erb
+++ b/app/views/state_file/questions/md_tax_refund/_md_bank_details.html.erb
@@ -64,7 +64,6 @@
     <%= form.cfa_input_field(:account_number, t("state_file.questions.tax_refund.bank_details.account_number"), classes: ["form-width--long", "disablecopy"]) %>
     <%= form.cfa_input_field(:account_number_confirmation, t("state_file.questions.tax_refund.bank_details.confirm_account_number"), classes: ["form-width--long", "disablepaste", "disablecopy"]) %>
   </div>
-  <%= form.cfa_checkbox(:bank_authorization_confirmed, t(".bank_authorization_confirmation"), options: { checked_value: "yes", unchecked_value: "no" }) %>
   <% if owe_taxes && !before_withdrawal_date_deadline?(current_state_code) %>
     <p>
       <%= t("state_file.questions.tax_refund.bank_details.after_deadline_default_withdrawal_info",

--- a/app/views/state_file/questions/md_tax_refund/edit.html.erb
+++ b/app/views/state_file/questions/md_tax_refund/edit.html.erb
@@ -26,6 +26,7 @@
           </div>
         </div>
       </div>
+      <%= f.cfa_checkbox(:bank_authorization_confirmed, t(".bank_authorization_confirmation"), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.continue %>
     </div>
   <% end %>

--- a/app/views/state_file/questions/shared/_abstract_review_header.html.erb
+++ b/app/views/state_file/questions/shared/_abstract_review_header.html.erb
@@ -57,6 +57,7 @@
         </div>
       <% end %>
     <% end %>
+    <%= yield(:additional_household_box_content) %>
   </div>
 
   <%= yield(:additional_review_header_sections) %>

--- a/app/views/state_file/questions/sms_terms/edit.html.erb
+++ b/app/views/state_file/questions/sms_terms/edit.html.erb
@@ -1,0 +1,36 @@
+<% content_for :page_title, t(".title") %>
+
+<% content_for :card do %>
+  <h1 class="h2 spacing-below-5"><%= t(".title") %></h1>
+  <div class="white-group">
+    <p class="spacing-below-10">
+      <ul class='list--numbered'>
+        <li><%= t(".term") %></li>
+        <li><%= t(".term_2_html") %></li>
+        <li><%= t(".term_3_html") %></li>
+        <li>
+          <%= t(".term_4_html") %>
+          <ol class="list--bulleted-indented" style="list-style-type: lower-alpha;">
+            <li><%= t(".term_5") %></li>
+            <li><%= t(".term_6") %></li>
+            <li><%= t(".term_7") %></li>
+          </ol>
+        </li>
+        <li><%= t(".term_8_html") %></li>
+        <li><%= t(".term_9_html") %></li>
+      </ul>
+    </p>
+  </div>
+  <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
+  <div class="options-wrapper">
+      <div class="yes-no-buttons">
+        <%= f.button :submit, name: "state_file_sms_terms_form[consented_to_sms_terms]", value: 'yes', class: 'button button--primary' do %>
+          <%= t("general.accept") %>
+        <% end %>
+        <%= f.button :submit, name: "state_file_sms_terms_form[consented_to_sms_terms]", value: 'no', class: 'button' do %>
+          <%= t("general.decline") %>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/state_file/questions/taxes_owed/edit.html.erb
+++ b/app/views/state_file/questions/taxes_owed/edit.html.erb
@@ -3,10 +3,14 @@
   <h1 class="h2">
     <%= t(".title_html", owed_amount: taxes_owed, state_name: current_state_name) %>
   </h1>
+  <% if current_state_code == "md" %>
+    <p><%= t('.subtitle_html') %></p>
+  <% end %>
 
   <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
     <div class="question-with-follow-up">
       <div class="question-with-follow-up__question white-group">
+        <p><%= t('.subtitle') %></p>
         <%= f.cfa_radio_set(
           :payment_or_deposit_type,
           collection: [

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3434,10 +3434,12 @@ en:
           title_html: Good news, you're getting a %{state_name} state tax refund of <strong>$%{refund_amount}.</strong> How would you like to receive your refund?
       taxes_owed:
         edit:
+          subtitle_html: For more information about tax due dates and payment methods, visit <a target="_blank" rel="noopener nofollow" href="https://marylandtaxes.gov/">Marylandtaxes.gov</a>
           page_title: You owe state taxes. How would you like to pay?
           pay_bank: Pay directly from your checking or savings account (direct debit)
           pay_mail_online_html: Pay by mail or online at <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a>
-          title_html: You owe <strong>$%{owed_amount}</strong> in %{state_name} state taxes. How would you like to pay?
+          title_html: You owe <strong>$%{owed_amount}</strong> in %{state_name} state taxes.
+          subtitle: How would you like to pay?
       terms_and_conditions:
         edit:
           accept: Accept

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2825,11 +2825,13 @@ en:
           subtitle: The Comptroller of Maryland requests the information from your Driver's License or state-issued ID card be included with the return, but won't reject the return if it's not included.
           why_ask_this: Why are you asking for this information?
       md_tax_refund:
+        edit:
+          bank_authorization_confirmation: Check here to confirm you authorize the State of Maryland to issue your refund by direct deposit.
         md_bank_details:
           account_holder_name: Account Holder Name
           bank_account_details: Bank Account Details
           bank_account_type: Bank Account Type
-          bank_authorization_confirmation: Check here to confirm you authorize the State of Maryland to issue your refund by direct deposit.
+
           bank_authorization_confirmation_error: Please confirm authorization or select pay by mail
           check_if_joint_account: Check here if you have a joint account
           joint_account_holder_name: Joint Account Holder Name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3382,18 +3382,20 @@ en:
           your_tax_owed: Your taxes owed
       sms_terms:
         edit:
-          title: Please review the FileYourStateTaxes text messaging terms and conditions
           term: When you opt-in to the service, we will send you an SMS message to confirm your signup. We will also text you updates on your tax return (message frequency will vary) and/or OTP/2FA codes (one message per request).
           term_2_html: You can cancel the SMS service at any time. Just <strong>text "STOP" to 46207</strong>. After you send the SMS message "STOP" to us, we will send you an SMS message to confirm that you have been unsubscribed. After this, you will no longer receive SMS messages from us. If you want to join again, just <strong>reply "START"</strong> and we will start sending SMS messages to you again.
           term_3_html: If at any time you forget what keywords are supported, just <strong>text "HELP" to 46207</strong>. After you send the SMS message "HELP" to us, we will respond with instructions on how to use our service as well as how to unsubscribe.
-          term_4_html: <strong>We are able to deliver messages to the following mobile phone carriers</strong>
-          term_5: "Major carriers: AT&T, Verizon Wireless, Sprint, T-Mobile, U.S. Cellular, Alltel, Boost Mobile, Nextel, and Virgin Mobile."
-          term_6: "Minor carriers: Alaska Communications Systems (ACS), Appalachian Wireless (EKN), Bluegrass Cellular, Cellular One of East Central IL (ECIT), Cellular One of Northeast Pennsylvania, Cincinnati Bell Wireless, Cricket, Coral Wireless (Mobi PCS), COX, Cross, Element Mobile (Flat Wireless), Epic Touch (Elkhart Telephone), GCI, Golden State, Hawkeye (Chat Mobility), Hawkeye (NW Missouri), Illinois Valley Cellular, Inland Cellular, iWireless (Iowa Wireless), Keystone Wireless (Immix Wireless/PC Man), Mosaic (Consolidated or CTC Telecom), Nex-Tech Wireless, NTelos, Panhandle Communications, Pioneer, Plateau (Texas RSA 3 Ltd), Revol, RINA, Simmetry (TMP Corporation), Thumb Cellular, Union Wireless, United Wireless, Viaero Wireless, and West Central (WCC or 5 Star Wireless)."
-          term_7: "Carriers (e.g. AT&T, Verizon, T-Mobile, Sprint, etc.) are not responsible or liable for undelivered or delayed messages."
-          term_8_html: |
-            As always, message and data rates may apply for any messages sent to you from us and to us from you. If you have any questions about your text plan or data plan, it is best to contact your wireless provider. <br><br>For all questions about the services provided by this short code, you can send an email to <strong>help@fileyourstatetaxes.org</strong>.
-          term_9_html: |
-            If you have any questions regarding privacy, please read our privacy policy:  <a target="_blank" rel="noopener nofollow" href="https://www.fileyourstatetaxes.org/privacy-policy">www.fileyourstatetaxes.org/privacy-policy</a>
+          term_4_html: "<strong>We are able to deliver messages to the following mobile phone carriers</strong>"
+          term_5: 'Major carriers: AT&T, Verizon Wireless, Sprint, T-Mobile, U.S. Cellular, Alltel, Boost Mobile, Nextel, and Virgin Mobile.'
+          term_6: 'Minor carriers: Alaska Communications Systems (ACS), Appalachian Wireless (EKN), Bluegrass Cellular, Cellular One of East Central IL (ECIT), Cellular One of Northeast Pennsylvania, Cincinnati Bell Wireless, Cricket, Coral Wireless (Mobi PCS), COX, Cross, Element Mobile (Flat Wireless), Epic Touch (Elkhart Telephone), GCI, Golden State, Hawkeye (Chat Mobility), Hawkeye (NW Missouri), Illinois Valley Cellular, Inland Cellular, iWireless (Iowa Wireless), Keystone Wireless (Immix Wireless/PC Man), Mosaic (Consolidated or CTC Telecom), Nex-Tech Wireless, NTelos, Panhandle Communications, Pioneer, Plateau (Texas RSA 3 Ltd), Revol, RINA, Simmetry (TMP Corporation), Thumb Cellular, Union Wireless, United Wireless, Viaero Wireless, and West Central (WCC or 5 Star Wireless).'
+          term_7: Carriers (e.g. AT&T, Verizon, T-Mobile, Sprint, etc.) are not responsible or liable for undelivered or delayed messages.
+          term_8_html: 'As always, message and data rates may apply for any messages sent to you from us and to us from you. If you have any questions about your text plan or data plan, it is best to contact your wireless provider. <br><br>For all questions about the services provided by this short code, you can send an email to <strong>help@fileyourstatetaxes.org</strong>.
+
+            '
+          term_9_html: 'If you have any questions regarding privacy, please read our privacy policy:  <a target="_blank" rel="noopener nofollow" href="https://www.fileyourstatetaxes.org/privacy-policy">www.fileyourstatetaxes.org/privacy-policy</a>
+
+            '
+          title: Please review the FileYourStateTaxes text messaging terms and conditions
       spouse_state_id:
         edit:
           title_html: We need some details from <strong>your spouse’s</strong> state-issued ID, if they have one

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2814,6 +2814,7 @@ en:
           why_ask_this: Why are you asking for this information?
       md_review:
         edit:
+          your_address: Address lived at on December 31, %{filing_year}
           county_html: "<strong>County</strong>"
           political_subdivision_html: "<strong>Political subdivision</strong>"
       md_spouse_state_id:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2807,8 +2807,10 @@ en:
           zip_label: Zip Code
       md_primary_state_id:
         md_primary:
-          encourage_sharing: If you and your spouse have a driver’s license or state issued identification card please provide the requested information from it. The return will not be rejected if you do not provide a driver’s license or state-issued identification. If you provide this information, it may help to identify you as the taxpayer.
+          dmv_bmv_label: MVA State ID
+          encourage_sharing: If you and your spouse have a driver's license or state issued identification card please provide the requested information from it. The return will not be rejected if you do not provide a driver’s license or state-issued identification. If you provide this information, it may help to identify you as the taxpayer.
           protect_identity: Many state revenue agencies, including Maryland, are requesting additional information in an effort to combat stolen-identity tax fraud and to protect you and your tax refund.
+          subtitle: The Comptroller of Maryland requests the information from your Driver's License or state-issued ID card be included with the return, but won't reject the return if it's not included.
           why_ask_this: Why are you asking for this information?
       md_review:
         edit:
@@ -2816,8 +2818,10 @@ en:
           political_subdivision_html: "<strong>Political subdivision</strong>"
       md_spouse_state_id:
         md_spouse:
+          dmv_bmv_label: MVA State ID
           encourage_sharing: If you and your spouse have a driver’s license or state issued identification card please provide the requested information from it. The return will not be rejected if you do not provide a driver’s license or state-issued identification. If you provide this information, it may help to identify you as the taxpayer.
           protect_identity: Many state revenue agencies, including Maryland, are requesting additional information in an effort to combat stolen-identity tax fraud and to protect you and your tax refund.
+          subtitle: The Comptroller of Maryland requests the information from your Driver's License or state-issued ID card be included with the return, but won't reject the return if it's not included.
           why_ask_this: Why are you asking for this information?
       md_tax_refund:
         md_bank_details:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3422,7 +3422,7 @@ en:
           confirm_routing_number: Confirm Routing Number
           date_withdraw_text: 'When would you like the funds withdrawn from your account? (Must be on or before %{withdrawal_deadline_date}, %{with_drawal_deadline_year}):'
           disclaimer: Check to make sure your bank information is correct. You won’t be able to correct this after you submit your return.
-          foreign_accounts: "(Foreign accounts are not accepted)"
+          foreign_accounts: Foreign accounts are not accepted
           routing_number: Routing Number
           withdraw_amount: How much do you authorize to be withdrawn from your account? (Your total amount due is&#58; $%{owed_amount}. Round to the nearest whole number.)
         edit:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -281,6 +281,7 @@ en:
   general:
     NA: N/A
     about: About
+    accept: Accept
     access_denied: You are not authorized to take this action.
     activate_all: Activate All
     active: active
@@ -339,6 +340,7 @@ en:
     days:
       one: "%{count} day"
       other: "%{count} days"
+    decline: Decline
     delete: Delete
     dependent_relationships:
       aunt: Aunt
@@ -3378,6 +3380,20 @@ en:
           income_details: Income Details
           your_refund: Your refund amount
           your_tax_owed: Your taxes owed
+      sms_terms:
+        edit:
+          title: Please review the FileYourStateTaxes text messaging terms and conditions
+          term: When you opt-in to the service, we will send you an SMS message to confirm your signup. We will also text you updates on your tax return (message frequency will vary) and/or OTP/2FA codes (one message per request).
+          term_2_html: You can cancel the SMS service at any time. Just <strong>text "STOP" to 46207</strong>. After you send the SMS message "STOP" to us, we will send you an SMS message to confirm that you have been unsubscribed. After this, you will no longer receive SMS messages from us. If you want to join again, just <strong>reply "START"</strong> and we will start sending SMS messages to you again.
+          term_3_html: If at any time you forget what keywords are supported, just <strong>text "HELP" to 46207</strong>. After you send the SMS message "HELP" to us, we will respond with instructions on how to use our service as well as how to unsubscribe.
+          term_4_html: <strong>We are able to deliver messages to the following mobile phone carriers</strong>
+          term_5: "Major carriers: AT&T, Verizon Wireless, Sprint, T-Mobile, U.S. Cellular, Alltel, Boost Mobile, Nextel, and Virgin Mobile."
+          term_6: "Minor carriers: Alaska Communications Systems (ACS), Appalachian Wireless (EKN), Bluegrass Cellular, Cellular One of East Central IL (ECIT), Cellular One of Northeast Pennsylvania, Cincinnati Bell Wireless, Cricket, Coral Wireless (Mobi PCS), COX, Cross, Element Mobile (Flat Wireless), Epic Touch (Elkhart Telephone), GCI, Golden State, Hawkeye (Chat Mobility), Hawkeye (NW Missouri), Illinois Valley Cellular, Inland Cellular, iWireless (Iowa Wireless), Keystone Wireless (Immix Wireless/PC Man), Mosaic (Consolidated or CTC Telecom), Nex-Tech Wireless, NTelos, Panhandle Communications, Pioneer, Plateau (Texas RSA 3 Ltd), Revol, RINA, Simmetry (TMP Corporation), Thumb Cellular, Union Wireless, United Wireless, Viaero Wireless, and West Central (WCC or 5 Star Wireless)."
+          term_7: "Carriers (e.g. AT&T, Verizon, T-Mobile, Sprint, etc.) are not responsible or liable for undelivered or delayed messages."
+          term_8_html: |
+            As always, message and data rates may apply for any messages sent to you from us and to us from you. If you have any questions about your text plan or data plan, it is best to contact your wireless provider. <br><br>For all questions about the services provided by this short code, you can send an email to <strong>help@fileyourstatetaxes.org</strong>.
+          term_9_html: |
+            If you have any questions regarding privacy, please read our privacy policy:  <a target="_blank" rel="noopener nofollow" href="https://www.fileyourstatetaxes.org/privacy-policy">www.fileyourstatetaxes.org/privacy-policy</a>
       spouse_state_id:
         edit:
           title_html: We need some details from <strong>your spouse’s</strong> state-issued ID, if they have one

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3367,7 +3367,20 @@ es:
           your_tax_owed: Tus impuestos adeudados
       sms_terms:
         edit:
-          title: Revise los términos y condiciones de mensajes de texto de FileYourStateTaxes
+          term: Cuando se registre en el servicio, le enviaremos un mensaje SMS para confirmar su inscripción. También le enviaremos actualizaciones sobre su declaración de impuestos (la frecuencia de los mensajes variará) y/o códigos OTP/2FA (un mensaje por solicitud).
+          term_2_html: Puede cancelar el servicio de SMS en cualquier momento. Solo <strong>envíe "STOP" al 46207</strong>. Después de enviar el mensaje SMS "STOP", le enviaremos un mensaje SMS para confirmar que se ha dado de baja. Después de esto, ya no recibirá mensajes SMS de nuestra parte. Si desea unirse nuevamente, simplemente <strong>responda "START"</strong> y comenzaremos a enviarle mensajes SMS otra vez.
+          term_3_html: Si en algún momento olvida qué palabras clave están disponibles, simplemente <strong>envíe "HELP" al 46207</strong>. Después de enviar el mensaje SMS "HELP", le responderemos con instrucciones sobre cómo usar nuestro servicio, así como cómo darse de baja.
+          term_4_html: "<strong>Podemos enviar mensajes a los siguientes operadores de telefonía móvil</strong>"
+          term_5: 'Operadores principales: AT&T, Verizon Wireless, Sprint, T-Mobile, U.S. Cellular, Alltel, Boost Mobile, Nextel y Virgin Mobile.'
+          term_6: 'Operadores secundarios: Alaska Communications Systems (ACS), Appalachian Wireless (EKN), Bluegrass Cellular, Cellular One of East Central IL (ECIT), Cellular One of Northeast Pennsylvania, Cincinnati Bell Wireless, Cricket, Coral Wireless (Mobi PCS), COX, Cross, Element Mobile (Flat Wireless), Epic Touch (Elkhart Telephone), GCI, Golden State, Hawkeye (Chat Mobility), Hawkeye (NW Missouri), Illinois Valley Cellular, Inland Cellular, iWireless (Iowa Wireless), Keystone Wireless (Immix Wireless/PC Man), Mosaic (Consolidated or CTC Telecom), Nex-Tech Wireless, NTelos, Panhandle Communications, Pioneer, Plateau (Texas RSA 3 Ltd), Revol, RINA, Simmetry (TMP Corporation), Thumb Cellular, Union Wireless, United Wireless, Viaero Wireless y West Central (WCC o 5 Star Wireless).'
+          term_7: Los operadores (por ejemplo, AT&T, Verizon, T-Mobile, Sprint, etc.) no son responsables ni están obligados por mensajes no entregados o retrasados.
+          term_8_html: 'Como siempre, pueden aplicarse tarifas de mensajes y datos para cualquier mensaje enviado a usted desde nosotros y para mensajes que usted nos envíe. Si tiene alguna pregunta sobre su plan de mensajes o datos, es mejor comunicarse con su proveedor de telefonía móvil. <br><br>Para todas las preguntas sobre los servicios proporcionados por este código corto, puede enviar un correo electrónico a <strong>help@fileyourstatetaxes.org</strong>.
+
+            '
+          term_9_html: 'Si tiene preguntas relacionadas con la privacidad, por favor lea nuestra política de privacidad: <a target="_blank" rel="noopener nofollow" href="https://www.fileyourstatetaxes.org/privacy-policy">www.fileyourstatetaxes.org/privacy-policy</a>
+
+            '
+          title: Por favor revise los términos y condiciones de mensajería de texto de FileYourStateTaxes
       spouse_state_id:
         edit:
           title_html: Proporciona la información para la identificación emitida por el estado de <strong>tu cónyuge</strong>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2784,6 +2784,7 @@ es:
           why_ask_this: "¿Por qué pides esta información?"
       md_review:
         edit:
+          your_address: Dirección donde vivía el 31 de diciembre de %{filing_year}
           county_html: "<strong>Condado</strong>"
           political_subdivision_html: "<strong>Subdivisión política</strong>"
       md_spouse_state_id:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2795,11 +2795,12 @@ es:
           subtitle: El Contralor de Maryland solicita que la información de su licencia de conducir o tarjeta de identificación emitida por el estado se incluya con la declaración, pero no rechazará la declaración si no está incluida.
           why_ask_this: "¿Por qué pides esta información?"
       md_tax_refund:
+        edit:
+          bank_authorization_confirmation: Marque aquí para confirmar que autoriza al estado de Maryland a emitir su reembolso mediante depósito directo.
         md_bank_details:
           account_holder_name: Nombre del titular de la cuenta
           bank_account_details: Detalles de la cuenta bancaria
           bank_account_type: Tipo de cuenta bancaria
-          bank_authorization_confirmation: Marque aquí para confirmar que autoriza al estado de Maryland a emitir su reembolso mediante depósito directo.
           bank_authorization_confirmation_error: Por favor confirme la autorización o seleccione pagar por correo
           check_if_joint_account: Marque aquí si tiene una cuenta conjunta
           joint_account_holder_name: Nombre del titular de la cuenta conjunta

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -282,6 +282,7 @@ es:
   general:
     NA: N/A
     about: Acerca de nosotros
+    accept: Aceptar
     access_denied: Usted no está autorizado a tomar esta acción.
     activate_all: Activar todo
     active: activos
@@ -341,6 +342,7 @@ es:
       many: "%{count} días"
       one: "%{count} día"
       other: "%{count} días"
+    decline: Rechazar
     delete: Eliminar
     dependent_relationships:
       aunt: Tía
@@ -3363,6 +3365,9 @@ es:
           income_details: Detalles de ingresos
           your_refund: Tu reembolso
           your_tax_owed: Tus impuestos adeudados
+      sms_terms:
+        edit:
+          title: Revise los términos y condiciones de mensajes de texto de FileYourStateTaxes
       spouse_state_id:
         edit:
           title_html: Proporciona la información para la identificación emitida por el estado de <strong>tu cónyuge</strong>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3407,7 +3407,7 @@ es:
           confirm_routing_number: Confirma el número de ruta bancaria (routing number)
           date_withdraw_text: "¿Cuándo te gustaría que se retiren los fondos de tu cuenta? (debe ser antes o en el dia del %{withdrawal_deadline_date} de %{with_drawal_deadline_year}):"
           disclaimer: Verifica que la información de tu banco sea correcta. No podrás corregirla después de enviar tu declaración.
-          foreign_accounts: "(Las cuentas extranjeras no son aceptadas)"
+          foreign_accounts: Las cuentas extranjeras no son aceptadas
           routing_number: Número de ruta bancaria (routing number)
           withdraw_amount: "¿Cuánto autorizas a retirar de tu cuenta? (Tu monto total adeudado es: %{owed_amount}. Redondea al número entero más cercano)"
         edit:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2777,8 +2777,10 @@ es:
           zip_label: Código postal
       md_primary_state_id:
         md_primary:
+          dmv_bmv_label: MVA State ID
           encourage_sharing: Si usted y su cónyuge tienen una licencia de conducir o una tarjeta de identificación emitida por el estado, proporcione la información solicitada. La devolución no será rechazada si no proporciona una licencia de conducir o una identificación emitida por el estado. Si proporciona esta información, puede ayudar a identificarlo como contribuyente.
           protect_identity: Muchas agencias de ingresos estatales, incluida Maryland, están solicitando información adicional en un esfuerzo por combatir el fraude fiscal por identidad robada y protegerlo a usted y a su reembolso de impuestos.
+          subtitle: El Contralor de Maryland solicita que la información de su licencia de conducir o tarjeta de identificación emitida por el estado se incluya con la declaración, pero no rechazará la declaración si no está incluida.
           why_ask_this: "¿Por qué pides esta información?"
       md_review:
         edit:
@@ -2786,8 +2788,10 @@ es:
           political_subdivision_html: "<strong>Subdivisión política</strong>"
       md_spouse_state_id:
         md_spouse:
+          dmv_bmv_label: MVA State ID
           encourage_sharing: Si usted y su cónyuge tienen una licencia de conducir o una tarjeta de identificación emitida por el estado, proporcione la información solicitada. La devolución no será rechazada si no proporciona una licencia de conducir o una identificación emitida por el estado. Si proporciona esta información, puede ayudar a identificarlo como contribuyente.
           protect_identity: Muchas agencias de ingresos estatales, incluida Maryland, están solicitando información adicional en un esfuerzo por combatir el fraude fiscal por identidad robada y protegerlo a usted y a su reembolso de impuestos.
+          subtitle: El Contralor de Maryland solicita que la información de su licencia de conducir o tarjeta de identificación emitida por el estado se incluya con la declaración, pero no rechazará la declaración si no está incluida.
           why_ask_this: "¿Por qué pides esta información?"
       md_tax_refund:
         md_bank_details:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3418,10 +3418,12 @@ es:
           title_html: Buenas noticias, recibirás un reembolso de impuestos del estado de %{state_name} de <strong>%{refund_amount}.</strong> ¿Cómo te gustaría recibirlo?
       taxes_owed:
         edit:
-          page_title: Debes impuestos estatales. ¿Cómo te gustaría pagar?
+          subtitle_html: Para obtener más información sobre las fechas de vencimiento de impuestos y los métodos de pago, visite <a target="_blank" rel="noopener nofollow" href="https://marylandtaxes.gov/">Marylandtaxes.gov</a>
+          page_title: Debes impuestos estatales.
           pay_bank: Directamente desde tu cuenta corriente o de ahorros (débito directo)
           pay_mail_online_html: Por correo o en línea en <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a>
           title_html: Debes <strong>$%{owed_amount}</strong> en impuestos estatales de %{state_name}. ¿Cómo te gustaría pagar?
+          subtitle: ¿Cómo te gustaría pagar?
       terms_and_conditions:
         edit:
           accept: Aceptar

--- a/db/migrate/20241205000153_add_sms_terms_consent_to_state_file_intakes.rb
+++ b/db/migrate/20241205000153_add_sms_terms_consent_to_state_file_intakes.rb
@@ -1,0 +1,10 @@
+class AddSmsTermsConsentToStateFileIntakes < ActiveRecord::Migration[7.1]
+  def change
+    add_column :state_file_az_intakes, :consented_to_sms_terms, :integer, default: 0, null: false
+    add_column :state_file_ny_intakes, :consented_to_sms_terms, :integer, default: 0, null: false
+    add_column :state_file_nc_intakes, :consented_to_sms_terms, :integer, default: 0, null: false
+    add_column :state_file_nj_intakes, :consented_to_sms_terms, :integer, default: 0, null: false
+    add_column :state_file_id_intakes, :consented_to_sms_terms, :integer, default: 0, null: false
+    add_column :state_file_md_intakes, :consented_to_sms_terms, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_12_02_184105) do
+ActiveRecord::Schema[7.1].define(version: 2024_12_05_000153) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -1697,6 +1697,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_02_184105) do
     t.decimal "charitable_cash_amount", precision: 12, scale: 2
     t.integer "charitable_contributions", default: 0, null: false
     t.decimal "charitable_noncash_amount", precision: 12, scale: 2
+    t.integer "consented_to_sms_terms", default: 0, null: false
     t.integer "consented_to_terms_and_conditions", default: 0, null: false
     t.integer "contact_preference", default: 0, null: false
     t.datetime "created_at", null: false
@@ -1824,6 +1825,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_02_184105) do
     t.decimal "american_red_cross_fund_donation", precision: 12, scale: 2
     t.string "bank_name"
     t.decimal "childrens_trust_fund_donation", precision: 12, scale: 2
+    t.integer "consented_to_sms_terms", default: 0, null: false
     t.integer "consented_to_terms_and_conditions", default: 0, null: false
     t.integer "contact_preference", default: 0, null: false
     t.datetime "created_at", null: false
@@ -1918,6 +1920,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_02_184105) do
     t.string "bank_name"
     t.string "city"
     t.integer "confirmed_permanent_address", default: 0, null: false
+    t.integer "consented_to_sms_terms", default: 0, null: false
     t.integer "consented_to_terms_and_conditions", default: 0, null: false
     t.integer "contact_preference", default: 0, null: false
     t.datetime "created_at", null: false
@@ -2018,6 +2021,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_02_184105) do
     t.integer "account_type", default: 0, null: false
     t.string "bank_name"
     t.string "city"
+    t.integer "consented_to_sms_terms", default: 0, null: false
     t.integer "consented_to_terms_and_conditions", default: 0, null: false
     t.integer "contact_preference", default: 0, null: false
     t.datetime "created_at", null: false
@@ -2102,6 +2106,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_02_184105) do
     t.string "bank_name"
     t.integer "claimed_as_dep"
     t.integer "claimed_as_eitc_qualifying_child", default: 0, null: false
+    t.integer "consented_to_sms_terms", default: 0, null: false
     t.integer "consented_to_terms_and_conditions", default: 0, null: false
     t.integer "contact_preference", default: 0, null: false
     t.string "county"
@@ -2228,6 +2233,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_02_184105) do
     t.string "bank_name"
     t.integer "confirmed_permanent_address", default: 0, null: false
     t.integer "confirmed_third_party_designee", default: 0, null: false
+    t.integer "consented_to_sms_terms", default: 0, null: false
     t.integer "consented_to_terms_and_conditions", default: 0, null: false
     t.integer "contact_preference", default: 0, null: false
     t.datetime "created_at", null: false

--- a/spec/factories/state_file_az_intakes.rb
+++ b/spec/factories/state_file_az_intakes.rb
@@ -10,6 +10,7 @@
 #  charitable_cash_amount                 :decimal(12, 2)
 #  charitable_contributions               :integer          default("unfilled"), not null
 #  charitable_noncash_amount              :decimal(12, 2)
+#  consented_to_sms_terms                 :integer          default("unfilled"), not null
 #  consented_to_terms_and_conditions      :integer          default("unfilled"), not null
 #  contact_preference                     :integer          default("unfilled"), not null
 #  current_sign_in_at                     :datetime

--- a/spec/factories/state_file_id_intakes.rb
+++ b/spec/factories/state_file_id_intakes.rb
@@ -7,6 +7,7 @@
 #  account_type                                   :integer          default("unfilled"), not null
 #  american_red_cross_fund_donation               :decimal(12, 2)
 #  childrens_trust_fund_donation                  :decimal(12, 2)
+#  consented_to_sms_terms                         :integer          default("unfilled"), not null
 #  consented_to_terms_and_conditions              :integer          default("unfilled"), not null
 #  contact_preference                             :integer          default("unfilled"), not null
 #  current_sign_in_at                             :datetime

--- a/spec/factories/state_file_md_intakes.rb
+++ b/spec/factories/state_file_md_intakes.rb
@@ -13,6 +13,7 @@
 #  bank_authorization_confirmed               :integer          default("unfilled"), not null
 #  city                                       :string
 #  confirmed_permanent_address                :integer          default("unfilled"), not null
+#  consented_to_sms_terms                     :integer          default("unfilled"), not null
 #  consented_to_terms_and_conditions          :integer          default("unfilled"), not null
 #  contact_preference                         :integer          default("unfilled"), not null
 #  current_sign_in_at                         :datetime

--- a/spec/factories/state_file_md_intakes.rb
+++ b/spec/factories/state_file_md_intakes.rb
@@ -144,6 +144,26 @@ FactoryBot.define do
       intake.raw_direct_file_data = intake.direct_file_data.to_s
     end
 
+    trait :with_permanent_address do
+      after(:build) do |intake|
+        intake.permanent_apartment = "Apt 1"
+        intake.permanent_street = "123 Main St"
+        intake.permanent_city = "Baltimore"
+        intake.permanent_zip = "21201"
+      end
+    end
+
+    trait :with_confirmed_address do
+      after(:build) do |intake|
+        intake.confirmed_permanent_address = "yes"
+        intake.direct_file_data.mailing_street = "321 Main St"
+        intake.direct_file_data.mailing_apartment = "Apt 2"
+        intake.direct_file_data.mailing_city = "Baltimore"
+        intake.direct_file_data.mailing_state = "MD"
+        intake.direct_file_data.mailing_zip = "21202"
+        intake.raw_direct_file_data = intake.direct_file_data.to_s
+      end
+    end
 
     trait :with_1099_rs_synced do
       after(:create, &:synchronize_df_1099_rs_to_database)

--- a/spec/factories/state_file_nc_intakes.rb
+++ b/spec/factories/state_file_nc_intakes.rb
@@ -6,6 +6,7 @@
 #  account_number                    :string
 #  account_type                      :integer          default("unfilled"), not null
 #  city                              :string
+#  consented_to_sms_terms            :integer          default("unfilled"), not null
 #  consented_to_terms_and_conditions :integer          default("unfilled"), not null
 #  contact_preference                :integer          default("unfilled"), not null
 #  current_sign_in_at                :datetime

--- a/spec/factories/state_file_nj_intakes.rb
+++ b/spec/factories/state_file_nj_intakes.rb
@@ -7,6 +7,7 @@
 #  account_type                                           :integer          default("unfilled"), not null
 #  claimed_as_dep                                         :integer
 #  claimed_as_eitc_qualifying_child                       :integer          default("unfilled"), not null
+#  consented_to_sms_terms                                 :integer          default("unfilled"), not null
 #  consented_to_terms_and_conditions                      :integer          default("unfilled"), not null
 #  contact_preference                                     :integer          default("unfilled"), not null
 #  county                                                 :string

--- a/spec/factories/state_file_ny_intakes.rb
+++ b/spec/factories/state_file_ny_intakes.rb
@@ -7,6 +7,7 @@
 #  account_type                       :integer          default("unfilled"), not null
 #  confirmed_permanent_address        :integer          default("unfilled"), not null
 #  confirmed_third_party_designee     :integer          default("unfilled"), not null
+#  consented_to_sms_terms             :integer          default("unfilled"), not null
 #  consented_to_terms_and_conditions  :integer          default("unfilled"), not null
 #  contact_preference                 :integer          default("unfilled"), not null
 #  current_sign_in_at                 :datetime

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -27,6 +27,9 @@ RSpec.feature "Completing a state file intake", active_job: true do
       fill_in "Your phone number", with: "+12025551212"
       click_on "Continue"
 
+      expect(page).to have_text I18n.t('state_file.questions.sms_terms.edit.title')
+      click_on I18n.t("general.accept")
+
       expect(page).to have_text I18n.t('state_file.questions.terms_and_conditions.edit.title')
       click_on I18n.t("state_file.questions.terms_and_conditions.edit.accept")
 
@@ -153,6 +156,9 @@ RSpec.feature "Completing a state file intake", active_job: true do
       check "Text message"
       fill_in "Your phone number", with: "+12025551212"
       click_on "Continue"
+
+      expect(page).to have_text I18n.t('state_file.questions.sms_terms.edit.title')
+      click_on I18n.t("general.accept")
 
       expect(page).to have_text I18n.t('state_file.questions.terms_and_conditions.edit.title')
       click_on I18n.t("state_file.questions.terms_and_conditions.edit.accept")
@@ -306,6 +312,9 @@ RSpec.feature "Completing a state file intake", active_job: true do
       fill_in "Your phone number", with: "+12025551212"
       click_on "Continue"
 
+      expect(page).to have_text I18n.t('state_file.questions.sms_terms.edit.title')
+      click_on I18n.t("general.accept")
+
       expect(page).to have_text I18n.t('state_file.questions.terms_and_conditions.edit.title')
       click_on I18n.t("state_file.questions.terms_and_conditions.edit.accept")
 
@@ -394,6 +403,9 @@ RSpec.feature "Completing a state file intake", active_job: true do
       check "Text message"
       fill_in "Your phone number", with: "+12025551212"
       click_on "Continue"
+
+      expect(page).to have_text I18n.t('state_file.questions.sms_terms.edit.title')
+      click_on I18n.t("general.accept")
 
       expect(page).to have_text I18n.t('state_file.questions.terms_and_conditions.edit.title')
       click_on I18n.t("state_file.questions.terms_and_conditions.edit.accept")
@@ -505,6 +517,9 @@ RSpec.feature "Completing a state file intake", active_job: true do
       fill_in "Your phone number", with: "+12025551212"
       click_on "Continue"
 
+      expect(page).to have_text I18n.t('state_file.questions.sms_terms.edit.title')
+      click_on I18n.t("general.accept")
+
       expect(page).to have_text I18n.t('state_file.questions.terms_and_conditions.edit.title')
       click_on I18n.t("state_file.questions.terms_and_conditions.edit.accept")
 
@@ -605,6 +620,9 @@ RSpec.feature "Completing a state file intake", active_job: true do
       check "Text message"
       fill_in "Your phone number", with: "+12025551212"
       click_on "Continue"
+
+      expect(page).to have_text I18n.t('state_file.questions.sms_terms.edit.title')
+      click_on I18n.t("general.accept")
 
       expect(page).to have_text I18n.t('state_file.questions.terms_and_conditions.edit.title')
       click_on I18n.t("state_file.questions.terms_and_conditions.edit.accept")

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -558,7 +558,8 @@ RSpec.feature "Completing a state file intake", active_job: true do
       click_on I18n.t("general.continue")
 
       expect(page).to have_text I18n.t('state_file.questions.primary_state_id.edit.title')
-      choose I18n.t('state_file.questions.primary_state_id.state_id.id_type_question.dmv')
+      choose I18n.t('state_file.questions.md_primary_state_id.md_primary.dmv_bmv_label')
+
       fill_in I18n.t('state_file.questions.primary_state_id.state_id.id_details.number'), with: "012345678"
       select_cfa_date "state_file_primary_state_id_form_issue_date", 4.years.ago.beginning_of_year
       select_cfa_date "state_file_primary_state_id_form_expiration_date", 4.years.from_now.beginning_of_year
@@ -588,7 +589,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
       fill_in 'state_file_md_tax_refund_form_routing_number_confirmation', with: "019456124"
       fill_in 'state_file_md_tax_refund_form_account_number', with: "123456789"
       fill_in 'state_file_md_tax_refund_form_account_number_confirmation', with: "123456789"
-      check I18n.t('state_file.questions.md_tax_refund.md_bank_details.bank_authorization_confirmation')
+      check I18n.t('state_file.questions.md_tax_refund.edit.bank_authorization_confirmation')
       click_on I18n.t("general.continue")
 
       expect(page).to have_text I18n.t("state_file.questions.esign_declaration.edit.title", state_name: "Maryland")

--- a/spec/features/state_file/data_transfer_spec.rb
+++ b/spec/features/state_file/data_transfer_spec.rb
@@ -19,10 +19,12 @@ RSpec.feature "Transferring data from Direct File", active_job: true do
     step_through_eligibility_screener(us_state: "ny")
 
     step_through_initial_authentication(contact_preference: :email)
-    check "Email"
     check "Text message"
     fill_in "Your phone number", with: "+12025551212"
     click_on "Continue"
+
+    expect(page).to have_text I18n.t('state_file.questions.sms_terms.edit.title')
+    click_on I18n.t("general.accept")
 
     expect(page).to have_text I18n.t('state_file.questions.terms_and_conditions.edit.title')
     click_on I18n.t("state_file.questions.terms_and_conditions.edit.accept")

--- a/spec/features/state_file/editing_df_xml_spec.rb
+++ b/spec/features/state_file/editing_df_xml_spec.rb
@@ -26,6 +26,9 @@ RSpec.feature "editing direct file XML with the FederalInfoController", active_j
     fill_in "Your phone number", with: "+12025551212"
     click_on "Continue"
 
+    expect(page).to have_text I18n.t('state_file.questions.sms_terms.edit.title')
+    click_on I18n.t("general.accept")
+
     expect(page).to have_text I18n.t('state_file.questions.terms_and_conditions.edit.title')
     click_on I18n.t("state_file.questions.terms_and_conditions.edit.accept")
 
@@ -54,6 +57,9 @@ RSpec.feature "editing direct file XML with the FederalInfoController", active_j
     check "Text message"
     fill_in "Your phone number", with: "+12025551212"
     click_on "Continue"
+
+    expect(page).to have_text I18n.t('state_file.questions.sms_terms.edit.title')
+    click_on I18n.t("general.accept")
 
     expect(page).to have_text I18n.t('state_file.questions.terms_and_conditions.edit.title')
     click_on I18n.t("state_file.questions.terms_and_conditions.edit.accept")
@@ -148,6 +154,9 @@ RSpec.feature "editing direct file XML with the FederalInfoController", active_j
     check "Text message"
     fill_in "Your phone number", with: "+12025551212"
     click_on "Continue"
+
+    expect(page).to have_text I18n.t('state_file.questions.sms_terms.edit.title')
+    click_on I18n.t("general.accept")
 
     expect(page).to have_text I18n.t('state_file.questions.terms_and_conditions.edit.title')
     click_on I18n.t("state_file.questions.terms_and_conditions.edit.accept")

--- a/spec/features/state_file/id_grocery_credit_nested_followups_spec.rb
+++ b/spec/features/state_file/id_grocery_credit_nested_followups_spec.rb
@@ -32,6 +32,9 @@ RSpec.feature "Idaho Grocery Credit nested questions with followup", active_job:
       fill_in "Your phone number", with: "+12025551212"
       click_on "Continue"
 
+      expect(page).to have_text I18n.t('state_file.questions.sms_terms.edit.title')
+      click_on I18n.t("general.accept")
+
       click_on I18n.t("state_file.questions.terms_and_conditions.edit.accept")
 
       step_through_df_data_transfer("Transfer John mfj 8 deps")

--- a/spec/features/state_file/review_page_spec.rb
+++ b/spec/features/state_file/review_page_spec.rb
@@ -188,10 +188,15 @@ RSpec.feature "Completing a state file intake", active_job: true do
     click_on I18n.t('general.get_started'), id: "firstCta"
     step_through_eligibility_screener(us_state: state_code)
     step_through_initial_authentication(contact_preference: :email)
+
     check "Email"
     check "Text message"
     fill_in "Your phone number", with: "+12025551212"
     click_on "Continue"
+
+    expect(page).to have_text I18n.t('state_file.questions.sms_terms.edit.title')
+    click_on I18n.t("general.accept")
+
     expect(page).to have_text I18n.t('state_file.questions.terms_and_conditions.edit.title')
 
     intake = StateFile::StateInformationService.intake_class(state_code).last

--- a/spec/forms/state_file/sms_terms_form_spec.rb
+++ b/spec/forms/state_file/sms_terms_form_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe StateFile::SmsTermsForm do
+  let!(:intake) { create :state_file_az_intake }
+
+  describe "#save" do
+    context "consented_to_sms_terms is invalid" do
+      let(:invalid_params) { {} }
+
+      subject(:form) { described_class.new(intake, invalid_params) }
+
+      it "is not valid" do
+        form.valid?
+        expect(form).to_not be_valid
+      end
+    end
+
+    context "consented_to_sms_terms is valid" do
+      let(:invalid_params) do
+        {
+          consented_to_sms_terms: "yes"
+        }
+      end
+      subject(:form) { described_class.new(intake, invalid_params) }
+
+      it "validates the form" do
+        form.valid?
+        expect(form).to be_valid
+      end
+
+      it "updates the intake with the provided attributes" do
+        expect { form.save }.to change(intake, :consented_to_sms_terms).from("unfilled").to("yes")
+      end
+    end
+  end
+end

--- a/spec/lib/navigation/state_file_az_question_navigation_spec.rb
+++ b/spec/lib/navigation/state_file_az_question_navigation_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Navigation::StateFileAzQuestionNavigation do
         StateFile::Questions::VerificationCodeController,
         StateFile::Questions::CodeVerifiedController,
         StateFile::Questions::NotificationPreferencesController,
+        StateFile::Questions::SmsTermsController,
         StateFile::Questions::TermsAndConditionsController,
         StateFile::Questions::DeclinedTermsAndConditionsController,
         StateFile::Questions::InitiateDataTransferController,

--- a/spec/lib/navigation/state_file_ny_question_navigation_spec.rb
+++ b/spec/lib/navigation/state_file_ny_question_navigation_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Navigation::StateFileNyQuestionNavigation do
         StateFile::Questions::VerificationCodeController,
         StateFile::Questions::CodeVerifiedController,
         StateFile::Questions::NotificationPreferencesController,
+        StateFile::Questions::SmsTermsController,
         StateFile::Questions::TermsAndConditionsController,
         StateFile::Questions::DeclinedTermsAndConditionsController,
         StateFile::Questions::InitiateDataTransferController,

--- a/spec/models/state_file_az_intake_spec.rb
+++ b/spec/models/state_file_az_intake_spec.rb
@@ -10,6 +10,7 @@
 #  charitable_cash_amount                 :decimal(12, 2)
 #  charitable_contributions               :integer          default("unfilled"), not null
 #  charitable_noncash_amount              :decimal(12, 2)
+#  consented_to_sms_terms                 :integer          default("unfilled"), not null
 #  consented_to_terms_and_conditions      :integer          default("unfilled"), not null
 #  contact_preference                     :integer          default("unfilled"), not null
 #  current_sign_in_at                     :datetime

--- a/spec/models/state_file_id_intake_spec.rb
+++ b/spec/models/state_file_id_intake_spec.rb
@@ -7,6 +7,7 @@
 #  account_type                                   :integer          default("unfilled"), not null
 #  american_red_cross_fund_donation               :decimal(12, 2)
 #  childrens_trust_fund_donation                  :decimal(12, 2)
+#  consented_to_sms_terms                         :integer          default("unfilled"), not null
 #  consented_to_terms_and_conditions              :integer          default("unfilled"), not null
 #  contact_preference                             :integer          default("unfilled"), not null
 #  current_sign_in_at                             :datetime

--- a/spec/models/state_file_md_intake_spec.rb
+++ b/spec/models/state_file_md_intake_spec.rb
@@ -216,4 +216,22 @@ RSpec.describe StateFileMdIntake, type: :model do
       end
     end
   end
+
+  describe "#address" do
+  context "a confirmed address" do
+    subject(:intake) { create :state_file_md_intake, :with_confirmed_address }
+
+      it "returns the permanent address" do
+        expect(intake.address).to eq("321 Main St Apt 2, Baltimore, MD 21202")
+      end
+    end
+
+    context "an unconfirmed address" do
+      subject(:intake) { create :state_file_md_intake, :with_permanent_address }
+
+      it "returns the submitted permanent address" do
+        expect(intake.address).to eq("123 Main St Apt 1, Baltimore MD, 21201")
+      end
+    end
+  end
 end

--- a/spec/models/state_file_md_intake_spec.rb
+++ b/spec/models/state_file_md_intake_spec.rb
@@ -13,6 +13,7 @@
 #  bank_authorization_confirmed               :integer          default("unfilled"), not null
 #  city                                       :string
 #  confirmed_permanent_address                :integer          default("unfilled"), not null
+#  consented_to_sms_terms                     :integer          default("unfilled"), not null
 #  consented_to_terms_and_conditions          :integer          default("unfilled"), not null
 #  contact_preference                         :integer          default("unfilled"), not null
 #  current_sign_in_at                         :datetime

--- a/spec/models/state_file_nc_intake_spec.rb
+++ b/spec/models/state_file_nc_intake_spec.rb
@@ -6,6 +6,7 @@
 #  account_number                    :string
 #  account_type                      :integer          default("unfilled"), not null
 #  city                              :string
+#  consented_to_sms_terms            :integer          default("unfilled"), not null
 #  consented_to_terms_and_conditions :integer          default("unfilled"), not null
 #  contact_preference                :integer          default("unfilled"), not null
 #  current_sign_in_at                :datetime

--- a/spec/models/state_file_nj_intake_spec.rb
+++ b/spec/models/state_file_nj_intake_spec.rb
@@ -7,6 +7,7 @@
 #  account_type                                           :integer          default("unfilled"), not null
 #  claimed_as_dep                                         :integer
 #  claimed_as_eitc_qualifying_child                       :integer          default("unfilled"), not null
+#  consented_to_sms_terms                                 :integer          default("unfilled"), not null
 #  consented_to_terms_and_conditions                      :integer          default("unfilled"), not null
 #  contact_preference                                     :integer          default("unfilled"), not null
 #  county                                                 :string

--- a/spec/models/state_file_ny_intake_spec.rb
+++ b/spec/models/state_file_ny_intake_spec.rb
@@ -7,6 +7,7 @@
 #  account_type                       :integer          default("unfilled"), not null
 #  confirmed_permanent_address        :integer          default("unfilled"), not null
 #  confirmed_third_party_designee     :integer          default("unfilled"), not null
+#  consented_to_sms_terms             :integer          default("unfilled"), not null
 #  consented_to_terms_and_conditions  :integer          default("unfilled"), not null
 #  contact_preference                 :integer          default("unfilled"), not null
 #  current_sign_in_at                 :datetime


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1291
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- added a `consented_to_sms_terms` flag to each state intake
- Add an sms terms that users must accept to proceed after setting notification preferences

## Screenshots (for visual changes)
![Screenshot 2024-12-04 at 5 07 43 PM](https://github.com/user-attachments/assets/dd503f2e-3aa3-48d2-89e7-0df19883fb29)


