### PR TITLE
GYR1-605 Add visa question and flip citizen question on life situations screens

### DIFF
--- a/app/forms/life_situations_form.rb
+++ b/app/forms/life_situations_form.rb
@@ -1,5 +1,5 @@
 class LifeSituationsForm < QuestionsForm
-  set_attributes_for :intake, :was_full_time_student, :primary_us_citizen, :had_disability, :was_blind
+  set_attributes_for :intake, :was_full_time_student, :primary_us_citizen, :primary_visa, :had_disability, :was_blind
   set_attributes_for :confirmation, :no_life_situations_apply
   validates :no_life_situations_apply, at_least_one_or_none_of_the_above_selected: true
 

--- a/app/forms/life_situations_form.rb
+++ b/app/forms/life_situations_form.rb
@@ -1,24 +1,22 @@
 class LifeSituationsForm < QuestionsForm
-  set_attributes_for :intake, :was_full_time_student, :primary_not_us_citizen, :had_disability, :was_blind
+  set_attributes_for :intake, :was_full_time_student, :primary_us_citizen, :had_disability, :was_blind
   set_attributes_for :confirmation, :no_life_situations_apply
   validates :no_life_situations_apply, at_least_one_or_none_of_the_above_selected: true
 
   def at_least_one_selected
     was_full_time_student == "yes" ||
-      primary_not_us_citizen == "yes" ||
+      primary_us_citizen == "yes" ||
       had_disability == "yes" ||
       was_blind == "yes"
   end
 
   def self.existing_attributes(intake)
     result = super
-    result[:primary_not_us_citizen] = result.delete(:primary_us_citizen) == 'no' ? 'yes' : 'no'
     result
   end
 
   def save
     modified_attributes = attributes_for(:intake)
-    modified_attributes[:primary_us_citizen] = modified_attributes.delete(:primary_not_us_citizen) == "yes" ? "no" : "yes"
 
     @intake.update(modified_attributes)
   end

--- a/app/forms/spouse_life_situations_form.rb
+++ b/app/forms/spouse_life_situations_form.rb
@@ -1,23 +1,21 @@
 class SpouseLifeSituationsForm < QuestionsForm
-  set_attributes_for :intake, :spouse_was_full_time_student, :spouse_not_us_citizen, :spouse_had_disability, :spouse_was_blind
+  set_attributes_for :intake, :spouse_was_full_time_student, :spouse_us_citizen, :spouse_had_disability, :spouse_was_blind
   set_attributes_for :confirmation, :no_life_situations_apply
   validates :no_life_situations_apply, at_least_one_or_none_of_the_above_selected: true
   def at_least_one_selected
     spouse_was_full_time_student == "yes" ||
-      spouse_not_us_citizen == "yes" ||
+      spouse_us_citizen == "yes" ||
       spouse_had_disability == "yes" ||
       spouse_was_blind == "yes"
   end
 
   def self.existing_attributes(intake)
     result = super
-    result[:spouse_not_us_citizen] = result.delete(:spouse_us_citizen) == 'no' ? 'yes' : 'no'
     result
   end
 
   def save
     modified_attributes = attributes_for(:intake)
-    modified_attributes[:spouse_us_citizen] = modified_attributes.delete(:spouse_not_us_citizen) == "yes" ? "no" : "yes"
 
     @intake.update(modified_attributes)
   end

--- a/app/forms/spouse_life_situations_form.rb
+++ b/app/forms/spouse_life_situations_form.rb
@@ -1,5 +1,5 @@
 class SpouseLifeSituationsForm < QuestionsForm
-  set_attributes_for :intake, :spouse_was_full_time_student, :spouse_us_citizen, :spouse_had_disability, :spouse_was_blind
+  set_attributes_for :intake, :spouse_was_full_time_student, :spouse_us_citizen, :spouse_visa, :spouse_had_disability, :spouse_was_blind
   set_attributes_for :confirmation, :no_life_situations_apply
   validates :no_life_situations_apply, at_least_one_or_none_of_the_above_selected: true
   def at_least_one_selected

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -182,6 +182,7 @@
 #  primary_suffix                                       :string
 #  primary_tin_type                                     :integer
 #  primary_us_citizen                                   :integer          default(0), not null
+#  primary_visa                                         :integer          default(0), not null
 #  product_year                                         :integer          not null
 #  receive_written_communication                        :integer          default(0), not null
 #  received_advance_ctc_payment                         :integer
@@ -237,6 +238,7 @@
 #  spouse_suffix                                        :string
 #  spouse_tin_type                                      :integer
 #  spouse_us_citizen                                    :integer          default(0), not null
+#  spouse_visa                                          :integer          default(0), not null
 #  spouse_was_blind                                     :integer          default(0), not null
 #  spouse_was_full_time_student                         :integer          default(0), not null
 #  state                                                :string

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -39,6 +39,7 @@
 #  demographic_primary_asian                            :boolean
 #  demographic_primary_black_african_american           :boolean
 #  demographic_primary_ethnicity                        :integer          default(0), not null
