### PR TITLE
sms terms only show to intakes with phone numbers

### DIFF
--- a/app/controllers/state_file/questions/sms_terms_controller.rb
+++ b/app/controllers/state_file/questions/sms_terms_controller.rb
@@ -1,6 +1,9 @@
 module StateFile
   module Questions
     class SmsTermsController < QuestionsController
+      def self.show?(intake)
+        intake.phone_number?
+      end
     end
   end
 end

--- a/spec/controllers/state_file/questions/sms_terms_controller_spec.rb
+++ b/spec/controllers/state_file/questions/sms_terms_controller_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe StateFile::Questions::SmsTermsController do
+  let(:intake) { create :state_file_md_intake }
+  before do
+    sign_in intake
+  end
+  describe "#show?" do
+    context "when phone number is present" do
+      let(:intake) { create :state_file_nj_intake, phone_number: "+15038675309" }
+      it "shows" do
+        expect(described_class.show?(intake)).to eq true
+      end
+    end
+
+    context "when phone number is not present" do
+      let(:intake) { create :state_file_nj_intake, phone_number: nil }
+      it "does not show" do
+        expect(described_class.show?(intake)).to eq false
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1436
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- made sms terms page only show to intakes with phone numbers
## How to test?
- start an intake and verify that you are not shown sms page

