### PR TITLE
Nj 172 2024pdf

### DIFF
--- a/app/lib/pdf_filler/nj1040_pdf.rb
+++ b/app/lib/pdf_filler/nj1040_pdf.rb
@@ -4,7 +4,7 @@ module PdfFiller
     include StateFile::NjPdfHelper
 
     def source_pdf_name
-      "nj1040-TY2023"
+      "nj1040-TY2024"
     end
 
     def initialize(submission)

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -89,15 +89,15 @@ RSpec.describe PdfFiller::Nj1040Pdf do
         end
 
         it 'leaves married filing separately spouse SSN fields blank' do
-          expect(pdf_fields["undefined_7"]).to eq ""
-          expect(pdf_fields["undefined_8"]).to eq ""
-          expect(pdf_fields["Enter spousesCU partners SSN"]).to eq ""
-          expect(pdf_fields["Text31"]).to eq ""
-          expect(pdf_fields["Text32"]).to eq ""
-          expect(pdf_fields["Text33"]).to eq ""
-          expect(pdf_fields["Text34"]).to eq ""
-          expect(pdf_fields["Text35"]).to eq ""
-          expect(pdf_fields["Text36"]).to eq ""
+          expect(pdf_fields["undefined_7"]).to eq nil
+          expect(pdf_fields["undefined_8"]).to eq nil
+          expect(pdf_fields["Enter spousesCU partners SSN"]).to eq nil
+          expect(pdf_fields["Text31"]).to eq nil
+          expect(pdf_fields["Text32"]).to eq nil
+          expect(pdf_fields["Text33"]).to eq nil
+          expect(pdf_fields["Text34"]).to eq nil
+          expect(pdf_fields["Text35"]).to eq nil
+          expect(pdf_fields["Text36"]).to eq nil
         end
       end
 
@@ -131,15 +131,15 @@ RSpec.describe PdfFiller::Nj1040Pdf do
         end
 
         it 'leaves header spouse SSN fields blank' do
-          expect(pdf_fields["undefined_3"]).to eq ""
-          expect(pdf_fields["undefined_4"]).to eq ""
-          expect(pdf_fields["undefined_5"]).to eq ""
-          expect(pdf_fields["Text9"]).to eq ""
-          expect(pdf_fields["Text10"]).to eq ""
-          expect(pdf_fields["Text11"]).to eq ""
-          expect(pdf_fields["Text12"]).to eq ""
-          expect(pdf_fields["Text13"]).to eq ""
-          expect(pdf_fields["Text14"]).to eq ""
+          expect(pdf_fields["undefined_3"]).to eq nil
+          expect(pdf_fields["undefined_4"]).to eq nil
+          expect(pdf_fields["undefined_5"]).to eq nil
+          expect(pdf_fields["Text9"]).to eq nil
+          expect(pdf_fields["Text10"]).to eq nil
+          expect(pdf_fields["Text11"]).to eq nil
+          expect(pdf_fields["Text12"]).to eq nil
+          expect(pdf_fields["Text13"]).to eq nil
+          expect(pdf_fields["Text14"]).to eq nil
         end
       end
     end
@@ -524,9 +524,9 @@ RSpec.describe PdfFiller::Nj1040Pdf do
             )
           }
           it "does not fill in" do
-            expect(pdf_fields["Text47"]).to eq ""
-            expect(pdf_fields["undefined_12"]).to eq ""
-            expect(pdf_fields["x  1500"]).to eq ""
+            expect(pdf_fields["Text47"]).to eq nil
+            expect(pdf_fields["undefined_12"]).to eq nil
+            expect(pdf_fields["x  1500"]).to eq nil
           end
         end
 
@@ -568,9 +568,9 @@ RSpec.describe PdfFiller::Nj1040Pdf do
             )
           }
           it "does not fill in" do
-            expect(pdf_fields["Text48"]).to eq ""
-            expect(pdf_fields["undefined_13"]).to eq ""
-            expect(pdf_fields["x  1500_2"]).to eq ""
+            expect(pdf_fields["Text48"]).to eq nil
+            expect(pdf_fields["undefined_13"]).to eq nil
+            expect(pdf_fields["x  1500_2"]).to eq nil
           end
         end
 
