### PR TITLE
Fix landing page content bugs

### DIFF
--- a/app/controllers/state_file/landing_page_controller.rb
+++ b/app/controllers/state_file/landing_page_controller.rb
@@ -12,8 +12,6 @@ module StateFile
       end
       @state_code = params[:us_state]
       @state_name = StateFile::StateInformationService.state_name(@state_code)
-      @built_with_name = @state_code == "nj" ? "New Jersey Office of Innovation" : @state_name
-
       if @state_code == "ny"
         render :ny_closed
       end

--- a/app/views/state_file/landing_page/edit.html.erb
+++ b/app/views/state_file/landing_page/edit.html.erb
@@ -32,7 +32,7 @@
           <% else %>
             <% unless @user_name.present? %>
               <p class="h2">
-                <%= t(".built_with_html", state_name: @built_with_name) %>
+                <%= t(".#{@state_code}.built_with_html", default: t(".built_with_html", state_name: @state_name) ) %>
               </p>
             <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2205,10 +2205,14 @@ en:
           supported_by: Supported by the state of North Carolina
           title: File your North Carolina state taxes for free
         nj:
+          built_with_html: |
+            <strong>FileYourStateTaxes</strong> takes about 10 to 15 minutes to complete. Get started by setting up your account.
+            <br/><br/>
+            This service is built in partnership with the New Jersey Office of Innovation to integrate with IRS Direct File.
           closed_html: "<strong>FileYourStateTaxes</strong> is built in partnership with the New Jersey Office of Innovation to integrate with IRS Direct File.<br /><br />\nWe're closed for the tax season. Unfortunately you can no longer file your state return with us this year.              \n"
           help_text_html: |
             <ul class="list--bulleted">
-              <li>To have filed your 2024 federal return using IRS Direct File</li>
+              <li>To have filed your 2024 federal return using <a href="https://directfile.irs.gov/" target="_blank" rel="noopener nofollow">IRS Direct File</a></li>
               <li>An email address or a phone number to receive a one-time verification code</li>
               <li>Bank routing and account numbers (if you want to receive your refund or make a tax payment electronically)</li>
               <li>(optional) Driver's license or state issued ID</li>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2154,12 +2154,13 @@ es:
           supported_by: Respaldada por el estado de Carolina del Norte
           title: Declara tus impuestos estatales de Carolina del Norte sin costo
         nj:
+          built_with_html: "Te tomará alrededor de 10 y 15 minutos completar tu declaración con <strong>FileYourStateTaxes</strong>. \n<br/><br/>\nEsta servicio ha sido creada en colaboración con el New Jersey Office of Innovation para integrarse con Direct File del IRS.\n"
           closed_html: |
             <strong>FileYourStateTaxes</strong> se creó en asociación con el New Jersey Office of Innovation para integrarse con la herramienta Direct File del IRS.<br /><br />
             Estamos cerrados por la temporada de impuestos. Desafortunadamente no puede presentar su declaración estatal con nosotros este año.
           help_text_html: |
             <ul class="list--bulleted">
-              <li>Haber presentado tu declaración federal de 2024 usando IRS Direct File</li>
+              <li>Haber presentado tu declaración federal de 2024 usando <a href="https://directfile.irs.gov/" target="_blank" rel="noopener nofollow">IRS Direct File</a></li>
               <li>Un email o un número de teléfono para recibir un código de verificación único</li>
               <li>Números de ruta y cuenta bancaria (si deseas recibir tu reembolso o realizar un pago de impuestos electrónicamente)</li>
               <li>(opcional) Licencia de conducir o identificación emitida por el estado</li>


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/261

## Is PM acceptance required? (delete one)
- No - merge after code review approval

## What was done?
Add built_with_html to NJ so that we can remove the "state of" text. Add a link to the help text html.

## How to test?
Go to the NJ landing page and check for removal of text and addition of link. Go to the other landing pages and make sure they're not broken.

## Screenshots (for visual changes)
- Before
![image](https://github.com/user-attachments/assets/008b7b79-ce47-4082-ad1f-6486f4a79a49)
- After 
![image](https://github.com/user-attachments/assets/31154134-364a-46b4-87d9-55bc2e3587b0)