### PR TITLE
NJ 235 - no negative values calc line 42

### DIFF
--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -376,7 +376,11 @@ module Efile
       end
 
       def calculate_line_42
-        should_use_property_tax_deduction ? line_or_zero(:NJ1040_LINE_39) - calculate_property_tax_deduction : line_or_zero(:NJ1040_LINE_39)
+        if should_use_property_tax_deduction
+          [line_or_zero(:NJ1040_LINE_39) - calculate_property_tax_deduction, 0].max
+        else
+          line_or_zero(:NJ1040_LINE_39)
+        end
       end
 
       def calculate_line_43

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -1365,36 +1365,28 @@ describe Efile::Nj::Nj1040Calculator do
   end
 
   describe 'line 42 - new jersey taxable income' do
-    context 'when should_use_property_tax_deduction and result is positive' do
-      it 'sets line 42 to line 39 (taxable income) minus prop tax deduction' do
-        allow(instance).to receive(:should_use_property_tax_deduction).and_return true
-        allow(instance).to receive(:calculate_line_39).and_return 20_000
-        allow(instance).to receive(:calculate_property_tax_deduction).and_return 15_000
-        instance.calculate
-        expect(instance.lines[:NJ1040_LINE_42].value).to eq(5_000)
-      end
+    it 'sets line 42 to line 39 (taxable income) minus prop tax deduction when should_use_property_tax_deduction and result is positive' do
+      allow(instance).to receive(:should_use_property_tax_deduction).and_return true
+      allow(instance).to receive(:calculate_line_39).and_return 20_000
+      allow(instance).to receive(:calculate_property_tax_deduction).and_return 15_000
+      instance.calculate
+      expect(instance.lines[:NJ1040_LINE_42].value).to eq(5_000)
     end
 
-    context 'when not using prop tax deduction and result is positive' do
-      let(:intake) { create(:state_file_nj_intake) }
-      it 'sets line 42 to line 39 (taxable income)' do
-        allow(instance).to receive(:should_use_property_tax_deduction).and_return false
-        allow(instance).to receive(:calculate_line_39).and_return 20_000
-        allow(instance).to receive(:calculate_property_tax_deduction).and_return 25_000
-        instance.calculate
-        expect(instance.lines[:NJ1040_LINE_42].value).to eq(20_000)
-      end
+    it 'sets line 42 to line 39 (taxable income) when not using prop tax deduction and result is positive' do
+      allow(instance).to receive(:should_use_property_tax_deduction).and_return false
+      allow(instance).to receive(:calculate_line_39).and_return 20_000
+      allow(instance).to receive(:calculate_property_tax_deduction).and_return 25_000
+      instance.calculate
+      expect(instance.lines[:NJ1040_LINE_42].value).to eq(20_000)
     end
 
-    context 'when using prop tax deduction and result is negative' do
-      let(:intake) { create(:state_file_nj_intake) }
-      it 'sets line 42 to 0' do
-        allow(instance).to receive(:should_use_property_tax_deduction).and_return true
-        allow(instance).to receive(:calculate_line_39).and_return 20_000
-        allow(instance).to receive(:calculate_property_tax_deduction).and_return 25_000
-        instance.calculate
-        expect(instance.lines[:NJ1040_LINE_42].value).to eq(0) # fails
-      end
+    it 'sets line 42 to 0 when using prop tax deduction and result is negative' do
+      allow(instance).to receive(:should_use_property_tax_deduction).and_return true
+      allow(instance).to receive(:calculate_line_39).and_return 20_000
+      allow(instance).to receive(:calculate_property_tax_deduction).and_return 25_000
+      instance.calculate
+      expect(instance.lines[:NJ1040_LINE_42].value).to eq(0)
     end
   end
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue

https://github.com/newjersey/affordability-pm/issues/235

## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- When subtracting property tax deduction, set to 0 if result is negative
- Adjusted tests for this expectation
- No changes needed downstream in XML or PDF logic because they already filter out non-positive values
## How to test?
- Use Devito persona, put in a very high amount like `999999` for property taxes paid. Before would see a negative value in details, now see $0
## Screenshots (for visual changes)
### Before
![image](https://github.com/user-attachments/assets/f131255a-8a35-46f8-9945-2366e1b4595d)

### After
<img width="329" alt="image" src="https://github.com/user-attachments/assets/26a9236b-22d4-4262-af1f-3bcebe65c4d6" />

