### PR TITLE
GYR1-616 Add Hub additional notes p5 + pertinent mappings

### DIFF
--- a/app/controllers/hub/clients_controller.rb
+++ b/app/controllers/hub/clients_controller.rb
@@ -128,6 +128,10 @@ module Hub
       @form = Update13614cFormPage4.from_client(@client)
     end
 
+    def edit_13614c_form_page5
+      @form = Update13614cFormPage5.from_client(@client)
+    end
+
     def save_and_maybe_exit(save_button_clicked, path_to_13614c_page)
       if save_button_clicked == I18n.t("general.save")
         redirect_to path_to_13614c_page
@@ -184,6 +188,17 @@ module Hub
       end
     end
 
+    def update_13614c_form_page5
+      @form = Update13614cFormPage5.new(@client, update_13614c_form_page5_params)
+
+      if @form.valid? && @form.save
+        SystemNote::ClientChange.generate!(initiated_by: current_user, intake: @client.intake)
+        GenerateF13614cPdfJob.perform_later(@client.intake.id, "Hub Edited 13614-C.pdf")
+        flash[:notice] = I18n.t("general.changes_saved")
+        save_and_maybe_exit(params[:commit], edit_13614c_form_page5_hub_client_path(id: @client.id))
+      end
+    end
+
     def cancel_13614c
       redirect_to hub_client_path(id: @client.id)
     end
@@ -231,6 +246,10 @@ module Hub
 
     def update_13614c_form_page4_params
       params.require(Update13614cFormPage4.form_param).permit(Update13614cFormPage4.attribute_names)
+    end
+
+    def update_13614c_form_page5_params
+      params.require(Update13614cFormPage5.form_param).permit(Update13614cFormPage5.attribute_names)
     end
 
     def create_client_form_params

--- a/app/forms/final_info_form.rb
+++ b/app/forms/final_info_form.rb
@@ -1,5 +1,5 @@
 class FinalInfoForm < QuestionsForm
-  set_attributes_for :intake, :final_info
+  set_attributes_for :intake, :additional_notes_comments
 
   def save
     @intake.update(attributes_for(:intake))

--- a/app/forms/hub/update_13614c_form_page5.rb
+++ b/app/forms/hub/update_13614c_form_page5.rb
@@ -1,0 +1,26 @@
+module Hub
+  class Update13614cFormPage5 < Form
+    include FormAttributes
+
+    set_attributes_for :intake, :additional_notes_comments
+                        
+    attr_accessor :client
+
+    def initialize(client, params = {})
+      @client = client
+      super(params)
+    end
+
+    def self.from_client(client)
+      intake = client.intake
+      attribute_keys = Attributes.new(attribute_names).to_sym
+      new(client, existing_attributes(intake).slice(*attribute_keys))
+    end
+
+    def save
+      @client.intake.update(attributes_for(:intake))
+      @client.touch(:last_13614c_update_at)
+    end
+  end
+end
+

--- a/app/lib/pdf_filler/f13614c_pdf.rb
+++ b/app/lib/pdf_filler/f13614c_pdf.rb
@@ -210,7 +210,9 @@ module PdfFiller
 
       # ty2024 page 5
 
-      answers["form1[0].page5[0].AdditionalComments[0].AdditionalNotesComments[0]"] = @intake.additional_notes_comments
+      cmts = @intake.additional_notes_comments || ''
+      cmts += "\n\n" << dependents_4th_and_up
+      answers["form1[0].page5[0].AdditionalComments[0].AdditionalNotesComments[0]"] = cmts
 
       # end - ty2024 page 5
 
@@ -476,34 +478,33 @@ module PdfFiller
       }
     end
 
-    def additional_comments
-      parts = []
+    def dependents_4th_and_up
+      return '' if @dependents.length < 4
 
-      parts << "#{@intake.additional_info} #{@intake.final_info}" if @intake.additional_info.present? || @intake.final_info.present?
+      s = "Additional Dependents:\n"
+      sep = ' // '
 
-      parts << "Other income types: #{@intake.other_income_types}" if @intake.other_income_types.present?
+      @dependents[3..].map do |dependent|
+        s << dependent.full_name << sep
+        s << strftime_date(dependent.birth_date) << sep
+        s << dependent.relationship << sep
+        s << 'Months lived in home in 2024: ' << dependent.months_in_home.to_s << sep
+        s << 'Single or married in 2024: ' << married_to_SM(dependent.was_married) << sep
+        s << 'US citizen: ' << yes_no_unfilled_to_YN(dependent.us_citizen) << sep
+        s << 'Resident of US/Canada/Mexico: ' << yes_no_unfilled_to_YN(dependent.north_american_resident) << sep
+        s << 'FT student: ' << yes_no_unfilled_to_YN(dependent.was_student) << sep
+        s << 'Disabled: ' << yes_no_unfilled_to_YN(dependent.disabled) << sep
+        s << 'Issued IPPIN: ' << yes_no_unfilled_to_YN(dependent.has_ip_pin) << sep
 
