### PR TITLE
FYST-1450 Add an sms equivalent to StateFileNotificationEmail objects

### DIFF
--- a/app/jobs/state_file/send_notification_text_message_job.rb
+++ b/app/jobs/state_file/send_notification_text_message_job.rb
@@ -1,0 +1,22 @@
+module StateFile
+  class SendNotificationTextMessageJob < ApplicationJob
+    def perform(state_file_notification_text_message_id)
+      state_file_notification_text_message = StateFileNotificationTextMessage.find(state_file_notification_text_message_id)
+      twilio = TwilioService.new(:statefile)
+
+      message = twilio.send_text_message(
+        to: state_file_notification_text_message.to_phone_number,
+        body: state_file_notification_text_message.body
+      )
+      state_file_notification_text_message.update(
+        twilio_sid: message.sid,
+        twilio_status: message.status,
+        sent_at: DateTime.now
+      )
+    end
+
+    def priority
+      PRIORITY_HIGH
+    end
+  end
+end

--- a/app/models/state_file_notification_text_message.rb
+++ b/app/models/state_file_notification_text_message.rb
@@ -22,4 +22,12 @@ class StateFileNotificationTextMessage < ApplicationRecord
   belongs_to :data_source, polymorphic: true, optional: true
   validates_presence_of :to_phone_number
   validates_presence_of :body
+
+  after_create_commit :deliver
+
+  private
+
+  def deliver
+    StateFile::SendNotificationTextMessageJob.perform_later(id)
+  end
 end

--- a/app/models/state_file_notification_text_message.rb
+++ b/app/models/state_file_notification_text_message.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: state_file_notification_text_messages
+#
+#  id               :bigint           not null, primary key
+#  body             :string           not null
+#  data_source_type :string
+#  error_code       :string
+#  sent_at          :datetime
+#  to_phone_number  :string           not null
+#  twilio_sid       :string
+#  twilio_status    :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  data_source_id   :bigint
+#
+# Indexes
+#
+#  index_state_file_notification_text_messages_on_data_source  (data_source_type,data_source_id)
+#
+class StateFileNotificationTextMessage < ApplicationRecord
+  belongs_to :data_source, polymorphic: true, optional: true
+  validates_presence_of :to_phone_number
+  validates_presence_of :body
+end

--- a/app/services/state_file/messaging_service.rb
+++ b/app/services/state_file/messaging_service.rb
@@ -66,13 +66,6 @@ module StateFile
           body: @message_instance.sms_body(locale: locale, **sms_args),
         )
         sent_messages << sent_message if sent_message.present?
-
-        twilio = TwilioService.new(:statefile)
-
-        twilio.send_text_message(
-          to: intake.phone_number,
-          body: @message_instance.sms_body(locale: @locale, **sms_args)
-        )
       end
     end
     

--- a/app/services/state_file/messaging_service.rb
+++ b/app/services/state_file/messaging_service.rb
@@ -60,6 +60,13 @@ module StateFile
       return if require_verification && !phone_number_verified
 
       if @message_instance.sms_body.present?
+        sent_message = StateFileNotificationTextMessage.create!(
+          data_source: intake,
+          to_phone_number: intake.phone_number,
+          body: @message_instance.sms_body(locale: locale, **sms_args),
+        )
+        sent_messages << sent_message if sent_message.present?
+
         twilio = TwilioService.new(:statefile)
 
         twilio.send_text_message(

--- a/db/migrate/20250106225119_create_state_file_notification_text_messages.rb
+++ b/db/migrate/20250106225119_create_state_file_notification_text_messages.rb
@@ -1,0 +1,15 @@
+class CreateStateFileNotificationTextMessages < ActiveRecord::Migration[7.1]
+  def change
+    create_table :state_file_notification_text_messages do |t|
+      t.string :body, null: false
+      t.string :to_phone_number, null: false
+      t.datetime :sent_at
+      t.string :error_code
+      t.string :twilio_sid
+      t.string :twilio_status
+      t.references :data_source, polymorphic: true, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_12_20_195915) do
+ActiveRecord::Schema[7.1].define(version: 2025_01_06_225119) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -2231,6 +2231,20 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_20_195915) do
     t.string "to", null: false
     t.datetime "updated_at", null: false
     t.index ["data_source_type", "data_source_id"], name: "index_state_file_notification_emails_on_data_source"