@@ -623,9 +623,9 @@ RSpec.describe PdfFiller::Nj1040Pdf do
             )
           }
           it 'does not fill count nor exemption total' do
-            expect(pdf_fields["Text49"]).to eq ""
-            expect(pdf_fields["undefined_14"]).to eq ""
-            expect(pdf_fields["x  1000_4"]).to eq ""
+            expect(pdf_fields["Text49"]).to eq nil
+            expect(pdf_fields["undefined_14"]).to eq nil
+            expect(pdf_fields["x  1000_4"]).to eq nil
           end
         end
       end
@@ -698,20 +698,20 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           expect(pdf_fields["Text62"]).to eq "3"
 
           # dependent 2
-          expect(pdf_fields["Last Name First Name Middle Initial 2"]).to eq ""
-          expect(pdf_fields["undefined_21"]).to eq ""
-          expect(pdf_fields["undefined_22"]).to eq ""
-          expect(pdf_fields["undefined_23"]).to eq ""
-          expect(pdf_fields["undefined_24"]).to eq ""
-          expect(pdf_fields["Text65"]).to eq ""
-          expect(pdf_fields["Text66"]).to eq ""
-          expect(pdf_fields["Text67"]).to eq ""
-          expect(pdf_fields["Text68"]).to eq ""
-          expect(pdf_fields["Text69"]).to eq ""
-          expect(pdf_fields["Text70"]).to eq ""
-          expect(pdf_fields["Text71"]).to eq ""
-          expect(pdf_fields["Text72"]).to eq ""
-          expect(pdf_fields["Text73"]).to eq ""
+          expect(pdf_fields["Last Name First Name Middle Initial 2"]).to eq nil
+          expect(pdf_fields["undefined_21"]).to eq nil
+          expect(pdf_fields["undefined_22"]).to eq nil
+          expect(pdf_fields["undefined_23"]).to eq nil
+          expect(pdf_fields["undefined_24"]).to eq nil
+          expect(pdf_fields["Text65"]).to eq nil
+          expect(pdf_fields["Text66"]).to eq nil
+          expect(pdf_fields["Text67"]).to eq nil
+          expect(pdf_fields["Text68"]).to eq nil
+          expect(pdf_fields["Text69"]).to eq nil
+          expect(pdf_fields["Text70"]).to eq nil
+          expect(pdf_fields["Text71"]).to eq nil
+          expect(pdf_fields["Text72"]).to eq nil
+          expect(pdf_fields["Text73"]).to eq nil
         end
       end
 
@@ -817,16 +817,16 @@ RSpec.describe PdfFiller::Nj1040Pdf do
         let(:intake) { create(:state_file_nj_intake, :df_data_minimal) }
 
         it "does not fill in any box on line 15" do
-          expect(pdf_fields["15"]).to eq ""
-          expect(pdf_fields["undefined_36"]).to eq ""
-          expect(pdf_fields["undefined_37"]).to eq ""
-          expect(pdf_fields["undefined_38"]).to eq ""
-          expect(pdf_fields["Text100"]).to eq ""
-          expect(pdf_fields["Text101"]).to eq ""
-          expect(pdf_fields["Text103"]).to eq ""
-          expect(pdf_fields["Text104"]).to eq ""
-          expect(pdf_fields["Text105"]).to eq ""
-          expect(pdf_fields["Text106"]).to eq ""
+          expect(pdf_fields["15"]).to eq nil
+          expect(pdf_fields["undefined_36"]).to eq nil
+          expect(pdf_fields["undefined_37"]).to eq nil
+          expect(pdf_fields["undefined_38"]).to eq nil
+          expect(pdf_fields["Text100"]).to eq nil
+          expect(pdf_fields["Text101"]).to eq nil
+          expect(pdf_fields["Text103"]).to eq nil
+          expect(pdf_fields["Text104"]).to eq nil
+          expect(pdf_fields["Text105"]).to eq nil
+          expect(pdf_fields["Text106"]).to eq nil
         end
       end
 
@@ -897,7 +897,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
            "undefined_41",
            "undefined_40",
            "undefined_39",
