### PR TITLE
FYST-1331-md-withdrawal-date-fix

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -418,15 +418,16 @@ class ApplicationController < ActionController::Base
   helper_method :before_state_file_launch?
 
   def withdrawal_date_deadline(state_code)
+    year = MultiTenantService.new(:statefile).current_tax_year + 1
     case state_code
     when 'ny'
-      Rails.configuration.state_file_withdrawal_date_deadline_ny
+      Rails.configuration.state_file_withdrawal_date_deadline_ny.change(year: year)
     when 'md'
-      Rails.configuration.state_file_withdrawal_date_deadline_md
+      Rails.configuration.state_file_withdrawal_date_deadline_md.change(year: year)
     else
       # Arizona's withdrawal date deadline is the same as the end-new-intakes date which is set in PDT,
       # if this was during daylight-savings, it would be different except in the Navajo Nation
-      Rails.configuration.state_file_end_of_new_intakes
+      Rails.configuration.state_file_end_of_new_intakes.change(year: year)
     end
   end
   helper_method :withdrawal_date_deadline

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -418,16 +418,15 @@ class ApplicationController < ActionController::Base
   helper_method :before_state_file_launch?
 
   def withdrawal_date_deadline(state_code)
-    year = MultiTenantService.new(:statefile).current_tax_year + 1
     case state_code
     when 'ny'
-      Rails.configuration.state_file_withdrawal_date_deadline_ny.change(year: year)
+      Rails.configuration.state_file_withdrawal_date_deadline_ny
     when 'md'
-      Rails.configuration.state_file_withdrawal_date_deadline_md.change(year: year)
+      Rails.configuration.state_file_withdrawal_date_deadline_md
     else
       # Arizona's withdrawal date deadline is the same as the end-new-intakes date which is set in PDT,
       # if this was during daylight-savings, it would be different except in the Navajo Nation
-      Rails.configuration.state_file_end_of_new_intakes.change(year: year)
+      Rails.configuration.state_file_end_of_new_intakes
     end
   end
   helper_method :withdrawal_date_deadline

--- a/app/forms/state_file/taxes_owed_form.rb
+++ b/app/forms/state_file/taxes_owed_form.rb
@@ -88,9 +88,5 @@ module StateFile
         errors.add(:date_electronic_withdrawal, @intake.errors[:date_electronic_withdrawal])
       end
     end
-
-    # def withdrawal_date_deadline
-    #   Date.parse("April 15th, #{MultiTenantService.new(:statefile).current_tax_year + 1}")
-    # end
   end
 end

--- a/app/forms/state_file/taxes_owed_form.rb
+++ b/app/forms/state_file/taxes_owed_form.rb
@@ -75,8 +75,9 @@ module StateFile
     end
 
     def withdrawal_date_before_deadline
+      withdrawal_date_deadline = withdrawal_date_deadline(intake.state_code)
       unless date_electronic_withdrawal.between?(Date.parse(app_time), withdrawal_date_deadline)
-        self.errors.add(:date_electronic_withdrawal, I18n.t("forms.errors.taxes_owed.withdrawal_date_deadline", year: withdrawal_date_deadline.year))
+        self.errors.add(:date_electronic_withdrawal, I18n.t("forms.errors.taxes_owed.withdrawal_date_deadline", year: withdrawal_date_deadline.year, day: withdrawal_date_deadline.day))
       end
     end
 
@@ -88,8 +89,8 @@ module StateFile
       end
     end
 
-    def withdrawal_date_deadline
-      Date.parse("April 15th, #{MultiTenantService.new(:statefile).current_tax_year + 1}")
-    end
+    # def withdrawal_date_deadline
+    #   Date.parse("April 15th, #{MultiTenantService.new(:statefile).current_tax_year + 1}")
+    # end
   end
 end

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -22,6 +22,10 @@ module DateHelper
     true
   end
 
+  def withdrawal_date_deadline(state_code)
+    ApplicationController.new.withdrawal_date_deadline(state_code)
+  end
+
   def valid_text_birth_date(birth_date_year, birth_date_month, birth_date_day, key = :birth_date)
     parsed_birth_date = parse_date_params(birth_date_year, birth_date_month, birth_date_day)
     unless parsed_birth_date.present?

--- a/config/application.rb
+++ b/config/application.rb
@@ -124,9 +124,9 @@ module VitaMin
 
     # StateFile
     config.state_file_start_of_open_intake = et.parse('2024-02-08 09:00:00')
-    config.state_file_end_of_new_intakes = pt.parse('2024-04-15 23:59:59')
+    config.state_file_end_of_new_intakes = pt.parse('2025-04-15 23:59:59')
     config.state_file_withdrawal_date_deadline_ny = et.parse('2024-04-15 23:59:59')
-    config.state_file_withdrawal_date_deadline_md = et.parse('2024-04-30 23:59:59')
+    config.state_file_withdrawal_date_deadline_md = et.parse('2025-04-30 23:59:59')
     config.state_file_end_of_in_progress_intakes = pt.parse('2024-04-25 23:59:59')
     config.state_file_show_faq_date = pt.parse('2024-12-10 00:00:00')
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -277,7 +277,7 @@ en:
         is_hsa: is HSA
       taxes_owed:
         withdraw_amount_higher_than_owed: Please enter in an amount less than or equal to %{owed_amount}
