### PR TITLE
FYST-1728 Fix MD client address updates

### DIFF
--- a/app/lib/submission_builder/ty2024/states/md/documents/md502.rb
+++ b/app/lib/submission_builder/ty2024/states/md/documents/md502.rb
@@ -54,7 +54,7 @@ class SubmissionBuilder::Ty2024::States::Md::Documents::Md502 < SubmissionBuilde
           xml.AddressLine1Txt sanitize_for_xml(@intake.permanent_street, 30)
           xml.AddressLine2Txt sanitize_for_xml(@intake.permanent_apartment, 30) if @intake.permanent_apartment.present?
           xml.CityNm sanitize_for_xml(@intake.permanent_city, 20)
-          xml.StateAbbreviationCd @intake.direct_file_data.mailing_state.upcase
+          xml.StateAbbreviationCd "MD"
           xml.ZIPCd sanitize_zipcode(@intake.permanent_zip)
         end
       end

--- a/spec/lib/submission_builder/ty2024/states/md/documents/md502_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/md/documents/md502_spec.rb
@@ -72,38 +72,25 @@ describe SubmissionBuilder::Ty2024::States::Md::Documents::Md502, required_schem
             expect(xml.at("MarylandAddress ZIPCd").text).to eq "214011234"
           end
 
-          context "when user had an out-of-state permanent address from DF" do
+          context "when user had an out-of-state permanent address from DF and enters a new address in MD" do
             before do
               intake.direct_file_data.mailing_city = "Denver"
               intake.direct_file_data.mailing_state = "CO"
               intake.direct_file_data.mailing_zip = "80212-1234"
+              intake.confirmed_permanent_address_no!
+              intake.permanent_street = "313 Poppy Street"
+              intake.permanent_apartment = "Apt A"
+              intake.permanent_city = "Baltimore"
+              intake.permanent_zip = "21201-1234"
             end
 
-            it "outputs their DF address as their physical address" do
-              expect(xml.at("MarylandAddress AddressLine1Txt").text).to eq "312 Poppy Street"
-              expect(xml.at("MarylandAddress AddressLine2Txt").text).to eq "Apt B"
-              expect(xml.at("MarylandAddress CityNm").text).to eq "Denver"
-              expect(xml.at("MarylandAddress StateAbbreviationCd").text).to eq "CO"
-              expect(xml.at("MarylandAddress ZIPCd").text).to eq "802121234"
+            it "outputs their entered address as their physical address" do
+              expect(xml.at("MarylandAddress AddressLine1Txt").text).to eq "313 Poppy Street"
+              expect(xml.at("MarylandAddress AddressLine2Txt").text).to eq "Apt A"
+              expect(xml.at("MarylandAddress CityNm").text).to eq "Baltimore"
+              expect(xml.at("MarylandAddress StateAbbreviationCd").text).to eq "MD"
+              expect(xml.at("MarylandAddress ZIPCd").text).to eq "212011234"
             end
-          end
-        end
-
-        context "when the user has entered a different permanent address" do
-          before do
-            intake.confirmed_permanent_address_no!
-            intake.permanent_street = "313 Poppy Street"
-            intake.permanent_apartment = "Apt A"
-            intake.permanent_city = "Baltimore"
-            intake.permanent_zip = "21201-1234"
-          end
-
-          it "outputs their entered address as their physical address" do
-            expect(xml.at("MarylandAddress AddressLine1Txt").text).to eq "313 Poppy Street"
-            expect(xml.at("MarylandAddress AddressLine2Txt").text).to eq "Apt A"
-            expect(xml.at("MarylandAddress CityNm").text).to eq "Baltimore"
-            expect(xml.at("MarylandAddress StateAbbreviationCd").text).to eq "MD"
-            expect(xml.at("MarylandAddress ZIPCd").text).to eq "212011234"
           end
         end
       end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/FYST-1728

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Make sure MD is hardcoded when the client changes their address in the permanent address controller. This is because in the form MD is hardcoded because permanent address must be within MD 

## How to test?
- Updated permanent address controller because there shouldn't be a case where a CO/out of state address is shown in the xml because in the flow it stops you to change the address to a MD one 

## Screenshots (for visual changes)
- Before
- After
