### PR TITLE
GYR1-615 Add new page 4 for Hub editable 14-C

### DIFF
--- a/app/controllers/hub/clients_controller.rb
+++ b/app/controllers/hub/clients_controller.rb
@@ -124,6 +124,10 @@ module Hub
       @form = Update13614cFormPage3.from_client(@client)
     end
 
+    def edit_13614c_form_page4
+      @form = Update13614cFormPage4.from_client(@client)
+    end
+
     def save_and_maybe_exit(save_button_clicked, path_to_13614c_page)
       if save_button_clicked == I18n.t("general.save")
         redirect_to path_to_13614c_page
@@ -162,10 +166,21 @@ module Hub
 
       if @form.valid? && @form.save
         SystemNote::ClientChange.generate!(initiated_by: current_user, intake: @client.intake)
-        @client.intake.update(demographic_questions_hub_edit: true)
         GenerateF13614cPdfJob.perform_later(@client.intake.id, "Hub Edited 13614-C.pdf")
         flash[:notice] = I18n.t("general.changes_saved")
         save_and_maybe_exit(params[:commit], edit_13614c_form_page3_hub_client_path(id: @client.id))
+      end
+    end
+
+    def update_13614c_form_page4
+      @form = Update13614cFormPage4.new(@client, update_13614c_form_page4_params)
+
+      if @form.valid? && @form.save
+        SystemNote::ClientChange.generate!(initiated_by: current_user, intake: @client.intake)
+        @client.intake.update(demographic_questions_hub_edit: true)
+        GenerateF13614cPdfJob.perform_later(@client.intake.id, "Hub Edited 13614-C.pdf")
+        flash[:notice] = I18n.t("general.changes_saved")
+        save_and_maybe_exit(params[:commit], edit_13614c_form_page4_hub_client_path(id: @client.id))
       end
     end
 
@@ -212,6 +227,10 @@ module Hub
 
     def update_13614c_form_page3_params
       params.require(Update13614cFormPage3.form_param).permit(Update13614cFormPage3.attribute_names)
+    end
+
+    def update_13614c_form_page4_params
+      params.require(Update13614cFormPage4.form_param).permit(Update13614cFormPage4.attribute_names)
     end
 
     def create_client_form_params

--- a/app/forms/hub/update_13614c_form_page4.rb
+++ b/app/forms/hub/update_13614c_form_page4.rb
@@ -1,0 +1,43 @@
+module Hub
+  class Update13614cFormPage4 < Form
+    include FormAttributes
+
+    set_attributes_for :intake,
+                       :demographic_english_conversation,
+                       :demographic_english_reading,
+                       :demographic_disability,
+                       :demographic_veteran,
+                       :demographic_primary_american_indian_alaska_native,
+                       :demographic_primary_asian,
+                       :demographic_primary_black_african_american,
+                       :demographic_primary_mena,
+                       :demographic_primary_native_hawaiian_pacific_islander,
+                       :demographic_primary_white,
+                       :demographic_primary_prefer_not_to_answer_race,
+                       :demographic_spouse_american_indian_alaska_native,
+                       :demographic_spouse_asian,
+                       :demographic_spouse_black_african_american,
+                       :demographic_spouse_mena,
+                       :demographic_spouse_native_hawaiian_pacific_islander,
+                       :demographic_spouse_white
+
+    attr_accessor :client
+
+    def initialize(client, params = {})
+      @client = client
+      super(params)
+    end
+
+    def self.from_client(client)
+      intake = client.intake
+      attribute_keys = Attributes.new(attribute_names).to_sym
+      new(client, existing_attributes(intake).slice(*attribute_keys))
+    end
+
+    def save
+      @client.intake.update(attributes_for(:intake))
+      @client.touch(:last_13614c_update_at)
+    end
+  end
+end
+

--- a/app/forms/hub/update_13614c_form_page4.rb
+++ b/app/forms/hub/update_13614c_form_page4.rb
@@ -10,6 +10,7 @@ module Hub
                        :demographic_primary_american_indian_alaska_native,
                        :demographic_primary_asian,
                        :demographic_primary_black_african_american,
+                       :demographic_primary_hispanic_latino,
                        :demographic_primary_mena,
                        :demographic_primary_native_hawaiian_pacific_islander,
                        :demographic_primary_white,
@@ -17,6 +18,7 @@ module Hub
                        :demographic_spouse_american_indian_alaska_native,
                        :demographic_spouse_asian,
                        :demographic_spouse_black_african_american,
+                       :demographic_spouse_hispanic_latino,
                        :demographic_spouse_mena,
                        :demographic_spouse_native_hawaiian_pacific_islander,
                        :demographic_spouse_white

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -131,6 +131,15 @@ module ApplicationHelper
     ]
   end
 