-           "undefined_43"].each { |pdf_field| expect(pdf_fields[pdf_field]).to eq "" }
+           "undefined_43"].each { |pdf_field| expect(pdf_fields[pdf_field]).to eq nil }
         end
       end 
   
@@ -931,7 +931,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
            "undefined_44",
            "16a",
            "undefined_42",
-           "16b"].each { |pdf_field| expect(pdf_fields[pdf_field]).to eq "" }
+           "16b"].each { |pdf_field| expect(pdf_fields[pdf_field]).to eq nil }
         end
       end
 
@@ -1055,20 +1055,20 @@ RSpec.describe PdfFiller::Nj1040Pdf do
 
         it "does not fill in any of the boxes on line 27" do
           # millions
-          expect(pdf_fields["263"]).to eq ""
-          expect(pdf_fields["27"]).to eq ""
-          expect(pdf_fields["183"]).to eq ""
+          expect(pdf_fields["263"]).to eq nil
+          expect(pdf_fields["27"]).to eq nil
+          expect(pdf_fields["183"]).to eq nil
           # thousands
-          expect(pdf_fields["undefined_78"]).to eq ""
-          expect(pdf_fields["184"]).to eq ""
-          expect(pdf_fields["185"]).to eq ""
+          expect(pdf_fields["undefined_78"]).to eq nil
+          expect(pdf_fields["184"]).to eq nil
+          expect(pdf_fields["185"]).to eq nil
           # hundreds
-          expect(pdf_fields["undefined_79"]).to eq ""
-          expect(pdf_fields["186"]).to eq ""
-          expect(pdf_fields["187"]).to eq ""
+          expect(pdf_fields["undefined_79"]).to eq nil
+          expect(pdf_fields["186"]).to eq nil
+          expect(pdf_fields["187"]).to eq nil
           # decimals
-          expect(pdf_fields["undefined_80"]).to eq ""
-          expect(pdf_fields["188"]).to eq ""
+          expect(pdf_fields["undefined_80"]).to eq nil
+          expect(pdf_fields["188"]).to eq nil
         end
       end
     end
@@ -1105,20 +1105,20 @@ RSpec.describe PdfFiller::Nj1040Pdf do
 
         it "does not fill in any of the boxes on line 29" do
           # millions
-          expect(pdf_fields["270"]).to eq ""
-          expect(pdf_fields["29"]).to eq ""
-          expect(pdf_fields["204"]).to eq ""
+          expect(pdf_fields["270"]).to eq nil
+          expect(pdf_fields["29"]).to eq nil
+          expect(pdf_fields["204"]).to eq nil
           # thousands
-          expect(pdf_fields["undefined_87"]).to eq ""
-          expect(pdf_fields["205"]).to eq ""
-          expect(pdf_fields["206"]).to eq ""
+          expect(pdf_fields["undefined_87"]).to eq nil
+          expect(pdf_fields["205"]).to eq nil
+          expect(pdf_fields["206"]).to eq nil
           # hundreds
-          expect(pdf_fields["undefined_88"]).to eq ""
-          expect(pdf_fields["207"]).to eq ""
-          expect(pdf_fields["208"]).to eq ""
+          expect(pdf_fields["undefined_88"]).to eq nil
+          expect(pdf_fields["207"]).to eq nil
+          expect(pdf_fields["208"]).to eq nil
           # decimals
-          expect(pdf_fields["undefined_89"]).to eq ""
-          expect(pdf_fields["209"]).to eq ""
+          expect(pdf_fields["undefined_89"]).to eq nil
+          expect(pdf_fields["209"]).to eq nil
         end
       end
     end
@@ -1157,16 +1157,16 @@ RSpec.describe PdfFiller::Nj1040Pdf do
         }
         it "does not fill line 31" do
           # thousands
-          expect(pdf_fields["31"]).to eq ""
-          expect(pdf_fields["215"]).to eq ""
-          expect(pdf_fields["216"]).to eq ""
+          expect(pdf_fields["31"]).to eq nil
+          expect(pdf_fields["215"]).to eq nil
+          expect(pdf_fields["216"]).to eq nil
           # hundreds
