### PR TITLE
GYR1-622 PAGE 3 Make sure all editable 13614-C fields populate into PDF correctly

### DIFF
--- a/app/lib/pdf_filler/f13614c_pdf.rb
+++ b/app/lib/pdf_filler/f13614c_pdf.rb
@@ -176,7 +176,7 @@ module PdfFiller
           'form1[0].page3[0].stndardItemizedDeductions[0].form1098Number[0]' => @intake.cv_1098_count.to_s,
           'form1[0].page3[0].stndardItemizedDeductions[0].standardDeduction[0]' => bool_checkbox(@intake.cv_med_expense_standard_deduction_cb == YES),
           'form1[0].page3[0].stndardItemizedDeductions[0].itemizedDeduction[0]' => bool_checkbox(@intake.cv_med_expense_itemized_deduction_cb == YES),
-          'form1[0].page3[0].stndardItemizedComments[0].stndardItemizedComments[0]' => @intake.cv_14c_page_3_notes_part_1.to_s,
+          'form1[0].page3[0].stndardItemizedComments[0].stndardItemizedComments[0]' => @intake.cv_14c_page_3_notes_part_1,
 
           # page 3 rhs section 2 of 3
           'form1[0].page3[0].expensesToReport[0].form1098E[0]' => bool_checkbox(@intake.cv_1098e_cb == YES),
@@ -188,7 +188,30 @@ module PdfFiller
           'form1[0].page3[0].expensesToReport[0].alimonyPayments[0].alimonyPaymentsAmount[0]' => @intake.cv_paid_alimony_w_spouse_ssn_amt.to_s,
           'form1[0].page3[0].expensesToReport[0].alimonyPayments[0].adjustementYes[0]' => yes_no_unfilled_to_checkbox(@intake.cv_alimony_income_adjustment_yn_cb),
           'form1[0].page3[0].expensesToReport[0].alimonyPayments[0].adjustementNo[0]' => yes_no_unfilled_to_opposite_checkbox(@intake.cv_alimony_income_adjustment_yn_cb),
-          'form1[0].page3[0].expensesReportComments[0].expensesReportComments[0]' => @intake.cv_14c_page_3_notes_part_2.to_s
+          'form1[0].page3[0].expensesReportComments[0].expensesReportComments[0]' => @intake.cv_14c_page_3_notes_part_2,
+
+          # page 3 rhs section 3 of 3
+          'form1[0].page3[0].informationToReport[0].taxableScholarshipIncome[0]' => bool_checkbox(@intake.cv_taxable_scholarship_income_cb == YES),
+          'form1[0].page3[0].informationToReport[0].form1098T[0]' => bool_checkbox(@intake.cv_1098t_cb == YES),
+          'form1[0].page3[0].informationToReport[0].educationCreditTuition[0]' => bool_checkbox(@intake.cv_edu_credit_or_tuition_deduction_cb == YES),
+          'form1[0].page3[0].informationToReport[0].saleOfHome[0]' => bool_checkbox(@intake.cv_1099s_cb == YES),
+          'form1[0].page3[0].informationToReport[0].hsaContributions[0]' => bool_checkbox(@intake.cv_hsa_contrib_cb == YES),
+          'form1[0].page3[0].informationToReport[0].hsaDistributions[0]' => bool_checkbox(@intake.cv_hsa_distrib_cb == YES),
+          'form1[0].page3[0].informationToReport[0].form1095A[0]' => bool_checkbox(@intake.cv_1095a_cb == YES),
+          'form1[0].page3[0].informationToReport[0].efficientHomeImprovement[0]' => bool_checkbox(@intake.cv_energy_efficient_home_improv_credit_cb == YES),
+          'form1[0].page3[0].informationToReport[0].form1099C[0]' => bool_checkbox(@intake.cv_1099c_cb == YES),
+          'form1[0].page3[0].informationToReport[0].form1099A[0]' => bool_checkbox(@intake.cv_1099a_cb == YES),
+          'form1[0].page3[0].informationToReport[0].disasterReliefImpacts[0]' => bool_checkbox(@intake.cv_disaster_relief_impacts_return_cb == YES),
+          'form1[0].page3[0].informationToReport[0].disallowedPreviousYear[0]' => bool_checkbox(@intake.cv_eitc_ctc_aotc_hoh_disallowed_in_a_prev_yr_cb == YES),
+          'form1[0].page3[0].informationToReport[0].YearDisallowedReason[0].yearDisallowed[0]' => @intake.tax_credit_disallowed_year,
+          'form1[0].page3[0].informationToReport[0].YearDisallowedReason[0].reasonDisallowed[0]' => @intake.cv_tax_credit_disallowed_reason,
+          'form1[0].page3[0].informationToReport[0].eligibleLITCReferral[0]' => bool_checkbox(@intake.cv_eligible_for_litc_referral_cb == YES),
+          'form1[0].page3[0].informationToReport[0].estimatedTaxPayments[0].estimatedTaxPayments[0]' => bool_checkbox(@intake.cv_estimated_tax_payments_cb == YES),
+          'form1[0].page3[0].informationToReport[0].estimatedTaxPayments[0].taxPaymentsAmount[0]' => @intake.cv_estimated_tax_payments_amt.to_s,
+          'form1[0].page3[0].informationToReport[0].lastYearsRefund[0].lastYearsRefund[0]' => bool_checkbox(@intake.cv_last_years_refund_applied_to_this_yr_cb == YES),
+          'form1[0].page3[0].informationToReport[0].lastYearsRefund[0].refundAmount[0]' => @intake.cv_last_years_refund_applied_to_this_yr_amt.to_s,
+          'form1[0].page3[0].informationToReport[0].lastReturnAvailable[0]' => bool_checkbox(@intake.cv_last_years_return_available_cb == YES),
+          'form1[0].page3[0].informationReportComment[0].informationReportComment[0]' => @intake.cv_14c_page_3_notes_part_3,
       )
 
       answers.merge!(

--- a/app/lib/pdf_filler/f13614c_pdf.rb
+++ b/app/lib/pdf_filler/f13614c_pdf.rb
@@ -41,6 +41,8 @@ module PdfFiller
       ],
     }
 
