### PR TITLE
Nj a11y 19 helper text

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rack', '>= 2.0.8'
 gem 'rails', '~> 7.1'
 gem 'puma', '>= 5.3.2'
 gem 'sass-rails', '~> 5.0'
-gem 'cfa-styleguide', '0.15.2', git: 'https://github.com/codeforamerica/honeycrisp-gem', branch: 'main', ref: '64379cc8e7cf77ed68a98e226146405864ab49b5'
+gem 'cfa-styleguide', '0.16.0', git: 'https://github.com/codeforamerica/honeycrisp-gem', branch: 'main', ref: '0e15fc7d74a330866049d58516c6f2449958fb1b'
 gem 'nokogiri', '>= 1.10.8'
 gem 'recaptcha'
 gem "activerecord-cte" # Can be removed when we move to Rails 7.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 GIT
   remote: https://github.com/codeforamerica/honeycrisp-gem
-  revision: 64379cc8e7cf77ed68a98e226146405864ab49b5
-  ref: 64379cc8e7cf77ed68a98e226146405864ab49b5
+  revision: 0e15fc7d74a330866049d58516c6f2449958fb1b
+  ref: 0e15fc7d74a330866049d58516c6f2449958fb1b
   branch: main
   specs:
-    cfa-styleguide (0.15.2)
+    cfa-styleguide (0.16.0)
       autoprefixer-rails
       bourbon
       jquery-rails
@@ -247,7 +247,7 @@ GEM
     erubi (1.13.0)
     erubis (2.7.0)
     excon (0.104.0)
-    execjs (2.9.1)
+    execjs (2.10.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -750,7 +750,7 @@ DEPENDENCIES
   byebug
   cancancan
   capybara (>= 2.15)
-  cfa-styleguide (= 0.15.2)!
+  cfa-styleguide (= 0.16.0)!
   combine_pdf
   data_migrate
   database_cleaner

--- a/app/assets/stylesheets/_state-file.scss
+++ b/app/assets/stylesheets/_state-file.scss
@@ -490,7 +490,7 @@
       margin-bottom: 2rem;
     }
 
-    radiogroup {
+    radiogroup, .honeycrisp-radiogroup {
       display: flex;
       margin-bottom: 1.5rem;
 

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -50,7 +50,7 @@ $color-state-file-input-border: #1B1B1B;
 $color-state-file-primary: #21C834;
 $color-state-file-separator: #BCBCBC;
 $color-state-file-chat: #4dcce3;
-$color-state-file-grey-darker: #595959;
+$color-state-file-grey-darker: #454545;
 
 // Size
 $intake-max-width: 570px;

--- a/app/helpers/vita_min_form_builder.rb
+++ b/app/helpers/vita_min_form_builder.rb
@@ -291,20 +291,11 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
       help_text: nil
     )
 
-    describedby_ids = []
-    
-    if help_text
-      help_id = help_text_id(method)
-      describedby_ids << help_id
-    end
-    
-    if object.errors[method].any?
-      describedby_ids << error_label(method)
-    end
+    describedby = get_describedby(method, help_text: help_text)
 
     text_field_options = standard_options.merge(error_attributes(method: method)).merge(
       class: (classes + ["text-input money-input"]).join(" "),
-      'aria-describedby': describedby_ids.join(' ')
+      'aria-describedby': describedby
     ).merge(placeholder: '0.00').merge(options)
     
     text_field_options[:id] ||= sanitized_id(method)
@@ -470,17 +461,12 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
 
     fieldset_classes = ["input-group", "form-group#{error_state(object, method)}"]
 
-    describedby_ids = []
+    describedby = get_describedby(method, help_text: help_text)
+
     if help_text.present?
       help_id = help_text_id(method)
       help_html = help_text_html(help_text, help_id)
-      describedby_ids << help_id
     end
-
-    if object.errors[method].any?
-      describedby_ids << error_label(method)
-    end
-    describedby = describedby_ids.join(' ')
 
     <<~HTML.html_safe
       <fieldset class="#{fieldset_classes.join(' ')}" aria-describedby="#{describedby}">
@@ -517,6 +503,21 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
       style: "display:none",
       'data-permitted': permitted_values.to_json
     )
+  end
+
+  def get_describedby(method, help_text: nil)
+    describedby_ids = []
+
+    if help_text
+      help_id = help_text_id(method)
+      describedby_ids << help_id
+    end
+
+    if object.errors[method].any?
+      describedby_ids << error_label(method)
+    end
+
+    describedby_ids.join(' ')
   end
 
   ##### Methods that copy from or override honeycrisp

