### PR TITLE
GYR1-647 Add tax slayer and direct file links to flow 

### DIFF
--- a/app/services/diy_support_experiment_service.rb
+++ b/app/services/diy_support_experiment_service.rb
@@ -1,4 +1,6 @@
 class DiySupportExperimentService
+  # The DIY support experiment was a one-time experiment done for TY2022.
+
   def self.fsa_domain
     if Rails.env.test?
       "https://www.example.com"

--- a/app/views/diy/continue_to_fsa/edit.html.erb
+++ b/app/views/diy/continue_to_fsa/edit.html.erb
@@ -48,7 +48,7 @@
         </div>
 
         <div class="text--small text--italic spacing-above-60 spacing-below-15"><%= t(".continue_help_text") %></div>
-        <%= link_to t("general.continue"), 'https://www.taxslayer.com/v.aspx?rdr=/vitafsa&source=TSUSATY2023&sidn=01011934', target: "_blank", class: "button button--primary text--centered button--wide", "data-track-click": "diy-cfa-taxslayer-link" %>
+        <%= link_to t("general.continue"), 'https://www.taxslayer.com/v.aspx?rdr=/vitafsa&source=TSUSATY2024&sidn=01011934', target: "_blank", class: "button button--primary text--centered button--wide", "data-track-click": "diy-cfa-taxslayer-link" %>
       </div>
     </div>
   </section>

--- a/app/views/shared/_service_comparison.html.erb
+++ b/app/views/shared/_service_comparison.html.erb
@@ -56,7 +56,7 @@
                   <%= t("views.shared.service_comparison.services.direct_file.service_description") %>
                 </div>
                 <div class="service__cta">
-                  <%= link_to t("views.shared.service_comparison.services.direct_file.cta"), "https://directfile.irs.gov/state" ,class: "button", "data-track-click": "service-comparison-direct-file"%>
+                  <%= link_to t("views.shared.service_comparison.services.direct_file.cta"), "https://directfile.irs.gov/?utm_source=CA-Nonprofit&utm_medium=email&utm_campaign=gyr&utm_id=directfile&utm_content=QRcode" ,class: "button", "data-track-click": "service-comparison-direct-file"%>
                 </div>
               </div>
             <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -577,7 +577,7 @@ en:
     sms_phone_number: Cell phone number
     sorry: We're sorry!
     spouse_last_four_ssn: Spouse's last 4 of SSN/ITIN
-    spread_the_word_html: Let your friends and family know about <a target="_blank" rel="noopener nofollow" href="https://directfile.irs.gov/">IRS Direct File</a> so they can file their taxes for free.
+    spread_the_word_html: Let your friends and family know about <a target="_blank" rel="noopener nofollow" href="https://directfile.irs.gov/?utm_source=CA-Nonprofit&utm_medium=email&utm_campaign=gyr&utm_id=directfile&utm_content=QRcode">IRS Direct File</a> so they can file their taxes for free.
     ssn: SSN
     ssn_itin: SSN/ITIN
     start_filing: Start filing
@@ -2179,7 +2179,7 @@ en:
         download_your_record: Download Your Record
         help_text_html: |
           <ul class="list--bulleted">
-            <li>An <strong>accepted</strong> %{filing_year} federal return using <a href="https://directfile.irs.gov/">IRS Direct File</a>. (You don’t need a copy of this return; you’ll transfer your return here.)
+            <li>An <strong>accepted</strong> %{filing_year} federal return using <a href="https://directfile.irs.gov/?utm_source=CA-Nonprofit&utm_medium=email&utm_campaign=gyr&utm_id=directfile&utm_content=QRcode">IRS Direct File</a>. (You don’t need a copy of this return; you’ll transfer your return here.)
             <li>Email address or phone number</li>
             <li>Driver’s license or state-issued ID, if you have one</li>
             <li>Form 1099-G (If you received unemployment benefits in %{filing_year}.)</li>
@@ -2212,7 +2212,7 @@ en:
           closed_html: "<strong>FileYourStateTaxes</strong> is built in partnership with the New Jersey Office of Innovation to integrate with IRS Direct File.<br /><br />\nWe're closed for the tax season. Unfortunately you can no longer file your state return with us this year.              \n"
           help_text_html: |
             <ul class="list--bulleted">
