### PR TITLE
GYR1-640 Updated written language preference logic for page 1 of Hub editable 14-c 

### DIFF
--- a/app/forms/hub/update_13614c_form_page1.rb
+++ b/app/forms/hub/update_13614c_form_page1.rb
@@ -92,9 +92,9 @@ module Hub
 
       # Intake flow assigns 2-char language code to preferred_written_language
       # but here we switch to the person-readable name of the language upon
-      # first loading of hub editable 14-c page 1. And upon first save, the
-      # string, possibly altered by the user, also is what gets saved into the
-      # field. See the method GyrIntake#preferred_written_language_string for
+      # first loading of hub editable 14-c page 1. (And upon a save, the
+      # string, possibly altered by the user, also is what will get saved into the
+      # field.) See the method GyrIntake#preferred_written_language_string for
       # more insight. (Jan. 2025)
       result.merge!(preferred_written_language: intake.preferred_written_language_string)
 

--- a/app/forms/hub/update_13614c_form_page1.rb
+++ b/app/forms/hub/update_13614c_form_page1.rb
@@ -90,6 +90,14 @@ module Hub
         )
       end
 
+      # Intake flow assigns 2-char language code to preferred_written_language
+      # but here we switch to the person-readable name of the language upon
+      # first loading of hub editable 14-c page 1. And upon first save, the
+      # string, possibly altered by the user, also is what gets saved into the
+      # field. See the method GyrIntake#preferred_written_language_string for
+      # more insight. (Jan. 2025)
+      result.merge!(preferred_written_language: intake.preferred_written_language_string)
+
       result
     end
 


### PR DESCRIPTION
## Link to Jira issue

- https://codeforamerica.atlassian.net/browse/GYR1-640

## Is PM acceptance required?

- Yes - don't merge until JIRA issue is accepted!

## What was done?

One-line change to ensure that the client-chosen preferred written language is displayed as the full name (not a 2-charactor code) in the field in the hub editable 14-c page 1.

## How to test?

The correct, human-readable name of the language should always appear in the Hub page 1 field for preferred wrriten language and in the equivalent field on the PDF. This should be true for at least these cases:
- the client made a choice in the intake flow, but then nobody ever did any edit+save on page 1 the Hub editable pages at any point 
- the Hub was updated with a language other than what’s in the preferred list (see 632)