--- a/app/helpers/vita_min_form_builder.rb
+++ b/app/helpers/vita_min_form_builder.rb
@@ -472,6 +472,7 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
     HTML
   end
 
+  alias v1_cfa_input_field cfa_input_field
   def cfa_input_field(
     method,
     label_text,
@@ -479,24 +480,41 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
     help_text: nil,
     options: {},
     autofocus: nil,
-
     classes: [],
-    prefix: nil,
-    postfix: nil,
     optional: false,
-    notice: nil
+    prefix: nil
   )
+    if prefix
+      return v1_cfa_input_field(
+        method,
+        label_text,
+        type: type,
+        help_text: help_text,
+        options: options,
+        autofocus: autofocus,
+        classes: classes,
+        optional: optional,
+        prefix: prefix,
+        postfix: nil, # not used in this application
+        notice: nil, # not used in this application
+      )
+    end
+
     text_field_options = options.merge(
       type: type,
       autofocus: autofocus,
-      # required: options.required || !optional  todo fix
+      required: options[:required]
     )
+
+    if !options[:required] && optional
+      text_field_options = text_field_options.merge(required: false)
+    end
 
     @v2_builder.cfa_text_field(
       method,
       label_text,
       help_text: help_text,
-      wrapper_options: {},
+      wrapper_options: { class: classes.join(' ') },
       label_options: {},
       **text_field_options
     )

--- a/app/helpers/vita_min_form_builder.rb
+++ b/app/helpers/vita_min_form_builder.rb
@@ -57,6 +57,7 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
 
     html_options = {
       class: "select__element",
+      'aria-describedby': get_describedby(method, help_text: options[:help_text]),
     }
 
     label_class = options[:label_class] || ""
@@ -67,10 +68,9 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
         label_text,
         has_help_text: !!options[:help_text],
         optional: options[:optional],
-        ),
+      ),
       class: label_class,
-      )
-    html_options_with_errors = html_options.merge(error_attributes(method: method))
+    )
 
     help_html = help_text_html(options[:help_text], method)
 
@@ -79,7 +79,7 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
         #{formatted_label}
         #{help_html}
         <div class="select">
-          #{select(method, collection, options, html_options_with_errors, &block)}
+          #{select(method, collection, options, html_options, &block)}
         </div>
         #{errors_for(object, method)}
       </div>

--- a/app/helpers/vita_min_form_builder.rb
+++ b/app/helpers/vita_min_form_builder.rb
@@ -12,6 +12,7 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
       wrapper_classes: []
   )
     # this override allows us to wrap the field in a label
+    # used only for file field
     if options[:input_id]
       for_options = options.merge(
           for: options[:input_id],
@@ -23,9 +24,10 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
 
     formatted_label = label(
         method,
-        label_contents(label_text, help_text, optional: optional) + field_html,
+        label_contents(label_text, has_help_text: help_text, optional: optional) + field_html,
         (for_options || options),
         )
+    formatted_label += help_text_html(help_text, method) if help_text
     formatted_label += notice_html(notice).html_safe if notice
 
     formatted_label.html_safe

--- a/app/helpers/vita_min_form_builder.rb
+++ b/app/helpers/vita_min_form_builder.rb
@@ -571,7 +571,7 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
   # Added help text to label and field method instead to remove it from label
   def label_contents(label_text, help_text, optional: false, include_help_text: true)
     label_text = <<~HTML
-      <div class="form-question">#{label_text + optional_text(optional)}</div>
+      <span class="form-question">#{label_text + optional_text(optional)}</span>
     HTML
 
     if help_text && include_help_text

--- a/app/helpers/vita_min_form_builder.rb
+++ b/app/helpers/vita_min_form_builder.rb
@@ -200,7 +200,7 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
     text_field_options = standard_options.merge(
       type: 'text',
       class: "text-input",
-    ).merge(options).merge(error_attributes(method: input_method))
+    ).merge(error_attributes(method: input_method)).merge(options)
 
     text_field_options[:id] ||= sanitized_id(input_method)
     text_field_options[:input_id] ||= sanitized_id(input_method)
@@ -299,18 +299,18 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
     end
     
     if object.errors[method].any?
-      describedby_ids << "##{error_label(method)}"
+      describedby_ids << error_label(method)
     end
 
