### PR TITLE
Focus box shadow and decorative image empty alt

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -56,4 +56,4 @@ $color-state-file-grey-darker: #595959;
 $intake-max-width: 570px;
 
 // Focus
-$focus-box-shadow: 0 0 0 5px $color-state-file-primary, inset 0px 2px 0px rgba(0, 0, 0, 0.15)
+$focus-box-shadow: 0 0 0 2px #ffffff, 0 0 0 7px #1A8CFF

--- a/app/assets/stylesheets/components/_reveal.scss
+++ b/app/assets/stylesheets/components/_reveal.scss
@@ -6,7 +6,7 @@
   padding: .2em .5em .3em .7em;
 
   &:focus-within {
-    box-shadow: 0 0 0 3px #FFFFFF, 0px 0px 0px 8px #C2850C;
+    box-shadow: $focus-box-shadow;
   }
 }
 

--- a/app/views/state_file/questions/post_data_transfer/edit.html.erb
+++ b/app/views/state_file/questions/post_data_transfer/edit.html.erb
@@ -4,7 +4,7 @@
 <% content_for :card do %>
   <div class='return-status'>
     <p>
-      <%= image_tag("icons/check.svg") %>
+      <%= image_tag("icons/check.svg", alt: "") %>
     </p>
   </div>
   <h1 class="h2" id="main-question"><%= title %></h1>


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/247

## Is PM acceptance required? (delete one)
- No - merge after code review approval
- But we probably do want design and Damian's approval

## What was done?
- Adjust the focus box shadow to include 2px of white and 5px of the new light blue
- Add an empty alt tag to a decorative image

## How to test?
Open any page and tab through

## Screenshots (for visual changes)
- Before
![image](https://github.com/user-attachments/assets/9ae34e1c-9cc3-4afa-ab1d-b03a674e41cd)
- After 
![image](https://github.com/user-attachments/assets/4b3ce422-c3f8-405e-a1c2-cc8430bad6a7)