-          expect(pdf_fields["undefined_92"]).to eq ""
-          expect(pdf_fields["217"]).to eq ""
-          expect(pdf_fields["218"]).to eq ""
+          expect(pdf_fields["undefined_92"]).to eq nil
+          expect(pdf_fields["217"]).to eq nil
+          expect(pdf_fields["218"]).to eq nil
           # decimals
-          expect(pdf_fields["undefined_93"]).to eq ""
-          expect(pdf_fields["219"]).to eq ""
+          expect(pdf_fields["undefined_93"]).to eq nil
+          expect(pdf_fields["219"]).to eq nil
         end
       end
     end
@@ -1294,16 +1294,16 @@ RSpec.describe PdfFiller::Nj1040Pdf do
         end
 
         it "does not insert property tax calculation on line 40a" do
-          expect(pdf_fields["39"]).to eq ""
-          expect(pdf_fields["280"]).to eq ""
-          expect(pdf_fields["undefined_112"]).to eq ""
-          expect(pdf_fields["281"]).to eq ""
-          expect(pdf_fields["282"]).to eq ""
-          expect(pdf_fields["undefined_113"]).to eq ""
-          expect(pdf_fields["283"]).to eq ""
-          expect(pdf_fields["37"]).to eq ""
-          expect(pdf_fields["245"]).to eq ""
-          expect(pdf_fields["24539a#2"]).to eq ""
+          expect(pdf_fields["39"]).to eq nil
+          expect(pdf_fields["280"]).to eq nil
+          expect(pdf_fields["undefined_112"]).to eq nil
+          expect(pdf_fields["281"]).to eq nil
+          expect(pdf_fields["282"]).to eq nil
+          expect(pdf_fields["undefined_113"]).to eq nil
+          expect(pdf_fields["283"]).to eq nil
+          expect(pdf_fields["37"]).to eq nil
+          expect(pdf_fields["245"]).to eq nil
+          expect(pdf_fields["24539a#2"]).to eq nil
         end
       end
 
@@ -1318,16 +1318,16 @@ RSpec.describe PdfFiller::Nj1040Pdf do
         end
 
         it "does not insert property tax calculation on line 40a" do
-          expect(pdf_fields["39"]).to eq ""
-          expect(pdf_fields["280"]).to eq ""
-          expect(pdf_fields["undefined_112"]).to eq ""
-          expect(pdf_fields["281"]).to eq ""
-          expect(pdf_fields["282"]).to eq ""
-          expect(pdf_fields["undefined_113"]).to eq ""
-          expect(pdf_fields["283"]).to eq ""
-          expect(pdf_fields["37"]).to eq ""
-          expect(pdf_fields["245"]).to eq ""
-          expect(pdf_fields["24539a#2"]).to eq ""
+          expect(pdf_fields["39"]).to eq nil
+          expect(pdf_fields["280"]).to eq nil
+          expect(pdf_fields["undefined_112"]).to eq nil
+          expect(pdf_fields["281"]).to eq nil
+          expect(pdf_fields["282"]).to eq nil
+          expect(pdf_fields["undefined_113"]).to eq nil
+          expect(pdf_fields["283"]).to eq nil
+          expect(pdf_fields["37"]).to eq nil
+          expect(pdf_fields["245"]).to eq nil
+          expect(pdf_fields["24539a#2"]).to eq nil
         end
       end
     end
@@ -1369,15 +1369,15 @@ RSpec.describe PdfFiller::Nj1040Pdf do
 
         it "does not fill fields" do
           # thousands
-          expect(pdf_fields["undefined_116"]).to eq ""
-          expect(pdf_fields["41"]).to eq ""
+          expect(pdf_fields["undefined_116"]).to eq nil
+          expect(pdf_fields["41"]).to eq nil
           # hundreds
-          expect(pdf_fields["undefined_117"]).to eq ""
-          expect(pdf_fields["undefined_118"]).to eq ""
-          expect(pdf_fields["Text1"]).to eq ""
+          expect(pdf_fields["undefined_117"]).to eq nil
+          expect(pdf_fields["undefined_118"]).to eq nil
+          expect(pdf_fields["Text1"]).to eq nil
           # decimals
