### PR TITLE
Fyst 1549 update income details card on final review page

### DIFF
--- a/app/views/state_file/questions/shared/_review_header.html.erb
+++ b/app/views/state_file/questions/shared/_review_header.html.erb
@@ -13,7 +13,7 @@
           <% if current_intake.state_file1099_rs.present? %>
             <li>1099R</li>
           <% end %>
-          <% if current_intake.direct_file_data.fed_unemployment.positive? %>
+          <% if current_intake.state_file1099_gs.count > 0 %>
             <li>1099G</li>
           <% end %>
           <% if current_intake.direct_file_json_data.interest_reports.count.positive? %>

--- a/app/views/state_file/questions/shared/_review_header.html.erb
+++ b/app/views/state_file/questions/shared/_review_header.html.erb
@@ -5,6 +5,24 @@
     </div>
     <div id="income-info" class="white-group">
       <div class="spacing-below-5">
+        <p><%= t(".income_forms_collected") %></p>
+        <ul class="list--bulleted">
+          <% if current_intake.state_file_w2s.present? %>
+            <li>W2</li>
+          <% end %>
+          <% if current_intake.state_file1099_rs.present? %>
+            <li>1099R</li>
+          <% end %>
+          <% if current_intake.direct_file_data.fed_unemployment.positive? %>
+            <li>1099G</li>
+          <% end %>
+          <% if current_intake.direct_file_json_data.interest_reports.count.positive? %>
+            <li>1099INT</li>
+          <% end %>
+          <% if current_intake.direct_file_data.fed_ssb.positive? || current_intake.direct_file_data.fed_taxable_ssb.positive? %>
+            <li>SSA1099</li>
+          <% end %>
+        </ul>
         <%= link_to StateFile::Questions::IncomeReviewController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
           <%= t("general.edit") %>
           <span class="sr-only"><%= t(".income_details") %></span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3715,6 +3715,7 @@ en:
           income_details: Income Details
           your_refund: Your refund amount
           your_tax_owed: Your taxes owed
+          income_forms_collected: "Income form(s) collected:"
       sms_terms:
         edit:
           term: When you opt-in to the service, we will send you an SMS message to confirm your signup. We will also text you updates on your tax return (message frequency will vary) and/or OTP/2FA codes (one message per request).

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3713,9 +3713,9 @@ en:
           your_name: Your name
         review_header:
           income_details: Income Details
+          income_forms_collected: 'Income form(s) collected:'
           your_refund: Your refund amount
           your_tax_owed: Your taxes owed
-          income_forms_collected: "Income form(s) collected:"
       sms_terms:
         edit:
           term: When you opt-in to the service, we will send you an SMS message to confirm your signup. We will also text you updates on your tax return (message frequency will vary) and/or OTP/2FA codes (one message per request).

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3689,6 +3689,7 @@ es:
           income_details: Detalles de ingresos
           your_refund: La cantidad de tu reembolso
           your_tax_owed: Los impuestos que debes
+          income_forms_collected: "Formulario(s) de ingresos recopilados:"
       sms_terms:
         edit:
           term: Cuando te inscribas en el servicio, te enviaremos un mensaje de texto (SMS) para confirmar tu registro. También te enviaremos actualizaciones sobre tu declaración de impuestos (la frecuencia de los mensajes puede variar) y/o códigos OTP/2FA (un mensaje por solicitud).

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3687,9 +3687,9 @@ es:
           your_name: Tu nombre
         review_header:
           income_details: Detalles de ingresos
+          income_forms_collected: 'Formulario(s) de ingresos recopilados:'
           your_refund: La cantidad de tu reembolso
           your_tax_owed: Los impuestos que debes
-          income_forms_collected: "Formulario(s) de ingresos recopilados:"
       sms_terms:
         edit:
           term: Cuando te inscribas en el servicio, te enviaremos un mensaje de texto (SMS) para confirmar tu registro. También te enviaremos actualizaciones sobre tu declaración de impuestos (la frecuencia de los mensajes puede variar) y/o códigos OTP/2FA (un mensaje por solicitud).

--- a/spec/controllers/state_file/questions/base_review_controller_spec.rb
+++ b/spec/controllers/state_file/questions/base_review_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe StateFile::Questions::BaseReviewController do
     context 'when income documents are present' do
       let(:intake) { create :state_file_id_intake }
 
-      it 'returns false' do
+      it 'returns true' do
         expect(controller.send(:income_documents_present?)).to be_truthy
       end
     end

--- a/spec/features/state_file/review_page_spec.rb
+++ b/spec/features/state_file/review_page_spec.rb
@@ -23,6 +23,8 @@ RSpec.feature "Completing a state file intake", active_job: true do
           expect(page).to have_text "W2"
           expect(page).to have_text "1099R"
           expect(page).to have_text "1099G"
+          expect(page).not_to have_text "1099INT"
+          expect(page).not_to have_text "SSA1099"
           click_on I18n.t("general.edit")
         end
 

--- a/spec/features/state_file/review_page_spec.rb
+++ b/spec/features/state_file/review_page_spec.rb
@@ -20,6 +20,9 @@ RSpec.feature "Completing a state file intake", active_job: true do
         # Final review page
         expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
         within "#income-info" do
+          expect(page).to have_text "W2"
+          expect(page).to have_text "1099R"
+          expect(page).to have_text "1099G"
           click_on I18n.t("general.edit")
         end
 
@@ -227,7 +230,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
       primary_first_name: "Deedee",
       primary_last_name: "Doodoo",
       primary_birth_date: Date.new((MultiTenantService.statefile.current_tax_year - 65), 12, 1),
-      )
+    )
     intake.direct_file_data.fed_unemployment = 1000
     intake.update(raw_direct_file_data: intake.direct_file_data)
     create(:state_file_w2, state_file_intake: intake)


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1549
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Show a list of income form types based (only the ones they have)
## How to test?
- I tried and failed to test this more robustly and for now only have the one addition to a feature spec that looks for a few income form names. I wanted to test for the absence of 
## Screenshots (for visual changes)
<img width="1073" alt="image" src="https://github.com/user-attachments/assets/4fd7c42c-281c-4098-8076-7351e2105705" />
<img width="992" alt="image" src="https://github.com/user-attachments/assets/b23257e6-43d8-4f20-be33-0c55e267b707" />