+#  demographic_primary_mena                             :boolean
 #  demographic_primary_native_hawaiian_pacific_islander :boolean
 #  demographic_primary_prefer_not_to_answer_race        :boolean
 #  demographic_primary_white                            :boolean
@@ -48,6 +49,7 @@
 #  demographic_spouse_asian                             :boolean
 #  demographic_spouse_black_african_american            :boolean
 #  demographic_spouse_ethnicity                         :integer          default(0), not null
+#  demographic_spouse_mena                              :boolean
 #  demographic_spouse_native_hawaiian_pacific_islander  :boolean
 #  demographic_spouse_prefer_not_to_answer_race         :boolean
 #  demographic_spouse_white                             :boolean

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -39,7 +39,6 @@
 #  demographic_primary_asian                            :boolean
 #  demographic_primary_black_african_american           :boolean
 #  demographic_primary_ethnicity                        :integer          default(0), not null
-#  demographic_primary_mena                             :boolean
 #  demographic_primary_native_hawaiian_pacific_islander :boolean
 #  demographic_primary_prefer_not_to_answer_race        :boolean
 #  demographic_primary_white                            :boolean
@@ -49,7 +48,6 @@
 #  demographic_spouse_asian                             :boolean
 #  demographic_spouse_black_african_american            :boolean
 #  demographic_spouse_ethnicity                         :integer          default(0), not null
-#  demographic_spouse_mena                              :boolean
 #  demographic_spouse_native_hawaiian_pacific_islander  :boolean
 #  demographic_spouse_prefer_not_to_answer_race         :boolean
 #  demographic_spouse_white                             :boolean

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -182,6 +182,7 @@
 #  primary_suffix                                       :string
 #  primary_tin_type                                     :integer
 #  primary_us_citizen                                   :integer          default(0), not null
+#  primary_visa                                         :integer          default(0), not null
 #  product_year                                         :integer          not null
 #  receive_written_communication                        :integer          default(0), not null
 #  received_advance_ctc_payment                         :integer
@@ -237,6 +238,7 @@
 #  spouse_suffix                                        :string
 #  spouse_tin_type                                      :integer
 #  spouse_us_citizen                                    :integer          default(0), not null
+#  spouse_visa                                          :integer          default(0), not null
 #  spouse_was_blind                                     :integer          default("unfilled"), not null
 #  spouse_was_full_time_student                         :integer          default(0), not null
 #  state                                                :string

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -39,6 +39,7 @@
 #  demographic_primary_asian                            :boolean
 #  demographic_primary_black_african_american           :boolean
 #  demographic_primary_ethnicity                        :integer          default(0), not null
+#  demographic_primary_mena                             :boolean
 #  demographic_primary_native_hawaiian_pacific_islander :boolean
 #  demographic_primary_prefer_not_to_answer_race        :boolean
 #  demographic_primary_white                            :boolean
@@ -48,6 +49,7 @@
 #  demographic_spouse_asian                             :boolean
 #  demographic_spouse_black_african_american            :boolean
 #  demographic_spouse_ethnicity                         :integer          default(0), not null
+#  demographic_spouse_mena                              :boolean
 #  demographic_spouse_native_hawaiian_pacific_islander  :boolean
 #  demographic_spouse_prefer_not_to_answer_race         :boolean
 #  demographic_spouse_white                             :boolean

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -39,7 +39,6 @@
 #  demographic_primary_asian                            :boolean
 #  demographic_primary_black_african_american           :boolean
 #  demographic_primary_ethnicity                        :integer          default(0), not null
-#  demographic_primary_mena                             :boolean
 #  demographic_primary_native_hawaiian_pacific_islander :boolean
 #  demographic_primary_prefer_not_to_answer_race        :boolean
 #  demographic_primary_white                            :boolean
@@ -49,7 +48,6 @@
 #  demographic_spouse_asian                             :boolean
 #  demographic_spouse_black_african_american            :boolean
 #  demographic_spouse_ethnicity                         :integer          default(0), not null
-#  demographic_spouse_mena                              :boolean
 #  demographic_spouse_native_hawaiian_pacific_islander  :boolean
 #  demographic_spouse_prefer_not_to_answer_race         :boolean
 #  demographic_spouse_white                             :boolean

--- a/app/models/intake/gyr_intake.rb
+++ b/app/models/intake/gyr_intake.rb
@@ -39,7 +39,6 @@
 #  demographic_primary_asian                            :boolean
 #  demographic_primary_black_african_american           :boolean
 #  demographic_primary_ethnicity                        :integer          default("unfilled"), not null
-#  demographic_primary_mena                             :boolean
 #  demographic_primary_native_hawaiian_pacific_islander :boolean
 #  demographic_primary_prefer_not_to_answer_race        :boolean
 #  demographic_primary_white                            :boolean
