### PR TITLE
nj 203 - added signature date to pdf

### DIFF
--- a/app/lib/pdf_filler/nj1040_pdf.rb
+++ b/app/lib/pdf_filler/nj1040_pdf.rb
@@ -94,6 +94,10 @@ module PdfFiller
         Group246: if get_mfj_spouse_ssn
                     @xml_document.at("Body SpouCuPartPrimGubernElectFund").present? ? 'Choice1' : 'Choice2'
                   end,
+        
+        # signature fields
+        'Date1_es_:signer:date': @xml_document.at("ReturnHeaderState Filer Primary DateSigned")&.text,
+        'Date2_es_:signer:date': @xml_document.at("ReturnHeaderState Filer Secondary DateSigned")&.text
       }
 
       dependents = get_dependents

--- a/app/lib/submission_builder/return_header.rb
+++ b/app/lib/submission_builder/return_header.rb
@@ -36,7 +36,7 @@ module SubmissionBuilder
             xml.TaxpayerSSN @submission.data_source.primary.ssn if @submission.data_source.primary.ssn.present?
             xml.DateOfBirth date_type(@submission.data_source.primary.birth_date) if @submission.data_source.primary.birth_date.present?
             xml.TaxpayerPIN @submission.data_source.primary_signature_pin if @submission.data_source.ask_for_signature_pin?
-            xml.DateSigned date_type_for_timezone(@submission.data_source.primary_esigned_at)&.strftime("%F") if @submission.data_source.ask_for_signature_pin?
+            xml.DateSigned date_type_for_timezone(@submission.data_source.primary_esigned_at)&.strftime("%F") if @submission.data_source.primary_esigned_yes?
             xml.USPhone @submission.data_source.direct_file_data.phone_number if @submission.data_source.direct_file_data.phone_number.present?
           end
           if @submission.data_source&.spouse&.ssn.present? && @submission.data_source&.spouse&.first_name.present? && !@intake.filing_status_mfs?
@@ -50,7 +50,7 @@ module SubmissionBuilder
               xml.TaxpayerSSN @submission.data_source.spouse.ssn if @submission.data_source.spouse.ssn.present?
               xml.DateOfBirth date_type(@submission.data_source.spouse.birth_date) if @submission.data_source.spouse.birth_date.present?
               xml.TaxpayerPIN @submission.data_source.spouse_signature_pin if @submission.data_source.ask_for_signature_pin? && @submission.data_source.ask_spouse_esign?
-              xml.DateSigned date_type_for_timezone(@submission.data_source.spouse_esigned_at)&.strftime("%F") if @submission.data_source.ask_for_signature_pin? && @submission.data_source.ask_spouse_esign?
+              xml.DateSigned date_type_for_timezone(@submission.data_source.spouse_esigned_at)&.strftime("%F") if @submission.data_source.spouse_esigned_yes? && @submission.data_source.ask_spouse_esign?
               xml.DateOfDeath @submission.data_source.direct_file_data.spouse_date_of_death if @submission.data_source.direct_file_data.spouse_date_of_death.present?
             end
           end

--- a/app/models/direct_file_data.rb
+++ b/app/models/direct_file_data.rb
@@ -192,6 +192,7 @@ class DirectFileData < DfXmlAccessor
   end
 
   def mailing_apartment=(value)
+    create_or_destroy_df_xml_node(__method__, value)
     write_df_xml_value(__method__, value)
   end
 

--- a/app/models/state_file_nj_intake.rb
+++ b/app/models/state_file_nj_intake.rb
@@ -60,7 +60,6 @@
 #  primary_last_name                                      :string
 #  primary_middle_initial                                 :string
 #  primary_signature                                      :string
-#  primary_signature_pin                                  :text
 #  primary_ssn                                            :string
 #  primary_suffix                                         :string
 #  primary_veteran                                        :integer          default("unfilled"), not null
@@ -84,7 +83,6 @@
 #  spouse_first_name                                      :string
 #  spouse_last_name                                       :string
 #  spouse_middle_initial                                  :string
-#  spouse_signature_pin                                   :text
 #  spouse_ssn                                             :string
 #  spouse_suffix                                          :string
 #  spouse_veteran                                         :integer          default("unfilled"), not null
@@ -113,6 +111,7 @@
 #  index_state_file_nj_intakes_on_spouse_state_id_id   (spouse_state_id_id)
 #
 class StateFileNjIntake < StateFileBaseIntake
+  self.ignored_columns += ["primary_signature_pin", "spouse_signature_pin"]
   encrypts :account_number, :routing_number, :raw_direct_file_data, :raw_direct_file_intake_data
 
   enum household_rent_own: { unfilled: 0, rent: 1, own: 2, neither: 3, both: 4 }, _prefix: :household_rent_own
