### PR TITLE
Fill in largest tax rate applied for Anne Arundel county in MD-502 line 28 pdf and XML

### DIFF
--- a/app/lib/efile/md/md502_calculator.rb
+++ b/app/lib/efile/md/md502_calculator.rb
@@ -500,7 +500,11 @@ module Efile
       end
 
       def local_tax_rate
-        @lines[:MD502_LINE_28_LOCAL_TAX_RATE]&.value || 0
+        if @intake.residence_county == "Anne Arundel"
+          0.027
+        else
+          @lines[:MD502_LINE_28_LOCAL_TAX_RATE]&.value || 0
+        end
       end
 
       def anne_arundel_local_tax_brackets

--- a/app/lib/submission_builder/ty2024/states/md/documents/md502.rb
+++ b/app/lib/submission_builder/ty2024/states/md/documents/md502.rb
@@ -157,7 +157,7 @@ class SubmissionBuilder::Ty2024::States::Md::Documents::Md502 < SubmissionBuilde
         end
       end
       xml.LocalTaxComputation do
-        add_element_if_present(xml, "LocalTaxRate", :MD502_LINE_28_LOCAL_TAX_RATE) unless @intake.residence_county == "Anne Arundel"
+        add_element_if_present(xml, "LocalTaxRate", :MD502_LINE_28_LOCAL_TAX_RATE)
         add_element_if_present(xml, "LocalIncomeTax", :MD502_LINE_28_LOCAL_TAX_AMOUNT)
         add_element_if_present(xml, "EarnedIncomeCredit", :MD502_LINE_29)
         add_element_if_present(xml, "PovertyLevelCredit", :MD502_LINE_30)

--- a/spec/lib/efile/md/md502_calculator_spec.rb
+++ b/spec/lib/efile/md/md502_calculator_spec.rb
@@ -1364,9 +1364,9 @@ describe Efile::Md::Md502Calculator do
 
     context "when county is Anne Arundel" do
       let(:county) { "Anne Arundel" }
-      it "uses 0.0281 as the local tax rate in the formula" do
-        # (0.0281 * 10) * 1001
-        expect(instance.lines[:MD502_LINE_29].value).to eq(281)
+      it "uses 0.027 as the local tax rate in the formula" do
+        # (0.027 * 10) * 1001
+        expect(instance.lines[:MD502_LINE_29].value).to eq(270)
       end
     end
 

--- a/spec/lib/efile/md/md502_calculator_spec.rb
+++ b/spec/lib/efile/md/md502_calculator_spec.rb
@@ -1316,7 +1316,7 @@ describe Efile::Md::Md502Calculator do
       let(:county) { "Anne Arundel" }
 
       context "when income is 300,000" do
-        # (0.027 * 50,000) + (0.0281 * 250,000) = 8375
+        # (0.027 * 50,000) + (0.0281 * 250,000) = 8,375
         it "calculates the local tax progressively" do
           expect(instance.lines[:MD502_LINE_28_LOCAL_TAX_AMOUNT].value).to eq(8375)
         end
@@ -1325,15 +1325,15 @@ describe Efile::Md::Md502Calculator do
       context "when income is 450,000" do
         let(:income) { 450_000 }
         it "calculates the local tax progressively" do
-          # (0.027 * 50,000) + (0.0281 * 350,000) + (.032 * 50,000) = 12785
-          expect(instance.lines[:MD502_LINE_28_LOCAL_TAX_AMOUNT].value).to eq(127_85)
+          # (0.027 * 50,000) + (0.0281 * 350,000) + (.032 * 50,000) = 12,785
+          expect(instance.lines[:MD502_LINE_28_LOCAL_TAX_AMOUNT].value).to eq(12_785)
         end
       end
 
       context "when income is 45,000" do
         let(:income) { 45_000 }
         it "calculates the local tax with the 0.027 tax rate" do
-          # (0.027 * 45,000) = 1215
+          # (0.027 * 45,000) = 1,215
           expect(instance.lines[:MD502_LINE_28_LOCAL_TAX_AMOUNT].value).to eq(1215)
         end
       end

--- a/spec/lib/efile/md/md502_calculator_spec.rb
+++ b/spec/lib/efile/md/md502_calculator_spec.rb
@@ -1229,19 +1229,20 @@ describe Efile::Md::Md502Calculator do
         let(:filing_status) { "married_filing_jointly" }
 
         context "when taxable net income is 65,000" do
+          let(:taxable_net_income) { 65_000 }
           it "returns 0.027" do
             expect(instance.lines[:MD502_LINE_28_LOCAL_TAX_RATE].value).to eq(0.027)
           end
         end
 
-        context "when taxable net income is 100,000" do
+        context "when taxable net income is 410,000" do
           let(:taxable_net_income) { 410_000 }
           it "returns 0.0281" do
             expect(instance.lines[:MD502_LINE_28_LOCAL_TAX_RATE].value).to eq(0.0281)
           end
         end
 
-        context "when taxable net income is 410,000" do
+        context "when taxable net income is 500,000" do
           let(:taxable_net_income) { 500_000 }
           it "returns 0.032" do
             expect(instance.lines[:MD502_LINE_28_LOCAL_TAX_RATE].value).to eq(0.032)


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. [link](https://codeforamerica.atlassian.net/browse/FYST-1453)
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Return largest local tax rate for Anne Arundel county in MD 502 
- previously because this county uses a progressive tax rate we didn't fill in line 28 on MD 502 but now we are
## How to test?
- Create a Maryland intake in the Anne Arundel county and make sure that line 28 is filled out and `LocalTaxRate` in the XML
## Screenshots (for visual changes)
- After
![Screenshot 2024-12-16 at 10 14 10 PM](https://github.com/user-attachments/assets/116b3fca-a963-4c59-a47d-9fbc159cd112)
![Screenshot 2024-12-16 at 10 14 49 PM](https://github.com/user-attachments/assets/0ef4885d-976c-46ff-a81f-e8d92d9ccb0b)

