### PR TITLE
remove hardcoded state for 1099-G mailing address

### DIFF
--- a/app/lib/submission_builder/state1099_g.rb
+++ b/app/lib/submission_builder/state1099_g.rb
@@ -4,7 +4,7 @@ module SubmissionBuilder
 
     def document
       form1099g = @kwargs[:form1099g]
-      state_abbreviation = form1099g.intake.direct_file_data.mailing_state.upcase
+      state_abbreviation = form1099g.recipient_state
 
       build_xml_doc("State1099G", documentId: "State1099G-#{form1099g.id}") do |xml|
         if form1099g.payer_name.present?

--- a/app/lib/submission_builder/state1099_g.rb
+++ b/app/lib/submission_builder/state1099_g.rb
@@ -4,7 +4,7 @@ module SubmissionBuilder
 
     def document
       form1099g = @kwargs[:form1099g]
-      state_abbreviation = form1099g.intake.state_code.upcase
+      state_abbreviation = form1099g.intake.direct_file_data.mailing_state.upcase
 
       build_xml_doc("State1099G", documentId: "State1099G-#{form1099g.id}") do |xml|
         if form1099g.payer_name.present?

--- a/app/lib/submission_builder/ty2024/states/md/documents/md502.rb
+++ b/app/lib/submission_builder/ty2024/states/md/documents/md502.rb
@@ -54,7 +54,7 @@ class SubmissionBuilder::Ty2024::States::Md::Documents::Md502 < SubmissionBuilde
           xml.AddressLine1Txt sanitize_for_xml(@intake.permanent_street, 30)
           xml.AddressLine2Txt sanitize_for_xml(@intake.permanent_apartment, 30) if @intake.permanent_apartment.present?
           xml.CityNm sanitize_for_xml(@intake.permanent_city, 20)
-          xml.StateAbbreviationCd @intake.state_code.upcase
+          xml.StateAbbreviationCd @intake.direct_file_data.mailing_state.upcase
           xml.ZIPCd @intake.permanent_zip
         end
       end

--- a/spec/lib/submission_builder/state1099_g_spec.rb
+++ b/spec/lib/submission_builder/state1099_g_spec.rb
@@ -20,6 +20,7 @@ describe SubmissionBuilder::State1099G do
       let(:recipient_street_address_apartment) { "Unit B" }
       let(:recipient_city) { "City" }
       let(:recipient_zip) { "11102" }
+      let(:recipient_state) { "CA" }
       let!(:form1099g) do
         create(
           :state_file1099_g,
@@ -35,6 +36,7 @@ describe SubmissionBuilder::State1099G do
           recipient_street_address: recipient_street_address,
           recipient_street_address_apartment: recipient_street_address_apartment,
           recipient_zip: recipient_zip,
+          recipient_state: recipient_state,
           unemployment_compensation_amount: unemployment_compensation_amount,
           federal_income_tax_withheld_amount: federal_income_tax_withheld_amount,
           state_income_tax_withheld_amount: state_income_tax_withheld_amount,
@@ -64,7 +66,7 @@ describe SubmissionBuilder::State1099G do
         expect(doc.at("BusinessNameLine1Txt").text).to eq payer_name
         expect(doc.at("PayerUSAddress AddressLine1Txt").text).to eq payer_street_address
         expect(doc.at("PayerUSAddress CityNm").text).to eq payer_city
-        expect(doc.at("PayerUSAddress StateAbbreviationCd").text).to eq df_state
+        expect(doc.at("PayerUSAddress StateAbbreviationCd").text).to eq recipient_state
         expect(doc.at("PayerUSAddress ZIPCd").text).to eq payer_zip
         expect(doc.at("PayerEIN").text).to eq payer_tin
         expect(doc.at("RecipientSSN").text).to eq primary_ssn
@@ -72,12 +74,12 @@ describe SubmissionBuilder::State1099G do
         expect(doc.at("RecipientUSAddress AddressLine1Txt").text).to eq recipient_street_address
         expect(doc.at("RecipientUSAddress AddressLine2Txt").text).to eq recipient_street_address_apartment
         expect(doc.at("RecipientUSAddress CityNm").text).to eq recipient_city
-        expect(doc.at("RecipientUSAddress StateAbbreviationCd").text).to eq df_state
+        expect(doc.at("RecipientUSAddress StateAbbreviationCd").text).to eq recipient_state
         expect(doc.at("RecipientUSAddress ZIPCd").text).to eq recipient_zip
         expect(doc.at("UnemploymentCompensation").text).to eq unemployment_compensation_amount
         expect(doc.at("FederalTaxWithheld").text).to eq federal_income_tax_withheld_amount
         expect(doc.at("State1099GStateLocalTaxGrp StateTaxWithheldAmt").text).to eq state_income_tax_withheld_amount
-        expect(doc.at("State1099GStateLocalTaxGrp StateAbbreviationCd").text).to eq df_state
+        expect(doc.at("State1099GStateLocalTaxGrp StateAbbreviationCd").text).to eq recipient_state
 
         expect(doc.at("State1099GStateLocalTaxGrp PayerStateIdNumber").text).to eq state_identification_number
       end

--- a/spec/lib/submission_builder/state1099_g_spec.rb
+++ b/spec/lib/submission_builder/state1099_g_spec.rb
@@ -53,6 +53,7 @@ describe SubmissionBuilder::State1099G do
           primary_last_name: primary_last_name,
         )
       end