@@ -202,7 +201,8 @@ class StateFileNjIntake < StateFileBaseIntake
   def validate_state_specific_w2_requirements(w2); end
 
   def ask_for_signature_pin?
-    true
+    false
   end
+
 end
 

--- a/spec/factories/state_file_az_intakes.rb
+++ b/spec/factories/state_file_az_intakes.rb
@@ -228,7 +228,7 @@ FactoryBot.define do
     end
 
     factory :state_file_az_refund_intake do
-      after(:build) do |intake, evaluator|
+      after(:build) do |intake|
         intake.direct_file_data.fed_agi = 10000
         intake.raw_direct_file_data = intake.direct_file_data.to_s
         intake.payment_or_deposit_type = "direct_deposit"
@@ -239,7 +239,7 @@ FactoryBot.define do
     end
 
     factory :state_file_az_owed_intake do
-      after(:build) do |intake, evaluator|
+      after(:build) do |intake|
         intake.direct_file_data.fed_agi = 120000
         intake.raw_direct_file_data = intake.direct_file_data.to_s
         intake.payment_or_deposit_type = "direct_deposit"

--- a/spec/factories/state_file_id_intakes.rb
+++ b/spec/factories/state_file_id_intakes.rb
@@ -108,7 +108,7 @@ FactoryBot.define do
     end
 
     factory :state_file_id_refund_intake do
-      after(:build) do |intake, evaluator|
+      after(:build) do |intake|
         intake.direct_file_data.fed_agi = 10000
         intake.raw_direct_file_data = intake.direct_file_data.to_s
         intake.payment_or_deposit_type = "direct_deposit"

--- a/spec/factories/state_file_md_intakes.rb
+++ b/spec/factories/state_file_md_intakes.rb
@@ -112,7 +112,7 @@ FactoryBot.define do
     end
 
     factory :state_file_md_refund_intake do
-      after(:build) do |intake, evaluator|
+      after(:build) do |intake|
         intake.direct_file_data.fed_agi = 10000
         intake.raw_direct_file_data = intake.direct_file_data.to_s
         intake.payment_or_deposit_type = "direct_deposit"
@@ -130,8 +130,6 @@ FactoryBot.define do
     primary_middle_initial { "A" }
     primary_last_name { "Lando" }
     primary_birth_date { Date.new(1950, 01, 01) } # matches the bday in md_minimal.json
-    primary_signature_pin { '12345' }
-    primary_esigned_at { DateTime.now }
     subdivision_code { "0111" }
     political_subdivision { "Mt Savage" }
     confirmed_permanent_address { "yes" }
@@ -193,8 +191,6 @@ FactoryBot.define do
       spouse_middle_initial { "B" }
       spouse_last_name { "Lando" }
       spouse_birth_date { MultiTenantService.statefile.end_of_current_tax_year - 40 }
-      spouse_signature_pin { '54321' }
-      spouse_esigned_at { DateTime.now }
     end
 
     trait :with_senior_spouse do

--- a/spec/factories/state_file_nc_intakes.rb
+++ b/spec/factories/state_file_nc_intakes.rb
@@ -87,11 +87,11 @@
 FactoryBot.define do
   factory :state_file_nc_intake do
     transient do
-      filing_status { 'married_filing_jointly' }
+      filing_status { 'single' }
     end
 
     factory :state_file_nc_refund_intake do
-      after(:build) do |intake, _evaluator|
+      after(:build) do |intake|
         intake.direct_file_data.fed_agi = 10000
         intake.raw_direct_file_data = intake.direct_file_data.to_s
         intake.payment_or_deposit_type = "direct_deposit"
@@ -101,8 +101,8 @@ FactoryBot.define do
       end
     end
 
-    raw_direct_file_data { StateFile::DirectFileApiResponseSampleService.new.read_xml('nc_nick') }
-    raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nc_nick') }
+    raw_direct_file_data { StateFile::DirectFileApiResponseSampleService.new.read_xml('nc_daffy_single') }
+    raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nc_daffy_single') }
     df_data_import_succeeded_at { DateTime.now }
 
     primary_first_name { "North" }
@@ -127,7 +127,7 @@ FactoryBot.define do
     end
 
     trait :taxes_owed do
-      after(:build) do |intake, _evaluator|
+      after(:build) do |intake|
         intake.direct_file_data.fed_agi = 120000
         intake.raw_direct_file_data = intake.direct_file_data.to_s
         intake.payment_or_deposit_type = "direct_deposit"