-              <li>To have filed your 2024 federal return using <a href="https://directfile.irs.gov/" target="_blank" rel="noopener nofollow">IRS Direct File</a></li>
+              <li>To have filed your 2024 federal return using <a href="https://directfile.irs.gov/?utm_source=CA-Nonprofit&utm_medium=email&utm_campaign=gyr&utm_id=directfile&utm_content=QRcode" target="_blank" rel="noopener nofollow">IRS Direct File</a></li>
               <li>An email address or a phone number to receive a one-time verification code</li>
               <li>Bank routing and account numbers (if you want to receive your refund or make a tax payment electronically)</li>
               <li>(optional) Driver's license or state issued ID</li>
@@ -2226,7 +2226,7 @@ en:
         welcome_back: Welcome back %{user_name}!
       ny_closed:
         body_html: |
-          This service doesn’t support New York State tax returns for 2024. You can still file with IRS Direct File and New York State Direct File. To see if you’re eligible and start your federal return, visit <a href="https://directfile.irs.gov/">IRS Direct File</a>.
+          This service doesn’t support New York State tax returns for 2024. You can still file with IRS Direct File and New York State Direct File. To see if you’re eligible and start your federal return, visit <a href="https://directfile.irs.gov/?utm_source=CA-Nonprofit&utm_medium=email&utm_campaign=gyr&utm_id=directfile&utm_content=QRcode">IRS Direct File</a>.
           <br /><br />
           To download your 2023 NY State tax return, please <a href="https://www.fileyourstatetaxes.org/en/az/faq/how_can_i_access_my_2023_state_tax_return">visit our FAQ</a>.
         supported_by: Supported by New York State
@@ -3937,9 +3937,9 @@ en:
         looking_for_return_html: "<strong>Looking for your 2023 Arizona or New York State Tax Return?</strong>"
         section1_html: |
           <ol class="list--numbered"  style="padding-left: 2rem">
-            <li>File and submit your federal return with <a target="_blank" rel="nofollow noopener" href="https://directfile.irs.gov/">IRS Direct File</a> before using this service.</li>
+            <li>File and submit your federal return with <a target="_blank" rel="nofollow noopener" href="https://directfile.irs.gov/?utm_source=CA-Nonprofit&utm_medium=email&utm_campaign=gyr&utm_id=directfile&utm_content=QRcode">IRS Direct File</a> before using this service.</li>
             <li>Follow the link from Direct File to FileYourStateTaxes.</li>
-            <li>Answer a few questions to make sure this is the right service for you. <a target="_blank" rel="nofollow noopener" href="https://directfile.irs.gov/state">Learn more</a> about who is eligible for this tax year.</li>
+            <li>Answer a few questions to make sure this is the right service for you. <a target="_blank" rel="nofollow noopener" href="https://directfile.irs.gov/?utm_source=CA-Nonprofit&utm_medium=email&utm_campaign=gyr&utm_id=directfile&utm_content=QRcode">Learn more</a> about who is eligible for this tax year.</li>
             <li>Transfer your federal return to fill in most of your state return.</li>
             <li>Answer a few additional questions to help maximize your state tax refund.</li>
             <li>E-file your return for free!</li>
@@ -3952,7 +3952,7 @@ en:
           This site will open at the start of the 2025 tax filing season and remain open until October 15, 2025 for you to file your state tax returns.
           <br /><br />
           <strong>In 2025, this service will support filing state tax returns in Arizona, Idaho, North Carolina, New Jersey, and Maryland.</strong>
-        subheader_2_html: To start filing your federal return, go to <a target="_blank" rel="nofollow noopener" href="https://directfile.irs.gov/">directfile.irs.gov.</a>
+        subheader_2_html: To start filing your federal return, go to <a target="_blank" rel="nofollow noopener" href="https://directfile.irs.gov/?utm_source=CA-Nonprofit&utm_medium=email&utm_campaign=gyr&utm_id=directfile&utm_content=QRcode">directfile.irs.gov.</a>
         subheader_3_html: "<strong>Already filed your federal return with IRS Direct File and need to complete your state return?</strong> <a href=%{login_path}>Sign in here</a>."
         tax_return_link: Click here to access your tax return
       card_postscript:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -579,7 +579,7 @@ es:
     sms_phone_number: Número de celular
     sorry: "¡Ay, no! ¡Lo sentimos!"
     spouse_last_four_ssn: Últimos 4 de SSN/ITIN de su cónyuge
