### PR TITLE
Add status for submission acknowledgement

### DIFF
--- a/app/services/efile/poll_for_acknowledgments_service.rb
+++ b/app/services/efile/poll_for_acknowledgments_service.rb
@@ -4,7 +4,7 @@ StatusRecordGroup = Struct.new(:irs_submission_id, :state, :xml)
 module Efile
   class PollForAcknowledgmentsService
     TRANSMITTED_STATUSES = ["Received", "Ready for Pickup", "Ready for Pick-Up", "Sent to State", "Received by State"]
-    READY_FOR_ACK_STATUSES = ["Denied by IRS", "Acknowledgement Received from State", "Acknowledgement Retrieved", "Notified"]
+    READY_FOR_ACK_STATUSES = ["Rejected Acknowledgment Created", "Denied by IRS", "Acknowledgement Received from State", "Acknowledgement Retrieved", "Notified"]
 
     def self.run
       Efile::GyrEfilerService.with_lock(ActiveRecord::Base.connection) do |lock_acquired|


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/FYST-1658

## Is PM acceptance required? (delete one)
- No - merge after code review approval

## What was done?
- We received the following error 
                   ` {"raw_response"=>"<StatusRecordGrp>\n\t\t<SubmissionId>########</SubmissionId>\n\t\t<SubmissionStatusTxt>Rejected Acknowledgement Created</SubmissionStatusTxt>\n\t\t<SubmsnStatusAcknowledgementDt>2025-01-22</SubmsnStatusAcknowledgementDt>\n\t\t<DisclaimerTxt>This status record provides information about what step in the process the return has completed.  It is not proof that the return was Accepted or Rejected.  You must retrieve the Acknowledgement File and keep it with the return records to prove that the return was Accepted or Rejected.</DisclaimerTxt>\n\t</StatusRecordGrp>"}`
- We assumed this was because we did not have the status "Rejected Acknowledgement Created" in the list for ready for acknowledgements. So this is now added 

## How to test?
- Units tests are passing 

