### PR TITLE
Fix zip code XML formatting across application

### DIFF
--- a/app/lib/submission_builder/formatting_methods.rb
+++ b/app/lib/submission_builder/formatting_methods.rb
@@ -14,6 +14,15 @@ module SubmissionBuilder
       sanitized_string&.strip
     end
 
+    def sanitize_zipcode(zipcode_str)
+      sanitized_zipcode = sanitize_for_xml(zipcode_str)
+      if @submission.data_source.state_code == "md"
+        sanitized_zipcode.gsub("-", "")
+      else
+        sanitized_zipcode
+      end
+    end
+
     def datetime_type(datetime)
       return nil unless datetime.present?
 

--- a/app/lib/submission_builder/formatting_methods.rb
+++ b/app/lib/submission_builder/formatting_methods.rb
@@ -16,11 +16,7 @@ module SubmissionBuilder
 
     def sanitize_zipcode(zipcode_str)
       sanitized_zipcode = sanitize_for_xml(zipcode_str)
-      if @submission.data_source.state_code == "md"
-        sanitized_zipcode.gsub("-", "")
-      else
-        sanitized_zipcode
-      end
+      sanitized_zipcode.gsub("-", "")
     end
 
     def datetime_type(datetime)

--- a/app/lib/submission_builder/return_header.rb
+++ b/app/lib/submission_builder/return_header.rb
@@ -17,7 +17,7 @@ module SubmissionBuilder
         end
         xml.TaxYr @submission.data_source.tax_return_year
         if state_submission_builder.ptin.present? && state_submission_builder.preparer_person_name.present?
-          xml.PaidPreparerInformationGrp do 
+          xml.PaidPreparerInformationGrp do
             xml.PTIN state_submission_builder.ptin
             xml.PreparerPersonNm state_submission_builder.preparer_person_name
           end
@@ -69,7 +69,7 @@ module SubmissionBuilder
               xml.CityNm sanitize_for_xml(@submission.data_source.direct_file_data.mailing_city, @submission.data_source.city_name_length_20? ? 20 : 22)
             end
             xml.StateAbbreviationCd @submission.data_source.direct_file_data.mailing_state.upcase
-            xml.ZIPCd @submission.data_source.direct_file_data.mailing_zip if @submission.data_source.direct_file_data.mailing_zip.present?
+            xml.ZIPCd sanitize_zipcode(@submission.data_source.direct_file_data.mailing_zip) if @submission.data_source.direct_file_data.mailing_zip.present?
           end
         end
       end

--- a/app/lib/submission_builder/state1099_g.rb
+++ b/app/lib/submission_builder/state1099_g.rb
@@ -15,7 +15,7 @@ module SubmissionBuilder
             xml.AddressLine1Txt sanitize_for_xml(form1099g.payer_street_address.tr('-', ' '), 35)
             xml.CityNm sanitize_for_xml(form1099g.payer_city, 22)
             xml.StateAbbreviationCd state_abbreviation
-            xml.ZIPCd form1099g.payer_zip
+            xml.ZIPCd sanitize_zipcode(form1099g.payer_zip)
           end
           xml.PayerEIN form1099g.payer_tin
         end
@@ -31,7 +31,7 @@ module SubmissionBuilder
           xml.AddressLine2Txt sanitize_for_xml(form1099g.recipient_address_line2, 35) if form1099g.recipient_address_line2.present?
           xml.CityNm sanitize_for_xml(form1099g.recipient_city, 22)
           xml.StateAbbreviationCd state_abbreviation
-          xml.ZIPCd sanitize_for_xml(form1099g.recipient_zip)
+          xml.ZIPCd sanitize_zipcode(form1099g.recipient_zip)
         end
         xml.UnemploymentCompensation form1099g.unemployment_compensation_amount&.round
         xml.FederalTaxWithheld form1099g.federal_income_tax_withheld_amount&.round

--- a/app/lib/submission_builder/state1099_r.rb
+++ b/app/lib/submission_builder/state1099_r.rb
@@ -17,7 +17,7 @@ module SubmissionBuilder
             xml.AddressLine2Txt sanitize_for_xml(form1099r.payer_address_line2, 35) if form1099r.payer_address_line2.present?
             xml.CityNm sanitize_for_xml(form1099r.payer_city_name, 22) if form1099r.payer_city_name.present?
             xml.StateAbbreviationCd form1099r.payer_state_code if form1099r.payer_state_code.present?
