### PR TITLE
NJ 259 - remove custom CSS for household details review

### DIFF
--- a/app/assets/stylesheets/_state-file.scss
+++ b/app/assets/stylesheets/_state-file.scss
@@ -864,10 +864,6 @@ $state-colors: (
       background-color: $color-nj-blue-darker;
     }
 
-    .review-header #household-info div:last-of-type {
-      display: none;
-    }
-
     .nj-review-outer .reveal hr {
       border:0;
       border-top: 2px dashed gray;

--- a/spec/features/state_file/nj/complete_intake_spec.rb
+++ b/spec/features/state_file/nj/complete_intake_spec.rb
@@ -244,6 +244,11 @@ RSpec.feature "Completing a state file intake", active_job: true do
 
       # Review
       expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
+      expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.your_name")
+      expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.spouse_name")
+      dependents_dob = page.all(:css, 'h4', text: I18n.t('state_file.questions.shared.abstract_review_header.dependent_dob')).count
+      expect(dependents_dob).to eq(6)
+
       expect(page).to be_axe_clean.within "main"
 
       groups = page.all(:css, '.white-group').count


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/259

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
From [this PR](https://github.com/codeforamerica/vita-min/pull/4902/files#diff-296123afaf4374655b7c97f7c22f4966c01cb8320dc72f62e047ea9f8f013aee), it seems like were hiding the last element when it was the "Edit" button. Now that the edit button has been removed globally from the component, we should remove our CSS fix so that it doesn't hide the last element in the household details.

## How to test?
Single - confirm section is not blank
MFJ - confirm spouse is present

## Screenshots (for visual changes)
- Before
![image](https://github.com/user-attachments/assets/29cdef13-f80c-47d3-8f24-18bae0573c17)


- After
![image](https://github.com/user-attachments/assets/138fb21a-ef9b-41a4-a09b-5a25e7bc8ee1)

