### PR TITLE
NJ 269 - populate fill if paying by check/card in PDF

### DIFF
--- a/app/lib/efile/line_data.yml
+++ b/app/lib/efile/line_data.yml
@@ -956,6 +956,8 @@ NJ1040_LINE_78:
   label: '78 Total Adjustments to Tax Due/Overpayment amount (Add lines 69 through 77)'
 NJ1040_LINE_79:
   label: '79 Balance due (If line 67 is more than zero, add line 67 and line 78)'
+NJ1040_LINE_79_CHECKBOX:
+  label: 'Fill in if paying by e-check or credit card'
 NJ1040_LINE_80:
   label: '80 Refund amount (If line 68 is more than zero, subtract line 78 from line 68)'
 NJ2450_COLUMN_A_TOTAL_PRIMARY:

--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -603,7 +603,7 @@ module Efile
       end
 
       def calculate_line_79_checkbox
-        @intake.payment_or_deposit_type_direct_deposit?
+        @intake.payment_or_deposit_type_direct_deposit? && line_or_zero(:NJ1040_LINE_79).positive?
       end
 
       def calculate_line_80

--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -78,6 +78,7 @@ module Efile
         set_line(:NJ1040_LINE_77, :calculate_line_77)
         set_line(:NJ1040_LINE_78, :calculate_line_78)
         set_line(:NJ1040_LINE_79, :calculate_line_79)
+        set_line(:NJ1040_LINE_79_CHECKBOX, :calculate_line_79_checkbox)
         set_line(:NJ1040_LINE_80, :calculate_line_80)
         @nj2450_primary.calculate if line_59_primary || line_61_primary
         @nj2450_spouse.calculate if line_59_spouse || line_61_spouse
@@ -599,6 +600,10 @@ module Efile
           return line_or_zero(:NJ1040_LINE_67) + line_or_zero(:NJ1040_LINE_78)
         end
         0
+      end
+
+      def calculate_line_79_checkbox
+        @intake.payment_or_deposit_type_direct_deposit?
       end
 
       def calculate_line_80

--- a/app/lib/pdf_filler/nj1040_pdf.rb
+++ b/app/lib/pdf_filler/nj1040_pdf.rb
@@ -89,6 +89,9 @@ module PdfFiller
         # line 65 nj child tax credit
         '64': @xml_document.at("Body NJChildTCNumOfDep")&.text,
 
+        # line 79 payment checkbox
+        Line77bdue: calculated_fields_not_in_xml.fetch(:NJ1040_LINE_79_CHECKBOX) ? "On" : "Off",
+
         # Gubernatorial elections fund
         Group245: @xml_document.at("Body PrimGubernElectFund").present? ? 'Choice1' : 'Choice2',
         Group246: if get_mfj_spouse_ssn

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -2148,19 +2148,35 @@ describe Efile::Nj::Nj1040Calculator do
   end
 
   describe 'line 79 checkbox' do
-    context 'when user selected pay by mail' do
+    def stub_balance_owed(balance)
+      allow(instance).to receive(:calculate_line_67).and_return balance
+      instance.calculate
+    end
+
+    context 'when user selected pay by mail & owes a balance' do
       let(:intake) { create(:state_file_nj_intake, payment_or_deposit_type: :mail) }
 
       it 'returns false' do
+        stub_balance_owed(100)
         expect(instance.lines[:NJ1040_LINE_79_CHECKBOX].value).to eq(false)
       end
     end
 
-    context 'when user selected pay by direct debit' do
+    context 'when user selected pay by direct debit & owes a balance' do
       let(:intake) { create(:state_file_nj_intake, payment_or_deposit_type: :direct_deposit) }
 
       it 'returns true' do
+        stub_balance_owed(100)
         expect(instance.lines[:NJ1040_LINE_79_CHECKBOX].value).to eq(true)
