### PR TITLE
Add financial transaction to NJ return xml

### DIFF
--- a/app/lib/submission_builder/ty2024/states/nj/nj_return_xml.rb
+++ b/app/lib/submission_builder/ty2024/states/nj/nj_return_xml.rb
@@ -26,6 +26,12 @@ module SubmissionBuilder
             "NJIndividual2024V0.1"
           end
 
+          def build_state_specific_tags(document)
+            if !@submission.data_source.routing_number.nil? && !@submission.data_source.account_number.nil?
+              document.at("ReturnState").add_child(financial_transaction)
+            end
+          end
+
           def documents_wrapper
             nil
           end
@@ -102,7 +108,20 @@ module SubmissionBuilder
           end
 
           def calculator 
-            @submission.data_source.tax_calculator
+            calculator = @submission.data_source.tax_calculator
+            calculator.calculate
+            calculator
+          end
+
+          def financial_transaction
+            calculator = @submission.data_source.tax_calculator
+            calculator.calculate
+
+            FinancialTransaction.build(
+              @submission,
+              validate: false,
+              kwargs: { refund_amount: calculator.refund_or_owed_amount }
+            ).document.at("*")
           end
         end
       end

--- a/spec/factories/state_file_nj_intakes.rb
+++ b/spec/factories/state_file_nj_intakes.rb
@@ -268,7 +268,7 @@ FactoryBot.define do
       raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nj_zeus_box_14') }
     end
 
-    factory :state_file_nj_refund_intake do
+    factory :state_file_nj_payment_info_intake do
       after(:build) do |intake, _evaluator|
         intake.direct_file_data.fed_agi = 10000
         intake.raw_direct_file_data = intake.direct_file_data.to_s

--- a/spec/factories/state_file_nj_intakes.rb
+++ b/spec/factories/state_file_nj_intakes.rb
@@ -268,6 +268,17 @@ FactoryBot.define do
       raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nj_zeus_box_14') }
     end
 
+    factory :state_file_nj_refund_intake do
+      after(:build) do |intake, _evaluator|
+        intake.direct_file_data.fed_agi = 10000
+        intake.raw_direct_file_data = intake.direct_file_data.to_s
+        intake.payment_or_deposit_type = "direct_deposit"
+        intake.account_type = "savings"
+        intake.routing_number = 111111111
+        intake.account_number = 222222222
+      end
+    end
+
     trait :married_filing_jointly do
       filing_status { "married_filing_jointly" }
       spouse_birth_date { Date.new(1990, 1, 1) }

--- a/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
@@ -24,6 +24,16 @@ describe SubmissionBuilder::Ty2024::States::Nj::NjReturnXml, required_schema: "n
         expect(xml.document.at('ReturnDataState FormNJ1040 Header')).to be_an_instance_of Nokogiri::XML::Element
       end
 
+      context "when there is a refund with banking info" do
+        let(:intake) { create(:state_file_nj_refund_intake) }
+  
+        it "generates FinancialTransaction xml without RefundAmt" do
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:refund_or_owed_amount).and_return 500
+          xml = Nokogiri::XML::Document.parse(described_class.build(submission).document.to_xml)
+          expect(xml.at("FinancialTransaction")).to be_present
+        end
+      end
+
       context "with JSON data" do
         let(:intake) { create(:state_file_nj_intake, :df_data_mfj) }
 

--- a/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
@@ -25,12 +25,24 @@ describe SubmissionBuilder::Ty2024::States::Nj::NjReturnXml, required_schema: "n
       end
 
       context "when there is a refund with banking info" do
-        let(:intake) { create(:state_file_nj_refund_intake) }
+        let(:intake) { create(:state_file_nj_payment_info_intake) }
   
-        it "generates FinancialTransaction xml without RefundAmt" do
-          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:refund_or_owed_amount).and_return 500
+        it "generates FinancialTransaction RefundDirectDeposit xml" do
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_80).and_return 500
           xml = Nokogiri::XML::Document.parse(described_class.build(submission).document.to_xml)
-          expect(xml.at("FinancialTransaction")).to be_present
+          expect(xml.at("FinancialTransaction RefundDirectDeposit")).to be_present
+        end
+      end
+
+      context "when money is owed with banking info" do
+        let(:intake) { 
+          create(:state_file_nj_payment_info_intake, withdraw_amount: 100, date_electronic_withdrawal: Date.new(Rails.configuration.statefile_current_tax_year, 4, 15))
+        }
+  
+        it "generates FinancialTransaction StatePayment xml" do
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_80).and_return(0)
+          xml = Nokogiri::XML::Document.parse(described_class.build(submission).document.to_xml)
+          expect(xml.at("FinancialTransaction StatePayment")).to be_present
         end
       end
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/232

## Is PM acceptance required? (delete one)
- No - merge after code review approval

## What was done?
Add the financial transaction element to NJ return xml

## How to test?
Generate any return, and add acct and routing number in the final screens
