### PR TITLE
GYR1-614 Addendum -- Sort annotations on intakes

### DIFF
--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -4,7 +4,6 @@
 #
 #  id                                                   :bigint           not null, primary key
 #  additional_info                                      :string
-#  additional_notes_comments                            :text
 #  adopted_child                                        :integer          default(0), not null
 #  advance_ctc_amount_received                          :integer
 #  advance_ctc_entry_method                             :integer          default(0), not null

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -4,6 +4,7 @@
 #
 #  id                                                   :bigint           not null, primary key
 #  additional_info                                      :string
+#  additional_notes_comments                            :text
 #  adopted_child                                        :integer          default(0), not null
 #  advance_ctc_amount_received                          :integer
 #  advance_ctc_entry_method                             :integer          default(0), not null
@@ -32,8 +33,15 @@
 #  contributed_to_other_retirement_account              :integer          default(0), not null
 #  contributed_to_roth_ira                              :integer          default(0), not null
 #  current_step                                         :string
+#  cv_1095a_cb                                          :integer          default(0), not null
+#  cv_1098_cb                                           :integer          default(0), not null
+#  cv_1098_count                                        :integer
+#  cv_1098e_cb                                          :integer          default(0), not null
+#  cv_1098t_cb                                          :integer          default(0), not null
+#  cv_1099a_cb                                          :integer          default(0), not null
 #  cv_1099b_cb                                          :integer          default(0), not null
 #  cv_1099b_count                                       :integer
+#  cv_1099c_cb                                          :integer          default(0), not null
 #  cv_1099div_cb                                        :integer          default(0), not null
 #  cv_1099div_count                                     :integer
 #  cv_1099g_cb                                          :integer          default(0), not null
@@ -50,44 +58,18 @@
 #  cv_1099r_charitable_dist_amt                         :decimal(12, 2)
 #  cv_1099r_charitable_dist_cb                          :integer          default(0), not null
 #  cv_1099r_count                                       :integer
-#  cv_alimony_excluded_from_income_cb                   :integer          default(0), not null
-#  cv_alimony_income_amt                                :decimal(12, 2)
-#  cv_alimony_income_cb                                 :integer          default(0), not null
-#  cv_capital_loss_carryover_cb                         :integer          default(0), not null
-#  cv_disability_benefits_1099r_or_w2_cb                :integer          default(0), not null
-#  cv_disability_benefits_1099r_or_w2_count             :integer
-#  cv_had_tips_cb                                       :integer          default(0), not null
-#  cv_itemized_last_year_cb                             :integer          default(0), not null
-#  cv_local_tax_refund_amt                              :decimal(12, 2)
-#  cv_local_tax_refund_cb                               :integer          default(0), not null
-#  cv_other_income_cb                                   :integer          default(0), not null
-#  cv_other_income_reported_elsewhere_cb                :integer          default(0), not null
-#  cv_p2_notes_comments                                 :string
-#  cv_rental_expense_amt                                :decimal(12, 2)
-#  cv_rental_expense_cb                                 :integer          default(0), not null
-#  cv_rental_income_cb                                  :integer          default(0), not null
-#  cv_schedule_c_cb                                     :integer          default(0), not null
-#  cv_schedule_c_expenses_amt                           :decimal(12, 2)
-#  cv_schedule_c_expenses_cb                            :integer          default(0), not null
-#  cv_ssa1099_rrb1099_cb                                :integer          default(0), not null
-#  cv_ssa1099_rrb1099_count                             :integer
-#  cv_w2g_or_other_gambling_winnings_cb                 :integer          default(0), not null
-#  cv_w2g_or_other_gambling_winnings_count              :integer
-#  cv_w2s_cb                                            :integer          default(0), not null
-#  cv_w2s_count                                         :integer
-#  cv_1095a_cb                                          :integer          default(0), not null
-#  cv_1098_cb                                           :integer          default(0), not null
-#  cv_1098_count                                        :integer
-#  cv_1098e_cb                                          :integer          default(0), not null
-#  cv_1098t_cb                                          :integer          default(0), not null
-#  cv_1099a_cb                                          :integer          default(0), not null
-#  cv_1099c_cb                                          :integer          default(0), not null
 #  cv_1099s_cb                                          :integer          default(0), not null
 #  cv_14c_page_3_notes_part_1                           :string
 #  cv_14c_page_3_notes_part_2                           :string
 #  cv_14c_page_3_notes_part_3                           :string
+#  cv_alimony_excluded_from_income_cb                   :integer          default(0), not null
 #  cv_alimony_income_adjustment_yn_cb                   :integer          default(0), not null
+#  cv_alimony_income_amt                                :decimal(12, 2)
+#  cv_alimony_income_cb                                 :integer          default(0), not null
+#  cv_capital_loss_carryover_cb                         :integer          default(0), not null
 #  cv_child_dependent_care_credit_cb                    :integer          default(0), not null
+#  cv_disability_benefits_1099r_or_w2_cb                :integer          default(0), not null
+#  cv_disability_benefits_1099r_or_w2_count             :integer
 #  cv_disaster_relief_impacts_return_cb                 :integer          default(0), not null
 #  cv_edu_credit_or_tuition_deduction_cb                :integer          default(0), not null
 #  cv_edu_expenses_deduction_amt                        :decimal(12, 2)