+      end
+    end
+
+    context 'when user selected pay by direct debit but is not owing a balance' do
+      let(:intake) { create(:state_file_nj_intake, payment_or_deposit_type: :direct_deposit) }
+
+      it 'returns false' do
+        stub_balance_owed(0)
+        expect(instance.lines[:NJ1040_LINE_79_CHECKBOX].value).to eq(false)
       end
     end
   end

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -2147,6 +2147,24 @@ describe Efile::Nj::Nj1040Calculator do
     end
   end
 
+  describe 'line 79 checkbox' do
+    context 'when user selected pay by mail' do
+      let(:intake) { create(:state_file_nj_intake, payment_or_deposit_type: :mail) }
+
+      it 'returns false' do
+        expect(instance.lines[:NJ1040_LINE_79_CHECKBOX].value).to eq(false)
+      end
+    end
+
+    context 'when user selected pay by direct debit' do
+      let(:intake) { create(:state_file_nj_intake, payment_or_deposit_type: :direct_deposit) }
+
+      it 'returns true' do
+        expect(instance.lines[:NJ1040_LINE_79_CHECKBOX].value).to eq(true)
+      end
+    end
+  end
+
   describe 'line 80 Refund amount' do
     it 'returns 0 when line 68 is not above 0' do
       allow(instance).to receive(:calculate_line_68).and_return 0

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -2148,13 +2148,15 @@ describe Efile::Nj::Nj1040Calculator do
   end
 
   describe 'line 79 checkbox' do
+    let(:intake) { create(:state_file_nj_intake, payment_or_deposit_type: payment_or_deposit_type) }
+
     def stub_balance_owed(balance)
       allow(instance).to receive(:calculate_line_67).and_return balance
       instance.calculate
     end
 
     context 'when user selected pay by mail & owes a balance' do
-      let(:intake) { create(:state_file_nj_intake, payment_or_deposit_type: :mail) }
+      let(:payment_or_deposit_type) { :mail }
 
       it 'returns false' do
         stub_balance_owed(100)
@@ -2163,7 +2165,7 @@ describe Efile::Nj::Nj1040Calculator do
     end
 
     context 'when user selected pay by direct debit & owes a balance' do
-      let(:intake) { create(:state_file_nj_intake, payment_or_deposit_type: :direct_deposit) }
+      let(:payment_or_deposit_type) { :direct_deposit }
 
       it 'returns true' do
         stub_balance_owed(100)
@@ -2172,7 +2174,7 @@ describe Efile::Nj::Nj1040Calculator do
     end
 
     context 'when user selected pay by direct debit but is not owing a balance' do
-      let(:intake) { create(:state_file_nj_intake, payment_or_deposit_type: :direct_deposit) }
+      let(:payment_or_deposit_type) { :direct_deposit }
 
       it 'returns false' do
         stub_balance_owed(0)

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -2201,6 +2201,18 @@ RSpec.describe PdfFiller::Nj1040Pdf do
       end
     end
 
+    describe 'line 79 - paying by e-check / credit card checkbox' do
+      it 'checks box when calculated is true' do
+        allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_79_checkbox).and_return true
+        expect(pdf_fields["Line77bdue"]).to eq "On"
+      end
+
+      it 'does not check box when calculated is false' do
+        allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_79_checkbox).and_return false
+        expect(pdf_fields["Line77bdue"]).to eq "Off"
+      end
+    end
+
     describe 'line 80 - Refund amount' do
       it 'inserts xml output' do
         allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_80).and_return 12_345_678


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/269

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Check line 79 box when: a) owes a balance AND b) selected directed deposit
- Do not check otherwise (if no balance owed, or if selected pay by mail)

## How to test?
- Use Lucky Single to test a persona who owes a balance
- Use Oneal MFJ for a persona who does not owe a balance

## Screenshots (for visual changes)
![image](https://github.com/user-attachments/assets/f137cb1c-b72b-49d0-a661-b7ba79072154)