-    text_field_options = standard_options.merge(
+    
+    text_field_options = standard_options.merge(error_attributes(method: method)).merge(
       class: (classes + ["text-input money-input"]).join(" "),
       'aria-describedby': describedby_ids.join(' ')
-      ).merge(error_attributes(method: method)).merge(placeholder: '0.00').merge(options)
-
+    ).merge(placeholder: '0.00').merge(options)
+    
     text_field_options[:id] ||= sanitized_id(method)
     options[:input_id] ||= sanitized_id(method)
-
-    # TODO: THIS IS OVERRIDING THE ARIA DESCRIBEDBY WHEN THERE ARE ERRORS
+    
     text_field_html = text_field(method, text_field_options)
 
     wrapper_classes = classes + ['money-input-group']
@@ -477,7 +477,7 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
     end
 
     if object.errors[method].any?
-      describedby_ids << "##{error_label(method)}"
+      describedby_ids << error_label(method)
     end
     describedby = describedby_ids.join(' ')
 

--- a/app/helpers/vita_min_form_builder.rb
+++ b/app/helpers/vita_min_form_builder.rb
@@ -28,7 +28,7 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
 
     formatted_label = label(
         method,
-        label_contents(label_text, help_text, optional: optional) + field_html,
+        label_contents(label_text, help_text, optional: optional, include_help_text: false) + field_html,
         (for_options || options),
         )
     formatted_label += notice_html(notice).html_safe if notice
@@ -70,6 +70,7 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
         label_text,
         options[:help_text],
         optional: options[:optional],
+        include_help_text: false
         ),
       class: label_class,
       )
@@ -568,10 +569,16 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
   end
 
   # Added help text to label and field method instead to remove it from label
-  def label_contents(label_text, help_text, optional: false)
+  def label_contents(label_text, help_text, optional: false, include_help_text: true)
     label_text = <<~HTML
       <div class="form-question">#{label_text + optional_text(optional)}</div>
     HTML
+
+    if help_text && include_help_text
+      label_text << <<~HTML
+        <p class="text--help">#{help_text}</p>
+      HTML
+    end
 
     label_text.html_safe
   end
@@ -604,7 +611,7 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
 
     formatted_label = label(
       method,
-      label_contents(label_text, help_text, optional: optional),
+      label_contents(label_text, help_text, optional: optional, include_help_text: false),
       (for_options || options),
     )
     formatted_label += notice_html(notice).html_safe if notice

--- a/app/helpers/vita_min_form_builder.rb
+++ b/app/helpers/vita_min_form_builder.rb
@@ -1,4 +1,9 @@
 class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
+  def initialize(*args)
+    super(*args)
+    @v2_builder = Cfa::Styleguide::CfaV2FormBuilder.new(*args)
+  end
+
   def vita_min_field_in_label(
       method,
       label_text,
@@ -465,6 +470,36 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
           #{errors_for(object, method)}
         </fieldset>
     HTML
+  end
+
+  def cfa_input_field(
+    method,
+    label_text,
+    type: "text",
+    help_text: nil,
+    options: {},
+    autofocus: nil,
+
+    classes: [],
+    prefix: nil,
+    postfix: nil,
+    optional: false,
+    notice: nil
+  )
+    text_field_options = options.merge(
+      type: type,
+      autofocus: autofocus,
+      # required: options.required || !optional  todo fix
+    )
+
+    @v2_builder.cfa_text_field(
+      method,
+      label_text,
+      help_text: help_text,
+      wrapper_options: {},
+      label_options: {},
+      **text_field_options
+    )
   end
 
   def submit(value, options = {})

--- a/app/helpers/vita_min_form_builder.rb
+++ b/app/helpers/vita_min_form_builder.rb
@@ -24,7 +24,7 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
 
     formatted_label = label(
         method,
-        label_contents(label_text, has_help_text: help_text, optional: optional) + field_html,
+        label_contents(label_text, has_help_text: !!help_text, optional: optional) + field_html,
         (for_options || options),
         )
     formatted_label += help_text_html(help_text, method) if help_text
@@ -72,7 +72,7 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
       )
     html_options_with_errors = html_options.merge(error_attributes(method: method))
 
-    help_html = help_text_html(options[:help_text], :method)
+    help_html = help_text_html(options[:help_text], method)
 
     html_output = <<~HTML
       <div class="form-group#{error_state(object, method)}">

--- a/app/views/state_file/questions/w2/edit.html.erb
+++ b/app/views/state_file/questions/w2/edit.html.erb
@@ -27,9 +27,9 @@
                     field_name.to_sym,
                     t(".box14_#{code['name'].downcase}_html"),
                     options: { value: value || 0 },
