### PR TITLE
FYST-1721 AZ include qual child dependent only if filer is hoh

### DIFF
--- a/app/lib/submission_builder/ty2022/states/az/az_return_xml.rb
+++ b/app/lib/submission_builder/ty2022/states/az/az_return_xml.rb
@@ -44,7 +44,7 @@ module SubmissionBuilder
             xml_doc = build_xml_doc("Form140") do |xml|
               xml.LNPriorYrs sanitize_for_xml(@submission.data_source.prior_last_names)
               xml.FilingStatus filing_status
-              if hoh_qualifying_person.present?
+              if hoh_qualifying_person.present? && @submission.data_source.filing_status_hoh?
                 xml.QualChildDependentName do
                   xml.FirstName sanitize_for_xml(hoh_qualifying_person[:first_name], 16)
                   xml.LastName sanitize_for_xml(hoh_qualifying_person[:last_name], 32)

--- a/spec/lib/submission_builder/ty2022/states/az/az_return_xml_spec.rb
+++ b/spec/lib/submission_builder/ty2022/states/az/az_return_xml_spec.rb
@@ -44,7 +44,21 @@ describe SubmissionBuilder::Ty2022::States::Az::AzReturnXml, required_schema: "a
           expect(instance.send(:xml_hoh_qualifying_person)).to be_nil
         end
 
-        # TODO: Write tests for when xml exists, when they exist
+        context 'when there is qualifying person in the xml' do
+          let(:intake) do
+            create(
+              :state_file_az_intake,
+              filing_status: :head_of_household,
+              raw_direct_file_data: StateFile::DirectFileApiResponseSampleService.new.read_xml('az_marge_hoh_no_deps'),
+              raw_direct_file_intake_data: StateFile::DirectFileApiResponseSampleService.new.read_json('az_marge_hoh_no_deps')
+            )
+          end
+          it 'should return a hash when there is a matching xml element' do
+            response = instance.send(:xml_hoh_qualifying_person)
+            expect(response).to be_kind_of(Hash)
+            expect(response.keys).to eq [:first_name, :last_name]
+          end
+        end
       end
 
       describe "#json_xml_qualifying_person" do
@@ -65,6 +79,21 @@ describe SubmissionBuilder::Ty2022::States::Az::AzReturnXml, required_schema: "a
       it 'should create the QualChildDependentName' do
         expect(xml.at('QualChildDependentName')).to be_present
         expect(xml.at('QualChildDependentName FirstName').text).to eq 'Axel'
+      end
+
+      describe 'when the filing status is not hoh but there is a qualifying person' do
+        let(:intake) do
+          create(
+            :state_file_az_intake,
+            filing_status: :single,
+            raw_direct_file_data: StateFile::DirectFileApiResponseSampleService.new.read_xml('az_alexis_hoh'),
+            raw_direct_file_intake_data: StateFile::DirectFileApiResponseSampleService.new.read_json('az_alexis_hoh')
+          )
+        end
+
+        it 'does not create the QualChildDependentName' do
+          expect(xml.at('QualChildDependentName')).to be_nil
+        end
       end
     end
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/FYST-1721

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Added a condition to make sure filer is hoh before adding qualifying dependent info

## How to test?
- Updated units test