+    YES = 'yes'
+
     def source_pdf_name
       "f13614c-TY2024"
     end
@@ -142,17 +144,22 @@ module PdfFiller
       )
       answers.merge!(
         keep_and_normalize({
-          "form1[0].page3[0].paidFollowingExpenses[0].mortgageinterest[0]" => @intake.wants_to_itemize_yes? && @intake.ever_owned_home_yes? && @intake.paid_mortgage_interest_yes?,
-          "form1[0].page3[0].paidFollowingExpenses[0].taxesStateLocal[0]" => @intake.wants_to_itemize_yes? && @intake.paid_local_tax_yes?,
-          "form1[0].page3[0].paidFollowingExpenses[0].mendicalDentalPrescription[0]" => @intake.wants_to_itemize_yes? && @intake.paid_medical_expenses_yes?,
-          "form1[0].page3[0].paidFollowingExpenses[0].charitableContributions[0]" => @intake.wants_to_itemize_yes? && @intake.paid_charitable_contributions_yes?,
+          # page 3 lhs section 1 of 3
+          "form1[0].page3[0].paidFollowingExpenses[0].mortgageinterest[0]" => @intake.paid_mortgage_interest_yes?,
+          "form1[0].page3[0].paidFollowingExpenses[0].taxesStateLocal[0]" => @intake.paid_local_tax_yes?,
+          "form1[0].page3[0].paidFollowingExpenses[0].mendicalDentalPrescription[0]" => @intake.paid_medical_expenses_yes?,
+          "form1[0].page3[0].paidFollowingExpenses[0].charitableContributions[0]" => @intake.paid_charitable_contributions_yes?,
+
+          # page 3 lhs section 2 of 3
           "form1[0].page3[0].paidExpenses[0].studentLoanInterest[0]" => @intake.paid_student_loan_interest_yes?,
-          "form1[0].page3[0].paidExpenses[0].childDependentCare[0]" => @intake.had_dependents_yes? && @intake.paid_dependent_care_yes?,
-          "form1[0].page3[0].paidExpenses[0].contributionsRetirementAccount[0]" => @intake.had_social_security_or_retirement_yes? && @intake.paid_retirement_contributions_yes?,
-          "form1[0].page3[0].paidExpenses[0].schooldSupplies[0]" => @intake.wants_to_itemize_yes? && @intake.paid_school_supplies_yes?,
-          "form1[0].page3[0].paidExpenses[0].alimonyPayments[0]" => @intake.ever_married_yes? && @intake.paid_alimony_yes?,
+          "form1[0].page3[0].paidExpenses[0].childDependentCare[0]" => @intake.paid_dependent_care_yes?,
+          "form1[0].page3[0].paidExpenses[0].contributionsRetirementAccount[0]" => @intake.paid_retirement_contributions_yes?,
+          "form1[0].page3[0].paidExpenses[0].schooldSupplies[0]" => @intake.paid_school_supplies_yes?,
+          "form1[0].page3[0].paidExpenses[0].alimonyPayments[0]" => @intake.paid_alimony_yes?,
+
+          # page 3 lhs section 3 of 3
           "form1[0].page3[0].followingHappenDuring[0].tookEducationalClasses[0].tookEducationalClasses[0]" => @intake.paid_post_secondary_educational_expenses_yes?,
-          "form1[0].page3[0].followingHappenDuring[0].sellAHome[0]" => @intake.ever_owned_home_yes? && @intake.sold_a_home_yes?,
+          "form1[0].page3[0].followingHappenDuring[0].sellAHome[0]" => @intake.sold_a_home_yes?,
           "form1[0].page3[0].followingHappenDuring[0].healthSavingsAccount[0]" => @intake.had_hsa_yes?,
           "form1[0].page3[0].followingHappenDuring[0].purchaseMarketplaceInsurance[0]" => @intake.bought_marketplace_health_insurance_yes?,
           "form1[0].page3[0].followingHappenDuring[0].energyEfficientItems[0].energyEfficientItems[0]" => @intake.bought_energy_efficient_items_yes?,
@@ -162,6 +169,14 @@ module PdfFiller
           "form1[0].page3[0].followingHappenDuring[0].receivedLetterBill[0]" => @intake.received_irs_letter_yes?,
           "form1[0].page3[0].followingHappenDuring[0].estimatedTaxPayments[0].estimatedTaxPayments[0]" => @intake.made_estimated_tax_payments_yes?,
         })
+      )
+      answers.merge!(
+          # page 3 rhs section 1 of 3
+          'form1[0].page3[0].stndardItemizedDeductions[0].form1098[0]' => bool_checkbox(@intake.cv_1098_cb == YES),
+          'form1[0].page3[0].stndardItemizedDeductions[0].form1098Number[0]' => @intake.cv_1098_count.to_s,
+          'form1[0].page3[0].stndardItemizedDeductions[0].standardDeduction[0]' => bool_checkbox(@intake.cv_med_expense_standard_deduction_cb == YES),
+          'form1[0].page3[0].stndardItemizedDeductions[0].itemizedDeduction[0]' => bool_checkbox(@intake.cv_med_expense_itemized_deduction_cb == YES),
+          'form1[0].page3[0].stndardItemizedComments[0].stndardItemizedComments[0]' => @intake.cv_14c_page_3_notes_part_1.to_s,
       )
 
       answers.merge!(

--- a/app/lib/pdf_filler/f13614c_pdf.rb
+++ b/app/lib/pdf_filler/f13614c_pdf.rb
@@ -177,6 +177,18 @@ module PdfFiller
           'form1[0].page3[0].stndardItemizedDeductions[0].standardDeduction[0]' => bool_checkbox(@intake.cv_med_expense_standard_deduction_cb == YES),
           'form1[0].page3[0].stndardItemizedDeductions[0].itemizedDeduction[0]' => bool_checkbox(@intake.cv_med_expense_itemized_deduction_cb == YES),
           'form1[0].page3[0].stndardItemizedComments[0].stndardItemizedComments[0]' => @intake.cv_14c_page_3_notes_part_1.to_s,
+
+          # page 3 rhs section 2 of 3
+          'form1[0].page3[0].expensesToReport[0].form1098E[0]' => bool_checkbox(@intake.cv_1098e_cb == YES),
+          'form1[0].page3[0].expensesToReport[0].childDependentCare[0]' => bool_checkbox(@intake.cv_child_dependent_care_credit_cb == YES),
+          'form1[0].page3[0].expensesToReport[0].iraBasicRoth[0]' => bool_checkbox(@intake. contributed_to_ira == YES),
+          'form1[0].page3[0].expensesToReport[0].educatorExpensesDeduction[0]' => bool_checkbox(@intake.cv_edu_expenses_deduction_cb == YES),
+          'form1[0].page3[0].expensesToReport[0].educatorExpensesDeductionAmount[0]' => @intake.cv_edu_expenses_deduction_amt.to_s,
+          'form1[0].page3[0].expensesToReport[0].alimonyPayments[0].alimonyPayments[0]' => bool_checkbox(@intake.cv_paid_alimony_w_spouse_ssn_cb == YES),
+          'form1[0].page3[0].expensesToReport[0].alimonyPayments[0].alimonyPaymentsAmount[0]' => @intake.cv_paid_alimony_w_spouse_ssn_amt.to_s,
+          'form1[0].page3[0].expensesToReport[0].alimonyPayments[0].adjustementYes[0]' => yes_no_unfilled_to_checkbox(@intake.cv_alimony_income_adjustment_yn_cb),
+          'form1[0].page3[0].expensesToReport[0].alimonyPayments[0].adjustementNo[0]' => yes_no_unfilled_to_opposite_checkbox(@intake.cv_alimony_income_adjustment_yn_cb),
+          'form1[0].page3[0].expensesReportComments[0].expensesReportComments[0]' => @intake.cv_14c_page_3_notes_part_2.to_s
       )
 
       answers.merge!(

--- a/app/lib/pdf_filler/f13614c_pdf.rb
+++ b/app/lib/pdf_filler/f13614c_pdf.rb
@@ -41,8 +41,6 @@ module PdfFiller
       ],
     }
 
