### PR TITLE
Do not attempt to fill out account holder names if taxes are owed (ac…

### DIFF
--- a/app/lib/pdf_filler/md502_pdf.rb
+++ b/app/lib/pdf_filler/md502_pdf.rb
@@ -178,7 +178,7 @@ module PdfFiller
 
     def full_names_of_bank_account_holders
       intake = @submission.data_source
-      return nil unless intake.payment_or_deposit_type.to_sym == :direct_deposit
+      return nil unless intake.payment_or_deposit_type.to_sym == :direct_deposit && intake.refund_or_owe_taxes_type == :refund
 
       if intake.has_joint_account_holder_yes?
         account_holder_full_name + " and " + account_holder_full_name(for_joint: true)
@@ -191,6 +191,8 @@ module PdfFiller
       attributes = %w[FirstName MiddleInitial LastName NameSuffix]
       account_holder_xmls = @xml_document.css('Form502 NameOnBankAccount')
       account_holder_xml = for_joint ? account_holder_xmls[1] : account_holder_xmls[0]
+      return if account_holder_xml.nil?
+
       attributes.map { |attr| account_holder_xml.at(attr)&.text }.filter_map(&:presence).join(" ")
     end
 

--- a/spec/lib/pdf_filler/md502_pdf_spec.rb
+++ b/spec/lib/pdf_filler/md502_pdf_spec.rb
@@ -495,6 +495,21 @@ RSpec.describe PdfFiller::Md502Pdf do
         expect(pdf_fields["50"]).to eq "100"
         expect(pdf_fields["50 decimal"]).to eq "00"
       end
+
+      context "direct deposit payment is chosen" do
+        before do
+          intake.update(
+            payment_or_deposit_type: :direct_deposit,
+            routing_number: "123456789",
+            account_number: "87654321",
+            account_type: "checking"
+          )
+        end
+
+        it "should not try to fill out names on bank account" do
+          expect(pdf_fields["51d Names as it appears on the bank account"]).to eq ""
+        end
+      end
     end
 
     context "when there is a refund" do


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1695
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- For the 502xml, `NameOnBankAccount` is only filled out if: `if @intake.payment_or_deposit_type.to_sym == :direct_deposit && @intake.refund_or_owe_taxes_type == :refund`
- this logic was not duplicated for the filling out of the PDF:
   -   See code:
   ```
    def full_names_of_bank_account_holders
         intake = @submission.data_source
         return nil unless intake.payment_or_deposit_type.to_sym == :direct_deposit
    ```

## How to test?
- Describe the testing approach taken to verify the changes, including:
  - added a test to catch this bug
  - manually loaded a `owed` MD intake and loaded up the pdf 
  - Use Nellie, choose direct_deposit at the `taxes-owed` controller, and hit download state return
  - confirmed in demo this was an error; confirmed on heroku that this no longer occurs
  
<img width="611" alt="Screenshot 2025-01-24 at 12 40 43 PM" src="https://github.com/user-attachments/assets/8b28e05b-27f8-4fdc-89ed-0e68e99eeca1" />

<img width="613" alt="Screenshot 2025-01-24 at 12 40 38 PM" src="https://github.com/user-attachments/assets/bef1c9c9-0574-495e-bed3-cb1ec150899b" />