-          expect(pdf_fields["Text2"]).to eq ""
-          expect(pdf_fields["Text18"]).to eq ""
+          expect(pdf_fields["Text2"]).to eq nil
+          expect(pdf_fields["Text18"]).to eq nil
         end
       end
 
@@ -1391,15 +1391,15 @@ RSpec.describe PdfFiller::Nj1040Pdf do
 
         it "does not fill fields" do
           # thousands
-          expect(pdf_fields["undefined_116"]).to eq ""
-          expect(pdf_fields["41"]).to eq ""
+          expect(pdf_fields["undefined_116"]).to eq nil
+          expect(pdf_fields["41"]).to eq nil
           # hundreds
-          expect(pdf_fields["undefined_117"]).to eq ""
-          expect(pdf_fields["undefined_118"]).to eq ""
-          expect(pdf_fields["Text1"]).to eq ""
+          expect(pdf_fields["undefined_117"]).to eq nil
+          expect(pdf_fields["undefined_118"]).to eq nil
+          expect(pdf_fields["Text1"]).to eq nil
           # decimals
-          expect(pdf_fields["Text2"]).to eq ""
-          expect(pdf_fields["Text18"]).to eq ""
+          expect(pdf_fields["Text2"]).to eq nil
+          expect(pdf_fields["Text18"]).to eq nil
         end
       end
 
@@ -1414,15 +1414,15 @@ RSpec.describe PdfFiller::Nj1040Pdf do
 
         it "does not fill fields" do
           # thousands
-          expect(pdf_fields["undefined_116"]).to eq ""
-          expect(pdf_fields["41"]).to eq ""
+          expect(pdf_fields["undefined_116"]).to eq nil
+          expect(pdf_fields["41"]).to eq nil
           # hundreds
-          expect(pdf_fields["undefined_117"]).to eq ""
-          expect(pdf_fields["undefined_118"]).to eq ""
-          expect(pdf_fields["Text1"]).to eq ""
+          expect(pdf_fields["undefined_117"]).to eq nil
+          expect(pdf_fields["undefined_118"]).to eq nil
+          expect(pdf_fields["Text1"]).to eq nil
           # decimals
-          expect(pdf_fields["Text2"]).to eq ""
-          expect(pdf_fields["Text18"]).to eq ""
+          expect(pdf_fields["Text2"]).to eq nil
+          expect(pdf_fields["Text18"]).to eq nil
         end
       end
     end
@@ -1594,23 +1594,23 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           expect(pdf_fields["Check Box147"]).to eq "Yes"
 
           # 53a
-          expect(pdf_fields["Check Box146aabb"]).to eq "Off"
+          expect(pdf_fields["Check Box146aabb"]).to eq nil
 
           # 53b
-          expect(pdf_fields["Check Box146aabbffdd"]).to eq "Off"
+          expect(pdf_fields["Check Box146aabbffdd"]).to eq nil
 
           # 53c amount
           # thousands
-          expect(pdf_fields["52"]).to eq ""
-          expect(pdf_fields["undefined_139"]).to eq ""
-          expect(pdf_fields["undefined_140"]).to eq ""
+          expect(pdf_fields["52"]).to eq nil
+          expect(pdf_fields["undefined_139"]).to eq nil
+          expect(pdf_fields["undefined_140"]).to eq nil
           # hundreds
-          expect(pdf_fields["Text141"]).to eq ""
-          expect(pdf_fields["Text142"]).to eq ""
-          expect(pdf_fields["Text143"]).to eq ""
+          expect(pdf_fields["Text141"]).to eq nil
+          expect(pdf_fields["Text142"]).to eq nil
+          expect(pdf_fields["Text143"]).to eq nil
           # decimals
-          expect(pdf_fields["Text144"]).to eq ""
-          expect(pdf_fields["Text145"]).to eq ""
+          expect(pdf_fields["Text144"]).to eq nil
+          expect(pdf_fields["Text145"]).to eq nil
         end
       end
 
@@ -1626,23 +1626,23 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           expect(pdf_fields["Check Box147"]).to eq "Off"
 
           # 53a
