### PR TITLE
NJ 267 - route ineligible both owner/renter out of flow after ineligible page

### DIFF
--- a/app/controllers/state_file/questions/nj_ineligible_property_tax_controller.rb
+++ b/app/controllers/state_file/questions/nj_ineligible_property_tax_controller.rb
@@ -60,6 +60,10 @@ module StateFile
         options = {}
         options[:return_to_review] = params[:return_to_review] if params[:return_to_review].present?
 
+        if Efile::Nj::NjPropertyTaxEligibility.ineligible?(current_intake)
+          return StateFile::NjPropertyTaxFlowOffRamp.next_controller(options)
+        end
+
         if current_intake.household_rent_own_both? && params[:on_home_or_rental] != "rental"
           NjTenantEligibilityController.to_path_helper(options)
         else

--- a/spec/controllers/state_file/questions/nj_ineligible_property_tax_controller_spec.rb
+++ b/spec/controllers/state_file/questions/nj_ineligible_property_tax_controller_spec.rb
@@ -133,6 +133,15 @@ RSpec.describe StateFile::Questions::NjIneligiblePropertyTaxController do
       end
     end
 
+    context "when indicated both rent and own and ineligible" do
+      let(:intake) { create :state_file_nj_intake, household_rent_own: "both" }
+      it "next path is next_controller for property tax flow" do
+        allow(Efile::Nj::NjPropertyTaxEligibility).to receive(:ineligible?).and_return true
+        get :edit, params: {on_home_or_rental: "home"}
+        expect(subject.next_path).to eq(StateFile::NjPropertyTaxFlowOffRamp.next_controller({}))
+      end
+    end
+
     context "when not both rent and own" do
       let(:intake) { create :state_file_nj_intake, household_rent_own: "own" }
       it "next path is next_controller for property tax flow" do

--- a/spec/features/state_file/nj/complete_intake_spec.rb
+++ b/spec/features/state_file/nj/complete_intake_spec.rb
@@ -495,7 +495,18 @@ RSpec.feature "Completing a state file intake", active_job: true do
         advance_disabled_exemption(false) # does NOT meet disabled exemption
         advance_veterans_exemption
         advance_medical_expenses
-        choose_household_rent_own("homeowner")
+        choose_household_rent_own("tenant")
+        expect_ineligible_page(nil, "income_mfj_qss_hoh")
+        expect_page_after_property_tax
+      end
+
+      it "handles property tax flow - MFJ and both homeowner/renter", required_schema: "nj" do
+        advance_to_start_of_intake("Married filing jointly 15k wages") # low income MFJ
+        advance_county_and_municipality
+        advance_disabled_exemption(false) # does NOT meet disabled exemption
+        advance_veterans_exemption
+        advance_medical_expenses
+        choose_household_rent_own("both")
         expect_ineligible_page(nil, "income_mfj_qss_hoh")
         expect_page_after_property_tax
       end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/267

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- when user is ineligible due to low income, they should proceed to use tax page after ineligible page regardless of whether they are a "both"

## How to test?
- use bon jovi health dependents persona (NOT disabled)
- go through to property tax credit screens
- select you were "both" a homeowner and renter