+  def yes_no_prefer_not_to_answer_options_for_select
+    [
+      ["", "unfilled"],
+      [I18n.t("general.affirmative"), "yes"],
+      [I18n.t("general.negative"), "no"],
+      [I18n.t("general.prefer_not_to_answer"), "prefer_not_to_answer"],
+    ]
+  end
+
   def submission_status_icon(status)
     case status
     when "intake_in_progress", "fraud_hold"

--- a/app/views/hub/clients/_13614c_page_links.html.erb
+++ b/app/views/hub/clients/_13614c_page_links.html.erb
@@ -16,4 +16,11 @@
   <% else %>
     <%= link_to "3", edit_13614c_form_page3_hub_client_path %>
   <% end %>
+ |
+  <% if current_page == 4 %>
+    4
+  <% else %>
+    <%= link_to "4", edit_13614c_form_page4_hub_client_path %>
+  <% end %>
+
 </div>

--- a/app/views/hub/clients/edit_13614c_form_page4.html.erb
+++ b/app/views/hub/clients/edit_13614c_form_page4.html.erb
@@ -1,0 +1,98 @@
+<% @title = 'Optional Information' %>
+<% content_for :page_title, @title %>
+<% content_for :card do %>
+  <div class="form_13614c slab slab--not-padded">
+    <h1><%= @title %></h1>
+    <p>Last client 13614-C
+      update: <%= @client.last_13614c_update_at&.in_time_zone("America/Los_Angeles")&.strftime("%b %-d %l:%M %p") %></p>
+
+    <%= form_with model: @form,
+                  url: edit_13614c_form_page4_hub_client_path,
+                  method: :put, local: true, builder: VitaMinFormBuilder,
+                  html: { class: 'form-card form-question-13614-page3' } do |f| %>
+      <div>
+        <div style="display: flex; justify-content: space-between;">
+          <h2><%= "The following information is for statistical purposes only. Your responses to these questions are not a part of your tax return and are not transmitted to the
+IRS with your tax return. You are not required to answer these questions." %></h2>
+
+          <%= render '13614c_page_links', current_page: 3 %>
+        </div>
+
+        <hr style="margin-top: 0;"/>
+
+        <div class="grid">
+          <div class="grid__item width-one-whole">
+            <%= f.cfa_select(:demographic_english_conversation, "1. Would you say you can carry on a conversation in English", [
+              ["", :unfilled],
+              [t("general.very_well"), :very_well],
+              [t("general.well"), :well],
+              [t("general.not_well"), :not_well],
+              [t("general.not_at_all"), :not_at_all],
+            ]) %>
+          </div>
+          <div class="grid__item width-one-whole">
+            <%= f.cfa_select(:demographic_english_reading, "2. Would you say you can read a newspaper in English", [
+              ["", :unfilled],
+              [t("general.very_well"), :very_well],
+              [t("general.well"), :well],
+              [t("general.not_well"), :not_well],
+              [t("general.not_at_all"), :not_at_all],
+            ]) %>
+          </div>
+          <div class="grid__item width-one-whole">
+            <%= f.cfa_select(:demographic_disability, "3. Do you or any member of your household have a disability", yes_no_options_for_select) %>
+          </div>
+          <div class="grid__item width-one-whole">
+            <%= f.cfa_select(:demographic_veteran, "4. Are you or your spouse a Veteran of the U.S. Armed Forces", yes_no_options_for_select) %>
+          </div>
+          <div class="grid__item width-one-whole">
+            <div class="form-group">
+              <p class="form-question"><%= "TODO" %></p>
+            </div>
+          </div>
+
+          <div class="grid__item width-one-whole primary-demographic-race">
+            <div class="form-group checkbox-set">
+              <%= f.hub_checkbox(:demographic_primary_american_indian_alaska_native, "TODO", options: { checked_value: true, unchecked_value: false }) %>
+              <%= f.hub_checkbox(:demographic_primary_asian, "TODO", options: { checked_value: true, unchecked_value: false }) %>
+              <%= f.hub_checkbox(:demographic_primary_black_african_american, "TODO", options: { checked_value: true, unchecked_value: false }) %>
+              <%= f.hub_checkbox(:demographic_primary_hispanic_latino, "TODO", options: { checked_value: true, unchecked_value: false }) %>
+              <%= f.hub_checkbox(:demographic_primary_mena, "TODO", options: { checked_value: true, unchecked_value: false }) %>
+              <%= f.hub_checkbox(:demographic_primary_native_hawaiian_pacific_islander, "TODO", options: { checked_value: true, unchecked_value: false }) %>
+              <%= f.hub_checkbox(:demographic_primary_white, "TODO", options: { checked_value: true, unchecked_value: false }) %>
+            </div>
+          </div>
+
+          <div class="grid__item width-one-whole">
+            <div class="form-group">
+              <p class="form-question"><%= "TODO" %></p>
+            </div>
+          </div>
+          <div class="grid__item width-one-whole spouse-demographic-race">
+            <div class="form-group checkbox-set">
+              <%= f.hub_checkbox(:demographic_spouse_american_indian_alaska_native, "TODO", options: { checked_value: true, unchecked_value: false }) %>
+              <%= f.hub_checkbox(:demographic_spouse_asian, "TODO", options: { checked_value: true, unchecked_value: false }) %>
+              <%= f.hub_checkbox(:demographic_spouse_black_african_american, "TODO", options: { checked_value: true, unchecked_value: false }) %>
+              <%= f.hub_checkbox(:demographic_spouse_hispanic_latino, "TODO", options: { checked_value: true, unchecked_value: false }) %>
+              <%= f.hub_checkbox(:demographic_spouse_mena, "TODO", options: { checked_value: true, unchecked_value: false }) %>
+              <%= f.hub_checkbox(:demographic_spouse_native_hawaiian_pacific_islander, "TODO", options: { checked_value: true, unchecked_value: false }) %>
+              <%= f.hub_checkbox(:demographic_spouse_white, "TODO", options: { checked_value: true, unchecked_value: false }) %>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div style="display: flex; justify-content: space-between;">
+        <div>
+          <%= f.submit t("general.save"), class: "button button--cta"%>
+          <%= f.submit t("general.save_and_exit"), class: "button button--cta"%>
+          <%= link_to t("general.cancel"), cancel_13614c_hub_client_path, class: "button button--danger",
+                      data: { confirm: t("general.confirm_exit_without_saving") } %>
+        </div>
+
+        <%= render '13614c_page_links', current_page: 4 %>
+      </div>
+    <% end %>
+  </div>
+<% end %>
+

