### PR TITLE
FYST-1603 updates to NY intake flow

### DIFF
--- a/app/controllers/concerns/state_file/state_file_intake_concern.rb
+++ b/app/controllers/concerns/state_file/state_file_intake_concern.rb
@@ -38,8 +38,7 @@ module StateFile
     end
 
     def redirect_deprecated_state
-      # this just handles controllers with "ny" in the name; other controllers are shared and should redirect to login
-      if params[:controller].include?("ny")
+      if params[:controller].include?("ny") || (current_intake.present? && current_state_code == "ny")
         redirect_to state_landing_page_path(us_state: :ny)
       end
     end

--- a/app/controllers/concerns/state_file/state_file_intake_concern.rb
+++ b/app/controllers/concerns/state_file/state_file_intake_concern.rb
@@ -38,7 +38,7 @@ module StateFile
     end
 
     def redirect_deprecated_state
-      if params[:controller].include?("ny") || (current_intake.present? && current_state_code == "ny")
+      if controller_name.starts_with?("ny") || (current_intake.present? && current_state_code == "ny")
         redirect_to state_landing_page_path(us_state: :ny)
       end
     end

--- a/app/controllers/concerns/state_file/state_file_intake_concern.rb
+++ b/app/controllers/concerns/state_file/state_file_intake_concern.rb
@@ -4,7 +4,7 @@ module StateFile
     include StateFile::StateFileControllerConcern
 
     included do
-      before_action :require_state_file_intake_login
+      before_action :redirect_deprecated_state, :require_state_file_intake_login
       helper_method :current_intake, :current_state_code, :current_state_name, :card_postscript
     end
 
@@ -34,6 +34,13 @@ module StateFile
         session[:after_state_file_intake_login_path] = request.original_fullpath if request.get?
         flash[:notice] = I18n.t("devise.failure.timeout")
         redirect_to StateFile::StateFilePagesController.to_path_helper(action: :login_options)
+      end
+    end
+
+    def redirect_deprecated_state
+      # this just handles controllers with "ny" in the name; other controllers are shared and should redirect to login
+      if params[:controller].include?("ny")
+        redirect_to state_landing_page_path(us_state: :ny)
       end
     end
   end

--- a/app/controllers/state_file/faq_controller.rb
+++ b/app/controllers/state_file/faq_controller.rb
@@ -13,6 +13,10 @@ class StateFile::FaqController < ApplicationController
   end
 
   def show
+    if params[:us_state] == 'ny'
+      redirect_to state_landing_page_path(us_state: "ny")
+      return
+    end
     @section_key = params[:section_key]
     @faq_category = FaqCategory.find_by(slug: @section_key, product_type: FaqCategory.state_to_product_type(params[:us_state]))
 

--- a/app/controllers/state_file/landing_page_controller.rb
+++ b/app/controllers/state_file/landing_page_controller.rb
@@ -1,11 +1,7 @@
 module StateFile
   class LandingPageController < ApplicationController
     include StateFile::StateFileControllerConcern
-    include StateFile::StateFileIntakeConcern
-    helper_method :prev_path, :illustration_path
     layout "state_file"
-
-    before_action :require_state_file_intake_login, except: [:edit, :update]
 
     def edit
       @closed = app_time.after?(Rails.configuration.state_file_end_of_in_progress_intakes)
@@ -37,15 +33,5 @@ module StateFile
       navigation = StateFile::StateInformationService.navigation_class(params[:us_state])
       redirect_to navigation.controllers.first.to_path_helper
     end
-
-    private
-
-    def prev_path; end
-
-    def illustration_path; end
-
-    def ny_closed; end
-
-    def redirect_deprecated_state; end # stops infinite redirect
   end
 end

--- a/app/controllers/state_file/landing_page_controller.rb
+++ b/app/controllers/state_file/landing_page_controller.rb
@@ -45,5 +45,7 @@ module StateFile
     def illustration_path; end
 
     def ny_closed; end
+
+    def redirect_deprecated_state; end # stops infinite redirect
   end
 end

--- a/app/controllers/state_file/landing_page_controller.rb
+++ b/app/controllers/state_file/landing_page_controller.rb
@@ -17,6 +17,10 @@ module StateFile
       @state_code = params[:us_state]
       @state_name = StateFile::StateInformationService.state_name(@state_code)
       @built_with_name = @state_code == "nj" ? "New Jersey Office of Innovation" : @state_name
+
+      if @state_code == "ny"
+        render :ny_closed
+      end
     end
 
     def update
@@ -40,5 +44,6 @@ module StateFile
 
     def illustration_path; end
 
+    def ny_closed; end
   end
 end

--- a/app/views/state_file/landing_page/edit.html.erb
+++ b/app/views/state_file/landing_page/edit.html.erb
@@ -29,7 +29,7 @@
                 <%= image_tag state_image_path, alt: "#{@state_name} state logo", class: "" %>
               </div>
               <div class="partner-logo-text text--body text--bold">
-                <%=t(".#{@state_code}.supported_by") %>
+                <%= t(".#{@state_code}.supported_by") %>
               </div>
             </div>
             <%= link_to StateFile::StateFilePagesController.to_path_helper(action: :login_options), class: "button button--primary button--wide", id: "firstCta" do %>
@@ -47,7 +47,7 @@
                 <%= image_tag state_image_path, alt: "#{@state_name} state logo", class: "" %>
               </div>
               <div class="partner-logo-text text--body text--bold">
