### PR TITLE
Move Maryland Health Connection screens after tax refund page

### DIFF
--- a/app/controllers/state_file/questions/md_had_health_insurance_controller.rb
+++ b/app/controllers/state_file/questions/md_had_health_insurance_controller.rb
@@ -3,11 +3,11 @@ module StateFile
     class MdHadHealthInsuranceController < QuestionsController
       def form_params
         if params[:state_file_md_had_health_insurance_form]
-        params
-          .fetch(:state_file_md_had_health_insurance_form, {})
-          .permit(
-            form_class.attribute_names +
-              [{ dependents_attributes: [:id, :md_did_not_have_health_insurance] }])
+          params
+            .fetch(:state_file_md_had_health_insurance_form, {})
+            .permit(
+              form_class.attribute_names +
+                [{ dependents_attributes: [:id, :md_did_not_have_health_insurance] }])
         end
       end
     end

--- a/app/lib/navigation/state_file_md_question_navigation.rb
+++ b/app/lib/navigation/state_file_md_question_navigation.rb
@@ -40,8 +40,8 @@ module Navigation
         Navigation::NavigationStep.new(StateFile::Questions::SpouseStateIdController),
         Navigation::NavigationStep.new(StateFile::Questions::MdReviewController),
         Navigation::NavigationStep.new(StateFile::Questions::TaxesOwedController),
-        Navigation::NavigationStep.new(StateFile::Questions::MdHadHealthInsuranceController),
         Navigation::NavigationStep.new(StateFile::Questions::MdTaxRefundController),
+        Navigation::NavigationStep.new(StateFile::Questions::MdHadHealthInsuranceController),
         Navigation::NavigationStep.new(StateFile::Questions::EsignDeclarationController), # creates EfileSubmission and transitions to preparing
       ]),
       Navigation::NavigationSection.new("state_file.navigation.section_6", [

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -598,15 +598,6 @@ RSpec.feature "Completing a state file intake", active_job: true do
       expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
       click_on I18n.t("general.continue")
 
-      expect(page).to have_text I18n.t("state_file.questions.md_had_health_insurance.edit.title")
-      choose I18n.t("general.affirmative")
-      check "Zeus L Thunder"
-      within "#answer-no-health-insurance" do
-        choose I18n.t("general.affirmative")
-      end
-
-      click_on I18n.t("general.continue")
-
       expect(strip_html_tags(page.body)).to have_text strip_html_tags(I18n.t("state_file.questions.tax_refund.edit.title_html", state_name: "Maryland", refund_amount: 1000))
       choose I18n.t('state_file.questions.tax_refund.edit.direct_deposit')
       choose I18n.t("views.questions.bank_details.account_type.checking")
@@ -621,6 +612,14 @@ RSpec.feature "Completing a state file intake", active_job: true do
       fill_in 'state_file_md_tax_refund_form_account_number', with: "123456789"
       fill_in 'state_file_md_tax_refund_form_account_number_confirmation', with: "123456789"
       check I18n.t('state_file.questions.md_tax_refund.edit.bank_authorization_confirmation')
+      click_on I18n.t("general.continue")
+
+      expect(page).to have_text I18n.t("state_file.questions.md_had_health_insurance.edit.title")
+      choose I18n.t("general.affirmative")
+      check "Zeus L Thunder"
+      within "#answer-no-health-insurance" do
+        choose I18n.t("general.affirmative")
+      end
       click_on I18n.t("general.continue")
 
       expect(page).to have_text I18n.t("state_file.questions.esign_declaration.edit.title", state_name: "Maryland")


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. [link](https://codeforamerica.atlassian.net/browse/FYST-1329?atlOrigin=eyJpIjoiM2Q1N2EzNzIzMDFlNDBlNzg5NTNlYTVjYWUxOTdhYzgiLCJwIjoiaiJ9)
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- moved maryland health connection screen to be after tax refund page
## How to test?
- 
