### PR TITLE
Sc 412 stepper accessibility

### DIFF
--- a/app/views/shared/_progress_steps.html.erb
+++ b/app/views/shared/_progress_steps.html.erb
@@ -5,11 +5,11 @@
     step_number = progress[:step_number]
     title = progress[:title]
     %>
-    <div class="progress-steps" title="<%=title%> (<%=step_number%> / <%=number_of_steps%>)"><%
+    <div class="progress-steps"><%
       (0..number_of_steps-1).each do |step| %>
         <div class="progress-step<%=(step_number >= step) ? " completed-step" : "" %>"></div>
       <% end %>
     </div>
-    <p class="progress-text"><%= title %></p>
+    <p class="progress-text"><%= I18n.t("state_file.navigation.step_description", current_step: step_number + 1, total_steps: number_of_steps).concat(title) %></p>
   <% end
  end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2238,19 +2238,19 @@ en:
         supported_by: Supported by New York State
         title: Thank you for visiting FileYourStateTaxes
     navigation:
-      step_description: 'Step %{current_step} of %{total_steps}: '
       nj:
-        section_1: 'Income'
-        section_2: 'Your household'
-        section_3: 'Deductions and credits'
-        section_4: 'Your %{filing_year} taxes'
-        section_5: 'Review and submit'
-      section_1: 'Can you use this service'
-      section_2: 'Create account'
-      section_3: 'Terms and conditions'
-      section_4: 'Transfer your data'
-      section_5: 'Complete your state tax return'
-      section_6: 'Submit your state taxes'
+        section_1: Income
+        section_2: Your household
+        section_3: Deductions and credits
+        section_4: Your %{filing_year} taxes
+        section_5: Review and submit
+      section_1: Can you use this service
+      section_2: Create account
+      section_3: Terms and conditions
+      section_4: Transfer your data
+      section_5: Complete your state tax return
+      section_6: Submit your state taxes
+      step_description: 'Step %{current_step} of %{total_steps}: '
     notification_mailer:
       user_message:
         unsubscribe: If you would like to unsubscribe from emails, click <a href="%{unsubscribe_link}">here</a>.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2238,18 +2238,19 @@ en:
         supported_by: Supported by New York State
         title: Thank you for visiting FileYourStateTaxes
     navigation:
+      step_description: 'Step %{current_step} of %{total_steps}: '
       nj:
-        section_1: 'Section 1: Income'
-        section_2: 'Section 2: Your household'
-        section_3: 'Section 3: Deductions and credits'
-        section_4: 'Section 4: Your %{filing_year} taxes'
-        section_5: 'Section 5: Review and submit'
-      section_1: 'Section 1: Can you use this service'
-      section_2: 'Section 2: Create account'
-      section_3: 'Section 3: Terms and conditions'
-      section_4: 'Section 4: Transfer your data'
-      section_5: 'Section 5: Complete your state tax return'
-      section_6: 'Section 6: Submit your state taxes'
+        section_1: 'Income'
+        section_2: 'Your household'
+        section_3: 'Deductions and credits'
+        section_4: 'Your %{filing_year} taxes'
+        section_5: 'Review and submit'
+      section_1: 'Can you use this service'
+      section_2: 'Create account'
+      section_3: 'Terms and conditions'
+      section_4: 'Transfer your data'
+      section_5: 'Complete your state tax return'
+      section_6: 'Submit your state taxes'
     notification_mailer:
       user_message:
         unsubscribe: If you would like to unsubscribe from emails, click <a href="%{unsubscribe_link}">here</a>.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2250,7 +2250,7 @@ en:
       section_4: Transfer your data
       section_5: Complete your state tax return
       section_6: Submit your state taxes
-      step_description: 'Step %{current_step} of %{total_steps}: '
+      step_description: 'Section %{current_step} of %{total_steps}: '
     notification_mailer:
       user_message:
         unsubscribe: If you would like to unsubscribe from emails, click <a href="%{unsubscribe_link}">here</a>.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2186,19 +2186,19 @@ es:
         supported_by: Respaldada por el estado de Nueva York
         title: Gracias por visitar FileYourStateTaxes
     navigation:
-      step_description: 'Paso %{current_step} de %{total_steps}: '
       nj:
-        section_1: 'Ingresos'
-        section_2: 'Tu hogar'
-        section_3: 'Deducciones y créditos'
-        section_4: 'Tus impuestos de %{filing_year}'
-        section_5: 'Revisar y enviar'
-      section_1: '¿Puedes usar esta herramienta?'
-      section_2: 'Crear cuenta'
-      section_3: 'Términos y condiciones'
-      section_4: 'Transferir tus datos'
-      section_5: 'Completa tu declaración de impuestos estatales'
-      section_6: 'Envía tus impuestos estatales'
+        section_1: Ingresos
+        section_2: Tu hogar
+        section_3: Deducciones y créditos
+        section_4: Tus impuestos de %{filing_year}
+        section_5: Revisar y enviar
+      section_1: "¿Puedes usar esta herramienta?"
+      section_2: Crear cuenta
+      section_3: Términos y condiciones
+      section_4: Transferir tus datos
+      section_5: Completa tu declaración de impuestos estatales
+      section_6: Envía tus impuestos estatales
+      step_description: 'Paso %{current_step} de %{total_steps}: '
     notification_mailer:
       user_message:
         unsubscribe: Si deseas cancelar la suscripción a los correos electrónicos, haz clic <a href="%{unsubscribe_link}">aquí</a>.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2198,7 +2198,7 @@ es:
       section_4: Transferir tus datos
       section_5: Completa tu declaración de impuestos estatales
       section_6: Envía tus impuestos estatales
-      step_description: 'Paso %{current_step} de %{total_steps}: '
+      step_description: 'Sección %{current_step} de %{total_steps}: '
     notification_mailer:
       user_message:
         unsubscribe: Si deseas cancelar la suscripción a los correos electrónicos, haz clic <a href="%{unsubscribe_link}">aquí</a>.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2186,18 +2186,19 @@ es:
         supported_by: Respaldada por el estado de Nueva York
         title: Gracias por visitar FileYourStateTaxes
     navigation:
+      step_description: 'Paso %{current_step} de %{total_steps}: '
       nj:
-        section_1: 'Sección 1: Ingresos'
-        section_2: 'Sección 2: Tu hogar'
-        section_3: 'Sección 3: Deducciones y créditos'
-        section_4: 'Sección 4: Tus impuestos de %{filing_year}'
-        section_5: 'Sección 5: Revisar y enviar'
-      section_1: 'Sección 1: ¿Puedes usar esta herramienta?'
-      section_2: 'Sección 2: Crear cuenta'
-      section_3: 'Sección 3: Términos y condiciones'
-      section_4: 'Sección 4: Transferir tus datos'
-      section_5: 'Sección 5: Completa tu declaración de impuestos estatales'
-      section_6: 'Sección 6: Envía tus impuestos estatales'
+        section_1: 'Ingresos'
+        section_2: 'Tu hogar'
+        section_3: 'Deducciones y créditos'
+        section_4: 'Tus impuestos de %{filing_year}'
+        section_5: 'Revisar y enviar'
+      section_1: '¿Puedes usar esta herramienta?'
+      section_2: 'Crear cuenta'
+      section_3: 'Términos y condiciones'
+      section_4: 'Transferir tus datos'
+      section_5: 'Completa tu declaración de impuestos estatales'
+      section_6: 'Envía tus impuestos estatales'
     notification_mailer:
       user_message:
         unsubscribe: Si deseas cancelar la suscripción a los correos electrónicos, haz clic <a href="%{unsubscribe_link}">aquí</a>.

--- a/spec/features/state_file/nj/complete_intake_spec.rb
+++ b/spec/features/state_file/nj/complete_intake_spec.rb
@@ -47,7 +47,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
       if expect_income_review
         expect(page).to have_text I18n.t("state_file.questions.income_review.edit.title")
         expect(page).to have_css(".progress-steps")
