### PR TITLE
NJ 161 - include veteran doc requirements on submission page

### DIFF
--- a/app/views/state_file/questions/submission_confirmation/_nj_additional_content.html.erb
+++ b/app/views/state_file/questions/submission_confirmation/_nj_additional_content.html.erb
@@ -1,6 +1,6 @@
 <% if current_intake.primary_veteran_yes? || current_intake.spouse_veteran_yes? %>
   <div class="white-group">
     <h2 class="h3"><%=t('.header') %></h2>
-    <p><%=t('.body_html') %></p>
+    <p><%=t('.body_html', or_spouse: current_intake.filing_status_mfj? ? t('.or_spouse') : '') %></p>
   </div>
 <% end %>

--- a/app/views/state_file/questions/submission_confirmation/_nj_additional_content.html.erb
+++ b/app/views/state_file/questions/submission_confirmation/_nj_additional_content.html.erb
@@ -1,0 +1,6 @@
+<% if current_intake.primary_veteran_yes? || current_intake.spouse_veteran_yes? %>
+  <div class="white-group">
+    <h2 class="h3"><%=t('.header') %></h2>
+    <p><%=t('.body_html') %></p>
+  </div>
+<% end %>

--- a/app/views/state_file/questions/submission_confirmation/edit.html.erb
+++ b/app/views/state_file/questions/submission_confirmation/edit.html.erb
@@ -36,6 +36,8 @@
 
   <p><%= t('general.spread_the_word_html') %></p>
 
+  <%= render partial: "state_file/questions/submission_confirmation/#{current_state_code}_additional_content" rescue nil %>
+
   <%= link_to t(".download_state_return_pdf"), StateFile::Questions::SubmissionPdfsController.to_path_helper(action: :show, id: current_intake.latest_submission), class: "button button--primary button--wide" %>
 
   <% if show_xml? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3653,8 +3653,8 @@ en:
           title: Your %{filing_year} %{state_name} state tax return is now submitted!
           title_resubmit: Your %{filing_year} %{state_name} state tax return is now resubmitted!
         nj_additional_content:
-          header: "Attention: if you are claiming the veteran exemption for the first time"
           body_html: You said you%{or_spouse} are filing for the veteran exemption. If it's your first time filing for <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/military/vetexemption.shtml">this exemption</a>, you have to provide <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/military/vetexemption-documentation.shtml">documentation</a> and a <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/pdf/veteransexemptionform.pdf">form</a> to the New Jersey Division of Taxation. It can be done <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/pdf/veteransexemptionform.pdf">online</a>.
+          header: 'Attention: if you are claiming the veteran exemption for the first time'
           or_spouse: " or your spouse"
       tax_refund:
         bank_details:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3652,6 +3652,9 @@ en:
           text_update: You'll receive an sms update when your state tax return is accepted.
           title: Your %{filing_year} %{state_name} state tax return is now submitted!
           title_resubmit: Your %{filing_year} %{state_name} state tax return is now resubmitted!
+        nj_additional_content:
+          header: "Attention: if you are claiming the veteran exemption for the first time"
+          body_html: You said you or your spouse are filing for the veteran exemption. If it's your first time filing for <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/military/vetexemption.shtml">this exemption</a>, you have to provide <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/military/vetexemption-documentation.shtml">documentation</a> and a <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/pdf/veteransexemptionform.pdf">form</a> to the New Jersey Division of Taxation. It can be done <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/pdf/veteransexemptionform.pdf">online</a>.
       tax_refund:
         bank_details:
           account_number: Account Number

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3654,7 +3654,8 @@ en:
           title_resubmit: Your %{filing_year} %{state_name} state tax return is now resubmitted!
         nj_additional_content:
           header: "Attention: if you are claiming the veteran exemption for the first time"
