### PR TITLE
White space bug: auto strip address attributes on 1099G

### DIFF
--- a/app/models/state_file1099_g.rb
+++ b/app/models/state_file1099_g.rb
@@ -32,6 +32,7 @@ class StateFile1099G < ApplicationRecord
   self.ignored_columns = %w[unemployment_compensation federal_income_tax_withheld state_income_tax_withheld]
   belongs_to :intake, polymorphic: true
   before_validation :update_conditional_attributes
+  auto_strip_attributes :payer_name, :payer_street_address, :payer_city, :payer_zip, :recipient_street_address, :recipient_street_address_apartment, :recipient_city, :recipient_zip
 
   enum address_confirmation: { unfilled: 0, yes: 1, no: 2 }, _prefix: :address_confirmation
   enum had_box_11: { unfilled: 0, yes: 1, no: 2 }, _prefix: :had_box_11

--- a/spec/controllers/state_file/questions/unemployment_controller_spec.rb
+++ b/spec/controllers/state_file/questions/unemployment_controller_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe StateFile::Questions::UnemploymentController do
       }
     end
 
-    it "updates the dependent and redirects to the index" do
+    it "updates the form and redirects to the index" do
       post :update, params: params
 
       expect(response).to redirect_to(StateFile::Questions::UnemploymentController.to_path_helper(action: :index))


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-541
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- This was reported as a bug where valid zip codes were being rejected by the validations but actually it was just an issue of leading whitespace
- I found this `auto_strip_attributes` thing which seems to do the trick. The unemployment controller doesn't have a corresponding form but this seems appropriate to put at the model level anyway
## How to test?
- I added a model spec
## Screenshots
before
<img width="1142" alt="image" src="https://github.com/user-attachments/assets/7c6ebe78-b147-427a-a69e-69c3a63c605d" />
after (had to trigger a separate validation bug so you can see it got fixed)
<img width="1141" alt="image" src="https://github.com/user-attachments/assets/992d33ae-4bf4-4524-9b14-a339c9292dc4" />