-    YES = 'yes'
-
     def source_pdf_name
       "f13614c-TY2024"
     end
@@ -172,45 +170,45 @@ module PdfFiller
       )
       answers.merge!(
           # page 3 rhs section 1 of 3
-          'form1[0].page3[0].stndardItemizedDeductions[0].form1098[0]' => bool_checkbox(@intake.cv_1098_cb == YES),
+          'form1[0].page3[0].stndardItemizedDeductions[0].form1098[0]' => bool_checkbox(@intake.cv_1098_cb_yes?),
           'form1[0].page3[0].stndardItemizedDeductions[0].form1098Number[0]' => @intake.cv_1098_count.to_s,
-          'form1[0].page3[0].stndardItemizedDeductions[0].standardDeduction[0]' => bool_checkbox(@intake.cv_med_expense_standard_deduction_cb == YES),
-          'form1[0].page3[0].stndardItemizedDeductions[0].itemizedDeduction[0]' => bool_checkbox(@intake.cv_med_expense_itemized_deduction_cb == YES),
+          'form1[0].page3[0].stndardItemizedDeductions[0].standardDeduction[0]' => bool_checkbox(@intake.cv_med_expense_standard_deduction_cb_yes?),
+          'form1[0].page3[0].stndardItemizedDeductions[0].itemizedDeduction[0]' => bool_checkbox(@intake.cv_med_expense_itemized_deduction_cb_yes?),
           'form1[0].page3[0].stndardItemizedComments[0].stndardItemizedComments[0]' => @intake.cv_14c_page_3_notes_part_1,
 
           # page 3 rhs section 2 of 3
-          'form1[0].page3[0].expensesToReport[0].form1098E[0]' => bool_checkbox(@intake.cv_1098e_cb == YES),
-          'form1[0].page3[0].expensesToReport[0].childDependentCare[0]' => bool_checkbox(@intake.cv_child_dependent_care_credit_cb == YES),
-          'form1[0].page3[0].expensesToReport[0].iraBasicRoth[0]' => bool_checkbox(@intake. contributed_to_ira == YES),
-          'form1[0].page3[0].expensesToReport[0].educatorExpensesDeduction[0]' => bool_checkbox(@intake.cv_edu_expenses_deduction_cb == YES),
+          'form1[0].page3[0].expensesToReport[0].form1098E[0]' => bool_checkbox(@intake.cv_1098e_cb_yes?),
+          'form1[0].page3[0].expensesToReport[0].childDependentCare[0]' => bool_checkbox(@intake.cv_child_dependent_care_credit_cb_yes?),
+          'form1[0].page3[0].expensesToReport[0].iraBasicRoth[0]' => bool_checkbox(@intake. contributed_to_ira_yes?),
+          'form1[0].page3[0].expensesToReport[0].educatorExpensesDeduction[0]' => bool_checkbox(@intake.cv_edu_expenses_deduction_cb_yes?),
           'form1[0].page3[0].expensesToReport[0].educatorExpensesDeductionAmount[0]' => @intake.cv_edu_expenses_deduction_amt.to_s,
-          'form1[0].page3[0].expensesToReport[0].alimonyPayments[0].alimonyPayments[0]' => bool_checkbox(@intake.cv_paid_alimony_w_spouse_ssn_cb == YES),
+          'form1[0].page3[0].expensesToReport[0].alimonyPayments[0].alimonyPayments[0]' => bool_checkbox(@intake.cv_paid_alimony_w_spouse_ssn_cb_yes?),
           'form1[0].page3[0].expensesToReport[0].alimonyPayments[0].alimonyPaymentsAmount[0]' => @intake.cv_paid_alimony_w_spouse_ssn_amt.to_s,
           'form1[0].page3[0].expensesToReport[0].alimonyPayments[0].adjustementYes[0]' => yes_no_unfilled_to_checkbox(@intake.cv_alimony_income_adjustment_yn_cb),
           'form1[0].page3[0].expensesToReport[0].alimonyPayments[0].adjustementNo[0]' => yes_no_unfilled_to_opposite_checkbox(@intake.cv_alimony_income_adjustment_yn_cb),
           'form1[0].page3[0].expensesReportComments[0].expensesReportComments[0]' => @intake.cv_14c_page_3_notes_part_2,
 
           # page 3 rhs section 3 of 3
-          'form1[0].page3[0].informationToReport[0].taxableScholarshipIncome[0]' => bool_checkbox(@intake.cv_taxable_scholarship_income_cb == YES),
-          'form1[0].page3[0].informationToReport[0].form1098T[0]' => bool_checkbox(@intake.cv_1098t_cb == YES),
-          'form1[0].page3[0].informationToReport[0].educationCreditTuition[0]' => bool_checkbox(@intake.cv_edu_credit_or_tuition_deduction_cb == YES),
-          'form1[0].page3[0].informationToReport[0].saleOfHome[0]' => bool_checkbox(@intake.cv_1099s_cb == YES),
-          'form1[0].page3[0].informationToReport[0].hsaContributions[0]' => bool_checkbox(@intake.cv_hsa_contrib_cb == YES),
-          'form1[0].page3[0].informationToReport[0].hsaDistributions[0]' => bool_checkbox(@intake.cv_hsa_distrib_cb == YES),
-          'form1[0].page3[0].informationToReport[0].form1095A[0]' => bool_checkbox(@intake.cv_1095a_cb == YES),
-          'form1[0].page3[0].informationToReport[0].efficientHomeImprovement[0]' => bool_checkbox(@intake.cv_energy_efficient_home_improv_credit_cb == YES),
-          'form1[0].page3[0].informationToReport[0].form1099C[0]' => bool_checkbox(@intake.cv_1099c_cb == YES),
-          'form1[0].page3[0].informationToReport[0].form1099A[0]' => bool_checkbox(@intake.cv_1099a_cb == YES),
-          'form1[0].page3[0].informationToReport[0].disasterReliefImpacts[0]' => bool_checkbox(@intake.cv_disaster_relief_impacts_return_cb == YES),
-          'form1[0].page3[0].informationToReport[0].disallowedPreviousYear[0]' => bool_checkbox(@intake.cv_eitc_ctc_aotc_hoh_disallowed_in_a_prev_yr_cb == YES),
+          'form1[0].page3[0].informationToReport[0].taxableScholarshipIncome[0]' => bool_checkbox(@intake.cv_taxable_scholarship_income_cb_yes?),
+          'form1[0].page3[0].informationToReport[0].form1098T[0]' => bool_checkbox(@intake.cv_1098t_cb_yes?),
+          'form1[0].page3[0].informationToReport[0].educationCreditTuition[0]' => bool_checkbox(@intake.cv_edu_credit_or_tuition_deduction_cb_yes?),
+          'form1[0].page3[0].informationToReport[0].saleOfHome[0]' => bool_checkbox(@intake.cv_1099s_cb_yes?),
+          'form1[0].page3[0].informationToReport[0].hsaContributions[0]' => bool_checkbox(@intake.cv_hsa_contrib_cb_yes?),
+          'form1[0].page3[0].informationToReport[0].hsaDistributions[0]' => bool_checkbox(@intake.cv_hsa_distrib_cb_yes?),
+          'form1[0].page3[0].informationToReport[0].form1095A[0]' => bool_checkbox(@intake.cv_1095a_cb_yes?),
+          'form1[0].page3[0].informationToReport[0].efficientHomeImprovement[0]' => bool_checkbox(@intake.cv_energy_efficient_home_improv_credit_cb_yes?),
+          'form1[0].page3[0].informationToReport[0].form1099C[0]' => bool_checkbox(@intake.cv_1099c_cb_yes?),
+          'form1[0].page3[0].informationToReport[0].form1099A[0]' => bool_checkbox(@intake.cv_1099a_cb_yes?),
+          'form1[0].page3[0].informationToReport[0].disasterReliefImpacts[0]' => bool_checkbox(@intake.cv_disaster_relief_impacts_return_cb_yes?),
+          'form1[0].page3[0].informationToReport[0].disallowedPreviousYear[0]' => bool_checkbox(@intake.cv_eitc_ctc_aotc_hoh_disallowed_in_a_prev_yr_cb_yes?),
           'form1[0].page3[0].informationToReport[0].YearDisallowedReason[0].yearDisallowed[0]' => @intake.tax_credit_disallowed_year,
           'form1[0].page3[0].informationToReport[0].YearDisallowedReason[0].reasonDisallowed[0]' => @intake.cv_tax_credit_disallowed_reason,
-          'form1[0].page3[0].informationToReport[0].eligibleLITCReferral[0]' => bool_checkbox(@intake.cv_eligible_for_litc_referral_cb == YES),
-          'form1[0].page3[0].informationToReport[0].estimatedTaxPayments[0].estimatedTaxPayments[0]' => bool_checkbox(@intake.cv_estimated_tax_payments_cb == YES),
+          'form1[0].page3[0].informationToReport[0].eligibleLITCReferral[0]' => bool_checkbox(@intake.cv_eligible_for_litc_referral_cb_yes?),
+          'form1[0].page3[0].informationToReport[0].estimatedTaxPayments[0].estimatedTaxPayments[0]' => bool_checkbox(@intake.cv_estimated_tax_payments_cb_yes?),
           'form1[0].page3[0].informationToReport[0].estimatedTaxPayments[0].taxPaymentsAmount[0]' => @intake.cv_estimated_tax_payments_amt.to_s,
-          'form1[0].page3[0].informationToReport[0].lastYearsRefund[0].lastYearsRefund[0]' => bool_checkbox(@intake.cv_last_years_refund_applied_to_this_yr_cb == YES),
+          'form1[0].page3[0].informationToReport[0].lastYearsRefund[0].lastYearsRefund[0]' => bool_checkbox(@intake.cv_last_years_refund_applied_to_this_yr_cb_yes?),
           'form1[0].page3[0].informationToReport[0].lastYearsRefund[0].refundAmount[0]' => @intake.cv_last_years_refund_applied_to_this_yr_amt.to_s,
-          'form1[0].page3[0].informationToReport[0].lastReturnAvailable[0]' => bool_checkbox(@intake.cv_last_years_return_available_cb == YES),
+          'form1[0].page3[0].informationToReport[0].lastReturnAvailable[0]' => bool_checkbox(@intake.cv_last_years_return_available_cb_yes?),
           'form1[0].page3[0].informationReportComment[0].informationReportComment[0]' => @intake.cv_14c_page_3_notes_part_3,
       )
 

