### PR TITLE
Add MD Subtraction Followups

### DIFF
--- a/app/models/state_file_md1099_r_followup.rb
+++ b/app/models/state_file_md1099_r_followup.rb
@@ -2,12 +2,14 @@
 #
 # Table name: state_file_md1099_r_followups
 #
-#  id         :bigint           not null, primary key
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id            :bigint           not null, primary key
+#  income_source :integer          default("unfilled"), not null
+#  service_type  :integer          default("unfilled"), not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
 #
 class StateFileMd1099RFollowup < ApplicationRecord
-
   has_one :state_file1099_r, inverse_of: :state_specific_followup
-
+  enum income_source: { unfilled: 0, pension_annuity_endowment: 1, other: 2 }, _prefix: :income_source
+  enum service_type: { unfilled: 0, military: 1, public_safety: 2, none: 3 }, _prefix: :service_type
 end

--- a/app/models/state_file_md_intake.rb
+++ b/app/models/state_file_md_intake.rb
@@ -123,6 +123,8 @@ class StateFileMdIntake < StateFileBaseIntake
   enum spouse_did_not_have_health_insurance: { unfilled: 0, yes: 1, no: 2}, _prefix: :spouse_did_not_have_health_insurance
   enum bank_authorization_confirmed: { unfilled: 0, yes: 1, no: 2 }, _prefix: :bank_authorization_confirmed
   enum has_joint_account_holder: { unfilled: 0, yes: 1, no: 2 }, _prefix: :has_joint_account_holder
+  enum primary_disabled: { unfilled: 0, yes: 1, no: 2 }, _prefix: :primary_disabled
+  enum spouse_disabled: { unfilled: 0, yes: 1, no: 2 }, _prefix: :spouse_disabled
 
   def disqualifying_df_data_reason
     w2_states = direct_file_data.parsed_xml.css('W2StateLocalTaxGrp W2StateTaxGrp StateAbbreviationCd')

--- a/db/migrate/20250123160619_add1099_r_subtraction_follow_ups.rb
+++ b/db/migrate/20250123160619_add1099_r_subtraction_follow_ups.rb
@@ -1,0 +1,8 @@
+class Add1099RSubtractionFollowUps < ActiveRecord::Migration[7.1]
+  def change
+    add_column :state_file_md1099_r_followups, :income_source, :integer, default: 0, null: false
+    add_column :state_file_md1099_r_followups, :service_type, :integer, default: 0, null: false
+    add_column :state_file_md_intakes, :primary_disabled, :integer, default: 0, null: false
+    add_column :state_file_md_intakes, :secondary_disabled, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_21_171015) do
+ActiveRecord::Schema[7.1].define(version: 2025_01_23_160619) do
+  create_schema "analytics"
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -2029,6 +2031,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_21_171015) do
 
   create_table "state_file_md1099_r_followups", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.integer "income_source", default: 0, null: false
+    t.integer "service_type", default: 0, null: false
     t.datetime "updated_at", null: false
   end
 
@@ -2090,6 +2094,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_21_171015) do
     t.string "political_subdivision"
     t.date "primary_birth_date"
     t.integer "primary_did_not_have_health_insurance", default: 0, null: false
+    t.integer "primary_disabled", default: 0, null: false
     t.integer "primary_esigned", default: 0, null: false
     t.datetime "primary_esigned_at"
     t.string "primary_first_name"
@@ -2106,6 +2111,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_21_171015) do
     t.string "referrer"
     t.string "residence_county"
     t.string "routing_number"
+    t.integer "secondary_disabled", default: 0, null: false
     t.integer "sign_in_count", default: 0, null: false
     t.integer "sms_notification_opt_in", default: 0, null: false
     t.string "source"

--- a/spec/factories/state_file_md1099_r_followups.rb
+++ b/spec/factories/state_file_md1099_r_followups.rb
@@ -2,9 +2,11 @@
 #
 # Table name: state_file_md1099_r_followups
 #
-#  id         :bigint           not null, primary key
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id            :bigint           not null, primary key
+#  income_source :integer          default("unfilled"), not null
+#  service_type  :integer          default("unfilled"), not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
 #
 FactoryBot.define do
   factory :state_file_md1099_r_followup do

--- a/spec/models/state_file_md1099_r_followup_spec.rb
+++ b/spec/models/state_file_md1099_r_followup_spec.rb
@@ -2,9 +2,11 @@
 #
 # Table name: state_file_md1099_r_followups
 #
-#  id         :bigint           not null, primary key
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id            :bigint           not null, primary key
+#  income_source :integer          default("unfilled"), not null
+#  service_type  :integer          default("unfilled"), not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
 #
 require 'rails_helper'
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/FYST-817

## Is PM acceptance required? (delete one)
- No - merge after code review approval

## What was done?
This adds fields to register responses for MD 1099R subtraction questions regarding income source and primary & spouse's disabilities. It helps to view these two UIs to understand the data model choices.

![image](https://github.com/user-attachments/assets/c58d211b-78aa-4456-a342-2815d6208d0a)

![image](https://github.com/user-attachments/assets/6ea1ca55-fb02-4a6c-8eb8-191d788bf717)

I've added the `primary_disabled` & `spouse_disabled` to the `state_file_md_intake`, since the answer will apply to _all_ 1099Rs. I've added the `income_source` and `service_type` to `state_file_md_1099R_followup` since these answers will apply to each `state_file1099_r `.

I hope this explanation makes sense. Please ask if it doesn't!

## How to test?
- Risk Assessment
If these database changes don't make sense, they can be changed! I hope they set up the following stories well. 