-      parts << <<~COMMENT.strip if @dependents.length > 3
-        Additional Dependents:
-        #{
-        @dependents[3..].map do |dependent|
-          letters = ('a'..'i').to_a
-          dependent_values = single_dependent_params(dependent, index: 0).values
-          cvp_values = []
-          tagged_values = []
-          dependent_values.each do |val|
-            letter = letters.shift
-            if letter
-              tagged_values << "(#{letter}) #{val}"
-            else
-              cvp_values << val
-            end
-          end.compact
-          "#{tagged_values.join(' ')} CVP: #{cvp_values.join('/')}"
-        end.join("\n")
-        }
-      COMMENT
-      parts.join("\n")
+        # gray fields
+        s << 'Qualifying child or relative of any other person: ' <<  yes_no_na_unfilled_to_YNNA(dependent.can_be_claimed_by_other) << sep
+        s << 'Provided more than 50% of their own support: ' << yes_no_na_unfilled_to_YNNA(dependent.provided_over_half_own_support) << sep
+        s << 'Had less than $5,050 income: ' << yes_no_na_unfilled_to_YNNA(dependent.below_qualifying_relative_income_requirement) << sep
+        s << 'Taxpayer(s) provided more than 50% of support: ' << yes_no_na_unfilled_to_YNNA(dependent.filer_provided_over_half_support) << sep
+        s << 'Taxpayer(s) paid more than half the cost of maintaining home for this person: ' << yes_no_na_unfilled_to_YNNA(dependent.filer_provided_over_half_housing_support) << "\n\n"
+      end.join()
+
+      s
     end
 
     def determine_direct_deposit(intake)
@@ -520,6 +521,16 @@ module PdfFiller
         "unfilled" => ""
       }[yes_no_unfilled]
     end
