### PR TITLE
Nj 78 2 checkbox

### DIFF
--- a/app/assets/stylesheets/_state-file.scss
+++ b/app/assets/stylesheets/_state-file.scss
@@ -247,6 +247,14 @@
       }
     }
 
+    .tight-ish-checkboxes {
+      @extend .tight-checkboxes;
+
+      .checkbox {
+        margin: 1rem 0
+      }
+    }
+
     .radio-button {
       border: none;
       background-color: transparent;

--- a/app/controllers/state_file/questions/nj_homeowner_eligibility_controller.rb
+++ b/app/controllers/state_file/questions/nj_homeowner_eligibility_controller.rb
@@ -22,12 +22,12 @@ module StateFile
           {
             method: :homeowner_main_home_multi_unit,
             label: I18n.t("state_file.questions.nj_homeowner_eligibility.edit.homeowner_main_home_multi_unit"),
-            has_follow_up_id: 'homeowner_multi_unit_followup'
+            opens_follow_up_with_id: 'homeowner_multi_unit_followup'
           },
           {
             method: :homeowner_main_home_multi_unit_max_four_one_commercial,
             label: I18n.t("state_file.questions.nj_homeowner_eligibility.edit.homeowner_main_home_multi_unit_max_four_one_commercial"),
-            is_follow_up_id: 'homeowner_multi_unit_followup'
+            follow_up_id: 'homeowner_multi_unit_followup'
           },
         ]
         if current_intake.filing_status_mfs?

--- a/app/controllers/state_file/questions/nj_homeowner_eligibility_controller.rb
+++ b/app/controllers/state_file/questions/nj_homeowner_eligibility_controller.rb
@@ -3,6 +3,45 @@ module StateFile
     class NjHomeownerEligibilityController < QuestionsController
       include ReturnToReviewConcern
 
+      before_action -> { set_checkboxes }
+
+      def set_checkboxes
+        @checkbox_collection = [
+          {
+            method: :homeowner_home_subject_to_property_taxes,
+            label: I18n.t("state_file.questions.nj_homeowner_eligibility.edit.homeowner_home_subject_to_property_taxes")
+          },
+          { 
+            method: :homeowner_more_than_one_main_home_in_nj,
+            label: I18n.t("state_file.questions.nj_homeowner_eligibility.edit.homeowner_more_than_one_main_home_in_nj"),
+          },
+          { 
+            method: :homeowner_shared_ownership_not_spouse,
+            label: I18n.t("state_file.questions.nj_homeowner_eligibility.edit.homeowner_shared_ownership_not_spouse"),
+          },
+          {
+            method: :homeowner_main_home_multi_unit,
+            label: I18n.t("state_file.questions.nj_homeowner_eligibility.edit.homeowner_main_home_multi_unit"),
+            has_follow_up_id: 'homeowner_multi_unit_followup'
+          },
+          {
+            method: :homeowner_main_home_multi_unit_max_four_one_commercial,
+            label: I18n.t("state_file.questions.nj_homeowner_eligibility.edit.homeowner_main_home_multi_unit_max_four_one_commercial"),
+            is_follow_up_id: 'homeowner_multi_unit_followup'
+          },
+        ]
+        if current_intake.filing_status_mfs?
+          @checkbox_collection << {
+            method: :homeowner_same_home_spouse,
+            label: I18n.t("state_file.questions.nj_homeowner_eligibility.edit.homeowner_same_home_spouse")
+          }
+        end
+        @checkbox_collection << {
+          method: :homeowner_none_of_the_above,
+          label: I18n.t("general.none_of_these")
+        }
+      end
+
       def next_path
         options = {}
         options[:return_to_review] = params[:return_to_review] if params[:return_to_review].present?

