### PR TITLE
Nj 237 prop tax credit bug

### DIFF
--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -336,7 +336,7 @@ module Efile
           StateFile::NjTenantEligibilityHelper.determine_eligibility(@intake) == StateFile::NjTenantEligibilityHelper::INELIGIBLE &&
             StateFile::NjHomeownerEligibilityHelper.determine_eligibility(@intake) == StateFile::NjHomeownerEligibilityHelper::INELIGIBLE
         else
-          nil
+          true
         end
       end
 

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -1190,6 +1190,7 @@ describe Efile::Nj::Nj1040Calculator do
           create(
             :state_file_nj_intake,
             :married_filing_separately,
+            household_rent_own: "rent",
             tenant_same_home_spouse: 'yes',
             )
         }
@@ -1204,6 +1205,7 @@ describe Efile::Nj::Nj1040Calculator do
           create(
             :state_file_nj_intake,
             :married_filing_separately,
+            household_rent_own: "own",
             homeowner_same_home_spouse: 'yes',
             )
         }
@@ -1218,6 +1220,7 @@ describe Efile::Nj::Nj1040Calculator do
           create(
             :state_file_nj_intake,
             :married_filing_separately,
+            household_rent_own: "rent",
             tenant_same_home_spouse: 'no',
             )
         }
@@ -1232,6 +1235,7 @@ describe Efile::Nj::Nj1040Calculator do
           create(
             :state_file_nj_intake,
             :married_filing_separately,
+            household_rent_own: "own",
             homeowner_same_home_spouse: 'no',
             )
         }

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -1304,6 +1304,16 @@ describe Efile::Nj::Nj1040Calculator do
           expect(instance.lines[:NJ1040_LINE_56].value).to eq(nil)
         end
       end
+
+      context 'when neither homeowner nor tenant' do
+        let(:intake) {
+          create(:state_file_nj_intake, household_rent_own: "neither")
+        }
+        it 'sets line 56 to nil' do
+          instance.calculate
+          expect(instance.lines[:NJ1040_LINE_56].value).to eq(nil)
+        end
+      end
     end
 
     context 'when ineligible for property tax deduction or credit due to housing details' do

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -1808,15 +1808,10 @@ RSpec.describe PdfFiller::Nj1040Pdf do
     end
 
     describe "line 56 - property tax credit" do
-      context 'when taxpayer income is above property tax minimum' do
-        let(:submission) {
-          create :efile_submission, tax_return: nil, data_source: create(
-            :state_file_nj_intake,
-            :df_data_many_w2s,
-            household_rent_own: 'own',
-            property_tax_paid: 0,
-            )
-        }
+      context 'when taxpayer claiming full property tax credit' do
+        before do
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_56).and_return 50
+        end
 
         it "writes $50.00 property tax credit" do
           # hundreds
@@ -1828,12 +1823,25 @@ RSpec.describe PdfFiller::Nj1040Pdf do
         end
       end
 
-      context 'when taxpayer income is below property tax minimum' do
-        let(:submission) {
-          create :efile_submission, tax_return: nil, data_source: create(
-            :state_file_nj_intake,
-            :df_data_minimal)
-        }
+      context 'when taxpayer claiming half property tax credit' do
+        before do
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_56).and_return 25
+        end
+
+        it "writes $50.00 property tax credit" do
+          # hundreds
+          expect(pdf_fields["Text161"]).to eq "2"
+          expect(pdf_fields["Text162"]).to eq "5"
+          # decimals
+          expect(pdf_fields["Text163"]).to eq "0"
+          expect(pdf_fields["Text164"]).to eq "0"
+        end
+      end
+
+      context 'when taxpayer not claiming property tax credit' do
+        before do
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_56).and_return nil
+        end
 
         it "does not fill property tax credit" do
           # hundreds
@@ -1842,24 +1850,6 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           # decimals
           expect(pdf_fields["Text163"]).to eq ""
           expect(pdf_fields["Text164"]).to eq ""
-        end
-      end
-
-      context 'when taxpayer income is below property tax minimum but eligible for credit' do
-        let(:submission) {
-          create :efile_submission, tax_return: nil, data_source: create(
-            :state_file_nj_intake,
-            :df_data_minimal,
-            :primary_blind)
-        }
-
-        it "writes $50.00 property tax credit" do
-          # hundreds
-          expect(pdf_fields["Text161"]).to eq "5"
-          expect(pdf_fields["Text162"]).to eq "0"
-          # decimals
-          expect(pdf_fields["Text163"]).to eq "0"
-          expect(pdf_fields["Text164"]).to eq "0"
         end
       end
     end

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -1828,7 +1828,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_56).and_return 25
         end
 
-        it "writes $50.00 property tax credit" do
+        it "writes $25.00 property tax credit" do
           # hundreds
           expect(pdf_fields["Text161"]).to eq "2"
           expect(pdf_fields["Text162"]).to eq "5"


### PR DESCRIPTION
## Link to pivotal/JIRA issue

https://github.com/newjersey/affordability-pm/issues/237

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- The "neither" case wasn't covered by a test in the calculator and revealed the issue- that the function to determine if eligible for the credit needed to return `true` but was returning `nil`

## How to test?
- Trout persona, choose "neither" for property tax question. Before, would still see $50 credit in XML and PDF. Now it's not there.

## Screenshots (for visual changes)
### Before

```
<PropertyTaxDeductOrCredit>
<PropertyTaxCredit>50</PropertyTaxCredit>
</PropertyTaxDeductOrCredit>
```
![image](https://github.com/user-attachments/assets/099c4363-8278-4a4e-a21a-5249a6458004)


### After

<img width="378" alt="image" src="https://github.com/user-attachments/assets/96088294-b917-4def-969e-a9bbc204b844" />

<img width="725" alt="image" src="https://github.com/user-attachments/assets/0bfbe3b4-16cc-4761-a198-ea14fb752fe9" />
