### PR TITLE
implement show for qualifying org contributions controller and add tests

### DIFF
--- a/app/controllers/state_file/questions/az_qualifying_organization_contributions_controller.rb
+++ b/app/controllers/state_file/questions/az_qualifying_organization_contributions_controller.rb
@@ -6,6 +6,10 @@ module StateFile
       before_action :maybe_opt_out_and_continue, only: [:update, :create]
       before_action :set_contribution_count
 
+      def self.show?(intake)
+        intake.charitable_contributions_yes? && intake.charitable_cash_amount.positive?
+      end
+
       def index
         @credit_limit = current_intake.filing_status_mfj? ? 938 : 470
         unless contributions.present?

--- a/spec/controllers/state_file/questions/az_qualifying_organization_contributions_controller_spec.rb
+++ b/spec/controllers/state_file/questions/az_qualifying_organization_contributions_controller_spec.rb
@@ -9,6 +9,51 @@ RSpec.describe StateFile::Questions::AzQualifyingOrganizationContributionsContro
     sign_in intake
   end
 
+  describe ".show?" do
+
+    context "when the intake has charitable contributions" do
+      before do
+        intake.charitable_contributions_yes!
+      end
+
+      context "when the intake has cash contributions" do
+
+        before do
+          intake.update(charitable_cash_amount: 1)
+        end
+
+        it "shows" do
+          expect(described_class).to be_show(intake)
+        end
+
+      end
+
+      context "when the intake does not have charitable contributions" do
+
+        before do
+          intake.update(charitable_cash_amount: 0)
+        end
+
+        it "does not show" do
+          expect(described_class).not_to be_show(intake)
+        end
+
+      end
+
+    end
+
+    context "when the intake does not have charitable contributions" do
+      before do
+        intake.charitable_contributions_no!
+      end
+
+      it "does not show" do
+        expect(described_class).not_to be_show(intake)
+      end
+    end
+
+  end
+
   describe "#index" do
     context "credit limit" do
       context "mfj filer" do

--- a/spec/controllers/state_file/questions/az_qualifying_organization_contributions_controller_spec.rb
+++ b/spec/controllers/state_file/questions/az_qualifying_organization_contributions_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe StateFile::Questions::AzQualifyingOrganizationContributionsContro
 
       end
 
-      context "when the intake does not have charitable contributions" do
+      context "when the intake does not have cash contributions" do
 
         before do
           intake.update(charitable_cash_amount: 0)

--- a/spec/support/shared_examples/return_to_review_concern.rb
+++ b/spec/support/shared_examples/return_to_review_concern.rb
@@ -15,6 +15,9 @@ shared_examples :return_to_review_concern do
       it "navigates to the next page in the flow" do
         post :update, params: form_params
 
+        # ensure that any changes made to the intake by `update` are accounted for when we call `show?`
+        intake.reload
+
         controllers = StateFile::StateInformationService.navigation_class(intake.state_code)::FLOW
         next_controller_to_show = nil
         increment = 1


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1435
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Added a `show` override to `AzQualifyingOrganizationContributionsController` that only allows the controller to show if the intake has cash charitable contributions recorded
## How to test?
- Go through the AZ flow and verify that:
  - if you answer yes on /az-charitable-contributions and enter a non-zero cash amount, you see the qualifying org contribution page next
  - in any other case, you do not see the qualifying org contribution page