### PR TITLE
sanitize html tags out of string used as page title to fix layout

### DIFF
--- a/app/views/state_file/questions/nc_subtractions/edit.html.erb
+++ b/app/views/state_file/questions/nc_subtractions/edit.html.erb
@@ -1,5 +1,5 @@
 <% title = t(".title_html", count: current_intake.filer_count) %>
-<% content_for :page_title, title %>
+<% content_for :page_title, ActionView::Base.full_sanitizer.sanitize(title) %>
 <% content_for :card do %>
   <h1 class="h2"><%= title %></h1>
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1574
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- We were setting the `<title>` contents on /nc-subtractions to a string with an `<a>` tag in it, which was breaking the page and causing part of the string to be displayed above the body.
- I used Rails' `sanitize` method to remove the html
- An alternative would have been to create a separate entry in the strings file without the `<a>` tag and use that for the title. I chose not to do this so as to avoid duplication, but it would be necessary if we wanted different text in the page title than in the question copy.
## How to test?
- Go through the NC flow on demo and verify that the page is broken (see screenshots below for what to look for), then do the same on this PR's heroku instance and verify that it works.
## Screenshots (for visual changes)
- Before
<img width="1377" alt="image" src="https://github.com/user-attachments/assets/e06639e2-c3e9-446c-b58a-908d13e5a72f" />
- After
<img width="1134" alt="image" src="https://github.com/user-attachments/assets/42a131e0-306c-42d2-854c-0f3adff6a4c6" />
