### PR TITLE
NJ 223 - add ineligible screen for low income property tax (no exemption)

### DIFF
--- a/app/controllers/state_file/questions/nj_household_rent_own_controller.rb
+++ b/app/controllers/state_file/questions/nj_household_rent_own_controller.rb
@@ -8,7 +8,7 @@ module StateFile
         options[:return_to_review] = params[:return_to_review] if params[:return_to_review].present?
 
         if Efile::Nj::NjPropertyTaxEligibility.ineligible?(current_intake)
-          return StateFile::NjPropertyTaxFlowOffRamp.next_controller(options)
+          return NjIneligiblePropertyTaxController.to_path_helper(options)
         end
         
         case current_intake.household_rent_own

--- a/app/controllers/state_file/questions/nj_ineligible_property_tax_controller.rb
+++ b/app/controllers/state_file/questions/nj_ineligible_property_tax_controller.rb
@@ -7,6 +7,14 @@ module StateFile
       helper_method :on_home_or_rental
 
       def determine_reason
+        if Efile::Nj::NjPropertyTaxEligibility.ineligible?(current_intake)
+          if current_intake.filing_status_single? || current_intake.filing_status_mfs?
+            return "income_single_mfs"
+          else
+            return "income_mfj_qss_hoh"
+          end
+        end
+
         if current_intake.household_rent_own_neither?
           return "neither"
         end

--- a/app/views/state_file/questions/nj_ineligible_property_tax/edit.html.erb
+++ b/app/views/state_file/questions/nj_ineligible_property_tax/edit.html.erb
@@ -6,12 +6,14 @@
 <% content_for :card do %>
   <h1 class="h2"><%= title %></h1>
   <p><%= t(".reason_html", reason: ineligible_reason) %></p>
-  <p>
-    <span><%= t(".mistake_text") %></span>
-    <%= link_to StateFile::Questions::NjHouseholdRentOwnController.to_path_helper do %>
-      <%= t(".go_back_link") %>
-    <% end %>
-  </p>
+  <% unless Efile::Nj::NjPropertyTaxEligibility.ineligible?(current_intake) %>
+    <p>
+      <span><%= t(".mistake_text") %></span>
+      <%= link_to StateFile::Questions::NjHouseholdRentOwnController.to_path_helper do %>
+        <%= t(".go_back_link") %>
+      <% end %>
+    </p>
+  <% end  %>
   <p><%= t(".continue_text") %></p>
 
   <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3302,6 +3302,8 @@ en:
           reason_multi_unit_conditions: this main home in a multi-unit building did not meet the requirements to claim this credit or deduction.
           reason_neither: you must have rented or owned a main home in %{filing_year} to receive this credit or deduction.
           reason_property_taxes: did not pay property taxes (directly, or through rent) on this main home.
+          reason_income_single_mfs: you did not meet the income filing threshold of $10,000.
+          reason_income_mfj_qss_hoh: you did not meet the income filing threshold of $20,000.
           title_html: It looks like you're not eligible for the Property Tax Deduction or Credit <strong>%{property}</strong>
       nj_medical_expenses:
         edit:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3299,11 +3299,11 @@ en:
           on_home: on the home you lived in and owned.
           on_rental: on the home you lived in and rented.
           reason_html: You are not eligible for this because <b>%{reason}</b>
+          reason_income_mfj_qss_hoh: you did not meet the income filing threshold of $20,000.
+          reason_income_single_mfs: you did not meet the income filing threshold of $10,000.
           reason_multi_unit_conditions: this main home in a multi-unit building did not meet the requirements to claim this credit or deduction.
           reason_neither: you must have rented or owned a main home in %{filing_year} to receive this credit or deduction.
           reason_property_taxes: did not pay property taxes (directly, or through rent) on this main home.
-          reason_income_single_mfs: you did not meet the income filing threshold of $10,000.
-          reason_income_mfj_qss_hoh: you did not meet the income filing threshold of $20,000.
           title_html: It looks like you're not eligible for the Property Tax Deduction or Credit <strong>%{property}</strong>
       nj_medical_expenses:
         edit:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3262,6 +3262,8 @@ es:
           reason_multi_unit_conditions: this main home in a multi-unit building did not meet the requirements to claim this credit or deduction.
           reason_neither: you must own rent or own a main home in %{filing_year} to receive this credit or deduction.
           reason_property_taxes: did not pay property taxes (directly, or through rent) on this main home.
+          reason_income_single_mfs: you did not meet the income filing threshold of $10,000.
+          reason_income_mfj_qss_hoh: you did not meet the income filing threshold of $20,000.
           title_html: It looks like you're not eligible for the Property Tax Deduction or Credit <strong>%{property}</strong>
       nj_medical_expenses:
         edit:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3259,11 +3259,11 @@ es:
           on_home: on the home you lived in and owned.
           on_rental: on the home you lived in and rented.
           reason_html: You are not eligible for this because <b>%{reason}</b>
+          reason_income_mfj_qss_hoh: you did not meet the income filing threshold of $20,000.
+          reason_income_single_mfs: you did not meet the income filing threshold of $10,000.
           reason_multi_unit_conditions: this main home in a multi-unit building did not meet the requirements to claim this credit or deduction.
           reason_neither: you must own rent or own a main home in %{filing_year} to receive this credit or deduction.
           reason_property_taxes: did not pay property taxes (directly, or through rent) on this main home.
