### PR TITLE
FYST-1485 fix md bundle failure of form 502

### DIFF
--- a/app/lib/submission_builder/ty2024/states/md/documents/md502.rb
+++ b/app/lib/submission_builder/ty2024/states/md/documents/md502.rb
@@ -106,6 +106,22 @@ class SubmissionBuilder::Ty2024::States::Md::Documents::Md502 < SubmissionBuilde
           end
         end
       end
+      if has_healthcare_coverage_section?
+        xml.MDHealthCareCoverage do
+          if @intake.primary_did_not_have_health_insurance_yes?
+            xml.PriWithoutHealthCoverageInd "X"
+            xml.PriDOB date_type(@intake.primary_birth_date)
+          end
+          if @intake.spouse_did_not_have_health_insurance_yes?
+            xml.SecWithoutHealthCoverageInd "X"
+            xml.SecDOB date_type(@intake.spouse_birth_date)
+          end
+          if @intake.authorize_sharing_of_health_insurance_info_yes?
+            xml.AuthorToShareInfoHealthExchInd "X"
+            xml.TaxpayerEmailAddress email_from_intake_or_df
+          end
+        end
+      end
       income_section(xml)
       xml.Additions do
         xml.StateRetirementPickup calculated_fields.fetch(:MD502_LINE_3)
@@ -128,22 +144,6 @@ class SubmissionBuilder::Ty2024::States::Md::Documents::Md502 < SubmissionBuilde
         xml.NetIncome calculated_fields.fetch(:MD502_LINE_18)
       end
       xml.ExemptionAmount calculated_fields.fetch(:MD502_LINE_19)
-      if has_healthcare_coverage_section?
-        xml.MDHealthCareCoverage do
-          if @intake.primary_did_not_have_health_insurance_yes?
-            xml.PriWithoutHealthCoverageInd "X"
-            xml.PriDOB date_type(@intake.primary_birth_date)
-          end
-          if @intake.spouse_did_not_have_health_insurance_yes?
-            xml.SecWithoutHealthCoverageInd "X"
-            xml.SecDOB date_type(@intake.spouse_birth_date)
-          end
-          if @intake.authorize_sharing_of_health_insurance_info_yes?
-            xml.AuthorToShareInfoHealthExchInd "X"
-            xml.TaxpayerEmailAddress email_from_intake_or_df
-          end
-        end
-      end
       if has_state_tax_computation?
         xml.StateTaxComputation do
           xml.TaxableNetIncome calculated_fields.fetch(:MD502_LINE_20) if @deduction_method_is_standard

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -599,7 +599,12 @@ RSpec.feature "Completing a state file intake", active_job: true do
       click_on I18n.t("general.continue")
 
       expect(page).to have_text I18n.t("state_file.questions.md_had_health_insurance.edit.title")
-      choose I18n.t("general.negative")
+      choose I18n.t("general.affirmative")
+      check "Zeus L Thunder"
+      within "#answer-no-health-insurance" do
+        choose I18n.t("general.affirmative")
+      end
+
       click_on I18n.t("general.continue")
 
       expect(strip_html_tags(page.body)).to have_text strip_html_tags(I18n.t("state_file.questions.tax_refund.edit.title_html", state_name: "Maryland", refund_amount: 1000))


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1485
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Moved `MDHealthCareCoverage` to its proper place in MD502 XML (after `Exemptions`, before `Income`)

## How to test?
- Describe the testing approach taken to verify the changes, including:
  - Wrote a test to catch bundle failure & implemented fix to pass the test
  - Manually went through the flow with both Felicity fixtures and filled out the health insurance information
## Screenshots (for visual changes)
<img width="1179" alt="Screenshot 2024-12-18 at 8 27 29 PM" src="https://github.com/user-attachments/assets/1dd7f9ee-8bfd-4451-9105-193dc5457663" />
<img width="622" alt="Screenshot 2024-12-18 at 8 27 39 PM" src="https://github.com/user-attachments/assets/00bb0821-9b81-463e-ab7c-cdd612fdc70b" />
