### PR TITLE
[FSYT-1649] Remove about us link from mobile

### DIFF
--- a/app/views/state_file/state_file_pages/_client_menu.html.erb
+++ b/app/views/state_file/state_file_pages/_client_menu.html.erb
@@ -2,9 +2,6 @@
   <div class="container">
     <div>
       <div class="client-menu-item">
-        <%= link_to t("general.about"), about_us_path %>
-      </div>
-      <div class="client-menu-item">
         <%= link_to t("general.faq"), state_faq_path(us_state: "us") %>
       </div>
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1649

## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
rm

## How to test?
navigate to homepage on mobile, then tap on the menu dropdown link on the top right

## Screenshots (for visual changes)
<img width="433" alt="Screenshot 2025-02-05 at 12 54 07 PM" src="https://github.com/user-attachments/assets/7a3ab4e9-2f43-46a9-b769-97f4aed8d427" />