--- a/app/views/hub/clients/edit_13614c_form_page4.html.erb
+++ b/app/views/hub/clients/edit_13614c_form_page4.html.erb
@@ -28,6 +28,7 @@ IRS with your tax return. You are not required to answer these questions." %></h
               [t("general.well"), :well],
               [t("general.not_well"), :not_well],
               [t("general.not_at_all"), :not_at_all],
+              ["Prefer not to answer", :prefer_not_to_answer],
             ]) %>
           </div>
           <div class="grid__item width-one-whole">
@@ -37,46 +38,47 @@ IRS with your tax return. You are not required to answer these questions." %></h
               [t("general.well"), :well],
               [t("general.not_well"), :not_well],
               [t("general.not_at_all"), :not_at_all],
+              ["Prefer not to answer", :prefer_not_to_answer],
             ]) %>
           </div>
           <div class="grid__item width-one-whole">
-            <%= f.cfa_select(:demographic_disability, "3. Do you or any member of your household have a disability", yes_no_options_for_select) %>
+            <%= f.cfa_select(:demographic_disability, "3. Do you or any member of your household have a disability", yes_no_prefer_not_to_answer_options_for_select) %>
           </div>
           <div class="grid__item width-one-whole">
-            <%= f.cfa_select(:demographic_veteran, "4. Are you or your spouse a Veteran of the U.S. Armed Forces", yes_no_options_for_select) %>
+            <%= f.cfa_select(:demographic_veteran, "4. Are you or your spouse a Veteran of the U.S. Armed Forces", yes_no_prefer_not_to_answer_options_for_select) %>
           </div>
           <div class="grid__item width-one-whole">
             <div class="form-group">
-              <p class="form-question"><%= "TODO" %></p>
+              <p class="form-question">5. What is your race and/or ethnicity? Select all that apply</p>
             </div>
           </div>
 
           <div class="grid__item width-one-whole primary-demographic-race">
             <div class="form-group checkbox-set">
