### PR TITLE
Only show the main error instead of the latest created efile error

### DIFF
--- a/app/controllers/state_file/questions/return_status_controller.rb
+++ b/app/controllers/state_file/questions/return_status_controller.rb
@@ -31,6 +31,18 @@ module StateFile
         return nil unless return_status == 'rejected'
         # in the case that its in the notified_of_rejection or waiting state
         # we can't just grab the efile errors from the last transition
+        last_efile_errors = @submission_to_show&.efile_submission_transitions&.where(to_state: 'rejected')&.last&.efile_errors
+
+        return nil if last_efile_errors.blank?
+
+        # Temporary solution to unblock clients in NC/MD
+        if last_efile_errors.where(code: "NCD400-1100").present?
+          return last_efile_errors.where(code: "NCD400-1100").first
+        end
+        if last_efile_errors.where(code: "Form502-01150-010").present?
+          return last_efile_errors.where(code: "Form502-01150-010").first
+        end
+
         @submission_to_show&.efile_submission_transitions&.where(to_state: 'rejected')&.last&.efile_errors&.last
       end
 

--- a/app/controllers/state_file/questions/return_status_controller.rb
+++ b/app/controllers/state_file/questions/return_status_controller.rb
@@ -31,7 +31,7 @@ module StateFile
         return nil unless return_status == 'rejected'
         # in the case that its in the notified_of_rejection or waiting state
         # we can't just grab the efile errors from the last transition
-        last_efile_errors = @submission_to_show&.efile_submission_transitions&.where(to_state: 'rejected')&.last&.efile_errors
+        last_efile_errors = @submission_to_show&.efile_submission_transitions&.where(to_state: 'rejected')&.last&.efile_errors&.order(id: :asc)
 
         return nil if last_efile_errors.blank?
 
@@ -43,7 +43,7 @@ module StateFile
           return last_efile_errors.where(code: "Form502-01150-010").first
         end
 
-        @submission_to_show&.efile_submission_transitions&.where(to_state: 'rejected')&.last&.efile_errors&.last
+        last_efile_errors.last
       end
 
       def return_status

--- a/app/controllers/state_file/questions/return_status_controller.rb
+++ b/app/controllers/state_file/questions/return_status_controller.rb
@@ -31,6 +31,7 @@ module StateFile
         return nil unless return_status == 'rejected'
         # in the case that its in the notified_of_rejection or waiting state
         # we can't just grab the efile errors from the last transition
+        # order(id: :asc) is purely to ensure consistent last efile error is returned for test purposes
         last_efile_errors = @submission_to_show&.efile_submission_transitions&.where(to_state: 'rejected')&.last&.efile_errors&.order(id: :asc)
 
         return nil if last_efile_errors.blank?

--- a/app/controllers/state_file/questions/return_status_controller.rb
+++ b/app/controllers/state_file/questions/return_status_controller.rb
@@ -41,8 +41,8 @@ module StateFile
         if last_efile_errors.where(code: "NCD400-1100").present?
           return last_efile_errors.where(code: "NCD400-1100").first
         end
-        if last_efile_errors.where(code: "Form502-01150-010").present?
-          return last_efile_errors.where(code: "Form502-01150-010").first
+        if last_efile_errors.where(code: "Form502-01550-010").present?
+          return last_efile_errors.where(code: "Form502-01550-010").first
         end
 
         last_efile_errors.last

--- a/app/controllers/state_file/questions/return_status_controller.rb
+++ b/app/controllers/state_file/questions/return_status_controller.rb
@@ -31,7 +31,8 @@ module StateFile
         return nil unless return_status == 'rejected'
         # in the case that its in the notified_of_rejection or waiting state
         # we can't just grab the efile errors from the last transition
-        # order(id: :asc) is purely to ensure consistent last efile error is returned for test purposes
+        # order(id: :asc) is purely to ensure consistent last efile error is returned for test purposes,
+        # currently, we do not care which efile error is "last" and shown on the return-status page
         last_efile_errors = @submission_to_show&.efile_submission_transitions&.where(to_state: 'rejected')&.last&.efile_errors&.order(id: :asc)
 
         return nil if last_efile_errors.blank?

--- a/spec/controllers/state_file/questions/return_status_controller_spec.rb
+++ b/spec/controllers/state_file/questions/return_status_controller_spec.rb
@@ -379,10 +379,8 @@ RSpec.describe StateFile::Questions::ReturnStatusController do
             end
           end
 
