### PR TITLE
Revert "FYST-1644 Make sure request record is persisted before navigating to verification page"

### DIFF
--- a/app/controllers/state_file/archived_intakes/email_address_controller.rb
+++ b/app/controllers/state_file/archived_intakes/email_address_controller.rb
@@ -11,9 +11,8 @@ module StateFile
 
         if @form.valid?
           archived_intake = StateFileArchivedIntake.find_by(email_address: @form.email_address)
-          # Make sure we reference the new request (ex: request.email_address) to ensure we have a current_request on the next page in cases where db operations run slowly (i.e. demo)
-          request = StateFileArchivedIntakeRequest.find_or_create_by(email_address: @form.email_address, ip_address: ip_for_irs, state_file_archived_intake_id: archived_intake&.id)
-          session[:email_address] = request.email_address
+          session[:email_address] = @form.email_address
+          StateFileArchivedIntakeRequest.find_or_create_by(email_address: @form.email_address, ip_address: ip_for_irs, state_file_archived_intake_id: archived_intake&.id )
           create_state_file_access_log("issued_email_challenge")
 
           redirect_to state_file_archived_intakes_edit_verification_code_path


### PR DESCRIPTION
Reverts codeforamerica/vita-min#5390

This was in fact not the issue which fixed the bug - https://github.com/codeforamerica/vita-min/pull/5405 was the actual solve 🫡 