-                    classes: ["form-width--long"]
+                    classes: ["form-width--long"],
+                    help_text: t(".box14_#{code['name'].downcase}_help_text_html", year: MultiTenantService.statefile.current_tax_year, default: nil)
                   ) %>
-                  <%= t(".box14_#{code['name'].downcase}_help_text", year: MultiTenantService.statefile.current_tax_year, default: nil) %>
             </div>
           <% end %>
         </fieldset>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4111,8 +4111,8 @@ en:
           box14_intro_nj_html: "<p>Employers may use Box 14 to report anything that doesn't fit somewhere else on a Form W-2.</p>\n<p>For this year, we will only need any amounts listed for <strong>UI/WF/SWF</strong> (may also appear as <strong>\"UI/HC/WD\"</strong> on your W2) <strong>and FLI</strong>.</p> \n<p><strong>If you do not see these, please leave these fields blank.</strong></p> \n<p>There may be other information in Box 14. That information doesn't need to be reported with this tool.</p>\n"
           box14_stpickup_help_text_html: For %{year}, we will only process the STPICKUP code. If you do not see this code or have other codes in Box 14, please leave it blank.
           box14_stpickup_html: "<strong>STPICKUP</strong>"
-          box14_ui_wf_swf_html: "<strong>UI/WF/SWF</strong>"
           box14_ui_wf_swf_help_text_html: "(This may also appear on your W2 as <strong>UI/HC/WD.</strong>)"
+          box14_ui_wf_swf_html: "<strong>UI/WF/SWF</strong>"
           box15_html: "<strong>Box 15,</strong> Employer’s state ID number"
           box16_html: "<strong>Box 16,</strong> State wages, tips, etc."
           box17_html: "<strong>Box 17,</strong> State income tax"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4109,9 +4109,10 @@ en:
           box14_fli_html: "<strong>FLI</strong>"
           box14_html: "<strong>Box 14,</strong> Other"
           box14_intro_nj_html: "<p>Employers may use Box 14 to report anything that doesn't fit somewhere else on a Form W-2.</p>\n<p>For this year, we will only need any amounts listed for <strong>UI/WF/SWF</strong> (may also appear as <strong>\"UI/HC/WD\"</strong> on your W2) <strong>and FLI</strong>.</p> \n<p><strong>If you do not see these, please leave these fields blank.</strong></p> \n<p>There may be other information in Box 14. That information doesn't need to be reported with this tool.</p>\n"
-          box14_stpickup_help_text: For %{year}, we will only process the STPICKUP code. If you do not see this code or have other codes in Box 14, please leave it blank.
+          box14_stpickup_help_text_html: For %{year}, we will only process the STPICKUP code. If you do not see this code or have other codes in Box 14, please leave it blank.
           box14_stpickup_html: "<strong>STPICKUP</strong>"
-          box14_ui_wf_swf_html: "<strong>UI/WF/SWF</strong> (This may also appear on your W2 as <strong>UI/HC/WD.</strong>)"
+          box14_ui_wf_swf_html: "<strong>UI/WF/SWF</strong>"
+          box14_ui_wf_swf_help_text_html: "(This may also appear on your W2 as <strong>UI/HC/WD.</strong>)"
           box15_html: "<strong>Box 15,</strong> Employer’s state ID number"
           box16_html: "<strong>Box 16,</strong> State wages, tips, etc."
           box17_html: "<strong>Box 17,</strong> State income tax"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4062,8 +4062,8 @@ es:
           box14_intro_nj_html: "<p>Los empleadores pueden usar el Casillero 14 para reportar datos que no encajen en otro lugar del Formulario W-2.</p>\n<p>Este año, solo necesitaremos cualquier monto indicado para <strong>UI/WF/SWF</strong> (también puede aparecer como <strong>\"UI/HC/WD\"</strong> en tu W2) <strong>y FLI</strong>.</p> \n<p><strong>Si no los ves, deja estos campos en blanco.</strong></p> \n<p>Puede haber otros datos en el casillero 14 que no necesitan ser reportados con esta herramienta.</p>\n"
           box14_stpickup_help_text_html: Para %{year}, solo procesaremos el código STPICKUP. Si no ves este código o tienes otros códigos en Box 14, por favor déjalo en blanco.
           box14_stpickup_html: "<strong>STPICKUP</strong>"