--- a/app/lib/pdf_filler/f13614c_pdf.rb
+++ b/app/lib/pdf_filler/f13614c_pdf.rb
@@ -215,10 +215,6 @@ module PdfFiller
       )
 
       answers.merge!(
-        yes_no_checkboxes("form1[0].page2[0].Part4[0].q7ExpensesRelatedTo[0]", @intake.paid_self_employment_expenses, include_unsure: true),
-        yes_no_checkboxes("form1[0].page2[0].Part5[0].q3AdoptAChild[0]", fetch_gated_value(@intake, :adopted_child), include_unsure: true),
-      )
-      answers.merge!(
         "form1[0].page2[0].Part5[0].q4HaveEarnedIncome[0].WhichTaxYear[0]" => @intake.tax_credit_disallowed_year
       )
       answers.merge!(

--- a/spec/lib/pdf_filler/f13614c_pdf_spec.rb
+++ b/spec/lib/pdf_filler/f13614c_pdf_spec.rb
@@ -643,6 +643,112 @@ RSpec.describe PdfFiller::F13614cPdf do
             )
           end
         end
+
+        describe 'section 3 on 3 ' do
+          it 'looks good when all choices are no and fields are nil' do
+            intake.update(
+              cv_taxable_scholarship_income_cb: 'no',
+              cv_1098t_cb: 'no',
+              cv_edu_credit_or_tuition_deduction_cb: 'no',
+              cv_1099s_cb: 'no',
+              cv_hsa_contrib_cb: 'no',
+              cv_hsa_distrib_cb: 'no',
+              cv_1095a_cb: 'no',
+              cv_energy_efficient_home_improv_credit_cb: 'no',
+              cv_1099c_cb: 'no',
+              cv_1099a_cb: 'no',
+              cv_disaster_relief_impacts_return_cb: 'no',
+              cv_eitc_ctc_aotc_hoh_disallowed_in_a_prev_yr_cb: 'no',
+              tax_credit_disallowed_year: nil,
+              cv_tax_credit_disallowed_reason: nil,
+              cv_eligible_for_litc_referral_cb: 'no',
+              cv_estimated_tax_payments_cb: 'no',
+              cv_estimated_tax_payments_amt: nil,
+              cv_last_years_refund_applied_to_this_yr_cb: 'no',
+              cv_last_years_refund_applied_to_this_yr_amt: nil,
+              cv_last_years_return_available_cb: 'no',
+              cv_14c_page_3_notes_part_3: nil,
+            )
+
+            output_file = intake_pdf.output_file
+            result = non_preparer_fields(output_file.path)
+            expect(result).to include(
+              'form1[0].page3[0].informationToReport[0].taxableScholarshipIncome[0]' => '',
+              'form1[0].page3[0].informationToReport[0].form1098T[0]' => '',
+              'form1[0].page3[0].informationToReport[0].educationCreditTuition[0]' => '',
+              'form1[0].page3[0].informationToReport[0].saleOfHome[0]' => '',
+              'form1[0].page3[0].informationToReport[0].hsaContributions[0]' => '',
+              'form1[0].page3[0].informationToReport[0].hsaDistributions[0]' => '',
+              'form1[0].page3[0].informationToReport[0].form1095A[0]' => '',
+              'form1[0].page3[0].informationToReport[0].efficientHomeImprovement[0]' => '',
+              'form1[0].page3[0].informationToReport[0].form1099C[0]' => '',
+              'form1[0].page3[0].informationToReport[0].form1099A[0]' => '',
+              'form1[0].page3[0].informationToReport[0].disasterReliefImpacts[0]' => '',
+              'form1[0].page3[0].informationToReport[0].disallowedPreviousYear[0]' => '',
+              'form1[0].page3[0].informationToReport[0].YearDisallowedReason[0].yearDisallowed[0]' => '',
+              'form1[0].page3[0].informationToReport[0].YearDisallowedReason[0].reasonDisallowed[0]' => '',
+              'form1[0].page3[0].informationToReport[0].eligibleLITCReferral[0]' => '',
+              'form1[0].page3[0].informationToReport[0].estimatedTaxPayments[0].estimatedTaxPayments[0]' => '',
+              'form1[0].page3[0].informationToReport[0].estimatedTaxPayments[0].taxPaymentsAmount[0]' => '',
+              'form1[0].page3[0].informationToReport[0].lastYearsRefund[0].lastYearsRefund[0]' => '',
+              'form1[0].page3[0].informationToReport[0].lastYearsRefund[0].refundAmount[0]' => '',
+              'form1[0].page3[0].informationToReport[0].lastReturnAvailable[0]' => '',
+              'form1[0].page3[0].informationReportComment[0].informationReportComment[0]' => '',
+            )
+          end
+
+          it 'works when all choices are all yes and filled in' do
+            intake.update(
+              cv_taxable_scholarship_income_cb: 'yes',
+              cv_1098t_cb: 'yes',
+              cv_edu_credit_or_tuition_deduction_cb: 'yes',
+              cv_1099s_cb: 'yes',
+              cv_hsa_contrib_cb: 'yes',
+              cv_hsa_distrib_cb: 'yes',
+              cv_1095a_cb: 'yes',
+              cv_energy_efficient_home_improv_credit_cb: 'yes',
+              cv_1099c_cb: 'yes',
+              cv_1099a_cb: 'yes',
+              cv_disaster_relief_impacts_return_cb: 'yes',
+              cv_eitc_ctc_aotc_hoh_disallowed_in_a_prev_yr_cb: 'yes',
+              tax_credit_disallowed_year: '2001',
+              cv_tax_credit_disallowed_reason: 'an explanation',
+              cv_eligible_for_litc_referral_cb: 'yes',
+              cv_estimated_tax_payments_cb: 'yes',
+              cv_estimated_tax_payments_amt: 2816,
+              cv_last_years_refund_applied_to_this_yr_cb: 'yes',
+              cv_last_years_refund_applied_to_this_yr_amt: 2817,
+              cv_last_years_return_available_cb: 'yes',
+              cv_14c_page_3_notes_part_3: 'section 3 note!!!',
+            )
+
+            output_file = intake_pdf.output_file
+            result = non_preparer_fields(output_file.path)
+            expect(result).to include(
+              'form1[0].page3[0].informationToReport[0].taxableScholarshipIncome[0]' => '1',
+              'form1[0].page3[0].informationToReport[0].form1098T[0]' => '1',
+              'form1[0].page3[0].informationToReport[0].educationCreditTuition[0]' => '1',
+              'form1[0].page3[0].informationToReport[0].saleOfHome[0]' => '1',
+              'form1[0].page3[0].informationToReport[0].hsaContributions[0]' => '1',
+              'form1[0].page3[0].informationToReport[0].hsaDistributions[0]' => '1',
+              'form1[0].page3[0].informationToReport[0].form1095A[0]' => '1',
+              'form1[0].page3[0].informationToReport[0].efficientHomeImprovement[0]' => '1',
+              'form1[0].page3[0].informationToReport[0].form1099C[0]' => '1',
+              'form1[0].page3[0].informationToReport[0].form1099A[0]' => '1',
+              'form1[0].page3[0].informationToReport[0].disasterReliefImpacts[0]' => '1',
+              'form1[0].page3[0].informationToReport[0].disallowedPreviousYear[0]' => '1',
+              'form1[0].page3[0].informationToReport[0].YearDisallowedReason[0].yearDisallowed[0]' => '2001',
+              'form1[0].page3[0].informationToReport[0].YearDisallowedReason[0].reasonDisallowed[0]' => 'an explanation',
+              'form1[0].page3[0].informationToReport[0].eligibleLITCReferral[0]' => '1',
+              'form1[0].page3[0].informationToReport[0].estimatedTaxPayments[0].estimatedTaxPayments[0]' => '1',
+              'form1[0].page3[0].informationToReport[0].estimatedTaxPayments[0].taxPaymentsAmount[0]' => '2816.0',
+              'form1[0].page3[0].informationToReport[0].lastYearsRefund[0].lastYearsRefund[0]' => '1',
+              'form1[0].page3[0].informationToReport[0].lastYearsRefund[0].refundAmount[0]' => '2817.0',
+              'form1[0].page3[0].informationToReport[0].lastReturnAvailable[0]' => '1',
+              'form1[0].page3[0].informationReportComment[0].informationReportComment[0]' => 'section 3 note!!!',
+            )
+          end
+        end
       end
 
       describe "#hash_for_pdf" do

