### PR TITLE
NJ 271 - fix when review screen displays health insurance section

### DIFF
--- a/app/controllers/state_file/questions/nj_dependents_health_insurance_controller.rb
+++ b/app/controllers/state_file/questions/nj_dependents_health_insurance_controller.rb
@@ -4,8 +4,7 @@ module StateFile
       include ReturnToReviewConcern
 
       def self.show?(intake)
-        return false unless intake.dependents.any?
-        intake.has_health_insurance_requirement_exception? || intake.eligibility_all_members_health_insurance_no?
+        intake.dependents.any? && intake.has_health_insurance_requirement_exception?
       end
 
       def form_params

--- a/app/views/state_file/questions/nj_review/edit.html.erb
+++ b/app/views/state_file/questions/nj_review/edit.html.erb
@@ -23,7 +23,7 @@
     </section>
   <% end %>
 
-  <% if current_intake.has_health_insurance_requirement_exception? || current_intake.eligibility_all_members_health_insurance_no? %>
+  <% if current_intake.dependents.any? && (current_intake.has_health_insurance_requirement_exception? || current_intake.eligibility_all_members_health_insurance_no?) %>
     <section id="missing-health-insurance" class="white-group">
       <div class="spacing-below-5">
         <h2 class="text--body text--bold spacing-below-5"><%=t(".missing_health_insurance") %></h2>

--- a/app/views/state_file/questions/nj_review/edit.html.erb
+++ b/app/views/state_file/questions/nj_review/edit.html.erb
@@ -23,7 +23,7 @@
     </section>
   <% end %>
 
-  <% if current_intake.dependents.any? && (current_intake.has_health_insurance_requirement_exception? || current_intake.eligibility_all_members_health_insurance_no?) %>
+  <% if current_intake.dependents.any? && current_intake.has_health_insurance_requirement_exception? %>
     <section id="missing-health-insurance" class="white-group">
       <div class="spacing-below-5">
         <h2 class="text--body text--bold spacing-below-5"><%=t(".missing_health_insurance") %></h2>

--- a/spec/controllers/state_file/questions/nj_dependents_health_insurance_controller_spec.rb
+++ b/spec/controllers/state_file/questions/nj_dependents_health_insurance_controller_spec.rb
@@ -29,14 +29,6 @@ RSpec.describe StateFile::Questions::NjDependentsHealthInsuranceController do
           expect(described_class.show?(intake)).to eq true
         end
       end
-     
-      context "and did not have a health insurance requirement exception, but all members did not have health insurance" do  
-        it "shows" do
-          allow_any_instance_of(StateFileNjIntake).to receive(:has_health_insurance_requirement_exception?).and_return(false)
-          allow_any_instance_of(StateFileNjIntake).to receive(:eligibility_all_members_health_insurance_no?).and_return(true)
-          expect(described_class.show?(intake)).to eq true
-        end
-      end
     end
   end
 

--- a/spec/controllers/state_file/questions/nj_review_controller_spec.rb
+++ b/spec/controllers/state_file/questions/nj_review_controller_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe StateFile::Questions::NjReviewController do
+  let(:intake) { create :state_file_nj_intake, :df_data_minimal }
+  before do
+    sign_in intake
+  end
+
+  describe "#edit" do
+    render_views
+    it 'succeeds' do
+      get :edit
+      expect(response).to be_successful
+    end
+
+    context 'when no dependents and gross income at threshold' do
+      it 'does not show the dependents without health insurance block' do
+        allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_29).and_return 20_000
+        get :edit       
+        expect(response.body).not_to have_text "Dependents who DO NOT have health insurance"
+      end
+    end
+  end
+end

--- a/spec/controllers/state_file/questions/nj_review_controller_spec.rb
+++ b/spec/controllers/state_file/questions/nj_review_controller_spec.rb
@@ -1,23 +1,38 @@
 require "rails_helper"
 
 RSpec.describe StateFile::Questions::NjReviewController do
-  let(:intake) { create :state_file_nj_intake, :df_data_minimal }
   before do
     sign_in intake
   end
 
   describe "#edit" do
     render_views
-    it 'succeeds' do
-      get :edit
-      expect(response).to be_successful
+    context 'when no dependents' do
+      let(:intake) { create :state_file_nj_intake, :df_data_no_deps }
+
+      it 'does not show the dependents without health insurance block' do
+        allow_any_instance_of(StateFileNjIntake).to receive(:has_health_insurance_requirement_exception?).and_return false
+        get :edit
+        expect(response.body).not_to have_text "Dependents who DO NOT have health insurance"
+      end
     end
 
-    context 'when no dependents and gross income at threshold' do
-      it 'does not show the dependents without health insurance block' do
-        allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_29).and_return 20_000
-        get :edit       
-        expect(response.body).not_to have_text "Dependents who DO NOT have health insurance"
+    context 'when taxpayer has dependents' do
+      let(:intake) { create :state_file_nj_intake, :df_data_qss }
+      context 'when taxpayer does not have health insurance exception' do
+        it 'does not show the dependents without health insurance block' do
+          allow_any_instance_of(StateFileNjIntake).to receive(:has_health_insurance_requirement_exception?).and_return false
+          get :edit
+          expect(response.body).not_to have_text "Dependents who DO NOT have health insurance"
+        end
+      end
+
+      context 'when taxpayer does have health insurance exception' do
+        it 'shows the dependents without health insurance block' do
+          allow_any_instance_of(StateFileNjIntake).to receive(:has_health_insurance_requirement_exception?).and_return true
+          get :edit
+          expect(response.body).to have_text "Dependents who DO NOT have health insurance"
+        end
       end
     end
   end

