### PR TITLE
FYST-1602 NC update link to TY25 sales use tax calculation worksheet

### DIFF
--- a/app/views/state_file/questions/nc_sales_use_tax/edit.html.erb
+++ b/app/views/state_file/questions/nc_sales_use_tax/edit.html.erb
@@ -21,22 +21,22 @@
         </div>
       </div>
       <div class="question-with-follow-up__follow-up" id="sut-method-field">
-        <div class="question-with-follow-up">
-          <div class="question-with-follow-up__question">
-            <div class="white-group">
+        <div class="white-group">
+          <div class="question-with-follow-up">
+            <div class="question-with-follow-up__question">
               <%=
                 f.cfa_radio_set(
                   :sales_use_tax_calculation_method,
                   label_text: t(".select_one"),
                   collection: [
-                    { value: :automated, label: t(".use_tax_method_automated"), input_html: { "onclick": "document.querySelector('#sut-field').style.display = 'none'"} },
+                    { value: :automated, label: t(".use_tax_method_automated"), input_html: { "onclick": "document.querySelector('#sut-field').style.display = 'none'" } },
                     { value: :manual, label: "#{t(".use_tax_method_manual")} #{t(".state_specific.#{current_state_code}.manual_instructions_html")}", input_html: { "data-follow-up": "#sut-field" } },
                   ]
                 )
               %>
-              <div class="question-with-follow-up__follow-up" id="sut-field">
-                <%= f.vita_min_money_field(:sales_use_tax, t(".calculated_use_tax"), classes: ["form-width--long"]) %>
-              </div>
+            </div>
+            <div class="question-with-follow-up__follow-up" id="sut-field">
+              <%= f.vita_min_money_field(:sales_use_tax, t(".calculated_use_tax"), classes: ["form-width--long"]) %>
             </div>
           </div>
         </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3097,7 +3097,7 @@ en:
           select_one: 'Select one of the following:'
           state_specific:
             nc:
-              manual_instructions_html: (<a href="https://www.ncdor.gov/2023-d-401-individual-income-tax-instructions/open" target="_blank" rel="noopener noreferrer">Learn more here</a> and search for 'consumer use worksheet').
+              manual_instructions_html: (<a href="https://www.ncdor.gov/2024-d-401-individual-income-tax-instructions/open" target="_blank" rel="noopener noreferrer">Learn more here</a> and search for 'consumer use worksheet').
           subtitle_html: This includes online purchases where sales tax was <b>not</b> applied.
           title:
             one: Did you make any out-of-state purchases in %{year} without paying sales tax?

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3055,7 +3055,7 @@ es:
           select_one: 'Selecciona una de las siguientes opciones:'
           state_specific:
             nc:
-              manual_instructions_html: (<a href="https://www.ncdor.gov/2023-d-401-individual-income-tax-instructions/open" target="_blank" rel="noopener noreferrer">Obtén más información aquí</a> y busca 'consumer use worksheet')
+              manual_instructions_html: (<a href="https://www.ncdor.gov/2024-d-401-individual-income-tax-instructions/open" target="_blank" rel="noopener noreferrer">Obtén más información aquí</a> y busca 'consumer use worksheet')
           subtitle_html: Esto incluye compras en línea donde <b>no</b> se aplicó el impuesto sobre ventas.
           title:
             many: "¿Usted o su cónyuge realizaron alguna compra fuera del estado en %{year} sin pagar impuestos sobre ventas o de uso?"


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1602
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Updated the link to the consumer use worksheet
- As a bonus, fixed a styling issue where the border of the box disappeared. Seems to be improper nesting of the follow-up question divs (but no functional impact)
## How to test?
- None, it's just a link and some styling
## Screenshots (for visual changes)
- Before
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/60588e23-16b6-4ec4-a999-a68c66545cc4" />

- After
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/de33e283-4b41-44a3-83b3-a159a597d434" />
