### PR TITLE
Modified nj_eitc_eligibility to use AGI

### DIFF
--- a/app/lib/efile/nj/nj_flat_eitc_eligibility.rb
+++ b/app/lib/efile/nj/nj_flat_eitc_eligibility.rb
@@ -4,8 +4,8 @@ module Efile
       class << self
         def eligible?(intake)
           possibly_eligible?(intake) &&
-          intake.claimed_as_eitc_qualifying_child_no? &&
-          (!intake.filing_status_mfj? || intake.spouse_claimed_as_eitc_qualifying_child_no?)
+            intake.claimed_as_eitc_qualifying_child_no? &&
+            (!intake.filing_status_mfj? || intake.spouse_claimed_as_eitc_qualifying_child_no?)
         end
 
         def possibly_eligible?(intake)
@@ -41,10 +41,10 @@ module Efile
             spouse_age_inclusive = intake.calculate_age(intake.spouse_birth_date, inclusive_of_jan_1: true)
 
             any_meets_minimum_age?(primary_age_exclusive, spouse_age_exclusive) &&
-            all_outside_fed_eitc_age_range?(primary_age_inclusive, spouse_age_inclusive)
+              all_outside_fed_eitc_age_range?(primary_age_inclusive, spouse_age_inclusive)
           else
             any_meets_minimum_age?(primary_age_exclusive) &&
-            all_outside_fed_eitc_age_range?(primary_age_inclusive)
+              all_outside_fed_eitc_age_range?(primary_age_inclusive)
           end
         end
 
@@ -57,11 +57,11 @@ module Efile
         end
 
         def is_under_income_total_limit?(intake)
-          if intake.filing_status_mfj?
-            intake.direct_file_data.fed_income_total < 25_511
-          else
-            intake.direct_file_data.fed_income_total < 18_591
-          end
+          intake.direct_file_data.fed_agi < if intake.filing_status_mfj?
+                                              25_511
+                                            else
+                                              18_591
+                                            end
         end
 
         def has_ssn_valid_for_employment?(intake)
@@ -78,7 +78,7 @@ module Efile
 
         def claimed_as_dependent?(intake)
           intake.direct_file_data.claimed_as_dependent? ||
-          (intake.filing_status_mfj? && intake.direct_file_data.spouse_is_a_dependent?)
+            (intake.filing_status_mfj? && intake.direct_file_data.spouse_is_a_dependent?)
         end
       end
     end

--- a/app/lib/efile/nj/nj_flat_eitc_eligibility.rb
+++ b/app/lib/efile/nj/nj_flat_eitc_eligibility.rb
@@ -57,11 +57,12 @@ module Efile
         end
 
         def is_under_income_total_limit?(intake)
-          intake.direct_file_data.fed_agi < if intake.filing_status_mfj?
-                                              25_511
-                                            else
-                                              18_591
-                                            end
+          income_threshold = if intake.filing_status_mfj?
+                               25_511
+                             else
+                               18_591
+                             end
+          intake.direct_file_data.fed_agi < income_threshold
         end
 
         def has_ssn_valid_for_employment?(intake)

--- a/spec/lib/efile/nj/nj_flat_eitc_eligibility_spec.rb
+++ b/spec/lib/efile/nj/nj_flat_eitc_eligibility_spec.rb
@@ -229,7 +229,7 @@ describe Efile::Nj::NjFlatEitcEligibility do
       context "when at or above 25_511" do
         let(:intake) { create(:state_file_nj_intake, :married_filing_jointly) }
         it "returns false" do
-          allow(intake.direct_file_data).to receive(:fed_income_total).and_return(25_511)
+          allow(intake.direct_file_data).to receive(:fed_agi).and_return(25_511)
           expect(Efile::Nj::NjFlatEitcEligibility.is_under_income_total_limit?(intake)).to eq(false)
         end
       end
@@ -237,7 +237,7 @@ describe Efile::Nj::NjFlatEitcEligibility do
       context "when below 25_511" do
         let(:intake) { create(:state_file_nj_intake, :married_filing_jointly) }
         it "returns true" do
-          allow(intake.direct_file_data).to receive(:fed_income_total).and_return(25_510)
+          allow(intake.direct_file_data).to receive(:fed_agi).and_return(25_510)
           expect(Efile::Nj::NjFlatEitcEligibility.is_under_income_total_limit?(intake)).to eq(true)
         end
       end
@@ -247,7 +247,7 @@ describe Efile::Nj::NjFlatEitcEligibility do
       context "when at or above 18_591" do
         let(:intake) { create(:state_file_nj_intake) }
         it "returns false" do
-          allow(intake.direct_file_data).to receive(:fed_income_total).and_return(18_591)
+          allow(intake.direct_file_data).to receive(:fed_agi).and_return(18_591)
           expect(Efile::Nj::NjFlatEitcEligibility.is_under_income_total_limit?(intake)).to eq(false)
         end
       end
@@ -255,7 +255,7 @@ describe Efile::Nj::NjFlatEitcEligibility do
       context "when below 18_591" do
         let(:intake) { create(:state_file_nj_intake) }
         it "returns true" do
-          allow(intake.direct_file_data).to receive(:fed_income_total).and_return(18_590)
+          allow(intake.direct_file_data).to receive(:fed_agi).and_return(18_590)
           expect(Efile::Nj::NjFlatEitcEligibility.is_under_income_total_limit?(intake)).to eq(true)
         end
       end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/200

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!


**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
Small change to update income check of EITC. It previously used `total_federal_income` from the Direct File import, swapped it to use `federal_agi`

## How to test?
Test Case 1
- Select `childless eitc` persona
- Answer NO to the "In 2024, could you be someone else's qualifying child for the Earned Income Tax Credit?" question
- Validate that Line 58 of the Tax returns has a 240$ Credit for EITC

Test Case 2
- Select `childess eitc` persona
- Click on the " let me edit the response XML" button
- Set AGI to 18591 (above the EITC income limit)
- Validate that Line 58 of the Tax returns does not have a 240$ Credit for EITC

## Screenshots (for visual changes)