--- a/app/controllers/state_file/questions/nj_tenant_eligibility_controller.rb
+++ b/app/controllers/state_file/questions/nj_tenant_eligibility_controller.rb
@@ -14,12 +14,12 @@ module StateFile
           { 
             method: :tenant_building_multi_unit,
             label: I18n.t("state_file.questions.nj_tenant_eligibility.edit.tenant_building_multi_unit"),
-            has_follow_up_id: "tenant_access_kitchen_bath_followup-2", 
+            opens_follow_up_with_id: "tenant_access_kitchen_bath_followup", 
           },
           { 
             method: :tenant_access_kitchen_bath,
             label: I18n.t("state_file.questions.nj_tenant_eligibility.edit.tenant_access_kitchen_bath"),
-            is_follow_up_id: "tenant_access_kitchen_bath_followup-2"
+            follow_up_id: "tenant_access_kitchen_bath_followup"
           },
           {
             method: :tenant_more_than_one_main_home_in_nj,

--- a/app/controllers/state_file/questions/nj_tenant_eligibility_controller.rb
+++ b/app/controllers/state_file/questions/nj_tenant_eligibility_controller.rb
@@ -3,6 +3,45 @@ module StateFile
     class NjTenantEligibilityController < QuestionsController
       include ReturnToReviewConcern
 
+      before_action -> { set_checkboxes }
+
+      def set_checkboxes
+        @checkbox_collection = [
+          {
+            method: :tenant_home_subject_to_property_taxes,
+            label: I18n.t("state_file.questions.nj_tenant_eligibility.edit.tenant_home_subject_to_property_taxes")
+          },
+          { 
+            method: :tenant_building_multi_unit,
+            label: I18n.t("state_file.questions.nj_tenant_eligibility.edit.tenant_building_multi_unit"),
+            has_follow_up_id: "tenant_access_kitchen_bath_followup-2", 
+          },
+          { 
+            method: :tenant_access_kitchen_bath,
+            label: I18n.t("state_file.questions.nj_tenant_eligibility.edit.tenant_access_kitchen_bath"),
+            is_follow_up_id: "tenant_access_kitchen_bath_followup-2"
+          },
+          {
+            method: :tenant_more_than_one_main_home_in_nj,
+            label: I18n.t("state_file.questions.nj_tenant_eligibility.edit.tenant_more_than_one_main_home_in_nj")
+          },
+          {
+            method: :tenant_shared_rent_not_spouse,
+            label: I18n.t("state_file.questions.nj_tenant_eligibility.edit.tenant_shared_rent_not_spouse")
+          },
+        ]
+        if current_intake.filing_status_mfs?
+          @checkbox_collection << {
+            method: :tenant_same_home_spouse,
+            label: I18n.t("state_file.questions.nj_tenant_eligibility.edit.tenant_same_home_spouse")
+          }
+        end
+        @checkbox_collection << {
+          method: :tenant_none_of_the_above,
+          label: I18n.t("general.none_of_these")
+        }
+      end
+
       def prev_path
         options = {}
         options[:return_to_review] = params[:return_to_review] if params[:return_to_review].present?

--- a/app/helpers/vita_min_form_builder.rb
+++ b/app/helpers/vita_min_form_builder.rb
@@ -408,12 +408,12 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
     container_id = nil
     container_class = ""
     item_options = item[:options] || {}
-    if item[:has_follow_up_id] 
+    if item[:opens_follow_up_with_id] 
       container_class = "question-with-follow-up__question"
-      item_options["data-follow-up"] = "#" + item[:has_follow_up_id]
-    elsif item[:is_follow_up_id]
+      item_options["data-follow-up"] = "#" + item[:opens_follow_up_with_id]
+    elsif item[:follow_up_id]
       container_class = "question-with-follow-up__follow-up"
-      container_id = item[:is_follow_up_id]
+      container_id = item[:follow_up_id]
     end
   
     joined_classes = ((item[:classes] || []) + ["checkbox"]).join(" ")
@@ -445,7 +445,7 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
     end.join).html_safe  
 
     checkbox_container_classes = ["tight-ish-checkboxes"]
-    includes_follow_up = (collection.any? { |item| item[:has_follow_up_id] }) || (checkbox_html.include? "follow-up")
+    includes_follow_up = (collection.any? { |item| item[:opens_follow_up_with_id] }) || (checkbox_html.include? "follow-up")
     checkbox_container_classes << "question-with-follow-up" if includes_follow_up
 
     fieldset_classes = ["input-group", "form-group#{error_state(object, method)}"]

--- a/app/helpers/vita_min_form_builder.rb
+++ b/app/helpers/vita_min_form_builder.rb
@@ -421,7 +421,7 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
     checkbox_args += ["yes", "no"] if enum
 
     <<~HTML.html_safe
