### PR TITLE
Fyst 1730 strip any values that are not allowed from middle initial field

### DIFF
--- a/app/lib/submission_builder/formatting_methods.rb
+++ b/app/lib/submission_builder/formatting_methods.rb
@@ -19,6 +19,14 @@ module SubmissionBuilder
       sanitized_zipcode.gsub("-", "")
     end
 
+    def sanitize_middle_initial(middle_initial)
+      return if middle_initial.blank?
+
+      sanitized_middle_initial = sanitize_for_xml(middle_initial)
+      sanitized_middle_initial = sanitized_middle_initial.tr('^A-Za-z', '')
+      sanitized_middle_initial&.first(1)
+    end
+
     def datetime_type(datetime)
       return nil unless datetime.present?
 

--- a/app/lib/submission_builder/return_header.rb
+++ b/app/lib/submission_builder/return_header.rb
@@ -33,7 +33,7 @@ module SubmissionBuilder
           xml.Primary do
             xml.TaxpayerName do
               xml.FirstName sanitize_for_xml(@submission.data_source.primary.first_name, 16) if @submission.data_source.primary.first_name.present?
-              xml.MiddleInitial sanitize_for_xml(@submission.data_source.primary.middle_initial, 1) if @submission.data_source.primary.middle_initial.present?
+              xml.MiddleInitial sanitize_middle_initial(@submission.data_source.primary.middle_initial) if sanitize_middle_initial(@submission.data_source.primary.middle_initial)
               xml.LastName sanitize_for_xml(@submission.data_source.primary.last_name, 32) if @submission.data_source.primary.last_name.present?
               xml.NameSuffix @submission.data_source.primary.suffix.upcase if @submission.data_source.primary.suffix.present?
             end

--- a/app/lib/submission_builder/return_header.rb
+++ b/app/lib/submission_builder/return_header.rb
@@ -33,7 +33,7 @@ module SubmissionBuilder
           xml.Primary do
             xml.TaxpayerName do
               xml.FirstName sanitize_for_xml(@submission.data_source.primary.first_name, 16) if @submission.data_source.primary.first_name.present?
-              xml.MiddleInitial sanitize_middle_initial(@submission.data_source.primary.middle_initial) if sanitize_middle_initial(@submission.data_source.primary.middle_initial)
+              xml.MiddleInitial sanitize_middle_initial(@submission.data_source.primary.middle_initial) if sanitize_middle_initial(@submission.data_source.primary.middle_initial).present?
               xml.LastName sanitize_for_xml(@submission.data_source.primary.last_name, 32) if @submission.data_source.primary.last_name.present?
               xml.NameSuffix @submission.data_source.primary.suffix.upcase if @submission.data_source.primary.suffix.present?
             end
@@ -47,7 +47,7 @@ module SubmissionBuilder
             xml.Secondary do
               xml.TaxpayerName do
                 xml.FirstName sanitize_for_xml(@submission.data_source.spouse.first_name, 16) if @submission.data_source.spouse.first_name.present?
-                xml.MiddleInitial sanitize_for_xml(@submission.data_source.spouse.middle_initial, 1) if @submission.data_source.spouse.middle_initial.present?
+                xml.MiddleInitial sanitize_middle_initial(@submission.data_source.spouse.middle_initial) if sanitize_middle_initial(@submission.data_source.spouse.middle_initial).present?
                 xml.LastName sanitize_for_xml(@submission.data_source.spouse.last_name, 32) if @submission.data_source.spouse.last_name.present?
                 xml.NameSuffix @submission.data_source.spouse.suffix.upcase if @submission.data_source.spouse.suffix.present?
               end

--- a/app/lib/submission_builder/ty2022/states/az/az_return_xml.rb
+++ b/app/lib/submission_builder/ty2022/states/az/az_return_xml.rb
@@ -63,7 +63,7 @@ module SubmissionBuilder
                   xml.DependentDetails do
                     xml.Name do
                       xml.FirstName sanitize_for_xml(dependent.first_name, 16)