-        withdrawal_date_deadline: Please enter a date between today and on or before April 15, %{year}
+        withdrawal_date_deadline: Please enter a date between today and on or before April %{day}, %{year}
   general:
     NA: N/A
     about: About

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -278,7 +278,7 @@ es:
         is_hsa: es HSA
       taxes_owed:
         withdraw_amount_higher_than_owed: Ingresa una cantidad menor o igual a %{owed_amount}
-        withdrawal_date_deadline: Ingrese una fecha entre hoy y el 15 de abril de %{year} o antes
+        withdrawal_date_deadline: "Por favor, ingrese una fecha entre hoy y hasta el %{day} de abril de %{year} inclusive"
   general:
     NA: N/A
     about: Acerca de nosotros

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -278,7 +278,7 @@ es:
         is_hsa: es HSA
       taxes_owed:
         withdraw_amount_higher_than_owed: Ingresa una cantidad menor o igual a %{owed_amount}
-        withdrawal_date_deadline: "Por favor, ingrese una fecha entre hoy y hasta el %{day} de abril de %{year} inclusive"
+        withdrawal_date_deadline: Por favor, ingrese una fecha entre hoy y hasta el %{day} de abril de %{year} inclusive
   general:
     NA: N/A
     about: Acerca de nosotros

--- a/spec/forms/state_file/nc_taxes_owed_form_spec.rb
+++ b/spec/forms/state_file/nc_taxes_owed_form_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe StateFile::NcTaxesOwedForm do
   let!(:withdraw_amount) { 68 }
   let!(:intake) {
-    create :state_file_nc_intake,
+    create :state_file_ny_intake,
            payment_or_deposit_type: "unfilled",
            withdraw_amount: withdraw_amount
   }
@@ -12,12 +12,9 @@ RSpec.describe StateFile::NcTaxesOwedForm do
       payment_or_deposit_type: "mail"
     }
   end
-  let(:current_year) { (MultiTenantService.new(:statefile).current_tax_year + 1).to_s }
+  let(:current_year) { "2024" }
   let(:pre_deadline_withdrawal_time) { DateTime.parse("April 15th, #{current_year} 11pm EST") }
   let(:post_deadline_withdrawal_time) { DateTime.parse("April 16th, #{current_year} 1am EST") }
-  before do
-    allow(intake).to receive(:calculated_refund_or_owed_amount).and_return(68)
-  end
 
   describe "#valid?" do
     let(:payment_or_deposit_type) { "direct_deposit" }
@@ -80,7 +77,7 @@ RSpec.describe StateFile::NcTaxesOwedForm do
       context "when the date is a federal holiday occurring on any day except Sunday" do
         let(:app_time) { DateTime.parse("February 16th, #{current_year} 4pm EST").to_s }
         let(:month) { "2" }
-        let(:day) { "17" } # Monday, Feb 17th, 2025 ~ President's day
+        let(:day) { "19" } # Monday, Feb 19th, 2024 ~ President's day
         it "is not valid" do
           form = described_class.new(intake, params)
           expect(form).not_to be_valid
@@ -90,7 +87,7 @@ RSpec.describe StateFile::NcTaxesOwedForm do
       end
 
       context "when it's 5pm EST and withdrawal date is less than 2 business days from today" do
-        let(:app_time) { DateTime.parse("March 10th, #{current_year} 7pm EST").to_s } # Friday
+        let(:app_time) { DateTime.parse("March 8th, #{current_year} 7pm EST").to_s } # Friday
         let(:day) { "11" } # Monday, March 11th, 2024
         it "is not valid" do
           form = described_class.new(intake, params)
@@ -101,9 +98,9 @@ RSpec.describe StateFile::NcTaxesOwedForm do
       end
 
       context "when it's 5 PM on a Sunday and the withdrawal date is more 2 days from today" do
-        let(:app_time) { DateTime.parse("February 23rd, 2025 8pm EST").to_s } # Sunday
-        let(:year) { "2025" }
-        let(:day) { "25" }
+        let(:app_time) { DateTime.parse("February 25rd, 2024 8pm EST").to_s } # Sunday
+        let(:year) { "2024" }
+        let(:day) { "27" }
         let(:month) { "2" }
         it "is valid" do
           form = described_class.new(intake, params)

--- a/spec/forms/state_file/nc_taxes_owed_form_spec.rb
+++ b/spec/forms/state_file/nc_taxes_owed_form_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe StateFile::NcTaxesOwedForm do
   let!(:withdraw_amount) { 68 }
   let!(:intake) {
-    create :state_file_ny_intake,
+    create :state_file_nc_intake,
            payment_or_deposit_type: "unfilled",
            withdraw_amount: withdraw_amount
   }

--- a/spec/forms/state_file/nc_taxes_owed_form_spec.rb
+++ b/spec/forms/state_file/nc_taxes_owed_form_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe StateFile::NcTaxesOwedForm do
   let!(:withdraw_amount) { 68 }
   let!(:intake) {
-    create :state_file_ny_intake,
+    create :state_file_nc_intake,
            payment_or_deposit_type: "unfilled",
            withdraw_amount: withdraw_amount
   }
