### PR TITLE
GYR1-626 TY2024 income guidelines and remove gating for greater than 84k

### DIFF
--- a/app/services/triage_result_service.rb
+++ b/app/services/triage_result_service.rb
@@ -17,7 +17,7 @@ class TriageResultService
     elsif intake.triage_income_level_66000_to_79000?
       route_to_diy
     elsif intake.triage_income_level_over_79000?
-      route_to_does_not_qualify
+      route_to_diy
     end
   end
 

--- a/app/services/triage_result_service.rb
+++ b/app/services/triage_result_service.rb
@@ -15,9 +15,9 @@ class TriageResultService
         route_to_gyr_diy_choice
       end
     elsif intake.triage_income_level_66000_to_79000?
-      route_to_diy
+      route_to_gyr_diy_choice
     elsif intake.triage_income_level_over_79000?
-      route_to_diy
+      route_to_gyr
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2039,12 +2039,12 @@ en:
 
             <p class="text--small spacing-above-15">Your income level should not include stimulus payments, public benefits, or SSI.</p>
           options:
-            12500_to_25000: "$12,500 - 25,000"
-            1_to_12500: "$1 - 12,500"
-            25000_to_40000: "$25,000 - 40,000"
-            40000_to_66000: "$40,000 - 66,000"
-            66000_to_79000: "$66,000 - 79,000"
-            over_79000: over $79,000
+            12500_to_25000: "$15,000 - 30,000"
+            1_to_12500: "$1 - $15,000"
+            25000_to_40000: "$30,000 - 45,000"
+            40000_to_66000: "$45,000 - 67,000"
+            66000_to_79000: "$67,000 - 84,000"
+            over_79000: over $84,000
             zero: "$0"
         title: Tell us about your filing status and income.
         vita_income_ineligible:
@@ -6348,10 +6348,10 @@ en:
         in_person: Prefer to talk to someone in person? Find a free tax preparation site near you using our
         in_person_link_text: VITA location finder
         income_limit:
-          direct_file: Most filers under $TBD
+          direct_file: Most filers under $200,000
           diy: under $84,000
           full_service: under $67,000
-          title: 'Income limit:'
+          title: 'Income guidance:'
         itin_assistance: ITIN application assistance
         mobile_friendly: Mobile-friendly
         required_information: Required information
@@ -6376,7 +6376,7 @@ en:
           subtitle: "(w2s, 1099s, etc)"
           title: Official tax documents
         tax_payer_residency:
-          direct_file: Available to full-year residents of Arizona, California, Florida, Massachusetts, New Hampshire, New York, Nevada, South Dakota, Tennessee, Texas, Washington, and Wyoming.
+          direct_file: Available to full-year residents of Alaska, Arizona, California, Connecticut, Florida, Idaho, Illinois, Kansas, Maine, Maryland, Massachusetts, Nevada, New Hampshire, New Jersey, New Mexico, New York, North Carolina, Oregon, Pennsylvania, South Dakota, Tennessee, Texas, Washington, Wisconsin, and Wyoming.
           diy: Available to residents of all states, Puerto Rico, and non-residents.
           full_service_html: |
             Available to residents of all states.<br>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -102,7 +102,7 @@ en:
     file_yourself:
       edit:
         info:
-        - File taxes online on your own using our partner website. This is our quickest option for households earning under $79,000 to file taxes and collect the tax credits you are owed!
+        - File taxes online on your own using our partner website. This is our quickest option for households earning under $84,000 to file taxes and collect the tax credits you are owed!
         - To get started, we’ll need to collect some basic information.
         title: File taxes on your own
   documents:
@@ -1981,7 +1981,7 @@ en:
         description: File quickly on your own.
         list:
           file: File for %{current_tax_year} only
-          income: 'Income: under $79,000'
+          income: 'Income: under $84,000'
         timeframe: 45 minutes to file
         title: File Myself
       gyr_tile:
@@ -1989,7 +1989,7 @@ en:
         description: File confidently with assistance from our IRS-certified volunteers.
         list:
           file: File for %{oldest_filing_year}-%{current_tax_year}
-          income: 'Income: under $66,000'
+          income: 'Income: under $67,000'
           ssn: Must show copies of your Social Security card or ITIN paperwork
         timeframe: 2-3 weeks to file
         title: File with Help