-    spread_the_word_html: Cuéntale a tus amigos y familiares sobre <a target="_blank" rel="noopener nofollow" href="https://directfile.irs.gov/">el servicio Direct File del IRS </a> para que puedan presentar sus impuestos de forma gratuita.
+    spread_the_word_html: Cuéntale a tus amigos y familiares sobre <a target="_blank" rel="noopener nofollow" href="https://directfile.irs.gov/?utm_source=CA-Nonprofit&utm_medium=email&utm_campaign=gyr&utm_id=directfile&utm_content=QRcode">el servicio Direct File del IRS </a> para que puedan presentar sus impuestos de forma gratuita.
     ssn: SSN
     ssn_itin: SSN/ITIN
     start_filing: Empiece a declarar
@@ -2128,7 +2128,7 @@ es:
         download_your_record: Descarga tu declaración
         help_text_html: |
           <ul class="list--bulleted">
-            <li>Una declaración federal de impuestos %{filing_year} <strong>aceptada</strong> A través de <a href="https://directfile.irs.gov/">IRS Direct File</a>. (No necesitas una copia de esta declaración; transferirás tu declaración aquí).
+            <li>Una declaración federal de impuestos %{filing_year} <strong>aceptada</strong> A través de <a href="https://directfile.irs.gov/?utm_source=CA-Nonprofit&utm_medium=email&utm_campaign=gyr&utm_id=directfile&utm_content=QRcode">IRS Direct File</a>. (No necesitas una copia de esta declaración; transferirás tu declaración aquí).
             <li>Una dirección de correo electrónico o un número de teléfono.</li>
             <li>Tu licencia de conducir o identificación emitida por el estado, si la tienes.</li>
             <li>El formulario 1099-G (si recibiste beneficios de desempleo en %{filing_year}).</li>
@@ -2160,7 +2160,7 @@ es:
             Estamos cerrados por la temporada de impuestos. Desafortunadamente no puede presentar su declaración estatal con nosotros este año.
           help_text_html: |
             <ul class="list--bulleted">
-              <li>Haber presentado tu declaración federal de 2024 usando <a href="https://directfile.irs.gov/" target="_blank" rel="noopener nofollow">IRS Direct File</a></li>
+              <li>Haber presentado tu declaración federal de 2024 usando <a href="https://directfile.irs.gov/?utm_source=CA-Nonprofit&utm_medium=email&utm_campaign=gyr&utm_id=directfile&utm_content=QRcode" target="_blank" rel="noopener nofollow">IRS Direct File</a></li>
               <li>Un email o un número de teléfono para recibir un código de verificación único</li>
               <li>Números de ruta y cuenta bancaria (si deseas recibir tu reembolso o realizar un pago de impuestos electrónicamente)</li>
               <li>(opcional) Licencia de conducir o identificación emitida por el estado</li>
@@ -2174,7 +2174,7 @@ es:
         welcome_back: "¡Bienvenido de nuevo %{user_name}!"
       ny_closed:
         body_html: |
-          No puedes usar este servicio para declarar tus impuestos estatales de Nueva York de 2024. Sin embargo, podrías declarar con IRS Direct File y New York State Direct File. Para verificar tu elegibilidad y comenzar a presentar tu declaración federal, visita a IRS Direct File. a <a href="https://directfile.irs.gov/">IRS Direct File</a>.
+          No puedes usar este servicio para declarar tus impuestos estatales de Nueva York de 2024. Sin embargo, podrías declarar con IRS Direct File y New York State Direct File. Para verificar tu elegibilidad y comenzar a presentar tu declaración federal, visita a IRS Direct File. a <a href="https://directfile.irs.gov/?utm_source=CA-Nonprofit&utm_medium=email&utm_campaign=gyr&utm_id=directfile&utm_content=QRcode">IRS Direct File</a>.
           <br /><br />
           Para descargar tu declaración de impuestos de Nueva York de 2023, <a href="https://www.fileyourstatetaxes.org/en/az/faq/how_can_i_access_my_2023_state_tax_return">visita nuestras preguntas frecuentes</a>.
         supported_by: Respaldada por el estado de Nueva York
@@ -3909,9 +3909,9 @@ es:
         looking_for_return_html: "<strong>¿Buscas tu declaración de impuestos de Arizona o del estado de Nueva York de 2023?</strong>"
         section1_html: |
           <ol class="list--numbered" style="padding-left: 2rem">