--- a/spec/lib/pdf_filler/f13614c_pdf_spec.rb
+++ b/spec/lib/pdf_filler/f13614c_pdf_spec.rb
@@ -564,6 +564,83 @@ RSpec.describe PdfFiller::F13614cPdf do
             )
           end
           it 'works when all choices are all yes and filled in' do
+            intake.update(
+              cv_1098_cb: 'yes',
+              cv_1098_count: 5,
+              cv_med_expense_standard_deduction_cb: 'yes',
+              cv_med_expense_itemized_deduction_cb: 'yes',
+              cv_14c_page_3_notes_part_1: 'section 1 note'
+            )
+
+            output_file = intake_pdf.output_file
+            result = non_preparer_fields(output_file.path)
+            expect(result).to include(
+              'form1[0].page3[0].stndardItemizedDeductions[0].form1098[0]' => '1',
+              'form1[0].page3[0].stndardItemizedDeductions[0].form1098Number[0]' => '5',
+              'form1[0].page3[0].stndardItemizedDeductions[0].standardDeduction[0]' => '1',
+              'form1[0].page3[0].stndardItemizedDeductions[0].itemizedDeduction[0]' => '1',
+              'form1[0].page3[0].stndardItemizedComments[0].stndardItemizedComments[0]' => 'section 1 note'
+            )
+          end
+        end
+
+        describe 'section 2 on 3' do
+          it 'looks good when all choices are no and fields are nil' do
+            intake.update(
+              cv_1098e_cb: 'no',
+              cv_child_dependent_care_credit_cb: 'no',
+              contributed_to_ira: 'no',
+              cv_edu_expenses_deduction_cb: 'no',
+              cv_edu_expenses_deduction_amt: nil,
+              cv_paid_alimony_w_spouse_ssn_cb: 'no',
+              cv_paid_alimony_w_spouse_ssn_amt: nil,
+              cv_alimony_income_adjustment_yn_cb: 'no',
+              cv_14c_page_3_notes_part_2: nil,
+            )
+
+            output_file = intake_pdf.output_file
+            result = non_preparer_fields(output_file.path)
+            expect(result).to include(
+              'form1[0].page3[0].expensesToReport[0].form1098E[0]' => '',
+              'form1[0].page3[0].expensesToReport[0].childDependentCare[0]' => '',
+              'form1[0].page3[0].expensesToReport[0].iraBasicRoth[0]' => '',
+              'form1[0].page3[0].expensesToReport[0].educatorExpensesDeduction[0]' => '',
+              'form1[0].page3[0].expensesToReport[0].educatorExpensesDeductionAmount[0]' => '',
+              'form1[0].page3[0].expensesToReport[0].alimonyPayments[0].alimonyPayments[0]' => '',
+              'form1[0].page3[0].expensesToReport[0].alimonyPayments[0].alimonyPaymentsAmount[0]' => '',
+              'form1[0].page3[0].expensesToReport[0].alimonyPayments[0].adjustementYes[0]' => '',
+              'form1[0].page3[0].expensesToReport[0].alimonyPayments[0].adjustementNo[0]' => '1',
+              'form1[0].page3[0].expensesReportComments[0].expensesReportComments[0]' => '',
+            )
+          end
+
+          it 'works when all choices are all yes and filled in' do
+            intake.update(
+              cv_1098e_cb: 'yes',
+              cv_child_dependent_care_credit_cb: 'yes',
+              contributed_to_ira: 'yes',
+              cv_edu_expenses_deduction_cb: 'yes',
+              cv_edu_expenses_deduction_amt: 2814,
+              cv_paid_alimony_w_spouse_ssn_cb: 'yes',
+              cv_paid_alimony_w_spouse_ssn_amt: 2815,
+              cv_alimony_income_adjustment_yn_cb: 'yes',
+              cv_14c_page_3_notes_part_2: 'section 2 note!!',
+            )
+
+            output_file = intake_pdf.output_file
+            result = non_preparer_fields(output_file.path)
+            expect(result).to include(
+              'form1[0].page3[0].expensesToReport[0].form1098E[0]' => '1',
+              'form1[0].page3[0].expensesToReport[0].childDependentCare[0]' => '1',
+              'form1[0].page3[0].expensesToReport[0].iraBasicRoth[0]' => '1',
+              'form1[0].page3[0].expensesToReport[0].educatorExpensesDeduction[0]' => '1',
+              'form1[0].page3[0].expensesToReport[0].educatorExpensesDeductionAmount[0]' => '2814.0',
+              'form1[0].page3[0].expensesToReport[0].alimonyPayments[0].alimonyPayments[0]' => '1',
+              'form1[0].page3[0].expensesToReport[0].alimonyPayments[0].alimonyPaymentsAmount[0]' => '2815.0',
+              'form1[0].page3[0].expensesToReport[0].alimonyPayments[0].adjustementYes[0]' => '1',
+              'form1[0].page3[0].expensesToReport[0].alimonyPayments[0].adjustementNo[0]' => '',
+              'form1[0].page3[0].expensesReportComments[0].expensesReportComments[0]' => 'section 2 note!!',
+            )
           end
         end
       end