+  end
+
+  create_table "state_file_notification_text_messages", force: :cascade do |t|
+    t.string "body", null: false
+    t.datetime "created_at", null: false
+    t.bigint "data_source_id"
+    t.string "data_source_type"
+    t.string "error_code"
+    t.datetime "sent_at"
+    t.string "to_phone_number", null: false
+    t.string "twilio_sid"
+    t.string "twilio_status"
+    t.datetime "updated_at", null: false
+    t.index ["data_source_type", "data_source_id"], name: "index_state_file_notification_text_messages_on_data_source"
   end
 
   create_table "state_file_ny_intakes", force: :cascade do |t|

--- a/spec/factories/state_file_notification_text_messages.rb
+++ b/spec/factories/state_file_notification_text_messages.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: state_file_notification_text_messages
+#
+#  id               :bigint           not null, primary key
+#  body             :string           not null
+#  data_source_type :string
+#  error_code       :string
+#  sent_at          :datetime
+#  to_phone_number  :string           not null
+#  twilio_sid       :string
+#  twilio_status    :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  data_source_id   :bigint
+#
+# Indexes
+#
+#  index_state_file_notification_text_messages_on_data_source  (data_source_type,data_source_id)
+#
+FactoryBot.define do
+  factory :state_file_notification_text_message do
+    body { "a text massage" }
+    to_phone_number { "+14155551212" }
+  end
+end

--- a/spec/jobs/state_file/send_notification_email_job_spec.rb
+++ b/spec/jobs/state_file/send_notification_email_job_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe StateFile::SendNotificationEmailJob, type: :job do
+  describe "#perform" do
+    let(:email) { create :state_file_notification_email }
+    let(:mailer_double) { double }
+    let(:fake_mailer_response) { double(message_id: 32) }
+
+    before do
+      allow(StateFile::NotificationMailer).to receive(:user_message).and_return(mailer_double)
+      allow(mailer_double).to receive(:deliver_now).and_return(fake_mailer_response)
+    end
+
+    it "finds the email record, uses mailer to send message, updates record" do
+      fake_time = DateTime.parse("2025-01-14")
+      Timecop.freeze(fake_time) do
+        described_class.perform_now(email.id)
+
+        expect(StateFile::NotificationMailer).to have_received(:user_message).with(notification_email: email)
+        expect(mailer_double).to have_received(:deliver_now)
+        email.reload
+        expect(email.message_id).to eq "32"
+        expect(email.sent_at).to eq fake_time
+      end
+    end
+  end
+end

--- a/spec/jobs/state_file/send_notification_text_message_job_spec.rb
+++ b/spec/jobs/state_file/send_notification_text_message_job_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe StateFile::SendNotificationTextMessageJob, type: :job do
-  include MockTwilio
-
   describe "#perform" do
     let(:text_message) { create :state_file_notification_text_message }
     let(:twilio_double) { instance_double(TwilioService) }

--- a/spec/jobs/state_file/send_notification_text_message_job_spec.rb
+++ b/spec/jobs/state_file/send_notification_text_message_job_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe StateFile::SendNotificationTextMessageJob, type: :job do
+  include MockTwilio
+
+  describe "#perform" do
+    let(:text_message) { create :state_file_notification_text_message }
+    let(:twilio_double) { instance_double(TwilioService) }
+    let(:fake_twilio_response) { double(sid: "123", status: "sending") }
+
+    before do
+      allow(TwilioService).to receive(:new).and_return(twilio_double)
+      allow(twilio_double).to receive(:send_text_message).and_return(fake_twilio_response)
+    end
+
+    it "finds the text message record, uses twilio service to send message, updates record" do
+      fake_time = DateTime.parse("2025-01-14")
+      Timecop.freeze(fake_time) do
+        described_class.perform_now(text_message.id)
+
+        expect(TwilioService).to have_received(:new).with(:statefile)
+        expect(twilio_double).to have_received(:send_text_message).with(
+          to: text_message.to_phone_number,
+          body: text_message.body,
+        )
+        text_message.reload
+        expect(text_message.sent_at).to eq fake_time
+        expect(text_message.twilio_sid).to eq "123"
+        expect(text_message.twilio_status).to eq "sending"
+      end
+    end
+  end
+end