-          body_html: You said you or your spouse are filing for the veteran exemption. If it's your first time filing for <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/military/vetexemption.shtml">this exemption</a>, you have to provide <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/military/vetexemption-documentation.shtml">documentation</a> and a <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/pdf/veteransexemptionform.pdf">form</a> to the New Jersey Division of Taxation. It can be done <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/pdf/veteransexemptionform.pdf">online</a>.
+          body_html: You said you%{or_spouse} are filing for the veteran exemption. If it's your first time filing for <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/military/vetexemption.shtml">this exemption</a>, you have to provide <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/military/vetexemption-documentation.shtml">documentation</a> and a <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/pdf/veteransexemptionform.pdf">form</a> to the New Jersey Division of Taxation. It can be done <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/pdf/veteransexemptionform.pdf">online</a>.
+          or_spouse: " or your spouse"
       tax_refund:
         bank_details:
           account_number: Account Number

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3626,6 +3626,9 @@ es:
           text_update: Recibirás una actualización por SMS cuando una vez tu declaración de impuestos haya sido aceptada.
           title: "¡Tu declaración de impuestos de %{state_name}de %{filing_year} ha sido enviada! "
           title_resubmit: "¡Tu declaración de impuestos de %{state_name} de %{filing_year} ha sido enviada de nuevo!"
+        nj_additional_content:
+          header: "Attention: if you are claiming the veteran exemption for the first time"
+          body_html: You said you or your spouse are filing for the veteran exemption. If it's your first time filing for <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/military/vetexemption.shtml">this exemption</a>, you have to provide <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/military/vetexemption-documentation.shtml">documentation</a> and a <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/pdf/veteransexemptionform.pdf">form</a> to the New Jersey Division of Taxation. It can be done <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/pdf/veteransexemptionform.pdf">online</a>.
       tax_refund:
         bank_details:
           account_number: Número de cuenta

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3627,8 +3627,8 @@ es:
           title: "¡Tu declaración de impuestos de %{state_name}de %{filing_year} ha sido enviada! "
           title_resubmit: "¡Tu declaración de impuestos de %{state_name} de %{filing_year} ha sido enviada de nuevo!"
         nj_additional_content:
-          header: "Attention: if you are claiming the veteran exemption for the first time"
           body_html: You said you%{or_spouse} are filing for the veteran exemption. If it's your first time filing for <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/military/vetexemption.shtml">this exemption</a>, you have to provide <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/military/vetexemption-documentation.shtml">documentation</a> and a <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/pdf/veteransexemptionform.pdf">form</a> to the New Jersey Division of Taxation. It can be done <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/pdf/veteransexemptionform.pdf">online</a>.
+          header: 'Attention: if you are claiming the veteran exemption for the first time'
           or_spouse: " or your spouse"
       tax_refund:
         bank_details:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3628,7 +3628,8 @@ es:
           title_resubmit: "¡Tu declaración de impuestos de %{state_name} de %{filing_year} ha sido enviada de nuevo!"
         nj_additional_content:
           header: "Attention: if you are claiming the veteran exemption for the first time"
-          body_html: You said you or your spouse are filing for the veteran exemption. If it's your first time filing for <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/military/vetexemption.shtml">this exemption</a>, you have to provide <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/military/vetexemption-documentation.shtml">documentation</a> and a <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/pdf/veteransexemptionform.pdf">form</a> to the New Jersey Division of Taxation. It can be done <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/pdf/veteransexemptionform.pdf">online</a>.
+          body_html: You said you%{or_spouse} are filing for the veteran exemption. If it's your first time filing for <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/military/vetexemption.shtml">this exemption</a>, you have to provide <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/military/vetexemption-documentation.shtml">documentation</a> and a <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/pdf/veteransexemptionform.pdf">form</a> to the New Jersey Division of Taxation. It can be done <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/pdf/veteransexemptionform.pdf">online</a>.
+          or_spouse: " or your spouse"
       tax_refund:
         bank_details:
           account_number: Número de cuenta

--- a/spec/controllers/state_file/questions/submission_confirmation_controller_spec.rb
+++ b/spec/controllers/state_file/questions/submission_confirmation_controller_spec.rb
@@ -17,30 +17,31 @@ describe StateFile::Questions::SubmissionConfirmationController do
   end
 
   describe "nj veteran content" do
+    render_views
+    let(:body_substring) { I18n.t('state_file.questions.submission_confirmation.nj_additional_content.body_html')[0..30] }
+    # Searching for html as text in the document throws an error
+
     context "when nj and primary veteran" do
       let(:intake) { create :state_file_nj_intake, :married_filing_jointly, primary_veteran: "yes", spouse_veteran: "no" }
-      render_views
       it "shows veteran documentation requirements" do
         get :edit