--- a/spec/factories/state_file_nj_intakes.rb
+++ b/spec/factories/state_file_nj_intakes.rb
@@ -60,7 +60,6 @@
 #  primary_last_name                                      :string
 #  primary_middle_initial                                 :string
 #  primary_signature                                      :string
-#  primary_signature_pin                                  :text
 #  primary_ssn                                            :string
 #  primary_suffix                                         :string
 #  primary_veteran                                        :integer          default("unfilled"), not null
@@ -84,7 +83,6 @@
 #  spouse_first_name                                      :string
 #  spouse_last_name                                       :string
 #  spouse_middle_initial                                  :string
-#  spouse_signature_pin                                   :text
 #  spouse_ssn                                             :string
 #  spouse_suffix                                          :string
 #  spouse_veteran                                         :integer          default("unfilled"), not null
@@ -122,10 +120,6 @@ FactoryBot.define do
     routing_number { "011234567" }
     account_number { "123456789" }
     account_type { 1 }
-    primary_signature_pin { '12345' }
-    spouse_signature_pin { '54321' }
-    primary_esigned_at { DateTime.now }
-    spouse_esigned_at { DateTime.now }
 
     raw_direct_file_data { StateFile::DirectFileApiResponseSampleService.new.read_xml("nj_zeus_one_dep") }
     raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nj_zeus_one_dep') }

--- a/spec/lib/pdf_filler/nc_d400_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nc_d400_pdf_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe PdfFiller::NcD400Pdf do
 
     context "pulling fields from xml" do
       let(:tomorrow_midnight) { DateTime.tomorrow.beginning_of_day }
