### PR TITLE
NJ 229 - Add static paid preparer fields to return header

### DIFF
--- a/app/lib/submission_builder/return_header.rb
+++ b/app/lib/submission_builder/return_header.rb
@@ -12,9 +12,11 @@ module SubmissionBuilder
           xml.TaxPeriodEndDt date_type(Date.new(@submission.data_source.tax_return_year, 12, 31))
         end
         xml.TaxYr @submission.data_source.tax_return_year
-        xml.PaidPreparerInformationGrp do
-          xml.PTIN "P99999999"
-          xml.PreparerPersonNm "Self Prepared"
+        if @submission.data_source.state_code.upcase == "NJ"
+          xml.PaidPreparerInformationGrp do 
+            xml.PTIN "P99999999"
+            xml.PreparerPersonNm "Self Prepared"
+          end
         end
         xml.DisasterReliefTxt @intake.disaster_relief_county if @intake.respond_to?(:disaster_relief_county)
         xml.OriginatorGrp do

--- a/app/lib/submission_builder/return_header.rb
+++ b/app/lib/submission_builder/return_header.rb
@@ -12,6 +12,10 @@ module SubmissionBuilder
           xml.TaxPeriodEndDt date_type(Date.new(@submission.data_source.tax_return_year, 12, 31))
         end
         xml.TaxYr @submission.data_source.tax_return_year
+        xml.PaidPreparerInformationGrp do
+          xml.PTIN "P99999999"
+          xml.PreparerPersonNm "Self Prepared"
+        end
         xml.DisasterReliefTxt @intake.disaster_relief_county if @intake.respond_to?(:disaster_relief_county)
         xml.OriginatorGrp do
           xml.EFIN EnvironmentCredentials.irs(:efin)
@@ -33,7 +37,7 @@ module SubmissionBuilder
             xml.DateSigned date_type_for_timezone(@submission.data_source.primary_esigned_at)&.strftime("%F") if @submission.data_source.ask_for_signature_pin?
             xml.USPhone @submission.data_source.direct_file_data.phone_number if @submission.data_source.direct_file_data.phone_number.present?
           end
-          if @submission.data_source&.spouse.ssn.present? && @submission.data_source&.spouse.first_name.present? && !@intake.filing_status_mfs?
+          if @submission.data_source&.spouse&.ssn.present? && @submission.data_source&.spouse&.first_name.present? && !@intake.filing_status_mfs?
             xml.Secondary do
               xml.TaxpayerName do
                 xml.FirstName sanitize_for_xml(@submission.data_source.spouse.first_name, 16) if @submission.data_source.spouse.first_name.present?
@@ -44,7 +48,7 @@ module SubmissionBuilder
               xml.TaxpayerSSN @submission.data_source.spouse.ssn if @submission.data_source.spouse.ssn.present?
               xml.DateOfBirth date_type(@submission.data_source.spouse.birth_date) if @submission.data_source.spouse.birth_date.present?
               xml.TaxpayerPIN @submission.data_source.spouse_signature_pin if @submission.data_source.ask_for_signature_pin? && @submission.data_source.ask_spouse_esign?
-              xml.DateSigned date_type_for_timezone(@submission.data_source.spouse_esigned_at)&.strftime("%F")  if @submission.data_source.ask_for_signature_pin? && @submission.data_source.ask_spouse_esign?
+              xml.DateSigned date_type_for_timezone(@submission.data_source.spouse_esigned_at)&.strftime("%F") if @submission.data_source.ask_for_signature_pin? && @submission.data_source.ask_spouse_esign?
               xml.DateOfDeath @submission.data_source.direct_file_data.spouse_date_of_death if @submission.data_source.direct_file_data.spouse_date_of_death.present?
             end
           end

--- a/spec/lib/submission_builder/ty2022/states/return_header_spec.rb
+++ b/spec/lib/submission_builder/ty2022/states/return_header_spec.rb
@@ -39,8 +39,25 @@ describe SubmissionBuilder::ReturnHeader do
           expect(doc.at("USAddress CityNm").text).to eq mailing_city
           expect(doc.at("USAddress StateAbbreviationCd").text).to eq state_code.upcase
           expect(doc.at("USAddress ZIPCd").text).to eq mailing_zip
-          expect(doc.at("PaidPreparerInformationGrp PTIN").text).to eq "P99999999"
-          expect(doc.at("PaidPreparerInformationGrp PreparerPersonNm").text).to eq "Self Prepared"
+        end
+      end
+
+      context "paid preparer information group" do
+        if state_code == "nj"
+          context "for NJ returns" do
+            it "adds XML elements for PaidPreparerInformationGrp" do
+              expect(doc.at("PaidPreparerInformationGrp PTIN").text).to eq "P99999999"
+              expect(doc.at("PaidPreparerInformationGrp PreparerPersonNm").text).to eq "Self Prepared"
+            end
+          end
+        else
+          context "for non NJ returns" do
+            it "does not add XML elements for PaidPreparerInformationGrp" do
+              expect(doc.at("PaidPreparerInformationGrp")).not_to be_present 
+              expect(doc.at("PaidPreparerInformationGrp PTIN")).not_to be_present 
+              expect(doc.at("PaidPreparerInformationGrp PreparerPersonNm")).not_to be_present 
+            end
+          end
         end
       end
 

--- a/spec/lib/submission_builder/ty2022/states/return_header_spec.rb
+++ b/spec/lib/submission_builder/ty2022/states/return_header_spec.rb
@@ -39,6 +39,8 @@ describe SubmissionBuilder::ReturnHeader do
           expect(doc.at("USAddress CityNm").text).to eq mailing_city
           expect(doc.at("USAddress StateAbbreviationCd").text).to eq state_code.upcase
           expect(doc.at("USAddress ZIPCd").text).to eq mailing_zip
+          expect(doc.at("PaidPreparerInformationGrp PTIN").text).to eq "P99999999"
+          expect(doc.at("PaidPreparerInformationGrp PreparerPersonNm").text).to eq "Self Prepared"
         end
       end
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://github.com/newjersey/affordability-pm/issues/229

## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- NJ Taxation is reporting MEF errors with all submissions since `PaidPreparerInformationGrp` is not present in the `StateReturnHeader` of XML submissions
- This change adds a static `PaidPreparerInformationGrp` block that corresponds to self prepared taxes.

## How to test?
- Unit Tests
- Run through `devito_single` persona on localhost/heroku, validate that XML contains `PaidPreparerInformationGrp`

## Screenshots (for visual changes)
- After
<img width="584" alt="image" src="https://github.com/user-attachments/assets/b3481d9e-55d2-4f66-828b-d5b5b0af6f39" />