-          box14_ui_wf_swf_html: "<strong>UI/WF/SWF</strong>"
           box14_ui_wf_swf_help_text_html: "(También puede aparecer en su W2 como <strong>UI/HC/WD.</strong>)"
+          box14_ui_wf_swf_html: "<strong>UI/WF/SWF</strong>"
           box15_html: "<strong>Casilla 15,</strong> Número de identificación estatal del empleador"
           box16_html: "<strong>Casilla 16</strong>, Salarios estatales, propinas, etc."
           box17_html: "<strong>Casilla 17</strong>, Impuesto estatal sobre los ingresos"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4060,9 +4060,10 @@ es:
           box14_fli_html: "<strong>FLI</strong>"
           box14_html: "<strong>Box 14,</strong> Other"
           box14_intro_nj_html: "<p>Los empleadores pueden usar el Casillero 14 para reportar datos que no encajen en otro lugar del Formulario W-2.</p>\n<p>Este año, solo necesitaremos cualquier monto indicado para <strong>UI/WF/SWF</strong> (también puede aparecer como <strong>\"UI/HC/WD\"</strong> en tu W2) <strong>y FLI</strong>.</p> \n<p><strong>Si no los ves, deja estos campos en blanco.</strong></p> \n<p>Puede haber otros datos en el casillero 14 que no necesitan ser reportados con esta herramienta.</p>\n"
-          box14_stpickup_help_text: Para %{year}, solo procesaremos el código STPICKUP. Si no ves este código o tienes otros códigos en Box 14, por favor déjalo en blanco.
+          box14_stpickup_help_text_html: Para %{year}, solo procesaremos el código STPICKUP. Si no ves este código o tienes otros códigos en Box 14, por favor déjalo en blanco.
           box14_stpickup_html: "<strong>STPICKUP</strong>"
-          box14_ui_wf_swf_html: "<strong>UI/WF/SWF</strong> (También puede aparecer en su W2 como <strong>UI/HC/WD.</strong>)"
+          box14_ui_wf_swf_html: "<strong>UI/WF/SWF</strong>"
+          box14_ui_wf_swf_help_text_html: "(También puede aparecer en su W2 como <strong>UI/HC/WD.</strong>)"
           box15_html: "<strong>Casilla 15,</strong> Número de identificación estatal del empleador"
           box16_html: "<strong>Casilla 16</strong>, Salarios estatales, propinas, etc."
           box17_html: "<strong>Casilla 17</strong>, Impuesto estatal sobre los ingresos"

--- a/spec/features/state_file/nj/complete_intake_spec.rb
+++ b/spec/features/state_file/nj/complete_intake_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
       continue
 
       expect(page).to be_axe_clean if check_a11y
-      step_through_initial_authentication(contact_preference: :email)
+      step_through_initial_authentication(contact_preference: :email, check_a11y: check_a11y)
       expect(page).to be_axe_clean if check_a11y
 
       check "Email"
@@ -97,6 +97,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
           check I18n.t('state_file.questions.nj_college_dependents_exemption.edit.filer_pays_tuition_books')
         end
       end
+      expect_programmatically_associated_help_text
       continue
     end
 

--- a/spec/support/helpers/state_file_intake_helper.rb
+++ b/spec/support/helpers/state_file_intake_helper.rb
@@ -75,6 +75,7 @@ module StateFileIntakeHelper
       click_on "Text me a code"
 
       expect(page).to have_text "Enter your phone number"
+      # TODO: EXPECT HELPER TEXT programmatically associated
       fill_in "Your phone number", with: "4153334444"
       click_on "Send code"
 
@@ -89,6 +90,7 @@ module StateFileIntakeHelper
       click_on "Email me a code"
 
       expect(page).to have_text "Enter your email address"
+      # TODO: EXPECT HELPER TEXT programmatically associated
       fill_in I18n.t("state_file.questions.email_address.edit.email_address_label"), with: "someone@example.com"
       click_on "Send code"
 

--- a/spec/support/helpers/state_file_intake_helper.rb
+++ b/spec/support/helpers/state_file_intake_helper.rb
@@ -71,12 +71,13 @@ module StateFileIntakeHelper
     help_texts = page.all(:css, '.text--help')
     help_texts.each do |el|
       id = el[:id]
-      inputs_described_by_el = page.all(:css, "input[aria-describedby='#{id}']")
-      expect(inputs_described_by_el.length).to eq(1)
+      expect(id).not_to be_empty
+      described_by_help_text = page.all(:css, "*[aria-describedby='#{id}']")
+      expect(described_by_help_text.length).to eq(1)
     end
   end
 
