### PR TITLE
FYST-1214 - Create feature flag for Retirement UI elements

### DIFF
--- a/app/views/state_file/questions/az_review/edit.html.erb
+++ b/app/views/state_file/questions/az_review/edit.html.erb
@@ -94,15 +94,19 @@
         <p><%= number_to_currency(current_intake.calculator.line_or_zero(:AZ140_LINE_12)) %></p>
       </div>
 
-      <div class="spacing-below-25">
-        <p class="text--bold spacing-below-5"><%=t(".exclusion_for_govt_pensions") %></p>
-        <p><%= number_to_currency(current_intake.calculator.line_or_zero(:AZ140_LINE_29A)) %></p>
-      </div>
+      <% if Flipper.enabled?(:show_retirement_ui) %>
+        <div class="spacing-below-25">
+          <p class="text--bold spacing-below-5"><%=t(".exclusion_for_govt_pensions") %></p>
+          <p><%= number_to_currency(current_intake.calculator.line_or_zero(:AZ140_LINE_29A)) %></p>
+        </div>
+      <% end %>
 
-      <div class="spacing-below-25">
-        <p class="text--bold spacing-below-5"><%=t(".exclusion_for_military_pensions") %></p>
-        <p><%= number_to_currency(current_intake.calculator.line_or_zero(:AZ140_LINE_29B)) %></p>
-      </div>
+      <% if Flipper.enabled?(:show_retirement_ui) %>
+        <div class="spacing-below-25">
+          <p class="text--bold spacing-below-5"><%=t(".exclusion_for_military_pensions") %></p>
+          <p><%= number_to_currency(current_intake.calculator.line_or_zero(:AZ140_LINE_29B)) %></p>
+        </div>
+      <% end %>
 
       <div class="spacing-below-25">
         <p class="text--bold spacing-below-5"><%=t(".ssn_not_taxed") %></p>

--- a/app/views/state_file/questions/id_review/edit.html.erb
+++ b/app/views/state_file/questions/id_review/edit.html.erb
@@ -96,10 +96,12 @@
         <p><%= number_to_currency(current_intake.calculator.line_or_zero(:ID39R_B_LINE_7)) %></p>
       </div>
 
-      <div class="spacing-below-25">
-        <p class="text--bold spacing-below-5"><%= t("state_file.general.id_retirement_benefits") %></p>
-        <p><%= number_to_currency(current_intake.calculator.line_or_zero(:ID39R_B_LINE_8f)) %></p>
-      </div>
+      <% if Flipper.enabled?(:show_retirement_ui) %>
+        <div class="spacing-below-25">
+          <p class="text--bold spacing-below-5"><%= t("state_file.general.id_retirement_benefits") %></p>
+          <p><%= number_to_currency(current_intake.calculator.line_or_zero(:ID39R_B_LINE_8f)) %></p>
+        </div>
+      <% end %>
 
       <div class="spacing-below-25">
         <p class="text--bold spacing-below-5"><%= t("state_file.general.id_interest_income") %></p>

--- a/app/views/state_file/questions/md_review/edit.html.erb
+++ b/app/views/state_file/questions/md_review/edit.html.erb
@@ -47,25 +47,31 @@
         <p><%= number_to_currency(current_intake.direct_file_data.total_qualifying_dependent_care_expenses_or_limit_amt) %></p>
       </div>
 
-      <div class="spacing-below-25">
-        <p class="text--bold spacing-below-5"><%= t("state_file.general.md_pension_income_exclusion") %></p>
-        <p><%= number_to_currency(current_intake.calculator.line_or_zero(:MD502_LINE_10A)) %></p>
-      </div>
+      <% if Flipper.enabled?(:show_retirement_ui) %>
+        <div class="spacing-below-25">
+          <p class="text--bold spacing-below-5"><%= t("state_file.general.md_pension_income_exclusion") %></p>
+          <p><%= number_to_currency(current_intake.calculator.line_or_zero(:MD502_LINE_10A)) %></p>
+        </div>
+      <% end %>
 
       <div class="spacing-below-25">
         <p class="text--bold spacing-below-5"><%= t("state_file.general.md_social_security_income_not_taxed") %></p>
         <p><%= number_to_currency(current_intake.direct_file_data.fed_taxable_ssb) %></p>
       </div>
 