-        expect(response_html).to have_text "You said you or your spouse are filing for the veteran exemption"
+        expect(response_html).to have_text body_substring
       end
     end
 
     context "when nj and spouse veteran" do
       let(:intake) { create :state_file_nj_intake, :married_filing_jointly, primary_veteran: "no", spouse_veteran: "yes" }
-      render_views
       it "shows veteran documentation requirements" do
         get :edit
-        expect(response_html).to have_text "You said you or your spouse are filing for the veteran exemption"
+        expect(response_html).to have_text body_substring
       end
     end
 
     context "when nj and neither primary nor spouse are veteran" do
       let(:intake) { create :state_file_nj_intake, :married_filing_jointly, primary_veteran: "no", spouse_veteran: "no" }
-      render_views
       it "does not show veteran documentation requirements" do
         get :edit
-        expect(response_html).not_to have_text "You said you or your spouse are filing for the veteran exemption"
+        expect(response_html).not_to have_text body_substring
       end
     end
   end

--- a/spec/controllers/state_file/questions/submission_confirmation_controller_spec.rb
+++ b/spec/controllers/state_file/questions/submission_confirmation_controller_spec.rb
@@ -15,4 +15,33 @@ describe StateFile::Questions::SubmissionConfirmationController do
       expect(response_html).to have_text "state tax return is now submitted"
     end
   end
+
+  describe "nj veteran content" do
+    context "when nj and primary veteran" do
+      let(:intake) { create :state_file_nj_intake, :married_filing_jointly, primary_veteran: "yes", spouse_veteran: "no" }
+      render_views
+      it "shows veteran documentation requirements" do
+        get :edit
+        expect(response_html).to have_text "You said you or your spouse are filing for the veteran exemption"
+      end
+    end
+
+    context "when nj and spouse veteran" do
+      let(:intake) { create :state_file_nj_intake, :married_filing_jointly, primary_veteran: "no", spouse_veteran: "yes" }
+      render_views
+      it "shows veteran documentation requirements" do
+        get :edit
+        expect(response_html).to have_text "You said you or your spouse are filing for the veteran exemption"
+      end
+    end
+
+    context "when nj and neither primary nor spouse are veteran" do
+      let(:intake) { create :state_file_nj_intake, :married_filing_jointly, primary_veteran: "no", spouse_veteran: "no" }
+      render_views
+      it "does not show veteran documentation requirements" do
+        get :edit
+        expect(response_html).not_to have_text "You said you or your spouse are filing for the veteran exemption"
+      end
+    end
+  end
 end

--- a/spec/controllers/state_file/questions/submission_confirmation_controller_spec.rb
+++ b/spec/controllers/state_file/questions/submission_confirmation_controller_spec.rb
@@ -5,6 +5,7 @@ describe StateFile::Questions::SubmissionConfirmationController do
   let!(:submission) { create :efile_submission, :for_state, data_source: intake }
   before do
     sign_in intake
+    allow(subject).to receive(:current_intake).and_return(intake)
   end
 
   describe '#edit' do
@@ -17,9 +18,19 @@ describe StateFile::Questions::SubmissionConfirmationController do
   end
 
   describe "nj veteran content" do
+    let(:or_spouse) { I18n.t('state_file.questions.submission_confirmation.nj_additional_content.or_spouse') }
+    let(:body_substring) { I18n.t('state_file.questions.submission_confirmation.nj_additional_content.body_html', or_spouse: or_spouse)[0..30] }
     render_views
-    let(:body_substring) { I18n.t('state_file.questions.submission_confirmation.nj_additional_content.body_html')[0..30] }
-    # Searching for html as text in the document throws an error
+
+    context "single veteran" do
+      let(:intake) { create :state_file_nj_intake, primary_veteran: "yes", filing_status: :single }
+      let(:or_spouse) { '' }
+      
+      it "shows veteran documentation requirements" do
+        get :edit
+        expect(response_html).to have_text body_substring
+      end
+    end
 
     context "when nj and primary veteran" do
       let(:intake) { create :state_file_nj_intake, :married_filing_jointly, primary_veteran: "yes", spouse_veteran: "no" }


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/161

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Conditionally show content box on submission confirmation screen if NJ and primary or spouse is veteran

## How to test?
- To see content, select yes for veteran
- To not see content, select no for veteran

## Screenshots (for visual changes)
