### PR TITLE
FYST-1650 Allow non-AdminRole accounts to be logged into using @codeforamerica oauth

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -321,7 +321,11 @@ class User < ApplicationRecord
     email = auth_hash.info['email']
     return nil unless google_login_domain?(email) && google_login_domain?(auth_hash.extra.id_info["hd"])
 
-    user = User.where(email: email, role_type: "AdminRole", external_provider: [nil, oauth2_provider_name], external_uid: [nil, auth_hash['uid']], suspended_at: nil).first
+    matching_users = User.where(email: email, external_provider: [nil, oauth2_provider_name], external_uid: [nil, auth_hash['uid']], suspended_at: nil)
+    user = matching_users.where(role_type: "AdminRole").first || matching_users.first
+    if matching_users.count > 1
+      Rails.logger.warn("Found multiple hub accounts for #{email}, logging into #{user.role_type} account")
+    end
     user.update!(external_provider: oauth2_provider_name, external_uid: auth_hash['uid']) if user.present? && user.external_uid.nil?
     user
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,8 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.1].define(version: 2025_01_16_220546) do
-  create_schema "analytics"
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -133,6 +133,13 @@ FactoryBot.define do
       role { build(:client_success_role) }
     end
 
+    factory :state_file_nj_staff_user do
+      sequence(:email) { |n| "state.file.nj.staff#{n}@example.com" }
+      sequence(:name) { |n| "State File NJ Staff the #{n}th" }
+
+      role { build(:state_file_nj_staff_role) }
+    end
+
     factory :invited_user do
       association :invited_by, factory: :admin_user
       invitation_created_at { 1.day.ago - 1.minute }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -739,15 +739,22 @@ RSpec.describe User, type: :model, requires_default_vita_partners: true do
 
     context "coalition lead" do
       let(:user) { create :coalition_lead_user }
-      it "is Admin" do
+      it "is Coalition Lead" do
         expect(user.role_name).to eq "Coalition Lead"
       end
     end
 
     context "organization lead" do
       let(:user) { create :organization_lead_user }
-      it "is Admin" do
+      it "is Organization Lead" do
         expect(user.role_name).to eq "Organization Lead"
+      end
+    end
+
+    context "State File Nj Staff" do
+      let(:user) { create :state_file_nj_staff_user }
+      it "is State File NJ Staff" do
+        expect(user.role_name).to eq "State File Nj Staff"
       end
     end
   end
@@ -784,14 +791,14 @@ RSpec.describe User, type: :model, requires_default_vita_partners: true do
 
     context "coalition lead" do
       let(:user) { create :coalition_lead_user, name: "Martha Mango", coalition: (create :coalition, name: "This Coalition") }
-      it "is Admin" do
+      it "is coalition lead" do
         expect(user.name_with_role_and_entity).to eq "Martha Mango (Coalition Lead) - This Coalition"
       end
     end
 
     context "organization lead" do
       let(:user) { create :organization_lead_user, name: "Patty Persimmon", organization: (create :organization, name: "Some Org") }
-      it "is Admin" do
+      it "is organization lead" do
         expect(user.name_with_role_and_entity).to eq "Patty Persimmon (Organization Lead) - Some Org"
       end
     end
@@ -822,7 +829,13 @@ RSpec.describe User, type: :model, requires_default_vita_partners: true do
     let(:suspended_at) { nil }
     let!(:user) { create :admin_user, email: email, suspended_at: suspended_at }
     let(:provider) { "google_oauth2" }
-    let(:auth_hash) { OmniAuth::AuthHash.new(provider: provider, uid: "12345678901234567890", info: { email: email, name: "Betty Boop" }, extra: { "id_info" => { "hd" => email.split("@")[1] } }) }
+    let(:auth_hash) {
+      OmniAuth::AuthHash.new(
+        provider: provider,
+        uid: "12345678901234567890",
+        info: { email: email, name: "Betty Boop" },
+        extra: { "id_info" => { "hd" => email.split("@")[1] } })
+    }
 
     context "has a @codeforamerica.org email" do
       context "has an admin account" do
@@ -841,8 +854,9 @@ RSpec.describe User, type: :model, requires_default_vita_partners: true do
           it "updates the uid and provider" do
             expect do
               User.from_omniauth(auth_hash)
-            end.to change { user.reload.external_provider }.from(nil).to(provider)
-                                                           .and change { user.reload.external_uid }.from(nil).to("12345678901234567890")
+            end.to change { user.reload.external_provider }
+                     .from(nil).to(provider)
+                     .and change { user.reload.external_uid }.from(nil).to("12345678901234567890")
           end
         end
 
@@ -856,11 +870,11 @@ RSpec.describe User, type: :model, requires_default_vita_partners: true do
         end
       end
 
-      context "is a greeter account" do
-        let!(:user) { create :greeter_user, email: email }
+      context "is a NJ Staff account" do
+        let!(:user) { create :state_file_nj_staff_user, email: email }
 
-        it "returns nil" do
-          expect(User.from_omniauth(auth_hash)).to eq nil
+        it "returns the NJ Staff account" do
+          expect(User.from_omniauth(auth_hash)).to eq user
         end
       end
     end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1650
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
#### Context
- the hub role `StateFileNjStaff` is the only role with access to view NJ submissions
- the standard `AdminRole` given to CfA employees only has access to non-NJ submissions
- In order for some select CfA staff to have access to NJ's hub view, we have provisioned some email addresses intended only for having the NJ role and accessing the hub (e.g. `*-njhub@codeforamerica.org`)
- Users with @codeforamerica.org emails were unable to log in as anything other than an Admin

#### Changes
- When logging in with oauth, look for a user to login to with **any** role type, but **prioritize** "AdminRole" if by some wild circumstance there are multiple
- Preserved existing logic as best I could

## How to test?
- locally I created nj user with nj email and logged in with it
   - this test is challenging to repeat in heroku because it requires the url to be a registered, authorized uri with our Google oauth account
      - update: I was able to add this specific heroku instance to enable oauth testing
   - it can be tested in demo by anyone with a `-njhub` email
- also still could login with normal email to admin account
- Risk: I think there is a very mild risk that this alters the login functionality to be slightly more permissive
   - ihowever, it is allowing accounts with cfa (& gyr) emails to be non-admin accounts, which is more restrictive access, so not a security concern
#### digging into data
I wanted to know if there are any active users that could be affected by this change, other than the known NJ users, in either prod or demo.

There are no users with duplicate emails in either prod or demo 👍 
```
User.all.group_by(&:email).select { |email, matching_users| matching_users.count > 1 }
=> {}
```

I also wanted to know if there are other existing non-Admin accounts with CFA or GYR (oauth required) domains that are in the same situation where they most likely cannot log in
```
User.where("email LIKE ?", "%@codeforamerica.org").where(suspended_at: nil).each { |user| puts user.email + ", " + user.role_name if user.role_name != "Admin" }
User.where("email LIKE ?", "%@getyourrefund.org").where(suspended_at: nil).each { |user| puts user.email + ", " + user.role_name if user.role_name != "Admin" }
```

- I discovered no prod accounts, but ~20 CFA accounts that were not admins
- a majority of them are using "+" to modify their email, from before oauth was used, and can't be logged into anymore anyway
- there are a few client success users in demo that may be affected, so I will reach out to them separately about logging in to the hub (Andrew, Elena, and Alyssa)

