### PR TITLE
Send resubmitted success message only if client initiated resubmission

### DIFF
--- a/app/state_machines/efile_submission_state_machine.rb
+++ b/app/state_machines/efile_submission_state_machine.rb
@@ -67,8 +67,7 @@ class EfileSubmissionStateMachine
     # only send if the most recent efile_submission was notified_of_rejection (i.e. any efile_submission_transitions have :auto_cancel)
     # previous_submission_id on EfileSubmission will lead us to the original submission
     # if original submission has any transitions with "notified_of_rejection" "to_state" then we DO send message, otherwise skip
-    if submission&.previous_submission_id.present?
-    else
+    unless submission.admin_resubmission?
       StateFile::AfterTransitionMessagingService.new(submission).send_efile_submission_successful_submission_message
     end
     submission.transition_to(:bundling)

--- a/app/state_machines/efile_submission_state_machine.rb
+++ b/app/state_machines/efile_submission_state_machine.rb
@@ -64,7 +64,13 @@ class EfileSubmissionStateMachine
   end
 
   after_transition(to: :preparing) do |submission|
-    StateFile::AfterTransitionMessagingService.new(submission).send_efile_submission_successful_submission_message
+    # only send if the most recent efile_submission was notified_of_rejection (i.e. any efile_submission_transitions have :auto_cancel)
+    # previous_submission_id on EfileSubmission will lead us to the original submission
+    # if original submission has any transitions with "notified_of_rejection" "to_state" then we DO send message, otherwise skip
+    if submission&.previous_submission_id.present?
+    else
+      StateFile::AfterTransitionMessagingService.new(submission).send_efile_submission_successful_submission_message
+    end
     submission.transition_to(:bundling)
   end
 

--- a/app/state_machines/efile_submission_state_machine.rb
+++ b/app/state_machines/efile_submission_state_machine.rb
@@ -64,9 +64,6 @@ class EfileSubmissionStateMachine
   end
 
   after_transition(to: :preparing) do |submission|
-    # only send if the most recent efile_submission was notified_of_rejection (i.e. any efile_submission_transitions have :auto_cancel)
-    # previous_submission_id on EfileSubmission will lead us to the original submission
-    # if original submission has any transitions with "notified_of_rejection" "to_state" then we DO send message, otherwise skip
     unless submission.admin_resubmission?
       StateFile::AfterTransitionMessagingService.new(submission).send_efile_submission_successful_submission_message
     end

--- a/spec/state_machines/efile_submission_state_machine_spec.rb
+++ b/spec/state_machines/efile_submission_state_machine_spec.rb
@@ -17,9 +17,35 @@ describe EfileSubmissionStateMachine do
         allow(messaging_service).to receive(:send_efile_submission_successful_submission_message)
       end
 
-      it "sends a successful submission message" do
-        submission.transition_to!(:preparing)
-        expect(messaging_service).to have_received(:send_efile_submission_successful_submission_message)
+      context "with a previous submission" do
+        let(:previous_submission) { create(:efile_submission, :resubmitted, :for_state) }
+
+        before do
+          allow(submission).to receive(:previous_submission_id).and_return(previous_submission.id)
+        end
+
+        context "client was notified_of_rejection" do
+          let!(:notified_of_rejection_transition) { create(:efile_submission_transition, efile_submission: previous_submission, to_state: "notified_of_rejection", most_recent: false, sort_key: 80) }
+
+          it "sends a successful submission message" do
+            submission.transition_to!(:preparing)
+            expect(messaging_service).to have_received(:send_efile_submission_successful_submission_message)
+          end
+        end
+
+        context "client was not notified_of_rejection" do
+          it "does not send a successful submission message" do
+            submission.transition_to!(:preparing)
+            expect(messaging_service).not_to have_received(:send_efile_submission_successful_submission_message)
+          end
+        end
+      end
+
+      context "without a previous submission" do
+        it "sends a successful submission message" do
+          submission.transition_to!(:preparing)
+          expect(messaging_service).to have_received(:send_efile_submission_successful_submission_message)
+        end
       end
     end
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/FYST-1668

## Is PM acceptance required?
- No - merge after code review approval

## What was done?
- We were sending resubmission successful messages to clients who never received a message that their submission failed/was rejected
- We put in a condition to check if the submission was resubmitted by an admin from the hub before sending resubmission successful message 

## How to test?
- Updated unit test for state machine for efile submissions
- Tested locally

