### PR TITLE
GYR1-604 Add dependent IP PIN question to dependent screen

### DIFF
--- a/app/controllers/questions/dependents_controller.rb
+++ b/app/controllers/questions/dependents_controller.rb
@@ -103,6 +103,7 @@ module Questions
         :north_american_resident,
         :disabled,
         :was_married,
+        :has_ip_pin,
       ]
       permitted_params = params.require(:dependent).permit(
         *dependent_attribute_keys, *birth_date_param_keys

--- a/app/views/questions/dependents/_form.html.erb
+++ b/app/views/questions/dependents/_form.html.erb
@@ -47,6 +47,7 @@
             <%= f.cfa_checkbox(:us_citizen, t("views.dependents.form.was_not_citizen"), options: {checked_value: "no", unchecked_value: "yes"}) %>
             <%= f.cfa_checkbox(:north_american_resident, t("views.dependents.form.north_american_resident"), options: {checked_value: "no", unchecked_value: "yes"}) %>
             <%= f.cfa_checkbox(:disabled, t("views.dependents.form.disabled"), options: {checked_value: "yes", unchecked_value: "no"}) %>
+            <%= f.cfa_checkbox(:has_ip_pin, t("views.dependents.form.has_ip_pin"), options: {checked_value: "yes", unchecked_value: "no"}) %>
           </div>
 
           <% if @allow_deletion %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5395,6 +5395,7 @@ en:
         delete_cta: Remove this person
         disabled: Permanently disabled
         first_name: First name
+        has_ip_pin: Has been issued an IP PIN
         last_name: Last name
         life_circumstances: Select any cases that describe their life this past year
         life_circumstances_help: We need these answers to determine which tax credits you may qualify for.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -5378,6 +5378,7 @@ es:
         delete_cta: Eliminar a esta persona
         disabled: Con discapacidad permanente
         first_name: Nombre
+        has_ip_pin: Se le emitió un IP PIN
         last_name: Apellido
         life_circumstances: Selecciona cualesquiera casos que describan sus vidas en el último año
         life_circumstances_help: Necesitamos estas respuestas para determinar para cuáles créditos tributarios te puedes calificar.

--- a/spec/lib/pdf_filler/md_el101_pdf_spec.rb
+++ b/spec/lib/pdf_filler/md_el101_pdf_spec.rb
@@ -92,3 +92,5 @@ RSpec.describe PdfFiller::MdEl101Pdf do
     end
   end
 end
+
+

--- a/spec/lib/pdf_filler/md_el101_pdf_spec.rb
+++ b/spec/lib/pdf_filler/md_el101_pdf_spec.rb
@@ -35,11 +35,7 @@ RSpec.describe PdfFiller::MdEl101Pdf do
         expect(pdf_fields["ERO firm name"]).to eq "FileYourStateTaxes"
         expect(pdf_fields["to enter or generate my PIN"]).to eq "23456"
         expect(pdf_fields["Primary signature"]).to eq "Mary Lando"
-<<<<<<< HEAD
         expect(pdf_fields["Date"]).to eq expected_signature_date_pdf_value
-=======
-        expect(pdf_fields["Date"]).to eq expected_signature_date
->>>>>>> 5391dad93 (fix rebase weirdness take 2)
         expect(pdf_fields["Spouses First Name"]).to eq("")
         expect(pdf_fields["Spouse MI"]).to eq("")
         expect(pdf_fields["Spouses Last Name"]).to eq("")
@@ -91,11 +87,7 @@ RSpec.describe PdfFiller::MdEl101Pdf do
         expect(pdf_fields["ERO firm name_2"]).to eq "FileYourStateTaxes"
         expect(pdf_fields["to enter or generate my PIN_2"]).to eq "11111"
         expect(pdf_fields["Spouses signature"]).to eq "Marty Lando"
-<<<<<<< HEAD
         expect(pdf_fields["Date_2"]).to eq expected_signature_date_pdf_value
-=======
-        expect(pdf_fields["Date_2"]).to eq expected_signature_date
->>>>>>> 5391dad93 (fix rebase weirdness take 2)
       end
     end
   end

--- a/spec/lib/pdf_filler/md_el101_pdf_spec.rb
+++ b/spec/lib/pdf_filler/md_el101_pdf_spec.rb
@@ -35,7 +35,11 @@ RSpec.describe PdfFiller::MdEl101Pdf do
         expect(pdf_fields["ERO firm name"]).to eq "FileYourStateTaxes"
         expect(pdf_fields["to enter or generate my PIN"]).to eq "23456"
         expect(pdf_fields["Primary signature"]).to eq "Mary Lando"
+<<<<<<< HEAD
         expect(pdf_fields["Date"]).to eq expected_signature_date_pdf_value
+=======
+        expect(pdf_fields["Date"]).to eq expected_signature_date
+>>>>>>> 5391dad93 (fix rebase weirdness take 2)
         expect(pdf_fields["Spouses First Name"]).to eq("")
         expect(pdf_fields["Spouse MI"]).to eq("")
         expect(pdf_fields["Spouses Last Name"]).to eq("")
@@ -87,7 +91,11 @@ RSpec.describe PdfFiller::MdEl101Pdf do
         expect(pdf_fields["ERO firm name_2"]).to eq "FileYourStateTaxes"
         expect(pdf_fields["to enter or generate my PIN_2"]).to eq "11111"
         expect(pdf_fields["Spouses signature"]).to eq "Marty Lando"
+<<<<<<< HEAD
         expect(pdf_fields["Date_2"]).to eq expected_signature_date_pdf_value
+=======
+        expect(pdf_fields["Date_2"]).to eq expected_signature_date
+>>>>>>> 5391dad93 (fix rebase weirdness take 2)
       end
     end
   end

--- a/spec/lib/pdf_filler/md_el101_pdf_spec.rb
+++ b/spec/lib/pdf_filler/md_el101_pdf_spec.rb
@@ -92,5 +92,3 @@ RSpec.describe PdfFiller::MdEl101Pdf do
     end
   end
 end
-
-


### PR DESCRIPTION
## Link to JIRA issue
- https://codeforamerica.atlassian.net/browse/GYR1-604

## Is PM acceptance required?
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main

## What was done?
- Just added one checkbox to the dependent screen/form
- There was already a `has_ip_pin` column on the dependent table, so *no* database changes were needed.

## How to test?
- Check that when using the dependent form, the IP PIN checkbox looks good and that the data element persists when going back to that dependent entry again (e.g., to edit).

## Screenshots (for visual changes)
- Before: see flows/gyr
- After: 
<img width="670" alt="ip pin checkbox on dependent screen EN - Screenshot 2024-12-19 at 8 11 17 PM" src="https://github.com/user-attachments/assets/88720e60-b69d-431c-b4a8-8f89bbe8ddfb" />
<img width="650" alt="ip pin checkbox on dependent screen ES -Screenshot 2024-12-19 at 8 12 14 PM" src="https://github.com/user-attachments/assets/23a0b756-5ad0-4c9a-8823-a79ee4478317" />

