### PR TITLE
remove 1 hour gap that was breaking us in MD, and simplify our expectations about signature dates on pdfs everywhere

### DIFF
--- a/spec/lib/pdf_filler/id40_pdf_spec.rb
+++ b/spec/lib/pdf_filler/id40_pdf_spec.rb
@@ -3,12 +3,13 @@ require 'rails_helper'
 RSpec.describe PdfFiller::Id40Pdf do
   include PdfSpecHelper
 
-  let(:tomorrow_midnight) { DateTime.tomorrow.beginning_of_day }
+  let(:signature_date) { DateTime.now }
+  let(:expected_signature_date_pdf_value) { signature_date.in_time_zone(StateFile::StateInformationService.timezone('id')).strftime("%m-%d-%Y") }
   let(:intake) {
     create(:state_file_id_intake,
            :single_filer_with_json, # includes phone number data
            primary_esigned: "yes",
-           primary_esigned_at: tomorrow_midnight)
+           primary_esigned_at: signature_date)
   }
   let(:submission) { create :efile_submission, tax_return: nil, data_source: intake }
   let(:pdf) { described_class.new(submission) }
@@ -23,8 +24,7 @@ RSpec.describe PdfFiller::Id40Pdf do
 
     context "when filer signed submission agreement" do
       it 'sets signature date field to the correct value' do
-        timezone = StateFile::StateInformationService.timezone('id')
-        expect(pdf_fields["DateSign 2"]).to eq tomorrow_midnight.in_time_zone(timezone).strftime("%m-%d-%Y")
+        expect(pdf_fields["DateSign 2"]).to eq expected_signature_date_pdf_value
         expect(pdf_fields["TaxpayerPhoneNo"]).to eq "2085551234"
       end
     end

--- a/spec/lib/pdf_filler/md_el101_pdf_spec.rb
+++ b/spec/lib/pdf_filler/md_el101_pdf_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe PdfFiller::MdEl101Pdf do
   let(:intake) { create(:state_file_md_intake) }
   let(:submission) { create :efile_submission, tax_return: nil, data_source: intake }
   let(:pdf) { described_class.new(submission) }
-  let(:expected_signature_date) { DateTime.now.in_time_zone(StateFile::StateInformationService.timezone('md')).strftime("%F") }
+  let(:signature_date) { DateTime.now }
+  let(:expected_signature_date_pdf_value) { signature_date.in_time_zone(StateFile::StateInformationService.timezone('md')).strftime("%F") }
 
   describe "#hash_for_pdf" do
     let(:file_path) { described_class.new(submission).output_file.path }
@@ -16,7 +17,7 @@ RSpec.describe PdfFiller::MdEl101Pdf do
     before do
       submission.data_source.direct_file_data.primary_ssn = '555123666'
       submission.data_source.primary_esigned_yes!
-      submission.data_source.primary_esigned_at = 1.hour.ago
+      submission.data_source.primary_esigned_at = signature_date
       submission.data_source.primary_signature_pin = '23456'
     end
 
@@ -34,7 +35,7 @@ RSpec.describe PdfFiller::MdEl101Pdf do
         expect(pdf_fields["ERO firm name"]).to eq "FileYourStateTaxes"
         expect(pdf_fields["to enter or generate my PIN"]).to eq "23456"
         expect(pdf_fields["Primary signature"]).to eq "Mary Lando"
-        expect(pdf_fields["Date"]).to eq expected_signature_date
+        expect(pdf_fields["Date"]).to eq expected_signature_date_pdf_value
         expect(pdf_fields["Spouses First Name"]).to eq("")
         expect(pdf_fields["Spouse MI"]).to eq("")
         expect(pdf_fields["Spouses Last Name"]).to eq("")
@@ -74,7 +75,7 @@ RSpec.describe PdfFiller::MdEl101Pdf do
       before do
         submission.data_source.direct_file_data.spouse_ssn = '555123456'
         submission.data_source.spouse_esigned_yes!