@@ -2000,7 +2000,7 @@ en:
     triage_do_not_qualify:
       edit:
         faq_link_text: If you have additional questions, visit our FAQ page.
-        help_text: Our free service is available to households earning less than $79,000 a year.
+        help_text: Our free service is available to households earning less than $84,000 a year.
         title: Unfortunately, it looks like you do not qualify for our free service.
     triage_gyr:
       edit:
@@ -5529,7 +5529,7 @@ en:
           quote:
             courtney: "“I'm excited to extend our free services to those who can't come into one of our physical locations.I know taxes can be intimidating, which is why we are here to help!”"
             denise: "“Being part of an organization that works to bridge the gap between where people are and where they want (or need) to be is both fulfilling and always exciting.”"
-          subheader: We've formed a national coalition of community partners and dedicated volunteers to help us provide free tax filing assistance to families earning less than about $66,000 a year.
+          subheader: We've formed a national coalition of community partners and dedicated volunteers to help us provide free tax filing assistance to families earning less than about $67,000 a year.
         title: About Us
       error:
         body: It looks like there was a server error. We've been notified of the issue and will work to fix it!
@@ -6348,9 +6348,9 @@ en:
         in_person: Prefer to talk to someone in person? Find a free tax preparation site near you using our
         in_person_link_text: VITA location finder
         income_limit:
-          direct_file: Most filers under $200,000
-          diy: under $79,000
-          full_service: under $66,000
+          direct_file: Most filers under $TBD
+          diy: under $84,000
+          full_service: under $67,000
           title: 'Income limit:'
         itin_assistance: ITIN application assistance
         mobile_friendly: Mobile-friendly

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1991,12 +1991,12 @@ es:
 
             <p class="text--small spacing-above-15">Su nivel de ingresos no debe incluir pagos de estímulo, prestaciones públicas o Seguridad de Ingreso Suplementario (SSI)</p>
           options:
-            12500_to_25000: De $12,500 a 25,000 dólares
-            1_to_12500: De $1 a 12,500 dólares
-            25000_to_40000: De $25,000 a 40,000 dólares
-            40000_to_66000: "$40,000 - 66,000"
-            66000_to_79000: "$66,000 - 79,000"
-            over_79000: más de $79,000
+            12500_to_25000: "De $15,000 a 30,000 dólares"
+            1_to_12500: "De $1 a $15,000 dólares"
+            25000_to_40000: "De $30,000 a 45,000 dólares"
+            40000_to_66000: "De $45,000 a 67,000 dólares"
+            66000_to_79000: "De $67,000 a 84,000 dólares"
+            over_79000: más de $84,000
             zero: "$0"
         title: Hablemos sobre su estado civil y sus ingresos.
         vita_income_ineligible:
@@ -6387,10 +6387,10 @@ es:
         in_person: "¿Prefiere hablar con alguien en persona? Encuentre un sitio de preparación de impuestos gratuito cerca de usted utilizando nuestro"
         in_person_link_text: Localizador de VITA
         income_limit:
-          direct_file: La mayoría de los declarantes que ganan menos de $TBD
+          direct_file: La mayoría de los declarantes que ganan menos de $200,000
           diy: menos de $84,000
           full_service: menos de $67,000
-          title: 'Límite de ingresos:'
+          title: 'Límite de asesoramiento:'
         itin_assistance: Asistencia para la solicitud del Número de Identificación Personal (ITIN)
         mobile_friendly: Adaptable para dispositivos móviles
         required_information: Información obligatoria
@@ -6415,7 +6415,7 @@ es:
           subtitle: "(w2s, 1099s, etc)"
           title: Documentos tributarios oficiales
         tax_payer_residency:
-          direct_file: Disponible para residentes de tiempo completo de Arizona, California, Florida, Massachusetts, New Hampshire, Nueva York, Nevada, Dakota del Sur, Tennessee, Texas, Washington y Wyoming.
+          direct_file: Disponible para residentes de tiempo completo de Alaska, Arizona, California, Connecticut, Florida, Idaho, Illinois, Kansas, Maine, Maryland, Massachusetts, Nevada, Nuevo Hampshire, Nueva Jersey, Nuevo México, Nuevo York, Carolina del Norte, Oregon, Pennsylvania, Dakota del Sur, Tennessee, Tejas, Washington, Wisconsin y Wyoming.
           diy: Disponible para residentes de todos los estados, Puerto Rico y no residentes.
           full_service_html: |
             Disponible para residentes de todos los estados.<br>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1933,7 +1933,7 @@ es:
         description: Declare rápidamente por su cuenta.
         list:
           file: Declare solo para %{current_tax_year}
