### PR TITLE
re-re-re-add foreign key constraint to intake table's references to drivers license table

### DIFF
--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -306,6 +306,8 @@
 #
 #  fk_rails_...  (client_id => clients.id)
 #  fk_rails_...  (matching_previous_year_intake_id => intakes.id)
+#  fk_rails_...  (primary_drivers_license_id => drivers_licenses.id)
+#  fk_rails_...  (spouse_drivers_license_id => drivers_licenses.id)
 #  fk_rails_...  (vita_partner_id => vita_partners.id)
 #
 

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -306,6 +306,8 @@
 #
 #  fk_rails_...  (client_id => clients.id)
 #  fk_rails_...  (matching_previous_year_intake_id => intakes.id)
+#  fk_rails_...  (primary_drivers_license_id => drivers_licenses.id)
+#  fk_rails_...  (spouse_drivers_license_id => drivers_licenses.id)
 #  fk_rails_...  (vita_partner_id => vita_partners.id)
 #
 class Intake::CtcIntake < Intake

--- a/app/models/intake/gyr_intake.rb
+++ b/app/models/intake/gyr_intake.rb
@@ -306,6 +306,8 @@
 #
 #  fk_rails_...  (client_id => clients.id)
 #  fk_rails_...  (matching_previous_year_intake_id => intakes.id)
+#  fk_rails_...  (primary_drivers_license_id => drivers_licenses.id)
+#  fk_rails_...  (spouse_drivers_license_id => drivers_licenses.id)
 #  fk_rails_...  (vita_partner_id => vita_partners.id)
 #
 class Intake::GyrIntake < Intake

--- a/db/migrate/20220426164834_create_drivers_license.rb
+++ b/db/migrate/20220426164834_create_drivers_license.rb
@@ -7,7 +7,7 @@ class CreateDriversLicense < ActiveRecord::Migration[6.1]
       t.date :issue_date, null: false
       t.date :expiration_date, null: false
     end
-    add_reference :intakes, :primary_drivers_license, index: true
-    add_reference :intakes, :spouse_drivers_license, index: true
+    add_reference :intakes, :primary_drivers_license, index: true, foreign_key: { to_table: :drivers_licenses }
+    add_reference :intakes, :spouse_drivers_license, index: true, foreign_key: { to_table: :drivers_licenses }
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2789,6 +2789,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_08_233940) do
   add_foreign_key "incoming_text_messages", "clients"
   add_foreign_key "intake_archives", "intakes", column: "id"
   add_foreign_key "intakes", "clients"
+  add_foreign_key "intakes", "drivers_licenses", column: "primary_drivers_license_id"
+  add_foreign_key "intakes", "drivers_licenses", column: "spouse_drivers_license_id"
   add_foreign_key "intakes", "intakes", column: "matching_previous_year_intake_id"
   add_foreign_key "intakes", "vita_partners"
   add_foreign_key "notes", "clients"

--- a/spec/models/intake/gyr_intake_spec.rb
+++ b/spec/models/intake/gyr_intake_spec.rb
@@ -306,6 +306,8 @@
 #
 #  fk_rails_...  (client_id => clients.id)
 #  fk_rails_...  (matching_previous_year_intake_id => intakes.id)
+#  fk_rails_...  (primary_drivers_license_id => drivers_licenses.id)
+#  fk_rails_...  (spouse_drivers_license_id => drivers_licenses.id)
 #  fk_rails_...  (vita_partner_id => vita_partners.id)
 #
 require "rails_helper"

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -306,6 +306,8 @@
 #
 #  fk_rails_...  (client_id => clients.id)
 #  fk_rails_...  (matching_previous_year_intake_id => intakes.id)
+#  fk_rails_...  (primary_drivers_license_id => drivers_licenses.id)
+#  fk_rails_...  (spouse_drivers_license_id => drivers_licenses.id)
 #  fk_rails_...  (vita_partner_id => vita_partners.id)
 #
 


### PR DESCRIPTION
## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
This change has been made and undone a few times without anyone totally knowing why. Hopefully this is the last time we ever think about this. Here's the timeline, as I understand it:

1. [4/7/22](https://github.com/codeforamerica/vita-min/pull/2405): the `drivers_licenses` table is added, and the `primary_drivers_license` and `spouse_drivers_license` references are added to the `intake` table. The migration uses a `references: :drivers_license` param to the `add_reference` method, which apparently works at the time.
2. [1/25/24](https://github.com/codeforamerica/vita-min/pull/4091): in the course of trying to bring staging back into working order after a long period of disuse, I notice that the aforementioned migration crashes due to the `references` parameter being unrecognized by the `add_reference` method. I still have no idea how it worked in the first place, but I made it run again by changing the `add_reference` call do what I assumed was the original intention: adding a foreign key constraint against the `drivers_licenses` table by replacing `references: :drivers_license` with `foreign_key: { to_table: :drivers_licenses }`. This results in new annotation output about the foreign key constraint, indicating that we didn't previously have a foreign key constraint in effect. 
3. January-June 2024: Multiple PRs remove & re-add this annotation output - I'm not entirely sure how or why
4. [6/3/24](https://github.com/codeforamerica/vita-min/pull/4568): I remove the foreign key constraint so that annotate will generate the same output as it did before my January PR, resulting in us once again not having the protection of a foreign key constraint on the `intake` table's `primary_drivers_license` and `spouse_drivers_license` references.
5. January 2025: Jey loads a schema from some time in Spring 2024 on a feature branch, resulting in the annotations being re-added, and I grumble and try to figure out why any of this happened in the first place.

IN SUMMARY:
- We should probably have foreign key constraints on the drivers license references from Intake, so that we keep referential integrity
- It's awkward to change old migrations, but this is easier & in a way, more historically accurate than adding a new migration to create the foreign key constraints (because I believe it's what the original migration was intended to do)
- We should flatten our migrations soon so that we don't have to think about this anymore

## How to test?
I tried creating an intake that pointed at a non-existent drivers license before & after adding the foreign key constraint.
Before:
```
> DriversLicense.find(100)
...
(irb):1:in `<main>': Couldn't find DriversLicense with 'id'=100 (ActiveRecord::RecordNotFound)

> intake = FactoryBot::create(:ctc_intake, primary_drivers_license_id: 100)
...

> intake.valid?
=> true
```

After:
```
> DriversLicense.find(100)
...
(irb):1:in `<main>': Couldn't find DriversLicense with 'id'=100 (ActiveRecord::RecordNotFound)

> intake = FactoryBot::create(:ctc_intake, primary_drivers_license_id: 100)
...
(irb):2:in `<main>': PG::ForeignKeyViolation: ERROR:  insert or update on table "intakes" violates foreign key constraint "fk_rails_33a6a5fc00" (ActiveRecord::InvalidForeignKey)
DETAIL:  Key (primary_drivers_license_id)=(100) is not present in table "drivers_licenses".

irb(main):003> intake.valid?
(irb):3:in `<main>': undefined method `valid?' for nil:NilClass (NoMethodError)
```