### PR TITLE
Nj 226 w2 progress bar

### DIFF
--- a/app/controllers/state_file/questions/w2_controller.rb
+++ b/app/controllers/state_file/questions/w2_controller.rb
@@ -2,6 +2,10 @@ module StateFile
   module Questions
     class W2Controller < QuestionsController
       before_action :load_w2
+
+      def self.show?(intake) # only accessed via button, not navigator
+        false
+      end
       
       def edit
         @state_code = current_state_code

--- a/app/lib/navigation/state_file_nj_question_navigation.rb
+++ b/app/lib/navigation/state_file_nj_question_navigation.rb
@@ -30,6 +30,7 @@ module Navigation
                                       ], false),
       Navigation::NavigationSection.new("state_file.navigation.nj.section_1", [
                                           Navigation::NavigationStep.new(StateFile::Questions::IncomeReviewController), # line 15-27, but intentionally moved up for eligibility checks
+                                          Navigation::NavigationStep.new(StateFile::Questions::W2Controller),
                                       ]),
       Navigation::NavigationSection.new("state_file.navigation.nj.section_2", [
                                           Navigation::NavigationStep.new(StateFile::Questions::NjEligibilityHealthInsuranceController),

--- a/spec/features/state_file/income_review_spec.rb
+++ b/spec/features/state_file/income_review_spec.rb
@@ -54,6 +54,7 @@ RSpec.feature "Income Review", active_job: true do
     it "displays w2 info on edit screen" do
       advance_to_income_edit
 
+      expect(page).to have_css(".progress-steps")
       expect(page).to have_field('state_file_w2_box14_ui_wf_swf', with: '180.0')
       expect(page).to have_field('state_file_w2_box14_fli', with: '145.0')
       expect(page).to have_field('state_file_w2_employer_state_id_num', with: '221236333')

--- a/spec/models/efile_error_spec.rb
+++ b/spec/models/efile_error_spec.rb
@@ -126,6 +126,7 @@ describe 'EfileError' do
       "terms-and-conditions",
       "unemployment",
       "verification-code",
+      "w2",
       "waiting-to-load-data"
     ]
   end


### PR DESCRIPTION
## Link to pivotal/JIRA issue

https://github.com/newjersey/affordability-pm/issues/226

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- I added the W2 Controller as a navigation step so that it would have a progress value associated with it, but then set its `show?` to `false` since it is always opened from a button on the income editing page
## Screenshots (for visual changes)

<img width="1265" alt="image" src="https://github.com/user-attachments/assets/d9c1e2b4-2f38-431e-818b-3a7d20572b22" />

