### PR TITLE
build archived intake verification error page

### DIFF
--- a/app/controllers/state_file/archived_intakes/verification_code_controller.rb
+++ b/app/controllers/state_file/archived_intakes/verification_code_controller.rb
@@ -4,8 +4,7 @@ module StateFile
       before_action :check_feature_flag
       def edit
         if current_request.access_locked?
-          # this redirect to be changed when we have an offboarding page
-          redirect_to root_path
+          redirect_to state_file_archived_intakes_verification_error_path
           return
         end
         @form = VerificationCodeForm.new(email_address: current_request.email_address)
@@ -30,8 +29,7 @@ module StateFile
           current_request.increment_failed_attempts
           if current_request.access_locked?
             create_state_file_access_log("client_lockout_begin")
-            # this redirect to be changed when we have an offboarding page
-            redirect_to root_path
+            redirect_to state_file_archived_intakes_verification_error_path
             return
           end
           render :edit

--- a/app/controllers/state_file/state_file_pages_controller.rb
+++ b/app/controllers/state_file/state_file_pages_controller.rb
@@ -42,6 +42,8 @@ module StateFile
       @sign_in_closed = app_time.after?(Rails.configuration.state_file_end_of_in_progress_intakes)
     end
 
+    def archived_intakes_verification_error; end
+
     private
 
     def transfer_url(key, redirect_url)

--- a/app/views/state_file/state_file_pages/archived_intakes_verification_error.html.erb
+++ b/app/views/state_file/state_file_pages/archived_intakes_verification_error.html.erb
@@ -1,0 +1,15 @@
+<% title = t("state_file.archived_intakes.verification_error.title") %>
+<% content_for :page_title, title %>
+
+<section class="slab question-layout <%= controller_name.gsub("_", "-") %>-outer">
+  <div class="grid">
+    <h1 class="h2"><%= title %></h1>
+    <p><%= t("state_file.archived_intakes.verification_error.subtitle", year: MultiTenantService.statefile.current_tax_year - 1) %></p>
+    <div class="bulleted">
+      <ul>
+        <li><a href="https://azdor.gov/forms/other-forms/request-copies-tax-documents"><%= t("state_file.archived_intakes.verification_error.az_dor") %></a></li>
+        <li><a href="https://www.tax.ny.gov/help/contact/get-copy-of-return.htm"><%= t("state_file.archived_intakes.verification_error.ny_dor") %></a></li>
+      </ul>
+    </div>
+  </div>
+</section>

--- a/app/views/state_file/state_file_pages/archived_intakes_verification_error.html.erb
+++ b/app/views/state_file/state_file_pages/archived_intakes_verification_error.html.erb
@@ -11,5 +11,8 @@
         <li><a href="https://www.tax.ny.gov/help/contact/get-copy-of-return.htm"><%= t("state_file.archived_intakes.verification_error.ny_dor") %></a></li>
       </ul>
     </div>
+    <%= link_to root_path, class: "button button--primary button--wide text--centered spacing-above-25" do %>
+      <%=t("general.return_to_homepage") %>
+    <% end %>
   </div>
 </section>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2075,10 +2075,10 @@ en:
           title_html: We’ve sent your code to <strong>%{email_address}</strong>
           verify: Verify code
       verification_error:
-        title: Sorry, we were not able to verify your account
-        subtitle: Please visit your state's tax agency website to request your %{year} tax return
         az_dor: Arizona Department of Revenue
         ny_dor: NY State Tax Department
+        subtitle: Please visit your state's tax agency website to request your %{year} tax return
+        title: Sorry, we were not able to verify your account
     faq:
       index:
         title: Common questions from %{state} taxpayers

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2074,6 +2074,11 @@ en:
           subtitle_html_2: If you still need help resubscribing, chat with us.
           title_html: We’ve sent your code to <strong>%{email_address}</strong>
           verify: Verify code
+      verification_error:
+        title: Sorry, we were not able to verify your account
+        subtitle: Please visit your state's tax agency website to request your %{year} tax return
+        az_dor: Arizona Department of Revenue
+        ny_dor: NY State Tax Department
     faq:
       index:
         title: Common questions from %{state} taxpayers

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2026,6 +2026,11 @@ es:
           subtitle_html_2: Si aún necesitas ayuda para resuscribirte, chatea con nosotros.
           title_html: Hemos enviado tu código a <strong>%{email_address}</strong>
           verify: Verificar el código
+      verification_error:
+        title: Lo sentimos, no pudimos verificar su cuenta
+        subtitle: Visite el sitio web de la agencia tributaria de su estado para solicitar su declaración de impuestos de %{year}
+        az_dor: Departamento de Ingresos de Arizona
+        ny_dor: Departamento de Impuestos del Estado de Nueva York
     faq:
       index:
         title: 'Preguntas frecuentes de los contribuyentes de %{state}:'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2027,10 +2027,10 @@ es:
           title_html: Hemos enviado tu código a <strong>%{email_address}</strong>
           verify: Verificar el código
       verification_error:
-        title: Lo sentimos, no pudimos verificar su cuenta
-        subtitle: Visite el sitio web de la agencia tributaria de su estado para solicitar su declaración de impuestos de %{year}
         az_dor: Departamento de Ingresos de Arizona
         ny_dor: Departamento de Impuestos del Estado de Nueva York
+        subtitle: Visite el sitio web de la agencia tributaria de su estado para solicitar su declaración de impuestos de %{year}
+        title: Lo sentimos, no pudimos verificar su cuenta
     faq:
       index:
         title: 'Preguntas frecuentes de los contribuyentes de %{state}:'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -562,6 +562,7 @@ Rails.application.routes.draw do
           patch 'email_address', to: 'email_address#update'
           get 'verification_code/edit', to: 'verification_code#edit', as: 'edit_verification_code'
           patch 'verification_code', to: 'verification_code#update'
+          get 'verification_error', to: "/state_file/state_file_pages#archived_intakes_verification_error"
         end
         namespace :questions do
           get "show_xml", to: "confirmation#show_xml"

--- a/spec/controllers/state_file/archived_intake/verification_code_controller_spec.rb
+++ b/spec/controllers/state_file/archived_intake/verification_code_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe StateFile::ArchivedIntakes::VerificationCodeController, type: :co
       it "redirects to the root path" do
         get :edit
 
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(state_file_archived_intakes_verification_error_path)
       end
     end
 
@@ -93,7 +93,7 @@ RSpec.describe StateFile::ArchivedIntakes::VerificationCodeController, type: :co
 
         expect(current_request.reload.failed_attempts).to eq(2)
         expect(current_request.reload.access_locked?).to be_truthy
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(state_file_archived_intakes_verification_error_path)
       end
     end
   end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1521
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Implemented the "knock-out" page for archived intakes, which will be used once the flow logic is implemented
## How to test?
- go to `/en/state_file/archived_intakes/verification_error` on heroku and verify that visuals match the design
- start the archived intake flow and get your verification code wrong twice, then verify that you get redirected to the error page
  - after doing this, try to enter the archived intake flow again from the same IP and with the same email address, within an hour, and verify that you get redirected immediately to the error page
- i don't know the timeout for the lockout, but that logic should be covered by another story
## Screenshots (for visual changes)
<img width="719" alt="image" src="https://github.com/user-attachments/assets/a85f1c19-2336-4bc5-ac49-c23df332afad" />