-                <%=t(".#{@state_code}.supported_by") %>
+                <%= t(".#{@state_code}.supported_by") %>
               </div>
             </div>
 
@@ -60,7 +60,7 @@
               <%= form_with model: @form, url: { action: :update }, local: true, method: :put, builder: VitaMinFormBuilder, id: "start-again-form" do |f| %>
                 <h2 class="h2">
                   <%= t(".not_you", user_name: @user_name) %>
-                  <%=f.submit t(".start_new", state_name: @state_name), class: "button--link" %>
+                  <%= f.submit t(".start_new", state_name: @state_name), class: "button--link" %>
                 </h2>
               <% end %>
             <% else %>
@@ -86,7 +86,6 @@
           <% end %>
         </div>
         <%= image_tag 'questions/welcome.svg', class: 'fyst-home-image', alt: '' %>
-
       </div>
     </div>
   </div>

--- a/app/views/state_file/landing_page/edit.html.erb
+++ b/app/views/state_file/landing_page/edit.html.erb
@@ -8,12 +8,6 @@
     <div class="grid__item question-wrapper">
       <%= yield :notices %>
       <div class="main-content-inner">
-        <% if illustration_path.present? %>
-          <div class="question__illustration">
-            <%= image_tag("#{illustration_folder}/#{illustration_path}", alt: "") %>
-          </div>
-        <% end %>
-
         <div class="landing-page-content">
           <h1 class="h1"><%= title %></h1>
 

--- a/app/views/state_file/landing_page/ny_closed.html.erb
+++ b/app/views/state_file/landing_page/ny_closed.html.erb
@@ -27,20 +27,6 @@
               <%= t(".supported_by") %>
             </div>
           </div>
-
-          <% if @user_name.present? %>
-            <p class="h2"><%= t(".welcome_back", user_name: @user_name) %></p>
-            <p class="h2"><%= t(".continue", state_name: @state_name) %></p>
-            <%= link_to StateFile::StateFilePagesController.to_path_helper(action: :login_options), class: "button button--primary button--wide", id: "firstCta" do %>
-              <%= t("general.sign_in") %>
-            <% end %>
-            <%= form_with model: @form, url: { action: :update }, local: true, method: :put, builder: VitaMinFormBuilder, id: "start-again-form" do |f| %>
-              <h2 class="h2">
-                <%= t(".not_you", user_name: @user_name) %>
-                <%= f.submit t(".start_new", state_name: @state_name), class: "button--link" %>
-              </h2>
-            <% end %>
-          <% end %>
         </div>
         <%= image_tag 'questions/welcome.svg', class: 'fyst-home-image', alt: '' %>
       </div>

--- a/app/views/state_file/landing_page/ny_closed.html.erb
+++ b/app/views/state_file/landing_page/ny_closed.html.erb
@@ -1,0 +1,49 @@
+<% state_image_path = "partner-logos/#{@state_code}gov-logo.svg" %>
+<% title = t(".title") %>
+
+<% content_for :page_title, title %>
+
+<section class="slab question-layout <%= controller_name.gsub("_", "-") %>-outer">
+  <div class="grid">
+    <div class="grid__item question-wrapper">
+      <%= yield :notices %>
+      <div class="main-content-inner">
+        <% if illustration_path.present? %>
+          <div class="question__illustration">
+            <%= image_tag("#{illustration_folder}/#{illustration_path}", alt: "") %>
+          </div>
+        <% end %>
+
+        <div class="landing-page-content">
+          <h1 class="h1"><%= title %></h1>
+
+          <p class="h2"><%= t(".body_html") %></p>
+
+          <div class="partner-logo-wrapper spacing-below-35">
+            <div class="partner-logo-image">
+              <%= image_tag state_image_path, alt: "#{@state_name} state logo", class: "" %>
+            </div>
+            <div class="partner-logo-text text--body text--bold">
+              <%= t(".supported_by") %>
+            </div>
+          </div>
+
+          <% if @user_name.present? %>
+            <p class="h2"><%= t(".welcome_back", user_name: @user_name) %></p>
+            <p class="h2"><%= t(".continue", state_name: @state_name) %></p>
+            <%= link_to StateFile::StateFilePagesController.to_path_helper(action: :login_options), class: "button button--primary button--wide", id: "firstCta" do %>
+              <%= t("general.sign_in") %>
+            <% end %>
+            <%= form_with model: @form, url: { action: :update }, local: true, method: :put, builder: VitaMinFormBuilder, id: "start-again-form" do |f| %>
+              <h2 class="h2">
+                <%= t(".not_you", user_name: @user_name) %>
+                <%= f.submit t(".start_new", state_name: @state_name), class: "button--link" %>
+              </h2>
+            <% end %>
+          <% end %>
+        </div>
+        <%= image_tag 'questions/welcome.svg', class: 'fyst-home-image', alt: '' %>
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/views/state_file/landing_page/ny_closed.html.erb
+++ b/app/views/state_file/landing_page/ny_closed.html.erb
@@ -8,12 +8,6 @@
     <div class="grid__item question-wrapper">
       <%= yield :notices %>
       <div class="main-content-inner">
