### PR TITLE
Open intake flow for soft launch 2025

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -123,7 +123,7 @@ module VitaMin
     config.ctc_end_of_login = et.parse("2024-12-31 23:59:00")
 
     # StateFile
-    config.state_file_start_of_open_intake = et.parse('2025-01-15 09:00:00')
+    config.state_file_start_of_open_intake = et.parse('2025-01-15 00:00:00')
     config.state_file_end_of_new_intakes = pt.parse('2025-04-15 23:59:59')
     config.state_file_withdrawal_date_deadline_ny = et.parse('2024-04-15 23:59:59')
     config.state_file_withdrawal_date_deadline_md = et.parse('2025-04-30 23:59:59')

--- a/config/application.rb
+++ b/config/application.rb
@@ -123,11 +123,11 @@ module VitaMin
     config.ctc_end_of_login = et.parse("2024-12-31 23:59:00")
 
     # StateFile
-    config.state_file_start_of_open_intake = et.parse('2024-02-08 09:00:00')
+    config.state_file_start_of_open_intake = et.parse('2025-01-15 09:00:00')
     config.state_file_end_of_new_intakes = pt.parse('2025-04-15 23:59:59')
     config.state_file_withdrawal_date_deadline_ny = et.parse('2024-04-15 23:59:59')
     config.state_file_withdrawal_date_deadline_md = et.parse('2025-04-30 23:59:59')
-    config.state_file_end_of_in_progress_intakes = pt.parse('2024-04-25 23:59:59')
+    config.state_file_end_of_in_progress_intakes = pt.parse('2025-10-15 23:59:59')
     config.state_file_show_faq_date_start = pt.parse('2024-12-10 00:00:00')
     config.state_file_show_faq_date_end = pt.parse('2025-04-25 23:59:59')
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1597
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Update relevant dates provided by Tiffany
- We also considered updating other dates 
```
    # StateFile
    config.state_file_end_of_new_intakes = pt.parse('2025-04-15 23:59:59')
    config.state_file_withdrawal_date_deadline_md = et.parse('2025-04-30 23:59:59')
    config.state_file_show_faq_date_end = pt.parse('2025-04-25 23:59:59')
```

## How to test?
- Describe the testing approach taken to verify the changes, including:
  - ~~test on heroku instance by using the session toggles to StateFile `Start of open intake` and see that the homepage allows clients to access the intake flows~~
  - merge & deploy and use `aptible ssh --app vita-min-prod` and `bin/rails c` and check `Rails.application.config.state_file_start_of_open_intake` &  and make sure it updates from what it was:

Before:
```
irb(main):001> Rails.application.config.state_file_start_of_open_intake
=> Thu, 08 Feb 2024 09:00:00.000000000 EST -05:00
irb(main):002> Rails.application.config.state_file_end_of_in_progress_intakes
=> Thu, 25 Apr 2024 23:59:59.000000000 PDT -07:00
```