@@ -97,17 +79,36 @@
 #  cv_energy_efficient_home_improv_credit_cb            :integer          default(0), not null
 #  cv_estimated_tax_payments_amt                        :decimal(12, 2)
 #  cv_estimated_tax_payments_cb                         :integer          default(0), not null
+#  cv_had_tips_cb                                       :integer          default(0), not null
 #  cv_hsa_contrib_cb                                    :integer          default(0), not null
 #  cv_hsa_distrib_cb                                    :integer          default(0), not null
+#  cv_itemized_last_year_cb                             :integer          default(0), not null
 #  cv_last_years_refund_applied_to_this_yr_amt          :decimal(12, 2)
 #  cv_last_years_refund_applied_to_this_yr_cb           :integer          default(0), not null
 #  cv_last_years_return_available_cb                    :integer          default(0), not null
+#  cv_local_tax_refund_amt                              :decimal(12, 2)
+#  cv_local_tax_refund_cb                               :integer          default(0), not null
 #  cv_med_expense_itemized_deduction_cb                 :integer          default(0), not null
 #  cv_med_expense_standard_deduction_cb                 :integer          default(0), not null
+#  cv_other_income_cb                                   :integer          default(0), not null
+#  cv_other_income_reported_elsewhere_cb                :integer          default(0), not null
+#  cv_p2_notes_comments                                 :string
 #  cv_paid_alimony_w_spouse_ssn_amt                     :decimal(12, 2)
 #  cv_paid_alimony_w_spouse_ssn_cb                      :integer          default(0), not null
+#  cv_rental_expense_amt                                :decimal(12, 2)
+#  cv_rental_expense_cb                                 :integer          default(0), not null
+#  cv_rental_income_cb                                  :integer          default(0), not null
+#  cv_schedule_c_cb                                     :integer          default(0), not null
+#  cv_schedule_c_expenses_amt                           :decimal(12, 2)
+#  cv_schedule_c_expenses_cb                            :integer          default(0), not null
+#  cv_ssa1099_rrb1099_cb                                :integer          default(0), not null
+#  cv_ssa1099_rrb1099_count                             :integer
 #  cv_tax_credit_disallowed_reason                      :string
 #  cv_taxable_scholarship_income_cb                     :integer          default(0), not null
+#  cv_w2g_or_other_gambling_winnings_cb                 :integer          default(0), not null
+#  cv_w2g_or_other_gambling_winnings_count              :integer
+#  cv_w2s_cb                                            :integer          default(0), not null
+#  cv_w2s_count                                         :integer
 #  demographic_disability                               :integer          default(0), not null
 #  demographic_english_conversation                     :integer          default(0), not null
 #  demographic_english_reading                          :integer          default(0), not null

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -4,7 +4,6 @@
 #
 #  id                                                   :bigint           not null, primary key
 #  additional_info                                      :string
-#  additional_notes_comments                            :text
 #  adopted_child                                        :integer          default(0), not null
 #  advance_ctc_amount_received                          :integer
 #  advance_ctc_entry_method                             :integer          default("unfilled"), not null

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -4,6 +4,7 @@
 #
 #  id                                                   :bigint           not null, primary key
 #  additional_info                                      :string
+#  additional_notes_comments                            :text
 #  adopted_child                                        :integer          default(0), not null
 #  advance_ctc_amount_received                          :integer
 #  advance_ctc_entry_method                             :integer          default("unfilled"), not null
@@ -32,8 +33,15 @@
 #  contributed_to_other_retirement_account              :integer          default(0), not null
 #  contributed_to_roth_ira                              :integer          default(0), not null
 #  current_step                                         :string
+#  cv_1095a_cb                                          :integer          default(0), not null
+#  cv_1098_cb                                           :integer          default(0), not null
+#  cv_1098_count                                        :integer
+#  cv_1098e_cb                                          :integer          default(0), not null
+#  cv_1098t_cb                                          :integer          default(0), not null
+#  cv_1099a_cb                                          :integer          default(0), not null
 #  cv_1099b_cb                                          :integer          default(0), not null
 #  cv_1099b_count                                       :integer
+#  cv_1099c_cb                                          :integer          default(0), not null
 #  cv_1099div_cb                                        :integer          default(0), not null
 #  cv_1099div_count                                     :integer
 #  cv_1099g_cb                                          :integer          default(0), not null
@@ -50,44 +58,18 @@
 #  cv_1099r_charitable_dist_amt                         :decimal(12, 2)
 #  cv_1099r_charitable_dist_cb                          :integer          default(0), not null
 #  cv_1099r_count                                       :integer
