### PR TITLE
FYST-1535 add faq link to homepage ahead of prior year access availability

### DIFF
--- a/app/views/state_file/state_file_pages/about_page.html.erb
+++ b/app/views/state_file/state_file_pages/about_page.html.erb
@@ -19,6 +19,13 @@
           <%= t(".section1_html", faq_link: state_faq_path(us_state: 'us')) %>
         </div>
       </div>
+
+      <% unless Flipper.enabled?(:get_your_pdf) %>
+        <div>
+          <p class="text--bold"><%= t(".check_back_for_prior_year_returns") %></p>
+          <%= link_to t(".faq_prior_year_returns"), state_faq_section_path(us_state: :az, section_key: "how_can_i_access_my_2023_state_tax_return") %>
+        </div>
+      <% end %>
     <% else %>
       <div>
         <%= t(".closed_subheader_html") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3905,10 +3905,12 @@ en:
           title_html: Just a moment, we’re transferring your federal tax return to complete parts of your state return.
     state_file_pages:
       about_page:
+        check_back_for_prior_year_returns: Check back at the start of filing season to download your 2023 Arizona or New York State tax return.
         closed_subheader_html: |
           <strong>FileYourStateTaxes</strong> integrates with <strong>IRS Direct File</strong> to help you complete your state tax return <strong>for free.</strong> <br/><br/>
           <strong>We're closed for the tax season. Unfortunately you can no longer file your state return with us this year.</strong><br /><br />
           Already filed your state taxes with us? <strong>You can download a copy of your state return until December 31, 2024</strong><br /><br />
+        faq_prior_year_returns: Visit our FAQ for questions about prior year returns
         header: A free state filing service for taxpayers using IRS Direct File
         helper_heading_html: "<strong>How does this service work? </strong>"
         looking_for_return_html: "<strong>Looking for your 2023 Arizona or New York State Tax Return?</strong>"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3879,10 +3879,12 @@ es:
           title_html: Un momento, estamos transfiriendo tu declaración de impuestos federal.
     state_file_pages:
       about_page:
+        check_back_for_prior_year_returns: Vuelva al comienzo de la temporada de presentación para descargar su declaración de impuestos de Arizona o del estado de Nueva York de 2023.
         closed_subheader_html: |
           <strong>FileYourStateTaxes</strong> se integra con <strong>IRS Direct File</strong> para ayudarte a completar tu declaración de impuestos estatales <strong>sin costo.</strong><br/><br/>
           <strong>Estamos cerrados por la temporada de impuestos. Desafortunadamente, no puede presentar tu declaración estatal con nosotros este año.</strong><br /><br />
           ¿Ya presentó tus impuestos estatales con nosotros? <strong>Puedes descargar una copia de tu declaración estatal hasta el 31 de diciembre de 2024</strong><br /><br />
+        faq_prior_year_returns: Visite nuestras preguntas frecuentes para preguntas sobre declaraciones de años anteriores
         header: Una herramienta sin costo para presentar impuestos estatales para los contribuyentes utilizando IRS Direct File
         helper_heading_html: "<strong>¿Cómo funciona este servicio?</strong>"
         looking_for_return_html: "<strong>¿Buscas tu declaración de impuestos de Arizona o del estado de Nueva York de 2023?</strong>"


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1535
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Adds a bit of text to the home page about checking back for prior year returns when get_your_pdf is enabled
## How to test?
- Didn't test because can be tested visually and will also be deleted soonish
## Screenshots (for visual changes)
these look a little weird because dev has those extra buttons
- with flipper flag enabled
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/a3b56276-23c2-477c-9124-6f955c860466" />

- without flipper flag enabled
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/e3743a78-4426-4f39-a598-5176ac2d8dd1" />