-      let(:mailing_apartment) { 'Apt 2B'}
+      let(:mailing_apartment) { 'Apt 2'}
       let(:intake) {
         create(:state_file_nc_intake,
                filing_status: "single",
@@ -50,7 +50,7 @@ RSpec.describe PdfFiller::NcD400Pdf do
           expect(pdf_fields['y_d400wf_lname1']).to eq 'Carolinianian'
           expect(pdf_fields['y_d400wf_ssn1']).to eq '145004904'
           expect(pdf_fields['y_d400wf_add']).to eq '7 Heavens Lane'
-          expect(pdf_fields['y_d400wf_apartment number']).to eq 'Apt 2'
+          expect(pdf_fields['y_d400wf_apartment number']).to eq mailing_apartment
           expect(pdf_fields['y_d400wf_city']).to eq 'Cary'
           expect(pdf_fields['y_d400wf_state']).to eq 'NC'
           expect(pdf_fields['y_d400wf_zip']).to eq '27511'

--- a/spec/lib/pdf_filler/nc_d400_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nc_d400_pdf_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe PdfFiller::NcD400Pdf do
           expect(pdf_fields['y_d400wf_li23_pg2_good']).to eq '4394'
           expect(pdf_fields['y_d400wf_li25_pg2_good']).to eq '4394'
           expect(pdf_fields['y_d400wf_dayphone']).to eq '8885564905'
-          expect(pdf_fields['y_d400wf_Consumer_Use_Tax']).to eq 'Yes'
+          expect(pdf_fields['y_d400wf_Consumer Use Tax']).to eq 'Yes'
           expect(pdf_fields['y_d400wf_li18_pg2_good']).to eq '0'
           expect(pdf_fields['y_d400wf_li19_pg2_good']).to eq '2887'
           expect(pdf_fields['y_d400wf_li26a_pg2_good']).to eq ''

--- a/spec/lib/pdf_filler/nc_d400_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nc_d400_pdf_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe PdfFiller::NcD400Pdf do
 
     context "pulling fields from xml" do
       let(:tomorrow_midnight) { DateTime.tomorrow.beginning_of_day }
+      let(:mailing_apartment) { 'Apt 2B'}
       let(:intake) {
         create(:state_file_nc_intake,
                filing_status: "single",
@@ -28,6 +29,10 @@ RSpec.describe PdfFiller::NcD400Pdf do
                primary_esigned: "yes",
                primary_esigned_at: tomorrow_midnight)
       }
+
+      before do
+        intake.direct_file_data.mailing_apartment = mailing_apartment
+      end
 
       context "single filer" do
         it 'sets static fields to the correct values' do
@@ -43,12 +48,12 @@ RSpec.describe PdfFiller::NcD400Pdf do
           expect(pdf_fields['y_d400wf_fname1']).to eq 'North'
           expect(pdf_fields['y_d400wf_mi1']).to eq 'A'
           expect(pdf_fields['y_d400wf_lname1']).to eq 'Carolinianian'
-          expect(pdf_fields['y_d400wf_ssn1']).to eq '400000030'
-          expect(pdf_fields['y_d400wf_add']).to eq '123 Red Right Hand St Apt 1'
-          expect(pdf_fields['y_d400wf_apartment number']).to eq 'Apt 1'
-          expect(pdf_fields['y_d400wf_city']).to eq 'Raleigh'
+          expect(pdf_fields['y_d400wf_ssn1']).to eq '145004904'
+          expect(pdf_fields['y_d400wf_add']).to eq '7 Heavens Lane'
+          expect(pdf_fields['y_d400wf_apartment number']).to eq 'Apt 2'
+          expect(pdf_fields['y_d400wf_city']).to eq 'Cary'
           expect(pdf_fields['y_d400wf_state']).to eq 'NC'
-          expect(pdf_fields['y_d400wf_zip']).to eq '27513'
+          expect(pdf_fields['y_d400wf_zip']).to eq '27511'
 
           expect(pdf_fields['y_d400wf_fstat1']).to eq 'Yes'
           expect(pdf_fields['y_d400wf_fstat2']).to eq 'Off'
@@ -56,23 +61,23 @@ RSpec.describe PdfFiller::NcD400Pdf do
           expect(pdf_fields['y_d400wf_fstat4']).to eq 'Off'
           expect(pdf_fields['y_d400wf_fstat5']).to eq 'Off'
 
-          expect(pdf_fields['y_d400wf_li6_good']).to eq '9000'
-          expect(pdf_fields['y_d400wf_li8_good']).to eq '9000'
+          expect(pdf_fields['y_d400wf_li6_good']).to eq '76902'
+          expect(pdf_fields['y_d400wf_li8_good']).to eq '76902'
           expect(pdf_fields['y_d400wf_ncstandarddeduction']).to eq 'Yes'
           expect(pdf_fields['y_d400wf_li11_page1_good']).to eq '12750'
 
           expect(pdf_fields['y_d400wf_lname2_PG2']).to eq 'Carolinian'
-          expect(pdf_fields['y_d400wf_li20a_pg2_good']).to eq '15'
-          expect(pdf_fields['y_d400wf_li23_pg2_good']).to eq '15'
-          expect(pdf_fields['y_d400wf_li25_pg2_good']).to eq '15'
-          expect(pdf_fields['y_d400wf_dayphone']).to eq '9845559876'
-          expect(pdf_fields['y_d400wf_Consumer Use Tax']).to eq 'Yes'
+          expect(pdf_fields['y_d400wf_li20a_pg2_good']).to eq '4394'
+          expect(pdf_fields['y_d400wf_li23_pg2_good']).to eq '4394'
+          expect(pdf_fields['y_d400wf_li25_pg2_good']).to eq '4394'
+          expect(pdf_fields['y_d400wf_dayphone']).to eq '8885564905'
+          expect(pdf_fields['y_d400wf_Consumer_Use_Tax']).to eq 'Yes'
           expect(pdf_fields['y_d400wf_li18_pg2_good']).to eq '0'
-          expect(pdf_fields['y_d400wf_li19_pg2_good']).to eq '0'
+          expect(pdf_fields['y_d400wf_li19_pg2_good']).to eq '2887'
           expect(pdf_fields['y_d400wf_li26a_pg2_good']).to eq ''
           expect(pdf_fields['y_d400wf_li27_pg2_good']).to eq '0'
-          expect(pdf_fields['y_d400wf_li28_pg2_good']).to eq '15'
-          expect(pdf_fields['y_d400wf_li34_pg2_good']).to eq '15'
+          expect(pdf_fields['y_d400wf_li28_pg2_good']).to eq '1507'
+          expect(pdf_fields['y_d400wf_li34_pg2_good']).to eq '1507'
           timezone = StateFile::StateInformationService.timezone('nc')
           expect(pdf_fields['y_d400wf_sigdate']).to eq tomorrow_midnight.in_time_zone(timezone).strftime("%Y-%m-%d")
           expect(pdf_fields['y_d400wf_sigdate2']).to eq ""
@@ -109,6 +114,7 @@ RSpec.describe PdfFiller::NcD400Pdf do
         let(:intake) { create(:state_file_nc_intake, :with_spouse, filing_status: "married_filing_jointly", primary_esigned: "yes", primary_esigned_at: tomorrow_midnight, spouse_esigned: "yes", spouse_esigned_at: tomorrow_midnight) }
 
         before do
+          submission.data_source.direct_file_data.spouse_ssn = "111100030"
           submission.data_source.direct_file_data.spouse_date_of_death = "2024-09-30"
           submission.data_source.direct_file_data.w2s[0].EmployeeSSN = submission.data_source.spouse.ssn
           intake.synchronize_df_w2s_to_database
@@ -124,7 +130,7 @@ RSpec.describe PdfFiller::NcD400Pdf do
           expect(pdf_fields['y_d400wf_fname2']).to eq 'Susie'
           expect(pdf_fields['y_d400wf_mi2']).to eq 'B'
           expect(pdf_fields['y_d400wf_lname2']).to eq 'Spouse'
-          expect(pdf_fields['y_d400wf_ssn2']).to eq '600000030'
+          expect(pdf_fields['y_d400wf_ssn2']).to eq '111100030'
           expect(pdf_fields['y_d400wf_dead2']).to eq '09-30-24'
 
           expect(pdf_fields['y_d400wf_fstat2']).to eq 'Yes'
@@ -133,7 +139,7 @@ RSpec.describe PdfFiller::NcD400Pdf do
           expect(pdf_fields['y_d400wf_fstat4']).to eq 'Off'
           expect(pdf_fields['y_d400wf_fstat5']).to eq 'Off'
 
-          expect(pdf_fields['y_d400wf_li20b_pg2_good']).to eq '15'
+          expect(pdf_fields['y_d400wf_li20b_pg2_good']).to eq '4394'
 
           timezone = StateFile::StateInformationService.timezone('nc')
           expect(pdf_fields['y_d400wf_sigdate']).to eq tomorrow_midnight.in_time_zone(timezone).strftime("%Y-%m-%d")
@@ -148,7 +154,7 @@ RSpec.describe PdfFiller::NcD400Pdf do
         end
 
         it "sets fields specific to filing status" do
-          expect(pdf_fields['y_d400wf_sname2']).to eq 'Susie K Cave'
+          expect(pdf_fields['y_d400wf_sname2']).to eq 'Susie B Spouse'
           expect(pdf_fields['y_d400wf_sssn2']).to eq '111100030'
 
           expect(pdf_fields['y_d400wf_fstat1']).to eq 'Off'

--- a/spec/lib/pdf_filler/nc_d400_schedule_s_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nc_d400_schedule_s_pdf_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe PdfFiller::NcD400ScheduleSPdf do
 
     context "pulling fields from xml" do
       it 'sets fields to the correct values' do
-        expect(pdf_fields['y_d400schswf_ssn']).to eq '400000030'
+        expect(pdf_fields['y_d400schswf_ssn']).to eq '145004904'
         expect(pdf_fields['y_d400wf_lname2_PG2']).to eq 'Carolinian'
         expect(pdf_fields['y_d400schswf_li18_good']).to eq '0'
         expect(pdf_fields['y_d400schswf_li19_good']).to eq '0'

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -279,6 +279,41 @@ RSpec.describe PdfFiller::Nj1040Pdf do
       end
     end
 
+    describe "esign date" do
+      context 'filer is single' do
+        let(:submission) {
+          create :efile_submission, tax_return: nil, data_source: create(
+            :state_file_nj_intake,
+            primary_ssn: "123456789",
+            primary_esigned: "yes",
+            primary_esigned_at: DateTime.new(2024, 12, 19, 12)
+          )
+        }
+        it 'enters the date into the PDF signature field' do
+          expect(pdf_fields["Date1_es_:signer:date"]).to eq "2024-12-19"
+          expect(pdf_fields["Date2_es_:signer:date"]).to eq ""
+        end
+      end
+
+      context 'filer is mfj' do
+        let(:submission) {
+          create :efile_submission, tax_return: nil, data_source: create(
+            :state_file_nj_intake,
+            :married_filing_jointly,
+            primary_ssn: "123456789",
+            primary_esigned: "yes",
+            primary_esigned_at: DateTime.new(2024, 12, 19, 12),
+            spouse_esigned: "yes",
+            spouse_esigned_at: DateTime.new(2024, 12, 18, 12)
+          )
+        }
+        it 'enters the date into the PDF signature field' do
+          expect(pdf_fields["Date1_es_:signer:date"]).to eq "2024-12-19"
+          expect(pdf_fields["Date2_es_:signer:date"]).to eq "2024-12-18"
+        end
+      end
+    end
+
     describe "exemptions" do
       describe "Line 6 exemptions" do
         context "single filer" do

--- a/spec/lib/submission_builder/ty2022/states/ny/ny_return_xml_spec.rb
+++ b/spec/lib/submission_builder/ty2022/states/ny/ny_return_xml_spec.rb
@@ -150,7 +150,7 @@ describe SubmissionBuilder::Ty2022::States::Ny::NyReturnXml, required_schema: "n
     end
 
     context "when getting a refund to a personal checking account" do
-      let(:intake) { create(:state_file_ny_intake, filing_status: filing_status, payment_or_deposit_type: "direct_deposit",  routing_number: "011234567", account_number: "123456789", account_type: 1) }
+      let(:intake) { create(:state_file_ny_intake, filing_status: filing_status, payment_or_deposit_type: "direct_deposit", routing_number: "011234567", account_number: "123456789", account_type: 1) }
       let(:filing_status) { 'single' }
 
       it 'generates XML from the database models' do

--- a/spec/lib/submission_builder/ty2022/states/return_header_spec.rb
+++ b/spec/lib/submission_builder/ty2022/states/return_header_spec.rb
@@ -15,6 +15,7 @@ describe SubmissionBuilder::ReturnHeader do
         let(:tax_return_year) { 2024 }
         let(:efin) { "123455" }
         let(:sin) { "223455" }
+
         before do
           intake.direct_file_data.mailing_street = mailing_street
           intake.direct_file_data.mailing_apartment = mailing_apartment
@@ -62,6 +63,24 @@ describe SubmissionBuilder::ReturnHeader do
       end
 
       context "filer personal info" do
+        let(:primary_birth_date) { 40.years.ago }
+        let(:primary_ssn) { "100000030" }
+        let(:primary_first_name) { "Prim" }
+        let(:primary_middle_initial) { "W" }
+        let(:primary_last_name) { "Filerton" }
+        let(:primary_suffix) { "JR" }
+        let(:primary_esigned_at) { DateTime.new(2024, 12, 19, 12) }
+        let(:primary_esigned) { 'yes' }
+
+        let(:spouse_birth_date) { nil }
+        let(:spouse_ssn) { nil }
+        let(:spouse_first_name) { nil }
+        let(:spouse_middle_initial) { nil }
+        let(:spouse_last_name) { nil }
+        let(:spouse_suffix) { nil }
+        let(:spouse_esigned_at) { nil }
+        let(:spouse_esigned) { 'unfilled' }
+
         let(:intake) {
           create(
             "state_file_#{state_code}_intake".to_sym,
@@ -76,25 +95,17 @@ describe SubmissionBuilder::ReturnHeader do
             spouse_last_name: spouse_last_name,
           )
         }
-        let(:primary_birth_date) { 40.years.ago }
-        let(:primary_ssn) { "100000030" }
-        let(:primary_first_name) { "Prim" }
-        let(:primary_middle_initial) { "W" }
-        let(:primary_last_name) { "Filerton" }
-        let(:primary_suffix) { "JR" }
-        let(:spouse_birth_date) { nil }
-        let(:spouse_ssn) { nil }
-        let(:spouse_first_name) { nil }
-        let(:spouse_middle_initial) { nil }
-        let(:spouse_last_name) { nil }
-        let(:spouse_suffix) { nil }
 
         before do
           intake.direct_file_data.primary_ssn = primary_ssn
           intake.primary_suffix = primary_suffix
+          intake.primary_esigned = primary_esigned
+          intake.primary_esigned_at = primary_esigned_at
           intake.direct_file_data.spouse_ssn = spouse_ssn
           intake.direct_file_data.phone_number = "5551231234"
           intake.spouse_suffix = spouse_suffix
+          intake.spouse_esigned = spouse_esigned
+          intake.spouse_esigned_at = spouse_esigned_at
         end
 
         context "single filer" do
@@ -108,6 +119,7 @@ describe SubmissionBuilder::ReturnHeader do
             expect(doc.at('Filer Primary TaxpayerName LastName').content).to eq primary_last_name
             expect(doc.at('Filer Primary TaxpayerName NameSuffix').content).to eq primary_suffix
             expect(doc.at("Filer Primary USPhone").text).to eq "5551231234"
+            expect(doc.at('Filer Primary DateSigned').text).to eq '2024-12-19'
 
             expect(doc.at("Filer Secondary DateOfBirth")).not_to be_present
             expect(doc.at('Filer Secondary TaxpayerSSN')).not_to be_present
@@ -115,6 +127,7 @@ describe SubmissionBuilder::ReturnHeader do
             expect(doc.at('Filer Secondary TaxpayerName MiddleInitial')).not_to be_present
             expect(doc.at('Filer Secondary TaxpayerName LastName')).not_to be_present
             expect(doc.at('Filer Secondary TaxpayerName NameSuffix')).not_to be_present
+            expect(doc.at('Filer Secondary DateSigned')).not_to be_present
           end
 
           context "excluding absent fields" do
@@ -123,6 +136,9 @@ describe SubmissionBuilder::ReturnHeader do
             let(:primary_first_name) { nil }
             let(:primary_middle_initial) { nil }
             let(:primary_last_name) { nil }
+            let(:primary_esigned) { 'unfilled' }
+            let(:primary_esigned_at) { nil }
+
             before do
               intake.direct_file_data.primary_ssn = nil
               intake.direct_file_data.spouse_ssn = nil
@@ -155,6 +171,7 @@ describe SubmissionBuilder::ReturnHeader do
               expect(doc.at('Filer Primary TaxpayerName LastName')).not_to be_present
               expect(doc.at('Filer Primary TaxpayerName NameSuffix')).not_to be_present
               expect(doc.at("Filer Primary USPhone")).not_to be_present
+              expect(doc.at("Filer Primary DateSigned")).not_to be_present
 
               expect(doc.at("Filer Secondary DateOfBirth")).not_to be_present
               expect(doc.at('Filer Secondary TaxpayerSSN')).not_to be_present
@@ -162,6 +179,7 @@ describe SubmissionBuilder::ReturnHeader do
               expect(doc.at('Filer Secondary TaxpayerName MiddleInitial')).not_to be_present
               expect(doc.at('Filer Secondary TaxpayerName LastName')).not_to be_present
               expect(doc.at('Filer Secondary TaxpayerName NameSuffix')).not_to be_present
+              expect(doc.at("Filer Secondary DateSigned")).not_to be_present
             end
           end
         end
@@ -174,9 +192,12 @@ describe SubmissionBuilder::ReturnHeader do
           let(:spouse_middle_initial) { "Z" }
           let(:spouse_last_name) { "Filerton" }
           let(:spouse_suffix) { "SR" }
+          let(:spouse_esigned_at) { DateTime.new(2024, 12, 18, 12) }
+          let(:spouse_esigned) { 'yes' }
 
           it "generates xml with primary and spouse DOBs" do
             expect(doc.at("Filer Primary DateOfBirth").text).to eq primary_birth_date.strftime("%F")
+            expect(doc.at('Filer Primary DateSigned').text).to eq '2024-12-19'
 
             expect(doc.at("Filer Secondary DateOfBirth").text).to eq spouse_birth_date.strftime("%F")
             expect(doc.at('Filer Secondary TaxpayerSSN').content).to eq spouse_ssn
@@ -184,6 +205,7 @@ describe SubmissionBuilder::ReturnHeader do
             expect(doc.at('Filer Secondary TaxpayerName MiddleInitial').content).to eq spouse_middle_initial
             expect(doc.at('Filer Secondary TaxpayerName LastName').content).to eq spouse_last_name
             expect(doc.at('Filer Secondary TaxpayerName NameSuffix').content).to eq spouse_suffix
+            expect(doc.at('Filer Secondary DateSigned').text).to eq '2024-12-18'
           end
 
           context "filers have lower cased suffixes" do
@@ -206,6 +228,7 @@ describe SubmissionBuilder::ReturnHeader do
               expect(doc.at('Filer Secondary TaxpayerName MiddleInitial')).not_to be_present
               expect(doc.at('Filer Secondary TaxpayerName LastName')).not_to be_present
               expect(doc.at('Filer Secondary TaxpayerName NameSuffix')).not_to be_present
+              expect(doc.at('Filer Secondary DateSigned')).not_to be_present
             end
           end
         end
@@ -279,15 +302,19 @@ describe SubmissionBuilder::ReturnHeader do
         :state_file_md_intake,
         filing_status: filing_status,
         primary_signature_pin: primary_signature_pin,
+        primary_esigned: primary_esigned,
         primary_esigned_at: primary_esigned_at,
         spouse_signature_pin: spouse_signature_pin,
+        spouse_esigned: spouse_esigned,
         spouse_esigned_at: spouse_esigned_at
       )
     }
     let(:tomorrow_midnight) { DateTime.tomorrow.beginning_of_day }
     let(:primary_signature_pin) { "12345" }
