### PR TITLE
Gyr1 608/remove adopted and buyer

### DIFF
--- a/app/controllers/questions/adopted_child_controller.rb
+++ b/app/controllers/questions/adopted_child_controller.rb
@@ -2,9 +2,7 @@ module Questions
   class AdoptedChildController < QuestionsController
     include AuthenticatedClientConcern
 
-    def self.show?(intake)
-      intake.had_dependents_yes?
-    end
+    def self.show?(intake) = false
 
     layout "yes_no_question"
   end

--- a/app/controllers/questions/homebuyer_credit_controller.rb
+++ b/app/controllers/questions/homebuyer_credit_controller.rb
@@ -4,9 +4,7 @@ module Questions
 
     layout "yes_no_question"
 
-    def self.show?(intake)
-      intake.ever_owned_home_yes?
-    end
+    def self.show?(intake) = false
 
     private
 

--- a/app/lib/navigation/gyr_question_navigation.rb
+++ b/app/lib/navigation/gyr_question_navigation.rb
@@ -80,7 +80,6 @@ module Navigation
 
       # Dependent related questions
       Questions::DependentCareController,
-      Questions::AdoptedChildController,
 
       # Student questions
       Questions::StudentController,
@@ -130,7 +129,6 @@ module Navigation
       Questions::EverOwnedHomeController,
       Questions::SoldHomeController,
       Questions::MortgageInterestController,
-      Questions::HomebuyerCreditController,
 
       # Miscellaneous
       Questions::DisasterLossController,

--- a/spec/controllers/questions/homebuyer_credit_controller_spec.rb
+++ b/spec/controllers/questions/homebuyer_credit_controller_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 
 RSpec.describe Questions::HomebuyerCreditController do
-  describe ".show?" do
-    it_behaves_like :a_show_method_dependent_on_ever_owned_home
-  end
+  # This controller was removed for TY 2024
+  # describe ".show?" do
+  #   it_behaves_like :a_show_method_dependent_on_ever_owned_home
+  # end
 end
 

--- a/spec/features/web_intake/new_joint_filers_spec.rb
+++ b/spec/features/web_intake/new_joint_filers_spec.rb
@@ -270,10 +270,6 @@ RSpec.feature "Web Intake Joint Filers", :flow_explorer_screenshot do
       expect(page).to have_selector("h1", text: "In #{current_tax_year}, did you or your spouse pay any child or dependent care expenses?")
     end
     click_on "Yes"
-    screenshot_after do
-      expect(page).to have_selector("h1", text: "In #{current_tax_year}, did you or your spouse adopt a child?")
-    end
-    click_on "Yes"
 
     # Student questions
     screenshot_after do

--- a/spec/features/web_intake/new_single_filer_spec.rb
+++ b/spec/features/web_intake/new_single_filer_spec.rb
@@ -207,8 +207,6 @@ RSpec.feature "Web Intake Single Filer", :flow_explorer_screenshot, active_job: 
     click_on "No"
     expect(page).to have_selector("h1", text: "In #{current_tax_year}, did you pay any mortgage interest?")
     click_on "No"
-    expect(page).to have_selector("h1", text: "Did you receive the First Time Homebuyer Credit in 2008?")
-    click_on "Yes"
 
     # Miscellaneous
     expect(intake.reload.current_step).to end_with("/questions/disaster-loss")


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/GYR1-608

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Removes the controllers from GYR flow and sets the `::show?` method to be false on both controllers to be double sure they won't pop up.

## How to test?
- Navigate through the flow, being careful to click both that you have owned a home and that you do have dependents.
- After the dependent care question, you should not see the adopted child question
- After the mortgage interest question, you should not see the homeowner buyer credit question

## Screenshots (for visual changes)
- Before
- After