-        submission.data_source.spouse_esigned_at = 1.hour.ago
+        submission.data_source.spouse_esigned_at = signature_date
         submission.data_source.spouse_signature_pin = '11111'
       end
 
@@ -86,7 +87,7 @@ RSpec.describe PdfFiller::MdEl101Pdf do
         expect(pdf_fields["ERO firm name_2"]).to eq "FileYourStateTaxes"
         expect(pdf_fields["to enter or generate my PIN_2"]).to eq "11111"
         expect(pdf_fields["Spouses signature"]).to eq "Marty Lando"
-        expect(pdf_fields["Date_2"]).to eq expected_signature_date
+        expect(pdf_fields["Date_2"]).to eq expected_signature_date_pdf_value
       end
     end
   end

--- a/spec/lib/pdf_filler/nc_d400_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nc_d400_pdf_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe PdfFiller::NcD400Pdf do
 
   describe '#hash_for_pdf' do
     let(:pdf_fields) { filled_in_values(submission.generate_filing_pdf.path) }
+    let(:signature_date) { DateTime.now }
+    let(:expected_signature_date_pdf_value) { signature_date.in_time_zone(StateFile::StateInformationService.timezone('nc')).strftime("%F") }
 
     it 'uses field names that exist in the pdf' do
       missing_fields = pdf.hash_for_pdf.keys.map(&:to_s) - pdf_fields.keys
@@ -19,7 +21,7 @@ RSpec.describe PdfFiller::NcD400Pdf do
     end
 
     context "pulling fields from xml" do
-      let(:tomorrow_midnight) { DateTime.tomorrow.beginning_of_day }
+
       let(:mailing_apartment) { 'Apt 2'}
       let(:intake) {
         create(:state_file_nc_intake,
@@ -27,7 +29,7 @@ RSpec.describe PdfFiller::NcD400Pdf do
                primary_last_name: "Carolinianian",
                untaxed_out_of_state_purchases: "no",
                primary_esigned: "yes",
-               primary_esigned_at: tomorrow_midnight)
+               primary_esigned_at: signature_date)
       }
 
       before do
@@ -78,8 +80,7 @@ RSpec.describe PdfFiller::NcD400Pdf do
           expect(pdf_fields['y_d400wf_li27_pg2_good']).to eq '0'
           expect(pdf_fields['y_d400wf_li28_pg2_good']).to eq '1507'
           expect(pdf_fields['y_d400wf_li34_pg2_good']).to eq '1507'
-          timezone = StateFile::StateInformationService.timezone('nc')
-          expect(pdf_fields['y_d400wf_sigdate']).to eq tomorrow_midnight.in_time_zone(timezone).strftime("%Y-%m-%d")
+          expect(pdf_fields['y_d400wf_sigdate']).to eq expected_signature_date_pdf_value
           expect(pdf_fields['y_d400wf_sigdate2']).to eq ""
         end
 
@@ -110,8 +111,7 @@ RSpec.describe PdfFiller::NcD400Pdf do
       end
 
       context "mfj filers" do
-        let(:tomorrow_midnight) { DateTime.tomorrow.beginning_of_day }
-        let(:intake) { create(:state_file_nc_intake, :with_spouse, filing_status: "married_filing_jointly", primary_esigned: "yes", primary_esigned_at: tomorrow_midnight, spouse_esigned: "yes", spouse_esigned_at: tomorrow_midnight) }
+        let(:intake) { create(:state_file_nc_intake, :with_spouse, filing_status: "married_filing_jointly", primary_esigned: "yes", primary_esigned_at: signature_date, spouse_esigned: "yes", spouse_esigned_at: signature_date) }
 
         before do
           submission.data_source.direct_file_data.spouse_ssn = "111100030"
