### PR TITLE
Nj 204 year

### DIFF
--- a/app/models/state_file_nj_intake.rb
+++ b/app/models/state_file_nj_intake.rb
@@ -200,5 +200,9 @@ class StateFileNjIntake < StateFileBaseIntake
   end
 
   def validate_state_specific_w2_requirements(w2); end
+
+  def ask_for_signature_pin?
+    true
+  end
 end
 

--- a/app/models/state_file_nj_intake.rb
+++ b/app/models/state_file_nj_intake.rb
@@ -60,6 +60,7 @@
 #  primary_last_name                                      :string
 #  primary_middle_initial                                 :string
 #  primary_signature                                      :string
+#  primary_signature_pin                                  :text
 #  primary_ssn                                            :string
 #  primary_suffix                                         :string
 #  primary_veteran                                        :integer          default("unfilled"), not null
@@ -83,6 +84,7 @@
 #  spouse_first_name                                      :string
 #  spouse_last_name                                       :string
 #  spouse_middle_initial                                  :string
+#  spouse_signature_pin                                   :text
 #  spouse_ssn                                             :string
 #  spouse_suffix                                          :string
 #  spouse_veteran                                         :integer          default("unfilled"), not null

--- a/db/migrate/20241213204321_add_signature_pins_to_state_file_nj_intake.rb
+++ b/db/migrate/20241213204321_add_signature_pins_to_state_file_nj_intake.rb
@@ -1,0 +1,6 @@
+class AddSignaturePinsToStateFileNjIntake < ActiveRecord::Migration[7.1]
+  def change
+    add_column :state_file_nj_intakes, :primary_signature_pin, :text
+    add_column :state_file_nj_intakes, :spouse_signature_pin, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_12_05_194857) do
+ActiveRecord::Schema[7.1].define(version: 2024_12_13_204321) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -2164,6 +2164,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_05_194857) do
     t.string "primary_last_name"
     t.string "primary_middle_initial"
     t.string "primary_signature"
+    t.text "primary_signature_pin"
     t.string "primary_ssn"
     t.bigint "primary_state_id_id"
     t.string "primary_suffix"
@@ -2188,6 +2189,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_05_194857) do
     t.string "spouse_first_name"
     t.string "spouse_last_name"
     t.string "spouse_middle_initial"
+    t.text "spouse_signature_pin"
     t.string "spouse_ssn"
     t.bigint "spouse_state_id_id"
     t.string "spouse_suffix"

--- a/spec/factories/state_file_nj_intakes.rb
+++ b/spec/factories/state_file_nj_intakes.rb
@@ -60,6 +60,7 @@
 #  primary_last_name                                      :string
 #  primary_middle_initial                                 :string
 #  primary_signature                                      :string
+#  primary_signature_pin                                  :text
 #  primary_ssn                                            :string
 #  primary_suffix                                         :string
 #  primary_veteran                                        :integer          default("unfilled"), not null
@@ -83,6 +84,7 @@
 #  spouse_first_name                                      :string
 #  spouse_last_name                                       :string
 #  spouse_middle_initial                                  :string
+#  spouse_signature_pin                                   :text
 #  spouse_ssn                                             :string
 #  spouse_suffix                                          :string
 #  spouse_veteran                                         :integer          default("unfilled"), not null

--- a/spec/factories/state_file_nj_intakes.rb
+++ b/spec/factories/state_file_nj_intakes.rb
@@ -122,6 +122,10 @@ FactoryBot.define do
     routing_number { "011234567" }
     account_number { "123456789" }
     account_type { 1 }
+    primary_signature_pin { '12345' }
+    spouse_signature_pin { '54321' }
+    primary_esigned_at { DateTime.now }
+    spouse_esigned_at { DateTime.now }
 
     raw_direct_file_data { StateFile::DirectFileApiResponseSampleService.new.read_xml("nj_zeus_one_dep") }
     raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nj_zeus_one_dep') }

--- a/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
@@ -9,13 +9,6 @@ describe SubmissionBuilder::Ty2024::States::Nj::NjReturnXml, required_schema: "n
     let(:build_response) { described_class.build(submission, validate: true) }
     let(:xml) { Nokogiri::XML::Document.parse(build_response.document.to_xml) }
 
-    before do
-      intake.primary_signature_pin = '12345'
-      if intake.filing_status_mfj?
-        intake.spouse_signature_pin = '12345'
-      end
-    end
-
     after do
       expect(build_response.errors).not_to be_present
     end

--- a/spec/models/state_file_nj_intake_spec.rb
+++ b/spec/models/state_file_nj_intake_spec.rb
@@ -60,6 +60,7 @@
 #  primary_last_name                                      :string
 #  primary_middle_initial                                 :string
 #  primary_signature                                      :string
+#  primary_signature_pin                                  :text
 #  primary_ssn                                            :string
 #  primary_suffix                                         :string
 #  primary_veteran                                        :integer          default("unfilled"), not null
@@ -83,6 +84,7 @@
 #  spouse_first_name                                      :string
 #  spouse_last_name                                       :string
 #  spouse_middle_initial                                  :string
+#  spouse_signature_pin                                   :text
 #  spouse_ssn                                             :string
 #  spouse_suffix                                          :string
 #  spouse_veteran                                         :integer          default("unfilled"), not null


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/204

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Require the pin as part of the signature. There is a separate ticket to do this after confirming with taxation how it should function, but we wanted to see if adding the signature and date would get NJ returns accepted.
- Remove some redundant tests in nj return xml spec. Some of the tests that still exist look silly now, but this is an improvement because we're only checking for build errors once

## How to test?
Submit one of the valid returns (Jennifer Brown etc)

## Screenshots (for visual changes)
I did not make any visual changes, but just added db fields and copied the func that enables pin from the MD intake