-#  cv_alimony_excluded_from_income_cb                   :integer          default(0), not null
-#  cv_alimony_income_amt                                :decimal(12, 2)
-#  cv_alimony_income_cb                                 :integer          default(0), not null
-#  cv_capital_loss_carryover_cb                         :integer          default(0), not null
-#  cv_disability_benefits_1099r_or_w2_cb                :integer          default(0), not null
-#  cv_disability_benefits_1099r_or_w2_count             :integer
-#  cv_had_tips_cb                                       :integer          default(0), not null
-#  cv_itemized_last_year_cb                             :integer          default(0), not null
-#  cv_local_tax_refund_amt                              :decimal(12, 2)
-#  cv_local_tax_refund_cb                               :integer          default(0), not null
-#  cv_other_income_cb                                   :integer          default(0), not null
-#  cv_other_income_reported_elsewhere_cb                :integer          default(0), not null
-#  cv_p2_notes_comments                                 :string
-#  cv_rental_expense_amt                                :decimal(12, 2)
-#  cv_rental_expense_cb                                 :integer          default(0), not null
-#  cv_rental_income_cb                                  :integer          default(0), not null
-#  cv_schedule_c_cb                                     :integer          default(0), not null
-#  cv_schedule_c_expenses_amt                           :decimal(12, 2)
-#  cv_schedule_c_expenses_cb                            :integer          default(0), not null
-#  cv_ssa1099_rrb1099_cb                                :integer          default(0), not null
-#  cv_ssa1099_rrb1099_count                             :integer
-#  cv_w2g_or_other_gambling_winnings_cb                 :integer          default(0), not null
-#  cv_w2g_or_other_gambling_winnings_count              :integer
-#  cv_w2s_cb                                            :integer          default(0), not null
-#  cv_w2s_count                                         :integer
-#  cv_1095a_cb                                          :integer          default(0), not null
-#  cv_1098_cb                                           :integer          default(0), not null
-#  cv_1098_count                                        :integer
-#  cv_1098e_cb                                          :integer          default(0), not null
-#  cv_1098t_cb                                          :integer          default(0), not null
-#  cv_1099a_cb                                          :integer          default(0), not null
-#  cv_1099c_cb                                          :integer          default(0), not null
 #  cv_1099s_cb                                          :integer          default(0), not null
 #  cv_14c_page_3_notes_part_1                           :string
 #  cv_14c_page_3_notes_part_2                           :string
 #  cv_14c_page_3_notes_part_3                           :string
+#  cv_alimony_excluded_from_income_cb                   :integer          default(0), not null
 #  cv_alimony_income_adjustment_yn_cb                   :integer          default(0), not null
+#  cv_alimony_income_amt                                :decimal(12, 2)
+#  cv_alimony_income_cb                                 :integer          default(0), not null
+#  cv_capital_loss_carryover_cb                         :integer          default(0), not null
 #  cv_child_dependent_care_credit_cb                    :integer          default(0), not null
+#  cv_disability_benefits_1099r_or_w2_cb                :integer          default(0), not null
+#  cv_disability_benefits_1099r_or_w2_count             :integer
 #  cv_disaster_relief_impacts_return_cb                 :integer          default(0), not null
 #  cv_edu_credit_or_tuition_deduction_cb                :integer          default(0), not null
 #  cv_edu_expenses_deduction_amt                        :decimal(12, 2)
@@ -97,17 +79,36 @@
 #  cv_energy_efficient_home_improv_credit_cb            :integer          default(0), not null
 #  cv_estimated_tax_payments_amt                        :decimal(12, 2)
 #  cv_estimated_tax_payments_cb                         :integer          default(0), not null
+#  cv_had_tips_cb                                       :integer          default(0), not null
 #  cv_hsa_contrib_cb                                    :integer          default(0), not null
 #  cv_hsa_distrib_cb                                    :integer          default(0), not null
+#  cv_itemized_last_year_cb                             :integer          default(0), not null
 #  cv_last_years_refund_applied_to_this_yr_amt          :decimal(12, 2)
 #  cv_last_years_refund_applied_to_this_yr_cb           :integer          default(0), not null
 #  cv_last_years_return_available_cb                    :integer          default(0), not null
+#  cv_local_tax_refund_amt                              :decimal(12, 2)
+#  cv_local_tax_refund_cb                               :integer          default(0), not null
 #  cv_med_expense_itemized_deduction_cb                 :integer          default(0), not null
 #  cv_med_expense_standard_deduction_cb                 :integer          default(0), not null
+#  cv_other_income_cb                                   :integer          default(0), not null
+#  cv_other_income_reported_elsewhere_cb                :integer          default(0), not null
+#  cv_p2_notes_comments                                 :string
 #  cv_paid_alimony_w_spouse_ssn_amt                     :decimal(12, 2)
 #  cv_paid_alimony_w_spouse_ssn_cb                      :integer          default(0), not null
+#  cv_rental_expense_amt                                :decimal(12, 2)
+#  cv_rental_expense_cb                                 :integer          default(0), not null
+#  cv_rental_income_cb                                  :integer          default(0), not null
+#  cv_schedule_c_cb                                     :integer          default(0), not null
+#  cv_schedule_c_expenses_amt                           :decimal(12, 2)
+#  cv_schedule_c_expenses_cb                            :integer          default(0), not null
+#  cv_ssa1099_rrb1099_cb                                :integer          default(0), not null
+#  cv_ssa1099_rrb1099_count                             :integer
 #  cv_tax_credit_disallowed_reason                      :string
 #  cv_taxable_scholarship_income_cb                     :integer          default(0), not null