-  def step_through_initial_authentication(contact_preference: :text_message)
+  def step_through_initial_authentication(check_a11y: false, contact_preference: :text_message)
     expect(page).to have_text I18n.t("state_file.questions.contact_preference.edit.title")
 
     case contact_preference
@@ -84,10 +85,9 @@ module StateFileIntakeHelper
       click_on "Text me a code"
 
       expect(page).to have_text "Enter your phone number"
-      expect_programmatically_associated_help_text
+      expect_programmatically_associated_help_text if check_a11y
       fill_in "Your phone number", with: "4153334444"
       click_on "Send code"
-
 
       expect(strip_html_tags(page.body)).to have_text strip_html_tags(I18n.t("state_file.questions.verification_code.edit.title_html", contact_info: '(415) 333-4444'))
       expect(page).to have_text "We’ve sent your code to (415) 333-4444"
@@ -99,7 +99,7 @@ module StateFileIntakeHelper
       click_on "Email me a code"
 
       expect(page).to have_text "Enter your email address"
-      expect_programmatically_associated_help_text
+      expect_programmatically_associated_help_text if check_a11y
       fill_in I18n.t("state_file.questions.email_address.edit.email_address_label"), with: "someone@example.com"
       click_on "Send code"
 

--- a/spec/support/helpers/state_file_intake_helper.rb
+++ b/spec/support/helpers/state_file_intake_helper.rb
@@ -70,7 +70,9 @@ module StateFileIntakeHelper
   def expect_programmatically_associated_help_text
     help_texts = page.all(:css, '.text--help')
     help_texts.each do |el|
-      binding.pry
+      id = el[:id]
+      inputs_described_by_el = page.all(:css, "input[aria-describedby='#{id}']")
+      expect(inputs_described_by_el.length).to eq(1)
     end
   end
 

--- a/spec/support/helpers/state_file_intake_helper.rb
+++ b/spec/support/helpers/state_file_intake_helper.rb
@@ -67,6 +67,13 @@ module StateFileIntakeHelper
     end
   end
 
+  def expect_programmatically_associated_help_text
+    help_texts = page.all(:css, '.text--help')
+    help_texts.each do |el|
+      binding.pry
+    end
+  end
+
   def step_through_initial_authentication(contact_preference: :text_message)
     expect(page).to have_text I18n.t("state_file.questions.contact_preference.edit.title")
 
@@ -75,7 +82,7 @@ module StateFileIntakeHelper
       click_on "Text me a code"
 
       expect(page).to have_text "Enter your phone number"
-      # TODO: EXPECT HELPER TEXT programmatically associated
+      expect_programmatically_associated_help_text
       fill_in "Your phone number", with: "4153334444"
       click_on "Send code"
 
@@ -90,7 +97,7 @@ module StateFileIntakeHelper
       click_on "Email me a code"
 
       expect(page).to have_text "Enter your email address"
-      # TODO: EXPECT HELPER TEXT programmatically associated
+      expect_programmatically_associated_help_text
       fill_in I18n.t("state_file.questions.email_address.edit.email_address_label"), with: "someone@example.com"
       click_on "Send code"
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
Project issue: https://github.com/newjersey/affordability-pm/issues/246
A11y issue: https://github.com/newjersey/accessibility-pm/issues/19

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Update honeycrisp
- Update components affected by the honeycrisp update
- Update help text and errors for non-honeycrisp components: money field and checkbox set, the latter of which is only used by NJ
- Update help text color
- Move box 14 help text to associate it with the input - **I did this for all states, so it does affect Maryland STPICKUP**

## How to test?
- This change can be observed on the contact info pages and in the box 14 editing section, as well as on the dependents attending college page

## Screenshots (for visual changes)
Before
![image](https://github.com/user-attachments/assets/8a6434d2-79f1-4957-80c2-90ed7f8d27a8)
![image](https://github.com/user-attachments/assets/171c6092-5b93-4b80-bed1-009d88490986)
After
![image](https://github.com/user-attachments/assets/b87d7415-763c-4d16-b81f-f49558a07059)
![image](https://github.com/user-attachments/assets/c5dba0e5-ba3b-4272-80d5-1bd360485664)

This is what the vita min select looks like with help text. We are not using this component with help text anywhere in the application.
![image](https://github.com/user-attachments/assets/fcf4a82e-fe42-40d2-9f0d-a0bc23582625)

