### PR TITLE
FYST-1509 offboard MD filers if permanent address is not in MD

### DIFF
--- a/app/controllers/state_file/questions/md_permanent_address_controller.rb
+++ b/app/controllers/state_file/questions/md_permanent_address_controller.rb
@@ -2,6 +2,7 @@ module StateFile
   module Questions
     class MdPermanentAddressController < QuestionsController
       include ReturnToReviewConcern
+      include EligibilityOffboardingConcern
     end
   end
 end

--- a/app/forms/state_file/md_permanent_address_form.rb
+++ b/app/forms/state_file/md_permanent_address_form.rb
@@ -32,7 +32,7 @@ module StateFile
                                         permanent_zip: @intake.direct_file_data.mailing_zip,
                                       } : {}
       attributes_from_direct_file[:permanent_address_outside_md] = @intake.direct_file_data.mailing_state != 'MD' && confirmed_permanent_address == "yes" ? "yes" : "no"
-      attributes_from_form = attributes_for(:intake).except(:permanent_zip).merge({permanent_zip: permanent_zip&.delete('-')})
+      attributes_from_form = attributes_for(:intake).except(:permanent_zip).merge({ permanent_zip: permanent_zip&.delete('-') })
       @intake.update(attributes_from_form.merge(attributes_from_direct_file))
     end
   end

--- a/app/models/state_file_md_intake.rb
+++ b/app/models/state_file_md_intake.rb
@@ -140,6 +140,7 @@ class StateFileMdIntake < StateFileBaseIntake
       eligibility_homebuyer_withdrawal_mfj: "yes",
       eligibility_homebuyer_withdrawal: "yes",
       eligibility_home_different_areas: "yes",
+      permanent_address_outside_md: "yes",
     }
   end
 

--- a/app/views/state_file/questions/eligibility_offboarding/edit.html.erb
+++ b/app/views/state_file/questions/eligibility_offboarding/edit.html.erb
@@ -8,5 +8,4 @@
   <% end %>
 
   <%= render 'state_file/questions/eligibility_offboarding/other_options' %>
-
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2447,6 +2447,7 @@ en:
             health_insurance_eligibility: and all members of your tax household did not have health insurance (with minimum essential coverage) for every month in %{filing_year}
             nyc_maintained_home: you lived in or maintained a home in New York City for some of the year.
             nyc_residency: you lived in or maintained a home in New York City for some of the year.
+            permanent_address_outside_md: did not reside in Maryland on Dec 31st
             permanent_address_outside_ny: you did not live in New York for all of %{filing_year}
           title: Unfortunately, you can't use this service this year. Don't worry, there are other filing options.
         other_options:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2403,6 +2403,7 @@ es:
             health_insurance_eligibility: and all members of your tax household did not have health insurance (with minimum essential coverage) for every month in %{filing_year}
             nyc_maintained_home: no viviste en Nueva York durante todo el
             nyc_residency: viviste o mantuviste una casa en la Ciudad de Nueva York durante parte del año.
+            permanent_address_outside_md: no residía en Maryland el 31 de diciembre.
             permanent_address_outside_ny: no viviste en Nueva York durante todo el %{filing_year}
           title: Lamentablemente no puedes usar esta herramienta este año. ¡No te preocupes, aquí tienes otras opciones para presentar tu declaración!
         other_options:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2384,7 +2384,7 @@ es:
           title: 'Has rechazado los términos y condiciones. '
       eligibility_offboarding:
         edit:
-          body_html: No puedes usar este servicio este año porque %{ineligible_reason}. <br><br><strong>¿Fue un error?</strong><a href=%{prev_link}>Regresa para corregirlo.</a>
+          body_html: No puedes usar este servicio este año porque %{ineligible_reason}. <br><br><strong>¿Fue un error?</strong> <a href=%{prev_link}>Regresa para corregirlo.</a>
           ineligible_reason:
             eligibility_529_for_non_qual_expense: retiraste dinero de una cuenta de ahorro universitario 529 y lo utilizaste para un gasto no calificado en el %{filing_year}
             eligibility_ed_loan_cancelled: " tuve un préstamo estudiantil cancelado bajo la Ley del Plan de Rescate Estadounidense."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2403,7 +2403,7 @@ es:
             health_insurance_eligibility: and all members of your tax household did not have health insurance (with minimum essential coverage) for every month in %{filing_year}
             nyc_maintained_home: no viviste en Nueva York durante todo el
             nyc_residency: viviste o mantuviste una casa en la Ciudad de Nueva York durante parte del año.
