### PR TITLE
FYST-1741 Completely undo deduction method based suppression on MD 502CR XML / PDF

### DIFF
--- a/app/lib/submission_builder/ty2024/states/md/documents/md502_cr.rb
+++ b/app/lib/submission_builder/ty2024/states/md/documents/md502_cr.rb
@@ -10,23 +10,19 @@ module SubmissionBuilder
 
             def document
               build_xml_doc("Form502CR", documentId: "Form502CR") do |xml|
-                if deduction_method_is_standard || calculated_fields.fetch(:MD502CR_PART_CC_LINE_7)&.positive?
-                  xml.ChildAndDependentCare do |child_dependent_care|
-                    add_non_zero_value(child_dependent_care, :FederalAdjustedGrossIncome, :MD502_LINE_1)
-                    add_non_zero_value(child_dependent_care, :FederalChildCareCredit, :MD502CR_PART_B_LINE_2)
-                    add_non_zero_float_value(child_dependent_care, :DecimalAmount, :MD502CR_PART_B_LINE_3)
-                    add_non_zero_value(child_dependent_care, :Credit, :MD502CR_PART_B_LINE_4)
-                  end
+                xml.ChildAndDependentCare do |child_dependent_care|
+                  add_non_zero_value(child_dependent_care, :FederalAdjustedGrossIncome, :MD502_LINE_1)
+                  add_non_zero_value(child_dependent_care, :FederalChildCareCredit, :MD502CR_PART_B_LINE_2)
+                  add_non_zero_float_value(child_dependent_care, :DecimalAmount, :MD502CR_PART_B_LINE_3)
+                  add_non_zero_value(child_dependent_care, :Credit, :MD502CR_PART_B_LINE_4)
                 end
-                if deduction_method_is_standard
-                  xml.Senior do |senior|
-                    add_non_zero_value(senior, :Credit, :MD502CR_PART_M_LINE_1)
-                  end
-                  xml.Summary do
-                    add_non_zero_value(xml, :ChildAndDependentCareCr, :MD502CR_PART_AA_LINE_2)
-                    add_non_zero_value(xml, :SeniorCr, :MD502CR_PART_AA_LINE_13)
-                    add_non_zero_value(xml, :TotalCredits, :MD502CR_PART_AA_LINE_14)
-                  end
+                xml.Senior do |senior|
+                  add_non_zero_value(senior, :Credit, :MD502CR_PART_M_LINE_1)
+                end
+                xml.Summary do
+                  add_non_zero_value(xml, :ChildAndDependentCareCr, :MD502CR_PART_AA_LINE_2)
+                  add_non_zero_value(xml, :SeniorCr, :MD502CR_PART_AA_LINE_13)
+                  add_non_zero_value(xml, :TotalCredits, :MD502CR_PART_AA_LINE_14)
                 end
                 xml.Refundable do
                   add_non_zero_value(xml, :ChildAndDependentCareCr, :MD502CR_PART_CC_LINE_7)
@@ -37,10 +33,6 @@ module SubmissionBuilder
             end
 
             private
-
-            def deduction_method_is_standard
-              calculated_fields.fetch(:MD502_DEDUCTION_METHOD) == "S"
-            end
 
             def intake
               @submission.data_source

--- a/spec/lib/submission_builder/ty2024/states/md/documents/md502_cr_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/md/documents/md502_cr_spec.rb
@@ -69,31 +69,20 @@ describe SubmissionBuilder::Ty2024::States::Md::Documents::Md502Cr, required_sch
 
       context "when deduction method is N" do
         before do
+          intake.direct_file_data.fed_credit_for_child_and_dependent_care_amount = 10
           allow_any_instance_of(Efile::Md::Md502Calculator).to receive(:calculate_deduction_method).and_return("N")
         end
 
-        it "does not output parts B, M or AA but still outputs part CC" do
-          expect(xml.at("Form502CR ChildAndDependentCare")).to be_nil
-          expect(xml.at("Form502CR Senior")).to be_nil
-          expect(xml.at("Form502CR Summary")).to be_nil
+        it "does output parts B, M, AA, and part CC" do
+          expect(xml.at("Form502CR ChildAndDependentCare FederalAdjustedGrossIncome").text.to_i).to eq(100)
+          expect(xml.at("Form502CR ChildAndDependentCare FederalChildCareCredit").text.to_i).to eq(10)
+          expect(xml.at("Form502CR ChildAndDependentCare DecimalAmount").text.to_d).to eq(0.32)
+          expect(xml.at("Form502CR ChildAndDependentCare Credit").text.to_i).to eq(3)
+          expect(xml.at("Form502CR Senior Credit").text.to_i).to eq(1_000)
+          expect(xml.at("Form502CR Summary ChildAndDependentCareCr").text.to_i).to eq(3)
+          expect(xml.at("Form502CR Summary SeniorCr").text.to_i).to eq(1_000)
+          expect(xml.at("Form502CR Summary TotalCredits").text.to_i).to eq(1003)
           expect(xml.at("Form502CR Refundable")).not_to be_nil
-        end
-
-        context "has positive MD502CR_PART_CC_LINE_7 value" do
-          before do
-            intake.direct_file_data.fed_credit_for_child_and_dependent_care_amount = 10
-            allow_any_instance_of(Efile::Md::Md502crCalculator).to receive(:calculate_part_cc_line_7).and_return 100
-          end
-
-          it "does output parts B but not M or AA but still outputs part CC" do
-            expect(xml.at("Form502CR ChildAndDependentCare FederalAdjustedGrossIncome").text.to_i).to eq(100)
-            expect(xml.at("Form502CR ChildAndDependentCare FederalChildCareCredit").text.to_i).to eq(10)
-            expect(xml.at("Form502CR ChildAndDependentCare DecimalAmount").text.to_d).to eq(0.32)
-            expect(xml.at("Form502CR ChildAndDependentCare Credit").text.to_i).to eq(3)
-            expect(xml.at("Form502CR Senior")).to be_nil
-            expect(xml.at("Form502CR Summary")).to be_nil
-            expect(xml.at("Form502CR Refundable")).not_to be_nil
-          end
         end
       end
     end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1741
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- MD is having some issues with us excluding these fields based on deduction type. We originally preemptively removed these fields to reduce confusion for our filers. Not sure if this will get accepted, but we're trying it out. We tried sending partial information before, too https://github.com/codeforamerica/vita-min/pull/5479
- Removed all logic to exclude fields from 502CR XML
- Basically going back to time before the changes here: https://github.com/codeforamerica/vita-min/pull/5158
## How to test?
- Describe the testing approach taken to verify the changes, including:
  - Unit tests
  - Test data used: Katie_HOH
  - should ensure xml/pdf still load with values for all fields on MD502CR for nonstandard deduction submission
  - the submission needs to be tested on demo
## Screenshots (for visual changes)
<img width="679" alt="Screenshot 2025-01-31 at 12 04 12 PM" src="https://github.com/user-attachments/assets/631a01ec-7aa1-4148-b8fe-5b467491de04" />
<img width="588" alt="Screenshot 2025-01-31 at 12 04 15 PM" src="https://github.com/user-attachments/assets/3d8882f9-000c-45c1-a905-b56039e41bf5" />