-      <div id="#{h container_id}" class="#{container_class}">
+      <div id="#{container_id}" class="#{container_class}">
         <label class="#{joined_classes}">
         #{check_box(*checkbox_args)} <span class="text--normal">#{item[:label]}</span>
         </label>

--- a/app/helpers/vita_min_form_builder.rb
+++ b/app/helpers/vita_min_form_builder.rb
@@ -401,6 +401,70 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
     HTML
   end
 
+  def vita_min_checkbox_in_set(
+    item,
+    enum: false
+  )
+    container_id = nil
+    container_class = ""
+    item_options = item[:options] || {}
+    if item[:has_follow_up_id] 
+      container_class = "question-with-follow-up__question"
+      item_options["data-follow-up"] = "#" + item[:has_follow_up_id]
+    elsif item[:is_follow_up_id]
+      container_class = "question-with-follow-up__follow-up"
+      container_id = item[:is_follow_up_id]
+    end
+  
+    joined_classes = ((item[:classes] || []) + ["checkbox"]).join(" ")
+    checkbox_args = [item[:method], item_options]
+    checkbox_args += ["yes", "no"] if enum
+
+    <<~HTML.html_safe
+      <div id="#{container_id}" class="#{container_class}">
+        <label class="#{joined_classes}">
+        #{check_box(*checkbox_args)} <span class="text--normal">#{item[:label]}</span>
+        </label>
+      </div>
+    HTML
+  end
+
+  # Coped from Honeycrisp form builder v1 cfa_checkbox_set, modified to allow checkboxes to have follow up
+  def vita_min_checkbox_set(
+    method,
+    collection = [],
+    label_text: "",
+    help_text: nil,
+    optional: false,
+    legend_class: "",
+    enum: false,
+    checkboxes: nil
+  )  
+    checkbox_html = (checkboxes || collection.map do |item|
+      vita_min_checkbox_in_set(item, enum: enum)
+    end.join).html_safe  
+
+    checkbox_container_classes = ["tight-ish-checkboxes"]
+    includes_follow_up = (collection.any? { |item| item[:has_follow_up_id] }) || (checkbox_html.include? "follow-up")
+    checkbox_container_classes << "question-with-follow-up" if includes_follow_up
+
+    fieldset_classes = ["input-group", "form-group#{error_state(object, method)}"]
+    <<~HTML.html_safe
+      <fieldset class="#{fieldset_classes.join(' ')}">
+        #{fieldset_label_contents(
+          label_text: label_text,
+          help_text: help_text,
+          legend_class: legend_class,
+          optional: optional,
+          )}
+          <div class="#{checkbox_container_classes.join(' ')}">
+            #{checkbox_html}
+          </div>
+          #{errors_for(object, method)}
+        </fieldset>
+    HTML
+  end
+
   def submit(value, options = {})
     options[:data] ||= {}
     options[:data][:disable_with] = value

--- a/app/helpers/vita_min_form_builder.rb
+++ b/app/helpers/vita_min_form_builder.rb
@@ -406,7 +406,7 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
     enum: false
   )
     container_id = nil
-    container_class = ""
+    container_class = nil
     item_options = item[:options] || {}
     if item[:opens_follow_up_with_id] 
       container_class = "question-with-follow-up__question"
@@ -421,7 +421,7 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
     checkbox_args += ["yes", "no"] if enum
 
     <<~HTML.html_safe
-      <div id="#{container_id}" class="#{container_class}">
+      <div id="#{h container_id}" class="#{container_class}">
         <label class="#{joined_classes}">
         #{check_box(*checkbox_args)} <span class="text--normal">#{item[:label]}</span>
         </label>

--- a/app/views/state_file/questions/nj_college_dependents_exemption/edit.html.erb
+++ b/app/views/state_file/questions/nj_college_dependents_exemption/edit.html.erb
@@ -36,16 +36,30 @@
       <% dependent = ff.object %>
       <% if dependent.under_22? %>
         <div class="white-group">
