### PR TITLE
Change path to unemployment controller to index path instead of edit

### DIFF
--- a/app/views/state_file/questions/income_review/edit.html.erb
+++ b/app/views/state_file/questions/income_review/edit.html.erb
@@ -35,7 +35,7 @@
             <p class="spacing-below-5"><%= state_1099g.payer_name %></p>
             <%= link_to t(".review_and_edit_state_info"),
                         StateFile::Questions::UnemploymentController.to_path_helper(
-                          action: :edit,
+                          action: :index,
                           id: state_1099g.id,
                           return_to_review: params[:return_to_review]
                         ),

--- a/spec/controllers/state_file/questions/income_review_controller_spec.rb
+++ b/spec/controllers/state_file/questions/income_review_controller_spec.rb
@@ -81,10 +81,10 @@ RSpec.describe StateFile::Questions::IncomeReviewController do
           expect(response.body).to have_text "Unemployment benefits (1099-G)"
           expect(response.body).to have_text "Payeur"
           expect(response.body).to have_text "Filer Oftaxes"
-          expect(response.body).to have_link(href: edit_unemployment_path(id: primary_1099g.id))
+          expect(response.body).to have_link(href: unemployment_index_path(id: primary_1099g.id))
           expect(response.body).to have_text "Payure"
           expect(response.body).to have_text "Mary Taxfiler"
-          expect(response.body).to have_link(href: edit_unemployment_path(id: spouse_1099g.id))
+          expect(response.body).to have_link(href: unemployment_index_path(id: spouse_1099g.id))
         end
       end
 

--- a/spec/features/state_file/review_page_spec.rb
+++ b/spec/features/state_file/review_page_spec.rb
@@ -92,6 +92,12 @@ RSpec.feature "Completing a state file intake", active_job: true do
           click_on I18n.t("state_file.questions.income_review.edit.review_and_edit_state_info")
         end
 
+        # 1099G index page
+        expect(page).to have_text I18n.t("state_file.questions.unemployment.index.lets_review")
+        within ".form1099__details" do
+          click_link I18n.t("general.edit")
+        end
+
         # 1099G edit page
         expect(page).to have_text strip_html_tags(I18n.t("state_file.questions.unemployment.edit.title", count: intake.filer_count, year: MultiTenantService.statefile.current_tax_year))
         fill_in strip_html_tags(I18n.t("state_file.questions.unemployment.edit.payer_name")), with: "beepboop"


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/FYST-1409
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Change path to unemployment controller to index path instead of edit
## How to test?
- Add a persona with unemployment data (for ex. Ida from Idaho) 
- Check at the income page that the unemployment link goes to the index page
- Specify any relevant testing environments used (e.g., development, staging, demo, Heroku).
