### PR TITLE
Updated GYR completion survey link

### DIFF
--- a/app/models/survey_messages/gyr_completion_survey.rb
+++ b/app/models/survey_messages/gyr_completion_survey.rb
@@ -32,7 +32,7 @@ module SurveyMessages
     end
 
     def self.survey_link(client)
-      "https://codeforamerica.co1.qualtrics.com/jfe/form/SV_0Gu4MGVVAM8p1NY?ExternalDataReference=#{client.id}"
+      "https://codeforamerica.co1.qualtrics.com/jfe/form/SV_cBCciMO9tvDpDX8?ExternalDataReference=#{client.id}"
     end
 
     def sms_body(**args)

--- a/spec/jobs/send_client_completion_survey_job_spec.rb
+++ b/spec/jobs/send_client_completion_survey_job_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe SendClientCompletionSurveyJob, type: :job do
 
             expect(ClientMessagingService).to have_received(:send_system_email).with(
               client: client,
-              body: a_string_including("qualtrics.com/jfe/form/SV_0Gu4MGVVAM8p1NY"),
+              body: a_string_including("qualtrics.com/jfe/form/SV_cBCciMO9tvDpDX8"),
               subject: I18n.t("messages.surveys.completion.email.subject", locale: "es"),
               locale: "es"
             )
@@ -42,7 +42,7 @@ RSpec.describe SendClientCompletionSurveyJob, type: :job do
 
             expect(ClientMessagingService).to have_received(:send_system_text_message).with(
               client: client,
-              body: a_string_including("qualtrics.com/jfe/form/SV_0Gu4MGVVAM8p1NY"),
+              body: a_string_including("qualtrics.com/jfe/form/SV_cBCciMO9tvDpDX8"),
               locale: "es"
             )
             expect(ClientMessagingService).not_to have_received(:send_system_email)
@@ -62,13 +62,13 @@ RSpec.describe SendClientCompletionSurveyJob, type: :job do
 
             expect(ClientMessagingService).to have_received(:send_system_email).with(
               client: client,
-              body: a_string_including("qualtrics.com/jfe/form/SV_0Gu4MGVVAM8p1NY"),
+              body: a_string_including("qualtrics.com/jfe/form/SV_cBCciMO9tvDpDX8"),
               subject: I18n.t("messages.surveys.completion.email.subject", locale: "es"),
               locale: "es"
             )
             expect(ClientMessagingService).to have_received(:send_system_text_message).with(
               client: client,
-              body: a_string_including("qualtrics.com/jfe/form/SV_0Gu4MGVVAM8p1NY"),
+              body: a_string_including("qualtrics.com/jfe/form/SV_cBCciMO9tvDpDX8"),
               locale: "es"
             )
             expect(client.reload.completion_survey_sent_at).to be_present


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/GYR1-634
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Just updates the survey link. Notably, it includes a client ID which was not listed in the ticket. I copied that over.

## How to test?
- Client/User in the following state
  -   Users that haven&rsquo;t yet had a sent survey
  -   Users with no active tax returns
  -   Users that have a tax return in `online_intake`
  -   Users that are in a transition of:
      -   State `file_accepted` or `file_mailed`
      -   In `most_recent = true`
      -   Created no more than 30 days ago and no less than one day ago.
  ```ruby
      def self.clients_to_survey(now)
        Client.includes(:intake, tax_returns: :tax_return_transitions)
          .where(SENT_AT_COLUMN => nil)
          .where(intake: { type: "Intake::GyrIntake" })
          .where.not(id: Client.has_active_tax_returns)
          .where(
            tax_returns: {
              service_type: "online_intake",
              tax_return_transitions: TaxReturnTransition
                .where(to_state: RELEVANT_STATES)
                .where(most_recent: true)
                .where(created_at: (now - 30.days)...(now - 1.day))
            }
          )
      end
  ```
- When satisfied, demo should shoot the emails out at the nearest 5 minute increment
```crontab
*/5 * * * * bundle exec rake client_status_updates:send_completion_surveys
```
## Screenshots (for visual changes)
- Before
- After
<img width="950" alt="image" src="https://github.com/user-attachments/assets/144fa46f-c6ec-498c-adc9-3ccf629e60bc" />
