### PR TITLE
Nj 220 bug remember amount worksheets

### DIFF
--- a/app/forms/state_file/nj_homeowner_eligibility_form.rb
+++ b/app/forms/state_file/nj_homeowner_eligibility_form.rb
@@ -11,7 +11,7 @@ module StateFile
     def save
       @intake.update(attributes_for(:intake))
 
-      if StateFile::NjHomeownerEligibilityHelper.determine_eligibility(@intake) != StateFile::NjHomeownerEligibilityHelper::ADVANCE
+      if StateFile::NjHomeownerEligibilityHelper.determine_eligibility(@intake) == StateFile::NjHomeownerEligibilityHelper::INELIGIBLE
         @intake.update({
           property_tax_paid: nil
         })

--- a/app/forms/state_file/nj_tenant_eligibility_form.rb
+++ b/app/forms/state_file/nj_tenant_eligibility_form.rb
@@ -11,7 +11,7 @@ module StateFile
     def save
       @intake.update(attributes_for(:intake))
 
-      if StateFile::NjTenantEligibilityHelper.determine_eligibility(@intake) != StateFile::NjTenantEligibilityHelper::ADVANCE
+      if StateFile::NjTenantEligibilityHelper.determine_eligibility(@intake) == StateFile::NjTenantEligibilityHelper::INELIGIBLE
         @intake.update({ rent_paid: nil })
       end
     end

--- a/spec/forms/state_file/nj_homeowner_eligibility_form_spec.rb
+++ b/spec/forms/state_file/nj_homeowner_eligibility_form_spec.rb
@@ -20,14 +20,15 @@ RSpec.describe StateFile::NjHomeownerEligibilityForm do
       end
     end
 
-    context "when unsupported" do
+    context "when worksheet" do
       let(:valid_params) do
         { homeowner_more_than_one_main_home_in_nj: "yes" }
       end
 
-      it "resets property_tax_paid" do
+      it "does not reset property_tax_paid" do
         form.save
-        expect(intake.property_tax_paid).to eq nil
+        expect(intake.rent_paid).to eq nil
+        expect(intake.property_tax_paid).to eq 123
       end
     end
 

--- a/spec/forms/state_file/nj_tenant_eligibility_form_spec.rb
+++ b/spec/forms/state_file/nj_tenant_eligibility_form_spec.rb
@@ -20,14 +20,15 @@ RSpec.describe StateFile::NjTenantEligibilityForm do
       end
     end
 
-    context "when unsupported" do
+    context "when worksheet" do
       let(:valid_params) do
         { tenant_more_than_one_main_home_in_nj: "yes" }
       end
 
-      it "resets rent_paid" do
+      it "does not reset rent_paid" do
         form.save
-        expect(intake.rent_paid).to eq nil
+        expect(intake.property_tax_paid).to eq nil
+        expect(intake.rent_paid).to eq 123
       end
     end
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/220

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
do not reset property_tax_paid or rent_paid when worksheet

## How to test?

1. choose any eligible persona like zeus one dep
2. step through property tax workflow - choose "homeowner" and select the first checkbox (for eligibility) and one of the other checkboxes that will trigger worksheet screen
3. enter a number on the worksheet screen
4. advance to review page
5. click "edit" on property tax rent/own
6. click continue on household rent/own page, and "continue" on the homeowner eligibility page, both without changing your selections
7. arrive on the worksheet screen again

## Screenshots (for visual changes)

### BEFORE


https://github.com/user-attachments/assets/1c5af549-3a07-455a-ba83-46800e480152



### AFTER

https://github.com/user-attachments/assets/175aecac-bfd6-4013-a3c5-1497a7511239


