### PR TITLE
Nj 204 2 xml validity

### DIFF
--- a/app/lib/submission_builder/document.rb
+++ b/app/lib/submission_builder/document.rb
@@ -73,7 +73,7 @@ module SubmissionBuilder
         # This method is requirement from NY to remove the namespace attribute from
         # any tag unrelated to the root XML tag. StateSubmissionManifest seems to
         # need it also in order for the XML to be valid.
-        false
+        return false
       elsif intake_class == 'StateFileNjIntake' && (Rails.env.production? || Rails.env.demo?)
         return { 'xmlns' => '' }
       end

--- a/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
@@ -8,9 +8,16 @@ describe SubmissionBuilder::Ty2024::States::Nj::NjReturnXml, required_schema: "n
     let!(:submission_efile_device_info) { create :state_file_efile_device_info, :submission, :filled, intake: intake }
     let(:build_response) { described_class.build(submission, validate: true) }
     let(:xml) { Nokogiri::XML::Document.parse(build_response.document.to_xml) }
-
+    
     after do
       expect(build_response.errors).not_to be_present
+    end
+
+    it "does not include the xmlns attribute on any element in the demo env" do
+      allow(Rails.env).to receive(:demo?).and_return true
+      nodes_with_namespace = xml.document.xpath('//*[namespace-uri()="http://www.irs.gov/efile"]')
+      expect(nodes_with_namespace.count).to eq(0)
+      # Do not check for build errors because schema cannot be validated against without namesapce
     end
 
     describe "XML schema" do


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/209

## Is PM acceptance required? (delete one)
- No - merge after code review approval

## What was done?
According to NJ taxation:

> All your opening tags have the xmlns = portion which should not be there. You need to remove the xmlns="http://www.irs.gov/efile" from those fields in order for your returns to reach the correct parser on our end. This is causing the current error you are receiving. I am anticipating other rejects once your returns get to the proper parser but we will work through them once we get through this issue.

> Under ReturnState you can have the xmlns entries but any tag under that cannot have it as our system can’t decipher the correct tag when it’s there.

However, we can't validate the xml without the default namespace. So we are removing the default namespace in demo and prod for NJ only to see whether that generates valid submissions.

## How to test?
After merging this, submit a return to NJ on the demo site.

## Screenshots (for visual changes)
No visual changes