+#  cv_w2g_or_other_gambling_winnings_cb                 :integer          default(0), not null
+#  cv_w2g_or_other_gambling_winnings_count              :integer
+#  cv_w2s_cb                                            :integer          default(0), not null
+#  cv_w2s_count                                         :integer
 #  demographic_disability                               :integer          default(0), not null
 #  demographic_english_conversation                     :integer          default(0), not null
 #  demographic_english_reading                          :integer          default(0), not null

--- a/app/models/intake/gyr_intake.rb
+++ b/app/models/intake/gyr_intake.rb
@@ -4,7 +4,6 @@
 #
 #  id                                                   :bigint           not null, primary key
 #  additional_info                                      :string
-#  additional_notes_comments                            :text
 #  adopted_child                                        :integer          default("unfilled"), not null
 #  advance_ctc_amount_received                          :integer
 #  advance_ctc_entry_method                             :integer          default(0), not null

--- a/app/models/intake/gyr_intake.rb
+++ b/app/models/intake/gyr_intake.rb
@@ -4,6 +4,7 @@
 #
 #  id                                                   :bigint           not null, primary key
 #  additional_info                                      :string
+#  additional_notes_comments                            :text
 #  adopted_child                                        :integer          default("unfilled"), not null
 #  advance_ctc_amount_received                          :integer
 #  advance_ctc_entry_method                             :integer          default(0), not null
@@ -32,8 +33,15 @@
 #  contributed_to_other_retirement_account              :integer          default("unfilled"), not null
 #  contributed_to_roth_ira                              :integer          default("unfilled"), not null
 #  current_step                                         :string
+#  cv_1095a_cb                                          :integer          default("unfilled"), not null
+#  cv_1098_cb                                           :integer          default("unfilled"), not null
+#  cv_1098_count                                        :integer
+#  cv_1098e_cb                                          :integer          default("unfilled"), not null
+#  cv_1098t_cb                                          :integer          default("unfilled"), not null
+#  cv_1099a_cb                                          :integer          default("unfilled"), not null
 #  cv_1099b_cb                                          :integer          default("unfilled"), not null
 #  cv_1099b_count                                       :integer
+#  cv_1099c_cb                                          :integer          default("unfilled"), not null
 #  cv_1099div_cb                                        :integer          default("unfilled"), not null
 #  cv_1099div_count                                     :integer
 #  cv_1099g_cb                                          :integer          default("unfilled"), not null
@@ -50,44 +58,18 @@
 #  cv_1099r_charitable_dist_amt                         :decimal(12, 2)
 #  cv_1099r_charitable_dist_cb                          :integer          default("unfilled"), not null
 #  cv_1099r_count                                       :integer
-#  cv_alimony_excluded_from_income_cb                   :integer          default("unfilled"), not null
-#  cv_alimony_income_amt                                :decimal(12, 2)
-#  cv_alimony_income_cb                                 :integer          default("unfilled"), not null
-#  cv_capital_loss_carryover_cb                         :integer          default("unfilled"), not null
-#  cv_disability_benefits_1099r_or_w2_cb                :integer          default("unfilled"), not null
-#  cv_disability_benefits_1099r_or_w2_count             :integer
-#  cv_had_tips_cb                                       :integer          default("unfilled"), not null
-#  cv_itemized_last_year_cb                             :integer          default("unfilled"), not null
-#  cv_local_tax_refund_amt                              :decimal(12, 2)
-#  cv_local_tax_refund_cb                               :integer          default("unfilled"), not null
-#  cv_other_income_cb                                   :integer          default("unfilled"), not null
-#  cv_other_income_reported_elsewhere_cb                :integer          default("unfilled"), not null
-#  cv_p2_notes_comments                                 :string
-#  cv_rental_expense_amt                                :decimal(12, 2)
-#  cv_rental_expense_cb                                 :integer          default("unfilled"), not null
-#  cv_rental_income_cb                                  :integer          default("unfilled"), not null
-#  cv_schedule_c_cb                                     :integer          default("unfilled"), not null
-#  cv_schedule_c_expenses_amt                           :decimal(12, 2)
-#  cv_schedule_c_expenses_cb                            :integer          default("unfilled"), not null
-#  cv_ssa1099_rrb1099_cb                                :integer          default("unfilled"), not null
-#  cv_ssa1099_rrb1099_count                             :integer
-#  cv_w2g_or_other_gambling_winnings_cb                 :integer          default("unfilled"), not null
-#  cv_w2g_or_other_gambling_winnings_count              :integer
-#  cv_w2s_cb                                            :integer          default("unfilled"), not null
-#  cv_w2s_count                                         :integer
-#  cv_1095a_cb                                          :integer          default("unfilled"), not null
-#  cv_1098_cb                                           :integer          default("unfilled"), not null
-#  cv_1098_count                                        :integer
-#  cv_1098e_cb                                          :integer          default("unfilled"), not null
-#  cv_1098t_cb                                          :integer          default("unfilled"), not null
-#  cv_1099a_cb                                          :integer          default("unfilled"), not null
-#  cv_1099c_cb                                          :integer          default("unfilled"), not null
 #  cv_1099s_cb                                          :integer          default("unfilled"), not null
 #  cv_14c_page_3_notes_part_1                           :string
 #  cv_14c_page_3_notes_part_2                           :string
 #  cv_14c_page_3_notes_part_3                           :string
