### PR TITLE
FYST-1714 Update 502CR behavior for nontaxable deduction returns

### DIFF
--- a/app/lib/submission_builder/ty2024/states/md/documents/md502_cr.rb
+++ b/app/lib/submission_builder/ty2024/states/md/documents/md502_cr.rb
@@ -10,13 +10,15 @@ module SubmissionBuilder
 
             def document
               build_xml_doc("Form502CR", documentId: "Form502CR") do |xml|
-                if calculated_fields.fetch(:MD502_DEDUCTION_METHOD) == "S"
+                if deduction_method_is_standard || calculated_fields.fetch(:MD502CR_PART_CC_LINE_7)&.positive?
                   xml.ChildAndDependentCare do |child_dependent_care|
                     add_non_zero_value(child_dependent_care, :FederalAdjustedGrossIncome, :MD502_LINE_1)
                     add_non_zero_value(child_dependent_care, :FederalChildCareCredit, :MD502CR_PART_B_LINE_2)
                     add_non_zero_float_value(child_dependent_care, :DecimalAmount, :MD502CR_PART_B_LINE_3)
                     add_non_zero_value(child_dependent_care, :Credit, :MD502CR_PART_B_LINE_4)
                   end
+                end
+                if deduction_method_is_standard
                   xml.Senior do |senior|
                     add_non_zero_value(senior, :Credit, :MD502CR_PART_M_LINE_1)
                   end
@@ -35,6 +37,10 @@ module SubmissionBuilder
             end
 
             private
+
+            def deduction_method_is_standard
+              calculated_fields.fetch(:MD502_DEDUCTION_METHOD) == "S"
+            end
 
             def intake
               @submission.data_source

--- a/spec/lib/submission_builder/ty2024/states/md/documents/md502_cr_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/md/documents/md502_cr_spec.rb
@@ -78,6 +78,23 @@ describe SubmissionBuilder::Ty2024::States::Md::Documents::Md502Cr, required_sch
           expect(xml.at("Form502CR Summary")).to be_nil
           expect(xml.at("Form502CR Refundable")).not_to be_nil
         end
+
+        context "has positive MD502CR_PART_CC_LINE_7 value" do
+          before do
+            intake.direct_file_data.fed_credit_for_child_and_dependent_care_amount = 10
+            allow_any_instance_of(Efile::Md::Md502crCalculator).to receive(:calculate_part_cc_line_7).and_return 100
+          end
+
+          it "does output parts B but not M or AA but still outputs part CC" do
+            expect(xml.at("Form502CR ChildAndDependentCare FederalAdjustedGrossIncome").text.to_i).to eq(100)
+            expect(xml.at("Form502CR ChildAndDependentCare FederalChildCareCredit").text.to_i).to eq(10)
+            expect(xml.at("Form502CR ChildAndDependentCare DecimalAmount").text.to_d).to eq(0.32)
+            expect(xml.at("Form502CR ChildAndDependentCare Credit").text.to_i).to eq(3)
+            expect(xml.at("Form502CR Senior")).to be_nil
+            expect(xml.at("Form502CR Summary")).to be_nil
+            expect(xml.at("Form502CR Refundable")).not_to be_nil
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1714
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Updated the logic to only return this section for Nonstandard filers if they have a value in the `MD502CR_PART_CC_LINE_7` (or `ChildAndDependentCareCr` on the xml)
## How to test?
- Describe the testing approach taken to verify the changes, including:
  - Unit tests updated
  - Test data used: Katie_HOH
## Screenshots (for visual changes)
- Before
<img width="620" alt="Screenshot 2025-01-29 at 1 50 56 PM" src="https://github.com/user-attachments/assets/6510d736-abf5-4a67-92bc-a901f890f495" />

- After
<img width="588" alt="Screenshot 2025-01-29 at 1 49 07 PM" src="https://github.com/user-attachments/assets/62d44670-e91f-4a28-9d7b-55a0c266c4bc" />