+    let(:primary_esigned) { "yes" }
     let(:primary_esigned_at) { tomorrow_midnight }
     let(:spouse_signature_pin) { "23456" }
+    let(:spouse_esigned) { "yes" }
     let(:spouse_esigned_at) { tomorrow_midnight }
     let(:submission) { create(:efile_submission, data_source: intake) }
     let(:doc) { SubmissionBuilder::ReturnHeader.new(submission).document }

--- a/spec/lib/submission_builder/ty2024/states/md/md_return_xml_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/md/md_return_xml_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe SubmissionBuilder::Ty2024::States::Md::MdReturnXml, required_schema: "md" do
   describe ".build" do
-    let(:intake) { create(:state_file_md_intake) }
+    let(:intake) { create(:state_file_md_intake, primary_esigned: "yes", primary_esigned_at: Time.now, primary_signature_pin: "11111" ) }
     let(:submission) { create(:efile_submission, data_source: intake.reload) }
     let!(:initial_efile_device_info) { create :state_file_efile_device_info, :initial_creation, :filled, intake: intake }
     let!(:submission_efile_device_info) { create :state_file_efile_device_info, :submission, :filled, intake: intake }

--- a/spec/lib/submission_builder/ty2024/states/nc/documents/d400_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nc/documents/d400_spec.rb
@@ -119,7 +119,7 @@ describe SubmissionBuilder::Ty2024::States::Nc::Documents::D400, required_schema
     end
 
     context "mfj filers" do