+
+    def yes_no_na_unfilled_to_YNNA(yes_no_na_unfilled)
+      {
+        "yes" => "Y",
+        "no" => "N",
+        "na" => "N/A",
+        "unfilled" => ""
+      }[yes_no_na_unfilled]
+    end
+
 
     def married_to_SM(was_married_yes_no_unfilled)
       {

--- a/app/lib/pdf_filler/f13614c_pdf.rb
+++ b/app/lib/pdf_filler/f13614c_pdf.rb
@@ -102,7 +102,6 @@ module PdfFiller
       answers["form1[0].page1[0].maritalStatus[0].statusLegallySeparated[0].dateSeparateDecree[0]"] = @intake.separated_year
       answers["form1[0].page1[0].maritalStatus[0].statusDivorced[0].dateFinalDecree[0]"] = @intake.divorced_year
       answers["form1[0].page1[0].maritalStatus[0].statusWidowed[0].yearSpousesDeath[0]"] = @intake.widowed_year
-      answers["form1[0].page1[0].additionalSpace[0].additionalSpace[0]"] = @dependents.length > 3 ? "1" : nil
 
       answers.merge!(
         yes_no_checkboxes("form1[0].page2[0].Part3[0].q1WagesOrSalary[0]", @intake.had_wages, include_unsure: true)
@@ -208,9 +207,13 @@ module PdfFiller
         yes_no_checkboxes("form1[0].page3[0].q7[0]", @intake.register_to_vote),
       )
       answers.merge!(demographic_info) if @intake.demographic_questions_opt_in_yes? || @intake.demographic_questions_hub_edit
-      answers.merge!(
-        "form1[0].page3[0].AdditionalComments[0].AdditionalComments[1]" => additional_comments,
-      )
+
+      # ty2024 page 5
+
+      answers["form1[0].page5[0].AdditionalComments[0].AdditionalNotesComments[0]"] = @intake.additional_notes_comments
+
+      # end - ty2024 page 5
+
       answers.merge!(vita_consent_to_disclose_info) if @intake.client&.consent&.disclose_consented_at
       answers
     end

--- a/app/lib/pdf_filler/f13614c_pdf.rb
+++ b/app/lib/pdf_filler/f13614c_pdf.rb
@@ -210,9 +210,7 @@ module PdfFiller
 
       # ty2024 page 5
 
-      cmts = @intake.additional_notes_comments || ''
-      cmts += "\n\n" << dependents_4th_and_up
-      answers["form1[0].page5[0].AdditionalComments[0].AdditionalNotesComments[0]"] = cmts
+      answers["form1[0].page5[0].AdditionalComments[0].AdditionalNotesComments[0]"] = (@intake.additional_notes_comments || '') << "\n\n" << dependents_4th_and_up
 
       # end - ty2024 page 5
 

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -4,6 +4,7 @@
 #
 #  id                                                   :bigint           not null, primary key
 #  additional_info                                      :string
+#  additional_notes_comments                            :text
 #  adopted_child                                        :integer          default(0), not null
 #  advance_ctc_amount_received                          :integer
 #  advance_ctc_entry_method                             :integer          default(0), not null

--- a/app/models/intake/ctc_intake.rb
+++ b/app/models/intake/ctc_intake.rb
@@ -4,6 +4,7 @@
 #
 #  id                                                   :bigint           not null, primary key
 #  additional_info                                      :string
+#  additional_notes_comments                            :text
 #  adopted_child                                        :integer          default(0), not null
 #  advance_ctc_amount_received                          :integer
 #  advance_ctc_entry_method                             :integer          default("unfilled"), not null

--- a/app/models/intake/gyr_intake.rb
+++ b/app/models/intake/gyr_intake.rb
@@ -4,6 +4,7 @@
 #
 #  id                                                   :bigint           not null, primary key
 #  additional_info                                      :string
+#  additional_notes_comments                            :text
 #  adopted_child                                        :integer          default("unfilled"), not null
 #  advance_ctc_amount_received                          :integer
 #  advance_ctc_entry_method                             :integer          default(0), not null

--- a/app/views/hub/clients/_13614c_page_links.html.erb
+++ b/app/views/hub/clients/_13614c_page_links.html.erb
@@ -22,5 +22,11 @@
   <% else %>
     <%= link_to "4", edit_13614c_form_page4_hub_client_path %>
   <% end %>
+ |
+  <% if current_page == 5 %>
+    5
+  <% else %>
+    <%= link_to "5", edit_13614c_form_page5_hub_client_path %>
+  <% end %>
 
 </div>

--- a/app/views/hub/clients/edit_13614c_form_page5.html.erb
+++ b/app/views/hub/clients/edit_13614c_form_page5.html.erb
@@ -1,0 +1,31 @@
+<% @title = 'Additional Notes/Comments' %>
+<% content_for :page_title, @title %>
+<% content_for :card do %>
+  <div class="form_13614c slab slab--not-padded">
+    <h1><%= @title %></h1>
+    <p>Last client 13614-C
+      update: <%= @client.last_13614c_update_at&.in_time_zone("America/Los_Angeles")&.strftime("%b %-d %l:%M %p") %></p>
+
+    <%= form_with model: @form,
+                  url: edit_13614c_form_page5_hub_client_path,
+                  method: :put, local: true, builder: VitaMinFormBuilder,
+                  html: { class: 'form-card form-question-13614-page5' } do |f| %>
+      <div>
+        <hr style="margin-top: 0;"/>
+        <%= f.cfa_textarea :additional_notes_comments, '', options: {rows: '2', columns: 100} %>
+      </div>
+
+      <div style="display: flex; justify-content: space-between;">
+        <div>
+          <%= f.submit t("general.save"), class: "button button--cta"%>
+          <%= f.submit t("general.save_and_exit"), class: "button button--cta"%>
+          <%= link_to t("general.cancel"), cancel_13614c_hub_client_path, class: "button button--danger",
+                      data: { confirm: t("general.confirm_exit_without_saving") } %>
+        </div>
+
+        <%= render '13614c_page_links', current_page: 4 %>
+      </div>
+    <% end %>
+  </div>
+<% end %>
+

--- a/app/views/hub/clients/edit_13614c_form_page5.html.erb
+++ b/app/views/hub/clients/edit_13614c_form_page5.html.erb
@@ -23,7 +23,7 @@
                       data: { confirm: t("general.confirm_exit_without_saving") } %>
         </div>
 
-        <%= render '13614c_page_links', current_page: 4 %>
+        <%= render '13614c_page_links', current_page: 5 %>
       </div>
     <% end %>
   </div>

--- a/app/views/questions/final_info/edit.html.erb
+++ b/app/views/questions/final_info/edit.html.erb
@@ -3,7 +3,7 @@
 <% content_for :card do %>
   <%= form_with model: @form, url: current_path, local: true, method: "put", builder: VitaMinFormBuilder, html: { class: "form-card" } do |f| %>
     <%= f.cfa_textarea(
-          :final_info,
+          :additional_notes_comments,
           content_for(:form_question),
           help_text: t("views.questions.final_info.help_text"),
           options: { rows: '5' }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -271,10 +271,12 @@ Rails.application.routes.draw do
           get "/edit_13614c_form_page2", to: "clients#edit_13614c_form_page2", on: :member
           get "/edit_13614c_form_page3", to: "clients#edit_13614c_form_page3", on: :member
           get "/edit_13614c_form_page4", to: "clients#edit_13614c_form_page4", on: :member
+          get "/edit_13614c_form_page5", to: "clients#edit_13614c_form_page5", on: :member
           put "/edit_13614c_form_page1", to: "clients#update_13614c_form_page1", on: :member
           put "/edit_13614c_form_page2", to: "clients#update_13614c_form_page2", on: :member
           put "/edit_13614c_form_page3", to: "clients#update_13614c_form_page3", on: :member
           put "/edit_13614c_form_page4", to: "clients#update_13614c_form_page4", on: :member
+          put "/edit_13614c_form_page5", to: "clients#update_13614c_form_page5", on: :member
           get "/cancel_13614c", to: "clients#cancel_13614c", on: :member
           get "/bai", to: "clients/bank_accounts#show", on: :member, as: :show_bank_account
           get "/hide-bai", to: "clients/bank_accounts#hide", on: :member, as: :hide_bank_account

--- a/db/migrate/20250124000028_add_additional_notes_comments_to_intakes.rb
+++ b/db/migrate/20250124000028_add_additional_notes_comments_to_intakes.rb
@@ -1,0 +1,5 @@
+class AddAdditionalNotesCommentsToIntakes < ActiveRecord::Migration[7.1]
+  def change
+    add_column :intakes, :additional_notes_comments, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_23_160619) do
+ActiveRecord::Schema[7.1].define(version: 2025_01_24_000028) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -1141,6 +1141,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_23_160619) do
 
   create_table "intakes", force: :cascade do |t|
     t.string "additional_info"