-          reason_income_single_mfs: you did not meet the income filing threshold of $10,000.
-          reason_income_mfj_qss_hoh: you did not meet the income filing threshold of $20,000.
           title_html: It looks like you're not eligible for the Property Tax Deduction or Credit <strong>%{property}</strong>
       nj_medical_expenses:
         edit:

--- a/spec/controllers/state_file/questions/nj_household_rent_own_controller_spec.rb
+++ b/spec/controllers/state_file/questions/nj_household_rent_own_controller_spec.rb
@@ -87,8 +87,8 @@ RSpec.describe StateFile::Questions::NjHouseholdRentOwnController do
 
       context "when not eligible for property tax deduction due to income" do
         let(:intake) {create :state_file_nj_intake, :df_data_minimal, household_rent_own: "own" }
-        it "next path is next_controller for property tax flow" do
-          expect(subject.next_path).to eq(StateFile::NjPropertyTaxFlowOffRamp.next_controller({}))
+        it "next path is ineligible page" do
+          expect(subject.next_path).to eq(StateFile::Questions::NjIneligiblePropertyTaxController.to_path_helper)
         end
       end
 

--- a/spec/controllers/state_file/questions/nj_ineligible_property_tax_controller_spec.rb
+++ b/spec/controllers/state_file/questions/nj_ineligible_property_tax_controller_spec.rb
@@ -60,6 +60,41 @@ RSpec.describe StateFile::Questions::NjIneligiblePropertyTaxController do
         end
       end
     end
+
+    describe "reason_income_single_mfs" do
+      context "when filing status is single and ineligible for exemption" do
+        let(:intake) { create :state_file_nj_intake, :df_data_minimal }
+        it "returns reason_income_single_mfs text" do
+          allow(Efile::Nj::NjPropertyTaxEligibility).to receive(:ineligible?).and_return true
+          get :edit, params: {}
+          expected_text = I18n.t("state_file.questions.nj_ineligible_property_tax.edit.reason_income_single_mfs")
+          expect(subject.ineligible_reason).to eq(expected_text)
+        end
+      end
+
+      context "when filing status is MFS and ineligible for exemption" do
+        let(:intake) { create :state_file_nj_intake, :df_data_mfs }
+        it "returns reason_income_single_mfs text" do
+          allow(Efile::Nj::NjPropertyTaxEligibility).to receive(:ineligible?).and_return true
+          get :edit, params: {}
+          expected_text = I18n.t("state_file.questions.nj_ineligible_property_tax.edit.reason_income_single_mfs")
+
+          expect(subject.ineligible_reason).to eq(expected_text)
+        end
+      end
+    end
+
+    describe "reason_income_mfj_qss_hoh" do
+      context "when filing status is MFJ/QSS/HOH and ineligible for exemption" do
+        let(:intake) { create :state_file_nj_intake, :df_data_mfj }
+        it "returns reason_income_mfj_qss_hoh text" do
+          allow(Efile::Nj::NjPropertyTaxEligibility).to receive(:ineligible?).and_return true
+          get :edit, params: {}
+          expected_text = I18n.t("state_file.questions.nj_ineligible_property_tax.edit.reason_income_mfj_qss_hoh")
+          expect(subject.ineligible_reason).to eq(expected_text)
+        end
+      end
+    end
   end
 
   describe "#on_home_or_rental" do

--- a/spec/controllers/state_file/questions/nj_ineligible_property_tax_controller_spec.rb
+++ b/spec/controllers/state_file/questions/nj_ineligible_property_tax_controller_spec.rb
@@ -153,5 +153,22 @@ RSpec.describe StateFile::Questions::NjIneligiblePropertyTaxController do
       get :edit
       expect(response).to be_successful
     end
+
+    context 'when reason is not income' do
+      let(:intake) { create :state_file_nj_intake, household_rent_own: "neither" }
+      it 'shows mistake text' do
+        allow(Efile::Nj::NjPropertyTaxEligibility).to receive(:ineligible?).and_return false
+        get :edit
+        expect(response.body).to have_text(I18n.t("state_file.questions.nj_ineligible_property_tax.edit.mistake_text"))
+      end
+    end
+
+    context 'when reason is income' do
+      it 'does not show mistake text' do
+        allow(Efile::Nj::NjPropertyTaxEligibility).to receive(:ineligible?).and_return true
+        get :edit
+        expect(response.body).not_to have_text(I18n.t("state_file.questions.nj_ineligible_property_tax.edit.mistake_text"))
+      end
+    end
   end
 end

--- a/spec/features/state_file/nj/complete_intake_spec.rb
+++ b/spec/features/state_file/nj/complete_intake_spec.rb
@@ -477,7 +477,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
         advance_medical_expenses
         choose_household_rent_own("homeowner")
         expect_ineligible_page(nil, "income_single_mfs")
-        expect_estimated_tax_page
+        expect_page_after_property_tax
       end
 
       it "handles property tax flow - MFJ", required_schema: "nj" do
@@ -488,7 +488,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
         advance_medical_expenses
         choose_household_rent_own("homeowner")
         expect_ineligible_page(nil, "income_mfj_qss_hoh")
-        expect_estimated_tax_page
+        expect_page_after_property_tax
       end
     end
   end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/223

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Reroute household_rent_own to ineligible page when low-income and does not meet exemption
- Handle new low-income reasons

## How to test?
- Use `minimal` for single low-income (select "no" for disabled)
- Use `mfj 15k wages` for MFJ low-income (select "no" for disabled)

## Screenshots (for visual changes)
![image](https://github.com/user-attachments/assets/cadb34ec-4799-4213-8be4-2d5f579334f7)