-        expect(page).to have_text("Step 1 of 5: Income")
+        expect(page).to have_text("Section 1 of 5: Income")
         expect(page).to be_axe_clean if check_a11y
         continue
       end
@@ -55,7 +55,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
 
     def advance_health_insurance_eligibility
       expect(page).to have_text I18n.t("state_file.questions.nj_eligibility_health_insurance.edit.title")
-      expect(page).to have_text("Step 2 of 5: Your household")
+      expect(page).to have_text("Section 2 of 5: Your household")
       choose I18n.t("general.affirmative")
       continue
     end
@@ -103,7 +103,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
 
     def advance_medical_expenses(amount: 1000)
       fill_in I18n.t('state_file.questions.nj_medical_expenses.edit.label', filing_year: filing_year), with: amount
-      expect(page).to have_text("Step 3 of 5: Deductions and credits")
+      expect(page).to have_text("Section 3 of 5: Deductions and credits")
       continue
     end
 
@@ -169,7 +169,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
 
     def expect_page_after_property_tax
       expect(page).to have_text I18n.t("state_file.questions.nj_sales_use_tax.edit.title", filing_year: filing_year)
-      expect(page).to have_text("Step 4 of 5: Your 2024 taxes")
+      expect(page).to have_text("Section 4 of 5: Your 2024 taxes")
     end
 
     def expect_ineligible_page(property, reason)
@@ -296,7 +296,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
 
       expect(page).to be_axe_clean
       expect(page).to have_css(".progress-steps")
-      expect(page).to have_text("Step 5 of 5: Review and submit")
+      expect(page).to have_text("Section 5 of 5: Review and submit")
       check I18n.t('state_file.questions.esign_declaration.edit.primary_esign')
       check I18n.t('state_file.questions.esign_declaration.edit.spouse_esign')
       click_on I18n.t('state_file.questions.esign_declaration.edit.submit')

--- a/spec/features/state_file/nj/complete_intake_spec.rb
+++ b/spec/features/state_file/nj/complete_intake_spec.rb
@@ -47,6 +47,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
       if expect_income_review
         expect(page).to have_text I18n.t("state_file.questions.income_review.edit.title")
         expect(page).to have_css(".progress-steps")
+        expect(page).to have_text("Step 1 of 5: Income")
         expect(page).to be_axe_clean if check_a11y
         continue
       end
@@ -54,6 +55,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
 
     def advance_health_insurance_eligibility
       expect(page).to have_text I18n.t("state_file.questions.nj_eligibility_health_insurance.edit.title")
+      expect(page).to have_text("Step 2 of 5: Your household")
       choose I18n.t("general.affirmative")
       continue
     end
@@ -101,6 +103,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
 
     def advance_medical_expenses(amount: 1000)
       fill_in I18n.t('state_file.questions.nj_medical_expenses.edit.label', filing_year: filing_year), with: amount
+      expect(page).to have_text("Step 3 of 5: Deductions and credits")
       continue
     end
 
@@ -166,6 +169,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
 
     def expect_page_after_property_tax
       expect(page).to have_text I18n.t("state_file.questions.nj_sales_use_tax.edit.title", filing_year: filing_year)
+      expect(page).to have_text("Step 4 of 5: Your 2024 taxes")
     end
 
     def expect_ineligible_page(property, reason)
@@ -292,6 +296,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
 
       expect(page).to be_axe_clean
       expect(page).to have_css(".progress-steps")
+      expect(page).to have_text("Step 5 of 5: Review and submit")
       check I18n.t('state_file.questions.esign_declaration.edit.primary_esign')
       check I18n.t('state_file.questions.esign_declaration.edit.spouse_esign')
       click_on I18n.t('state_file.questions.esign_declaration.edit.submit')

