### PR TITLE
FYST-1395 Validate year for state id page

### DIFF
--- a/app/forms/state_file/state_id_concern.rb
+++ b/app/forms/state_file/state_id_concern.rb
@@ -24,12 +24,12 @@ module StateFile
 
       validates :issue_date,
                 inclusion: {
-                  in: Date.new(2000)..DateTime.now, message: I18n.t('errors.attributes.birth_date.blank')
+                  in: Date.new(2000)..DateTime.now, message: ->(_object, _data) {I18n.t('errors.attributes.birth_date.blank')}
                 },
                 presence: true, unless: -> { id_type == "no_id" }
       validates :expiration_date,
                 inclusion: {
-                  in: Date.new(Time.now.year - 3)..Date.new(Time.now.year + 50), message: I18n.t('errors.attributes.birth_date.blank')
+                  in: Date.new(Time.now.year - 3)..Date.new(Time.now.year + 50), message: ->(_object, _data) { I18n.t('errors.attributes.birth_date.blank') }
                 },
                 presence: true, unless: -> { id_type == "no_id" || non_expiring == "1" }
       validates :state, presence: true, inclusion: { in: States.keys }, unless: -> { id_type == "no_id" }

--- a/app/forms/state_file/state_id_concern.rb
+++ b/app/forms/state_file/state_id_concern.rb
@@ -22,8 +22,16 @@ module StateFile
       # Position is important. Must be below `set_attributes_for` to overwrite the standard `attr_accessor`s
       date_accessor :expiration_date, :issue_date
 
-      validates :issue_date, presence: true, unless: -> { id_type == "no_id" }
-      validates :expiration_date, presence: true, unless: -> { id_type == "no_id" || non_expiring == "1" }
+      validates :issue_date,
+                inclusion: {
+                  in: Date.new(2000)..DateTime.now, message: I18n.t('errors.attributes.birth_date.blank')
+                },
+                presence: true, unless: -> { id_type == "no_id" }
+      validates :expiration_date,
+                inclusion: {
+                  in: Date.new(Time.now.year - 3)..Date.new(Time.now.year + 50), message: I18n.t('errors.attributes.birth_date.blank')
+                },
+                presence: true, unless: -> { id_type == "no_id" || non_expiring == "1" }
       validates :state, presence: true, inclusion: { in: States.keys }, unless: -> { id_type == "no_id" }
       validates :id_type, presence: true
       validates :id_number,

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -67,7 +67,6 @@ module DateHelper
   end
 
   def parse_date_params(year, month, day)
-    binding.pry
     date_values = [year, month, day]
     return nil if date_values.any?(&:blank?)
 

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -67,6 +67,7 @@ module DateHelper
   end
 
   def parse_date_params(year, month, day)
+    binding.pry
     date_values = [year, month, day]
     return nil if date_values.any?(&:blank?)
 

--- a/app/models/concerns/date_accessible.rb
+++ b/app/models/concerns/date_accessible.rb
@@ -73,17 +73,6 @@ module DateAccessible
       end
     end
 
-    # date part. Values can be strings as long as #to_i renders an appropriate
-    # integer. Note that Date#change only accepts :year, :month, and :day as
-    # keys, all other keys will be treated as nothing was passed at all.
-    #
-    # Note that until all three fragments are passed; month, day, and year, the
-    # year is nonsense. This is expected to be caught by validation.
-    #
-    # @see Date#change
-    #
-    # @param date_property [Symbol] The property to manipulate
-    # @param args [Hash<Symbol, String | Integer>] Arguments conforming to Date#change
     def try_set_date(property)
       year = instance_variable_get("@#{property}_year_val")
       month = instance_variable_get("@#{property}_month_val")

--- a/app/models/concerns/date_accessible.rb
+++ b/app/models/concerns/date_accessible.rb
@@ -72,8 +72,8 @@ module DateAccessible
     # integer. Note that Date#change only accepts :year, :month, and :day as
     # keys, all other keys will be treated as nothing was passed at all.
     #
-    # Note that until all three fragments are passed; month, day, and year, the
-    # year is nonsense. This is expected to be caught by validation.
+    # Note that until all three fragments are passed; month, day, and year
+    # For year, a range must be indicated or else it is not validated.
     #
     # @see Date#change
     #

--- a/app/models/concerns/date_accessible.rb
+++ b/app/models/concerns/date_accessible.rb
@@ -16,10 +16,6 @@ module DateAccessible
     def self.date_accessor(*properties)
       self.date_reader(*properties)
       self.date_writer(*properties)