--- a/spec/controllers/state_file/questions/nj_review_controller_spec.rb
+++ b/spec/controllers/state_file/questions/nj_review_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe StateFile::Questions::NjReviewController do
   describe "#edit" do
     render_views
     context 'when no dependents' do
-      let(:intake) { create :state_file_nj_intake, :df_data_no_deps }
+      let(:intake) { create :state_file_nj_intake, :df_data_box_14 }
 
       it 'does not show the dependents without health insurance block' do
         allow_any_instance_of(StateFileNjIntake).to receive(:has_health_insurance_requirement_exception?).and_return false

--- a/spec/factories/state_file_nj_intakes.rb
+++ b/spec/factories/state_file_nj_intakes.rb
@@ -178,6 +178,13 @@ FactoryBot.define do
       raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nj_minimal') }
     end
 
+    trait :df_data_no_deps do
+      raw_direct_file_data { StateFile::DirectFileApiResponseSampleService.new.read_xml('nj_springsteen_mfj') }
+      raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nj_springsteen_mfj') }
+      primary_birth_date { Date.new(1990, 1, 1) }
+      spouse_birth_date { Date.new(1990, 1, 1) }
+    end
+
     trait :df_data_many_deps do
       raw_direct_file_data { StateFile::DirectFileApiResponseSampleService.new.read_xml('nj_zeus_many_deps') }
       raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nj_zeus_many_deps') }

--- a/spec/factories/state_file_nj_intakes.rb
+++ b/spec/factories/state_file_nj_intakes.rb
@@ -128,14 +128,6 @@ FactoryBot.define do
     
     after(:build) do |intake, evaluator|
       intake.municipality_code = "0101"
-      numeric_status = {
-        single: 1,
-        married_filing_jointly: 2,
-        married_filing_separately: 3,
-        head_of_household: 4,
-        qualifying_widow: 5,
-        }[evaluator.filing_status.to_sym] || evaluator.filing_status
-      intake.direct_file_data.filing_status = numeric_status
       intake.direct_file_data.primary_ssn = evaluator.primary_ssn || intake.direct_file_data.primary_ssn
       intake.direct_file_data.spouse_ssn = evaluator.spouse_ssn || intake.direct_file_data.spouse_ssn
       intake.raw_direct_file_data = intake.direct_file_data.to_s
@@ -181,8 +173,6 @@ FactoryBot.define do
     trait :df_data_no_deps do
       raw_direct_file_data { StateFile::DirectFileApiResponseSampleService.new.read_xml('nj_springsteen_mfj') }
       raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nj_springsteen_mfj') }
-      primary_birth_date { Date.new(1990, 1, 1) }
-      spouse_birth_date { Date.new(1990, 1, 1) }
     end
 
     trait :df_data_many_deps do

--- a/spec/factories/state_file_nj_intakes.rb
+++ b/spec/factories/state_file_nj_intakes.rb
@@ -128,6 +128,14 @@ FactoryBot.define do
     
     after(:build) do |intake, evaluator|
       intake.municipality_code = "0101"
+      numeric_status = {
+        single: 1,
+        married_filing_jointly: 2,
+        married_filing_separately: 3,
+        head_of_household: 4,
+        qualifying_widow: 5,
+        }[evaluator.filing_status.to_sym] || evaluator.filing_status
+      intake.direct_file_data.filing_status = numeric_status
       intake.direct_file_data.primary_ssn = evaluator.primary_ssn || intake.direct_file_data.primary_ssn
       intake.direct_file_data.spouse_ssn = evaluator.spouse_ssn || intake.direct_file_data.spouse_ssn
       intake.raw_direct_file_data = intake.direct_file_data.to_s
@@ -168,11 +176,6 @@ FactoryBot.define do
     trait :df_data_minimal do
       raw_direct_file_data { StateFile::DirectFileApiResponseSampleService.new.read_xml('nj_minimal') }
       raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nj_minimal') }
-    end
-
-    trait :df_data_no_deps do
-      raw_direct_file_data { StateFile::DirectFileApiResponseSampleService.new.read_xml('nj_springsteen_mfj') }
-      raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nj_springsteen_mfj') }
     end
 
     trait :df_data_many_deps do


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://github.com/newjersey/affordability-pm/issues/271

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Update NJ Review screen to have the same logic as the controller, only displays if there are dependents

https://github.com/codeforamerica/vita-min/blob/da604920eee7df593281810b9b36bcb3be9a9c7f/app/controllers/state_file/questions/nj_dependents_health_insurance_controller.rb#L7

## How to test?
- Use Springsteen MFJ, navigate to review screen, ensure that "Dependents DO NOT have Health Insurance" section does not appear

## Screenshots (for visual changes)
- Before
<img width="746" alt="image" src="https://github.com/user-attachments/assets/3b102a7a-e538-4871-9ef0-01e98b207d9a" />

- After
<img width="736" alt="image" src="https://github.com/user-attachments/assets/cad9af83-86e5-4a8c-8389-6837ee8c4a84" />