### PR TITLE
FYST-1370 fix xml for 1099int

### DIFF
--- a/app/lib/submission_builder/state1099_int.rb
+++ b/app/lib/submission_builder/state1099_int.rb
@@ -13,19 +13,19 @@ module SubmissionBuilder
             xml.BusinessNameLine1Txt sanitize_for_xml(form1099int.payer.tr('-', ' '), 75)
           end
         end
-        xml.PayerEIN form1099int.payer_tin&.tr('-', '')
-        xml.RecipientSSN form1099int.recipient_tin.tr('-', '')
+        xml.PayerEIN form1099int.payer_tin&.tr('-', '') if form1099int.payer_tin
+        xml.RecipientSSN form1099int.recipient_tin.tr('-', '') if form1099int.recipient_tin
         recipient = if form1099int.recipient_tin.tr('-', '') == intake.primary.ssn
                       intake.primary
                     elsif form1099int.recipient_tin.tr('-', '') == intake.spouse.ssn
                       intake.spouse
                     end
         xml.RecipientName sanitize_for_xml(recipient.full_name)
-        xml.InterestIncome form1099int.amount_1099
-        xml.InterestOnBondsAndTreasury form1099int.interest_on_government_bonds
-        xml.FederalTaxWithheld form1099int.tax_withheld
-        xml.TaxExemptInterest form1099int.tax_exempt_interest
-        xml.TaxExemptCUSIP form1099int.tax_exempt_and_tax_credit_bond_cusip_number
+        xml.InterestIncome form1099int.amount_1099 if form1099int.amount_1099
+        xml.InterestOnBondsAndTreasury form1099int.interest_on_government_bonds if form1099int.interest_on_government_bonds
+        xml.FederalTaxWithheld form1099int.tax_withheld if form1099int.tax_withheld
+        xml.TaxExemptInterest form1099int.tax_exempt_interest if form1099int.tax_exempt_interest
+        xml.TaxExemptCUSIP form1099int.tax_exempt_and_tax_credit_bond_cusip_number if form1099int.tax_exempt_and_tax_credit_bond_cusip_number
       end
     end
   end

--- a/spec/lib/submission_builder/state1099_int_spec.rb
+++ b/spec/lib/submission_builder/state1099_int_spec.rb
@@ -13,14 +13,17 @@ describe SubmissionBuilder::State1099Int do
     it "generates xml with the right values" do
       expect(doc.at("PayerName")['payerNameControl']).to eq "BANK"
       expect(doc.at("PayerName/BusinessNameLine1Txt").text).to eq "Bank of Potatoes"
-      expect(doc.at("PayerEIN").text).to eq ""
       expect(doc.at("RecipientSSN").text).to eq "400005957"
       expect(doc.at("RecipientName").text).to eq "Miguel Estrada"
       expect(doc.at("InterestIncome").text).to eq "550.0"
       expect(doc.at("InterestOnBondsAndTreasury").text).to eq "50.0"
       expect(doc.at("FederalTaxWithheld").text).to eq "0.0"
       expect(doc.at("TaxExemptInterest").text).to eq "0"
-      expect(doc.at("TaxExemptCUSIP").text).to eq ""
+    end
+
+    it "does not add nodes for values that are nil" do
+      expect(doc.at("PayerEIN")).to be_nil
+      expect(doc.at("TaxExemptCUSIP")).to be_nil
     end
   end
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/FYST-1370

## Is PM acceptance required? 
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Fix 1099int xml so that it is only filled for fields where values are present

## How to test?
- Units tests pass
- Persona felicity was tested and no xml errors were shown

## Screenshots (for visual changes)
- Before
<img width="645" alt="Screenshot 2024-12-05 at 2 38 05 PM" src="https://github.com/user-attachments/assets/74308856-5eea-4838-a17f-b9240f2e7ef0">

- After
<img width="640" alt="Screenshot 2024-12-05 at 2 37 43 PM" src="https://github.com/user-attachments/assets/a02a34bb-34a9-4b24-bd26-6a91eeb400e6">


