### PR TITLE
GYR1-607 Update rental property text on triage-income-level screen

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2048,7 +2048,7 @@ en:
             zero: "$0"
         title: Tell us about your filing status and income.
         vita_income_ineligible:
-          label: Did you earn income from a rental property, a farm, or cryptocurrency?
+          label: 'Did you earn income from a rental property (ex: home or car), a farm, or cryptocurrency?'
   signups:
     flash_notice: Thank you! You will receive a notification when we open.
     new:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2000,7 +2000,7 @@ es:
             zero: "$0"
         title: Hablemos sobre su estado civil y sus ingresos.
         vita_income_ineligible:
-          label: "¿Recibió ingresos de una propiedad de renta/alquiler, una granja o criptomoneda?"
+          label: "¿Recibió ingresos de una propiedad de renta/alquiler (ej. casa or coche), una granja o criptomoneda?"
   signups:
     flash_notice: "¡Gracias! Recibirás una notificación cuando abramos."
     new:


### PR DESCRIPTION
## Link to pivotal/JIRA issue

- https://codeforamerica.atlassian.net/browse/GYR1-607

## Is PM acceptance required?

- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main

## What was done?
- Updated one line of text (English and Spanish) on the Triage Income Level screen.

## How to test?
- Review the text in English and Spanish.

## Screenshots (for visual changes)
- Before: see /flows
- After:

<img width="406" alt="Screenshot 2025-01-09 at 4 35 54 PM" src="https://github.com/user-attachments/assets/23bea5b0-366b-4cb7-9449-a2d105b41893" />

<img width="419" alt="Screenshot 2025-01-09 at 4 36 11 PM" src="https://github.com/user-attachments/assets/38682ed5-1522-44fa-83b0-106ac030ee7b" />