--- a/spec/lib/navigation/state_file_az_question_navigation_spec.rb
+++ b/spec/lib/navigation/state_file_az_question_navigation_spec.rb
@@ -4,40 +4,40 @@ RSpec.describe Navigation::StateFileAzQuestionNavigation do
   describe "Flow" do
     it "Flow has not changed" do
       expect(Navigation::StateFileAzQuestionNavigation::FLOW).to eq([
-        StateFile::Questions::EligibleController,
-        StateFile::Questions::ContactPreferenceController,
-        StateFile::Questions::PhoneNumberController,
-        StateFile::Questions::EmailAddressController,
-        StateFile::Questions::VerificationCodeController,
-        StateFile::Questions::CodeVerifiedController,
-        StateFile::Questions::NotificationPreferencesController,
-        StateFile::Questions::SmsTermsController,
-        StateFile::Questions::TermsAndConditionsController,
-        StateFile::Questions::DeclinedTermsAndConditionsController,
-        StateFile::Questions::InitiateDataTransferController,
-        StateFile::Questions::CanceledDataTransferController, # show? false
-        StateFile::Questions::WaitingToLoadDataController,
-        StateFile::Questions::PostDataTransferController,
-        StateFile::Questions::FederalInfoController,
-        StateFile::Questions::DataTransferOffboardingController,
-        StateFile::Questions::AzSeniorDependentsController,
-        StateFile::Questions::AzPriorLastNamesController,
-        StateFile::Questions::IncomeReviewController,
-        StateFile::Questions::UnemploymentController,
-        StateFile::Questions::AzPublicSchoolContributionsController,
-        StateFile::Questions::AzCharitableContributionsController,
-        StateFile::Questions::AzQualifyingOrganizationContributionsController,
-        StateFile::Questions::AzSubtractionsController,
-        StateFile::Questions::AzExciseCreditController,
-        StateFile::Questions::PrimaryStateIdController,
-        StateFile::Questions::SpouseStateIdController,
-        StateFile::Questions::AzReviewController,
-        StateFile::Questions::TaxesOwedController,
-        StateFile::Questions::TaxRefundController,
-        StateFile::Questions::EsignDeclarationController, # creates EfileSubmission and transitions to preparing
-        StateFile::Questions::SubmissionConfirmationController,
-        StateFile::Questions::ReturnStatusController,
-      ])
+                                                                      StateFile::Questions::EligibleController,
+                                                                      StateFile::Questions::ContactPreferenceController,
+                                                                      StateFile::Questions::PhoneNumberController,
+                                                                      StateFile::Questions::EmailAddressController,
+                                                                      StateFile::Questions::VerificationCodeController,
+                                                                      StateFile::Questions::CodeVerifiedController,
+                                                                      StateFile::Questions::NotificationPreferencesController,
+                                                                      StateFile::Questions::SmsTermsController,
+                                                                      StateFile::Questions::TermsAndConditionsController,
+                                                                      StateFile::Questions::DeclinedTermsAndConditionsController,
+                                                                      StateFile::Questions::InitiateDataTransferController,
+                                                                      StateFile::Questions::CanceledDataTransferController, # show? false
+                                                                      StateFile::Questions::WaitingToLoadDataController,
+                                                                      StateFile::Questions::PostDataTransferController,
+                                                                      StateFile::Questions::FederalInfoController,
+                                                                      StateFile::Questions::DataTransferOffboardingController,
+                                                                      StateFile::Questions::AzSeniorDependentsController,
+                                                                      StateFile::Questions::AzPriorLastNamesController,
+                                                                      StateFile::Questions::IncomeReviewController,
+                                                                      StateFile::Questions::UnemploymentController,
+                                                                      StateFile::Questions::AzPublicSchoolContributionsController,
+                                                                      StateFile::Questions::AzCharitableContributionsController,
+                                                                      StateFile::Questions::AzQualifyingOrganizationContributionsController,
+                                                                      StateFile::Questions::AzSubtractionsController,
+                                                                      StateFile::Questions::AzExciseCreditController,
+                                                                      StateFile::Questions::PrimaryStateIdController,
+                                                                      StateFile::Questions::SpouseStateIdController,
+                                                                      StateFile::Questions::AzReviewController,
+                                                                      StateFile::Questions::TaxesOwedController,
+                                                                      StateFile::Questions::TaxRefundController,
+                                                                      StateFile::Questions::EsignDeclarationController, # creates EfileSubmission and transitions to preparing
+                                                                      StateFile::Questions::SubmissionConfirmationController,
+                                                                      StateFile::Questions::ReturnStatusController,
+                                                                    ])
     end
   end
 
