### PR TITLE
ubutnu 24.04 and heroku

### DIFF
--- a/.github/workflows/heroku-pull-request.yml
+++ b/.github/workflows/heroku-pull-request.yml
@@ -16,6 +16,10 @@ jobs:
           fetch-depth: ${{ github.event.action == 'closed' && 1 || 0 }}
           ref: ${{ github.event.action != 'closed' && github.head_ref || '' }}
 
+      - name: Install Heroku CLI
+        run: |
+          curl https://cli-assets.heroku.com/install.sh | sh
+
       - name: Login to Heroku
         uses: akhileshns/heroku-deploy@v3.12.13
         with:

--- a/.github/workflows/heroku-remove-app.yml
+++ b/.github/workflows/heroku-remove-app.yml
@@ -18,6 +18,10 @@ jobs:
           heroku_app_name: ${{ env.HEROKU_APP_NAME }}
           justlogin: true
 
+      - name: Install Heroku CLI
+        run: |
+          curl https://cli-assets.heroku.com/install.sh | sh
+
       - name: Predestroy the app associated with the closed PR
         run: heroku run rails heroku:review_app_predestroy --app=${{ env.HEROKU_APP_NAME }}
         env:


### PR DESCRIPTION
## Link to pivotal/JIRA issue
n/a

## Is PM acceptance required? (delete one)
No - merge after code review approval

## What was done?
Added a step to manually install the heroku cli to the github actions that setup and teardown our heroku environments. The actions run in a docker container that uses ubuntu `latest`, and, around 3:15pm (pacific) on the 17th, `latest` moved from 22.04 to 24.04, a side effect of which is the heroku cli no longer being available by default.

## How to test?
Both hard and easy to test. With this code change, heroku builds/teardowns should succeed. Without it, they'll fail.
- heroku setup: https://github.com/codeforamerica/vita-min/actions/runs/12892104152
- heroku teardown: https://github.com/codeforamerica/vita-min/actions/runs/12892443053

## Risk Assessment
This adds an additional step in all our builds, and that step relies on an external script being available and usable and secure _for every PR forever_. That's not great. Admittedly, we were defacto relying on this same cli being available in our base ubuntu image, so it's not an entirely new risk, but this new setup is definitely an increase in risk.

I would love for us to have an artifact repository (like Artifactory or similar) to house intermediate images and external dependencies to help manage the shifting sands of software versions.

## Screenshots (for visual changes)
you'll see this in all our heroku setup and teardown actions now:
![image](https://github.com/user-attachments/assets/f8698ad7-ddbe-44e6-b63b-c63f5e23a623)


