### PR TITLE
detach the old submission pdf from an intake which is being resubmitted asap

### DIFF
--- a/app/forms/state_file/esign_declaration_form.rb
+++ b/app/forms/state_file/esign_declaration_form.rb
@@ -38,6 +38,7 @@ module StateFile
       old_efile_submission = @intake.efile_submissions&.last
       if old_efile_submission.present?
         # the after_transitions :resubmission creates a new efile submission and transitions it to :preparing
+        @intake.submission_pdf.detach
         old_efile_submission.transition_to!(:resubmitted) if ["rejected", "notified_of_rejection", "waiting"].include?(old_efile_submission.current_state)
       else
         # Submits new return

--- a/app/forms/state_file/esign_declaration_form.rb
+++ b/app/forms/state_file/esign_declaration_form.rb
@@ -37,8 +37,12 @@ module StateFile
 
       old_efile_submission = @intake.efile_submissions&.last
       if old_efile_submission.present?
-        # the after_transitions :resubmission creates a new efile submission and transitions it to :preparing
+        # we need to detach the existing submission PDF from the intake to avoid it being briefly accessible
+        # from the /submission-confirmation page while the new PDF is being generated & attached.
+        # See https://github.com/codeforamerica/vita-min/pull/5282 for more details
         @intake.submission_pdf.detach
+
+        # the after_transitions :resubmission creates a new efile submission and transitions it to :preparing
         old_efile_submission.transition_to!(:resubmitted) if ["rejected", "notified_of_rejection", "waiting"].include?(old_efile_submission.current_state)
       else
         # Submits new return

--- a/app/views/state_file/questions/submission_confirmation/edit.html.erb
+++ b/app/views/state_file/questions/submission_confirmation/edit.html.erb
@@ -36,7 +36,7 @@
 
   <p><%= t('general.spread_the_word_html') %></p>
 
-  <%= link_to t(".download_state_return_pdf"), StateFile::Questions::SubmissionPdfsController.to_path_helper(action: :show, id: EfileSubmission.where(data_source: current_intake).first), class: "button button--primary button--wide" %>
+  <%= link_to t(".download_state_return_pdf"), StateFile::Questions::SubmissionPdfsController.to_path_helper(action: :show, id: current_intake.latest_submission), class: "button button--primary button--wide" %>
 
   <% if show_xml? %>
     <p>


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1274
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- I realized that without a way to determine which `EfileSubmission` generated the intake's currently-attached `submission_pdf`, we aren't able to decide in `SubmissionPdfsController#show` whether to wait for a new PDF to be generated or whether we already have the most up-to-date one. 
- Therefore, the only way to get the latest submission's PDF without adding an arbitrary delay to the button is to use the fallback behavior of `SubmissionPdfsController#show` that triggers when there is no attached `submission_pdf`, which builds and streams the requested submission's filing PDF (in parallel with it being built & attached by the background job).
  - I also made the change suggested by @jnf to have `/submission-confirmation` link to the current intake's _latest_ submission instead of its first one, since otherwise we could end up showing the wrong IRS submission ID to the user in the case of this fallback behavior.
- The only way to get that fallback behavior to fire for a resubmitted intake is to detach the `submission_pdf` before the page is loaded.
  - I also observed that the `BuildSubmissionPdfJob` often isn't started until after the `/submission-confirmation` page has been loaded, due to delays in the multiple state machine transitions that happen before that job is kicked off. Thus, we couldn't detach the existing `submission_pdf` at the beginning of the job, since the old PDF would still be reachable if you're very quick on the mouse.
  - Therefore, I added the `detach` at the earliest point where the old submission is definitively out-of-date: in the `:resubmitted` state machine transition hook.
  - Note: I used `detach` instead of `purge` so that the blob will not be removed from s3, i.e. we should still be able to retrieve old submission PDFs from s3 if we need them.
## How to test?
- Follow the repro steps in the story and verify that you can't access the old PDF no matter how fast you click.