+    t.text "additional_notes_comments"
     t.integer "adopted_child", default: 0, null: false
     t.integer "advance_ctc_amount_received"
     t.integer "advance_ctc_entry_method", default: 0, null: false

--- a/spec/controllers/hub/clients_controller_spec.rb
+++ b/spec/controllers/hub/clients_controller_spec.rb
@@ -2102,6 +2102,57 @@ RSpec.describe Hub::ClientsController do
         end
       end
     end
+
+    describe "#update_13614c_form_page5" do
+      let(:params) {
+        {
+          id: client.id,
+          commit: I18n.t('general.save'),
+          hub_update13614c_form_page5: {
+            additional_notes_comments: 'Call me Ishmael.'
+          }
+        }
+      }
+
+      it_behaves_like :a_post_action_for_authenticated_users_only, action: :update_13614c_form_page5
+
+      context "with a signed in user" do
+        let(:user) { create(:user, role: create(:organization_lead_role, organization: organization)) }
+
+        before do
+          sign_in user
+        end
+
+        it "updates the clients intake with the 13614c data, creates a system note, and regenerates the pdf when clients press Save" do
+          expect do
+            put :update_13614c_form_page5, params: params
+          end.to have_enqueued_job(GenerateF13614cPdfJob)
+
+          expect(flash[:notice]).to eq I18n.t("general.changes_saved")
+          expect(response).to redirect_to edit_13614c_form_page5_hub_client_path(id: client)
+          client.reload
+          expect(client.intake.additional_notes_comments).to eq 'Call me Ishmael.'
+
+          system_note = SystemNote::ClientChange.last
+          expect(system_note.client).to eq(client)
+          expect(system_note.user).to eq(user)
+          expect(system_note.data['changes']).to match({"additional_notes_comments"=>[nil, 'Call me Ishmael.']})
+          expect(client.last_13614c_update_at).to be_within(1.second).of(DateTime.now)
+        end
+
+        it "updates the clients intake with the 13614c page 5 data, and direct to hub client page when client clicks Save and Exit" do
+          expect do
+            put :update_13614c_form_page5, params: params.update(commit: I18n.t('general.save_and_exit'))
+          end.to have_enqueued_job(GenerateF13614cPdfJob)
+
+          expect(flash[:notice]).to eq "Changes saved"
+          expect(response).to redirect_to hub_client_path(id: client.id)
+
+          client.reload
+          expect(client.intake.additional_notes_comments).to eq 'Call me Ishmael.'
+        end
+      end
+    end
   end
 
   context "as a greeter" do