--- a/spec/models/state_file_notification_email_spec.rb
+++ b/spec/models/state_file_notification_email_spec.rb
@@ -33,4 +33,13 @@ describe StateFileNotificationEmail do
       expect(email).to have_received(:deliver)
     end
   end
+
+  describe "#deliver" do
+    it "queues a SendNotificationEmailJob" do
+      email = build :state_file_notification_email
+      expect {
+        email.save!
+      }.to have_enqueued_job(StateFile::SendNotificationEmailJob).with(email.id)
+    end
+  end
 end

--- a/spec/models/state_file_notification_text_message_spec.rb
+++ b/spec/models/state_file_notification_text_message_spec.rb
@@ -1,0 +1,45 @@
+# == Schema Information
+#
+# Table name: state_file_notification_text_messages
+#
+#  id               :bigint           not null, primary key
+#  body             :string           not null
+#  data_source_type :string
+#  error_code       :string
+#  sent_at          :datetime
+#  to_phone_number  :string           not null
+#  twilio_sid       :string
+#  twilio_status    :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  data_source_id   :bigint
+#
+# Indexes
+#
+#  index_state_file_notification_text_messages_on_data_source  (data_source_type,data_source_id)
+#
+require 'rails_helper'
+
+RSpec.describe StateFileNotificationTextMessage, type: :model do
+  describe "after create" do
+    let(:text_message) { build :state_file_notification_text_message }
+    before do
+      allow(text_message).to receive(:deliver)
+    end
+
+    it "calls deliver" do
+      text_message.save!
+
+      expect(text_message).to have_received(:deliver)
+    end
+  end
+
+  describe "#deliver" do
+    it "queues a SendNotificationTextMessageJob" do
+      text_message = build :state_file_notification_text_message
+      expect {
+        text_message.save!
+      }.to have_enqueued_job(StateFile::SendNotificationTextMessageJob).with(text_message.id)
+    end
+  end
+end

--- a/spec/services/state_file/after_transition_messaging_service_spec.rb
+++ b/spec/services/state_file/after_transition_messaging_service_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 describe StateFile::AfterTransitionMessagingService do
   include MockTwilio
+  include ActiveJob::TestHelper
 
   let(:intake) do
     create :state_file_az_intake,
@@ -126,6 +127,7 @@ describe StateFile::AfterTransitionMessagingService do
     it "sends the terminal rejected refund sms" do
       expect do
         messaging_service.send_efile_submission_terminal_rejected_message
+        perform_enqueued_jobs
       end.to change(FakeTwilioClient.messages, :count).by(1)
 
       expect(efile_submission.message_tracker).to include "messages.state_file.terminal_rejected"

--- a/spec/services/state_file/messaging_service_spec.rb
+++ b/spec/services/state_file/messaging_service_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 describe StateFile::MessagingService do
-  include MockTwilio
-
   let(:intake) do
     create(
       :state_file_az_intake,
@@ -62,8 +60,7 @@ describe StateFile::MessagingService do
     it "should send a message if the number is verified" do
       expect {
         messaging_service.send_message
-      }.to change { FakeTwilioClient.messages.count }
-             .and change(StateFileNotificationTextMessage, :count).by(1)
+      }.to change(StateFileNotificationTextMessage, :count).by(1)
     end
 
     it "should not send a message if the number is unverified" do
@@ -72,7 +69,6 @@ describe StateFile::MessagingService do
       expect {
         messaging_service.send_message
       }.to not_change(StateFileNotificationTextMessage, :count)
-             .and not_change { FakeTwilioClient.messages.count }
     end
   end
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1450
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Made a new model so we can have records of outgoing notification texts for state file
- Tried to replicate the same patterns we use for email which includes putting the actual sending of the text in a job and triggering the job when the record is persisted
- Doesn't include leveraging the twilio webhooks to update the message sending status; can add as a follow-up?
## How to test?
- Added some coverage for emails (new spec file for delayed job, model spec for #deliver)
- Coverage for texts:
  - delayed job spec mocks twilio methods (tried briefly to use MockTwilio but couldn't figure out how to mock response with sid)
  - model spec checks after_create and deliver
  - messaging service now looks at record count instead of using MockTwilio
- Risk Assessment
  - the only real risk i guess is that texts stop working so acceptance testing should include trying to send texts
## Screenshots (for visual changes)
- N/A