@@ -49,7 +48,6 @@
 #  demographic_spouse_asian                             :boolean
 #  demographic_spouse_black_african_american            :boolean
 #  demographic_spouse_ethnicity                         :integer          default("unfilled"), not null
-#  demographic_spouse_mena                              :boolean
 #  demographic_spouse_native_hawaiian_pacific_islander  :boolean
 #  demographic_spouse_prefer_not_to_answer_race         :boolean
 #  demographic_spouse_white                             :boolean

--- a/app/models/intake/gyr_intake.rb
+++ b/app/models/intake/gyr_intake.rb
@@ -182,6 +182,7 @@
 #  primary_suffix                                       :string
 #  primary_tin_type                                     :integer
 #  primary_us_citizen                                   :integer          default("unfilled"), not null
+#  primary_visa                                         :integer          default("unfilled"), not null
 #  product_year                                         :integer          not null
 #  receive_written_communication                        :integer          default("unfilled"), not null
 #  received_advance_ctc_payment                         :integer
@@ -237,6 +238,7 @@
 #  spouse_suffix                                        :string
 #  spouse_tin_type                                      :integer
 #  spouse_us_citizen                                    :integer          default("unfilled"), not null
+#  spouse_visa                                          :integer          default("unfilled"), not null
 #  spouse_was_blind                                     :integer          default("unfilled"), not null
 #  spouse_was_full_time_student                         :integer          default("unfilled"), not null
 #  state                                                :string
@@ -383,6 +385,7 @@ class Intake::GyrIntake < Intake
   enum paid_student_loan_interest: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :paid_student_loan_interest
   enum phone_number_can_receive_texts: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :phone_number_can_receive_texts
   enum primary_us_citizen: { unfilled: 0, yes: 1, no: 2 }, _prefix: :primary_us_citizen
+  enum primary_visa: { unfilled: 0, yes: 1, no: 2 }, _prefix: :primary_visa
   enum received_alimony: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :received_alimony
   enum received_homebuyer_credit: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :received_homebuyer_credit
   enum received_irs_letter: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :received_irs_letter
@@ -401,6 +404,7 @@ class Intake::GyrIntake < Intake
   enum spouse_us_citizen: { unfilled: 0, yes: 1, no: 2 }, _prefix: :spouse_us_citizen
   enum spouse_was_full_time_student: { unfilled: 0, yes: 1, no: 2 }, _prefix: :spouse_was_full_time_student
   enum spouse_was_blind: { unfilled: 0, yes: 1, no: 2 }, _prefix: :spouse_was_blind
+  enum spouse_visa: { unfilled: 0, yes: 1, no: 2 }, _prefix: :spouse_visa
   enum was_blind: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :was_blind
   enum was_full_time_student: { unfilled: 0, yes: 1, no: 2, unsure: 3 }, _prefix: :was_full_time_student
   enum widowed: { unfilled: 0, yes: 1, no: 2 }, _prefix: :widowed

--- a/app/models/intake/gyr_intake.rb
+++ b/app/models/intake/gyr_intake.rb
@@ -39,6 +39,7 @@
 #  demographic_primary_asian                            :boolean
 #  demographic_primary_black_african_american           :boolean
 #  demographic_primary_ethnicity                        :integer          default("unfilled"), not null
+#  demographic_primary_mena                             :boolean
 #  demographic_primary_native_hawaiian_pacific_islander :boolean
 #  demographic_primary_prefer_not_to_answer_race        :boolean
 #  demographic_primary_white                            :boolean
@@ -48,6 +49,7 @@
 #  demographic_spouse_asian                             :boolean
 #  demographic_spouse_black_african_american            :boolean
 #  demographic_spouse_ethnicity                         :integer          default("unfilled"), not null
+#  demographic_spouse_mena                              :boolean
 #  demographic_spouse_native_hawaiian_pacific_islander  :boolean
 #  demographic_spouse_prefer_not_to_answer_race         :boolean
 #  demographic_spouse_white                             :boolean