-
-      properties.each do |property|
-        attr_accessor "#{property}_month_val", "#{property}_day_val", "#{property}_year_val"
-      end
     end
 
     # Creates *_day, *_month, and *_year setters for the specified date
@@ -33,15 +29,15 @@ module DateAccessible
 
       properties.each do |property|
         self.define_method("#{property}_month") do
-          instance_variable_get("@#{property}_month_val") || send(property)&.month
+          send(property)&.month
         end
 
         self.define_method("#{property}_year") do
-          instance_variable_get("@#{property}_year_val") || send(property)&.year
+          send(property)&.year
         end
 
         self.define_method("#{property}_day") do
-          instance_variable_get("@#{property}_day_val") || send(property)&.day
+          send(property)&.day
         end
       end
     end
@@ -57,36 +53,41 @@ module DateAccessible
 
       properties.each do |property|
         self.define_method("#{property}_month=") do |month|
-          instance_variable_set("@#{property}_month_val", month.presence&.to_i)
-          try_set_date(property)
+          change_date_property(property, month: month) unless month.blank?
         end
 
         self.define_method("#{property}_year=") do |year|
-          instance_variable_set("@#{property}_year_val", year.presence&.to_i)
-          try_set_date(property)
+          change_date_property(property, year: year) unless year.blank?
         end
 
         self.define_method("#{property}_day=") do |day|
-          instance_variable_set("@#{property}_day_val", day.presence&.to_i)
-          try_set_date(property)
+          change_date_property(property, day: day) unless day.blank?
         end
       end
     end
 
-    def try_set_date(property)
-      year = instance_variable_get("@#{property}_year_val")
-      month = instance_variable_get("@#{property}_month_val")
-      day = instance_variable_get("@#{property}_day_val")
+    # Takes in valid arguments to Date#change. Will create a new date if
+    # `date_of_contribution` is nil, otherwise will merely modify the correct
+    # date part. Values can be strings as long as #to_i renders an appropriate
+    # integer. Note that Date#change only accepts :year, :month, and :day as
+    # keys, all other keys will be treated as nothing was passed at all.
+    #
+    # Note that until all three fragments are passed; month, day, and year, the
+    # year is nonsense. This is expected to be caught by validation.
+    #
+    # @see Date#change
+    #
+    # @param date_property [Symbol] The property to manipulate
+    # @param args [Hash<Symbol, String | Integer>] Arguments conforming to Date#change
+    def change_date_property(date_property, args)
+      existing_date = send(date_property) || Date.new
 
-      if year.present? && month.present? && day.present?
-        begin
-          self.send("#{property}=", Date.new(year, month, day))
-        rescue Date::Error
-          self.send("#{property}=", nil)
-        end
-      else
-        self.send("#{property}=", nil)
-      end
+      self.send(
+          "#{date_property}=",
+          existing_date.change(**args.transform_values(&:to_i))
+      )
+    rescue Date::Error
+      nil
     end
   end
 end

--- a/app/models/concerns/date_accessible.rb
+++ b/app/models/concerns/date_accessible.rb
@@ -73,7 +73,7 @@ module DateAccessible
     # keys, all other keys will be treated as nothing was passed at all.
     #
     # Note that until all three fragments are passed; month, day, and year
-    # For year, a range must be indicated or else it is not validated.
+    # For year, a range must be indicated on the validator on the property itself
     #
     # @see Date#change
     #

--- a/app/models/concerns/date_accessible.rb
+++ b/app/models/concerns/date_accessible.rb
@@ -16,6 +16,10 @@ module DateAccessible
     def self.date_accessor(*properties)
       self.date_reader(*properties)
       self.date_writer(*properties)
+
+      properties.each do |property|
+        attr_accessor "#{property}_month_val", "#{property}_day_val", "#{property}_year_val"
+      end
     end
 
     # Creates *_day, *_month, and *_year setters for the specified date
@@ -29,15 +33,15 @@ module DateAccessible
 
       properties.each do |property|
         self.define_method("#{property}_month") do
-          send(property)&.month
+          instance_variable_get("@#{property}_month_val") || send(property)&.month
         end
 
         self.define_method("#{property}_year") do
-          send(property)&.year
+          instance_variable_get("@#{property}_year_val") || send(property)&.year
         end
 
         self.define_method("#{property}_day") do
-          send(property)&.day
+          instance_variable_get("@#{property}_day_val") || send(property)&.day
         end
       end
     end
@@ -53,21 +57,22 @@ module DateAccessible
 
       properties.each do |property|
         self.define_method("#{property}_month=") do |month|
