### PR TITLE
FYST-1421 Allow ID FAQ Creation

### DIFF
--- a/app/models/faq_category.rb
+++ b/app/models/faq_category.rb
@@ -22,7 +22,7 @@ class FaqCategory < ApplicationRecord
   has_rich_text :description_en
   has_rich_text :description_es
 
-  enum product_type: { gyr: 0, state_file_ny: 1, state_file_az: 2, state_file_nc: 3, state_file_md: 4, state_file_nj: 5 }, _prefix: :product_type
+  enum product_type: { gyr: 0, state_file_ny: 1, state_file_az: 2, state_file_nc: 3, state_file_md: 4, state_file_nj: 5, state_file_id: 6 }, _prefix: :product_type
 
   def name(locale)
     case locale


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1421
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Added `state_file_id` as an enum option for `product_type`
## How to test?
- Describe the testing approach taken to verify the changes, including:
  - Wrote tests to make sure we catch this in the future
  - Also verified making ID FaqCategory and FaqItem on localhost
- Specify any relevant testing environments used (e.g., development, staging, demo, Heroku).
- Risk Assessment
  - Since NJ requires special permissions to create FAQ, I did not add a test for this state. Could spend a few minutes making that but felt out of scope, since all I'm trying to do is make sure we don't add any _new_ states that we maintain without capacity to create faqs.
## Screenshots (for visual changes)
Before:
<img width="727" alt="Screenshot 2024-12-09 at 9 38 39 PM" src="https://github.com/user-attachments/assets/cd4e7b7f-7e27-46d8-9c71-925b0a0283f1">

After:
<img width="1609" alt="Screenshot 2024-12-09 at 9 55 38 PM" src="https://github.com/user-attachments/assets/41b1f5df-1c71-4a6b-9e5a-d8cdbfb2b13e">