-                      xml.MiddleInitial sanitize_for_xml(dependent.middle_initial, 1) if dependent.middle_initial.present?
+                      xml.MiddleInitial sanitize_middle_initial(dependent.middle_initial) if sanitize_middle_initial(dependent.middle_initial).present?
                       xml.LastName sanitize_for_xml(dependent.last_name, 32)
                     end
                     unless dependent.ssn.nil?
@@ -82,7 +82,7 @@ module SubmissionBuilder
                   xml.QualParentsAncestors do
                     xml.Name do
                       xml.FirstName sanitize_for_xml(dependent.first_name, 16)
-                      xml.MiddleInitial sanitize_for_xml(dependent.middle_initial, 1) if dependent.middle_initial.present?
+                      xml.MiddleInitial sanitize_middle_initial(dependent.middle_initial) if sanitize_middle_initial(dependent.middle_initial).present?
                       xml.LastName sanitize_for_xml(dependent.last_name, 32)
                     end
                     unless dependent.ssn.nil?

--- a/app/lib/submission_builder/ty2024/states/md/documents/md502b.rb
+++ b/app/lib/submission_builder/ty2024/states/md/documents/md502b.rb
@@ -19,7 +19,7 @@ module SubmissionBuilder
                     xml.Dependent do
                       xml.Name do
                         xml.FirstName sanitize_for_xml(dependent.first_name, 16)
-                        xml.MiddleInitial sanitize_for_xml(dependent.middle_initial, 1) if dependent.middle_initial.present?
+                        xml.MiddleInitial sanitize_middle_initial(dependent.middle_initial) if sanitize_middle_initial(dependent.middle_initial).present?
                         xml.LastName sanitize_for_xml(dependent.last_name, 32)
                       end
                       xml.SSN dependent.ssn

--- a/app/lib/submission_builder/ty2024/states/nc/documents/d400.rb
+++ b/app/lib/submission_builder/ty2024/states/nc/documents/d400.rb
@@ -30,7 +30,7 @@ module SubmissionBuilder
                 if @submission.data_source.filing_status_mfs?
                   xml.MFSSpouseName do
                     xml.FirstName sanitize_for_xml(@submission.data_source.spouse.first_name, 16) if @submission.data_source.spouse.first_name.present?
-                    xml.MiddleInitial sanitize_for_xml(@submission.data_source.spouse.middle_initial, 1) if @submission.data_source.spouse.middle_initial.present?
+                    xml.MiddleInitial sanitize_middle_initial(@submission.data_source.spouse.middle_initial) if sanitize_middle_initial(@submission.data_source.spouse.middle_initial).present?
                     xml.LastName sanitize_for_xml(@submission.data_source.spouse.last_name, 32) if @submission.data_source.spouse.last_name.present?
                   end
                   xml.MFSSpouseSSN @submission.data_source.direct_file_data.spouse_ssn
@@ -72,7 +72,7 @@ module SubmissionBuilder
                   xml.PaymentContact do
                     xml.PersonName do
                       xml.FirstName sanitize_for_xml(@submission.data_source.primary.first_name, 16) if @submission.data_source.primary.first_name.present?
-                      xml.MiddleInitial sanitize_for_xml(@submission.data_source.primary.middle_initial, 1) if @submission.data_source.primary.middle_initial.present?
+                      xml.MiddleInitial sanitize_middle_initial(@submission.data_source.primary.middle_initial) if sanitize_middle_initial(@submission.data_source.primary.middle_initial).present?
                       xml.LastName sanitize_for_xml(@submission.data_source.primary.last_name, 32) if @submission.data_source.primary.last_name.present?
                       xml.NameSuffix @submission.data_source.primary.suffix.upcase if @submission.data_source.primary.suffix.present?
                     end