--- a/spec/features/hub/edit_13614c_spec.rb
+++ b/spec/features/hub/edit_13614c_spec.rb
@@ -652,5 +652,29 @@ RSpec.describe "a user editing a clients 13614c form" do
         expect(form_fields.find { |field| field.name == "form1[0].page4[0].yourSpousesRaceEthnicity[0].blackAfricanAmerican[0]]" }.value).to eq("1")
       end
     end
+
+    scenario 'I can see and update the 13614c page 5 form', js: true do
+      visit hub_client_path(id: client.id)
+      within '.client-profile' do
+        click_on 'Edit 13614-C'
+      end
+
+      within '.form_13614c-page-links', match: :first do
+        click_on '5'
+      end
+      header = 'Additional Notes/Comments'
+      expect(page).to have_text header
+
+      note = 'It was very late and everyone had left the café except an old man who sat in the shadow the leaves of the tree made against the electric light.'
+      fill_in 'hub_update13614c_form_page5_additional_notes_comments', with: note
+
+      click_on I18n.t('general.save')
+
+      expect(page).to have_text header
+      expect(page).to have_text I18n.t('general.changes_saved')
+
+      intake = client.intake.reload
+      expect(intake.additional_notes_comments).to eq note
+    end
   end
 end

--- a/spec/lib/pdf_filler/f13614c_pdf_spec.rb
+++ b/spec/lib/pdf_filler/f13614c_pdf_spec.rb
@@ -608,6 +608,16 @@ RSpec.describe PdfFiller::F13614cPdf do
               COMMENT
             end
           end
+
+          context "when there is nothing to put in the notes field" do
+              before do
+                intake.update(additional_notes_comments: nil)
+              end
+
+              it "everything still works ok" do
+                expect(intake_pdf.hash_for_pdf[additional_comments_key]).to eq("\n\n")
+              end
+            end
         end
       end
 

--- a/spec/models/intake/gyr_intake_spec.rb
+++ b/spec/models/intake/gyr_intake_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id                                                   :bigint           not null, primary key
 #  additional_info                                      :string
+#  additional_notes_comments                            :text
 #  adopted_child                                        :integer          default("unfilled"), not null
 #  advance_ctc_amount_received                          :integer
 #  advance_ctc_entry_method                             :integer          default(0), not null

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id                                                   :bigint           not null, primary key
 #  additional_info                                      :string
+#  additional_notes_comments                            :text
 #  adopted_child                                        :integer          default(0), not null
 #  advance_ctc_amount_received                          :integer
 #  advance_ctc_entry_method                             :integer          default(0), not null


### PR DESCRIPTION
## Link to Jira issue

- https://codeforamerica.atlassian.net/browse/GYR1-616

## Is PM acceptance required?

- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main

## What was done?

- Added an editable 14-C page 5 into the Hub, which has just the "Additional 
  Notes/Comments" field. This field should "start out" with whatever comments 
  the client entered into the FinalInfoController screen back during the intake 
  flow.
- The mapping was also added so that the comments/notes get properly written to 
  the PDF.
- For this PR, mappings were also added to write out dependent records onto the 
  5th page when there are 4 or more dependents. 
  - This includes the new dependent IPPIN field as well.

## Technical Notes

- `additional_notes_comments` has been created, which is a `text` column, to 
  replace the legacy `final_info` `string` column. I think `text` is the 
  preferable data type here.
- It looks like `additional_info` wasn't really being used, so it's no longer
   included in the string that gets written out to the PDF.

## How to test?

- Ensure that the text entered into the FinalInfoController shows up when 
  navigating to page 5 in the Hub
- Ensure that if changes/additions are made to the text in the Hub, it will all 
  show up properly on the PDF.
- Enter in at least 5 dependents and ensure that the 4th and 5th records show up 
  properly on page 5 of the PDF. 
  - Switch up the values and spot-check that no wires were crossed in terms of 
    the order of how values were written out on the PDF.
- Ensure it all works when there's *only* a note but only 3 or fewer dependent 
  records.

## Example

<img width="787" alt="image" src="https://github.com/user-attachments/assets/4c3a8548-f9ee-4e2c-8f25-3f36f67b30c9" />