-            permanent_address_outside_md: no residía en Maryland el 31 de diciembre.
+            permanent_address_outside_md: no residía en Maryland el 31 de diciembre
             permanent_address_outside_ny: no viviste en Nueva York durante todo el %{filing_year}
           title: Lamentablemente no puedes usar esta herramienta este año. ¡No te preocupes, aquí tienes otras opciones para presentar tu declaración!
         other_options:

--- a/spec/controllers/state_file/questions/md_permanent_address_controller_spec.rb
+++ b/spec/controllers/state_file/questions/md_permanent_address_controller_spec.rb
@@ -1,18 +1,43 @@
 require "rails_helper"
 
 describe StateFile::Questions::MdPermanentAddressController do
-
-  let(:intake) { create :state_file_ny_refund_intake}
+  let(:intake) { create :state_file_md_intake }
   before do
     sign_in intake
   end
 
-  describe '#edit' do
+  describe "#edit" do
     render_views
-    it 'succeeds' do
+    it "succeeds" do
       get :edit
       expect(response).to be_successful
       expect(response_html).to have_text "Did you live at this address"
+    end
+  end
+
+  describe "#update" do
+    # the disqualifying param here is permanent_address_outside_md but this is set in the form based on:
+    # * whether they are using the address from DF
+    # * if so, whether that address is in MD
+    # so we have to mock the DF data
+    it_behaves_like :eligibility_offboarding_concern, intake_factory: :state_file_md_intake do
+      let(:eligible_params) do
+        allow_any_instance_of(DirectFileData).to receive(:mailing_state).and_return "MD"
+        {
+          state_file_md_permanent_address_form: {
+            confirmed_permanent_address: "yes",
+          }
+        }
+      end
+
+      let(:ineligible_params) do
+        allow_any_instance_of(DirectFileData).to receive(:mailing_state).and_return "NC"
+        {
+          state_file_md_permanent_address_form: {
+            confirmed_permanent_address: "yes",
+          }
+        }
+      end
     end
   end
 end

--- a/spec/forms/state_file/md_permanent_address_form_spec.rb
+++ b/spec/forms/state_file/md_permanent_address_form_spec.rb
@@ -199,6 +199,20 @@ RSpec.describe StateFile::MdPermanentAddressForm do
         expect(intake.permanent_zip).to eq "12345"
       end
 
+      context "permanent_address_outside_md" do
+        it "saves permanent_address_outside_md as yes when DF mailing address state is not MD" do
+          allow_any_instance_of(DirectFileData).to receive(:mailing_state).and_return "NC"
+          form.save
+          expect(intake.permanent_address_outside_md).to eq "yes"
+        end
+
+        it "saves permanent_address_outside_md as no when DF mailing address state is MD" do
+          allow_any_instance_of(DirectFileData).to receive(:mailing_state).and_return "MD"
+          form.save
+          expect(intake.permanent_address_outside_md).to eq "no"
+        end
+      end
+
       context "intake already has permanent address fields saved" do
         let(:intake) { create :state_file_md_intake,
                               permanent_street: "123 Throwa Way",
@@ -244,6 +258,12 @@ RSpec.describe StateFile::MdPermanentAddressForm do
         expect(intake.permanent_apartment).to eq permanent_apartment
         expect(intake.permanent_city).to eq permanent_city
         expect(intake.permanent_zip).to eq permanent_zip
+      end
+
+      it "saves permanent_address_outside_md as no because state is required to be MD when filling out a new address" do
+        allow_any_instance_of(DirectFileData).to receive(:mailing_state).and_return "NC"
+        form.save
+        expect(intake.permanent_address_outside_md).to eq "no"
       end
     end
   end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1509
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Redirect to offboarding page from /md-permanent-address if they select "yes" their permanent address is the one from DF and that address is in a state other than MD
- Added one extra test for setting this `permanent_address_outside_md` in the form because as far as I could tell that line was not tested
## How to test?
- Used shared example controller spec for EligibilityOffboardingConcern (albeit in a slightly janky way)
- Frodo has an out-of-state mailing address
## Screenshots (for visual changes)
- N/A