-          <fieldset>
-            <legend class="h3"><%= dependent.full_name %> <%= t('.dependent_header') %></legend>
-            <p><%= t('.birthdate_label') %> <%= dependent.dob.strftime('%m/%d/%Y') %></p>
-            <div class="tight-checkboxes spacing-above-0">
-              <%= ff.cfa_checkbox(:nj_dependent_attends_accredited_program, t(".dependent_attends_accredited_program", dependent_first: dependent.first_name_title_case), options: { checked_value: "yes", unchecked_value: "no" }) %>
-              <%= ff.cfa_checkbox(:nj_dependent_enrolled_full_time, t(".dependent_enrolled_full_time", dependent_first: dependent.first_name_title_case), options: { checked_value: "yes", unchecked_value: "no" }) %>
-              <%= ff.cfa_checkbox(:nj_dependent_five_months_in_college, t(".dependent_five_months_in_college", dependent_first: dependent.first_name_title_case), options: { checked_value: "yes", unchecked_value: "no" }) %>
-              <%= ff.cfa_checkbox(:nj_filer_pays_tuition_for_dependent, t(".filer_pays_tuition_books", dependent_first: dependent.first_name_title_case), options: { checked_value: "yes", unchecked_value: "no" }) %>
-            </div>
-          </fieldset>
+          <%= ff.vita_min_checkbox_set(
+            :college_dependents,
+            [
+              {
+                method: :nj_dependent_attends_accredited_program,
+                label: t(".dependent_attends_accredited_program", dependent_first: dependent.first_name_title_case),
+              },
+              {
+                method: :nj_dependent_enrolled_full_time,
+                label: t(".dependent_enrolled_full_time", dependent_first: dependent.first_name_title_case)
+              },
+              {
+                method: :nj_dependent_five_months_in_college,
+                label: t(".dependent_five_months_in_college", dependent_first: dependent.first_name_title_case)
+              },
+              {
+                method: :nj_filer_pays_tuition_for_dependent,
+                label: t(".filer_pays_tuition_books", dependent_first: dependent.first_name_title_case)
+              },
+            ],
+            enum: true,
+            label_text: "#{dependent.full_name} #{t('.dependent_header')}",
+            help_text: "#{t('.birthdate_label')} #{dependent.dob.strftime('%m/%d/%Y')}"
+          )%>
         </div>
       <% end %>
     <% end %>

--- a/app/views/state_file/questions/nj_dependents_health_insurance/edit.html.erb
+++ b/app/views/state_file/questions/nj_dependents_health_insurance/edit.html.erb
@@ -1,24 +1,22 @@
-<% title = t(".title_html") %>
+<%
+  content_for :page_title, t(".title") 
+%>
 
-<% content_for :page_title, title %>
 <% content_for :card do %>
-  <h1 class="h2"><%= title %></h1>
+  <h1 class="h2"><%= t(".title_html") %></h1>
 
   <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
     <div class="white-group">
-      <fieldset class="tight-checkboxes">
-        <legend class="form-question" style="margin-bottom: 3rem;"><%= t('.label') %></legend>
-        <div class="input-group--block">
-          <%= f.fields_for :dependents do |ff| %>
-            <% dependent = ff.object %>
-            <%= ff.cfa_checkbox(
-              :nj_did_not_have_health_insurance,
-              dependent.full_name,
-              options: { checked_value: "yes", unchecked_value: "no" }
-            ) %>
-          <% end %>
-        </div>
-      </fieldset>
+      <% checkboxes = f.fields_for :dependents do |ff|
+        ff.vita_min_checkbox_in_set({ method: :nj_did_not_have_health_insurance, label: ff.object.full_name }, enum: true)
+      end %>
+
+      <%= f.vita_min_checkbox_set(
+        :college_dependents,
+        checkboxes: checkboxes,
+        enum: true,
+        label_text: t('.label'),
+      )%>
     </div>
 
     <p class="text--italic"><%= t('.continue') %></p>

--- a/app/views/state_file/questions/nj_homeowner_eligibility/edit.html.erb
+++ b/app/views/state_file/questions/nj_homeowner_eligibility/edit.html.erb
@@ -6,49 +6,8 @@
 <% content_for :card do %>
   <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder, html: { class: "form-card form-card--long" } do |f| %>
     <h1 class="h2"><%= title %></h1>
-    <p><%= t(".label") %></p>
 