-      let(:intake) { create(:state_file_nc_intake, filing_status: "married_filing_jointly") }
+      let(:intake) { create(:state_file_nc_intake, :with_spouse) }
 
       it "correctly fills spouse-specific answers" do
         expect(xml.document.at('ResidencyStatusSpouse')&.text).to eq "true"
@@ -134,14 +134,18 @@ describe SubmissionBuilder::Ty2024::States::Nc::Documents::D400, required_schema
     end
 
     context "mfs filers" do
-      let(:intake) { create(:state_file_nc_intake, :with_filers_synced, filing_status: "married_filing_separately") }
+      let(:intake) { create(:state_file_nc_intake, :with_filers_synced, :with_spouse, filing_status: "married_filing_separately") }
+
+      before do
+        intake.direct_file_data.spouse_ssn = "111100030"
+      end
 
       it "correctly fills spouse-specific answers" do
         expect(xml.document.at('FilingStatus')&.text).to eq "MFS"
         expect(xml.document.at('MFSSpouseName FirstName')&.text).to eq "Susie"
-        expect(xml.document.at('MFSSpouseName MiddleInitial')&.text).to eq "K"
-        expect(xml.document.at('MFSSpouseName LastName')&.text).to eq "Cave"
-        expect(xml.document.at('MFSSpouseSSN')&.text).to eq "600000030"
+        expect(xml.document.at('MFSSpouseName MiddleInitial')&.text).to eq "B"
+        expect(xml.document.at('MFSSpouseName LastName')&.text).to eq "Spouse"
+        expect(xml.document.at('MFSSpouseSSN')&.text).to eq "111100030"
       end
     end
 

