### PR TITLE
Hide intercom everywhere

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -69,6 +69,8 @@ class ApplicationController < ActionController::Base
     state_file? && pages_to_hide_from.any? do |controller, action|
       self.class.name == controller && (action == "" || action_name == action)
     end
+
+    true # todo: remove once key rotated
   end
   helper_method :hide_intercom?
 


### PR DESCRIPTION
## Is PM acceptance required? (delete one)
- Not sure...

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Preventing intercom from rendering anywhere on GYR or FYST; currently its not rendering on FYST anyways
- we want to do this to protect client messages while we rotate an intercom key
- 
## How to test?
- See if intercom widget loads on GYR homepage

## Screenshots (for visual changes)
- After (observe no intercom widget)
![Screenshot 2024-12-13 at 4 41 00 PM](https://github.com/user-attachments/assets/54724f96-0045-4101-8d58-38f448fca2a7)