-    <div class="spacing-above-0 question-with-follow-up">
-      <div class="white-group">
-        <div class="tight-checkboxes">
-          <%= f.cfa_checkbox(:homeowner_home_subject_to_property_taxes, t(".homeowner_home_subject_to_property_taxes"), options: { checked_value: "yes", unchecked_value: "no" }) %>
-        </div>
-      </div>
-      <div class="white-group">
-        <div class="tight-checkboxes">
-          <%= f.cfa_checkbox(:homeowner_more_than_one_main_home_in_nj, t(".homeowner_more_than_one_main_home_in_nj"), options: { checked_value: "yes", unchecked_value: "no" }) %>
-        </div>
-      </div>
-      <div class="white-group">
-        <div class="tight-checkboxes">
-          <%= f.cfa_checkbox(:homeowner_shared_ownership_not_spouse, t(".homeowner_shared_ownership_not_spouse"), options: { checked_value: "yes", unchecked_value: "no" }) %>
-        </div>
-      </div>
-      <div class="white-group question-with-follow-up__question">
-        <div class="tight-checkboxes">
-        <%= f.cfa_checkbox(:homeowner_main_home_multi_unit, t(".homeowner_main_home_multi_unit"), options: { checked_value: "yes", unchecked_value: "no", "data-follow-up": "#homeowner_multi_unit_followup", "aria-controls": "homeowner_multi_unit_followup"}) %>
-        </div>
-      </div>
-      <div class="question-with-follow-up__follow-up" id="homeowner_multi_unit_followup">
-        <div class="white-group">
-          <div class="tight-checkboxes">
-            <%= f.cfa_checkbox(:homeowner_main_home_multi_unit_max_four_one_commercial, t(".homeowner_main_home_multi_unit_max_four_one_commercial"), options: { checked_value: "yes", unchecked_value: "no" }) %>
-          </div>
-        </div>
-      </div>
-      <% if current_intake.filing_status_mfs? %>
-        <div class="white-group">
-          <div class="tight-checkboxes">
-            <%= f.cfa_checkbox(:homeowner_same_home_spouse, t(".homeowner_same_home_spouse"), options: { checked_value: "yes", unchecked_value: "no" }) %>
-          </div>
-        </div>
-      <% end %>
-      <div class="white-group">
-        <div class="tight-checkboxes">
-          <%= f.cfa_checkbox(:homeowner_none_of_the_above, t("general.none_of_these"), options: { checked_value: "yes", unchecked_value: "no" }) %>
-        </div>
-      </div>
-    </div>
+    <%= f.vita_min_checkbox_set(:homeowner_eligibility, @checkbox_collection, enum: true, label_text: t(".label")) %>
 
     <% if params[:return_to_review].present? %>
       <%= hidden_field_tag "return_to_review", params[:return_to_review] %>

--- a/app/views/state_file/questions/nj_tenant_eligibility/edit.html.erb
+++ b/app/views/state_file/questions/nj_tenant_eligibility/edit.html.erb
@@ -6,56 +6,8 @@
 <% content_for :card do %>
   <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder, html: { class: "form-card form-card--long" } do |f| %>
     <h1 class="h2"><%= title %></h1>
-    <fieldset>
-      <legend style="margin-bottom: 2.5rem"><%= t(".label") %></legend>
 