-          <li>Primero, presenta y envía tu declaración federal con <a target="_blank" rel="nofollow noopener" href="https://directfile.irs.gov/">el servicio Direct File del IRS</a> antes de usar este servicio.</li>
+          <li>Primero, presenta y envía tu declaración federal con <a target="_blank" rel="nofollow noopener" href="https://directfile.irs.gov/?utm_source=CA-Nonprofit&utm_medium=email&utm_campaign=gyr&utm_id=directfile&utm_content=QRcode">el servicio Direct File del IRS</a> antes de usar este servicio.</li>
           <li>Sigue el enlace de Direct File a FileYourStateTaxes.</li>
-          <li>Responde algunas preguntas para asegurarte de que este servicio sea adecuado para ti. <a target="_blank" rel="nofollow noopener" href="https://directfile.irs.gov/state">Obtén más información</a> sobre quién es elegible este año fiscal.</li>
+          <li>Responde algunas preguntas para asegurarte de que este servicio sea adecuado para ti. <a target="_blank" rel="nofollow noopener" href="https://directfile.irs.gov/?utm_source=CA-Nonprofit&utm_medium=email&utm_campaign=gyr&utm_id=directfile&utm_content=QRcode">Obtén más información</a> sobre quién es elegible este año fiscal.</li>
           <li>Transfiere tu declaración federal para completar automáticamente la mayor parte de tu declaración estatal.</li>
           <li>Responde algunas preguntas adicionales para aumentar tu reembolso de impuestos estatal.</li>
           <li>¡Presenta tu declaración electrónicamente sin costo!</li>
@@ -3924,7 +3924,7 @@ es:
           Este sitio empezará a funcionar al inicio de la temporada de impuestos de 2025 y estará activo hasta el 15 de octubre de 2025 para que puedas presentar tus declaraciones de impuestos estatales.
           <br /><br />
           <strong>En 2025, este servicio funcionará para presentar los impuestos estatales en Arizona, Idaho, Carolina del Norte, Nueva Jersey y Maryland.</strong>
-        subheader_2_html: Para declarar tus impuestos federales, visita <a target="_blank" rel="nofollow noopener" href="https://directfile.irs.gov/">directfile.irs.gov.</a>
+        subheader_2_html: Para declarar tus impuestos federales, visita <a target="_blank" rel="nofollow noopener" href="https://directfile.irs.gov/?utm_source=CA-Nonprofit&utm_medium=email&utm_campaign=gyr&utm_id=directfile&utm_content=QRcode">directfile.irs.gov.</a>
         subheader_3_html: "<strong>¿Ya presentaste tu declaración federal con IRS Direct File y necesitas completar tu declaración estatal?</strong> <a href=%{login_path}>Inicia sesión aquí</a>."
         tax_return_link: Haga clic aquí para acceder a su declaración de impuestos.
       card_postscript:


### PR DESCRIPTION
## Link to Jira issue


## Is PM acceptance required?

- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main

## What was done?

- For the "File Myself" pathways, the user eventually is taken to TaxSlayer (see 
  screenshots). Updated the URL for that to: `https://www.taxslayer.com/v.aspx?rdr=/vitafsa&source=TSUSATY2024&sidn=01011934`
- On the home page, and in the language translation files, I updated the Direct 
  File link to: 
  `https://directfile.irs.gov/?utm_source=CA-Nonprofit&utm_medium=email&utm_campaign=gyr&utm_id=directfile&utm_content=QRcode`

## How to test?

- Review the screenshots. Using the flows screen), choose a high income (in 
  TriageIncomeController), and flow the next couple screens or so, till you get 
  to TS. The URL should be this: 
  `https://www.taxslayer.com/v.aspx?rdr=/vitafsa&source=TSUSATY2024&sidn=01011934`
  -  And I believe the flow is similar, though not exactly the same, if one chooses "File Myself" button on the home page.
- Check the home page Direct File link. (As I mentioned, I updated the translation files as well, bt I'm not sure where else in the site the link shows up -- it's not straightforward to check.)

## Screenshots (for visual changes)

Fie Myself flow step 1:

<img width="1159" alt="file myself flow 1 - Screenshot 2025-01-27 at 6 02 04 PM" src="https://github.com/user-attachments/assets/9f898681-abef-4d3d-8c5d-482614529fb5" />

File Myself flow step 2:

<img width="1168" alt="file myself flow 2 - Screenshot 2025-01-27 at 6 02 17 PM" src="https://github.com/user-attachments/assets/cd0b97e1-2bcc-4b7d-883f-e21fdc8f4184" />

Direct File link on home page:

<img width="1297" alt="direct file link on home page" src="https://github.com/user-attachments/assets/b2cd810f-1fee-430c-85f8-a00229593bbc" />