-      <div class="spacing-below-25">
-        <p class="text--bold spacing-below-5"><%= t("state_file.general.md_military_retirement_income_exclusion") %></p>
-        <p><%= number_to_currency(current_intake.calculator.line_or_zero(:MD502_SU_LINE_U)) %></p>
-      </div>
+      <% if Flipper.enabled?(:show_retirement_ui) %>
+        <div class="spacing-below-25">
+          <p class="text--bold spacing-below-5"><%= t("state_file.general.md_military_retirement_income_exclusion") %></p>
+          <p><%= number_to_currency(current_intake.calculator.line_or_zero(:MD502_SU_LINE_U)) %></p>
+        </div>
+      <% end %>
 
-      <div class="spacing-below-25">
-        <p class="text--bold spacing-below-5"><%= t("state_file.general.md_public_safety_retirement_income_exclusion") %></p>
-        <p><%= number_to_currency(current_intake.calculator.line_or_zero(:MD502_SU_LINE_V)) %></p>
-      </div>
+      <% if Flipper.enabled?(:show_retirement_ui) %>
+        <div class="spacing-below-25">
+          <p class="text--bold spacing-below-5"><%= t("state_file.general.md_public_safety_retirement_income_exclusion") %></p>
+          <p><%= number_to_currency(current_intake.calculator.line_or_zero(:MD502_SU_LINE_V)) %></p>
+        </div>
+      <% end %>
 
       <div class="spacing-below-25">
         <p class="text--bold spacing-below-5"><%= t("state_file.general.md_subtraction_income_us_gov_bonds") %></p>

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -8,6 +8,7 @@ end
 # This structure is borrowed from https://github.com/department-of-veterans-affairs/vets-api/blob/247c84c0226d4cc90477b96a46107c6bace62bd5/config/initializers/flipper.rb
 # Make sure that each feature we reference in code is present in the UI, as long as we have a Database already
 begin
+  Flipper.disable :show_retirement_ui unless Flipper.exist?(:show_retirement_ui)
   Flipper.disable :sms_notifications unless Flipper.exist?(:sms_notifications)
   Flipper.disable :hub_dashboard unless Flipper.exist?(:hub_dashboard)
   if Rails.env.heroku? || Rails.env.demo?

--- a/spec/controllers/state_file/questions/az_review_controller_spec.rb
+++ b/spec/controllers/state_file/questions/az_review_controller_spec.rb
@@ -76,6 +76,11 @@ RSpec.describe StateFile::Questions::AzReviewController do
       render_views
       let(:intake) { create :state_file_az_intake }
 
+      before do
+        allow(Flipper).to receive(:enabled?).and_call_original
+        allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)
+      end
+
       it "shows all relevant details" do
         intake.direct_file_data.fed_agi = 23_112
         intake.direct_file_data.fed_taxable_ssb = 1_000

--- a/spec/controllers/state_file/questions/id_review_controller_spec.rb
+++ b/spec/controllers/state_file/questions/id_review_controller_spec.rb
@@ -9,6 +9,11 @@ RSpec.describe StateFile::Questions::IdReviewController do
   describe "#edit" do
     render_views
 
+    before do
+      allow(Flipper).to receive(:enabled?).and_call_original
+      allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)
+    end
+
     it "renders" do
       get :edit
       expect(response).to be_successful

--- a/spec/controllers/state_file/questions/md_review_controller_spec.rb
+++ b/spec/controllers/state_file/questions/md_review_controller_spec.rb
@@ -9,6 +9,11 @@ RSpec.describe StateFile::Questions::MdReviewController do
   describe "#edit" do
     render_views
 
+    before do
+      allow(Flipper).to receive(:enabled?).and_call_original
+      allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)
+    end
+
     it "renders" do
       get :edit
       expect(response).to be_successful


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1214
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Added a flipper flag and used it to hide retirement UI on review pages
- Set a default value such that retirement UI will be hidden
- Stub it to true in tests that check retirement UI
- Tiny style note: I added individual flag checks around each line in the review page, even if they are next to each other, to prevent accidentally including new elements in the flagged-out section if a new line is added between two currently-adjacent retirement lines in the future.
## How to test?
- Go through the flow for ID, MD and AZ and verify that the lines specified in the story are not shown on the review page in the details box.
- Turn on the flag (at /en/hub/flipper after signing in as admin) and verify that the lines show up