+#  cv_alimony_excluded_from_income_cb                   :integer          default("unfilled"), not null
 #  cv_alimony_income_adjustment_yn_cb                   :integer          default("unfilled"), not null
+#  cv_alimony_income_amt                                :decimal(12, 2)
+#  cv_alimony_income_cb                                 :integer          default("unfilled"), not null
+#  cv_capital_loss_carryover_cb                         :integer          default("unfilled"), not null
 #  cv_child_dependent_care_credit_cb                    :integer          default("unfilled"), not null
+#  cv_disability_benefits_1099r_or_w2_cb                :integer          default("unfilled"), not null
+#  cv_disability_benefits_1099r_or_w2_count             :integer
 #  cv_disaster_relief_impacts_return_cb                 :integer          default("unfilled"), not null
 #  cv_edu_credit_or_tuition_deduction_cb                :integer          default("unfilled"), not null
 #  cv_edu_expenses_deduction_amt                        :decimal(12, 2)
@@ -97,17 +79,36 @@
 #  cv_energy_efficient_home_improv_credit_cb            :integer          default("unfilled"), not null
 #  cv_estimated_tax_payments_amt                        :decimal(12, 2)
 #  cv_estimated_tax_payments_cb                         :integer          default("unfilled"), not null
+#  cv_had_tips_cb                                       :integer          default("unfilled"), not null
 #  cv_hsa_contrib_cb                                    :integer          default("unfilled"), not null
 #  cv_hsa_distrib_cb                                    :integer          default("unfilled"), not null
+#  cv_itemized_last_year_cb                             :integer          default("unfilled"), not null
 #  cv_last_years_refund_applied_to_this_yr_amt          :decimal(12, 2)
 #  cv_last_years_refund_applied_to_this_yr_cb           :integer          default("unfilled"), not null
 #  cv_last_years_return_available_cb                    :integer          default("unfilled"), not null
+#  cv_local_tax_refund_amt                              :decimal(12, 2)
+#  cv_local_tax_refund_cb                               :integer          default("unfilled"), not null
 #  cv_med_expense_itemized_deduction_cb                 :integer          default("unfilled"), not null
 #  cv_med_expense_standard_deduction_cb                 :integer          default("unfilled"), not null
+#  cv_other_income_cb                                   :integer          default("unfilled"), not null
+#  cv_other_income_reported_elsewhere_cb                :integer          default("unfilled"), not null
+#  cv_p2_notes_comments                                 :string
 #  cv_paid_alimony_w_spouse_ssn_amt                     :decimal(12, 2)
 #  cv_paid_alimony_w_spouse_ssn_cb                      :integer          default("unfilled"), not null
+#  cv_rental_expense_amt                                :decimal(12, 2)
+#  cv_rental_expense_cb                                 :integer          default("unfilled"), not null
+#  cv_rental_income_cb                                  :integer          default("unfilled"), not null
+#  cv_schedule_c_cb                                     :integer          default("unfilled"), not null
+#  cv_schedule_c_expenses_amt                           :decimal(12, 2)
+#  cv_schedule_c_expenses_cb                            :integer          default("unfilled"), not null
+#  cv_ssa1099_rrb1099_cb                                :integer          default("unfilled"), not null
+#  cv_ssa1099_rrb1099_count                             :integer
 #  cv_tax_credit_disallowed_reason                      :string
 #  cv_taxable_scholarship_income_cb                     :integer          default("unfilled"), not null
+#  cv_w2g_or_other_gambling_winnings_cb                 :integer          default("unfilled"), not null
+#  cv_w2g_or_other_gambling_winnings_count              :integer
+#  cv_w2s_cb                                            :integer          default("unfilled"), not null
+#  cv_w2s_count                                         :integer
 #  demographic_disability                               :integer          default("unfilled"), not null
 #  demographic_english_conversation                     :integer          default("unfilled"), not null
 #  demographic_english_reading                          :integer          default("unfilled"), not null

--- a/spec/models/intake/gyr_intake_spec.rb
+++ b/spec/models/intake/gyr_intake_spec.rb
@@ -4,7 +4,6 @@
 #
 #  id                                                   :bigint           not null, primary key
 #  additional_info                                      :string
-#  additional_notes_comments                            :text
 #  adopted_child                                        :integer          default("unfilled"), not null
 #  advance_ctc_amount_received                          :integer
 #  advance_ctc_entry_method                             :integer          default(0), not null

--- a/spec/models/intake/gyr_intake_spec.rb
+++ b/spec/models/intake/gyr_intake_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id                                                   :bigint           not null, primary key
 #  additional_info                                      :string
+#  additional_notes_comments                            :text
 #  adopted_child                                        :integer          default("unfilled"), not null
 #  advance_ctc_amount_received                          :integer
 #  advance_ctc_entry_method                             :integer          default(0), not null
@@ -32,8 +33,15 @@
 #  contributed_to_other_retirement_account              :integer          default("unfilled"), not null
 #  contributed_to_roth_ira                              :integer          default("unfilled"), not null
 #  current_step                                         :string
