### PR TITLE
Add flipper flag for turning hiding intercom

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -66,9 +66,11 @@ class ApplicationController < ActionController::Base
       ["StateFile::StateFilePagesController", "privacy_policy"],
       ["StateFile::FaqController", ""]
     ]
-    state_file? && pages_to_hide_from.any? do |controller, action|
-      self.class.name == controller && (action == "" || action_name == action)
-    end
+    is_hidden_page = state_file? && pages_to_hide_from.any? do |controller, action|
+                      self.class.name == controller && (action == "" || action_name == action)
+                    end
+
+    is_hidden_page || Flipper.enabled?(:hide_intercom)
   end
   helper_method :hide_intercom?
 

--- a/spec/features/ctc/client_session_duration_spec.rb
+++ b/spec/features/ctc/client_session_duration_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature "Session duration", requires_default_vita_partners: true do
       let(:fake_time) { Time.utc(2022, 2, 6, 0, 0, 0) }
       before do
         allow(Flipper).to receive(:enabled?).with(:eitc).and_return(true)
+        allow(Flipper).to receive(:enabled?).with(:hide_intercom).and_return(false)
       end
 
       scenario "accumulating session duration" do

--- a/spec/features/visit_home_page_spec.rb
+++ b/spec/features/visit_home_page_spec.rb
@@ -14,10 +14,24 @@ RSpec.feature "Visit home page" do
       end
     end
 
+    expect(page).to have_text("Chat with us")
+
     within ".slab--hero" do
       click_on I18n.t('general.get_started')
     end
     expect(page).to have_text I18n.t('views.questions.personal_info.title')
+  end
+
+  context "hide_intercom flipper flag is enabled" do
+    before do
+      Flipper.enable :hide_intercom
+    end
+
+    scenario "doesn't render intercom widget", js: true do
+      visit "/"
+
+      expect(page).not_to have_text("Chat with us")
+    end
   end
 
   describe "faq questions" do


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. https://codeforamerica.atlassian.net/browse/ABCD-123
## Is PM acceptance required? (delete one)
- Eng review only?

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Added a flipper flag for hiding intercom
- needed this for turning intercom off while doing some key rotation work
## How to test?
- Go to `/en/hub/flipper/features` page in heroku; select `hide_intercom`, click `Fully enable`, notice that the homepage of getyourrefund no longer has the "chat with us" widget
## Screenshots (for visual changes)
- After
![Screenshot 2024-12-16 at 4 11 59 PM](https://github.com/user-attachments/assets/7a20e621-99eb-4667-9e19-57b9b94d0a8f)