-          expect(pdf_fields["Check Box146aabb"]).to eq "Off"
+          expect(pdf_fields["Check Box146aabb"]).to eq nil
 
           # 53b
-          expect(pdf_fields["Check Box146aabbffdd"]).to eq "Off"
+          expect(pdf_fields["Check Box146aabbffdd"]).to eq nil
 
           # 53c amount
           # thousands
-          expect(pdf_fields["52"]).to eq ""
-          expect(pdf_fields["undefined_139"]).to eq ""
-          expect(pdf_fields["undefined_140"]).to eq ""
+          expect(pdf_fields["52"]).to eq nil
+          expect(pdf_fields["undefined_139"]).to eq nil
+          expect(pdf_fields["undefined_140"]).to eq nil
           # hundreds
-          expect(pdf_fields["Text141"]).to eq ""
-          expect(pdf_fields["Text142"]).to eq ""
-          expect(pdf_fields["Text143"]).to eq ""
+          expect(pdf_fields["Text141"]).to eq nil
+          expect(pdf_fields["Text142"]).to eq nil
+          expect(pdf_fields["Text143"]).to eq nil
           # decimals
-          expect(pdf_fields["Text144"]).to eq ""
-          expect(pdf_fields["Text145"]).to eq ""
+          expect(pdf_fields["Text144"]).to eq nil
+          expect(pdf_fields["Text145"]).to eq nil
         end
       end
     end
@@ -1706,19 +1706,19 @@ RSpec.describe PdfFiller::Nj1040Pdf do
 
         it "does not fill line 55" do
           # millions
-          expect(pdf_fields["undefined_1471qerw"]).to eq ""
-          expect(pdf_fields["undefined_114"]).to eq ""
+          expect(pdf_fields["undefined_1471qerw"]).to eq nil
+          expect(pdf_fields["undefined_114"]).to eq nil
           # thousands
-          expect(pdf_fields["undefined_143"]).to eq ""
-          expect(pdf_fields["undefined_144"]).to eq ""
-          expect(pdf_fields["undefined_145"]).to eq ""
+          expect(pdf_fields["undefined_143"]).to eq nil
+          expect(pdf_fields["undefined_144"]).to eq nil
+          expect(pdf_fields["undefined_145"]).to eq nil
           # hundreds
-          expect(pdf_fields["Text153"]).to eq ""
-          expect(pdf_fields["Text154"]).to eq ""
-          expect(pdf_fields["Text155"]).to eq ""
+          expect(pdf_fields["Text153"]).to eq nil
+          expect(pdf_fields["Text154"]).to eq nil
+          expect(pdf_fields["Text155"]).to eq nil
           # decimals
-          expect(pdf_fields["Text156"]).to eq ""
-          expect(pdf_fields["Text157"]).to eq ""
+          expect(pdf_fields["Text156"]).to eq nil
+          expect(pdf_fields["Text157"]).to eq nil
         end
       end
     end
@@ -1753,11 +1753,11 @@ RSpec.describe PdfFiller::Nj1040Pdf do
 
         it "does not fill property tax credit" do
           # hundreds
-          expect(pdf_fields["Text161"]).to eq ""
-          expect(pdf_fields["Text162"]).to eq ""
+          expect(pdf_fields["Text161"]).to eq nil
+          expect(pdf_fields["Text162"]).to eq nil
           # decimals
-          expect(pdf_fields["Text163"]).to eq ""
-          expect(pdf_fields["Text164"]).to eq ""
+          expect(pdf_fields["Text163"]).to eq nil
+          expect(pdf_fields["Text164"]).to eq nil
         end
       end
 
@@ -1807,19 +1807,19 @@ RSpec.describe PdfFiller::Nj1040Pdf do
 
         it "does not fill EstimatedPaymentTotal" do
           # millions
-          expect(pdf_fields["56!\#$$"]).to eq ""
-          expect(pdf_fields["56"]).to eq ""
+          expect(pdf_fields["56!\#$$"]).to eq nil
+          expect(pdf_fields["56"]).to eq nil
           # thousands
