### PR TITLE
Fyst 1720 md disqualify dependent taxpayers from claiming poverty level credit

### DIFF
--- a/app/lib/efile/md/md502_calculator.rb
+++ b/app/lib/efile/md/md502_calculator.rb
@@ -374,7 +374,7 @@ module Efile
                        [1_000..2_000, 20, 0.03],
                        [2_000..3_000, 50, 0.04],
                      ]
-                   elsif filing_status_single? || filing_status_mfs? || filing_status_dependent?
+                   elsif filing_status_single? || filing_status_mfs? || md_filing_status_dependent?
                      [
                        [3_000..100_000, 90, 0.0475],
                        [100_000..125_000, 4_697.5, 0.05],
@@ -404,7 +404,7 @@ module Efile
 
       def calculate_line_22
         # Earned Income Credit (EIC)
-        return if filing_status_dependent?
+        return if md_filing_status_dependent?
 
         if filing_status_mfj? || filing_status_mfs? || @direct_file_data.fed_eic_qc_claimed
           (@direct_file_data.fed_eic * 0.50).round
@@ -418,7 +418,7 @@ module Efile
       end
 
       def calculate_line_23
-        return 0 if filing_status_dependent? || @lines[:MD502_LINE_1B].value <= 0 || !deduction_method_is_standard?
+        return 0 if md_filing_status_dependent? || @lines[:MD502_LINE_1B].value <= 0 || !deduction_method_is_standard?
 
         comparison_amount = [@lines[:MD502_LINE_7].value, @lines[:MD502_LINE_1B].value].max
 
@@ -481,7 +481,7 @@ module Efile
                    when "Anne Arundel"
                      anne_arundel_local_tax_brackets.find { |bracket| taxable_net_income <= bracket[:threshold] }[:rate]
                    when "Frederick"
-                     if filing_status_dependent? || filing_status_single? || filing_status_mfs?
+                     if md_filing_status_dependent? || filing_status_single? || filing_status_mfs?
                        if taxable_net_income <= 25_000
                          0.0225
                        elsif taxable_net_income <= 50_000
@@ -516,7 +516,7 @@ module Efile
       end
 
       def anne_arundel_local_tax_brackets
-        if filing_status_dependent? || filing_status_single? || filing_status_mfs?
+        if md_filing_status_dependent? || filing_status_single? || filing_status_mfs?
           [
             { threshold: 50_000, rate: 0.0270 },
             { threshold: 400_000, rate: 0.0281 },
@@ -601,7 +601,7 @@ module Efile
 
       def calculate_line_42
         # Earned Income Credit (EIC)
-        return if filing_status_dependent?
+        return if md_filing_status_dependent?
 
         if filing_status_mfj? || filing_status_mfs? || @direct_file_data.fed_eic_qc_claimed
           [(@direct_file_data.fed_eic * 0.45).round - line_or_zero(:MD502_LINE_21), 0].max
@@ -636,10 +636,6 @@ module Efile
 
       def calculate_line_50
         line_or_zero(:MD502_LINE_45) + line_or_zero(:MD502_LINE_49)
-      end
-
-      def filing_status_dependent?
-        @intake.direct_file_data.claimed_as_dependent?
       end
 
       def deduction_method_is_standard?

--- a/app/lib/efile/md/md502_calculator.rb
+++ b/app/lib/efile/md/md502_calculator.rb
@@ -404,6 +404,8 @@ module Efile
 
       def calculate_line_22
         # Earned Income Credit (EIC)
+        return if filing_status_dependent?
+
         if filing_status_mfj? || filing_status_mfs? || @direct_file_data.fed_eic_qc_claimed
           (@direct_file_data.fed_eic * 0.50).round
         elsif filing_status_single? || filing_status_hoh? || filing_status_qw?
@@ -599,6 +601,8 @@ module Efile
 
       def calculate_line_42
         # Earned Income Credit (EIC)
+        return if filing_status_dependent?
+
         if filing_status_mfj? || filing_status_mfs? || @direct_file_data.fed_eic_qc_claimed
           [(@direct_file_data.fed_eic * 0.45).round - line_or_zero(:MD502_LINE_21), 0].max
         elsif filing_status_single? || filing_status_hoh? || filing_status_qw?
@@ -635,7 +639,7 @@ module Efile
       end
 
       def filing_status_dependent?
-        @filing_status == :dependent
+        @intake.direct_file_data.claimed_as_dependent?
       end
 
       def deduction_method_is_standard?

--- a/app/lib/efile/md/md502cr_calculator.rb
+++ b/app/lib/efile/md/md502cr_calculator.rb
@@ -52,7 +52,7 @@ module Efile
           if @intake.primary_senior?
             credit = 1750
           end
-        elsif (filing_status_single? || filing_status_mfs? || filing_status_dependent?) && agi <= 100_000
+        elsif (filing_status_single? || filing_status_mfs? || md_filing_status_dependent?) && agi <= 100_000
           if @intake.primary_senior?
             credit = 1000
           end

--- a/app/lib/efile/tax_calculator.rb
+++ b/app/lib/efile/tax_calculator.rb
@@ -78,8 +78,8 @@ module Efile
       @filing_status == :qualifying_widow
     end
 
-    def filing_status_dependent?
-      @filing_status == :dependent
+    def md_filing_status_dependent?
+      @direct_file_data.claimed_as_dependent?
     end
   end
 end

--- a/app/services/state_file/submission_id_lookup.yml
+++ b/app/services/state_file/submission_id_lookup.yml
@@ -26,6 +26,7 @@ id_yukon_child_dep_care: 1016422024338re6kw7t
 md_anchovies_mfj: 1016422024337d6xqdk3
 md_annabelle_single: 1016422024326lssbe1f
 md_ariel_mfj_1099_g: 10164220243417ryhym3
+md_avril_dep: 7812652025030wk22tky
 md_barramundi_qss: 781265202433963pwy8k
 md_dorothy_mfj_1099_r: 10164220250282j47man
 md_drum_mfs_over_1000: 1016422024337uhx6vkg

--- a/spec/fixtures/state_file/fed_return_jsons/md/avril_dep.json
+++ b/spec/fixtures/state_file/fed_return_jsons/md/avril_dep.json
@@ -1,0 +1,29 @@
+{
+  "familyAndHousehold": [],
+  "filers": [
+    {
+      "lastName": "Complicated",
+      "dateOfBirth": "1995-01-01",
+      "suffix": null,
+      "isPrimaryFiler": true,
+      "firstName": "Avril",
+      "middleInitial": "L",
+      "educatorExpenses": "0.00",
+      "tin": "400-00-1234",
+      "interestReportsTotal": "0.00",
+      "isDisabled": false,
+      "form1099GsTotal": "0.00",
+      "isStudent": false,
+      "hsaTotalDeductibleAmount": null,
+      "ssnNotValidForEmployment": null
+    }
+  ],
+  "form1099Gs": [],
+  "formW2s": [
+    {
+      "usedTin": "400-00-1234",
+      "unionDuesAmount": null
+    }
+  ],
+  "interestReports": []
+}

--- a/spec/fixtures/state_file/fed_return_xmls/md/avril_dep.xml
+++ b/spec/fixtures/state_file/fed_return_xmls/md/avril_dep.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Return xmlns="http://www.irs.gov/efile" xmlns:efile="http://www.irs.gov/efile" returnVersion="2024v5.0">
+    <ReturnHeader binaryAttachmentCnt="0">
+        <TaxYr>2024</TaxYr>
+        <TaxPeriodBeginDt>2024-01-01</TaxPeriodBeginDt>
+        <TaxPeriodEndDt>2024-12-31</TaxPeriodEndDt>
+        <SoftwareVersionNum>c21d6eb3</SoftwareVersionNum>
+        <ReturnTypeCd>1040</ReturnTypeCd>
+        <Filer>
+            <PrimarySSN>400001234</PrimarySSN>
+            <NameLine1Txt>AVRIL L&lt;COMPLICATED</NameLine1Txt>
+            <PrimaryNameControlTxt>COMP</PrimaryNameControlTxt>
+            <USAddress>
+                <AddressLine1Txt>123 Crab Way</AddressLine1Txt>
+                <CityNm>Rockville</CityNm>
+                <StateAbbreviationCd>MD</StateAbbreviationCd>
+                <ZIPCd>20850</ZIPCd>
+            </USAddress>
+            <PhoneNum>2223334444</PhoneNum>
+        </Filer>
+        <AdditionalFilerInformation>
+            <AtSubmissionFilingGrp>
+                <EmailAddressTxt>test-user+40000123-4838-41e2-81f9-96bf565d71f9@directfile.test</EmailAddressTxt>
+            </AtSubmissionFilingGrp>
+        </AdditionalFilerInformation>
+    </ReturnHeader>
+    <ReturnData documentCnt="2">
+        <IRS1040 documentId="IRS10400001">
+            <IndividualReturnFilingStatusCd>1</IndividualReturnFilingStatusCd>
+            <VirtualCurAcquiredDurTYInd>false</VirtualCurAcquiredDurTYInd>
+            <PrimaryClaimAsDependentInd>X</PrimaryClaimAsDependentInd>
+            <TotalExemptPrimaryAndSpouseCnt>1</TotalExemptPrimaryAndSpouseCnt>
+            <ChldWhoLivedWithYouCnt>0</ChldWhoLivedWithYouCnt>
+            <OtherDependentsListedCnt>0</OtherDependentsListedCnt>
+            <TotalExemptionsCnt>1</TotalExemptionsCnt>
+            <WagesAmt referenceDocumentId="W20001" referenceDocumentName="IRSW2">14850</WagesAmt>
+            <WagesSalariesAndTipsAmt>14850</WagesSalariesAndTipsAmt>
+            <TotalIncomeAmt>14850</TotalIncomeAmt>
+            <AdjustedGrossIncomeAmt>14850</AdjustedGrossIncomeAmt>
+            <TotalItemizedOrStandardDedAmt>14600</TotalItemizedOrStandardDedAmt>
+            <TotalDeductionsAmt>14600</TotalDeductionsAmt>
+            <TaxableIncomeAmt>250</TaxableIncomeAmt>
+            <TaxAmt>26</TaxAmt>
+            <TotalTaxBeforeCrAndOthTaxesAmt>26</TotalTaxBeforeCrAndOthTaxesAmt>
+            <TaxLessCreditsAmt>26</TaxLessCreditsAmt>
+            <TotalTaxAmt>26</TotalTaxAmt>
+            <FormW2WithheldTaxAmt>500</FormW2WithheldTaxAmt>
+            <WithholdingTaxAmt>500</WithholdingTaxAmt>
+            <TotalPaymentsAmt>500</TotalPaymentsAmt>
+            <OverpaidAmt>474</OverpaidAmt>
+            <RefundAmt>474</RefundAmt>
+            <OwedAmt>0</OwedAmt>
+            <ThirdPartyDesigneeInd>false</ThirdPartyDesigneeInd>
+            <PrimaryOccupationTxt>music</PrimaryOccupationTxt>
+            <RefundProductCd>NO FINANCIAL PRODUCT</RefundProductCd>
+        </IRS1040>
+        <IRSW2 documentId="W20001" documentName="IRSW2">
+            <EmployeeSSN>400001234</EmployeeSSN>
+            <EmployerEIN>001234568</EmployerEIN>
+            <EmployerNameControlTxt>YEAH</EmployerNameControlTxt>
+            <EmployerName>
+                <BusinessNameLine1Txt>Yeah No Factory</BusinessNameLine1Txt>
+            </EmployerName>
+            <EmployerUSAddress>
+                <AddressLine1Txt>300 Fake street</AddressLine1Txt>
+                <CityNm>bethesda</CityNm>
+                <StateAbbreviationCd>MD</StateAbbreviationCd>
+                <ZIPCd>20814</ZIPCd>
+            </EmployerUSAddress>
+            <EmployeeNm>Avril L Complicated</EmployeeNm>
+            <EmployeeUSAddress>
+                <AddressLine1Txt>123 Crab Way</AddressLine1Txt>
+                <CityNm>Rockville</CityNm>
+                <StateAbbreviationCd>MD</StateAbbreviationCd>
+                <ZIPCd>20850</ZIPCd>
+            </EmployeeUSAddress>
+            <WagesAmt>14850</WagesAmt>
+            <WithholdingAmt>500</WithholdingAmt>
+            <SocialSecurityWagesAmt>14850</SocialSecurityWagesAmt>
+            <SocialSecurityTaxAmt>200</SocialSecurityTaxAmt>
+            <MedicareWagesAndTipsAmt>14850</MedicareWagesAndTipsAmt>
+            <MedicareTaxWithheldAmt>200</MedicareTaxWithheldAmt>
+            <W2StateLocalTaxGrp>
+                <W2StateTaxGrp>
+                    <StateAbbreviationCd>MD</StateAbbreviationCd>
+                    <EmployerStateIdNum>12345</EmployerStateIdNum>
+                    <StateWagesAmt>14850</StateWagesAmt>
+                    <StateIncomeTaxAmt>100</StateIncomeTaxAmt>
+                    <W2LocalTaxGrp/>
+                </W2StateTaxGrp>
+            </W2StateLocalTaxGrp>
+            <StandardOrNonStandardCd>S</StandardOrNonStandardCd>
+        </IRSW2>
+    </ReturnData>
+</Return>

--- a/spec/lib/efile/md/md502_calculator_spec.rb
+++ b/spec/lib/efile/md/md502_calculator_spec.rb
@@ -1024,7 +1024,7 @@ describe Efile::Md::Md502Calculator do
   end
 
   describe "#calculate_line_23" do
-    let (:deduction_method_standard) { true}
+    let (:deduction_method_standard) { true }
     let (:claimed_as_dependent) { false }
 
     before do

--- a/spec/lib/efile/md/md502_calculator_spec.rb
+++ b/spec/lib/efile/md/md502_calculator_spec.rb
@@ -14,7 +14,7 @@ describe Efile::Md::Md502Calculator do
   describe "#calculate_line_a_primary" do
     context 'primary not claimed as a dependent' do
       before do
-        intake.direct_file_data.primary_claim_as_dependent = ""
+        allow_any_instance_of(DirectFileData).to receive(:claimed_as_dependent?).and_return false
       end
 
       it "checks the value" do
@@ -25,7 +25,7 @@ describe Efile::Md::Md502Calculator do
 
     context 'primary is claimed as a dependent' do
       before do
-        intake.direct_file_data.primary_claim_as_dependent = "X"
+        allow_any_instance_of(DirectFileData).to receive(:claimed_as_dependent?).and_return true
       end
 
       it "returns nil" do
@@ -70,7 +70,7 @@ describe Efile::Md::Md502Calculator do
     context "when line a yourself is checked but spouse isn't" do
       before do
         intake.direct_file_data.filing_status = 1 # single
-        intake.direct_file_data.primary_claim_as_dependent = ""
+        allow_any_instance_of(DirectFileData).to receive(:claimed_as_dependent?).and_return false
       end
 
       it "returns 1" do
@@ -82,7 +82,7 @@ describe Efile::Md::Md502Calculator do
     context "when line a yourself and spouse isn't checked" do
       before do
         intake.direct_file_data.filing_status = 1 # single
-        intake.direct_file_data.primary_claim_as_dependent = "X"
+        allow_any_instance_of(DirectFileData).to receive(:claimed_as_dependent?).and_return true
       end
 
       it "returns 1" do
@@ -95,7 +95,7 @@ describe Efile::Md::Md502Calculator do
   describe "#calculate_line_a_amount" do
     context "when primary or spouse is claimed as a dependent" do
       before do
-        intake.direct_file_data.primary_claim_as_dependent = "X"
+        allow_any_instance_of(DirectFileData).to receive(:claimed_as_dependent?).and_return true
       end
 
       it "returns 0" do
@@ -698,7 +698,7 @@ describe Efile::Md::Md502Calculator do
                 before do
                   allow_any_instance_of(described_class).to receive(:calculate_line_16).and_return agi_limit
                   if filing_status == "dependent"
-                    intake.direct_file_data.primary_claim_as_dependent = "X"
+                    allow_any_instance_of(DirectFileData).to receive(:claimed_as_dependent?).and_return true
                   end
                 end
 

--- a/spec/lib/efile/md/md502_calculator_spec.rb
+++ b/spec/lib/efile/md/md502_calculator_spec.rb
@@ -95,7 +95,7 @@ describe Efile::Md::Md502Calculator do
   describe "#calculate_line_a_amount" do
     context "when primary or spouse is claimed as a dependent" do
       before do
-        intake.direct_file_data.filing_status = 6 # dependent
+        intake.direct_file_data.primary_claim_as_dependent = "X"
       end
 
       it "returns 0" do
@@ -697,6 +697,9 @@ describe Efile::Md::Md502Calculator do
 
                 before do
                   allow_any_instance_of(described_class).to receive(:calculate_line_16).and_return agi_limit
+                  if filing_status == "dependent"
+                    intake.direct_file_data.primary_claim_as_dependent = "X"
+                  end
                 end
 
                 it "returns the value corresponding to #{agi_limit} MD AGI limit" do
@@ -966,8 +969,10 @@ describe Efile::Md::Md502Calculator do
     end
 
     context "when filing as a dependent and no qualifying children" do
-      let(:filing_status) { "dependent" }
       let(:df_xml_key) { "md_zeus_two_w2s" }
+      before do
+        intake.direct_file_data.primary_claim_as_dependent = "X"
+      end
       it 'EIC is nil' do
         expect(instance.lines[:MD502_LINE_22].value).to eq nil
       end
@@ -1039,9 +1044,14 @@ describe Efile::Md::Md502Calculator do
     end
 
     context "when filing as dependent" do
-      let(:filing_status) { "dependent" }
       let(:line_1b) { 20_000 }
       let(:line_7) { 15_000 }
+
+      before do
+        intake.direct_file_data.primary_claim_as_dependent = "X"
+      end
+
+      # TODO THIS TEST DOES NOT BREAK WHEN NOT FILING AS DEPENDENT
 
       it "returns 0" do
         expect(instance.lines[:MD502_LINE_23].value).to eq(0)
@@ -1603,8 +1613,12 @@ describe Efile::Md::Md502Calculator do
     end
 
     context "when filing as a dependent and no qualifying children" do
-      let(:filing_status) { "dependent" }
       let(:df_xml_key) { "md_zeus_two_w2s" }
+
+      before do
+        intake.direct_file_data.primary_claim_as_dependent = "X"
+      end
+
       it 'refundable EIC is nil' do
         expect(instance.lines[:MD502_LINE_42].value).to eq nil
       end

--- a/spec/lib/efile/md/md502cr_calculator_spec.rb
+++ b/spec/lib/efile/md/md502cr_calculator_spec.rb
@@ -227,7 +227,17 @@ describe Efile::Md::Md502crCalculator do
 
     %w[single married_filing_separately dependent].each do |filing_status|
       context "when filing status is #{filing_status}" do
-        let(:filing_status) { filing_status }
+        if filing_status == "dependent"
+          let(:filing_status) { "single" }
+          let(:claimed_as_dependent) { true}
+        else
+          let(:filing_status) { filing_status }
+          let(:claimed_as_dependent) { false }
+        end
+
+        before do
+          allow_any_instance_of(DirectFileData).to receive(:claimed_as_dependent?).and_return claimed_as_dependent
+        end
 
         context "when filer is 65 or older" do
           before do


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1720
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- The MD 502 calculator is supposed to make certain decisions based on whether the filer will use the filing status "dependent" on their Maryland return. However, this filing status only exists for Maryland, and will never be present on the federal return - we decide whether to use it in MD based on whether the filer's direct file data indicates that they are claimed as a dependent.
- This means that the previous implementation of `Md502Calculator#filing_status_dependent?` would never return true for a real user, since it checked the intake's filing status (which is their federal filing status) for a value it could never have.
- This PR changes that method to instead check the `direct_file_data.claimed_as_dependent?` method, which is the same way we decide to set their MD filing status to "dependent".
- Several tests started failing when we made this change, since they were incorrectly setting the federal filing status of test data to 6 (dependent) in their setup methods, which it can never be. These methods (MD502 line 22 and line 42) both relate to EIC and now both return if the filer is claimed as a dependent, which from talking with Courtney I believe is correct, but we should double check.
- I think that we need a subsequent change that will uniformize how we use filing status in the calculators. It sounds like we calculate a state filing status that could differ from the federal filing status in at least one other state. IMO we should have a `federal_filing_status` and `state_filing_status` method on intakes, the latter of which in MD would return `dependent` if the filer is claimed as a dependent (as we do in Md502.rb on lines 63-74), and switch our calculators over to use `#state_filing_status` everywhere (or almost everywhere, if there are calculations that explicitly use federal filing status)
  - Notably, there are still a number of tests for Md502Calculator that pass `:dependent` as a filing status to the StateFileMdIntake constructor, which I believe will never happen in real usage since that is not a valid federal filing status.
## How to test?
- We need to be careful with this one, since we failed to catch this bug in acceptance previously.
- We should reproduce the error on demo with a persona that is claimed as a dependent but has a valid federal filing status and is otherwise eligible for poverty level credit (and EIC, since i suspect we had the same kind of bug with that credit)
- We should then use the same persona and do the same checks on this PR's heroku instance and verify that we are not able to claim those credits