--- a/spec/lib/pdf_filler/f13614c_pdf_spec.rb
+++ b/spec/lib/pdf_filler/f13614c_pdf_spec.rb
@@ -542,6 +542,32 @@ RSpec.describe PdfFiller::F13614cPdf do
         end
       end
 
+      describe 'page 3 (expenses) gray questions on right-hand side' do
+        describe 'section 1 on 3' do
+          it 'looks good when all choices are no and fields are nil' do
+            intake.update(
+              cv_1098_cb: 'no',
+              cv_1098_count: nil,
+              cv_med_expense_standard_deduction_cb: 'no',
+              cv_med_expense_itemized_deduction_cb: 'no',
+              cv_14c_page_3_notes_part_1: nil
+            )
+
+            output_file = intake_pdf.output_file
+            result = non_preparer_fields(output_file.path)
+            expect(result).to include(
+              'form1[0].page3[0].stndardItemizedDeductions[0].form1098[0]' => '',
+              'form1[0].page3[0].stndardItemizedDeductions[0].form1098Number[0]' => '',
+              'form1[0].page3[0].stndardItemizedDeductions[0].standardDeduction[0]' => '',
+              'form1[0].page3[0].stndardItemizedDeductions[0].itemizedDeduction[0]' => '',
+              'form1[0].page3[0].stndardItemizedComments[0].stndardItemizedComments[0]' => ''
+            )
+          end
+          it 'works when all choices are all yes and filled in' do
+          end
+        end
+      end
+
       describe "#hash_for_pdf" do
         describe 'additional comments field' do
           let(:additional_comments_key) { "form1[0].page3[0].AdditionalComments[0].AdditionalComments[1]" }


### PR DESCRIPTION
## Link to Jira issue

- https://codeforamerica.atlassian.net/browse/GYR1-622

## Is PM acceptance required?

- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main

## What was done?

- Did some 'tidying' of the mappings for page 3, LHS.
- Added pdf mappings and spec tests for page 3, RHS (the gray fields)

## How to test?

For page 3, LHS ...

- Do some light smoke testing.

For page 3, RHS (gray questions) of the PDF ...

- Ensure that when fields are no or blank in the Hub, that checkmarks are *not* 
  checked off on the PDF, and that fields are empty.
- When fields are filled in with 'Yes' or a value in the Hub, ensure these show up on the 
  PDF, including the three distinct "Notes/Comments" fields on the right edge.
- Confirm that both the Yes and No checkboxes for the 'Adjustment to income' 
  question (near the middle of the page) work correctly on the PDF.

## Example

<img width="546" alt="image" src="https://github.com/user-attachments/assets/ef8a4684-cae7-4c7e-93c8-730df7dc9a30" />
