### PR TITLE
NJ 248 - clarify health insurance tests in XML logic

### DIFF
--- a/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
@@ -737,42 +737,24 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
     end
 
     describe "lines 53a, 53b, 53c: health insurance indicators" do
-      context "when taxpayer indicated all members of household have health insurance" do
-        before do
-          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:line_53c_checkbox).and_return true
-        end
-        
-        it "checks 53c Schedule NJ-HCC checkbox and leaves 53a, 53b, and 53c amount blank" do
-          expect(xml.at("NoHealthInsurance")).to eq(nil) # 53a
-          expect(xml.at("NJAssistObtainingHC")).to eq(nil) # 53b
-          expect(xml.at("SharedResPay")).to eq(nil) # 53c amount
-          expect(xml.at("HCCEnclosed").text).to eq("X") # 53c checkbox
-        end
-      end
-
-      context "when taxpayer indicated all members of household do NOT have health insurance" do
-        before do
-          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:line_53c_checkbox).and_return false
-        end
-
-        context "when qualifies for income exemption" do
-          it "does not check 53c Schedule NJ-HCC checkbox and leaves 53a, 53b, and 53c amount blank" do
-            single_income_threshold = 10_000
-            allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_29).and_return single_income_threshold
+      context "when taxpayer has passed intake health insurance eligibility" do
+        context "when taxpayer indicated all members of household have health insurance" do
+          before do
+            allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:line_53c_checkbox).and_return true
+          end
+          
+          it "checks 53c Schedule NJ-HCC checkbox and leaves 53a, 53b, and 53c amount blank" do
             expect(xml.at("NoHealthInsurance")).to eq(nil) # 53a
             expect(xml.at("NJAssistObtainingHC")).to eq(nil) # 53b
             expect(xml.at("SharedResPay")).to eq(nil) # 53c amount
-            expect(xml.at("HCCEnclosed")).to eq(nil) # 53c checkbox
+            expect(xml.at("HCCEnclosed").text).to eq("X") # 53c checkbox
           end
         end
-
-        context "when qualifies for claimed as dependent exemption" do
-          let(:intake) { 
-            create(:state_file_nj_intake,
-                                :df_data_mfj_primary_claimed_dep,
-          )
-          }
-
+  
+        context "when taxpayer indicated all members of household do NOT have health insurance" do
+          before do
+            allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:line_53c_checkbox).and_return false
+          end
           it "does not check 53c Schedule NJ-HCC checkbox and leaves 53a, 53b, and 53c amount blank" do
             expect(xml.at("NoHealthInsurance")).to eq(nil) # 53a
             expect(xml.at("NJAssistObtainingHC")).to eq(nil) # 53b


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://github.com/newjersey/affordability-pm/issues/248

## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Update tests, removing unused logic and clarify what the tests are doing
- Previously, we broke out the test into:
  - has health insurance
  - does not have health insurance but eligible
    - eligible because income is at or below threshold
    - eligible because qualifies for claimed as dependent

However, eligibility occurs in [intake,](https://github.com/codeforamerica/vita-min/blob/87a85beb00715269b4945b34aa15bb47d4bec99b/app/models/state_file_nj_intake.rb#L191) not in the XML submission_builder. By the time that the class under test is run, eligibility check has already been passed. Therefore the only real XML logic is whether or not Line 53c checkbox is checked ([original ticket](https://github.com/newjersey/affordability-pm/issues/123)) and this test should be simplified.

- all members have health insurance
- all members DO NOT have health insurance

## How to test?
- Run tests suite

## Screenshots (for visual changes)
- N/A