+#  cv_1095a_cb                                          :integer          default("unfilled"), not null
+#  cv_1098_cb                                           :integer          default("unfilled"), not null
+#  cv_1098_count                                        :integer
+#  cv_1098e_cb                                          :integer          default("unfilled"), not null
+#  cv_1098t_cb                                          :integer          default("unfilled"), not null
+#  cv_1099a_cb                                          :integer          default("unfilled"), not null
 #  cv_1099b_cb                                          :integer          default("unfilled"), not null
 #  cv_1099b_count                                       :integer
+#  cv_1099c_cb                                          :integer          default("unfilled"), not null
 #  cv_1099div_cb                                        :integer          default("unfilled"), not null
 #  cv_1099div_count                                     :integer
 #  cv_1099g_cb                                          :integer          default("unfilled"), not null
@@ -50,44 +58,18 @@
 #  cv_1099r_charitable_dist_amt                         :decimal(12, 2)
 #  cv_1099r_charitable_dist_cb                          :integer          default("unfilled"), not null
 #  cv_1099r_count                                       :integer
-#  cv_alimony_excluded_from_income_cb                   :integer          default("unfilled"), not null
-#  cv_alimony_income_amt                                :decimal(12, 2)
-#  cv_alimony_income_cb                                 :integer          default("unfilled"), not null
-#  cv_capital_loss_carryover_cb                         :integer          default("unfilled"), not null
-#  cv_disability_benefits_1099r_or_w2_cb                :integer          default("unfilled"), not null
-#  cv_disability_benefits_1099r_or_w2_count             :integer
-#  cv_had_tips_cb                                       :integer          default("unfilled"), not null
-#  cv_itemized_last_year_cb                             :integer          default("unfilled"), not null
-#  cv_local_tax_refund_amt                              :decimal(12, 2)
-#  cv_local_tax_refund_cb                               :integer          default("unfilled"), not null
-#  cv_other_income_cb                                   :integer          default("unfilled"), not null
-#  cv_other_income_reported_elsewhere_cb                :integer          default("unfilled"), not null
-#  cv_p2_notes_comments                                 :string
-#  cv_rental_expense_amt                                :decimal(12, 2)
-#  cv_rental_expense_cb                                 :integer          default("unfilled"), not null
-#  cv_rental_income_cb                                  :integer          default("unfilled"), not null
-#  cv_schedule_c_cb                                     :integer          default("unfilled"), not null
-#  cv_schedule_c_expenses_amt                           :decimal(12, 2)
-#  cv_schedule_c_expenses_cb                            :integer          default("unfilled"), not null
-#  cv_ssa1099_rrb1099_cb                                :integer          default("unfilled"), not null
-#  cv_ssa1099_rrb1099_count                             :integer
-#  cv_w2g_or_other_gambling_winnings_cb                 :integer          default("unfilled"), not null
-#  cv_w2g_or_other_gambling_winnings_count              :integer
-#  cv_w2s_cb                                            :integer          default("unfilled"), not null
-#  cv_w2s_count                                         :integer
-#  cv_1095a_cb                                          :integer          default("unfilled"), not null
-#  cv_1098_cb                                           :integer          default("unfilled"), not null
-#  cv_1098_count                                        :integer
-#  cv_1098e_cb                                          :integer          default("unfilled"), not null
-#  cv_1098t_cb                                          :integer          default("unfilled"), not null
-#  cv_1099a_cb                                          :integer          default("unfilled"), not null
-#  cv_1099c_cb                                          :integer          default("unfilled"), not null
 #  cv_1099s_cb                                          :integer          default("unfilled"), not null
 #  cv_14c_page_3_notes_part_1                           :string
 #  cv_14c_page_3_notes_part_2                           :string
 #  cv_14c_page_3_notes_part_3                           :string
+#  cv_alimony_excluded_from_income_cb                   :integer          default("unfilled"), not null
 #  cv_alimony_income_adjustment_yn_cb                   :integer          default("unfilled"), not null
+#  cv_alimony_income_amt                                :decimal(12, 2)
+#  cv_alimony_income_cb                                 :integer          default("unfilled"), not null
+#  cv_capital_loss_carryover_cb                         :integer          default("unfilled"), not null
 #  cv_child_dependent_care_credit_cb                    :integer          default("unfilled"), not null
+#  cv_disability_benefits_1099r_or_w2_cb                :integer          default("unfilled"), not null
+#  cv_disability_benefits_1099r_or_w2_count             :integer
 #  cv_disaster_relief_impacts_return_cb                 :integer          default("unfilled"), not null
 #  cv_edu_credit_or_tuition_deduction_cb                :integer          default("unfilled"), not null
 #  cv_edu_expenses_deduction_amt                        :decimal(12, 2)
@@ -97,17 +79,36 @@
 #  cv_energy_efficient_home_improv_credit_cb            :integer          default("unfilled"), not null
 #  cv_estimated_tax_payments_amt                        :decimal(12, 2)
 #  cv_estimated_tax_payments_cb                         :integer          default("unfilled"), not null
+#  cv_had_tips_cb                                       :integer          default("unfilled"), not null
 #  cv_hsa_contrib_cb                                    :integer          default("unfilled"), not null
 #  cv_hsa_distrib_cb                                    :integer          default("unfilled"), not null