-            xml.ZIPCd form1099r.payer_zip if form1099r.payer_zip.present?
+            xml.ZIPCd sanitize_zipcode(form1099r.payer_zip) if form1099r.payer_zip.present?
           end
           xml.PayerEIN form1099r.payer_identification_number
           xml.RecipientSSN sanitize_for_xml(form1099r.recipient_ssn) if form1099r.recipient_ssn.present?

--- a/app/lib/submission_builder/ty2024/states/md/documents/md1099_g.rb
+++ b/app/lib/submission_builder/ty2024/states/md/documents/md1099_g.rb
@@ -19,7 +19,7 @@ module SubmissionBuilder
                       xml.AddressLine1Txt sanitize_for_xml(form1099g.payer_street_address.tr('-', ' '), 35)
                       xml.CityNm sanitize_for_xml(form1099g.payer_city, 22)
                       xml.StateAbbreviationCd "MD"
-                      xml.ZIPCd form1099g.payer_zip
+                      xml.ZIPCd sanitize_zipcode(form1099g.payer_zip)
                     end
                     xml.IDNumber form1099g.payer_tin
                   end
@@ -38,7 +38,7 @@ module SubmissionBuilder
                       xml.AddressLine2Txt sanitize_for_xml(form1099g.recipient_address_line2, 35) if form1099g.recipient_address_line2.present?
                       xml.CityNm sanitize_for_xml(form1099g.recipient_city, 22)
                       xml.StateAbbreviationCd form1099g.recipient_state
-                      xml.ZIPCd sanitize_for_xml(form1099g.recipient_zip)
+                      xml.ZIPCd sanitize_zipcode(form1099g.recipient_zip)
                     end
                   end
                 end

--- a/app/lib/submission_builder/ty2024/states/md/documents/md502.rb
+++ b/app/lib/submission_builder/ty2024/states/md/documents/md502.rb
@@ -49,13 +49,13 @@ class SubmissionBuilder::Ty2024::States::Md::Documents::Md502 < SubmissionBuilde
           extract_apartment_from_mailing_street(xml)
           xml.CityNm sanitize_for_xml(@intake.direct_file_data.mailing_city, 20)
           xml.StateAbbreviationCd @intake.direct_file_data.mailing_state.upcase
-          xml.ZIPCd @intake.direct_file_data.mailing_zip
+          xml.ZIPCd sanitize_zipcode(@intake.direct_file_data.mailing_zip)
         elsif @intake.confirmed_permanent_address_no?
           xml.AddressLine1Txt sanitize_for_xml(@intake.permanent_street, 30)
           xml.AddressLine2Txt sanitize_for_xml(@intake.permanent_apartment, 30) if @intake.permanent_apartment.present?
           xml.CityNm sanitize_for_xml(@intake.permanent_city, 20)
           xml.StateAbbreviationCd @intake.direct_file_data.mailing_state.upcase
-          xml.ZIPCd @intake.permanent_zip
+          xml.ZIPCd sanitize_zipcode(@intake.permanent_zip)
         end
       end
       xml.MarylandCounty county_abbreviation

--- a/spec/factories/state_file1099_rs.rb
+++ b/spec/factories/state_file1099_rs.rb
@@ -46,7 +46,7 @@ FactoryBot.define do
     payer_address_line1 { "123 Sesame ST" }
     payer_address_line2 { "Apt 202" }
     payer_city_name { "Long Island" }
-    payer_zip { "12345" }
+    payer_zip { "12345-1234" }
     payer_identification_number { "22345" }
     recipient_ssn { "123456789" }
     recipient_name { "Dorothy Jane Red" }

--- a/spec/lib/submission_builder/state1099_g_spec.rb
+++ b/spec/lib/submission_builder/state1099_g_spec.rb
@@ -10,7 +10,7 @@ describe SubmissionBuilder::State1099G do
       let(:payer_name) { "Business Geese" }
       let(:payer_street_address) { "123 Duck St" }
       let(:payer_city) { "City" }
-      let(:payer_zip) { "11102" }
+      let(:payer_zip) { "11102-1234" }
       let(:payer_tin) { "270293117" }
       let(:unemployment_compensation_amount) { "1" }
       let(:federal_income_tax_withheld_amount) { "0" }
