### PR TITLE
NJ 230 - refactor return_header to remove state_code

### DIFF
--- a/app/lib/submission_builder/return_header.rb
+++ b/app/lib/submission_builder/return_header.rb
@@ -16,7 +16,7 @@ module SubmissionBuilder
           xml.TaxPeriodEndDt date_type(Date.new(@submission.data_source.tax_return_year, 12, 31))
         end
         xml.TaxYr @submission.data_source.tax_return_year
-        if !state_submission_builder.ptin.nil? && !state_submission_builder.preparer_person_name.nil?
+        if state_submission_builder.ptin.present? && state_submission_builder.preparer_person_name.present?
           xml.PaidPreparerInformationGrp do 
             xml.PTIN state_submission_builder.ptin
             xml.PreparerPersonNm state_submission_builder.preparer_person_name

--- a/app/lib/submission_builder/return_header.rb
+++ b/app/lib/submission_builder/return_header.rb
@@ -3,6 +3,10 @@ module SubmissionBuilder
     include SubmissionBuilder::FormattingMethods
     include SubmissionBuilder::BusinessLogicMethods
 
+    def state_submission_builder
+      StateFile::StateInformationService.submission_builder_class(@submission.data_source.state_code)
+    end
+
     def document
       build_xml_doc("ReturnHeaderState") do |xml|
         xml.Jurisdiction "#{@submission.data_source.state_code.upcase}ST"
@@ -12,10 +16,10 @@ module SubmissionBuilder
           xml.TaxPeriodEndDt date_type(Date.new(@submission.data_source.tax_return_year, 12, 31))
         end
         xml.TaxYr @submission.data_source.tax_return_year
-        if @submission.data_source.state_code.upcase == "NJ"
+        if !state_submission_builder.ptin.nil? && !state_submission_builder.preparer_person_name.nil?
           xml.PaidPreparerInformationGrp do 
-            xml.PTIN "P99999999"
-            xml.PreparerPersonNm "Self Prepared"
+            xml.PTIN state_submission_builder.ptin
+            xml.PreparerPersonNm state_submission_builder.preparer_person_name
           end
         end
         xml.DisasterReliefTxt @intake.disaster_relief_county if @intake.respond_to?(:disaster_relief_county)

--- a/app/lib/submission_builder/state_return.rb
+++ b/app/lib/submission_builder/state_return.rb
@@ -1,18 +1,20 @@
 module SubmissionBuilder
   class StateReturn < SubmissionBuilder::Document
     def document
-      @document = state_schema_version.present? ?
-                    build_xml_doc(build_xml_doc_tag, stateSchemaVersion: state_schema_version) :
+      @document = if state_schema_version.present?
+                    build_xml_doc(build_xml_doc_tag, stateSchemaVersion: state_schema_version)
+                  else
                     build_xml_doc(build_xml_doc_tag)
+                  end
       build_headers
       build_main_document
       build_documents
       build_state_specific_tags(@document)
       @document
     end
-
+    
     def pdf_documents
-      included_documents.map { |item| item if item.pdf }.compact
+      included_documents.select { |item| item.pdf }
     end
 
     def build_headers
@@ -50,7 +52,7 @@ module SubmissionBuilder
     end
 
     def xml_documents
-      included_documents.map { |item| item if item.xml }.compact
+      included_documents.select { |item| item.xml }
     end
 
     def included_documents
@@ -128,5 +130,9 @@ module SubmissionBuilder
     def build_state_specific_tags(_); end
 
     def documents_wrapper; end
+      
+    def self.preparer_person_name; end
+      
+    def self.ptin; end
   end
 end

--- a/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
+++ b/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
@@ -20,7 +20,7 @@ module SubmissionBuilder
               SchemaFileLoader.load_file("us_states", "unpacked", "NJIndividual2024V0.1", "NJIndividual", "NJForms", "FormNJ1040.xsd")
             end
 
-            def document              
+            def document
               build_xml_doc("FormNJ1040") do |xml|
                 xml.Header do
                   xml.FilingStatus do