--- a/app/views/questions/life_situations/edit.html.erb
+++ b/app/views/questions/life_situations/edit.html.erb
@@ -12,7 +12,7 @@
       <%= f.cfa_checkbox(:had_disability, t('views.questions.life_situations.options.had_disability'), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox(:was_blind, t('views.questions.life_situations.options.was_blind'), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox(:was_full_time_student, t('views.questions.life_situations.options.was_full_time_student'), options: { checked_value: "yes", unchecked_value: "no" }) %>
-      <%= f.cfa_checkbox(:primary_not_us_citizen, t('views.questions.life_situations.options.was_not_citizen'), options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <%= f.cfa_checkbox(:primary_us_citizen, t('views.questions.life_situations.options.was_citizen'), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox(:no_life_situations_apply, t("general.none_of_the_above"), options: { id: "none__checkbox", checked_value: "yes", unchecked_value: "no" }) %>
     </div>
 

--- a/app/views/questions/life_situations/edit.html.erb
+++ b/app/views/questions/life_situations/edit.html.erb
@@ -13,6 +13,7 @@
       <%= f.cfa_checkbox(:was_blind, t('views.questions.life_situations.options.was_blind'), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox(:was_full_time_student, t('views.questions.life_situations.options.was_full_time_student'), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox(:primary_us_citizen, t('views.questions.life_situations.options.was_citizen'), options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <%= f.cfa_checkbox(:primary_visa, t('views.questions.life_situations.options.was_on_visa'), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox(:no_life_situations_apply, t("general.none_of_the_above"), options: { id: "none__checkbox", checked_value: "yes", unchecked_value: "no" }) %>
     </div>
 

--- a/app/views/questions/spouse_life_situations/edit.html.erb
+++ b/app/views/questions/spouse_life_situations/edit.html.erb
@@ -12,7 +12,7 @@
       <%= f.cfa_checkbox(:spouse_had_disability, t('views.questions.spouse_life_situations.options.had_disability'), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox(:spouse_was_blind, t('views.questions.spouse_life_situations.options.was_blind'), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox(:spouse_was_full_time_student, t('views.questions.spouse_life_situations.options.was_full_time_student'), options: { checked_value: "yes", unchecked_value: "no" }) %>
-      <%= f.cfa_checkbox(:spouse_not_us_citizen, t('views.questions.spouse_life_situations.options.was_not_citizen'), options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <%= f.cfa_checkbox(:spouse_us_citizen, t('views.questions.spouse_life_situations.options.was_citizen'), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox(:no_life_situations_apply, t("general.none_of_the_above"), options: { id: "none__checkbox", checked_value: "yes", unchecked_value: "no" }) %>
     </div>
 

--- a/app/views/questions/spouse_life_situations/edit.html.erb
+++ b/app/views/questions/spouse_life_situations/edit.html.erb
@@ -13,6 +13,7 @@
       <%= f.cfa_checkbox(:spouse_was_blind, t('views.questions.spouse_life_situations.options.was_blind'), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox(:spouse_was_full_time_student, t('views.questions.spouse_life_situations.options.was_full_time_student'), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox(:spouse_us_citizen, t('views.questions.spouse_life_situations.options.was_citizen'), options: { checked_value: "yes", unchecked_value: "no" }) %>
+      <%= f.cfa_checkbox(:spouse_visa, t('views.questions.spouse_life_situations.options.was_on_visa'), options: { checked_value: "yes", unchecked_value: "no" }) %>
       <%= f.cfa_checkbox(:no_life_situations_apply, t("general.none_of_the_above"), options: { id: "none__checkbox", checked_value: "yes", unchecked_value: "no" }) %>
     </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6150,6 +6150,7 @@ en:
           was_blind: I was legally blind
           was_citizen: I was a US citizen
           was_full_time_student: I was a full-time student in a college or a trade school
+          was_on_visa: I was in the US on a visa
         title: Select any situations that were true for you in %{year}
       lived_with_spouse:
         title: Did you live with your spouse during any part of the last six months of %{year}?
@@ -6308,6 +6309,7 @@ en:
           was_blind: They were legally blind
           was_citizen: They were a US citizen
           was_full_time_student: They were a full-time student in a college or a trade school
+          was_on_visa: They were in the US on a visa
         title: Select any situations that were true for your spouse in %{year}
       ssn_itin:
         title: Please provide your taxpayer identification information.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5520,7 +5520,6 @@ en:
         title: Tell us about your dependent. Please provide a few more details.
         was_married: Married as of 12/31/%{year}
         was_not_citizen: Not a US citizen
-        was_citizen: A US citizen
         was_student: Full time higher education student
       index:
         add_person: Add a person
@@ -6149,8 +6148,8 @@ en:
         options:
           had_disability: I had a permanent disability
           was_blind: I was legally blind
+          was_citizen: I was a US citizen
           was_full_time_student: I was a full-time student in a college or a trade school
-          was_not_citizen: I was not a US citizen
         title: Select any situations that were true for you in %{year}
       lived_with_spouse:
         title: Did you live with your spouse during any part of the last six months of %{year}?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6306,8 +6306,8 @@ en:
         options:
           had_disability: They had a permanent disability
           was_blind: They were legally blind
+          was_citizen: They were a US citizen
           was_full_time_student: They were a full-time student in a college or a trade school
-          was_not_citizen: They were not a US citizen
         title: Select any situations that were true for your spouse in %{year}
       ssn_itin:
         title: Please provide your taxpayer identification information.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5520,6 +5520,7 @@ en:
         title: Tell us about your dependent. Please provide a few more details.
         was_married: Married as of 12/31/%{year}
         was_not_citizen: Not a US citizen
+        was_citizen: A US citizen
         was_student: Full time higher education student
       index:
         add_person: Add a person

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -6165,8 +6165,9 @@ es:
         options:
           had_disability: Yo tenía una discapacidad permanente
           was_blind: Yo estaba legalmente ciego
-          was_citizen: Era ciudadano estadounidense
+          was_citizen: Yo era ciudadano estadounidense
           was_full_time_student: Yo era un estudiante a tiempo completo en una universidad o una escuela de oficios
+          was_on_visa: Yo estaba en los Estados Unidos con visado
         title: Seleccione las situaciones que fueron verdaderas para usted en el %{year}
       lived_with_spouse:
         title: "¿Vivió con su cónyuge durante alguna parte de los últimos seis meses de %{year}?"
@@ -6340,6 +6341,7 @@ es:
           was_blind: Mi cónyuge era legalmente ciego
           was_citizen: Eran ciudadanos estadounidenses
           was_full_time_student: Mi cónyuge era un estudiante a tiempo completo en una universidad o una escuela de oficios
+          was_on_visa: Mi cónyuge estaba en los Estados Unidos con visado
         title: Seleccione cualquier situación que haya sido cierta para su cónyuge en %{year}
       ssn_itin:
         title: Favor de proporcionar su información de identificación del contribuyente, "taxpayer identification information" en inglés.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -5503,6 +5503,7 @@ es:
         title: Háblenos de su dependiente. Por favor, proporcione algunos detalles más.
         was_married: Casado/a desde 12/31/%{year}
         was_not_citizen: No es ciudadano estadounidense
+        was_citizen: Es ciudadano estadounidense
         was_student: Estudiante de educación superior de tiempo completo
       index:
         add_person: Agregue a una persona

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -6338,8 +6338,8 @@ es:
         options:
           had_disability: Mi cónyuge tenía una discapacidad permanente
           was_blind: Mi cónyuge era legalmente ciego
+          was_citizen: Eran ciudadanos estadounidenses
           was_full_time_student: Mi cónyuge era un estudiante a tiempo completo en una universidad o una escuela de oficios
-          was_not_citizen: No eran ciudadanos estadounidenses
         title: Seleccione cualquier situación que haya sido cierta para su cónyuge en %{year}
       ssn_itin:
         title: Favor de proporcionar su información de identificación del contribuyente, "taxpayer identification information" en inglés.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -5503,7 +5503,6 @@ es:
         title: Háblenos de su dependiente. Por favor, proporcione algunos detalles más.
         was_married: Casado/a desde 12/31/%{year}
         was_not_citizen: No es ciudadano estadounidense
-        was_citizen: Es ciudadano estadounidense
         was_student: Estudiante de educación superior de tiempo completo
       index:
         add_person: Agregue a una persona
@@ -6166,8 +6165,8 @@ es:
         options:
           had_disability: Yo tenía una discapacidad permanente
           was_blind: Yo estaba legalmente ciego
+          was_citizen: Era ciudadano estadounidense
           was_full_time_student: Yo era un estudiante a tiempo completo en una universidad o una escuela de oficios
-          was_not_citizen: No era ciudadano estadounidense
         title: Seleccione las situaciones que fueron verdaderas para usted en el %{year}
       lived_with_spouse:
         title: "¿Vivió con su cónyuge durante alguna parte de los últimos seis meses de %{year}?"

--- a/db/migrate/20241219031602_add_primary_visa_and_spouse_visa_to_gyr_intake.rb
+++ b/db/migrate/20241219031602_add_primary_visa_and_spouse_visa_to_gyr_intake.rb
@@ -1,0 +1,6 @@
+class AddPrimaryVisaAndSpouseVisaToGyrIntake < ActiveRecord::Migration[7.1]
+  def change
+    add_column :intakes, :primary_visa, :integer, default: 0, null: false
+    add_column :intakes, :spouse_visa, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1178,6 +1178,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_13_222716) do
     t.boolean "demographic_primary_asian"
     t.boolean "demographic_primary_black_african_american"
     t.integer "demographic_primary_ethnicity", default: 0, null: false
+    t.boolean "demographic_primary_mena"
     t.boolean "demographic_primary_native_hawaiian_pacific_islander"
     t.boolean "demographic_primary_prefer_not_to_answer_race"
     t.boolean "demographic_primary_white"
@@ -1187,6 +1188,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_13_222716) do
     t.boolean "demographic_spouse_asian"
     t.boolean "demographic_spouse_black_african_american"
     t.integer "demographic_spouse_ethnicity", default: 0, null: false
+    t.boolean "demographic_spouse_mena"
     t.boolean "demographic_spouse_native_hawaiian_pacific_islander"
     t.boolean "demographic_spouse_prefer_not_to_answer_race"
     t.boolean "demographic_spouse_white"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1178,7 +1178,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_13_222716) do
     t.boolean "demographic_primary_asian"
     t.boolean "demographic_primary_black_african_american"
     t.integer "demographic_primary_ethnicity", default: 0, null: false
-    t.boolean "demographic_primary_mena"
     t.boolean "demographic_primary_native_hawaiian_pacific_islander"
     t.boolean "demographic_primary_prefer_not_to_answer_race"
     t.boolean "demographic_primary_white"
@@ -1188,7 +1187,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_13_222716) do
     t.boolean "demographic_spouse_asian"
     t.boolean "demographic_spouse_black_african_american"
     t.integer "demographic_spouse_ethnicity", default: 0, null: false
-    t.boolean "demographic_spouse_mena"
     t.boolean "demographic_spouse_native_hawaiian_pacific_islander"
     t.boolean "demographic_spouse_prefer_not_to_answer_race"
     t.boolean "demographic_spouse_white"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1324,6 +1324,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_13_222716) do
     t.string "primary_suffix"
     t.integer "primary_tin_type"
     t.integer "primary_us_citizen", default: 0, null: false
+    t.integer "primary_visa", default: 0, null: false
     t.integer "product_year", null: false
     t.integer "receive_written_communication", default: 0, null: false
     t.integer "received_advance_ctc_payment"
@@ -1380,6 +1381,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_13_222716) do
     t.string "spouse_suffix"
     t.integer "spouse_tin_type"
     t.integer "spouse_us_citizen", default: 0, null: false
+    t.integer "spouse_visa", default: 0, null: false
     t.integer "spouse_was_blind", default: 0, null: false
     t.integer "spouse_was_full_time_student", default: 0, null: false
     t.string "state"

--- a/spec/features/web_intake/new_joint_filers_spec.rb
+++ b/spec/features/web_intake/new_joint_filers_spec.rb
@@ -140,7 +140,7 @@ RSpec.feature "Web Intake Joint Filers", :flow_explorer_screenshot do
       check "I had a permanent disability"
       check "I was legally blind"
       check "I was a full-time student in a college or a trade school"
-      check "I was not a US citizen"
+      check "I was a US citizen"
     end
     click_on "Continue"
 

--- a/spec/forms/life_situations_form_spec.rb
+++ b/spec/forms/life_situations_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe LifeSituationsForm do
     {
       had_disability: "no",
       was_blind: "no",
-      primary_not_us_citizen: "no",
+      primary_us_citizen: "no",
       was_full_time_student: "no",
       no_life_situations_apply: "yes"
     }
@@ -17,7 +17,7 @@ RSpec.describe LifeSituationsForm do
     {
         had_disability: "yes",
         was_blind: "yes",
-        primary_not_us_citizen: "yes",
+        primary_us_citizen: "yes",
         was_full_time_student: "yes",
         no_life_situations_apply: "no",
     }
@@ -30,7 +30,7 @@ RSpec.describe LifeSituationsForm do
       intake.reload
 
       expect(intake.had_disability).to eq "no"
-      expect(intake.primary_us_citizen).to eq "yes"
+      expect(intake.primary_us_citizen).to eq "no"
       expect(intake.was_blind).to eq "no"
       expect(intake.was_full_time_student).to eq "no"
     end
@@ -41,7 +41,7 @@ RSpec.describe LifeSituationsForm do
       intake.reload
 
       expect(intake.had_disability).to eq "yes"
-      expect(intake.primary_us_citizen).to eq "no"
+      expect(intake.primary_us_citizen).to eq "yes"
       expect(intake.was_blind).to eq "yes"
       expect(intake.was_full_time_student).to eq "yes"
     end

--- a/spec/forms/life_situations_form_spec.rb
+++ b/spec/forms/life_situations_form_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe LifeSituationsForm do
       had_disability: "no",
       was_blind: "no",
       primary_us_citizen: "no",
+      primary_visa: "no",
       was_full_time_student: "no",
       no_life_situations_apply: "yes"
     }
@@ -18,6 +19,7 @@ RSpec.describe LifeSituationsForm do
         had_disability: "yes",
         was_blind: "yes",
         primary_us_citizen: "yes",
+        primary_visa: "yes",
         was_full_time_student: "yes",
         no_life_situations_apply: "no",
     }
@@ -31,6 +33,7 @@ RSpec.describe LifeSituationsForm do
 
       expect(intake.had_disability).to eq "no"
       expect(intake.primary_us_citizen).to eq "no"
+      expect(intake.primary_visa).to eq "no"
       expect(intake.was_blind).to eq "no"
       expect(intake.was_full_time_student).to eq "no"
     end
@@ -42,6 +45,7 @@ RSpec.describe LifeSituationsForm do
 
       expect(intake.had_disability).to eq "yes"
       expect(intake.primary_us_citizen).to eq "yes"
+      expect(intake.primary_visa).to eq "yes"
       expect(intake.was_blind).to eq "yes"
       expect(intake.was_full_time_student).to eq "yes"
     end

--- a/spec/forms/spouse_life_situations_form_spec.rb
+++ b/spec/forms/spouse_life_situations_form_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe SpouseLifeSituationsForm do
       spouse_had_disability: "no",
       spouse_was_blind: "no",
       spouse_us_citizen: "no",
+      spouse_visa: "no",
       spouse_was_full_time_student: "no",
       no_life_situations_apply: "yes",
     }
@@ -18,6 +19,7 @@ RSpec.describe SpouseLifeSituationsForm do
         spouse_had_disability: "yes",
         spouse_was_blind: "yes",
         spouse_us_citizen: "yes",
+        spouse_visa: "yes",
         spouse_was_full_time_student: "yes",
         no_life_situations_apply: "no",
     }
@@ -31,6 +33,7 @@ RSpec.describe SpouseLifeSituationsForm do
 
       expect(intake.spouse_had_disability).to eq "no"
       expect(intake.spouse_us_citizen).to eq "no"
+      expect(intake.spouse_visa).to eq "no"
       expect(intake.spouse_was_blind).to eq "no"
       expect(intake.spouse_was_full_time_student).to eq "no"
     end
@@ -42,6 +45,7 @@ RSpec.describe SpouseLifeSituationsForm do
 
       expect(intake.spouse_had_disability).to eq "yes"
       expect(intake.spouse_us_citizen).to eq "yes"
+      expect(intake.spouse_visa).to eq "yes"
       expect(intake.spouse_was_blind).to eq "yes"
       expect(intake.spouse_was_full_time_student).to eq "yes"
     end

--- a/spec/forms/spouse_life_situations_form_spec.rb
+++ b/spec/forms/spouse_life_situations_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SpouseLifeSituationsForm do
     {
       spouse_had_disability: "no",
       spouse_was_blind: "no",
-      spouse_not_us_citizen: "no",
+      spouse_us_citizen: "no",
       spouse_was_full_time_student: "no",
       no_life_situations_apply: "yes",
     }
@@ -17,7 +17,7 @@ RSpec.describe SpouseLifeSituationsForm do
     {
         spouse_had_disability: "yes",
         spouse_was_blind: "yes",
-        spouse_not_us_citizen: "yes",
+        spouse_us_citizen: "yes",
         spouse_was_full_time_student: "yes",
         no_life_situations_apply: "no",
     }
@@ -30,7 +30,7 @@ RSpec.describe SpouseLifeSituationsForm do
       intake.reload
 
       expect(intake.spouse_had_disability).to eq "no"
-      expect(intake.spouse_us_citizen).to eq "yes"
+      expect(intake.spouse_us_citizen).to eq "no"
       expect(intake.spouse_was_blind).to eq "no"
       expect(intake.spouse_was_full_time_student).to eq "no"
     end
@@ -41,7 +41,7 @@ RSpec.describe SpouseLifeSituationsForm do
       intake.reload
 
       expect(intake.spouse_had_disability).to eq "yes"
-      expect(intake.spouse_us_citizen).to eq "no"
+      expect(intake.spouse_us_citizen).to eq "yes"
       expect(intake.spouse_was_blind).to eq "yes"
       expect(intake.spouse_was_full_time_student).to eq "yes"
     end

--- a/spec/models/intake/gyr_intake_spec.rb
+++ b/spec/models/intake/gyr_intake_spec.rb
@@ -39,7 +39,6 @@
 #  demographic_primary_asian                            :boolean
 #  demographic_primary_black_african_american           :boolean
 #  demographic_primary_ethnicity                        :integer          default("unfilled"), not null
-#  demographic_primary_mena                             :boolean
 #  demographic_primary_native_hawaiian_pacific_islander :boolean
 #  demographic_primary_prefer_not_to_answer_race        :boolean
 #  demographic_primary_white                            :boolean
@@ -49,7 +48,6 @@
 #  demographic_spouse_asian                             :boolean
 #  demographic_spouse_black_african_american            :boolean
 #  demographic_spouse_ethnicity                         :integer          default("unfilled"), not null
-#  demographic_spouse_mena                              :boolean
 #  demographic_spouse_native_hawaiian_pacific_islander  :boolean
 #  demographic_spouse_prefer_not_to_answer_race         :boolean
 #  demographic_spouse_white                             :boolean

--- a/spec/models/intake/gyr_intake_spec.rb
+++ b/spec/models/intake/gyr_intake_spec.rb
@@ -182,6 +182,7 @@
 #  primary_suffix                                       :string
 #  primary_tin_type                                     :integer
 #  primary_us_citizen                                   :integer          default("unfilled"), not null
+#  primary_visa                                         :integer          default("unfilled"), not null
 #  product_year                                         :integer          not null
 #  receive_written_communication                        :integer          default("unfilled"), not null
 #  received_advance_ctc_payment                         :integer
@@ -237,6 +238,7 @@
 #  spouse_suffix                                        :string
 #  spouse_tin_type                                      :integer
 #  spouse_us_citizen                                    :integer          default("unfilled"), not null
+#  spouse_visa                                          :integer          default("unfilled"), not null
 #  spouse_was_blind                                     :integer          default("unfilled"), not null
 #  spouse_was_full_time_student                         :integer          default("unfilled"), not null
 #  state                                                :string

--- a/spec/models/intake/gyr_intake_spec.rb
+++ b/spec/models/intake/gyr_intake_spec.rb
@@ -39,6 +39,7 @@
 #  demographic_primary_asian                            :boolean
 #  demographic_primary_black_african_american           :boolean
 #  demographic_primary_ethnicity                        :integer          default("unfilled"), not null
+#  demographic_primary_mena                             :boolean
 #  demographic_primary_native_hawaiian_pacific_islander :boolean
 #  demographic_primary_prefer_not_to_answer_race        :boolean
 #  demographic_primary_white                            :boolean
@@ -48,6 +49,7 @@
 #  demographic_spouse_asian                             :boolean
 #  demographic_spouse_black_african_american            :boolean
 #  demographic_spouse_ethnicity                         :integer          default("unfilled"), not null
+#  demographic_spouse_mena                              :boolean
 #  demographic_spouse_native_hawaiian_pacific_islander  :boolean
 #  demographic_spouse_prefer_not_to_answer_race         :boolean
 #  demographic_spouse_white                             :boolean

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -182,6 +182,7 @@
 #  primary_suffix                                       :string
 #  primary_tin_type                                     :integer
 #  primary_us_citizen                                   :integer          default(0), not null
+#  primary_visa                                         :integer          default(0), not null
 #  product_year                                         :integer          not null
 #  receive_written_communication                        :integer          default(0), not null
 #  received_advance_ctc_payment                         :integer
@@ -237,6 +238,7 @@
 #  spouse_suffix                                        :string
 #  spouse_tin_type                                      :integer
 #  spouse_us_citizen                                    :integer          default(0), not null
+#  spouse_visa                                          :integer          default(0), not null
 #  spouse_was_blind                                     :integer          default(0), not null
 #  spouse_was_full_time_student                         :integer          default(0), not null
 #  state                                                :string

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -39,6 +39,7 @@
 #  demographic_primary_asian                            :boolean
 #  demographic_primary_black_african_american           :boolean
 #  demographic_primary_ethnicity                        :integer          default(0), not null
+#  demographic_primary_mena                             :boolean
 #  demographic_primary_native_hawaiian_pacific_islander :boolean
 #  demographic_primary_prefer_not_to_answer_race        :boolean
 #  demographic_primary_white                            :boolean
@@ -48,6 +49,7 @@
 #  demographic_spouse_asian                             :boolean
 #  demographic_spouse_black_african_american            :boolean
 #  demographic_spouse_ethnicity                         :integer          default(0), not null
+#  demographic_spouse_mena                              :boolean
 #  demographic_spouse_native_hawaiian_pacific_islander  :boolean
 #  demographic_spouse_prefer_not_to_answer_race         :boolean
 #  demographic_spouse_white                             :boolean

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -39,7 +39,6 @@
 #  demographic_primary_asian                            :boolean
 #  demographic_primary_black_african_american           :boolean
 #  demographic_primary_ethnicity                        :integer          default(0), not null
-#  demographic_primary_mena                             :boolean
 #  demographic_primary_native_hawaiian_pacific_islander :boolean
 #  demographic_primary_prefer_not_to_answer_race        :boolean
 #  demographic_primary_white                            :boolean
@@ -49,7 +48,6 @@
 #  demographic_spouse_asian                             :boolean
 #  demographic_spouse_black_african_american            :boolean
 #  demographic_spouse_ethnicity                         :integer          default(0), not null
-#  demographic_spouse_mena                              :boolean
 #  demographic_spouse_native_hawaiian_pacific_islander  :boolean
 #  demographic_spouse_prefer_not_to_answer_race         :boolean
 #  demographic_spouse_white                             :boolean


### PR DESCRIPTION
## Link to JIRA issue
- https://codeforamerica.atlassian.net/browse/GYR1-605

## Is PM acceptance required?
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main

## What was done?
- Flipped the US citizen question (so it's phrased in an affirmative manner) on the primary/spouse life situations screens.
- Added a new question to those screens about being on a visa

## How to test?
- The standard GYR UI/UX process should be fine here. 
- Should confirm that the citizen and visa answers, when submitted via the flow, do show up properly in the Hub 

## Screenshots (for visual changes)
- Before: see flows
- After: 
<img width="658" alt="primary life situations EN - Screenshot 2024-12-19 at 7 11 14 PM" src="https://github.com/user-attachments/assets/1a8945b4-42bc-4562-8b5b-97a51a1dada0" />
<img width="666" alt="primary life situations ES - Screenshot 2024-12-19 at 7 11 29 PM" src="https://github.com/user-attachments/assets/f5b05d1d-cf47-4570-b510-f46679eb4157" />
<img width="665" alt="spouse life situations EN - Screenshot 2024-12-19 at 7 12 37 PM" src="https://github.com/user-attachments/assets/75290bb6-60c4-4a4f-858c-b90aab247f3c" />
<img width="666" alt="spouse life situations ES - Screenshot 2024-12-19 at 7 12 07 PM" src="https://github.com/user-attachments/assets/a47b319e-86fb-40e5-95dc-419f91fb4aa8" />
