### PR TITLE
[FYST-1697] update StateInformationService to be locale aware

### DIFF
--- a/app/services/state_file/state_information_service.rb
+++ b/app/services/state_file/state_information_service.rb
@@ -5,7 +5,6 @@ module StateFile
     GETTER_METHODS = [
       :intake_class,
       :calculator_class,
-      :department_of_taxation,
       :filing_years,
       :mail_voucher_address,
       :navigation_class,
@@ -14,7 +13,6 @@ module StateFile
       :review_controller_class,
       :schema_file_name,
       :software_id_key,
-      :state_name,
       :submission_builder_class,
       :submission_type,
       :survey_link,
@@ -39,6 +37,16 @@ module StateFile
 
           STATES_INFO[state_code][attribute]
         end
+      end
+
+      def state_name(state_code)
+        raise InvalidStateCodeError, state_code unless STATES_INFO.key?(state_code)
+        I18n.t("state_file.state_information_service.#{state_code}.state_name")
+      end
+
+      def department_of_taxation(state_code)
+        raise InvalidStateCodeError, state_code unless STATES_INFO.key?(state_code)
+        I18n.t("state_file.state_information_service.#{state_code}.department_of_taxation")
       end
 
       def active_state_codes
@@ -72,14 +80,12 @@ module StateFile
         review_controller_class: StateFile::Questions::AzReviewController,
         schema_file_name: "AZIndividual2024v2.0.zip",
         software_id_key: "sin",
-        state_name: "Arizona",
         submission_builder_class: SubmissionBuilder::Ty2022::States::Az::AzReturnXml,
         survey_link: "https://codeforamerica.co1.qualtrics.com/jfe/form/SV_0v0BnYNRoLIqzhY",
         submission_type: "Form140",
         tax_payment_info_text: "https://azdor.gov/make-payment-online",
         tax_payment_info_url: "https://azdor.gov/making-payments-late-payments-and-filing-extensions",
         tax_refund_url: "https://aztaxes.gov/home/checkrefund",
-        department_of_taxation: "Arizona Department of Revenue",
         timezone: 'America/Phoenix',
         vita_link_en: "https://airtable.com/appMTIDgfgmMZjPqh/pag78AN26G3oA2i9q/form",
         vita_link_es: " https://airtable.com/appMTIDgfgmMZjPqh/pagpZYWNWu2uH2JZh/form",
@@ -99,7 +105,6 @@ module StateFile
         pay_taxes_link: "https://tax.idaho.gov/online-services/e-pay/",
         return_type: "Form40",
         review_controller_class: StateFile::Questions::IdReviewController,
-        state_name: "Idaho",
         schema_file_name: "ID_MeF2024V0.1.zip",
         software_id_key: "sin",
         submission_type: "Form40",
@@ -108,7 +113,6 @@ module StateFile
         tax_payment_info_text: "https://tax.idaho.gov/e-pay/",
         tax_payment_info_url: "https://tax.idaho.gov/online-services/e-pay/",
         tax_refund_url: "https://tax.idaho.gov/taxes/income-tax/individual-income/refund/",
-        department_of_taxation: "Idaho State Tax Commission",
         timezone: 'America/Boise',
         vita_link_en: "https://airtable.com/appqG5OGbTLBiQ408/pagt2JWaKQRG5I0gl/form",
         vita_link_es: "https://airtable.com/appqG5OGbTLBiQ408/pagTE56DjYpVNc5pX/form",
@@ -122,23 +126,21 @@ module StateFile
         calculator_class: Efile::Md::Md502Calculator,
         filing_years: [2024],
         mail_voucher_address: "Comptroller of Maryland<br/>" \
-          "Payment Processing<br/>" \
-          "PO Box 8888<br/>" \
-          "Annapolis, MD 21401-8888".html_safe,
+                              "Payment Processing<br/>" \
+                              "PO Box 8888<br/>" \
+                              "Annapolis, MD 21401-8888".html_safe,
         navigation_class: Navigation::StateFileMdQuestionNavigation,
         pay_taxes_link: "https://www.marylandtaxes.gov/individual/individual-payments.php",
         return_type: "502",
         review_controller_class: StateFile::Questions::MdReviewController,
         schema_file_name: "MDIndividual2024v1.0.zip",
         software_id_key: "md_sin", # MD assigned us a unique software id only in use for MD
-        state_name: "Maryland",
         submission_type: "MD502",
         submission_builder_class: SubmissionBuilder::Ty2024::States::Md::MdReturnXml,
         survey_link: "https://codeforamerica.co1.qualtrics.com/jfe/form/SV_24BAmNMNrpkhLwy",
         tax_payment_info_text: "Marylandtaxes.gov",
         tax_payment_info_url: "https://www.marylandtaxes.gov/individual/individual-payments.php",
         tax_refund_url: "https://interactive.marylandtaxes.gov/INDIV/refundstatus/home.aspx",
-        department_of_taxation: "Comptroller of Maryland",
         timezone: 'America/New_York',
         vita_link_en: "https://airtable.com/appAgBw351Iig0YI4/pagVvtGPWrpURJrrd/form",
         vita_link_es: "https://airtable.com/appAgBw351Iig0YI4/pagpUP2HSWNXzPlIz/form",
@@ -160,14 +162,12 @@ module StateFile
         review_controller_class: StateFile::Questions::NcReviewController,
         schema_file_name: "NCIndividual2024v1.0.zip",
         software_id_key: "sin",
-        state_name: "North Carolina",
         submission_type: "FormNCD400",
         submission_builder_class: SubmissionBuilder::Ty2024::States::Nc::NcReturnXml,
         survey_link: "https://codeforamerica.co1.qualtrics.com/jfe/form/SV_1MM0vBfZ5N2OMLA",
         tax_payment_info_text: "NCDOR.gov",
         tax_payment_info_url: "https://www.ncdor.gov/file-pay/pay-individual-income-tax",
         tax_refund_url: "https://eservices.dor.nc.gov/wheresmyrefund/SelectionServlet",
-        department_of_taxation: "N.C. Department of Revenue",
         timezone: 'America/New_York',
         vita_link_en: "https://airtable.com/appqG5OGbTLBiQ408/pagJPN5iPinERGb3Q/form",
         vita_link_es: "https://airtable.com/appqG5OGbTLBiQ408/pagS982AjKEml809R/form",
@@ -184,7 +184,6 @@ module StateFile
         review_controller_class: StateFile::Questions::NjReviewController,
         submission_builder_class: SubmissionBuilder::Ty2024::States::Nj::NjReturnXml,
         software_id_key: "sin",
-        state_name: "New Jersey",
         return_type: "Resident",
         schema_file_name: "NJIndividual2024V0.1.zip",
         mail_voucher_address: "State of New Jersey<br/>" \
@@ -197,7 +196,6 @@ module StateFile
         tax_payment_info_text: "https://www1.state.nj.us/TYTR_RevTaxPortal/jsp/IndTaxLoginJsp.jsp",
         tax_payment_info_url: "https://www.state.nj.us/treasury/taxation/payments-notices.shtml",
         tax_refund_url: "https://www20.state.nj.us/TYTR_TGI_INQ/jsp/prompt.jsp",
-        department_of_taxation: "New Jersey Division of Taxation",
         timezone: 'America/New_York',
         vita_link_en: "https://airtable.com/appqG5OGbTLBiQ408/pag9EUHzAZzfRIwUn/form",
         vita_link_es: "https://airtable.com/appqG5OGbTLBiQ408/pagVcLm52Stg9p4hY/form",
@@ -218,7 +216,6 @@ module StateFile
         pay_taxes_link: "https://www.tax.ny.gov/pay/",
         return_type: "IT201",
         review_controller_class: StateFile::Questions::NyReviewController,
-        state_name: "New York",
         submission_type: "IT201",
         schema_file_name: "NYSIndividual2023V4.0.zip",
         software_id_key: "sin",
@@ -227,7 +224,6 @@ module StateFile
         tax_payment_info_text: "Tax.NY.gov",
         tax_payment_info_url: "https://www.tax.ny.gov/pay/ind/pay-income-tax-online.htm",
         tax_refund_url: "https://www.tax.ny.gov/pit/file/refund.htm",
-        department_of_taxation: "",
         timezone: 'America/New_York',
         vita_link_en: "",
         vita_link_es: "",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4073,6 +4073,25 @@ en:
         header: FileYourStateTaxes text messaging terms and conditions
         major_carriers: 'Major carriers: AT&T, Verizon Wireless, Sprint, T-Mobile, U.S. Cellular, Alltel, Boost Mobile, Nextel, and Virgin Mobile.'
         minor_carriers: 'Minor carriers: Alaska Communications Systems (ACS), Appalachian Wireless (EKN), Bluegrass Cellular, Cellular One of East Central IL (ECIT), Cellular One of Northeast Pennsylvania, Cincinnati Bell Wireless, Cricket, Coral Wireless (Mobi PCS), COX, Cross, Element Mobile (Flat Wireless), Epic Touch (Elkhart Telephone), GCI, Golden State, Hawkeye (Chat Mobility), Hawkeye (NW Missouri), Illinois Valley Cellular, Inland Cellular, iWireless (Iowa Wireless), Keystone Wireless (Immix Wireless/PC Man), Mosaic (Consolidated or CTC Telecom), Nex-Tech Wireless, NTelos, Panhandle Communications, Pioneer, Plateau (Texas RSA 3 Ltd), Revol, RINA, Simmetry (TMP Corporation), Thumb Cellular, Union Wireless, United Wireless, Viaero Wireless, and West Central (WCC or 5 Star Wireless).'
+    state_information_service:
+      az:
+        department_of_taxation: Arizona Department of Revenue
+        state_name: Arizona
+      id:
+        department_of_taxation: Idaho State Tax Commission
+        state_name: Idaho
+      md:
+        department_of_taxation: Comptroller of Maryland
+        state_name: Maryland
+      nc:
+        department_of_taxation: N.C. Department of Revenue
+        state_name: North Carolina
+      nj:
+        department_of_taxation: New Jersey Division of Taxation
+        state_name: New Jersey
+      ny:
+        department_of_taxation: I don't know
+        state_name: New York
   validators:
     account_number: This account number is not valid for direct deposit transactions. Please review your account number or switch to check payments.
     alpha: Only letters A-Z and a-z are accepted.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4090,7 +4090,7 @@ en:
         department_of_taxation: New Jersey Division of Taxation
         state_name: New Jersey
       ny:
-        department_of_taxation: I don't know
+        department_of_taxation: Department of Taxation and Finance
         state_name: New York
   validators:
     account_number: This account number is not valid for direct deposit transactions. Please review your account number or switch to check payments.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4045,6 +4045,25 @@ es:
         header: FileYourStateTaxes términos y condiciones de mensajería de texto
         major_carriers: 'Proveedores principales: AT&T, Verizon Wireless, Sprint, T-Mobile, U.S. Cellular, Alltel, Boost Mobile, Nextel y Virgin Mobile.'
         minor_carriers: 'Proveedores menores: Alaska Communications Systems (ACS), Appalachian Wireless (EKN), Bluegrass Cellular, Cellular One of East Central IL (ECIT), Cellular One of Northeast Pennsylvania, Cincinnati Bell Wireless, Cricket, Coral Wireless (Mobi PCS), COX, Cross, Element Mobile (Flat Wireless), Epic Touch (Elkhart Telephone), GCI, Golden State, Hawkeye (Chat Mobility), Hawkeye (NW Missouri), Illinois Valley Cellular, Inland Cellular, iWireless (Iowa Wireless), Keystone Wireless (Immix Wireless/PC Man), Mosaic (Consolidated o CTC Telecom), Nex-Tech Wireless, NTelos, Panhandle Communications, Pioneer, Plateau (Texas RSA 3 Ltd), Revol, RINA, Simmetry (TMP Corporation), Thumb Cellular, Union Wireless, United Wireless, Viaero Wireless, y West Central (WCC o 5 Star Wireless).'
+    state_information_service:
+      az:
+        department_of_taxation: Arizona Department of Revenue
+        state_name: Arizona
+      id:
+        department_of_taxation: Idaho State Tax Commission
+        state_name: Idaho
+      md:
+        department_of_taxation: Contralor de Maryland
+        state_name: Maryland
+      nc:
+        department_of_taxation: N.C. Department of Revenue
+        state_name: Carolina del Norte
+      nj:
+        department_of_taxation: New Jersey Division of Taxation
+        state_name: New Jersey
+      ny:
+        department_of_taxation: I don't know
+        state_name: New York
   validators:
     account_number: Este número de cuenta no es válido para transacciones de depósito directo. Revise su número de cuenta o cambie a pagos con cheque.
     alpha: Sólo se aceptan las letras A-Z y a-z.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4047,23 +4047,23 @@ es:
         minor_carriers: 'Proveedores menores: Alaska Communications Systems (ACS), Appalachian Wireless (EKN), Bluegrass Cellular, Cellular One of East Central IL (ECIT), Cellular One of Northeast Pennsylvania, Cincinnati Bell Wireless, Cricket, Coral Wireless (Mobi PCS), COX, Cross, Element Mobile (Flat Wireless), Epic Touch (Elkhart Telephone), GCI, Golden State, Hawkeye (Chat Mobility), Hawkeye (NW Missouri), Illinois Valley Cellular, Inland Cellular, iWireless (Iowa Wireless), Keystone Wireless (Immix Wireless/PC Man), Mosaic (Consolidated o CTC Telecom), Nex-Tech Wireless, NTelos, Panhandle Communications, Pioneer, Plateau (Texas RSA 3 Ltd), Revol, RINA, Simmetry (TMP Corporation), Thumb Cellular, Union Wireless, United Wireless, Viaero Wireless, y West Central (WCC o 5 Star Wireless).'
     state_information_service:
       az:
-        department_of_taxation: Arizona Department of Revenue
+        department_of_taxation: Departamento de Ingresos de Arizona
         state_name: Arizona
       id:
-        department_of_taxation: Idaho State Tax Commission
+        department_of_taxation: Comisión Estatal de Impuestos de Idaho
         state_name: Idaho
       md:
         department_of_taxation: Contralor de Maryland
         state_name: Maryland
       nc:
-        department_of_taxation: N.C. Department of Revenue
+        department_of_taxation: Departamento de Ingresos de Carolina del Norte
         state_name: Carolina del Norte
       nj:
         department_of_taxation: New Jersey Division of Taxation
         state_name: New Jersey
       ny:
-        department_of_taxation: I don't know
-        state_name: New York
+        department_of_taxation: Departamento de Impuestos y Finanzas de Nueva York
+        state_name: Nueva York
   validators:
     account_number: Este número de cuenta no es válido para transacciones de depósito directo. Revise su número de cuenta o cambie a pagos con cheque.
     alpha: Sólo se aceptan las letras A-Z y a-z.

--- a/spec/services/state_file/state_information_service_spec.rb
+++ b/spec/services/state_file/state_information_service_spec.rb
@@ -33,6 +33,42 @@ describe StateFile::StateInformationService do
     end
   end
 
+  context "locale-aware methods" do
+    around do |example|
+      I18n.with_locale(:es) do
+        example.run
+      end
+    end
+
+    describe ".state_name" do
+      it "is locale aware" do
+        expected = "Carolina del Norte"
+        actual = described_class.send(:state_name, "nc")
+        expect(actual).to eq(expected)
+      end
+
+      it "throw an error for an invalid state code" do
+        expect do
+          described_class.send(:state_name, "boop")
+        end.to raise_error(InvalidStateCodeError, "Invalid state code: boop")
+      end
+    end
+
+    describe ".department_of_taxation" do
+      it "is locale aware" do
+        expected = "Departamento de Ingresos de Carolina del Norte"
+        actual = described_class.send(:department_of_taxation, "nc")
+        expect(actual).to eq(expected)
+      end
+
+      it "throw an error for an invalid state code" do
+        expect do
+          described_class.send(:department_of_taxation, "boop")
+        end.to raise_error(InvalidStateCodeError, "Invalid state code: boop")
+      end
+    end
+  end
+
   described_class::GETTER_METHODS.each do |getter_method|
     describe ".#{getter_method}" do
       described_class.active_state_codes.each do |state_code|


### PR DESCRIPTION
## Link to pivotal/JIRA issue
[FYST-1697](https://codeforamerica.atlassian.net/browse/FYST-1697)

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
instead of the StateInformationService knowing a state's name and taxation department, it now knows where to _find_ the name and taxation department in our locale files. this lets us easily localize those proper nouns (if/when we want to) the same way we manage all other localized content. this is similar to the 'sin' value in the StateInformationService; it's not the software identifier itself, rather it's where to find it.

### Slack threads with more context
- https://cfastaff.slack.com/archives/C087E6C7NBZ/p1737673798932829
- https://cfastaff.slack.com/archives/C087E6C7NBZ/p1737648072450549

## How to test?
- Ensure page contents are properly localized when switching locales. Look for content strings that bring in a `state_name` parameter.

## Screenshots (for visual changes)
### Before
![image](https://github.com/user-attachments/assets/4a44bc3a-2637-4e25-b25a-69f72d15bd1a)

### After
![image](https://github.com/user-attachments/assets/e000a28f-7a5f-4f28-982a-925eba736ff7)



[FYST-1697]: https://codeforamerica.atlassian.net/browse/FYST-1697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