### PR TITLE
FYST 1747 Strip soft dash from employer state id number

### DIFF
--- a/app/models/state_file_base_intake.rb
+++ b/app/models/state_file_base_intake.rb
@@ -145,7 +145,7 @@ class StateFileBaseIntake < ApplicationRecord
         employer_name: direct_file_w2.EmployerName,
         employee_name: direct_file_w2.EmployeeNm,
         employee_ssn: direct_file_w2.EmployeeSSN,
-        employer_state_id_num: direct_file_w2.EmployerStateIdNum,
+        employer_state_id_num: direct_file_w2.EmployerStateIdNum&.delete("\u00AD"),
         local_income_tax_amount: direct_file_w2.LocalIncomeTaxAmt,
         local_wages_and_tips_amount: direct_file_w2.LocalWagesAndTipsAmt,
         locality_nm: direct_file_w2.LocalityNm,

--- a/app/models/state_file_w2.rb
+++ b/app/models/state_file_w2.rb
@@ -122,7 +122,7 @@ class StateFileW2 < ApplicationRecord
 
     xml_template = Nokogiri::XML(STATE_TAX_GRP_TEMPLATE)
     xml_template.at(:StateAbbreviationCd).content = state_code&.upcase
-    xml_template.at(:EmployerStateIdNum).content = employer_state_id_num
+    xml_template.at(:EmployerStateIdNum).content = employer_state_id_num.delete("\u00AD")
     xml_template.at(:StateWagesAmt).content = state_wages_amount&.round
     xml_template.at(:StateIncomeTaxAmt).content = state_income_tax_amount&.round
     xml_template.at(:LocalWagesAndTipsAmt).content = local_wages_and_tips_amount&.round

--- a/app/models/state_file_w2.rb
+++ b/app/models/state_file_w2.rb
@@ -122,7 +122,7 @@ class StateFileW2 < ApplicationRecord
 
     xml_template = Nokogiri::XML(STATE_TAX_GRP_TEMPLATE)
     xml_template.at(:StateAbbreviationCd).content = state_code&.upcase
-    xml_template.at(:EmployerStateIdNum).content = employer_state_id_num.delete("\u00AD")
+    xml_template.at(:EmployerStateIdNum).content = employer_state_id_num&.delete("\u00AD")
     xml_template.at(:StateWagesAmt).content = state_wages_amount&.round
     xml_template.at(:StateIncomeTaxAmt).content = state_income_tax_amount&.round
     xml_template.at(:LocalWagesAndTipsAmt).content = local_wages_and_tips_amount&.round

--- a/spec/models/state_file_w2_spec.rb
+++ b/spec/models/state_file_w2_spec.rb
@@ -233,9 +233,9 @@ describe StateFileW2 do
 
     context "when EmployerStateIdNum contains soft hyphens" do
       it "removes soft hyphens when generating XML" do
-        w2.employer_state_id_num = "123\u00AD456"
+        w2.employer_state_id_num = "86­2124319"
         xml = Nokogiri::XML(w2.state_tax_group_xml_node)
-        expect(xml.at("EmployerStateIdNum").text).to eq "123456"
+        expect(xml.at("EmployerStateIdNum").text).to eq "862124319"
       end
     end
   end

--- a/spec/models/state_file_w2_spec.rb
+++ b/spec/models/state_file_w2_spec.rb
@@ -230,6 +230,14 @@ describe StateFileW2 do
         expect(xml.at("StateAbbreviationCd").text).to eq "MD"
       end
     end
+
+    context "when EmployerStateIdNum contains soft hyphens" do
+      it "removes soft hyphens when generating XML" do
+        w2.employer_state_id_num = "123\u00AD456"
+        xml = Nokogiri::XML(w2.state_tax_group_xml_node)
+        expect(xml.at("EmployerStateIdNum").text).to eq "123456"
+      end
+    end
   end
 
   describe "box14_ui_wf_swf getter override" do


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/FYST-1747

## Is PM acceptance required? 
- Yes - don't merge until JIRA issue is accepted!

## What was done?
Fixed validation error caused by soft hyphens (U+AD00) in employer_state_id_num field
Added delete("\u00AD") to remove soft hyphens during XML generation while preserving original value

## How to test?
Added a unit test for state file w2 model

