### PR TITLE
Nj 199 qss year

### DIFF
--- a/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
+++ b/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
@@ -43,9 +43,9 @@ module SubmissionBuilder
                       xml.QualWidOrWider do
                         xml.QualWidOrWiderSurvCuPartner 'X'
                         case yod
-                        when MultiTenantService.new(:statefile).current_tax_year.to_s
-                          xml.LastYear 'X'
                         when (MultiTenantService.new(:statefile).current_tax_year - 1).to_s
+                          xml.LastYear 'X'
+                        when (MultiTenantService.new(:statefile).current_tax_year - 2).to_s
                           xml.TwoYearPrior 'X'
                         end
                       end

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -1006,7 +1006,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
         context "spouse passed in the last year" do
           before do
             submission.data_source.direct_file_data.filing_status = 5
-            date_within_prior_year = "#{MultiTenantService.new(:statefile).current_tax_year}-09-30"
+            date_within_prior_year = "#{MultiTenantService.new(:statefile).current_tax_year - 1}-09-30"
             submission.data_source.direct_file_data.spouse_date_of_death = date_within_prior_year
           end
 
@@ -1022,7 +1022,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
         context "spouse passed two years prior" do
           before do
             submission.data_source.direct_file_data.filing_status = 5
-            date_two_years_prior = "#{MultiTenantService.new(:statefile).current_tax_year - 1}-09-30"
+            date_two_years_prior = "#{MultiTenantService.new(:statefile).current_tax_year - 2}-09-30"
             submission.data_source.direct_file_data.spouse_date_of_death = date_two_years_prior
           end
 

--- a/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
@@ -213,9 +213,9 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
     context "qualifying widow/er filers" do
       let(:intake) { create(:state_file_nj_intake, filing_status: "qualifying_widow") }
       
-      context "when spouse passed last year" do
+      context "when spouse passed in previous calendar year" do
         before do
-          date_within_prior_year = "#{MultiTenantService.new(:statefile).current_tax_year}-09-30"
+          date_within_prior_year = "#{MultiTenantService.new(:statefile).current_tax_year - 1}-09-30"
           submission.data_source.direct_file_data.spouse_date_of_death = date_within_prior_year
         end
   
@@ -233,7 +233,7 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
 
       context "when spouse passed two years prior" do
         before do
-          date_within_prior_year = "#{MultiTenantService.new(:statefile).current_tax_year - 1}-09-30"
+          date_within_prior_year = "#{MultiTenantService.new(:statefile).current_tax_year - 2}-09-30"
           submission.data_source.direct_file_data.spouse_date_of_death = date_within_prior_year
         end
   


### PR DESCRIPTION
## Link to pivotal/JIRA issue

https://github.com/newjersey/affordability-pm/issues/199

## Is PM acceptance required?
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Adjusted the year logic by one
- Decoupled downstream tests from calculator while I was at it
## How to test?

1. Import the Qualified widow profile. Notice <SpouseDeathDt>2022-06-08</SpouseDeathDt> means spouse death in 2022.

2. Complete the rest of the return in any way

3. Notice the XML now contains TwoYearPrior
Image

4. Notice the PDF has the 2022 box checked

## Screenshots (for visual changes)

<img width="550" alt="image" src="https://github.com/user-attachments/assets/ab5d679a-5bef-40f1-95bb-6c9e50ef3f97">

<img width="527" alt="image" src="https://github.com/user-attachments/assets/07ef894c-4805-4d02-9f37-3ba44c6cc7f1">
