### PR TITLE
fix a flaky home page test

### DIFF
--- a/spec/features/visit_home_page_spec.rb
+++ b/spec/features/visit_home_page_spec.rb
@@ -24,7 +24,8 @@ RSpec.feature "Visit home page" do
 
   context "hide_intercom flipper flag is enabled" do
     before do
-      Flipper.enable :hide_intercom
+      allow(Flipper).to receive(:enabled?).and_call_original
+      allow(Flipper).to receive(:enabled?).with(:hide_intercom).and_return(true)
     end
 
     scenario "doesn't render intercom widget", js: true do


### PR DESCRIPTION
This test was failing for some reason when the whole test file was run, but passed when it was run by itself. For some reason, stubbing the Flipper.enabled? check instead of setting the flag made it pass, and is better in general since changing Flipper flags in test setup could affect other tests.