-        <% if illustration_path.present? %>
-          <div class="question__illustration">
-            <%= image_tag("#{illustration_folder}/#{illustration_path}", alt: "") %>
-          </div>
-        <% end %>
-
         <div class="landing-page-content">
           <h1 class="h1"><%= title %></h1>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2233,15 +2233,16 @@ en:
           supported_by: Supported by the New Jersey Division of Taxation
           title: File your New Jersey taxes for free
         not_you: Not %{user_name}?
-        ny:
-          closed_html: |
-            <strong>FileYourStateTaxes</strong> is built in partnership with New York State to integrate with IRS Direct File.<br /><br />
-            We're closed for the tax season. Unfortunately you can no longer file your state return with us this year.
-          supported_by: Supported by New York State
-          title: File your New York State taxes for free
         start_new: Click here to start a new %{state_name} State return.
         title_closed: Our free %{state_name} tax filing service is closed for the season
         welcome_back: Welcome back %{user_name}!
+      ny_closed:
+        body_html: |
+          This service doesn’t support New York State tax returns for 2024. You can still file with IRS Direct File and New York State Direct File. To see if you’re eligible and start your federal return, visit <a href="https://directfile.irs.gov/">IRS Direct File</a>.
+          <br /><br />
+          To download your 2023 NY State tax return, please <a href="https://www.fileyourstatetaxes.org/en/az/faq/how_can_i_access_my_2023_state_tax_return">visit our FAQ</a>.
+        supported_by: Supported by New York State
+        title: Thank you for visiting FileYourStateTaxes
     navigation:
       nj:
         section_1: 'Section 1: Income'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2184,15 +2184,16 @@ es:
           supported_by: Respaldada por el New Jersey Office of Innovation
           title: Presenta tus impuestos estatales de New Jersey sin costo
         not_you: "¿No es %{user_name}?"
-        ny:
-          closed_html: |
-            <strong>FileYourStateTaxes</strong> se creó en asociación con el estado de Nueva York para integrarse con la herramienta Direct File del IRS.<br /><br />
-            Estamos cerrados por la temporada de impuestos. Lamentablemente no puede presentar su declaración estatal con nosotros este año.
-          supported_by: Respaldada por el estado de Nueva York
-          title: Declara tus impuestos Estatales de Nueva York sin costo
         start_new: Haga clic aquí para iniciar una nueva declaración estatal de %{state_name}.
         title_closed: Nuestro servicio gratuito para declarar tus impuestos estatales de %{state_name} está cerrado por temporada
         welcome_back: "¡Bienvenido de nuevo %{user_name}!"
+      ny_closed:
+        body_html: |
+          No puedes usar este servicio para declarar tus impuestos estatales de Nueva York de 2024. Sin embargo, podrías declarar con IRS Direct File y New York State Direct File. Para verificar tu elegibilidad y comenzar a presentar tu declaración federal, visita a IRS Direct File. a <a href="https://directfile.irs.gov/">IRS Direct File</a>.
+          <br /><br />
+          Para descargar tu declaración de impuestos de Nueva York de 2023, <a href="https://www.fileyourstatetaxes.org/en/az/faq/how_can_i_access_my_2023_state_tax_return">visita nuestras preguntas frecuentes</a>.
+        supported_by: Respaldada por el estado de Nueva York
+        title: Gracias por visitar FileYourStateTaxes
     navigation:
       nj:
         section_1: 'Section 1: Income'

--- a/spec/controllers/state_file/faq_controller_spec.rb
+++ b/spec/controllers/state_file/faq_controller_spec.rb
@@ -145,4 +145,25 @@ RSpec.describe StateFile::FaqController do
       end
     end
   end
+
+  describe "#show" do
+    let(:section_key) { "sluggy_slug" }
+    let!(:faq_category) { create :faq_category, slug: section_key, product_type: "state_file_az" }
+
+    it "shows the description" do
+      get :show, params: { section_key: section_key, us_state: "az" }
+
+      expect(response.body).to have_text faq_category.description_en
+    end
+
+    context "for new york" do
+      let!(:faq_category) { create :faq_category, slug: section_key, product_type: "state_file_ny" }
+
+      it "redirects to the ny landing page" do
+        get :show, params: { section_key: section_key, us_state: "ny" }
+
+        expect(response).to redirect_to state_landing_page_path(us_state: "ny")
+      end
+    end
+  end
 end

--- a/spec/controllers/state_file/landing_page_controller_spec.rb
+++ b/spec/controllers/state_file/landing_page_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe StateFile::LandingPageController do
   StateFile::StateInformationService.active_state_codes.excluding(:ny).each do |state_code|
     describe "#update" do
