### PR TITLE
GYR1-650 Reenable spec test "demographic questions on page 4 work in tandem with other flags" (edit_f13614c_spec.rb)

### DIFF
--- a/spec/features/hub/edit_13614c_spec.rb
+++ b/spec/features/hub/edit_13614c_spec.rb
@@ -615,8 +615,7 @@ RSpec.describe "a user editing a clients 13614c form" do
       expect(intake.demographic_spouse_white).to be_truthy
     end
 
-    # TODO reenable this after GYR1-603 / https://github.com/codeforamerica/vita-min/pull/5406 gets merged.
-    xdescribe "demographic questions on page 4 work in tandem with other flags" do
+    describe "demographic questions on page 4 work in tandem with other flags" do
       before do
         client.intake.update(
           demographic_questions_opt_in: 'no',
@@ -624,7 +623,7 @@ RSpec.describe "a user editing a clients 13614c form" do
         )
       end
 
-      it "does not write the answers to the PDF unless the client opted in during intake or the hub user has saved page4" do
+      it "does not write the answers to the PDF unless the client opted in during intake or the hub user has saved page 4" do
         # generate pdf, prove spouse ethnicity is not filled in because demographic_questions_opt_in is false
         form_fields = PdfForms.new.get_fields(PdfFiller::F13614cPdf.new(client.intake).output_file)
         expect(form_fields.find { |field| field.name == "form1[0].page4[0].yourSpousesRaceEthnicity[0].hawaiianPacific[0]" }.value).to eq("Off")

--- a/spec/features/hub/edit_13614c_spec.rb
+++ b/spec/features/hub/edit_13614c_spec.rb
@@ -648,7 +648,7 @@ RSpec.describe "a user editing a clients 13614c form" do
         # generate pdf, prove spouse ethnicity is filled in because demographic_questions_hub_edit is true
         form_fields = PdfForms.new.get_fields(PdfFiller::F13614cPdf.new(client.reload.intake).output_file)
         expect(form_fields.find { |field| field.name == "form1[0].page4[0].yourSpousesRaceEthnicity[0].hawaiianPacific[0]" }.value).to eq("Off")
-        expect(form_fields.find { |field| field.name == "form1[0].page4[0].yourSpousesRaceEthnicity[0].blackAfricanAmerican[0]]" }.value).to eq("1")
+        expect(form_fields.find { |field| field.name == "form1[0].page4[0].yourSpousesRaceEthnicity[0].blackAfricanAmerican[0]" }.value).to eq("1")
       end
     end
 


### PR DESCRIPTION
## Link to Jira issue

https://codeforamerica.atlassian.net/browse/GYR1-650

## Is PM acceptance required?

No - merge after code review approval

## What was done?

Merely reenabled a single spec test (and added a tiny fix) that was turned off temporarily during the 
GYR pre-launch development mêlée. (It did need updated keys for ty2024 but those
updates were made a bit earlier in a prior PR.)

## How to test?

No need. If spec tests show all green in GH, we're good.