@@ -58,7 +58,7 @@ RSpec.describe Navigation::StateFileAzQuestionNavigation do
     it "returns the correct progress" do
       progress = Navigation::StateFileAzQuestionNavigation.get_progress(StateFile::Questions::FederalInfoController)
       expect(progress).to eq({
-                               title: "Section 5: Complete your state tax return",
+                               title: "Complete your state tax return",
                                step_number: 4,
                                number_of_steps: 6
                              })

--- a/spec/lib/navigation/state_file_az_question_navigation_spec.rb
+++ b/spec/lib/navigation/state_file_az_question_navigation_spec.rb
@@ -3,41 +3,42 @@ require "rails_helper"
 RSpec.describe Navigation::StateFileAzQuestionNavigation do
   describe "Flow" do
     it "Flow has not changed" do
-      expect(Navigation::StateFileAzQuestionNavigation::FLOW).to eq([
-                                                                      StateFile::Questions::EligibleController,
-                                                                      StateFile::Questions::ContactPreferenceController,
-                                                                      StateFile::Questions::PhoneNumberController,
-                                                                      StateFile::Questions::EmailAddressController,
-                                                                      StateFile::Questions::VerificationCodeController,
-                                                                      StateFile::Questions::CodeVerifiedController,
-                                                                      StateFile::Questions::NotificationPreferencesController,
-                                                                      StateFile::Questions::SmsTermsController,
-                                                                      StateFile::Questions::TermsAndConditionsController,
-                                                                      StateFile::Questions::DeclinedTermsAndConditionsController,
-                                                                      StateFile::Questions::InitiateDataTransferController,
-                                                                      StateFile::Questions::CanceledDataTransferController, # show? false
-                                                                      StateFile::Questions::WaitingToLoadDataController,
-                                                                      StateFile::Questions::PostDataTransferController,
-                                                                      StateFile::Questions::FederalInfoController,
-                                                                      StateFile::Questions::DataTransferOffboardingController,
-                                                                      StateFile::Questions::AzSeniorDependentsController,
-                                                                      StateFile::Questions::AzPriorLastNamesController,
-                                                                      StateFile::Questions::IncomeReviewController,
-                                                                      StateFile::Questions::UnemploymentController,
-                                                                      StateFile::Questions::AzPublicSchoolContributionsController,
-                                                                      StateFile::Questions::AzCharitableContributionsController,
-                                                                      StateFile::Questions::AzQualifyingOrganizationContributionsController,
-                                                                      StateFile::Questions::AzSubtractionsController,
-                                                                      StateFile::Questions::AzExciseCreditController,
-                                                                      StateFile::Questions::PrimaryStateIdController,
-                                                                      StateFile::Questions::SpouseStateIdController,
-                                                                      StateFile::Questions::AzReviewController,
-                                                                      StateFile::Questions::TaxesOwedController,
-                                                                      StateFile::Questions::TaxRefundController,
-                                                                      StateFile::Questions::EsignDeclarationController, # creates EfileSubmission and transitions to preparing
-                                                                      StateFile::Questions::SubmissionConfirmationController,
-                                                                      StateFile::Questions::ReturnStatusController,
-                                                                    ])
+      expected_flow = [
+        StateFile::Questions::EligibleController,
+        StateFile::Questions::ContactPreferenceController,
+        StateFile::Questions::PhoneNumberController,
+        StateFile::Questions::EmailAddressController,
+        StateFile::Questions::VerificationCodeController,
+        StateFile::Questions::CodeVerifiedController,
+        StateFile::Questions::NotificationPreferencesController,
+        StateFile::Questions::SmsTermsController,
+        StateFile::Questions::TermsAndConditionsController,
+        StateFile::Questions::DeclinedTermsAndConditionsController,
+        StateFile::Questions::InitiateDataTransferController,
+        StateFile::Questions::CanceledDataTransferController, # show? false
+        StateFile::Questions::WaitingToLoadDataController,
+        StateFile::Questions::PostDataTransferController,
+        StateFile::Questions::FederalInfoController,
+        StateFile::Questions::DataTransferOffboardingController,
+        StateFile::Questions::AzSeniorDependentsController,
+        StateFile::Questions::AzPriorLastNamesController,
+        StateFile::Questions::IncomeReviewController,
+        StateFile::Questions::UnemploymentController,
+        StateFile::Questions::AzPublicSchoolContributionsController,
+        StateFile::Questions::AzCharitableContributionsController,
+        StateFile::Questions::AzQualifyingOrganizationContributionsController,
+        StateFile::Questions::AzSubtractionsController,
+        StateFile::Questions::AzExciseCreditController,
+        StateFile::Questions::PrimaryStateIdController,
+        StateFile::Questions::SpouseStateIdController,
+        StateFile::Questions::AzReviewController,
+        StateFile::Questions::TaxesOwedController,
+        StateFile::Questions::TaxRefundController,
+        StateFile::Questions::EsignDeclarationController, # creates EfileSubmission and transitions to preparing
+        StateFile::Questions::SubmissionConfirmationController,
+        StateFile::Questions::ReturnStatusController,
+      ]
+      expect(Navigation::StateFileAzQuestionNavigation::FLOW).to eq(expected_flow)
     end
   end
 