-      it_behaves_like :start_intake_concern, intake_class: StateFile::StateInformationService.intake_class(state_code), intake_factory: :state_file_az_intake do
+      it_behaves_like :start_intake_concern, intake_class: StateFile::StateInformationService.intake_class(state_code) do
         let(:valid_params) do
           {
             us_state: state_code

--- a/spec/controllers/state_file/landing_page_controller_spec.rb
+++ b/spec/controllers/state_file/landing_page_controller_spec.rb
@@ -1,49 +1,40 @@
 require 'rails_helper'
 
 RSpec.describe StateFile::LandingPageController do
-  describe "#update" do
-    # use the shared example to test functionality for creating the intake
-    # This can be moved to a different controller spec but the valid params
-    # will need to be defined for the new controller
-
-    it_behaves_like :start_intake_concern, intake_class: StateFileAzIntake, intake_factory: :state_file_az_intake do
-      let(:valid_params) do
-        {
-          us_state: "az"
-        }
-      end
-    end
-
-    it_behaves_like :start_intake_concern, intake_class: StateFileNjIntake, intake_factory: :state_file_nj_intake do
-      let(:valid_params) do
-        {
-          us_state: "nj"
-        }
-      end
-    end
-  end
-
-  describe "#edit" do
-    let(:intake) { create :state_file_az_intake }
-    before do
-      sign_in intake
-    end
-
-    it "does not set the current_step" do
-      get :edit, params: { us_state: :az }
-      expect(response).to be_ok
-      expect(StateFileAzIntake.last.current_step).to be_nil
-    end
-
-    context "when it is after closing" do
-      around do |example|
-        Timecop.freeze(Rails.configuration.state_file_end_of_in_progress_intakes + 1.day) do
-          example.run
+  StateFile::StateInformationService.active_state_codes.excluding(:ny).each do |state_code|
+    describe "#update" do
+      it_behaves_like :start_intake_concern, intake_class: StateFile::StateInformationService.intake_class(state_code), intake_factory: :state_file_az_intake do
+        let(:valid_params) do
+          {
+            us_state: state_code
+          }
         end
       end
-      it "does not redirect them to the about page" do
-        get :edit, params: { us_state: :az }
-        expect(response).not_to have_http_status(:redirect)
+    end
+
+    describe "#edit" do
+      let(:intake) { create(StateFile::StateInformationService.intake_class(state_code).name.underscore.to_sym) }
+      before do
+        sign_in intake
+      end
+
+      it "does not set the current_step" do
+        get :edit, params: { us_state: state_code }
+        expect(response).to be_ok
+        expect(StateFile::StateInformationService.intake_class(state_code).last.current_step).to be_nil
+      end
+
+      context "when it is after closing" do
+        around do |example|
+          Timecop.freeze(Rails.configuration.state_file_end_of_in_progress_intakes + 1.day) do
+            example.run
+          end
+        end
+
+        it "does not redirect them to the about page" do
+          get :edit, params: { us_state: state_code }
+          expect(response).not_to have_http_status(:redirect)
+        end
       end
     end
   end

--- a/spec/controllers/state_file/landing_page_controller_spec.rb
+++ b/spec/controllers/state_file/landing_page_controller_spec.rb
@@ -14,14 +14,6 @@ RSpec.describe StateFile::LandingPageController do
       end
     end
 
-    it_behaves_like :start_intake_concern, intake_class: StateFileNyIntake, intake_factory: :state_file_ny_intake do
-      let(:valid_params) do
-        {
-          us_state: "ny"
-        }
-      end
-    end
-
     it_behaves_like :start_intake_concern, intake_class: StateFileNjIntake, intake_factory: :state_file_nj_intake do
       let(:valid_params) do
         {
@@ -32,15 +24,15 @@ RSpec.describe StateFile::LandingPageController do
   end
 
   describe "#edit" do
-    let(:intake) { create :state_file_ny_intake }
+    let(:intake) { create :state_file_az_intake }
     before do
       sign_in intake
     end
 
     it "does not set the current_step" do
-      get :edit, params: { us_state: :ny }
+      get :edit, params: { us_state: :az }
       expect(response).to be_ok
-      expect(StateFileNyIntake.last.current_step).to be_nil
+      expect(StateFileAzIntake.last.current_step).to be_nil
     end
 
     context "when it is after closing" do
@@ -50,7 +42,7 @@ RSpec.describe StateFile::LandingPageController do
         end
       end
       it "does not redirect them to the about page" do
-        get :edit, params: { us_state: :ny }
+        get :edit, params: { us_state: :az }
         expect(response).not_to have_http_status(:redirect)
       end
     end

--- a/spec/controllers/state_file/questions/confirmation_controller_spec.rb
+++ b/spec/controllers/state_file/questions/confirmation_controller_spec.rb
@@ -2,24 +2,21 @@ require 'rails_helper'
 
 RSpec.describe StateFile::Questions::ConfirmationController do
   describe "#show_xml" do
-    context "in ny" do
-      let(:ny_intake) do
+    context "in az" do
+      let(:az_intake) do
         create(
-          :state_file_ny_intake,
+          :state_file_az_intake,
           :with_efile_device_infos,
           primary_first_name: "Jerry",
-          school_district_id: 441,
-          school_district: "Bellmore-Merrick CHS",
-          school_district_number: 46
         )
       end
-      let(:efile_submission) { create :efile_submission, :for_state, data_source: ny_intake }
+      let(:efile_submission) { create :efile_submission, :for_state, data_source: az_intake }
 
       before do
-        sign_in ny_intake
+        sign_in az_intake
       end
 
-      it "returns some xml", required_schema: "ny" do
+      it "returns some xml", required_schema: "az" do
         get :show_xml, params: { id: efile_submission.id }
         expect(Nokogiri::XML(response.body).at('Primary FirstName').text).to eq("Jerry")
       end
@@ -33,16 +30,6 @@ RSpec.describe StateFile::Questions::ConfirmationController do
 
     before do
       sign_in intake
-    end
-
-    context "in ny" do
-      let(:intake) { create :state_file_ny_intake, :with_efile_device_infos, primary_first_name: "Jerry" }
-
-      it "shows a little bit about how each line was calculated" do
-        get :explain_calculations, params: { id: efile_submission.id }
-        expect(response.body).to include('IT201_LINE_1')
-        expect(response.body).to include('IT213_LINE_14')
-      end
     end
 
     context "in az" do

--- a/spec/controllers/state_file/questions/eligibility_offboarding_controller_spec.rb
+++ b/spec/controllers/state_file/questions/eligibility_offboarding_controller_spec.rb
@@ -18,12 +18,12 @@ RSpec.describe StateFile::Questions::EligibilityOffboardingController do
   end
 
   describe "#edit" do
-    let(:intake) { create :state_file_ny_intake }
+    let(:intake) { create :state_file_id_intake }
 
     context "with offboarded_from set in the session" do
       render_views
       let(:offboarded_from_path) do
-        StateFile::Questions::NyEligibilityResidenceController.to_path_helper
+        StateFile::Questions::IdEligibilityResidenceController.to_path_helper
       end
       before do
         sign_in intake

--- a/spec/controllers/state_file/questions/esign_declaration_controller_spec.rb
+++ b/spec/controllers/state_file/questions/esign_declaration_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe StateFile::Questions::EsignDeclarationController do
-  let(:intake) { create :state_file_ny_intake }
+  let(:intake) { create :state_file_az_intake }
   let(:device_id) { "ABC123" }
   let(:params) do
     {

--- a/spec/controllers/state_file/questions/initiate_data_transfer_controller_spec.rb
+++ b/spec/controllers/state_file/questions/initiate_data_transfer_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe StateFile::Questions::InitiateDataTransferController do
-  let(:intake) { create :state_file_ny_intake }
+  let(:intake) { create :state_file_az_intake }
   let(:state_file_analytics) { intake.state_file_analytics }
   before do
     sign_in intake

--- a/spec/controllers/state_file/questions/ny_county_controller_spec.rb
+++ b/spec/controllers/state_file/questions/ny_county_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe StateFile::Questions::NyCountyController do
+RSpec.describe StateFile::Questions::NyCountyController, skip: true do
   let(:intake) { create :state_file_ny_intake }
   before do
     sign_in intake

--- a/spec/controllers/state_file/questions/ny_eligibility_college_savings_withdrawal_controller_spec.rb
+++ b/spec/controllers/state_file/questions/ny_eligibility_college_savings_withdrawal_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe StateFile::Questions::NyEligibilityCollegeSavingsWithdrawalController do
+RSpec.describe StateFile::Questions::NyEligibilityCollegeSavingsWithdrawalController, skip: true do
   describe "#update" do
     # use the eligibility_offboarding_concern shared example if the page
     # should redirect to the state file eligibility offboarding page

--- a/spec/controllers/state_file/questions/ny_eligibility_out_of_state_income_controller_spec.rb
+++ b/spec/controllers/state_file/questions/ny_eligibility_out_of_state_income_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe StateFile::Questions::NyEligibilityOutOfStateIncomeController do
+RSpec.describe StateFile::Questions::NyEligibilityOutOfStateIncomeController, skip: true do
   describe "#update" do
     # use the eligibility_offboarding_concern shared example if the page
     # should redirect to the state file eligibility offboarding page

--- a/spec/controllers/state_file/questions/ny_eligibility_residence_controller_spec.rb
+++ b/spec/controllers/state_file/questions/ny_eligibility_residence_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe StateFile::Questions::NyEligibilityResidenceController do
+RSpec.describe StateFile::Questions::NyEligibilityResidenceController, skip: true do
   describe "#update" do
     # use the eligibility_offboarding_concern shared example if the page
     # should redirect to the state file eligibility offboarding page

--- a/spec/controllers/state_file/questions/ny_permanent_address_controller_spec.rb
+++ b/spec/controllers/state_file/questions/ny_permanent_address_controller_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
-describe StateFile::Questions::NyPermanentAddressController do
-
+describe StateFile::Questions::NyPermanentAddressController, skip: true do
   let(:intake) { create :state_file_ny_refund_intake}
   before do
     sign_in intake

--- a/spec/controllers/state_file/questions/ny_primary_state_id_controller_spec.rb
+++ b/spec/controllers/state_file/questions/ny_primary_state_id_controller_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
-describe StateFile::Questions::NyPrimaryStateIdController do
-
+describe StateFile::Questions::NyPrimaryStateIdController, skip: true do
   let(:intake) { create :state_file_ny_refund_intake}
   before do
     sign_in intake

--- a/spec/controllers/state_file/questions/ny_review_controller_spec.rb
+++ b/spec/controllers/state_file/questions/ny_review_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe StateFile::Questions::NyReviewController do
+RSpec.describe StateFile::Questions::NyReviewController, skip: true do
   describe "#edit" do
     before do
       sign_in intake

--- a/spec/controllers/state_file/questions/ny_sales_use_tax_controller_spec.rb
+++ b/spec/controllers/state_file/questions/ny_sales_use_tax_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe StateFile::Questions::NySalesUseTaxController do
+RSpec.describe StateFile::Questions::NySalesUseTaxController, skip: true do
   let(:intake) { create :state_file_ny_intake }
   before do
     sign_in intake

--- a/spec/controllers/state_file/questions/ny_school_district_controller_spec.rb
+++ b/spec/controllers/state_file/questions/ny_school_district_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe StateFile::Questions::NySchoolDistrictController do
+RSpec.describe StateFile::Questions::NySchoolDistrictController, skip: true do
   let(:intake) { create :state_file_ny_intake, residence_county: "Nassau" }
   before do
     sign_in intake

--- a/spec/controllers/state_file/questions/ny_spouse_state_id_controller_spec.rb
+++ b/spec/controllers/state_file/questions/ny_spouse_state_id_controller_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
-describe StateFile::Questions::NySpouseStateIdController do
-
+describe StateFile::Questions::NySpouseStateIdController, skip: true do
   let(:intake) { create :state_file_ny_refund_intake}
   before do
     sign_in intake

--- a/spec/controllers/state_file/questions/nyc_residency_controller_spec.rb
+++ b/spec/controllers/state_file/questions/nyc_residency_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe StateFile::Questions::NycResidencyController do
+RSpec.describe StateFile::Questions::NycResidencyController, skip: true do
   let(:intake) { create :state_file_ny_intake }
   before do
     sign_in intake

--- a/spec/controllers/state_file/questions/return_status_controller_spec.rb
+++ b/spec/controllers/state_file/questions/return_status_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe StateFile::Questions::ReturnStatusController do
-  StateFile::StateInformationService.active_state_codes.each do |state_code|
+  StateFile::StateInformationService.active_state_codes.excluding("ny").each do |state_code|
     context "#{state_code}" do
       describe "#edit" do
         render_views

--- a/spec/controllers/state_file/questions/submission_pdfs_controller_spec.rb
+++ b/spec/controllers/state_file/questions/submission_pdfs_controller_spec.rb
@@ -4,23 +4,6 @@ RSpec.describe StateFile::Questions::SubmissionPdfsController do
   include PdfSpecHelper
 
   describe "#show" do
-    context "NY" do
-      let(:ny_intake) { create :state_file_ny_intake, primary_first_name: "Jerry" }
-      let(:efile_submission) { create :efile_submission, :for_state, data_source: ny_intake }
-
-      before do
-        sign_in ny_intake
-      end
-
-      it "creates the pdf and then shows it" do
-        get :show, params: { id: efile_submission.id }
-
-        tempfile = Tempfile.new(['output', '.pdf'])
-        tempfile.write(response.body)
-        expect(filled_in_values(tempfile.path)).to match(a_hash_including("TP_first_name" => "Jerry"))
-      end
-    end
-
     context "AZ" do
       let(:az_intake) { create :state_file_az_intake, primary_first_name: "Jerry", primary_middle_initial: "L" }
       let(:efile_submission) { create :efile_submission, :for_state, data_source: az_intake }

--- a/spec/controllers/state_file/questions/unemployment_controller_spec.rb
+++ b/spec/controllers/state_file/questions/unemployment_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe StateFile::Questions::UnemploymentController do
-  let(:intake) { create :state_file_ny_intake, filing_status: :married_filing_jointly, spouse_first_name: "Glenn", spouse_last_name: "Gary" }
+  let(:intake) { create :state_file_az_intake, filing_status: :married_filing_jointly, spouse_first_name: "Glenn", spouse_last_name: "Gary" }
   before do
     sign_in intake
   end
@@ -13,12 +13,12 @@ RSpec.describe StateFile::Questions::UnemploymentController do
     end
 
     it "is false for a return that did not have unemployment income" do
-      intake = create :state_file_ny_intake, raw_direct_file_data: StateFile::DirectFileApiResponseSampleService.new.read_xml("ny_single_w2")
+      intake = create :state_file_az_intake, raw_direct_file_data: StateFile::DirectFileApiResponseSampleService.new.read_xml("az_johnny_mfj")
       expect(described_class.show?(intake)).to be_falsey
     end
 
     it "is false for a return that has a zero unemployment income" do
-      intake = create :state_file_ny_intake, raw_direct_file_data: StateFile::DirectFileApiResponseSampleService.new.read_xml("ny_educator_deduction")
+      intake = create :state_file_id_intake, raw_direct_file_data: StateFile::DirectFileApiResponseSampleService.new.read_xml("id_lana_single")
       expect(described_class.show?(intake)).to be_falsey
     end
   end
@@ -134,7 +134,7 @@ RSpec.describe StateFile::Questions::UnemploymentController do
     end
 
     context "if the intake was anything other than married filing jointly" do
-      let(:intake) { create :state_file_ny_intake, filing_status: :single, spouse_first_name: nil, spouse_last_name: nil }
+      let(:intake) { create :state_file_az_intake, filing_status: :single, spouse_first_name: nil, spouse_last_name: nil }
 
       before do
         params[:state_file1099_g].delete(:recipient)

--- a/spec/controllers/state_file/questions/waiting_to_load_data_controller_spec.rb
+++ b/spec/controllers/state_file/questions/waiting_to_load_data_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe StateFile::Questions::WaitingToLoadDataController do
-  let!(:intake) { create(:state_file_ny_intake) }
+  let!(:intake) { create(:state_file_az_intake) }
 
   before do
     sign_in intake

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -561,7 +561,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
         expect(page).to have_text I18n.t("state_file.landing_page.ny_closed.title")
 
         # try to log in with existing ny intake and get redirected
-        visit "/login-options"
+        visit "/questions/return-status"
         expect(page).to have_text "Sign in to FileYourStateTaxes"
         click_on "Sign in with email"
         expect(page).to have_text "Sign in with your email address"

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -544,7 +544,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
         allow(VerificationCodeService).to receive(:hash_verification_code_with_contact_info).with(email_address, verification_code).and_return(hashed_verification_code)
       end
 
-      it "doesn't allow filers in anymore and redirects all pages to landing page", required_schema: "ny" do
+      it "doesn't allow filers in anymore and redirects all pages to landing page" do
         visit "/"
         click_on "Start Test NY"
 

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -537,7 +537,14 @@ RSpec.feature "Completing a state file intake", active_job: true do
 
         expect(page).to have_text I18n.t("state_file.landing_page.ny_closed.title")
 
+        # spot check a few pages for redirecting to landing page
         visit "/questions/ny-eligibility-residence"
+        expect(page).to have_text I18n.t("state_file.landing_page.ny_closed.title")
+
+        visit "/questions/ny-sales-use-tax"
+        expect(page).to have_text I18n.t("state_file.landing_page.ny_closed.title")
+
+        visit "/questions/ny-review"
         expect(page).to have_text I18n.t("state_file.landing_page.ny_closed.title")
       end
     end

--- a/spec/features/state_file/data_transfer_spec.rb
+++ b/spec/features/state_file/data_transfer_spec.rb
@@ -11,12 +11,12 @@ RSpec.feature "Transferring data from Direct File", active_job: true do
 
   it "advances past the loading screen by listening for an actioncable broadcast", js: true do
     visit "/"
-    click_on "Start Test NY"
+    click_on "Start Test AZ"
 
-    expect(page).to have_text "File your New York State taxes for free"
+    expect(page).to have_text I18n.t("state_file.landing_page.edit.az.title")
     click_on "Get Started", id: "firstCta"
 
-    step_through_eligibility_screener(us_state: "ny")
+    step_through_eligibility_screener(us_state: "az")
 
     step_through_initial_authentication(contact_preference: :email)
     check "Text message"
@@ -29,7 +29,7 @@ RSpec.feature "Transferring data from Direct File", active_job: true do
     expect(page).to have_text I18n.t('state_file.questions.terms_and_conditions.edit.title')
     click_on I18n.t("state_file.questions.terms_and_conditions.edit.accept")
 
-    step_through_df_data_transfer("Transfer Javier")
-    expect(page).to have_text "Note: New York City includes the Bronx, Brooklyn, Manhattan, Queens, and Staten Island."
+    step_through_df_data_transfer("Transfer Alexis hoh")
+    expect(page).to have_text I18n.t("state_file.questions.az_prior_last_names.edit.title", count: 1)
   end
 end

--- a/spec/features/state_file/edit_return_spec.rb
+++ b/spec/features/state_file/edit_return_spec.rb
@@ -9,12 +9,12 @@ RSpec.feature "Editing a rejected intake with an auto-wait error" do
   let(:hashed_verification_code) { "hashed_verification_code" }
   let(:double_hashed_verification_code) { "double_hashed_verification_code" }
 
-  let!(:ny_intake) { create :state_file_ny_intake, email_address: email_address, hashed_ssn: hashed_ssn, primary_first_name: "Jerry" }
+  let!(:az_intake) { create :state_file_az_intake, email_address: email_address, hashed_ssn: hashed_ssn, primary_first_name: "Jerry" }
   let!(:efile_submission) {
     create :efile_submission,
            :for_state,
            :transmitted,
-           data_source: ny_intake
+           data_source: az_intake
   }
   let!(:efile_error) {
     create :efile_error,
@@ -24,7 +24,7 @@ RSpec.feature "Editing a rejected intake with an auto-wait error" do
            code: "STATE-901",
            severity: "Reject",
            source: "irs",
-           service_type: :state_file_ny
+           service_type: :state_file_az
   }
   let(:raw_response) do
     "<Acknowledgement>\n
@@ -84,11 +84,11 @@ RSpec.feature "Editing a rejected intake with an auto-wait error" do
     fill_in "Enter your Social Security number or ITIN. For example, 123-45-6789.", with: ssn
     click_on "Continue"
 
-    expect(page).to have_text "Unfortunately, your #{filing_year} New York state tax return was rejected"
+    expect(page).to have_text I18n.t("state_file.questions.return_status.rejected.title", filing_year: filing_year, state_name: "Arizona")
     click_on "Edit your state return"
 
-    # goes back to the NY review page
-    expect(page).to have_text I18n.t("state_file.questions.ny_review.edit.total_ny_tax")
+    # goes back to the AZ review page
+    expect(page).to have_text I18n.t("state_file.questions.az_review.edit.az_tax")
     click_on I18n.t("general.continue")
 
     expect(URI.parse(current_url).path).to eq "/en/questions/taxes-owed"

--- a/spec/features/state_file/editing_df_xml_spec.rb
+++ b/spec/features/state_file/editing_df_xml_spec.rb
@@ -13,12 +13,12 @@ RSpec.feature "editing direct file XML with the FederalInfoController", active_j
 
   it "does not modify the df xml if nothing was changed" do
     visit "/"
-    click_on "Start Test NY"
+    click_on "Start Test AZ"
 
-    expect(page).to have_text I18n.t("state_file.landing_page.edit.ny.title")
+    expect(page).to have_text I18n.t("state_file.landing_page.edit.az.title")
     click_on "Get Started", id: "firstCta"
 
-    step_through_eligibility_screener(us_state: "ny")
+    step_through_eligibility_screener(us_state: "az")
 
     step_through_initial_authentication(contact_preference: :text_message)
     check "Email"
@@ -32,14 +32,14 @@ RSpec.feature "editing direct file XML with the FederalInfoController", active_j
     expect(page).to have_text I18n.t('state_file.questions.terms_and_conditions.edit.title')
     click_on I18n.t("state_file.questions.terms_and_conditions.edit.accept")
 
-    step_through_df_data_transfer("Transfer Javier")
+    step_through_df_data_transfer("Transfer Alexis hoh")
 
-    xml_before = StateFileNyIntake.last.raw_direct_file_data.strip
+    xml_before = StateFileAzIntake.last.raw_direct_file_data.strip
 
     click_on I18n.t("general.continue")
-    expect(page).to have_text I18n.t('state_file.questions.nyc_residency.edit.title', year: tax_year)
+    expect(page).to have_text I18n.t("state_file.questions.az_prior_last_names.edit.title", count: 1)
 
-    xml_after = StateFileNyIntake.last.raw_direct_file_data.strip
+    xml_after = StateFileAzIntake.last.raw_direct_file_data.strip
     expect(xml_before).to eq(xml_after)
   end
 

--- a/spec/features/state_file/login_spec.rb
+++ b/spec/features/state_file/login_spec.rb
@@ -8,10 +8,9 @@ RSpec.feature "Logging in with an existing account" do
   let(:ssn) { "111223333" }
   let(:hashed_ssn) { "hashed_ssn" }
   let!(:az_intake) { create :state_file_az_intake, phone_number: phone_number, hashed_ssn: hashed_ssn, df_data_import_succeeded_at: 5.minutes.ago }
-  let!(:ny_intake) { create :state_file_ny_intake, email_address: email_address, hashed_ssn: hashed_ssn, df_data_import_succeeded_at: 5.minutes.ago  }
+  let!(:az_intake_2) { create :state_file_az_intake, email_address: email_address, hashed_ssn: hashed_ssn, df_data_import_succeeded_at: 5.minutes.ago  }
   let(:verification_code) { "000004" }
   let(:hashed_verification_code) { "hashed_verification_code" }
-  let(:double_hashed_verification_code) { "double_hashed_verification_code" }
 
   before do
     allow_any_instance_of(Routes::StateFileDomain).to receive(:matches?).and_return(true)

--- a/spec/features/state_file/manage_email_notification_settings_spec.rb
+++ b/spec/features/state_file/manage_email_notification_settings_spec.rb
@@ -10,14 +10,14 @@ RSpec.feature "Unsubscribing from email", active_job: true do
 
   scenario "the link in the email unsubscribes the client" do
     visit "/"
-    click_on "Start Test NY"
+    click_on "Start Test AZ"
 
-    expect(page).to have_text I18n.t("state_file.landing_page.edit.ny.title")
+    expect(page).to have_text I18n.t("state_file.landing_page.edit.az.title")
     click_on I18n.t('general.get_started'), id: "firstCta"
 
-    step_through_eligibility_screener(us_state: "ny")
+    step_through_eligibility_screener(us_state: "az")
 
-    intake = StateFileNyIntake.last
+    intake = StateFileAzIntake.last
     expect(intake.unsubscribed_from_email).to eq false
 
     step_through_initial_authentication(contact_preference: :email)

--- a/spec/features/state_file/review_page_spec.rb
+++ b/spec/features/state_file/review_page_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
     allow_any_instance_of(Routes::StateFileDomain).to receive(:matches?).and_return(true)
   end
 
-  StateFile::StateInformationService.active_state_codes.without("nc").each do |state_code|
+  StateFile::StateInformationService.active_state_codes.without("nc", "ny").each do |state_code|
     context "#{state_code.upcase}", js: true do
       it "allows user to navigate to income review page, edit an income form, and then navigate back to final review page", required_schema: state_code do
         set_up_intake_and_associated_records(state_code)

--- a/spec/support/shared_examples/start_intake_concern.rb
+++ b/spec/support/shared_examples/start_intake_concern.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-shared_examples :start_intake_concern do |intake_class:, intake_factory:|
+shared_examples :start_intake_concern do |intake_class:|
   describe "start of intake" do
     before do
       cookies.encrypted[:visitor_id] = "visitor-id"
@@ -21,7 +21,7 @@ shared_examples :start_intake_concern do |intake_class:, intake_factory:|
 
     context "with an existing intake in the session" do
       let(:existing_intake) do
-        create(intake_factory)
+        create(intake_class.name.underscore)
       end
 
       before { sign_in existing_intake }


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1603
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Remove get started button on landing page for NY and display some copy about not supporting it anymore
- Redirect from NY intake pages to landing page
  - note about this: it's already the case that pages in the intake flow require an intake in the session, so the only real purpose of redirecting is for the edge case where a client logs in using an existing NY intake and tries to manually visit the pages. this seems fairly unlikely but also it's fine to implement it temporarily until we delete more NY code?
  - update to this note: i only just realized that we won't have any ny intakes to log in with because we deleted them :( so maybe it was all for naught
  - another update: we're now just skipping the tests for ny controllers
## How to test?
- Added a feature spec
## Screenshots (for visual changes)
- Before
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/562090d2-c204-4dd1-abf3-490bb4609387" />

- After
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/8fd13bad-5ab5-49cc-afdd-7a49d4b45316" />
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/7c766b9a-329b-4473-9d8f-4aac26973544" />