@@ -142,8 +142,8 @@ RSpec.describe PdfFiller::NcD400Pdf do
           expect(pdf_fields['y_d400wf_li20b_pg2_good']).to eq '4394'
 
           timezone = StateFile::StateInformationService.timezone('nc')
-          expect(pdf_fields['y_d400wf_sigdate']).to eq tomorrow_midnight.in_time_zone(timezone).strftime("%Y-%m-%d")
-          expect(pdf_fields['y_d400wf_sigdate2']).to eq tomorrow_midnight.in_time_zone(timezone).strftime("%Y-%m-%d")
+          expect(pdf_fields['y_d400wf_sigdate']).to eq expected_signature_date_pdf_value
+          expect(pdf_fields['y_d400wf_sigdate2']).to eq expected_signature_date_pdf_value
         end
       end
 

--- a/spec/lib/submission_builder/ty2022/states/return_header_spec.rb
+++ b/spec/lib/submission_builder/ty2022/states/return_header_spec.rb
@@ -320,13 +320,14 @@ describe SubmissionBuilder::ReturnHeader do
         spouse_esigned_at: spouse_esigned_at
       )
     }
-    let(:tomorrow_midnight) { DateTime.tomorrow.beginning_of_day }
+    let(:signature_date) { DateTime.now }
+    let(:expected_signature_date_pdf_value) { signature_date.in_time_zone(StateFile::StateInformationService.timezone("md")).strftime("%F") }
     let(:primary_signature_pin) { "12345" }
     let(:primary_esigned) { "yes" }
-    let(:primary_esigned_at) { tomorrow_midnight }
+    let(:primary_esigned_at) { signature_date }
     let(:spouse_signature_pin) { "23456" }
     let(:spouse_esigned) { "yes" }
-    let(:spouse_esigned_at) { tomorrow_midnight }
+    let(:spouse_esigned_at) { signature_date }
     let(:submission) { create(:efile_submission, data_source: intake) }
     let(:doc) { SubmissionBuilder::ReturnHeader.new(submission).document }
 
@@ -339,7 +340,7 @@ describe SubmissionBuilder::ReturnHeader do
       end
 
       it "handles timezone correctly for signature date when the filer esigns after midnight UTC but not after midnight in the State's timezone" do
-        expect(doc.at('Filer Primary DateSigned').content).to eq tomorrow_midnight.in_time_zone("America/New_York").strftime("%Y-%m-%d")
+        expect(doc.at('Filer Primary DateSigned').content).to eq expected_signature_date_pdf_value
         expect(doc.at('Filer Secondary DateSigned')).not_to be_present
       end
     end
@@ -358,8 +359,8 @@ describe SubmissionBuilder::ReturnHeader do
       end
 
       it "it correctly signs with the date of the correct timezone when the filer esigns after midnight UTC but not after midnight in the State's timezone" do
-        expect(doc.at('Filer Primary DateSigned').content).to eq tomorrow_midnight.in_time_zone("America/New_York").strftime("%Y-%m-%d")
-        expect(doc.at('Filer Secondary DateSigned').content).to eq tomorrow_midnight.in_time_zone("America/New_York").strftime("%Y-%m-%d")
+        expect(doc.at('Filer Primary DateSigned').content).to eq expected_signature_date_pdf_value
+        expect(doc.at('Filer Secondary DateSigned').content).to eq expected_signature_date_pdf_value
       end
     end
   end


### PR DESCRIPTION
## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Removed all adjustments to signature dates in PDF tests
  - "1.hour.ago" in an MD test
  - "tomorrow.midnight" in a bunch of other tests
- This simplifies the test logic and avoids time-dependent failures
## How to test?
- We should make sure that all tests pass regardless of when they are run
- This is hard to verify on CircleCi, so we set the system time locally to different times near midnight and made sure the tests passed with e.g. `sudo date 1224200124 && bundle exec rspec spec/lib/pdf_filler/nc_d400_pdf_spec.rb`, where the command line argument to `date` is Month-Day-Hour-Minute-Year