-          context "with NCD400-1100 and NCD400-1080 errors" do
+          context "specified error-shown edge cases" do
             let(:rejected_transition) { efile_submission.efile_submission_transitions.where(to_state: 'rejected').last }
-            let(:main_efile_error) { create :efile_error, code: "NCD400-1100", service_type: :state_file_nc, expose: true, auto_wait: true }
-            let(:related_efile_error) { create :efile_error, code: "NCD400-1080", service_type: :state_file_nc, expose: true, auto_wait: true }
             let!(:transition_error) {
               create :efile_submission_transition_error,
                      efile_error: main_efile_error,
@@ -396,42 +394,34 @@ RSpec.describe StateFile::Questions::ReturnStatusController do
                      efile_submission_id: efile_submission.id
             }
 
-            it "should show the NCD400-1100 even though NCD400-1080 is the last error" do
-              get :edit
-              expect(response.body).to include main_efile_error.code
-              expect(response.body).not_to include related_efile_error.code
+            context "with NCD400-1100 and NCD400-1080 errors" do
+              let(:main_efile_error) { create :efile_error, code: "NCD400-1100", service_type: :state_file_nc, expose: true, auto_wait: true }
+              let(:related_efile_error) { create :efile_error, code: "NCD400-1080", service_type: :state_file_nc, expose: true, auto_wait: true }
+
+              it "should show the NCD400-1100 even though NCD400-1080 is the last error" do
+                get :edit
+                expect(response.body).to include main_efile_error.code
+                expect(response.body).not_to include related_efile_error.code
+              end
             end
-          end
 
-          context "with Form502-01550-010 and related errors" do
-            let(:rejected_transition) { efile_submission.efile_submission_transitions.where(to_state: 'rejected').last }
-            let(:main_efile_error) { create :efile_error, code: "Form502-01150-010", service_type: :state_file_md, expose: true, auto_wait: true }
-            let(:related_efile_error) { create :efile_error, code: "Form502-01230-005", service_type: :state_file_md, expose: true, auto_wait: true }
-            let(:related_efile_error_2) { create :efile_error, code: "Form502-01150-005", service_type: :state_file_md, expose: true, auto_wait: true }
-            let!(:transition_error) {
-              create :efile_submission_transition_error,
-                     efile_error: main_efile_error,
-                     efile_submission_transition: rejected_transition,
-                     efile_submission_id: efile_submission.id
-            }
-            let!(:related_transition_error) {
-              create :efile_submission_transition_error,
-                     efile_error: related_efile_error,
-                     efile_submission_transition: rejected_transition,
-                     efile_submission_id: efile_submission.id
-            }
-            let!(:related_transition_error_2) {
-              create :efile_submission_transition_error,
-                     efile_error: related_efile_error_2,
-                     efile_submission_transition: rejected_transition,
-                     efile_submission_id: efile_submission.id
-            }
+            context "with Form502-01550-010 and related errors" do
+              let(:main_efile_error) { create :efile_error, code: "Form502-01150-010", service_type: :state_file_md, expose: true, auto_wait: true }
+              let(:related_efile_error) { create :efile_error, code: "Form502-01230-005", service_type: :state_file_md, expose: true, auto_wait: true }
+              let(:related_efile_error_2) { create :efile_error, code: "Form502-01150-005", service_type: :state_file_md, expose: true, auto_wait: true }
+              let!(:related_transition_error_2) {
+                create :efile_submission_transition_error,
+                       efile_error: related_efile_error_2,
+                       efile_submission_transition: rejected_transition,
+                       efile_submission_id: efile_submission.id
+              }
 
-            it "should show the NCD400-1100 even though NCD400-1080 is the last error" do
-              get :edit
-              expect(response.body).to include main_efile_error.code
-              expect(response.body).not_to include related_efile_error.code
-              expect(response.body).not_to include related_efile_error_2.code
+              it "should show the NCD400-1100 even though NCD400-1080 is the last error" do
+                get :edit
+                expect(response.body).to include main_efile_error.code
+                expect(response.body).not_to include related_efile_error.code
+                expect(response.body).not_to include related_efile_error_2.code
+              end
             end
           end
         end