-          income: 'Ingresos: menos de $79,000'
+          income: 'Ingresos: menos de $84,000'
         timeframe: 45 minutos para declarar
         title: Declarar por cuenta propia
       gyr_tile:
@@ -1941,7 +1941,7 @@ es:
         description: Presente su declaración de impuestos con confianza con la ayuda de nuestros voluntarios certificados por el IRS.
         list:
           file: Presentar para %{oldest_filing_year}-%{current_tax_year}
-          income: 'Ingresos: menos de $66,000'
+          income: 'Ingresos: menos de $67,000'
           ssn: Debe mostrar copias de su tarjeta de Seguro Social o papeleo de su Número de Identificación Personal (ITIN)
         timeframe: De 2-3 semanas para declarar sus impuestos
         title: " Declare con Ayuda"
@@ -1952,7 +1952,7 @@ es:
     triage_do_not_qualify:
       edit:
         faq_link_text: Si tiene preguntas adicionales, visite nuestra página de preguntas frecuentes.
-        help_text: Nuestro servicio sin costo está disponible para hogares con ingresos inferiores a $79,000 al año.
+        help_text: Nuestro servicio sin costo está disponible para hogares con ingresos inferiores a $84,000 al año.
         title: Desafortunadamente, parece que no califica para nuestro servicio gratuito.
     triage_gyr:
       edit:
@@ -5514,7 +5514,7 @@ es:
           quote:
             courtney: '"Me alegra mucho poder extender nuestros servicios gratuitos a aquellos que no están cerca de nuestras oficinas. Sé que preparar una declaración de impuestos puede asustar a algunas personas, ¡pero estamos aquí para ayudarlas!"'
             denise: '"Formar parte de una organización que hace todo lo posible por disminuir la distancia entre el lugar donde están las personas y el lugar en el que quieren (o necesitan) estar, es muy gratificante y siempre emocionante".'
-          subheader: 'Hemos formado una coalición nacional de socios comunitarios y voluntarios dedicados a ayudarnos a proporcionarles asistencia gratuita para la declaración de impuestos a las familias que ganan menos de $66,000 dólares al año. '
+          subheader: 'Hemos formado una coalición nacional de socios comunitarios y voluntarios dedicados a ayudarnos a proporcionarles asistencia gratuita para la declaración de impuestos a las familias que ganan menos de $67,000 dólares al año. '
         title: Quiénes somos
       error:
         body: Parece que hubo un error en el servidor. Nos han informado del problema y haremos lo posible para solucionarlo.
@@ -6387,9 +6387,9 @@ es:
         in_person: "¿Prefiere hablar con alguien en persona? Encuentre un sitio de preparación de impuestos gratuito cerca de usted utilizando nuestro"
         in_person_link_text: Localizador de VITA
         income_limit:
-          direct_file: La mayoría de los declarantes que ganan menos de $200,000
-          diy: menos de $79,000
-          full_service: menos de $66,000
+          direct_file: La mayoría de los declarantes que ganan menos de $TBD
+          diy: menos de $84,000
+          full_service: menos de $67,000
           title: 'Límite de ingresos:'
         itin_assistance: Asistencia para la solicitud del Número de Identificación Personal (ITIN)
         mobile_friendly: Adaptable para dispositivos móviles

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1991,11 +1991,11 @@ es:
 
             <p class="text--small spacing-above-15">Su nivel de ingresos no debe incluir pagos de estímulo, prestaciones públicas o Seguridad de Ingreso Suplementario (SSI)</p>
           options:
-            12500_to_25000: "De $15,000 a 30,000 dólares"
-            1_to_12500: "De $1 a $15,000 dólares"
-            25000_to_40000: "De $30,000 a 45,000 dólares"
-            40000_to_66000: "De $45,000 a 67,000 dólares"
-            66000_to_79000: "De $67,000 a 84,000 dólares"
+            12500_to_25000: De $15,000 a 30,000 dólares
+            1_to_12500: De $1 a $15,000 dólares
+            25000_to_40000: De $30,000 a 45,000 dólares
+            40000_to_66000: De $45,000 a 67,000 dólares
+            66000_to_79000: De $67,000 a 84,000 dólares
             over_79000: más de $84,000
             zero: "$0"
         title: Hablemos sobre su estado civil y sus ingresos.

--- a/spec/features/web_intake/triage-results.csv
+++ b/spec/features/web_intake/triage-results.csv
@@ -8,5 +8,5 @@ zero,single or jointly,Any,Any,GYR,we'll allow these people to connect with VITA
 ,,Any,No,GYR-DIY,
 25000_to_40000 or 40000_to_66000,single or jointly,Any,Yes,DIY,
 25000_to_40000 or 40000_to_66000,single or jointly,Any,No,GYR-DIY,
-66000_to_79000,single or jointly,Any,Any,DIY,
-over_79000,single or jointly,Any,Any,Does not qualify,
+66000_to_79000,single or jointly,Any,Any,GYR-DIY,
+over_79000,single or jointly,Any,Any,GYR,

--- a/spec/features/web_intake/triage_spec.rb
+++ b/spec/features/web_intake/triage_spec.rb
@@ -84,7 +84,7 @@ RSpec.feature "triage flow" do
       when 'GYR-DIY'
         Questions::TriageGyrDiyController
       when 'Does not qualify'
-        Questions::TriageDoNotQualifyController
+        Questions::TriageDiyController
       end
     end
 

--- a/spec/features/web_intake/triage_spec.rb
+++ b/spec/features/web_intake/triage_spec.rb
@@ -84,7 +84,7 @@ RSpec.feature "triage flow" do
       when 'GYR-DIY'
         Questions::TriageGyrDiyController
       when 'Does not qualify'
-        Questions::TriageDiyController
+        Questions::TriageDoNotQualifyController
       end
     end
 


### PR DESCRIPTION
## Link to Jira issue

- https://codeforamerica.atlassian.net/browse/GYR1-626

## Is PM acceptance required?

- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main

## What was done?

Behavior change:
- On the triage income controller: 
  - if client indicates over 84k income, they used to get a 'sorry / does not qualify' message, but now they will get a message suggesting they use "File with Help". 
  - Clients that choose 67k-84k get both options (File with Help / File Yourself).

Text/etc updates:
- Updated new income caps in the text wherever appropriate.
- Updated the income bands in the dropdown on  Questions::TriageIncomeLevelController 
- On the home page, changed "Income limit" to "Income guidance"
- Also, on the home page, updated the states for Direct File
- Important: updated the app/services/triage_result_service.rb logic including making it so nobody gets an 'ineligible' message anymore.

## How to test?

I'm not 100% sure where all the text slugs that I updated are getting used (these changes happened in the yamls). But mainly, check:
- the home page (see screenshot)
-  the income triage controller page and the subsequent pages -- they will either suggest "File with Help", "File Myself", or both, depending on the value chosen in the income dropdown.
- Make sure the "does not qualify" message does *not* show when choose greater than 84k as income (again, the income triage controller page).
  - a small spec test change was made to test this behavior.

## Screenshots (for visual changes)

- Before: see `/flows`
- After:
<img width="1315" alt="a Screenshot 2025-01-15 at 12 58 11 AM" src="https://github.com/user-attachments/assets/35a906bb-6caa-4161-99b5-0a10dd3d35c5" />
<img width="1311" alt="b Screenshot 2025-01-15 at 12 58 31 AM" src="https://github.com/user-attachments/assets/1a0f4f4e-58ba-46b0-a208-2fd24ecb77ca" />
<img width="1034" alt="c Screenshot 2025-01-15 at 12 59 35 AM" src="https://github.com/user-attachments/assets/01996fc8-286d-4e65-b664-8b69bfe4c892" />
<img width="826" alt="d Screenshot 2025-01-15 at 12 59 06 AM" src="https://github.com/user-attachments/assets/d1e3ef76-b5da-45b8-a570-0a45d10ea7e4" />




