### PR TITLE
get all box 14 fields within fieldset

### DIFF
--- a/app/views/state_file/questions/w2/edit.html.erb
+++ b/app/views/state_file/questions/w2/edit.html.erb
@@ -31,8 +31,8 @@
                   ) %>
                   <%= t(".box14_#{code['name'].downcase}_help_text", year: MultiTenantService.statefile.current_tax_year, default: nil) %>
             </div>
-          </fieldset>
-        <% end %>
+          <% end %>
+        </fieldset>
       <% end %>
       <div class="form-question spacing-below-25">
         <%= f.cfa_input_field(:employer_state_id_num, t(".box15_html"), classes: ["form-width--long"]) %>

--- a/spec/features/state_file/income_review_spec.rb
+++ b/spec/features/state_file/income_review_spec.rb
@@ -1,4 +1,6 @@
 require "rails_helper"
+require 'axe-capybara'
+require 'axe-rspec'
 
 RSpec.feature "Income Review", active_job: true do
   include StateFileIntakeHelper
@@ -54,6 +56,7 @@ RSpec.feature "Income Review", active_job: true do
     it "displays w2 info on edit screen" do
       advance_to_income_edit
 
+      expect(page).to be_axe_clean
       expect(page).to have_css(".progress-steps")
       expect(page).to have_field('state_file_w2_box14_ui_wf_swf', with: '180.0')
       expect(page).to have_field('state_file_w2_box14_fli', with: '145.0')


### PR DESCRIPTION
## Link to pivotal/JIRA issue

followup to https://github.com/newjersey/affordability-pm/issues/217 for https://github.com/newjersey/accessibility-pm/issues/27

## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- the `<fieldset>` was within the iterator creating fields instead of outside of it
- since the other recommendations in the accessibility ticket are design changes or shared components I think we should keep that ticket open but address separately

## How to test?
- Open up W2 editing, and while everything looks and behaves the same you can see the difference with Inspector
## Screenshots (for visual changes)
- Before

<img width="625" alt="image" src="https://github.com/user-attachments/assets/55937304-93ad-473d-ac03-895e0e7d8599" />

- After
<img width="632" alt="image" src="https://github.com/user-attachments/assets/43d9ba82-673f-4d60-91cb-a95a9a87ec4c" />

