### PR TITLE
make one more local tax validation only apply in states where we show local tax boxes for w2s

### DIFF
--- a/app/models/state_file_w2.rb
+++ b/app/models/state_file_w2.rb
@@ -65,7 +65,7 @@ class StateFileW2 < ApplicationRecord
     validates :locality_nm, presence: { message: ->(_object, _data) { I18n.t('state_file.questions.w2.edit.locality_nm_missing_error') } }, if: -> { local_wages_and_tips_amount.present? && local_wages_and_tips_amount.positive? && StateFile::StateInformationService.w2_include_local_income_boxes(state_file_intake.state_code) }
     validates :employer_state_id_num, presence: true, if: -> { state_wages_amount.present? && state_wages_amount.positive? }
     validates :employer_ein, presence: true, format: { with: /\A[0-9]{9}\z/, message: ->(*_args) { I18n.t('validators.ein') } }
-    validates :locality_nm, format: { with: /\A[a-zA-Z]{1}([A-Za-z\-\s']{0,19})\z/, message: :only_letters }, if: -> { locality_nm.present? }
+    validates :locality_nm, format: { with: /\A[a-zA-Z]{1}([A-Za-z\-\s']{0,19})\z/, message: :only_letters }, if: -> { locality_nm.present? && StateFile::StateInformationService.w2_include_local_income_boxes(state_file_intake.state_code) }
     validate :validate_box14_limits, if: :check_box14_limits
     validate :validate_tax_amts
     validate :state_specific_validation

--- a/spec/models/state_file_w2_spec.rb
+++ b/spec/models/state_file_w2_spec.rb
@@ -71,10 +71,10 @@ describe StateFileW2 do
     end
 
     context "states where we don't show local boxes" do
-      let(:intake) { create :state_file_nc_intake }
+      let(:intake) { create :state_file_az_intake }
 
       it "doesn't validate local tax fields" do
-        w2.locality_nm = "asdf"
+        w2.locality_nm = "0"
         w2.local_wages_and_tips_amount = -1
         w2.local_income_tax_amount = -1
         expect(w2).to be_valid(:state_file_edit)


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1710
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- I missed one W2 validation of local tax info that should only be applied in states where we show local tax boxes for w2s, and therefore where users can actually address the error (only MD for now)
## How to test?
- Go through the flow for AZ (or any state other than MD), choose a persona with a w2, edit the XML and set LocalityNm to 0, then verify that you can proceed through the Income Review page
