### PR TITLE
Bug: do not block NC clients on income review due to invalid W-2s (they cannot edit them)

### DIFF
--- a/app/controllers/state_file/questions/income_review_controller.rb
+++ b/app/controllers/state_file/questions/income_review_controller.rb
@@ -21,7 +21,7 @@ module StateFile
       end
 
       def update
-        if @w2s.any? do |w2|
+        if current_intake.allows_w2_editing? && @w2s.any? do |w2|
             w2.check_box14_limits = true
             !w2.valid?(:state_file_edit)
           end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1732
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Check whether the intake type allows w2 editing before blocking clients from continuing past income review page due to invalid w2s
## How to test?
- Added a controller test for the NC case (the only state that doesn't allow w2 editing)
- Added another bit to the existing test because it feels more thorough to check that it's actually continuing on, not just that there's no flash message
  - the mocking-next-path thing felt a bit unorthodox but shockingly I could not remember whether we have a common method for testing redirect to next path in the intake flow? `shared_examples :return_to_review_concern` has a really complicated way of doing this that seemed like overkill for this situation