+      let(:df_state) { intake.direct_file_data.mailing_state.upcase }
       let(:doc) { described_class.new(submission, kwargs: { form1099g: form1099g }).document }
       before do
         intake.direct_file_data.primary_ssn = primary_ssn
@@ -63,7 +64,7 @@ describe SubmissionBuilder::State1099G do
         expect(doc.at("BusinessNameLine1Txt").text).to eq payer_name
         expect(doc.at("PayerUSAddress AddressLine1Txt").text).to eq payer_street_address
         expect(doc.at("PayerUSAddress CityNm").text).to eq payer_city
-        expect(doc.at("PayerUSAddress StateAbbreviationCd").text).to eq state_code.upcase
+        expect(doc.at("PayerUSAddress StateAbbreviationCd").text).to eq df_state
         expect(doc.at("PayerUSAddress ZIPCd").text).to eq payer_zip
         expect(doc.at("PayerEIN").text).to eq payer_tin
         expect(doc.at("RecipientSSN").text).to eq primary_ssn
@@ -71,12 +72,13 @@ describe SubmissionBuilder::State1099G do
         expect(doc.at("RecipientUSAddress AddressLine1Txt").text).to eq recipient_street_address
         expect(doc.at("RecipientUSAddress AddressLine2Txt").text).to eq recipient_street_address_apartment
         expect(doc.at("RecipientUSAddress CityNm").text).to eq recipient_city
-        expect(doc.at("RecipientUSAddress StateAbbreviationCd").text).to eq state_code.upcase
+        expect(doc.at("RecipientUSAddress StateAbbreviationCd").text).to eq df_state
         expect(doc.at("RecipientUSAddress ZIPCd").text).to eq recipient_zip
         expect(doc.at("UnemploymentCompensation").text).to eq unemployment_compensation_amount
         expect(doc.at("FederalTaxWithheld").text).to eq federal_income_tax_withheld_amount
         expect(doc.at("State1099GStateLocalTaxGrp StateTaxWithheldAmt").text).to eq state_income_tax_withheld_amount
-        expect(doc.at("State1099GStateLocalTaxGrp StateAbbreviationCd").text).to eq state_code.upcase
+        expect(doc.at("State1099GStateLocalTaxGrp StateAbbreviationCd").text).to eq df_state
+
         expect(doc.at("State1099GStateLocalTaxGrp PayerStateIdNumber").text).to eq state_identification_number
       end
     end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1545

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- instead of hardcoding state to current state in flow, display the df's mailing state and pass it along to xml

## How to test?
- Verify with a persona with unemployment income and a different StateAbbreviationCd