+#  cv_itemized_last_year_cb                             :integer          default("unfilled"), not null
 #  cv_last_years_refund_applied_to_this_yr_amt          :decimal(12, 2)
 #  cv_last_years_refund_applied_to_this_yr_cb           :integer          default("unfilled"), not null
 #  cv_last_years_return_available_cb                    :integer          default("unfilled"), not null
+#  cv_local_tax_refund_amt                              :decimal(12, 2)
+#  cv_local_tax_refund_cb                               :integer          default("unfilled"), not null
 #  cv_med_expense_itemized_deduction_cb                 :integer          default("unfilled"), not null
 #  cv_med_expense_standard_deduction_cb                 :integer          default("unfilled"), not null
+#  cv_other_income_cb                                   :integer          default("unfilled"), not null
+#  cv_other_income_reported_elsewhere_cb                :integer          default("unfilled"), not null
+#  cv_p2_notes_comments                                 :string
 #  cv_paid_alimony_w_spouse_ssn_amt                     :decimal(12, 2)
 #  cv_paid_alimony_w_spouse_ssn_cb                      :integer          default("unfilled"), not null
+#  cv_rental_expense_amt                                :decimal(12, 2)
+#  cv_rental_expense_cb                                 :integer          default("unfilled"), not null
+#  cv_rental_income_cb                                  :integer          default("unfilled"), not null
+#  cv_schedule_c_cb                                     :integer          default("unfilled"), not null
+#  cv_schedule_c_expenses_amt                           :decimal(12, 2)
+#  cv_schedule_c_expenses_cb                            :integer          default("unfilled"), not null
+#  cv_ssa1099_rrb1099_cb                                :integer          default("unfilled"), not null
+#  cv_ssa1099_rrb1099_count                             :integer
 #  cv_tax_credit_disallowed_reason                      :string
 #  cv_taxable_scholarship_income_cb                     :integer          default("unfilled"), not null
+#  cv_w2g_or_other_gambling_winnings_cb                 :integer          default("unfilled"), not null
+#  cv_w2g_or_other_gambling_winnings_count              :integer
+#  cv_w2s_cb                                            :integer          default("unfilled"), not null
+#  cv_w2s_count                                         :integer
 #  demographic_disability                               :integer          default("unfilled"), not null
 #  demographic_english_conversation                     :integer          default("unfilled"), not null
 #  demographic_english_reading                          :integer          default("unfilled"), not null

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -4,7 +4,6 @@
 #
 #  id                                                   :bigint           not null, primary key
 #  additional_info                                      :string
-#  additional_notes_comments                            :text
 #  adopted_child                                        :integer          default(0), not null
 #  advance_ctc_amount_received                          :integer
 #  advance_ctc_entry_method                             :integer          default(0), not null

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id                                                   :bigint           not null, primary key
 #  additional_info                                      :string
+#  additional_notes_comments                            :text
 #  adopted_child                                        :integer          default(0), not null
 #  advance_ctc_amount_received                          :integer
 #  advance_ctc_entry_method                             :integer          default(0), not null
@@ -32,8 +33,15 @@
 #  contributed_to_other_retirement_account              :integer          default(0), not null
 #  contributed_to_roth_ira                              :integer          default(0), not null
 #  current_step                                         :string
+#  cv_1095a_cb                                          :integer          default(0), not null
+#  cv_1098_cb                                           :integer          default(0), not null
+#  cv_1098_count                                        :integer
+#  cv_1098e_cb                                          :integer          default(0), not null
+#  cv_1098t_cb                                          :integer          default(0), not null
+#  cv_1099a_cb                                          :integer          default(0), not null
 #  cv_1099b_cb                                          :integer          default(0), not null
 #  cv_1099b_count                                       :integer
+#  cv_1099c_cb                                          :integer          default(0), not null
 #  cv_1099div_cb                                        :integer          default(0), not null
 #  cv_1099div_count                                     :integer
 #  cv_1099g_cb                                          :integer          default(0), not null
@@ -50,44 +58,18 @@
 #  cv_1099r_charitable_dist_amt                         :decimal(12, 2)
 #  cv_1099r_charitable_dist_cb                          :integer          default(0), not null
 #  cv_1099r_count                                       :integer