-              <%= f.hub_checkbox(:demographic_primary_american_indian_alaska_native, "TODO", options: { checked_value: true, unchecked_value: false }) %>
-              <%= f.hub_checkbox(:demographic_primary_asian, "TODO", options: { checked_value: true, unchecked_value: false }) %>
-              <%= f.hub_checkbox(:demographic_primary_black_african_american, "TODO", options: { checked_value: true, unchecked_value: false }) %>
-              <%= f.hub_checkbox(:demographic_primary_hispanic_latino, "TODO", options: { checked_value: true, unchecked_value: false }) %>
-              <%= f.hub_checkbox(:demographic_primary_mena, "TODO", options: { checked_value: true, unchecked_value: false }) %>
-              <%= f.hub_checkbox(:demographic_primary_native_hawaiian_pacific_islander, "TODO", options: { checked_value: true, unchecked_value: false }) %>
-              <%= f.hub_checkbox(:demographic_primary_white, "TODO", options: { checked_value: true, unchecked_value: false }) %>
+              <%= f.hub_checkbox(:demographic_primary_american_indian_alaska_native, "American Indian or Alaska Native", options: { checked_value: true, unchecked_value: false }) %>
+              <%= f.hub_checkbox(:demographic_primary_asian, "Asian", options: { checked_value: true, unchecked_value: false }) %>
+              <%= f.hub_checkbox(:demographic_primary_black_african_american, "Black or African American", options: { checked_value: true, unchecked_value: false }) %>
+              <%= f.hub_checkbox(:demographic_primary_hispanic_latino, "Hispanic or Latino", options: { checked_value: true, unchecked_value: false }) %>
+              <%= f.hub_checkbox(:demographic_primary_mena, "Middle Eastern or North African", options: { checked_value: true, unchecked_value: false }) %>
+              <%= f.hub_checkbox(:demographic_primary_native_hawaiian_pacific_islander, "Native Hawaiian or Pacific Islander", options: { checked_value: true, unchecked_value: false }) %>
+              <%= f.hub_checkbox(:demographic_primary_white, "White", options: { checked_value: true, unchecked_value: false }) %>
             </div>
           </div>
 
           <div class="grid__item width-one-whole">
             <div class="form-group">
-              <p class="form-question"><%= "TODO" %></p>
+              <p class="form-question">6. What is your spouse’s race and/or ethnicity? Select all that apply</p>
             </div>
           </div>
           <div class="grid__item width-one-whole spouse-demographic-race">
             <div class="form-group checkbox-set">
-              <%= f.hub_checkbox(:demographic_spouse_american_indian_alaska_native, "TODO", options: { checked_value: true, unchecked_value: false }) %>
-              <%= f.hub_checkbox(:demographic_spouse_asian, "TODO", options: { checked_value: true, unchecked_value: false }) %>
-              <%= f.hub_checkbox(:demographic_spouse_black_african_american, "TODO", options: { checked_value: true, unchecked_value: false }) %>
-              <%= f.hub_checkbox(:demographic_spouse_hispanic_latino, "TODO", options: { checked_value: true, unchecked_value: false }) %>
-              <%= f.hub_checkbox(:demographic_spouse_mena, "TODO", options: { checked_value: true, unchecked_value: false }) %>
-              <%= f.hub_checkbox(:demographic_spouse_native_hawaiian_pacific_islander, "TODO", options: { checked_value: true, unchecked_value: false }) %>
-              <%= f.hub_checkbox(:demographic_spouse_white, "TODO", options: { checked_value: true, unchecked_value: false }) %>
+              <%= f.hub_checkbox(:demographic_spouse_american_indian_alaska_native, "American Indian or Alaska Native", options: { checked_value: true, unchecked_value: false }) %>
+              <%= f.hub_checkbox(:demographic_spouse_asian, "Asian", options: { checked_value: true, unchecked_value: false }) %>
+              <%= f.hub_checkbox(:demographic_spouse_black_african_american, "Black or African American", options: { checked_value: true, unchecked_value: false }) %>
+              <%= f.hub_checkbox(:demographic_spouse_hispanic_latino, "Hispanic or Latino", options: { checked_value: true, unchecked_value: false }) %>
+              <%= f.hub_checkbox(:demographic_spouse_mena, "Middle Eastern or North African", options: { checked_value: true, unchecked_value: false }) %>
+              <%= f.hub_checkbox(:demographic_spouse_native_hawaiian_pacific_islander, "Native Hawaiian or Pacific Islander", options: { checked_value: true, unchecked_value: false }) %>
+              <%= f.hub_checkbox(:demographic_spouse_white, "White", options: { checked_value: true, unchecked_value: false }) %>
             </div>
           </div>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -270,9 +270,11 @@ Rails.application.routes.draw do
           get "/edit_13614c_form_page1", to: "clients#edit_13614c_form_page1", on: :member, as: :edit_13614c_form_page1
           get "/edit_13614c_form_page2", to: "clients#edit_13614c_form_page2", on: :member
           get "/edit_13614c_form_page3", to: "clients#edit_13614c_form_page3", on: :member