-          change_date_property(property, month: month) unless month.blank?
+          instance_variable_set("@#{property}_month_val", month.presence&.to_i)
+          try_set_date(property)
         end
 
         self.define_method("#{property}_year=") do |year|
-          change_date_property(property, year: year) unless year.blank?
+          instance_variable_set("@#{property}_year_val", year.presence&.to_i)
+          try_set_date(property)
         end
 
         self.define_method("#{property}_day=") do |day|
-          change_date_property(property, day: day) unless day.blank?
+          instance_variable_set("@#{property}_day_val", day.presence&.to_i)
+          try_set_date(property)
         end
       end
     end
 
-    # Takes in valid arguments to Date#change. Will create a new date if
-    # `date_of_contribution` is nil, otherwise will merely modify the correct
     # date part. Values can be strings as long as #to_i renders an appropriate
     # integer. Note that Date#change only accepts :year, :month, and :day as
     # keys, all other keys will be treated as nothing was passed at all.
@@ -79,15 +84,20 @@ module DateAccessible
     #
     # @param date_property [Symbol] The property to manipulate
     # @param args [Hash<Symbol, String | Integer>] Arguments conforming to Date#change
-    def change_date_property(date_property, args)
-      existing_date = send(date_property) || Date.new
+    def try_set_date(property)
+      year = instance_variable_get("@#{property}_year_val")
+      month = instance_variable_get("@#{property}_month_val")
+      day = instance_variable_get("@#{property}_day_val")
 
-      self.send(
-          "#{date_property}=",
-          existing_date.change(**args.transform_values(&:to_i))
-      )
-    rescue Date::Error
-      nil
+      if year.present? && month.present? && day.present?
+        begin
+          self.send("#{property}=", Date.new(year, month, day))
+        rescue Date::Error
+          self.send("#{property}=", nil)
+        end
+      else
+        self.send("#{property}=", nil)
+      end
     end
   end
 end

--- a/spec/forms/state_file/primary_state_id_form_spec.rb
+++ b/spec/forms/state_file/primary_state_id_form_spec.rb
@@ -35,6 +35,29 @@ RSpec.describe StateFile::PrimaryStateIdForm do
   end
 
   describe "#valid?" do
+    context "when params are invalid" do
+      let(:invalid_params) do
+        {
+          "id_type" => "driver_license",
+          "id_number" => "123456789",
+          "issue_date_month" => "3",
+          "issue_date_day" => "6",
+          "issue_date_year" => "",
+          "expiration_date_month" => "4",
+          "expiration_date_day" => "5",
+          "expiration_date_year" => "",
+          "state" => "AZ",
+        }
+      end
+
+      it "returns false" do
+        form = described_class.new(intake, invalid_params)
+        expect(form).not_to be_valid
+        expect(form.errors[:issue_date]).to be_present
+        expect(form.errors[:expiration_date]).to be_present
+      end
+    end
+
     context "when no state id" do
       let(:params) do
         {

--- a/spec/forms/state_file/spouse_state_id_form_spec.rb
+++ b/spec/forms/state_file/spouse_state_id_form_spec.rb
@@ -35,6 +35,29 @@ RSpec.describe StateFile::SpouseStateIdForm do
   end
 
   describe "#valid?" do
+    context "when params are invalid" do
+      let(:invalid_params) do
+        {
+          "id_type" => "driver_license",
+          "id_number" => "123456789",
+          "issue_date_month" => "3",
+          "issue_date_day" => "6",
+          "issue_date_year" => "",
+          "expiration_date_month" => "4",
+          "expiration_date_day" => "5",
+          "expiration_date_year" => "",
+          "state" => "AZ",
+        }
+      end
+
+      it "returns false" do
+        form = described_class.new(intake, invalid_params)
+        expect(form).not_to be_valid
+        expect(form.errors[:issue_date]).to be_present
+        expect(form.errors[:expiration_date]).to be_present
+      end
+    end
+
     context "when no state id" do
       let(:params) do
         {


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/FYST-1395

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Right now the state id page does not validate year for issue dat and expiration date. To use the date accessor class for validations a range needs to be used for year. 
- The validations for the stat id concern were updated to include a range for the year and have a proper error message saying "Please enter a valid date"

## How to test?
- Added a test for state id classes from primary id and spouse id

## Screenshots (for visual changes)
Before
<img width="627" alt="Screenshot 2025-01-30 at 2 31 35 PM" src="https://github.com/user-attachments/assets/baf546e4-f7fb-423a-859b-0554601df088" />
After
<img width="589" alt="Screenshot 2025-01-30 at 2 29 33 PM" src="https://github.com/user-attachments/assets/08e5f991-5d14-4b0d-9e63-246767ddefc6" />