-#  cv_alimony_excluded_from_income_cb                   :integer          default(0), not null
-#  cv_alimony_income_amt                                :decimal(12, 2)
-#  cv_alimony_income_cb                                 :integer          default(0), not null
-#  cv_capital_loss_carryover_cb                         :integer          default(0), not null
-#  cv_disability_benefits_1099r_or_w2_cb                :integer          default(0), not null
-#  cv_disability_benefits_1099r_or_w2_count             :integer
-#  cv_had_tips_cb                                       :integer          default(0), not null
-#  cv_itemized_last_year_cb                             :integer          default(0), not null
-#  cv_local_tax_refund_amt                              :decimal(12, 2)
-#  cv_local_tax_refund_cb                               :integer          default(0), not null
-#  cv_other_income_cb                                   :integer          default(0), not null
-#  cv_other_income_reported_elsewhere_cb                :integer          default(0), not null
-#  cv_p2_notes_comments                                 :string
-#  cv_rental_expense_amt                                :decimal(12, 2)
-#  cv_rental_expense_cb                                 :integer          default(0), not null
-#  cv_rental_income_cb                                  :integer          default(0), not null
-#  cv_schedule_c_cb                                     :integer          default(0), not null
-#  cv_schedule_c_expenses_amt                           :decimal(12, 2)
-#  cv_schedule_c_expenses_cb                            :integer          default(0), not null
-#  cv_ssa1099_rrb1099_cb                                :integer          default(0), not null
-#  cv_ssa1099_rrb1099_count                             :integer
-#  cv_w2g_or_other_gambling_winnings_cb                 :integer          default(0), not null
-#  cv_w2g_or_other_gambling_winnings_count              :integer
-#  cv_w2s_cb                                            :integer          default(0), not null
-#  cv_w2s_count                                         :integer
-#  cv_1095a_cb                                          :integer          default(0), not null
-#  cv_1098_cb                                           :integer          default(0), not null
-#  cv_1098_count                                        :integer
-#  cv_1098e_cb                                          :integer          default(0), not null
-#  cv_1098t_cb                                          :integer          default(0), not null
-#  cv_1099a_cb                                          :integer          default(0), not null
-#  cv_1099c_cb                                          :integer          default(0), not null
 #  cv_1099s_cb                                          :integer          default(0), not null
 #  cv_14c_page_3_notes_part_1                           :string
 #  cv_14c_page_3_notes_part_2                           :string
 #  cv_14c_page_3_notes_part_3                           :string
+#  cv_alimony_excluded_from_income_cb                   :integer          default(0), not null
 #  cv_alimony_income_adjustment_yn_cb                   :integer          default(0), not null
+#  cv_alimony_income_amt                                :decimal(12, 2)
+#  cv_alimony_income_cb                                 :integer          default(0), not null
+#  cv_capital_loss_carryover_cb                         :integer          default(0), not null
 #  cv_child_dependent_care_credit_cb                    :integer          default(0), not null
+#  cv_disability_benefits_1099r_or_w2_cb                :integer          default(0), not null
+#  cv_disability_benefits_1099r_or_w2_count             :integer
 #  cv_disaster_relief_impacts_return_cb                 :integer          default(0), not null
 #  cv_edu_credit_or_tuition_deduction_cb                :integer          default(0), not null
 #  cv_edu_expenses_deduction_amt                        :decimal(12, 2)
@@ -97,17 +79,36 @@
 #  cv_energy_efficient_home_improv_credit_cb            :integer          default(0), not null
 #  cv_estimated_tax_payments_amt                        :decimal(12, 2)
 #  cv_estimated_tax_payments_cb                         :integer          default(0), not null
+#  cv_had_tips_cb                                       :integer          default(0), not null
 #  cv_hsa_contrib_cb                                    :integer          default(0), not null
 #  cv_hsa_distrib_cb                                    :integer          default(0), not null
+#  cv_itemized_last_year_cb                             :integer          default(0), not null
 #  cv_last_years_refund_applied_to_this_yr_amt          :decimal(12, 2)
 #  cv_last_years_refund_applied_to_this_yr_cb           :integer          default(0), not null
 #  cv_last_years_return_available_cb                    :integer          default(0), not null
+#  cv_local_tax_refund_amt                              :decimal(12, 2)
+#  cv_local_tax_refund_cb                               :integer          default(0), not null
 #  cv_med_expense_itemized_deduction_cb                 :integer          default(0), not null
 #  cv_med_expense_standard_deduction_cb                 :integer          default(0), not null
+#  cv_other_income_cb                                   :integer          default(0), not null
+#  cv_other_income_reported_elsewhere_cb                :integer          default(0), not null
+#  cv_p2_notes_comments                                 :string
 #  cv_paid_alimony_w_spouse_ssn_amt                     :decimal(12, 2)
 #  cv_paid_alimony_w_spouse_ssn_cb                      :integer          default(0), not null
+#  cv_rental_expense_amt                                :decimal(12, 2)
+#  cv_rental_expense_cb                                 :integer          default(0), not null
+#  cv_rental_income_cb                                  :integer          default(0), not null
+#  cv_schedule_c_cb                                     :integer          default(0), not null
+#  cv_schedule_c_expenses_amt                           :decimal(12, 2)
+#  cv_schedule_c_expenses_cb                            :integer          default(0), not null
+#  cv_ssa1099_rrb1099_cb                                :integer          default(0), not null
+#  cv_ssa1099_rrb1099_count                             :integer
 #  cv_tax_credit_disallowed_reason                      :string
 #  cv_taxable_scholarship_income_cb                     :integer          default(0), not null
+#  cv_w2g_or_other_gambling_winnings_cb                 :integer          default(0), not null
+#  cv_w2g_or_other_gambling_winnings_count              :integer
+#  cv_w2s_cb                                            :integer          default(0), not null
+#  cv_w2s_count                                         :integer
 #  demographic_disability                               :integer          default(0), not null
 #  demographic_english_conversation                     :integer          default(0), not null
 #  demographic_english_reading                          :integer          default(0), not null


### PR DESCRIPTION
The PR for GYR1-614 (#5397) had some annotations that weren't alphabetically sorted (the result of a rather daunting rebase). nbd, but to avoid confusion, this PR sorts them properly via `bundle exec annotate --sort`.