-      <div class="spacing-above-0 question-with-follow-up">
-        <div class="white-group">
-          <div class="tight-checkboxes">
-            <%= f.cfa_checkbox(:tenant_home_subject_to_property_taxes, t(".tenant_home_subject_to_property_taxes"), options: { checked_value: "yes", unchecked_value: "no" }) %>
-          </div>
-        </div>
-
-        <div class="white-group question-with-follow-up__question">
-          <div class="tight-checkboxes">
-            <%= f.cfa_checkbox(:tenant_building_multi_unit, t(".tenant_building_multi_unit"), options: { checked_value: "yes", unchecked_value: "no", "data-follow-up": "#tenant_access_kitchen_bath_followup", "aria-controls": "tenant_access_kitchen_bath_followup" }) %>
-          </div>
-        </div>
-
-        <div class="question-with-follow-up__follow-up" id="tenant_access_kitchen_bath_followup">
-          <div class="white-group">
-            <div class="tight-checkboxes">
-              <%= f.cfa_checkbox(:tenant_access_kitchen_bath, t(".tenant_access_kitchen_bath"), options: { checked_value: "yes", unchecked_value: "no" }) %>
-            </div>
-          </div>
-        </div>
-
-        <div class="white-group">
-          <div class="tight-checkboxes">
-            <%= f.cfa_checkbox(:tenant_more_than_one_main_home_in_nj, t(".tenant_more_than_one_main_home_in_nj"), options: { checked_value: "yes", unchecked_value: "no" }) %>
-          </div>
-        </div>
-
-        <div class="white-group">
-          <div class="tight-checkboxes">
-            <%= f.cfa_checkbox(:tenant_shared_rent_not_spouse, t(".tenant_shared_rent_not_spouse"), options: { checked_value: "yes", unchecked_value: "no" }) %>
-          </div>
-        </div>
-
-        <% if current_intake.filing_status_mfs? %>
-          <div class="white-group">
-            <div class="tight-checkboxes">
-              <%= f.cfa_checkbox(:tenant_same_home_spouse, t(".tenant_same_home_spouse"), options: { checked_value: "yes", unchecked_value: "no" }) %>
-            </div>
-          </div>
-        <% end %>
-      </div>
-      <div class="white-group">
-        <div class="tight-checkboxes">
-          <%= f.cfa_checkbox(:tenant_none_of_the_above, t("general.none_of_these"), options: { checked_value: "yes", unchecked_value: "no" }) %>
-        </div>
-      </div>
-    </fieldset>
+    <%= f.vita_min_checkbox_set(:tenant_eligibility, @checkbox_collection, enum: true, label_text: t(".label")) %>
 
     <div class="reveal">
       <button class="reveal__button"><%= t('.helper_heading') %></button>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3143,6 +3143,7 @@ en:
           continue: Click "continue" if all these people had health insurance.
           coverage_heading: What is health insurance with minimum essential coverage?
           label: 'Check all the people that did NOT have health insurance:'
+          title: Please tell us which dependents were missing health insurance (with minimum essential health coverage) in 2024.
           title_html: Please tell us which dependents were missing health insurance (<a target=" _blank" rel="noopener noreferrer" href="https://nj.gov/treasury/njhealthinsurancemandate/getinfo.shtml">with minimum essential health coverage</a>) in 2024.
       nj_disabled_exemption:
         edit:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3103,6 +3103,7 @@ es:
           continue: Click "continue" if all these people had health insurance.
           coverage_heading: What is health insurance with minimum essential coverage?
           label: 'Check all the people that did NOT have health insurance:'
+          title: Please tell us which dependents were missing health insurance (with minimum essential health coverage) in 2024.
           title_html: Please tell us which dependents were missing health insurance (<a target=" _blank" rel="noopener noreferrer" href="https://nj.gov/treasury/njhealthinsurancemandate/getinfo.shtml">with minimum essential health coverage</a>) in 2024.
       nj_disabled_exemption:
         edit:


### PR DESCRIPTION
## Link to pivotal/JIRA issue
Addresses some of the fieldset issues identified here https://github.com/newjersey/affordability-pm/issues/78
And explained in depth here:
- https://github.com/newjersey/accessibility-pm/issues/28
- https://github.com/newjersey/accessibility-pm/issues/30
- https://github.com/newjersey/accessibility-pm/issues/31

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
Add a fieldset component that allows us to include a follow up question. Replace all of our weirdly nested fieldsets with this one. Abstract some fieldset checkbox logic to controllers where it's more complex.

Also deal with an existing title html issue that was making the title appear strangely at the top of the page (seemingly on local only??).

Note: this does apply the tight checkbox styling to all checkboxes using this component. We could change that but I thought the more uniform spacing might be an improvement, esp since our implementation was not a pixel perfect match of the designs to begin with.

## How to test?
For homeowner and tenant eligibility, select a married filing separately profile and make sure the conditional checkboxes still show up.

For college dependents and dependent health insurance, select the "many deps claimed as dep" and make sure those checkboxes still work.

## Screenshots (for visual changes)
- Before
![image](https://github.com/user-attachments/assets/5c1c9469-a141-44ec-b582-9abd28f32074)

- After
![image](https://github.com/user-attachments/assets/1ce67fa2-751d-4748-be54-c79bc13e7e1d)