--- a/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
+++ b/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
@@ -31,7 +31,7 @@ module SubmissionBuilder
                         xml.SpouseSSN intake.spouse.ssn
                         xml.SpouseName do
                           xml.FirstName sanitize_for_xml(intake.spouse.first_name)
-                          xml.MiddleInitial sanitize_for_xml(intake.spouse.middle_initial) if intake.spouse.middle_initial.present?
+                          xml.MiddleInitial sanitize_middle_initial(intake.spouse.middle_initial) if sanitize_middle_initial(intake.spouse.middle_initial).present?
                           xml.LastName sanitize_for_xml(intake.spouse.last_name)
                           xml.NameSuffix intake.spouse.suffix.upcase if intake.spouse.suffix.present?
                         end

--- a/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
+++ b/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
@@ -97,7 +97,7 @@ module SubmissionBuilder
                       xml.Dependents do
                         xml.DependentsName do
                           xml.FirstName sanitize_for_xml(dependent.first_name)
-                          xml.MiddleInitial sanitize_for_xml(dependent.middle_initial) if dependent.middle_initial.present?
+                          xml.MiddleInitial sanitize_middle_initial(dependent.middle_initial) if sanitize_middle_initial(dependent.middle_initial).present?
                           xml.LastName sanitize_for_xml(dependent.last_name)
                           xml.NameSuffix dependent.suffix.upcase if dependent.suffix.present?
                         end

--- a/spec/lib/submission_builder/formatting_methods_spec.rb
+++ b/spec/lib/submission_builder/formatting_methods_spec.rb
@@ -146,6 +146,30 @@ describe SubmissionBuilder::FormattingMethods do
     end
   end
 
+  describe "#sanitize_middle_initial" do
+    let(:middle_initial) { nil }
+
+    it "should return nil if middle_initial is not present" do
+      expect(dummy_class.sanitize_middle_initial(middle_initial)).to be_nil
+    end
+
+    context "with bad middle initial" do
+      let(:middle_initial) { "-" }
+
+      it "should remove unaccepted character" do
+        expect(dummy_class.sanitize_middle_initial(middle_initial)).to eq("")
+      end
+    end
+
+    context "with preceding unaccepted characters before an acceptable character" do
+      let(:middle_initial) { " -0 A B" }
+
+      it "should remove unaccepted character and return the first acceptable character" do
+        expect(dummy_class.sanitize_middle_initial(middle_initial)).to eq("A")
+      end
+    end
+  end
+
   describe "#truncate" do
     include SubmissionBuilder::FormattingMethods
     it "doesn't affect valid strings" do


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1730
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Stripping all values that is not allowed -- will regular sanitize (`sanitize_for_xml`) first to without limiting length to 1 incase an acceptable letter was somehow provided for this field, then after rejecting unacceptable characters, limit to 1
- Addressed middle initials in all places where it was pulling from `direct_file_data` (notably: I did not sanitize `account_holder_middle_initial` b/c this is input through intake & we validate this field.
- **Further thoughts** we do not validate any other fields in this manner except zip_code (remove unaccepted characters from first name/last name -- suffix is a drop down I think so there is little reason to think this would contain unaccepted characters). Should we apply something like this for the first/last names? I didn't want to block this PR with that effort since first/last names are probably used more heavily across the app.
## How to test?
- Describe the testing approach taken to verify the changes, including:
  - Unit/manual tests
  - Test data used: none, but there is an example on prod?
- Risk Assessment
  - XMLS touched:
     - return header
     - az_return_xml:
       - DependentDetails Name Middle Initial
       - QualParentsAncestors Name MiddleInitial
       - 
     - md_502b xml:
       - Dependent Name MiddleInitial
     - nc d400 xml:
       - MFSSposueName MiddleInitial
       - PaymentContact PersonName MiddleInitial
     - nj1040:
       - MarriedCuPartFilingSeparate SpouseName MiddleInitial 

 
## Screenshots (for visual changes)
- Before
- After