--- a/spec/models/state_file_nj_intake_spec.rb
+++ b/spec/models/state_file_nj_intake_spec.rb
@@ -60,7 +60,6 @@
 #  primary_last_name                                      :string
 #  primary_middle_initial                                 :string
 #  primary_signature                                      :string
-#  primary_signature_pin                                  :text
 #  primary_ssn                                            :string
 #  primary_suffix                                         :string
 #  primary_veteran                                        :integer          default("unfilled"), not null
@@ -84,7 +83,6 @@
 #  spouse_first_name                                      :string
 #  spouse_last_name                                       :string
 #  spouse_middle_initial                                  :string
-#  spouse_signature_pin                                   :text
 #  spouse_ssn                                             :string
 #  spouse_suffix                                          :string
 #  spouse_veteran                                         :integer          default("unfilled"), not null


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://github.com/newjersey/affordability-pm/issues/203#issue-2738881181

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Paired Arin from CfA, thanks @arinchoi03 for the help!
- NJ does not plan to use PIN for FY2024, but wants Signature Date to be filled in XML and PDF
- Make `primary_signature_pin` and `spouse_signature_pin` ignored so the columns can be dropped in the future

## How to test?
- Validated using `zeus_one_dep` (married) and `devito_single` (single), clicking through the flow, and checking the following:
- Signature PIN is no longer required
- XML contains Esign Date on under `ReturnHeaderState > Filer > Primary > Date Signed`
- PDF contains Signature Dates on Page 4.

## Screenshots (for visual changes)
- Single Filer
<img width="955" alt="image" src="https://github.com/user-attachments/assets/6f77ef3b-960f-4d05-9bc2-71a794792ad8" />
<img width="417" alt="image" src="https://github.com/user-attachments/assets/bdf10829-8152-40e7-bef5-f407db42ac1f" />

- Married Filer
<img width="403" alt="image" src="https://github.com/user-attachments/assets/8b78b599-5054-4434-8404-ae3809deb751" />
<img width="946" alt="image" src="https://github.com/user-attachments/assets/3c6015d9-f0c5-4f5a-87ff-bb622587e69e" />