-          expect(pdf_fields["undefined_147"]).to eq ""
-          expect(pdf_fields["undefined_148"]).to eq ""
-          expect(pdf_fields["undefined_149"]).to eq ""
+          expect(pdf_fields["undefined_147"]).to eq nil
+          expect(pdf_fields["undefined_148"]).to eq nil
+          expect(pdf_fields["undefined_149"]).to eq nil
           # hundreds
-          expect(pdf_fields["Text160"]).to eq ""
-          expect(pdf_fields["55"]).to eq ""
-          expect(pdf_fields["undefined_146"]).to eq ""
+          expect(pdf_fields["Text160"]).to eq nil
+          expect(pdf_fields["55"]).to eq nil
+          expect(pdf_fields["undefined_146"]).to eq nil
           # decimals
-          expect(pdf_fields["Text158"]).to eq ""
-          expect(pdf_fields["Text159"]).to eq ""
+          expect(pdf_fields["Text158"]).to eq nil
+          expect(pdf_fields["Text159"]).to eq nil
         end
       end
     end
@@ -1847,7 +1847,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           expect(pdf_fields["Check Box168"]).to eq "Yes"
 
           # NJ CU checkbox
-          expect(pdf_fields["Check Box169"]).to eq "Off"
+          expect(pdf_fields["Check Box169"]).to eq nil
         end
       end
 
@@ -1875,7 +1875,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           expect(pdf_fields["Check Box168"]).to eq "Off"
 
           # NJ CU checkbox
-          expect(pdf_fields["Check Box169"]).to eq "Off"
+          expect(pdf_fields["Check Box169"]).to eq nil
         end
       end
 
@@ -1888,20 +1888,20 @@ RSpec.describe PdfFiller::Nj1040Pdf do
 
         it "does not fill line 58 and does not check any checkboxes" do
           # thousands
-          expect(pdf_fields["58"]).to eq ""
+          expect(pdf_fields["58"]).to eq nil
           # hundreds
-          expect(pdf_fields["undefined_152"]).to eq ""
-          expect(pdf_fields["undefined_153"]).to eq ""
-          expect(pdf_fields["Text170"]).to eq ""
+          expect(pdf_fields["undefined_152"]).to eq nil
+          expect(pdf_fields["undefined_153"]).to eq nil
+          expect(pdf_fields["Text170"]).to eq nil
           # decimals
-          expect(pdf_fields["Text171"]).to eq ""
-          expect(pdf_fields["Text172"]).to eq ""
+          expect(pdf_fields["Text171"]).to eq nil
+          expect(pdf_fields["Text172"]).to eq nil
 
           # federal checkbox
-          expect(pdf_fields["Check Box168"]).to eq "Off"
+          expect(pdf_fields["Check Box168"]).to eq nil
 
           # NJ CU checkbox
-          expect(pdf_fields["Check Box169"]).to eq "Off"
+          expect(pdf_fields["Check Box169"]).to eq nil
         end
       end
     end
@@ -1918,7 +1918,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
             "undefined_155",
             "undefined_154",
             "59"
-          ].each { |pdf_field| expect(pdf_fields[pdf_field]).to eq "" }
+          ].each { |pdf_field| expect(pdf_fields[pdf_field]).to eq nil }
         end
       end
 
@@ -1953,7 +1953,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
             "undefined_157",
             "undefined_156",
             "60"
-          ].each { |pdf_field| expect(pdf_fields[pdf_field]).to eq "" }
+          ].each { |pdf_field| expect(pdf_fields[pdf_field]).to eq nil }
         end
       end
 
@@ -2200,21 +2200,21 @@ RSpec.describe PdfFiller::Nj1040Pdf do
     describe "driver license/ID number" do
       context "primary ID not given" do
         it "leaves all boxes blank" do