+          get "/edit_13614c_form_page4", to: "clients#edit_13614c_form_page4", on: :member
           put "/edit_13614c_form_page1", to: "clients#update_13614c_form_page1", on: :member
           put "/edit_13614c_form_page2", to: "clients#update_13614c_form_page2", on: :member
           put "/edit_13614c_form_page3", to: "clients#update_13614c_form_page3", on: :member
+          put "/edit_13614c_form_page4", to: "clients#update_13614c_form_page4", on: :member
           get "/cancel_13614c", to: "clients#cancel_13614c", on: :member
           get "/bai", to: "clients/bank_accounts#show", on: :member, as: :show_bank_account
           get "/hide-bai", to: "clients/bank_accounts#hide", on: :member, as: :hide_bank_account

--- a/spec/controllers/hub/clients_controller_spec.rb
+++ b/spec/controllers/hub/clients_controller_spec.rb
@@ -2030,6 +2030,73 @@ RSpec.describe Hub::ClientsController do
         end
       end
     end
+
+    describe "#update_13614c_form_page4" do
+      let(:params) {
+        {
+          id: client.id,
+          commit: I18n.t('general.save'),
+          hub_update13614c_form_page4: {
+            demographic_english_conversation: intake.demographic_english_conversation,
+            demographic_english_reading: intake.demographic_english_reading,
+            demographic_disability: intake.demographic_disability,
+            demographic_veteran: intake.demographic_veteran,
+            demographic_primary_american_indian_alaska_native: intake.demographic_primary_american_indian_alaska_native,
+            demographic_primary_asian: intake.demographic_primary_asian,
+            demographic_primary_black_african_american: intake.demographic_primary_black_african_american,
+            demographic_primary_mena: intake.demographic_primary_mena,
+            demographic_primary_native_hawaiian_pacific_islander: intake.demographic_primary_native_hawaiian_pacific_islander,
+            demographic_primary_white: intake.demographic_primary_white,
+            demographic_primary_prefer_not_to_answer_race: intake.demographic_primary_prefer_not_to_answer_race,
+            demographic_spouse_american_indian_alaska_native: intake.demographic_spouse_american_indian_alaska_native,
+            demographic_spouse_asian: intake.demographic_spouse_asian,
+            demographic_spouse_black_african_american: intake.demographic_spouse_black_african_american,
+            demographic_spouse_mena: intake.demographic_spouse_asian,
+            demographic_spouse_native_hawaiian_pacific_islander: intake.demographic_spouse_native_hawaiian_pacific_islander,
+            demographic_spouse_white: intake.demographic_spouse_white,
+          }
+        }
+      }
+
+      it_behaves_like :a_post_action_for_authenticated_users_only, action: :update_13614c_form_page4
+
+      context "with a signed in user" do
+        let(:user) { create(:user, role: create(:organization_lead_role, organization: organization)) }
+
+        before do
+          sign_in user
+        end
+
+        it "updates the clients intake with the 13614c data, creates a system note, and regenerates the pdf when clients press Save" do
+          expect do
+            put :update_13614c_form_page3, params: params
+          end.to have_enqueued_job(GenerateF13614cPdfJob)
+
+          expect(flash[:notice]).to eq I18n.t("general.changes_saved")
+          expect(response).to redirect_to edit_13614c_form_page4_hub_client_path(id: client)
+          client.reload
+          expect(client.intake.preferred_written_language).to eq "Greek"
+
+          system_note = SystemNote::ClientChange.last
+          expect(system_note.client).to eq(client)
+          expect(system_note.user).to eq(user)
+          expect(system_note.data['changes']).to match({ "preferred_written_language" => [intake.preferred_written_language, "Greek"] })
+          expect(client.last_13614c_update_at).to be_within(1.second).of(DateTime.now)
+        end
+
+        it "updates the clients intake with the 13614c page 4 data, and direct to hub client page when client clicks Save and Exit" do
+          expect do
+            put :update_13614c_form_page4, params: params.update(commit: I18n.t('general.save_and_exit'))
+          end.to have_enqueued_job(GenerateF13614cPdfJob)
+
+          expect(flash[:notice]).to eq "Changes saved"
+          expect(response).to redirect_to hub_client_path(id: client.id)
+
+          client.reload
+          expect(client.intake.preferred_written_language).to eq "Greek"
+        end
+      end
+    end
   end
 
   context "as a greeter" do

--- a/spec/controllers/hub/clients_controller_spec.rb
+++ b/spec/controllers/hub/clients_controller_spec.rb
@@ -1979,7 +1979,7 @@ RSpec.describe Hub::ClientsController do
       end
     end
 
