### PR TITLE
remove copy from az unsupported credits reveal, and remove strings

### DIFF
--- a/app/views/state_file/questions/eligible/_az_credits_unsupported.html.erb
+++ b/app/views/state_file/questions/eligible/_az_credits_unsupported.html.erb
@@ -3,14 +3,6 @@
 
   <div class="reveal__content">
     <div class="spacing-below-25">
-      <%=t('.public_school_tax_credit_heading_html') %>
-      <ul>
-        <li><%=t('.public_school_tax_credit_paid_fees') %></li>
-        <li><%=t('.public_school_tax_credit_provide_info_html') %></li>
-      </ul>
-    </div>
-
-    <div class="spacing-below-25 with-top-separator">
       <%=t('.property_tax_credit_heading_html') %>
       <ul>
         <li><%=t('.property_tax_credit_age') %></li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2516,9 +2516,6 @@ en:
           property_tax_credit_heading_html: '<a href="https://azdor.gov/individuals/income-tax-filing-assistance/tax-credits" target="_blank" rel="noopener nofollow">Property Tax Credit</a>. To qualify for this credit you must:'
           property_tax_credit_income: have total household income less than $3,751 if you live alone; or total household income less than $5,501 if you live with others; and
           property_tax_credit_paid: have paid property taxes or rent on a home in Arizona during the year
-          public_school_tax_credit_heading_html: '<a href="https://azdor.gov/tax-credits/public-school-tax-credit" target="_blank" rel="noopener nofollow">Public School Tax Credit</a>. To qualify for this credit, you must:'
-          public_school_tax_credit_paid_fees: Have paid school-related fees or donated money to a public school
-          public_school_tax_credit_provide_info_html: Provide school information, including the <a href="https://azdor.gov/sites/default/files/2023-03/PUBLICATION_ADESchoolListing.pdf" target="_blank" rel="noopener nofollow">CTDS code</a>
         az_supported:
           charitable_contributions_credit: Credit for Contributions to Qualifying Charitable Organizations
           dependent_credit: Dependent Credit

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2472,9 +2472,6 @@ es:
           property_tax_credit_heading_html: '<a href="https://azdor.gov/individuals/income-tax-filing-assistance/tax-credits" target="_blank" rel="noopener nofollow">Crédito por impuestos a la propiedad. </a>. Para calificar para este crédito debes:'
           property_tax_credit_income: Tener un ingreso total del hogar menor a $3,751 si vives solo; o un ingreso total del hogar menor a $5,501 si vives con otros
           property_tax_credit_paid: Haber pagado impuestos a la propiedad o alquiler de una vivienda en Arizona durante el año
-          public_school_tax_credit_heading_html: '<a href="https://azdor.gov/tax-credits/public-school-tax-credit" target="_blank" rel="noopener nofollow">Public School Tax Credit</a>. To qualify for this credit, you must:'
-          public_school_tax_credit_paid_fees: Have paid school-related fees or donated money to a public school
-          public_school_tax_credit_provide_info_html: Provide school information, including the <a href="https://azdor.gov/sites/default/files/2023-03/PUBLICATION_ADESchoolListing.pdf" target="_blank" rel="noopener nofollow">CTDS code</a>
         az_supported:
           charitable_contributions_credit: Crédito por contribuciones a organizaciones caritativas calificadas
           dependent_credit: Crédito por dependientes


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1626
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Removed some copy from the AZ unsupported credits reveal
## How to test?
- Start an AZ intake, then on the first page (`/en/questions/eligible`) open the first reveal and verify that there's nothing there about public schools.
## Screenshots (for visual changes)
- Before
<img width="1012" alt="image" src="https://github.com/user-attachments/assets/abbe2c2a-9bd9-43dd-934a-ac915bfa789e" />

- After
<img width="1016" alt="image" src="https://github.com/user-attachments/assets/a58b6244-b60a-4564-b965-ac29460bc322" />