--- a/spec/lib/navigation/state_file_nj_question_navigation_spec.rb
+++ b/spec/lib/navigation/state_file_nj_question_navigation_spec.rb
@@ -15,5 +15,16 @@ RSpec.describe Navigation::StateFileNjQuestionNavigation do
         expect(described_class.show_progress?(controller_class)).to eq(true)
       end
     end
+
+    context "get_progress" do
+      it "returns the correct progress" do
+        progress = Navigation::StateFileNjQuestionNavigation.get_progress(StateFile::Questions::NjEligibilityHealthInsuranceController)
+        expect(progress).to eq({
+                                 title: "Your household",
+                                 step_number: 1,
+                                 number_of_steps: 5
+                               })
+      end
+    end
   end
 end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://github.com/newjersey/accessibility-pm/issues/13#issue-2768910995

This issue is public! Highly recommend that both CFA and NJ reviewers check out the ticket.

## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Removed title attribute, which has inconsistent accessibility support (does not work for NVDA on Windows)
- Added text description of progress to <p> tag so screen readers can convey the same information to users
- Added Spanish translation for "Step X of Y", approved by OOI Spanish Content team ✅ 

## How to test?
- Validated that stepper component attribute does not have title element
- Validated that step description now includes total step count
- Use any persona, navigate to after DF import to display stepper component
- Step through tax flow and verify that stepper component behaves correctly

- Download NVDA on Windows state laptop, check heroku deploy and validate that screen reader issue no longer exists.

## Screenshots (for visual changes)
- Before (turn sound on)

https://github.com/user-attachments/assets/f266f991-51bf-469c-99bc-58e3739d88f4

https://github.com/user-attachments/assets/4c5bcb97-b2e3-4ce5-b5ff-c71d7c1cf11a

- After
Video to come

<img width="991" alt="image" src="https://github.com/user-attachments/assets/5446c019-3e48-4346-ac58-b93ee212d8d8" />

<img width="1358" alt="image" src="https://github.com/user-attachments/assets/1497e053-5698-4086-8ad5-835353d4ba86" />