-    xdescribe "#update_13614c_form_page3" do
+    describe "#update_13614c_form_page3" do
       let(:params) {
         {
           id: client.id,
@@ -2037,21 +2037,20 @@ RSpec.describe Hub::ClientsController do
           id: client.id,
           commit: I18n.t('general.save'),
           hub_update13614c_form_page4: {
-            demographic_english_conversation: intake.demographic_english_conversation,
+            demographic_english_conversation: "well",
             demographic_english_reading: intake.demographic_english_reading,
-            demographic_disability: intake.demographic_disability,
+            demographic_disability: "yes",
             demographic_veteran: intake.demographic_veteran,
-            demographic_primary_american_indian_alaska_native: intake.demographic_primary_american_indian_alaska_native,
+            demographic_primary_american_indian_alaska_native: true,
             demographic_primary_asian: intake.demographic_primary_asian,
             demographic_primary_black_african_american: intake.demographic_primary_black_african_american,
-            demographic_primary_mena: intake.demographic_primary_mena,
+            demographic_primary_mena: true,
             demographic_primary_native_hawaiian_pacific_islander: intake.demographic_primary_native_hawaiian_pacific_islander,
             demographic_primary_white: intake.demographic_primary_white,
-            demographic_primary_prefer_not_to_answer_race: intake.demographic_primary_prefer_not_to_answer_race,
             demographic_spouse_american_indian_alaska_native: intake.demographic_spouse_american_indian_alaska_native,
             demographic_spouse_asian: intake.demographic_spouse_asian,
             demographic_spouse_black_african_american: intake.demographic_spouse_black_african_american,
-            demographic_spouse_mena: intake.demographic_spouse_asian,
+            demographic_spouse_mena: true,
             demographic_spouse_native_hawaiian_pacific_islander: intake.demographic_spouse_native_hawaiian_pacific_islander,
             demographic_spouse_white: intake.demographic_spouse_white,
           }
@@ -2069,18 +2068,24 @@ RSpec.describe Hub::ClientsController do
 
         it "updates the clients intake with the 13614c data, creates a system note, and regenerates the pdf when clients press Save" do
           expect do
-            put :update_13614c_form_page3, params: params
+            put :update_13614c_form_page4, params: params
           end.to have_enqueued_job(GenerateF13614cPdfJob)
 
           expect(flash[:notice]).to eq I18n.t("general.changes_saved")
           expect(response).to redirect_to edit_13614c_form_page4_hub_client_path(id: client)
           client.reload
-          expect(client.intake.preferred_written_language).to eq "Greek"
+          expect(client.intake.demographic_english_conversation).to eq "well"
 
           system_note = SystemNote::ClientChange.last
           expect(system_note.client).to eq(client)
           expect(system_note.user).to eq(user)
-          expect(system_note.data['changes']).to match({ "preferred_written_language" => [intake.preferred_written_language, "Greek"] })
+          expect(system_note.data['changes']).to match({
+            "demographic_english_conversation" => [intake.demographic_english_conversation, "well"],
+            "demographic_disability" => ["unfilled", "yes"],
+            "demographic_primary_american_indian_alaska_native" => [nil, true],
+            "demographic_primary_mena" => [nil, true],
+            "demographic_spouse_mena" => [nil, true],
+          })
           expect(client.last_13614c_update_at).to be_within(1.second).of(DateTime.now)
         end
 
@@ -2093,7 +2098,7 @@ RSpec.describe Hub::ClientsController do
           expect(response).to redirect_to hub_client_path(id: client.id)
 
           client.reload
-          expect(client.intake.preferred_written_language).to eq "Greek"
+          expect(client.intake.demographic_english_conversation).to eq "well"
         end
       end
     end

--- a/spec/features/hub/edit_13614c_spec.rb
+++ b/spec/features/hub/edit_13614c_spec.rb
@@ -550,5 +550,65 @@ RSpec.describe "a user editing a clients 13614c form" do
 
       expect(intake.cv_14c_page_3_notes_part_3).to eq "Hello, note 3"
     end
+
+    scenario "I can see and update the 13614c page 4 form" do
+      visit hub_client_path(id: client.id)
+      within ".client-profile" do
+        click_on "Edit 13614-C"
+      end
+
+      within '.form_13614c-page-links', match: :first do
+        click_on "4"
+      end
+      expect(page).to have_text "Optional Information"
+      expect(page).to have_text "You are not required to answer these questions"
+
+      # select "Yes", from: "TODO"
+
+      click_on I18n.t("general.save")
+
+      expect(page).to have_text "Optional Information"
+      expect(page).to have_text I18n.t("general.changes_saved")
+
+      intake = client.intake.reload
+      #expect(intake.TODO).to eq "yes"
+    end
+
+    describe "demographic questions on page 4 work in tandem with other flags" do
+      before do
+        client.intake.update(
+          demographic_questions_opt_in: 'no',
+          demographic_spouse_native_hawaiian_pacific_islander: true, # somehow exists in the db even though demographic opt in is false
+        )
+      end
+
+      it "does not write the answers to the PDF unless the client opted in during intake or the hub user has saved page4" do
+        # generate pdf, prove spouse ethnicity is not filled in because demographic_questions_opt_in is false
+        form_fields = PdfForms.new.get_fields(PdfFiller::F13614cPdf.new(client.intake).output_file)
+        expect(form_fields.find { |field| field.name == "form1[0].page4[0].yourRaceEthnicity[0].hawaiianPacific[0]" }.value).to eq("Off")
+        expect(form_fields.find { |field| field.name == "form1[0].page4[0].yourRaceEthnicity[0].blackAfricanAmerican[0]" }.value).to eq("Off")
+
+        visit hub_client_path(id: client.id)
+        within ".client-profile" do
+          click_on "Edit 13614-C"
+        end
+
+        within '.form_13614c-page-links', match: :first do
+          click_on "4"
+        end
+
+        within ".spouse-demographic-race" do
+          uncheck "Native Hawaiian or Pacific Islander"
+          check "Black or African American"
+        end
+
+        click_on I18n.t("general.save")
+
+        # generate pdf, prove spouse ethnicity is filled in because demographic_questions_hub_edit is true
+        form_fields = PdfForms.new.get_fields(PdfFiller::F13614cPdf.new(client.reload.intake).output_file)
+        expect(form_fields.find { |field| field.name == "form1[0].page4[0].yourRaceEthnicity[0].hawaiianPacific[0]" }.value).to eq("")
+        expect(form_fields.find { |field| field.name == "form1[0].page4[0].yourRaceEthnicity[0].blackAfricanAmerican[0]" }.value).to eq("1")
+      end
+    end
   end
 end

--- a/spec/features/hub/edit_13614c_spec.rb
+++ b/spec/features/hub/edit_13614c_spec.rb
@@ -563,7 +563,29 @@ RSpec.describe "a user editing a clients 13614c form" do
       expect(page).to have_text "Optional Information"
       expect(page).to have_text "You are not required to answer these questions"
 
-      # select "Yes", from: "TODO"
+      select "Very well", from: "hub_update13614c_form_page4_demographic_english_conversation"
+      select "Prefer not to answer", from: "hub_update13614c_form_page4_demographic_english_reading"
+      select "Yes", from: "hub_update13614c_form_page4_demographic_disability"
+      select "Prefer not to answer", from: "hub_update13614c_form_page4_demographic_veteran"
+
+     within ".primary-demographic-race" do
+        check "American Indian or Alaska Native"
+        check "Asian"
+        check "Black or African American"
+        check "Hispanic or Latino"
+        check "Middle Eastern or North African"
+        # check "Native Hawaiian or Pacific Islander"
+        check "White"
+      end
+      within ".spouse-demographic-race" do
+        check "American Indian or Alaska Native"
+        # check "Asian"
+        check "Black or African American"
+        check "Hispanic or Latino"
+        check "Middle Eastern or North African"
+        check "Native Hawaiian or Pacific Islander"
+        check "White"
+      end
 
       click_on I18n.t("general.save")
 
@@ -571,10 +593,30 @@ RSpec.describe "a user editing a clients 13614c form" do
       expect(page).to have_text I18n.t("general.changes_saved")
 
       intake = client.intake.reload
-      #expect(intake.TODO).to eq "yes"
+      expect(intake.demographic_english_conversation).to eq "very_well"
+      expect(intake.demographic_english_reading).to eq "prefer_not_to_answer"
+      expect(intake.demographic_disability).to eq "yes"
+      expect(intake.demographic_veteran).to eq "prefer_not_to_answer"
+
+      expect(intake.demographic_primary_american_indian_alaska_native).to be_truthy
+      expect(intake.demographic_primary_asian).to be_truthy
+      expect(intake.demographic_primary_black_african_american).to be_truthy
+      expect(intake.demographic_primary_hispanic_latino).to be_truthy
+      expect(intake.demographic_primary_mena).to be_truthy
+      expect(intake.demographic_primary_native_hawaiian_pacific_islander).to be_falsy
+      expect(intake.demographic_primary_white).to be_truthy
+
+      expect(intake.demographic_spouse_american_indian_alaska_native).to be_truthy
+      expect(intake.demographic_spouse_asian).to be_falsy
+      expect(intake.demographic_spouse_black_african_american).to be_truthy
+      expect(intake.demographic_spouse_hispanic_latino).to be_truthy
+      expect(intake.demographic_spouse_mena).to be_truthy
+      expect(intake.demographic_spouse_native_hawaiian_pacific_islander).to be_truthy
+      expect(intake.demographic_spouse_white).to be_truthy
     end
 
-    describe "demographic questions on page 4 work in tandem with other flags" do
+    # TODO reenable this after GYR1-603 / https://github.com/codeforamerica/vita-min/pull/5406 gets merged.
+    xdescribe "demographic questions on page 4 work in tandem with other flags" do
       before do
         client.intake.update(
           demographic_questions_opt_in: 'no',
@@ -585,8 +627,8 @@ RSpec.describe "a user editing a clients 13614c form" do
       it "does not write the answers to the PDF unless the client opted in during intake or the hub user has saved page4" do
         # generate pdf, prove spouse ethnicity is not filled in because demographic_questions_opt_in is false
         form_fields = PdfForms.new.get_fields(PdfFiller::F13614cPdf.new(client.intake).output_file)
-        expect(form_fields.find { |field| field.name == "form1[0].page4[0].yourRaceEthnicity[0].hawaiianPacific[0]" }.value).to eq("Off")
-        expect(form_fields.find { |field| field.name == "form1[0].page4[0].yourRaceEthnicity[0].blackAfricanAmerican[0]" }.value).to eq("Off")
+        expect(form_fields.find { |field| field.name == "form1[0].page4[0].yourSpousesRaceEthnicity[0].hawaiianPacific[0]" }.value).to eq("Off")
+        expect(form_fields.find { |field| field.name == "form1[0].page4[0].yourSpousesRaceEthnicity[0].blackAfricanAmerican[0]" }.value).to eq("Off")
 
         visit hub_client_path(id: client.id)
         within ".client-profile" do
@@ -606,8 +648,8 @@ RSpec.describe "a user editing a clients 13614c form" do
 
         # generate pdf, prove spouse ethnicity is filled in because demographic_questions_hub_edit is true
         form_fields = PdfForms.new.get_fields(PdfFiller::F13614cPdf.new(client.reload.intake).output_file)
-        expect(form_fields.find { |field| field.name == "form1[0].page4[0].yourRaceEthnicity[0].hawaiianPacific[0]" }.value).to eq("")
-        expect(form_fields.find { |field| field.name == "form1[0].page4[0].yourRaceEthnicity[0].blackAfricanAmerican[0]" }.value).to eq("1")
+        expect(form_fields.find { |field| field.name == "form1[0].page4[0].yourSpousesRaceEthnicity[0].hawaiianPacific[0]" }.value).to eq("Off")
+        expect(form_fields.find { |field| field.name == "form1[0].page4[0].yourSpousesRaceEthnicity[0].blackAfricanAmerican[0]]" }.value).to eq("1")
       end
     end
   end


### PR DESCRIPTION
## Link to pivotal/JIRA issue

- https://codeforamerica.atlassian.net/browse/GYR1-615

## Is PM acceptance required?

- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main

## What was done?
- Created a new page 4 in the Hub editable 14-C flow
- The page contains fields that were previously in page 3 for ty2023. Light updates were made to the front-end code to match ty2024.
- Reworked the spec tests.
- There's a link to page 4 now in the footer of the hub 14-c pages.

> [!NOTE] 
> There's an odd spec test at the end of spec/features/hub/edit_13614c_spec.rb that tests certain flags that pertain to writing or not writing to the PDF. it's ready for this year's pdf but it's disabled right now, but i'll separately get a PR up once GYR1 603 (https://github.com/codeforamerica/vita-min/pull/5406) gets merged (demographic question mappings). (I am keeping track of this task personally.)

## How to test?

- As usual, ensure the fields match what's in page 4 of the ty2024 14-C pdf.
- add values everywhere and ensure they persist after a save
- similarly, remove all values, save, and ensure they're still removed
- try out the "Prefer not to answer" option, where it exists.
- ensure the "1" | "2" | "3" | "4" links in the footer work, generally.

## Data Fields

<img width="929" alt="image" src="https://github.com/user-attachments/assets/115b9d3d-ac87-4031-bb67-9541d96fac75" />
 
## Screenshots (for visual changes)

- Before: it's a new page! But you can see what the page 3 was for last year, which has last year's version of these questions; check the 'before' screenshots here: https://github.com/codeforamerica/vita-min/pull/5397

- After:

<img width="1316" alt="image" src="https://github.com/user-attachments/assets/65179c89-cc9e-49eb-8b4f-7eae057a2e3d" />