@@ -41,6 +41,10 @@ RSpec.describe StateFile::NcTaxesOwedForm do
         date_electronic_withdrawal_day: day,
         app_time: app_time
       }
+    end
+
+    before do
+      allow(intake).to receive(:calculated_refund_or_owed_amount).and_return(100)
     end
 
     context "NC withdrawal date validations" do

--- a/spec/forms/state_file/taxes_owed_form_spec.rb
+++ b/spec/forms/state_file/taxes_owed_form_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe StateFile::TaxesOwedForm do
   let!(:withdraw_amount) { 68 }
   let!(:intake) {
-    create :state_file_ny_intake,
+    create :state_file_id_intake,
            payment_or_deposit_type: "unfilled",
            withdraw_amount: withdraw_amount
   }
@@ -234,6 +234,28 @@ RSpec.describe StateFile::TaxesOwedForm do
       it "is valid" do
         form = described_class.new(intake, params)
         expect(form).not_to be_valid
+      end
+    end
+
+    context "when the state is Maryland" do
+      let!(:withdraw_amount) { 68 }
+      let!(:intake) {
+        create :state_file_md_intake,
+               payment_or_deposit_type: "unfilled",
+               withdraw_amount: withdraw_amount
+      }
+
+      context "the date is April 30th" do
+        let(:month) { "04" }
+        let(:day) { "30" }
+        let(:year) { current_year }
+
+        it "is valid" do
+          form = described_class.new(intake, params)
+          binding.pry
+          expect(form).to be_valid
+          expect(form.errors).to include :date_electronic_withdrawal
+        end
       end
     end
   end

--- a/spec/forms/state_file/taxes_owed_form_spec.rb
+++ b/spec/forms/state_file/taxes_owed_form_spec.rb
@@ -89,10 +89,9 @@ RSpec.describe StateFile::TaxesOwedForm do
             expect(intake.routing_number).to eq "019456124"
             expect(intake.account_number).to eq "12345"
             expect(intake.date_electronic_withdrawal).to eq Date.parse("April 15th, #{current_year}")
-          end
         end
 
-        context "after ID's deadline and before MD's for MD intake" do
+        context "after other states' deadline and before MD's for MD intake" do
           before do
             allow(intake).to receive(:calculated_refund_or_owed_amount).and_return(100)
           end

--- a/spec/forms/state_file/taxes_owed_form_spec.rb
+++ b/spec/forms/state_file/taxes_owed_form_spec.rb
@@ -89,9 +89,10 @@ RSpec.describe StateFile::TaxesOwedForm do
             expect(intake.routing_number).to eq "019456124"
             expect(intake.account_number).to eq "12345"
             expect(intake.date_electronic_withdrawal).to eq Date.parse("April 15th, #{current_year}")
+          end
         end
 
-        context "after other states' deadline and before MD's for MD intake" do
+        context "after other states's  deadline and before MD's for MD intake" do
           before do
             allow(intake).to receive(:calculated_refund_or_owed_amount).and_return(100)
           end

--- a/spec/forms/state_file/taxes_owed_form_spec.rb
+++ b/spec/forms/state_file/taxes_owed_form_spec.rb
@@ -1,6 +1,11 @@
 require "rails_helper"
 
 RSpec.describe StateFile::TaxesOwedForm do
+  before do
+    allow_any_instance_of(StateFile::TaxesOwedForm).to receive(:withdrawal_date_deadline)
+                                                   .and_return(Date.parse("April 30th, #{current_year}"))
+  end
+
   let!(:withdraw_amount) { 68 }
   let!(:intake) {
     create :state_file_id_intake,

--- a/spec/forms/state_file/taxes_owed_form_spec.rb
+++ b/spec/forms/state_file/taxes_owed_form_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe StateFile::TaxesOwedForm do
           end
         end
 
-        context "after other states's  deadline and before MD's for MD intake" do
+        context "after other states' deadline and before MD's for MD intake" do
           before do
             allow(intake).to receive(:calculated_refund_or_owed_amount).and_return(100)
           end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/FYST-1425
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Changes were made so that Maryland could actually withdraw funds after the 15th and before the 30th of april
## How to test?
- Use minimal in Maryland.
- change agi to 40k
- try different dates in taxes owed page

## Screenshots (for visual ch
<img width="497" alt="Screenshot 2024-12-10 at 12 14 08 PM" src="https://github.com/user-attachments/assets/a1adc530-410b-4d16-9b39-ecc8a76047c3">
anges)
<img width="710" alt="Screenshot 2024-12-10 at 12 15 50 PM" src="https://github.com/user-attachments/assets/eea3fab0-5d24-4fab-9f67-33dd3166886c">

Dangers:
The new way of determining withdrawal dates broke the Nc taxes owed tests. As is once a year the tests would need to be updated to new dates for the calendar year. Some code could be written to automatically determine which dates the tests need i.e  `def presidents_day(year)`  but I thought that could wait til after launch. 
