### PR TITLE
en tweaks

### DIFF
--- a/config/locales/en.rb
+++ b/config/locales/en.rb
@@ -2,7 +2,7 @@
   :en => {
     :date => {
       :formats => {
-        :medium => lambda { |date, _| "%B #{date.day.ordinalize}" }
+        :medium => ->(date, _) { "%B #{date.day.ordinalize}" }
       }
     }
   }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1593,7 +1593,7 @@ en:
 
             We noticed that you have not submitted a state tax return yet with the account associated with this email address. If you submitted your state return another way, or you submitted your return under a different email address, you can disregard this message.
 
-            This is a reminder that state taxes were due by April 15, but it's still not too late to file! Go to https://www.fileyourstatetaxes.org/en/us/login-options to check your return status or finish your return now. We encourage you to submit your return as soon as possible in order to avoid late filings fees from %{state_name}. Our services will be closing for the year on April 25. After this date, you will no longer be able to file through FileYourStateTaxes.
+            This is a reminder that state taxes were due by April 15, but it's still not too late to file! Go to https://www.fileyourstatetaxes.org/en/login-options to check your return status or finish your return now. We encourage you to submit your return as soon as possible in order to avoid late filings fees from %{state_name}. Our services will be closing for the year on April 25. After this date, you will no longer be able to file through FileYourStateTaxes.
 
             Need help? Reply to this email.
 
@@ -1601,14 +1601,14 @@ en:
             The FileYourStateTaxes team
           subject: 'Final Reminder: FileYourStateTaxes closes April 25.'
         sms: |
-          Hi %{primary_first_name} - You haven't submitted your state tax return yet. Make sure to submit your state taxes as soon as possible to avoid late filing fees. Go to fileyourstatetaxes.org/en/us/login-options to finish them now. FileYourStateTaxes will be closing its services for the year on April 25.
+          Hi %{primary_first_name} - You haven't submitted your state tax return yet. Make sure to submit your state taxes as soon as possible to avoid late filing fees. Go to fileyourstatetaxes.org/en/login-options to finish them now. FileYourStateTaxes will be closing its services for the year on April 25.
           Need help? Email us at help@fileyourstatetaxes.org.
       pre_deadline_reminder:
         email:
-          body: "Hi %{primary_first_name},\n\nYou haven't submitted your state tax return yet. As a reminder, state taxes are due by April 15. Make sure to submit your state tax return by April 15 in order to avoid late filing fees from %{state_name}. \n\nGo to fileyourstatetaxes.org/en/us/login-options to finish them now.\n\nNeed help? Reply to this email.\n\nBest,\nThe FileYourStateTaxes team\n"
+          body: "Hi %{primary_first_name},\n\nYou haven't submitted your state tax return yet. As a reminder, state taxes are due by April 15. Make sure to submit your state tax return by April 15 in order to avoid late filing fees from %{state_name}. \n\nGo to fileyourstatetaxes.org/en/login-options to finish them now.\n\nNeed help? Reply to this email.\n\nBest,\nThe FileYourStateTaxes team\n"
           subject: Don't forget to finish your state tax return by April 15!
         sms: |
-          Hi %{primary_first_name} - You haven't submitted your state tax return yet. Make sure to submit your state taxes by April 15 in order to avoid late filing fees. Go to fileyourstatetaxes.org/en/us/login-options to finish them now.
+          Hi %{primary_first_name} - You haven't submitted your state tax return yet. Make sure to submit your state taxes by April 15 in order to avoid late filing fees. Go to fileyourstatetaxes.org/en/login-options to finish them now.
           Need help? Email us at help@fileyourstatetaxes.org.
       reject_resolution_reminder:
         email:
@@ -3958,7 +3958,7 @@ en:
               <li>if there weren’t enough taxes withheld from your paycheck (you may want to discuss with your employer for future years), or</li>
               <li>if you haven’t made enough in estimated tax payments.</li>
             </ul>
-            <p> You might be charged interest on what you owe. If that applies to you, you will get a notice from the State of New Jersey Division of Taxation in the mail.</p>
+            <p>You might be charged interest on what you owe. If that applies to you, you will get a notice from the State of New Jersey Division of Taxation in the mail.</p>
             <p><strong>You should definitely continue with this filing. The sooner you file, the less you will eventually have to pay in penalties.</strong></p>
       terms_and_conditions:
         edit:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,7 +54,6 @@ en:
     formats:
       default: "%-m/%-d/%Y"
       long: "%B %-d, %Y"
-      medium: "%-d de %B"
   devise:
     failure:
       invalid: Incorrect email or password. After 5 login attempts, accounts are locked.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,7 @@ en:
     formats:
       default: "%-m/%-d/%Y"
       long: "%B %-d, %Y"
+      medium: "%-d de %B"
   devise:
     failure:
       invalid: Incorrect email or password. After 5 login attempts, accounts are locked.

--- a/config/locales/es.rb
+++ b/config/locales/es.rb
@@ -1,0 +1,9 @@
+{
+  :es => {
+    :date => {
+      :formats => {
+        :medium => "%-d de %B"
+      }
+    }
+  }
+}

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -54,7 +54,6 @@ es:
     formats:
       default: "%-m/%-d/%Y"
       long: "%-d de %B de %Y"
-      medium: "%-d de %B"
   devise:
     failure:
       invalid: Correo o contraseña incorrectos. Después de 5 intentos de inicio de sesión, las cuentas se bloquean.


### PR DESCRIPTION
## Link to pivotal/JIRA issue
n/a

## Is PM acceptance required? (delete one)
No - merge after code review approval

## What was done?
A couple wee fixes my recent delve into transifex bubbled up.

- Fixed a couple broken urls
- the medium date format in the `es.yml` keeps getting dropped by the i18n normalizer because it doesn't appear in the `en.yml`. for english, the medium date format is defined as a lambda so we can get ordinal numbers. that's not a thing for spanish, so we don't need a lambda, but this PR moves the es format definition into a structure similar to en so it's consistent and not confusing to the i18n normalizer anymore.