-          expect(pdf_fields["Drivers License Number Voluntary Instructions page 44"]).to eq ""
-          expect(pdf_fields["Text246"]).to eq ""
-          expect(pdf_fields["Text247"]).to eq ""
-          expect(pdf_fields["Text248"]).to eq ""
-          expect(pdf_fields["Text249"]).to eq ""
-          expect(pdf_fields["Text250"]).to eq ""
-          expect(pdf_fields["Text251"]).to eq ""
-          expect(pdf_fields["Text252"]).to eq ""
-          expect(pdf_fields["Text253"]).to eq ""
-          expect(pdf_fields["Text254"]).to eq ""
-          expect(pdf_fields["Text255"]).to eq ""
-          expect(pdf_fields["Text256"]).to eq ""
-          expect(pdf_fields["Text257"]).to eq ""
-          expect(pdf_fields["Text258"]).to eq ""
-          expect(pdf_fields["Text259"]).to eq ""
+          expect(pdf_fields["Drivers License Number Voluntary Instructions page 44"]).to eq nil
+          expect(pdf_fields["Text246"]).to eq nil
+          expect(pdf_fields["Text247"]).to eq nil
+          expect(pdf_fields["Text248"]).to eq nil
+          expect(pdf_fields["Text249"]).to eq nil
+          expect(pdf_fields["Text250"]).to eq nil
+          expect(pdf_fields["Text251"]).to eq nil
+          expect(pdf_fields["Text252"]).to eq nil
+          expect(pdf_fields["Text253"]).to eq nil
+          expect(pdf_fields["Text254"]).to eq nil
+          expect(pdf_fields["Text255"]).to eq nil
+          expect(pdf_fields["Text256"]).to eq nil
+          expect(pdf_fields["Text257"]).to eq nil
+          expect(pdf_fields["Text258"]).to eq nil
+          expect(pdf_fields["Text259"]).to eq nil
         end
       end
 

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -989,6 +989,20 @@ RSpec.describe PdfFiller::Nj1040Pdf do
       end
 
       context "qualifying widow" do
+        # even though behavior is correct, values map this way
+        def map_spouse_death_year(input)
+          case input
+          when "0"
+            "Choice1"
+          when "1"
+            "Off"
+          when nil
+            ""
+          else
+            input
+          end
+        end
+
         context "spouse passed in the last year" do
           before do
             submission.data_source.direct_file_data.filing_status = 5
@@ -1001,7 +1015,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           end
 
           it "checks the one year prior spouse date of death" do
-            expect(pdf_fields["Group1qualwi5ab"]).to eq "1"
+            expect(pdf_fields["Group1qualwi5ab"]).to eq map_spouse_death_year("1")
           end
         end
 
@@ -1017,7 +1031,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           end
 
           it "checks the two years prior spouse date of death" do
-            expect(pdf_fields["Group1qualwi5ab"]).to eq "0"
+            expect(pdf_fields["Group1qualwi5ab"]).to eq map_spouse_death_year("0")
           end
         end
       end


### PR DESCRIPTION
## Link to pivotal/JIRA issue

https://github.com/newjersey/affordability-pm/issues/172

## Is PM acceptance required?
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- In the implementation, it was actually a clean swap!
- In the tests, 99% of the updates needed were just a different type of empty expectation (`nil` instead of `""` when a field is not set)
- The one weird field that I was never able to really figure out is `Group1qualwi5ab`, which is the checkbox for the spouse's year of death when QSS.
  -  I manually checked that the field actually still behaves correctly (it does, screenshots below) and ended up adjusting the expectations to what the values become. Even if they aren't what I would normally expect, there is a weird predictability to them so we can still test on them.
  
## How to test?
- All cases and values should appear the same, just on 2024 PDF now.

## Screenshots (for visual changes)
Here is the PDF still filling out correctly for the Spouse year of death:

Input is `"0"`, meaning `"TwoYearPrior"`. Output is `"Choice1"` and the below:
<img width="536" alt="image" src="https://github.com/user-attachments/assets/049f51de-d942-4f06-b90d-319c0e7f86df">

---

Input is `"1"`, meaning `"LastYear"`. Output is `"Off"` and the below:
<img width="582" alt="image" src="https://github.com/user-attachments/assets/5f7cfe9d-9f23-417e-8ed6-8dad39ddfe52">

---

Input is `nil`, meaning not that filing status. Output is `""` and the below:
<img width="561" alt="image" src="https://github.com/user-attachments/assets/36a5bab9-a34a-4bfc-8079-5541cb586643">