--- a/app/lib/submission_builder/ty2024/states/nj/nj_return_xml.rb
+++ b/app/lib/submission_builder/ty2024/states/nj/nj_return_xml.rb
@@ -12,6 +12,14 @@ module SubmissionBuilder
 
           private
 
+          def self.ptin 
+            "P99999999"  
+          end
+
+          def self.preparer_person_name
+            "Self Prepared"
+          end
+
           def attached_documents_parent_tag
             # Line 29 in ReturnDataNj1040.xsd
             'ReturnDataState'

--- a/spec/lib/submission_builder/ty2022/states/return_header_spec.rb
+++ b/spec/lib/submission_builder/ty2022/states/return_header_spec.rb
@@ -54,25 +54,6 @@ describe SubmissionBuilder::ReturnHeader do
         end
       end
 
-      context "paid preparer information group" do
-        if state_code == "nj"
-          context "for NJ returns" do
-            it "adds XML elements for PaidPreparerInformationGrp" do
-              expect(doc.at("PaidPreparerInformationGrp PTIN").text).to eq "P99999999"
-              expect(doc.at("PaidPreparerInformationGrp PreparerPersonNm").text).to eq "Self Prepared"
-            end
-          end
-        else
-          context "for non NJ returns" do
-            it "does not add XML elements for PaidPreparerInformationGrp" do
-              expect(doc.at("PaidPreparerInformationGrp")).not_to be_present 
-              expect(doc.at("PaidPreparerInformationGrp PTIN")).not_to be_present 
-              expect(doc.at("PaidPreparerInformationGrp PreparerPersonNm")).not_to be_present 
-            end
-          end
-        end
-      end
-
       context "filer personal info" do
         let(:primary_birth_date) { 40.years.ago }
         let(:primary_ssn) { "100000030" }
@@ -361,6 +342,31 @@ describe SubmissionBuilder::ReturnHeader do
       it "it correctly signs with the date of the correct timezone when the filer esigns after midnight UTC but not after midnight in the State's timezone" do
         expect(doc.at('Filer Primary DateSigned').content).to eq expected_signature_date_pdf_value
         expect(doc.at('Filer Secondary DateSigned').content).to eq expected_signature_date_pdf_value
+      end
+    end
+  end
+
+  context "paid preparer information group" do
+    context "for NJ returns", required_schema: "nj" do
+      let(:intake) { create(:state_file_nj_intake) }
+      let(:submission) { create(:efile_submission, data_source: intake) }
+      let(:doc) { SubmissionBuilder::ReturnHeader.new(submission).document }
+      it "adds XML elements for PaidPreparerInformationGrp" do
+        expect(doc.at("PaidPreparerInformationGrp PTIN").text).to eq "P99999999"
+        expect(doc.at("PaidPreparerInformationGrp PreparerPersonNm").text).to eq "Self Prepared"
+      end
+    end
+
+    StateFile::StateInformationService.active_state_codes.excluding("nj").each do |state_code|
+      let(:intake) { create "state_file_#{state_code}_intake".to_sym }
+      let(:submission) { create(:efile_submission, data_source: intake) }
+      let(:doc) { SubmissionBuilder::ReturnHeader.new(submission).document }
+      context "for #{state_code} returns" do
+        it "does not add XML elements for PaidPreparerInformationGrp" do
+          expect(doc.at("PaidPreparerInformationGrp")).not_to be_present 
+          expect(doc.at("PaidPreparerInformationGrp PTIN")).not_to be_present 
+          expect(doc.at("PaidPreparerInformationGrp PreparerPersonNm")).not_to be_present 
+        end
       end
     end
   end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://github.com/newjersey/affordability-pm/issues/230

## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Refactor based on Martha's comment on PR: https://github.com/codeforamerica/vita-min/pull/5266#discussion_r1894355150
- Previously, we relied on an `if state_code == 'nj'` statement to conditionally place PaidPreparerFields. This refactor makes the logic consistent across all states - if `ptin` and `preparer_person_name` are overwritten in the state's submission builder, it places the relevant fields in the Header. 

## How to test?
- Run unit tests
- Ran through FYST with `jones_mfj` persona, validated that NJ XML had PaidPreparerField block

