### PR TITLE
don't poll for efile submission acks/status on sunday

### DIFF
--- a/crontab
+++ b/crontab
@@ -6,7 +6,7 @@
 */20 * * * * bundle exec rake client_status_updates:send_client_in_progress_automated_messages
 15 20 * * * bundle exec rake not_ready_reminders:remind
 */5 * * * * bundle exec rake worker_heartbeat:perform
-*/10 * * * * bundle exec rake efile:poll_and_get_acknowledgments
+*/10 * * * 1-6 bundle exec rake efile:poll_and_get_acknowledgments
 0 */2 * * * bundle exec rake state_file:reminder_to_finish_state_return
 0 19 23 4 * bundle exec rake state_file:post_deadline_reminder
 0 21 23 4 * bundle exec rake send_reject_resolution_reminder_notifications:send


### PR DESCRIPTION
**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Change our crontab to exclude sundays from the schedule for polling MeF for acks & status of our submissions, since it's always down on sunday
  - [Sentry error](https://codeforamerica.sentry.io/issues/6231326310/?)
  - [crontab explained](https://crontab.guru/#*/10_*_*_*_1-6)
  - [relevant slack thread](https://cfastaff.slack.com/archives/C0544ERAFQV/p1737907339604899)
project=1880327&query=is%3Aunresolved&referrer=issue-stream&sort=freq&statsPeriod=14d&stream_index=0)
## How to test?
- We should see this change's effect by observing a lack of errors on sentry on sundays - i.e. the above-linked sentry error should not have a large number of new occurrences on sundays after this PR is merged & released