@@ -19,7 +19,7 @@ describe SubmissionBuilder::State1099G do
       let(:recipient_street_address) { "234 Recipient St" }
       let(:recipient_street_address_apartment) { "Unit B" }
       let(:recipient_city) { "City" }
-      let(:recipient_zip) { "11102" }
+      let(:recipient_zip) { "11102-1234" }
       let(:recipient_state) { "CA" }
       let!(:form1099g) do
         create(
@@ -67,7 +67,7 @@ describe SubmissionBuilder::State1099G do
         expect(doc.at("PayerUSAddress AddressLine1Txt").text).to eq payer_street_address
         expect(doc.at("PayerUSAddress CityNm").text).to eq payer_city
         expect(doc.at("PayerUSAddress StateAbbreviationCd").text).to eq recipient_state
-        expect(doc.at("PayerUSAddress ZIPCd").text).to eq payer_zip
+        expect(doc.at("PayerUSAddress ZIPCd").text).to eq "111021234"
         expect(doc.at("PayerEIN").text).to eq payer_tin
         expect(doc.at("RecipientSSN").text).to eq primary_ssn
         expect(doc.at("RecipientName").text).to eq "Merlin A Monroe"
@@ -75,7 +75,7 @@ describe SubmissionBuilder::State1099G do
         expect(doc.at("RecipientUSAddress AddressLine2Txt").text).to eq recipient_street_address_apartment
         expect(doc.at("RecipientUSAddress CityNm").text).to eq recipient_city
         expect(doc.at("RecipientUSAddress StateAbbreviationCd").text).to eq recipient_state
-        expect(doc.at("RecipientUSAddress ZIPCd").text).to eq recipient_zip
+        expect(doc.at("RecipientUSAddress ZIPCd").text).to eq "111021234"
         expect(doc.at("UnemploymentCompensation").text).to eq unemployment_compensation_amount
         expect(doc.at("FederalTaxWithheld").text).to eq federal_income_tax_withheld_amount
         expect(doc.at("State1099GStateLocalTaxGrp StateTaxWithheldAmt").text).to eq state_income_tax_withheld_amount

--- a/spec/lib/submission_builder/state1099_r_spec.rb
+++ b/spec/lib/submission_builder/state1099_r_spec.rb
@@ -24,7 +24,7 @@ describe SubmissionBuilder::State1099R do
         expect(doc.at("PayerUSAddress AddressLine2Txt").text).to eq "Apt 202"
         expect(doc.at("PayerUSAddress CityNm").text).to eq "Long Island"
         expect(doc.at("PayerUSAddress StateAbbreviationCd").text).to eq "#{state_code.upcase}"
-        expect(doc.at("PayerUSAddress ZIPCd").text).to eq "12345"
+        expect(doc.at("PayerUSAddress ZIPCd").text).to eq "123451234"
         expect(doc.at("PayerEIN").text).to eq "22345"
         expect(doc.at("RecipientSSN").text).to eq "123456789"
         expect(doc.at("RecipientNm").text).to eq "Dorothy Jane Red"

--- a/spec/lib/submission_builder/ty2022/states/return_header_spec.rb
+++ b/spec/lib/submission_builder/ty2022/states/return_header_spec.rb
@@ -40,11 +40,7 @@ describe SubmissionBuilder::ReturnHeader do
           expect(doc.at("USAddress AddressLine2Txt").text).to eq mailing_apartment
           expect(doc.at("USAddress CityNm").text).to eq mailing_city
           expect(doc.at("USAddress StateAbbreviationCd").text).to eq state_code.upcase
-          if state_code == "md"
-            expect(doc.at("USAddress ZIPCd").text).to eq "123451234"
-          else
-            expect(doc.at("USAddress ZIPCd").text).to eq "12345-1234"
-          end
+          expect(doc.at("USAddress ZIPCd").text).to eq "123451234"
         end
 
         context "with out-of-state mailing state" do

--- a/spec/lib/submission_builder/ty2022/states/return_header_spec.rb
+++ b/spec/lib/submission_builder/ty2022/states/return_header_spec.rb
@@ -11,7 +11,7 @@ describe SubmissionBuilder::ReturnHeader do
         let(:mailing_street) { "1234 Main Street" }
         let(:mailing_apartment) { "B" }
         let(:mailing_city) { "Citayy" }
-        let(:mailing_zip) { "54321" }
+        let(:mailing_zip) { "12345-1234" }
         let(:tax_return_year) { 2024 }
         let(:efin) { "123455" }
         let(:sin) { "223455" }
@@ -40,7 +40,11 @@ describe SubmissionBuilder::ReturnHeader do
           expect(doc.at("USAddress AddressLine2Txt").text).to eq mailing_apartment
           expect(doc.at("USAddress CityNm").text).to eq mailing_city
           expect(doc.at("USAddress StateAbbreviationCd").text).to eq state_code.upcase
-          expect(doc.at("USAddress ZIPCd").text).to eq mailing_zip
+          if state_code == "md"
+            expect(doc.at("USAddress ZIPCd").text).to eq "123451234"
+          else
+            expect(doc.at("USAddress ZIPCd").text).to eq "12345-1234"
+          end
         end
 
         context "with out-of-state mailing state" do
@@ -363,9 +367,9 @@ describe SubmissionBuilder::ReturnHeader do
       let(:doc) { SubmissionBuilder::ReturnHeader.new(submission).document }
       context "for #{state_code} returns" do
         it "does not add XML elements for PaidPreparerInformationGrp" do
-          expect(doc.at("PaidPreparerInformationGrp")).not_to be_present 
-          expect(doc.at("PaidPreparerInformationGrp PTIN")).not_to be_present 
-          expect(doc.at("PaidPreparerInformationGrp PreparerPersonNm")).not_to be_present 
+          expect(doc.at("PaidPreparerInformationGrp")).not_to be_present
+          expect(doc.at("PaidPreparerInformationGrp PTIN")).not_to be_present
+          expect(doc.at("PaidPreparerInformationGrp PreparerPersonNm")).not_to be_present
         end
       end
     end

--- a/spec/lib/submission_builder/ty2024/states/md/documents/md1099_g_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/md/documents/md1099_g_spec.rb
@@ -8,7 +8,7 @@ describe SubmissionBuilder::Ty2024::States::Md::Documents::Md1099G do
     let(:payer_name) { "Business Geese" }
     let(:payer_street_address) { "123 Duck St" }
     let(:payer_city) { "City" }
-    let(:payer_zip) { "11102" }
+    let(:payer_zip) { "11102-1234" }
     let(:payer_tin) { "270293117" }
     let(:unemployment_compensation_amount) { "1" }
     let(:federal_income_tax_withheld_amount) { "0" }
@@ -18,7 +18,7 @@ describe SubmissionBuilder::Ty2024::States::Md::Documents::Md1099G do
     let(:recipient_street_address_apartment) { "Unit B" }
     let(:recipient_city) { "City" }
     let(:recipient_state) { "CA" }
-    let(:recipient_zip) { "11102" }
+    let(:recipient_zip) { "11102-1234" }
     let!(:form1099g) do
       create(
         :state_file1099_g,
@@ -63,7 +63,7 @@ describe SubmissionBuilder::Ty2024::States::Md::Documents::Md1099G do
       expect(doc.at("Payer Address AddressLine1Txt").text).to eq payer_street_address
       expect(doc.at("Payer Address CityNm").text).to eq payer_city
       expect(doc.at("Payer Address StateAbbreviationCd").text).to eq "MD"
-      expect(doc.at("Payer Address ZIPCd").text).to eq payer_zip
+      expect(doc.at("Payer Address ZIPCd").text).to eq "111021234"
       expect(doc.at("Payer IDNumber").text).to eq payer_tin
       expect(doc.at("Recipient SSN").text).to eq primary_ssn
       expect(doc.at("Recipient Name").text).to eq "Merlin A Monroe"
@@ -71,7 +71,7 @@ describe SubmissionBuilder::Ty2024::States::Md::Documents::Md1099G do
       expect(doc.at("Recipient Address USAddress AddressLine2Txt").text).to eq recipient_street_address_apartment
       expect(doc.at("Recipient Address USAddress CityNm").text).to eq recipient_city
       expect(doc.at("Recipient Address USAddress StateAbbreviationCd").text).to eq recipient_state
-      expect(doc.at("Recipient Address USAddress ZIPCd").text).to eq recipient_zip
+      expect(doc.at("Recipient Address USAddress ZIPCd").text).to eq "111021234"
       expect(doc.at("UnemploymentCompensationPaid").text).to eq unemployment_compensation_amount
       expect(doc.at("FederalTaxWithheld").text).to eq federal_income_tax_withheld_amount
       expect(doc.at("StateTaxWithheld").text).to eq state_income_tax_withheld_amount

--- a/spec/lib/submission_builder/ty2024/states/md/documents/md502_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/md/documents/md502_spec.rb
@@ -52,7 +52,7 @@ describe SubmissionBuilder::Ty2024::States::Md::Documents::Md502, required_schem
           intake.direct_file_data.mailing_apartment = "Apt B"
           intake.direct_file_data.mailing_city = "Annapolis"
           intake.direct_file_data.mailing_state = "MD"
-          intake.direct_file_data.mailing_zip = "21401"
+          intake.direct_file_data.mailing_zip = "21401-1234"
         end
 
         context "when user confirms that address from DF is correct" do
@@ -61,7 +61,7 @@ describe SubmissionBuilder::Ty2024::States::Md::Documents::Md502, required_schem
             intake.direct_file_data.mailing_street = "312 Poppy Street"
             intake.direct_file_data.mailing_apartment = "Apt B"
             intake.direct_file_data.mailing_city = "Annapolis"
-            intake.direct_file_data.mailing_zip = "21401"
+            intake.direct_file_data.mailing_zip = "21401-1234"
           end
 
           it "outputs their DF address as their physical address" do
@@ -69,14 +69,14 @@ describe SubmissionBuilder::Ty2024::States::Md::Documents::Md502, required_schem
             expect(xml.at("MarylandAddress AddressLine2Txt").text).to eq "Apt B"
             expect(xml.at("MarylandAddress CityNm").text).to eq "Annapolis"
             expect(xml.at("MarylandAddress StateAbbreviationCd").text).to eq "MD"
-            expect(xml.at("MarylandAddress ZIPCd").text).to eq "21401"
+            expect(xml.at("MarylandAddress ZIPCd").text).to eq "214011234"
           end
 
           context "when user had an out-of-state permanent address from DF" do
             before do
               intake.direct_file_data.mailing_city = "Denver"
               intake.direct_file_data.mailing_state = "CO"
-              intake.direct_file_data.mailing_zip = "80212"
+              intake.direct_file_data.mailing_zip = "80212-1234"
             end
 
             it "outputs their DF address as their physical address" do
@@ -84,7 +84,7 @@ describe SubmissionBuilder::Ty2024::States::Md::Documents::Md502, required_schem
               expect(xml.at("MarylandAddress AddressLine2Txt").text).to eq "Apt B"
               expect(xml.at("MarylandAddress CityNm").text).to eq "Denver"
               expect(xml.at("MarylandAddress StateAbbreviationCd").text).to eq "CO"
-              expect(xml.at("MarylandAddress ZIPCd").text).to eq "80212"
+              expect(xml.at("MarylandAddress ZIPCd").text).to eq "802121234"
             end
           end
         end
@@ -95,7 +95,7 @@ describe SubmissionBuilder::Ty2024::States::Md::Documents::Md502, required_schem
             intake.permanent_street = "313 Poppy Street"
             intake.permanent_apartment = "Apt A"
             intake.permanent_city = "Baltimore"
-            intake.permanent_zip = "21201"
+            intake.permanent_zip = "21201-1234"
           end
 
           it "outputs their entered address as their physical address" do
@@ -103,7 +103,7 @@ describe SubmissionBuilder::Ty2024::States::Md::Documents::Md502, required_schem
             expect(xml.at("MarylandAddress AddressLine2Txt").text).to eq "Apt A"
             expect(xml.at("MarylandAddress CityNm").text).to eq "Baltimore"
             expect(xml.at("MarylandAddress StateAbbreviationCd").text).to eq "MD"
-            expect(xml.at("MarylandAddress ZIPCd").text).to eq "21201"
+            expect(xml.at("MarylandAddress ZIPCd").text).to eq "212011234"
           end
         end
       end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/FYST-1700
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
* Removes hyphens from all XML for ZipCd

## How to test?
verify zipcodes do not have hyphens:
* return header for all states
* 1099R for all states
* 1099G all states except MD
*  MD502
* MD 1099G 

What was not updated:
* 1040 (used by previous years)
* NY XML
* IRS W2 (not used by our current code)