--- a/spec/controllers/state_file/questions/return_status_controller_spec.rb
+++ b/spec/controllers/state_file/questions/return_status_controller_spec.rb
@@ -378,6 +378,62 @@ RSpec.describe StateFile::Questions::ReturnStatusController do
               expect(response.body).to include I18n.t("state_file.questions.return_status.rejected.next_steps.can_edit.body")
             end
           end
+
+          context "with NCD400-1100 and NCD400-1080 errors" do
+            let(:rejected_transition) { efile_submission.efile_submission_transitions.where(to_state: 'rejected').last }
+            let(:main_efile_error) { create :efile_error, code: "NCD400-1100", service_type: :state_file_nc, expose: true, auto_wait: true }
+            let(:related_efile_error) { create :efile_error, code: "NCD400-1080", service_type: :state_file_nc, expose: true, auto_wait: true }
+            let!(:transition_error) {
+              create :efile_submission_transition_error,
+                     efile_error: main_efile_error,
+                     efile_submission_transition: rejected_transition,
+                     efile_submission_id: efile_submission.id
+            }
+            let!(:related_transition_error) {
+              create :efile_submission_transition_error,
+                     efile_error: related_efile_error,
+                     efile_submission_transition: rejected_transition,
+                     efile_submission_id: efile_submission.id
+            }
+
+            it "should show the NCD400-1100 even though NCD400-1080 is the last error" do
+              get :edit
+              expect(response.body).to include main_efile_error.code
+              expect(response.body).not_to include related_efile_error.code
+            end
+          end
+
+          context "with Form502-01550-010 and related errors" do
+            let(:rejected_transition) { efile_submission.efile_submission_transitions.where(to_state: 'rejected').last }
+            let(:main_efile_error) { create :efile_error, code: "Form502-01150-010", service_type: :state_file_md, expose: true, auto_wait: true }
+            let(:related_efile_error) { create :efile_error, code: "Form502-01230-005", service_type: :state_file_md, expose: true, auto_wait: true }
+            let(:related_efile_error_2) { create :efile_error, code: "Form502-01150-005", service_type: :state_file_md, expose: true, auto_wait: true }
+            let!(:transition_error) {
+              create :efile_submission_transition_error,
+                     efile_error: main_efile_error,
+                     efile_submission_transition: rejected_transition,
+                     efile_submission_id: efile_submission.id
+            }
+            let!(:related_transition_error) {
+              create :efile_submission_transition_error,
+                     efile_error: related_efile_error,
+                     efile_submission_transition: rejected_transition,
+                     efile_submission_id: efile_submission.id
+            }
+            let!(:related_transition_error_2) {
+              create :efile_submission_transition_error,
+                     efile_error: related_efile_error_2,
+                     efile_submission_transition: rejected_transition,
+                     efile_submission_id: efile_submission.id
+            }
+
+            it "should show the NCD400-1100 even though NCD400-1080 is the last error" do
+              get :edit
+              expect(response.body).to include main_efile_error.code
+              expect(response.body).not_to include related_efile_error.code
+              expect(response.body).not_to include related_efile_error_2.code
+            end
+          end
         end
       end
     end

--- a/spec/controllers/state_file/questions/return_status_controller_spec.rb
+++ b/spec/controllers/state_file/questions/return_status_controller_spec.rb
@@ -406,7 +406,7 @@ RSpec.describe StateFile::Questions::ReturnStatusController do
             end
 
             context "with Form502-01550-010 and related errors" do
-              let(:main_efile_error) { create :efile_error, code: "Form502-01150-010", service_type: :state_file_md, expose: true, auto_wait: true }
+              let(:main_efile_error) { create :efile_error, code: "Form502-01550-010", service_type: :state_file_md, expose: true, auto_wait: true }
               let(:related_efile_error) { create :efile_error, code: "Form502-01230-005", service_type: :state_file_md, expose: true, auto_wait: true }
               let(:related_efile_error_2) { create :efile_error, code: "Form502-01150-005", service_type: :state_file_md, expose: true, auto_wait: true }
               let!(:related_transition_error_2) {


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1761
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Hackiest, narrowest solution possible to unblock clients, so they'll see the main error they need to correct which should help resolve the related errors.

## How to test?
- Describe the testing approach taken to verify the changes, including:
  - Unit tests
  - Should test on heroku by creating these efile errors & put client in rejected state
- Risk Assessment
  - I hate it, but there's supposed to be a long-term solution coming soon, that probably involves some kind of mapping between related issues