### PR TITLE
NJ 79 - add page to select income source for 1099-R retirement income

### DIFF
--- a/app/assets/stylesheets/_state-file.scss
+++ b/app/assets/stylesheets/_state-file.scss
@@ -546,11 +546,9 @@
     line-height: 2.4rem;
   }
 
-  .review-header {
-    .with-top-separator {
-      padding-top: 25px;
-      border-top: 1px solid $color-state-file-separator;
-    }
+  .with-top-separator {
+    padding-top: 25px;
+    border-top: 1px solid $color-state-file-separator;
   }
 
   .review-section {

--- a/app/controllers/state_file/questions/nj_retirement_income_source_controller.rb
+++ b/app/controllers/state_file/questions/nj_retirement_income_source_controller.rb
@@ -39,7 +39,7 @@ module StateFile
       end
 
       def self.show?(intake)
-        intake.state_file1099_rs.length.positive?
+        Flipper.enabled?(:show_retirement_ui) && intake.state_file1099_rs.length.positive?
       end
 
       def prev_path

--- a/app/controllers/state_file/questions/nj_retirement_income_source_controller.rb
+++ b/app/controllers/state_file/questions/nj_retirement_income_source_controller.rb
@@ -1,0 +1,71 @@
+module StateFile
+  module Questions
+    class NjRetirementIncomeSourceController < QuestionsController
+      include ReturnToReviewConcern
+
+      before_action :load_1099r
+
+      def load_1099r
+        @index = params[:index].present? ? params[:index].to_i : 0
+        @state_file_1099r =
+          if params[:index].present?
+            current_intake.state_file1099_rs[params[:index].to_i]
+          else
+            current_intake.state_file1099_rs.first
+          end
+
+        @name_1099r = @state_file_1099r.payer_name
+        @taxpayer_name = @state_file_1099r.recipient_name
+        @amount = @state_file_1099r.taxable_amount
+      end
+
+      def initialized_edit_form
+        attribute_keys = Attributes.new(form_class.attribute_names).to_sym
+        state_specific_followup = retrieve_or_create_state_specific_followup
+        form_class.new(state_specific_followup, form_class.existing_attributes(state_specific_followup).slice(*attribute_keys))
+      end
+
+      def initialized_update_form
+        form_class.new(retrieve_or_create_state_specific_followup, form_params)
+      end
+
+      def retrieve_or_create_state_specific_followup
+        unless @state_file_1099r.state_specific_followup.present?
+          @state_file_1099r.state_specific_followup = StateFileNj1099RFollowup.create
+          @state_file_1099r.save
+        end
+
+        @state_file_1099r.state_specific_followup
+      end
+
+      def self.show?(intake)
+        intake.state_file1099_rs.length.positive?
+      end
+
+      def prev_path
+        options = {}
+        options[:return_to_review] = params[:return_to_review] if params[:return_to_review].present?
+        prev_index = @index - 1
+        if prev_index.negative?
+          super
+        else
+          options[:index] = prev_index
+          NjRetirementIncomeSourceController.to_path_helper(options)
+        end
+      end
+
+      def next_path
+        options = {}
+        options[:return_to_review] = params[:return_to_review] if params[:return_to_review].present?
+        next_index = @index + 1
+        if next_index >= current_intake.direct_file_data.form1099r_nodes.length
+          super
+        else
+          options[:index] = next_index
+          NjRetirementIncomeSourceController.to_path_helper(options)
+        end
+      end
+    end
+  end
+end
+

--- a/app/forms/state_file/nj_retirement_income_source_form.rb
+++ b/app/forms/state_file/nj_retirement_income_source_form.rb
@@ -1,0 +1,22 @@
+module StateFile
+  class NjRetirementIncomeSourceForm < Form
+    include FormAttributes
+
+    set_attributes_for :state_specific_followup,
+                       :income_source
+
+    attr_accessor :state_specific_followup
+
+    validates :income_source, presence: true
+
+    def initialize(state_specific_followup = nil, params = {})
+      @state_specific_followup = state_specific_followup
+      super(params)
+    end
+
+    def save
+      @state_specific_followup.income_source = self.income_source
+      @state_specific_followup.save
+    end
+  end
+end

--- a/app/lib/navigation/state_file_nj_question_navigation.rb
+++ b/app/lib/navigation/state_file_nj_question_navigation.rb
@@ -43,6 +43,7 @@ module Navigation
                                           Navigation::NavigationStep.new(StateFile::Questions::NjDependentsHealthInsuranceController), # Line 14
                                       ]),
       Navigation::NavigationSection.new("state_file.navigation.nj.section_3", [
+                                          Navigation::NavigationStep.new(StateFile::Questions::NjRetirementIncomeSourceController),
                                           Navigation::NavigationStep.new(StateFile::Questions::NjMedicalExpensesController), # Line 31
                                           Navigation::NavigationStep.new(StateFile::Questions::NjEitcQualifyingChildController), # Line 58, intentionally moved up to be in the context of other credits and deductions, and to ensure there is a consistent page after the property taxes section.
                                           Navigation::NavigationStep.new(StateFile::Questions::NjHouseholdRentOwnController), # Line 40b

--- a/app/models/state_file_nj1099_r_followup.rb
+++ b/app/models/state_file_nj1099_r_followup.rb
@@ -2,12 +2,14 @@
 #
 # Table name: state_file_nj1099_r_followups
 #
-#  id         :bigint           not null, primary key
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id            :bigint           not null, primary key
+#  income_source :integer          default("unfilled"), not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
 #
 class StateFileNj1099RFollowup < ApplicationRecord
 
   has_one :state_file1099_r, inverse_of: :state_specific_followup
 
+  enum income_source: { unfilled: 0, military_pension: 1, military_survivors_benefits: 2, none: 3 }, _prefix: :income_source
 end

--- a/app/views/state_file/questions/nj_retirement_income_source/edit.html.erb
+++ b/app/views/state_file/questions/nj_retirement_income_source/edit.html.erb
@@ -4,8 +4,10 @@
 %>
 
 <% content_for :card do %>
-  <h1 class="h2"><%= title %></h1>
-  <h2 class="h3"><%= t(".subtitle") %></h2>
+  <hgroup>
+    <h1 class="h2"><%= title %></h1>
+    <p class="h3"><%= t(".subtitle") %></p>
+  </hgroup>
   <p><%= t(".doc_1099r_label") %> <b><%= @name_1099r %></b></p>
   <p><%= t(".taxpayer_name_label") %> <b><%= @taxpayer_name %></b></p>
   <p><%= t(".taxable_amount_label") %> <b><%= number_to_currency(@amount, precision: 0) %></b></p>

--- a/app/views/state_file/questions/nj_retirement_income_source/edit.html.erb
+++ b/app/views/state_file/questions/nj_retirement_income_source/edit.html.erb
@@ -6,7 +6,7 @@
 <% content_for :card do %>
   <hgroup>
     <h1 class="h2"><%= title %></h1>
-    <p class="h3"><%= t(".subtitle") %></p>
+    <p><%= t(".subtitle") %></p>
   </hgroup>
   <p><%= t(".doc_1099r_label") %> <b><%= @name_1099r %></b></p>
   <p><%= t(".taxpayer_name_label") %> <b><%= @taxpayer_name %></b></p>
@@ -20,7 +20,7 @@
             collection: [
               { value: :military_pension, label: t(".option_military_pension") },
               { value: :military_survivors_benefits, label: t(".option_military_survivor_benefit") },
-              { value: :none, label: t(".option_none_html") },
+              { value: :none, label: t(".option_none") },
             ],
           ) %>
     </div>

--- a/app/views/state_file/questions/nj_retirement_income_source/edit.html.erb
+++ b/app/views/state_file/questions/nj_retirement_income_source/edit.html.erb
@@ -1,0 +1,41 @@
+<%
+    title = t(".title" )
+    content_for :page_title, title
+%>
+
+<% content_for :card do %>
+  <h1 class="h2"><%= title %></h1>
+  <h2 class="h3"><%= t(".subtitle") %></h2>
+  <p><%= t(".doc_1099r_label") %> <b><%= @name_1099r %></b></p>
+  <p><%= t(".taxpayer_name_label") %> <b><%= @taxpayer_name %></b></p>
+  <p><%= t(".taxable_amount_label") %> <b><%= number_to_currency(@amount, precision: 0) %></b></p>
+
+  <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
+    <div class="white-group">
+      <%= f.cfa_radio_set(
+            :income_source,
+            label_text: t(".label"),
+            collection: [
+              { value: :military_pension, label: t(".option_military_pension") },
+              { value: :military_survivors_benefits, label: t(".option_military_survivor_benefit") },
+              { value: :none, label: t(".option_none_html") },
+            ],
+          ) %>
+    </div>
+
+    <div class="reveal">
+      <button class="reveal__button"><%= t('.helper_heading') %></button>
+      <div class="reveal__content">
+        <%= t('.helper_description_html') %>
+      </div>
+    </div>
+
+    <% if params[:return_to_review].present? %>
+      <%= hidden_field_tag "return_to_review", params[:return_to_review] %>
+    <% end %>
+    <% if params[:index].present? %>
+      <%= hidden_field_tag "index", params[:index] %>
+    <% end %>
+    <%= f.continue %>
+  <% end %>
+<% end %>

--- a/app/views/state_file/questions/nj_review/edit.html.erb
+++ b/app/views/state_file/questions/nj_review/edit.html.erb
@@ -108,7 +108,37 @@
     </section>
   <% end %>
 
-  <%# Dependents %>
+  <% if current_intake.state_file1099_rs.length.positive? %>
+    <section id="retirement-income-source" class="white-group">
+      <div class="spacing-below-5">
+        <h2 class="text--body text--bold spacing-below-25"><%=t(".retirement_income_source") %></h2>
+
+        <% current_intake.state_file1099_rs.each do |state_file1099_r| %>
+          <div class="spacing-below-5 with-top-separator">
+            <p><%= t(".retirement_income_source_doc_1099r_label") %> <b><%= state_file1099_r.payer_name %></b></p>
+            <p><%= t(".retirement_income_source_taxpayer_name_label") %> <b><%= state_file1099_r.recipient_name %></b></p>
+            <p><%= t(".retirement_income_source_taxable_amount_label") %> <b><%= number_to_currency(state_file1099_r.taxable_amount, precision: 0) %></b></p>
+            <p>
+              <%= t(".retirement_income_source_label") %>
+              <b>
+                <% if state_file1099_r.state_specific_followup.income_source_military_pension? %>
+                  <%= t(".retirement_income_source_military_pension") %>
+                <% elsif state_file1099_r.state_specific_followup.income_source_military_survivors_benefits? %>
+                  <%= t(".retirement_income_source_military_survivor_benefit") %>
+                <% else %>
+                  <%= t(".retirement_income_source_none") %>
+                <% end %>
+              </b>
+            </p>
+          </div>
+        <% end %>
+        <%= link_to StateFile::Questions::NjRetirementIncomeSourceController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
+          <%= t(".review_and_edit") %>
+          <span class="sr-only"><%= t(".retirement_income_source") %></span>
+        <% end %>
+      </div>
+    </section>
+  <% end %>
 
   <section id="medical_expenses" class="white-group">
     <div class="spacing-below-5">

--- a/app/views/state_file/questions/nj_review/edit.html.erb
+++ b/app/views/state_file/questions/nj_review/edit.html.erb
@@ -108,7 +108,7 @@
     </section>
   <% end %>
 
-  <% if current_intake.state_file1099_rs.length.positive? %>
+  <% if current_intake.state_file1099_rs.length.positive? && Flipper.enabled?(:show_retirement_ui) %>
     <section id="retirement-income-source" class="white-group">
       <div class="spacing-below-5">
         <h2 class="text--body text--bold spacing-below-25"><%=t(".retirement_income_source") %></h2>

--- a/app/views/state_file/questions/nj_review/edit.html.erb
+++ b/app/views/state_file/questions/nj_review/edit.html.erb
@@ -114,23 +114,25 @@
         <h2 class="text--body text--bold spacing-below-25"><%=t(".retirement_income_source") %></h2>
 
         <% current_intake.state_file1099_rs.each do |state_file1099_r| %>
-          <div class="spacing-below-5 with-top-separator">
-            <p><%= t(".retirement_income_source_doc_1099r_label") %> <b><%= state_file1099_r.payer_name %></b></p>
-            <p><%= t(".retirement_income_source_taxpayer_name_label") %> <b><%= state_file1099_r.recipient_name %></b></p>
-            <p><%= t(".retirement_income_source_taxable_amount_label") %> <b><%= number_to_currency(state_file1099_r.taxable_amount, precision: 0) %></b></p>
-            <p>
-              <%= t(".retirement_income_source_label") %>
-              <b>
-                <% if state_file1099_r.state_specific_followup.income_source_military_pension? %>
-                  <%= t(".retirement_income_source_military_pension") %>
-                <% elsif state_file1099_r.state_specific_followup.income_source_military_survivors_benefits? %>
-                  <%= t(".retirement_income_source_military_survivor_benefit") %>
-                <% else %>
-                  <%= t(".retirement_income_source_none") %>
-                <% end %>
-              </b>
-            </p>
-          </div>
+          <% unless state_file1099_r.state_specific_followup.nil? %>
+            <div class="spacing-below-5 with-top-separator">
+              <p><%= t(".retirement_income_source_doc_1099r_label") %> <b><%= state_file1099_r.payer_name %></b></p>
+              <p><%= t(".retirement_income_source_taxpayer_name_label") %> <b><%= state_file1099_r.recipient_name %></b></p>
+              <p><%= t(".retirement_income_source_taxable_amount_label") %> <b><%= number_to_currency(state_file1099_r.taxable_amount, precision: 0) %></b></p>
+              <p>
+                <%= t(".retirement_income_source_label") %>
+                <b>
+                  <% if state_file1099_r.state_specific_followup.income_source_military_pension? %>
+                    <%= t(".retirement_income_source_military_pension") %>
+                  <% elsif state_file1099_r.state_specific_followup.income_source_military_survivors_benefits? %>
+                    <%= t(".retirement_income_source_military_survivor_benefit") %>
+                  <% else %>
+                    <%= t(".retirement_income_source_none") %>
+                  <% end %>
+                </b>
+              </p>
+            </div>
+          <% end %>
         <% end %>
         <%= link_to StateFile::Questions::NjRetirementIncomeSourceController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
           <%= t(".review_and_edit") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3530,6 +3530,21 @@ en:
           no_id: No driver's license or state ID / Prefer not to share
           subtitle: Details from your state-issued ID, if you have one, will help New Jersey combat stolen-identity tax fraud and protect you and your tax refund.
           title: Confirm Your Identity (Optional)
+      nj_retirement_income_source:
+        edit:
+          title: Some of your retirement income might not be taxed in New Jersey.
+          subtitle: We need more information about this 1099-R.
+          doc_1099r_label: "1099-R:"
+          taxpayer_name_label: "Taxpayer Name:"
+          taxable_amount_label: "Taxable Amount:"
+          label: "Select the source of this income:"
+          option_military_pension: U.S. military pension
+          option_military_survivor_benefit: U.S. military survivor's benefits
+          option_none_html: None of these apply <i>(Choose this if you have a civil service pension or annuity)</i>
+          helper_description_html: |
+            <p>U.S. military pensions result from service in the Army, Navy, Air Force, Marine Corps, or Coast Guard. Generally, qualifying military pensions and military survivor's benefit payments are paid by the U.S. Defense Finance and Accounting Service.</p>
+            <p>Civil service pensions and annuities do not count as military pensions, even if they are based on credit for military service. Generally, civil service annuities are paid by the U.S. Office of Personnel Management.</p>
+          helper_heading: What counts as a U.S. military pension?
       nj_review:
         edit:
           amount_calculated: Calculated Amount
@@ -3556,6 +3571,14 @@ en:
           property_tax_credit_deduction: New Jersey Property Tax Deduction or Credit
           property_tax_paid: Property taxes paid in %{filing_year}
           rent_paid: Rent paid in %{filing_year}
+          retirement_income_source: 1099-R Retirement Income
+          retirement_income_source_doc_1099r_label: "1099-R:"
+          retirement_income_source_taxpayer_name_label: "Taxpayer Name:"
+          retirement_income_source_taxable_amount_label: "Taxable Amount:"
+          retirement_income_source_label: "Source:"
+          retirement_income_source_military_pension: U.S. military pension
+          retirement_income_source_military_survivor_benefit: U.S. military survivor's benefits
+          retirement_income_source_none: Neither U.S. military pension nor U.S. military survivor's benefits
           reveal:
             15_wages_salaries_tips: Wages, salaries, tips
             16a_interest_income: Interest income

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3532,19 +3532,19 @@ en:
           title: Confirm Your Identity (Optional)
       nj_retirement_income_source:
         edit:
-          title: Some of your retirement income might not be taxed in New Jersey.
-          subtitle: We need more information about this 1099-R.
-          doc_1099r_label: "1099-R:"
-          taxpayer_name_label: "Taxpayer Name:"
-          taxable_amount_label: "Taxable Amount:"
-          label: "Select the source of this income:"
-          option_military_pension: U.S. military pension
-          option_military_survivor_benefit: U.S. military survivor's benefits
-          option_none_html: None of these apply <i>(Choose this if you have a civil service pension or annuity)</i>
+          doc_1099r_label: '1099-R:'
           helper_description_html: |
             <p>U.S. military pensions result from service in the Army, Navy, Air Force, Marine Corps, or Coast Guard. Generally, qualifying military pensions and military survivor's benefit payments are paid by the U.S. Defense Finance and Accounting Service.</p>
             <p>Civil service pensions and annuities do not count as military pensions, even if they are based on credit for military service. Generally, civil service annuities are paid by the U.S. Office of Personnel Management.</p>
           helper_heading: What counts as a U.S. military pension?
+          label: 'Select the source of this income:'
+          option_military_pension: U.S. military pension
+          option_military_survivor_benefit: U.S. military survivor's benefits
+          option_none_html: None of these apply <i>(Choose this if you have a civil service pension or annuity)</i>
+          subtitle: We need more information about this 1099-R.
+          taxable_amount_label: 'Taxable Amount:'
+          taxpayer_name_label: 'Taxpayer Name:'
+          title: Some of your retirement income might not be taxed in New Jersey.
       nj_review:
         edit:
           amount_calculated: Calculated Amount
@@ -3572,13 +3572,13 @@ en:
           property_tax_paid: Property taxes paid in %{filing_year}
           rent_paid: Rent paid in %{filing_year}
           retirement_income_source: 1099-R Retirement Income
-          retirement_income_source_doc_1099r_label: "1099-R:"
-          retirement_income_source_taxpayer_name_label: "Taxpayer Name:"
-          retirement_income_source_taxable_amount_label: "Taxable Amount:"
-          retirement_income_source_label: "Source:"
+          retirement_income_source_doc_1099r_label: '1099-R:'
+          retirement_income_source_label: 'Source:'
           retirement_income_source_military_pension: U.S. military pension
           retirement_income_source_military_survivor_benefit: U.S. military survivor's benefits
           retirement_income_source_none: Neither U.S. military pension nor U.S. military survivor's benefits
+          retirement_income_source_taxable_amount_label: 'Taxable Amount:'
+          retirement_income_source_taxpayer_name_label: 'Taxpayer Name:'
           reveal:
             15_wages_salaries_tips: Wages, salaries, tips
             16a_interest_income: Interest income

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3540,7 +3540,7 @@ en:
           label: 'Select the source of this income:'
           option_military_pension: U.S. military pension
           option_military_survivor_benefit: U.S. military survivor's benefits
-          option_none_html: None of these apply <i>(Choose this if you have a civil service pension or annuity)</i>
+          option_none: None of these apply (Choose this if you have a civil service pension or annuity)
           subtitle: We need more information about this 1099-R.
           taxable_amount_label: 'Taxable Amount:'
           taxpayer_name_label: 'Taxpayer Name:'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3477,7 +3477,7 @@ es:
           label: 'Select the source of this income:'
           option_military_pension: U.S. military pension
           option_military_survivor_benefit: U.S. military survivor's benefits
-          option_none_html: None of these apply <i>(Choose this if you have a civil service pension or annuity)</i>
+          option_none: None of these apply (Choose this if you have a civil service pension or annuity)
           subtitle: We need more information about this 1099-R.
           taxable_amount_label: 'Taxable Amount:'
           taxpayer_name_label: 'Taxpayer Name:'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3469,19 +3469,19 @@ es:
           title: Confirma tu Identidad (Opcional)
       nj_retirement_income_source:
         edit:
-          title: Some of your retirement income might not be taxed in New Jersey.
-          subtitle: We need more information about this 1099-R.
-          doc_1099r_label: "1099-R:"
-          taxpayer_name_label: "Taxpayer Name:"
-          taxable_amount_label: "Taxable Amount:"
-          label: "Select the source of this income:"
-          option_military_pension: U.S. military pension
-          option_military_survivor_benefit: U.S. military survivor's benefits
-          option_none_html: None of these apply <i>(Choose this if you have a civil service pension or annuity)</i>
+          doc_1099r_label: '1099-R:'
           helper_description_html: |
             <p>U.S. military pensions result from service in the Army, Navy, Air Force, Marine Corps, or Coast Guard. Generally, qualifying military pensions and military survivor's benefit payments are paid by the U.S. Defense Finance and Accounting Service.</p>
             <p>Civil service pensions and annuities do not count as military pensions, even if they are based on credit for military service. Generally, civil service annuities are paid by the U.S. Office of Personnel Management.</p>
           helper_heading: What counts as a U.S. military pension?
+          label: 'Select the source of this income:'
+          option_military_pension: U.S. military pension
+          option_military_survivor_benefit: U.S. military survivor's benefits
+          option_none_html: None of these apply <i>(Choose this if you have a civil service pension or annuity)</i>
+          subtitle: We need more information about this 1099-R.
+          taxable_amount_label: 'Taxable Amount:'
+          taxpayer_name_label: 'Taxpayer Name:'
+          title: Some of your retirement income might not be taxed in New Jersey.
       nj_review:
         edit:
           amount_calculated: Monto calculado
@@ -3509,13 +3509,13 @@ es:
           property_tax_paid: Impuestos sobre la propiedad pagados en %{filing_year}
           rent_paid: Alquiler pagado en %{filing_year}
           retirement_income_source: 1099-R Retirement Income Source
-          retirement_income_source_doc_1099r_label: "1099-R:"
-          retirement_income_source_taxpayer_name_label: "Taxpayer Name:"
-          retirement_income_source_taxable_amount_label: "Taxable Amount:"
-          retirement_income_source_label: "Source:"
+          retirement_income_source_doc_1099r_label: '1099-R:'
+          retirement_income_source_label: 'Source:'
           retirement_income_source_military_pension: U.S. military pension
           retirement_income_source_military_survivor_benefit: U.S. military survivor's benefits
           retirement_income_source_none: Neither U.S. military pension nor U.S. military survivor's benefits
+          retirement_income_source_taxable_amount_label: 'Taxable Amount:'
+          retirement_income_source_taxpayer_name_label: 'Taxpayer Name:'
           reveal:
             15_wages_salaries_tips: Salarios, sueldos, propinas
             16a_interest_income: Ingreso total

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3467,6 +3467,21 @@ es:
           no_id: No tiene licencia de conducir ni identificación estatal/ Prefiere no compartirla
           subtitle: Si tienes una identificación emitida por el estado (state-issued ID), ayudará a New Jersey a combatir el fraude fiscal por robo de identidad y a protegerte a ti y a tu reembolso de impuestos.
           title: Confirma tu Identidad (Opcional)
+      nj_retirement_income_source:
+        edit:
+          title: Some of your retirement income might not be taxed in New Jersey.
+          subtitle: We need more information about this 1099-R.
+          doc_1099r_label: "1099-R:"
+          taxpayer_name_label: "Taxpayer Name:"
+          taxable_amount_label: "Taxable Amount:"
+          label: "Select the source of this income:"
+          option_military_pension: U.S. military pension
+          option_military_survivor_benefit: U.S. military survivor's benefits
+          option_none_html: None of these apply <i>(Choose this if you have a civil service pension or annuity)</i>
+          helper_description_html: |
+            <p>U.S. military pensions result from service in the Army, Navy, Air Force, Marine Corps, or Coast Guard. Generally, qualifying military pensions and military survivor's benefit payments are paid by the U.S. Defense Finance and Accounting Service.</p>
+            <p>Civil service pensions and annuities do not count as military pensions, even if they are based on credit for military service. Generally, civil service annuities are paid by the U.S. Office of Personnel Management.</p>
+          helper_heading: What counts as a U.S. military pension?
       nj_review:
         edit:
           amount_calculated: Monto calculado
@@ -3493,6 +3508,14 @@ es:
           property_tax_credit_deduction: Deducción o Crédito por Impuestos a la Propiedad
           property_tax_paid: Impuestos sobre la propiedad pagados en %{filing_year}
           rent_paid: Alquiler pagado en %{filing_year}
+          retirement_income_source: 1099-R Retirement Income Source
+          retirement_income_source_doc_1099r_label: "1099-R:"
+          retirement_income_source_taxpayer_name_label: "Taxpayer Name:"
+          retirement_income_source_taxable_amount_label: "Taxable Amount:"
+          retirement_income_source_label: "Source:"
+          retirement_income_source_military_pension: U.S. military pension
+          retirement_income_source_military_survivor_benefit: U.S. military survivor's benefits
+          retirement_income_source_none: Neither U.S. military pension nor U.S. military survivor's benefits
           reveal:
             15_wages_salaries_tips: Salarios, sueldos, propinas
             16a_interest_income: Ingreso total

--- a/db/migrate/20250205160115_add_income_source_to_state_file_nj1099_r_followup.rb
+++ b/db/migrate/20250205160115_add_income_source_to_state_file_nj1099_r_followup.rb
@@ -1,0 +1,5 @@
+class AddIncomeSourceToStateFileNj1099RFollowup < ActiveRecord::Migration[7.1]
+  def change
+    add_column :state_file_nj1099_r_followups, :income_source, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_05_153246) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_05_160115) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -2242,6 +2242,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_05_153246) do
 
   create_table "state_file_nj1099_r_followups", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.integer "income_source", default: 0, null: false
     t.datetime "updated_at", null: false
   end
 

--- a/spec/controllers/state_file/questions/nj_retirement_income_source_controller_spec.rb
+++ b/spec/controllers/state_file/questions/nj_retirement_income_source_controller_spec.rb
@@ -1,0 +1,134 @@
+require "rails_helper"
+
+RSpec.describe StateFile::Questions::NjRetirementIncomeSourceController do
+  let(:intake) { create :state_file_nj_intake }
+  before do
+    sign_in intake
+  end
+
+  describe "#show?" do
+    context "when they have no 1099Rs in their DF XML" do
+      let(:intake) { create :state_file_nj_intake, :df_data_2_w2s }
+      it "does not show" do
+        expect(described_class.show?(intake)).to eq false
+      end
+    end
+
+    context "when they have at least one 1099R in their DF XML" do
+      let(:intake) { create :state_file_nj_intake, :df_data_2_1099r }
+      it "shows" do
+        expect(described_class.show?(intake)).to eq true
+      end
+    end
+  end
+
+  describe "#edit" do
+    let(:intake) { create :state_file_nj_intake, :df_data_2_1099r }
+    render_views
+
+    it 'succeeds' do
+      get :edit
+      expect(response).to be_successful
+    end
+
+    context "when an index is not provided" do
+      it "renders the data for the first 1099R" do
+        get :edit
+        expect(response.body).to include("Payer Name")
+        expect(response.body).to include("$1,000")
+        expect(response.body).to include("Zeus Thunder")
+
+        expect(response.body).not_to include("Payer 2 Name")
+        expect(response.body).not_to include("$3,000")
+        expect(response.body).not_to include("Hera Thunder")
+      end
+    end
+
+    context "when an index param is provided" do
+      it "renders the data for the 1099R at that index" do
+        get :edit, params: { index: 1 }
+        expect(response.body).to include("Payer 2 Name")
+        expect(response.body).to include("$3,000")
+        expect(response.body).to include("Hera Thunder")
+
+        expect(response.body).not_to include("Payer Name")
+        expect(response.body).not_to include("$1,000")
+      end
+    end
+  end
+
+  describe "#next_path" do
+    let(:intake) { create :state_file_nj_intake, :df_data_2_1099r }
+
+    context 'when not return_to_review' do
+      context "when there are additional 1099Rs to view" do
+        it "next path is NjRetirementIncomeSourceController with new index set" do
+          post :update
+          expect(subject.next_path).to eq("/en/questions/nj-retirement-income-source?index=1")
+        end
+      end
+
+      context "when there are no additional 1099Rs to view" do
+        it "next path is whichever is next overall" do
+          post :update, params: {index: "1"}
+          allow_any_instance_of(described_class.superclass).to receive(:next_path).and_return("/mocked/super/path")
+          expect(subject.next_path).to eq("/mocked/super/path")
+        end
+      end
+    end
+
+    context 'when return_to_review' do
+      context "when there are additional 1099Rs to view" do
+        it "next path is NjRetirementIncomeSourceController with new index set and review param" do
+          post :update, params: { return_to_review: "y" }
+          expect(subject.next_path).to eq("/en/questions/nj-retirement-income-source?index=1&return_to_review=y")
+        end
+      end
+
+      context "when there are no additional 1099Rs to view" do
+        it "next path is Review Controller" do
+          post :update, params: {index: "1", return_to_review: "y"}
+          expect(subject.next_path).to eq("/en/questions/#{intake.state_code}-review")
+        end
+      end
+    end
+  end
+
+  describe "#prev_path" do
+    let(:intake) { create :state_file_nj_intake, :df_data_2_1099r }
+
+    context 'when not return_to_review' do
+      context "when there are previous 1099Rs to view" do
+        it "prev path is NjRetirementIncomeSourceController with prev index set" do
+          get :edit, params: { index: "1" }
+          expect(subject.prev_path).to eq("/en/questions/nj-retirement-income-source?index=0")
+        end
+      end
+
+      context "when there are no previous 1099Rs to view" do
+        it "prev path is whichever is previous overall" do
+          get :edit
+          allow_any_instance_of(described_class.superclass).to receive(:prev_path).and_return("/mocked/super/path")
+          expect(subject.prev_path).to eq("/mocked/super/path")
+        end
+      end
+    end
+
+    context 'when return_to_review' do
+      context "when there are previous 1099Rs to view" do
+        it "prev path is NjRetirementIncomeSourceController with prev index and return to review set" do
+          get :edit, params: { index: "1", return_to_review: "y" }
+          expect(subject.prev_path).to eq("/en/questions/nj-retirement-income-source?index=0&return_to_review=y")
+        end
+      end
+
+      context "when there are no previous 1099Rs to view" do
+        it "prev path is review screen" do
+          get :edit, params: { return_to_review: "y" }
+          expect(subject.prev_path).to eq("/en/questions/nj-review")
+        end
+      end
+    end
+  end
+end
+

--- a/spec/controllers/state_file/questions/nj_retirement_income_source_controller_spec.rb
+++ b/spec/controllers/state_file/questions/nj_retirement_income_source_controller_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe StateFile::Questions::NjRetirementIncomeSourceController do
   let(:intake) { create :state_file_nj_intake }
   before do
     sign_in intake
+    allow(Flipper).to receive(:enabled?).and_call_original
+    allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)
   end
 
   describe "#show?" do

--- a/spec/factories/state_file_nj1099_r_followups.rb
+++ b/spec/factories/state_file_nj1099_r_followups.rb
@@ -2,9 +2,10 @@
 #
 # Table name: state_file_nj1099_r_followups
 #
-#  id         :bigint           not null, primary key
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id            :bigint           not null, primary key
+#  income_source :integer          default("unfilled"), not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
 #
 FactoryBot.define do
   factory :state_file_nj1099_r_followup do

--- a/spec/factories/state_file_nj_intakes.rb
+++ b/spec/factories/state_file_nj_intakes.rb
@@ -125,7 +125,7 @@ FactoryBot.define do
     raw_direct_file_data { StateFile::DirectFileApiResponseSampleService.new.read_xml("nj_zeus_one_dep") }
     raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nj_zeus_one_dep') }
     df_data_import_succeeded_at { DateTime.now }
-    
+
     after(:build) do |intake, evaluator|
       intake.municipality_code = "0101"
       numeric_status = {
@@ -152,6 +152,7 @@ FactoryBot.define do
       intake.update(overrides)
 
       intake.synchronize_df_w2s_to_database
+      intake.synchronize_df_1099_rs_to_database
       intake.synchronize_df_dependents_to_database
       intake.dependents.each_with_index do |dependent, i|
         dependent.update(dob: Date.new(MultiTenantService.new(:statefile).current_tax_year - i, 1, 1))
@@ -161,6 +162,11 @@ FactoryBot.define do
     trait :df_data_2_w2s do
       raw_direct_file_data { StateFile::DirectFileApiResponseSampleService.new.read_xml('nj_zeus_two_w2s') }
       raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nj_zeus_two_w2s') }
+    end
+
+    trait :df_data_2_1099r do
+      raw_direct_file_data { StateFile::DirectFileApiResponseSampleService.new.read_xml('nj_zeus_two_1099r') }
+      raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nj_zeus_two_1099r') }
     end
 
     trait :df_data_irs_test_with_missing_info do
@@ -264,7 +270,7 @@ FactoryBot.define do
       raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nj_jones_mfj') }
       filing_status { "married_filing_jointly" }
     end
-    
+
     trait :df_data_box_14 do
       raw_direct_file_data { StateFile::DirectFileApiResponseSampleService.new.read_xml('nj_lucky_single') }
       raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nj_lucky_single') }

--- a/spec/fixtures/state_file/fed_return_jsons/nj/zeus_two_1099r.json
+++ b/spec/fixtures/state_file/fed_return_jsons/nj/zeus_two_1099r.json
@@ -1,0 +1,32 @@
+{
+  "familyAndHousehold": [
+    {
+      "firstName": "Kronos",
+      "middleInitial": "T",
+      "lastName": "Athens",
+      "dateOfBirth": "1920-01-01",
+      "relationship": "parent",
+      "eligibleDependent": true,
+      "isClaimedDependent": true,
+      "tin": "300-00-0029"
+    }
+  ],
+  "filers": [
+    {
+      "firstName": "Zeus",
+      "middleInitial": "L",
+      "lastName": "Thunder",
+      "dateOfBirth": "1980-01-01",
+      "isPrimaryFiler": true,
+      "tin": "400-00-0015"
+    },
+    {
+      "firstName": "Hera",
+      "middleInitial": null,
+      "lastName": "Thunder",
+      "dateOfBirth": "1980-01-01",
+      "isPrimaryFiler": false,
+      "tin": "600-00-0013"
+    }
+  ]
+}

--- a/spec/fixtures/state_file/fed_return_xmls/nj/zeus_two_1099r.xml
+++ b/spec/fixtures/state_file/fed_return_xmls/nj/zeus_two_1099r.xml
@@ -1,0 +1,350 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Return xmlns="http://www.irs.gov/efile" xmlns:efile="http://www.irs.gov/efile" returnVersion="2023v5.0">
+  <ReturnHeader binaryAttachmentCnt="0">
+    <ReturnTs>******</ReturnTs>
+    <TaxYr>2023</TaxYr>
+    <TaxPeriodBeginDt>2023-01-01</TaxPeriodBeginDt>
+    <TaxPeriodEndDt>2023-12-31</TaxPeriodEndDt>
+    <SoftwareId>******</SoftwareId>
+    <SoftwareVersionNum>******</SoftwareVersionNum>
+    <OriginatorGrp>
+      <EFIN>******</EFIN>
+      <OriginatorTypeCd>OnlineFiler</OriginatorTypeCd>
+    </OriginatorGrp>
+    <SelfSelectPINGrp>
+      <PrimaryBirthDt>1973-01-02</PrimaryBirthDt>
+      <SpouseBirthDt>1978-02-03</SpouseBirthDt>
+      <PrimaryPriorYearPIN>12345</PrimaryPriorYearPIN>
+      <SpousePriorYearPIN>54321</SpousePriorYearPIN>
+    </SelfSelectPINGrp>
+    <PINTypeCd>Self-Select On-Line</PINTypeCd>
+    <JuratDisclosureCd>Online Self Select PIN</JuratDisclosureCd>
+    <PrimaryPINEnteredByCd>Taxpayer</PrimaryPINEnteredByCd>
+    <SpousePINEnteredByCd>Taxpayer</SpousePINEnteredByCd>
+    <PrimarySignaturePIN>54321</PrimarySignaturePIN>
+    <SpouseSignaturePIN>12345</SpouseSignaturePIN>
+    <PrimarySignatureDt>2024-01-27</PrimarySignatureDt>
+    <SpouseSignatureDt>2024-01-27</SpouseSignatureDt>
+    <ReturnTypeCd>1040</ReturnTypeCd>
+    <Filer>
+      <PrimarySSN>400000015</PrimarySSN>
+      <SpouseSSN>600000013</SpouseSSN>
+      <NameLine1Txt>ZEUS L &amp; HERA&lt;THUNDER</NameLine1Txt>
+      <PrimaryNameControlTxt>THUN</PrimaryNameControlTxt>
+      <SpouseNameControlTxt>THUN</SpouseNameControlTxt>
+      <USAddress>
+        <AddressLine1Txt>391 US-206</AddressLine1Txt>
+        <CityNm>Hammonton</CityNm>
+        <StateAbbreviationCd>NJ</StateAbbreviationCd>
+        <ZIPCd>08037</ZIPCd>
+      </USAddress>
+      <PhoneNum>2125555555</PhoneNum>
+    </Filer>
+    <AdditionalFilerInformation>
+      <AtSubmissionCreationGrp/>
+      <AtSubmissionFilingGrp>
+        <RefundProductElectionInd>false</RefundProductElectionInd>
+        <RefundDisbursementGrp>
+          <RefundDisbursementCd>3</RefundDisbursementCd>
+        </RefundDisbursementGrp>
+        <EmailAddressTxt>zeus.thunder@aol.com</EmailAddressTxt>
+      </AtSubmissionFilingGrp>
+      <TrustedCustomerGrp>
+        <TrustedCustomerCd>0</TrustedCustomerCd>
+        <OOBSecurityVerificationCd>11</OOBSecurityVerificationCd>
+        <AuthenticationAssuranceLevelCd>AAL2</AuthenticationAssuranceLevelCd>
+        <IdentityAssuranceLevelCd>IAL2</IdentityAssuranceLevelCd>
+        <FederatedAssuranceLevelCd>FAL2</FederatedAssuranceLevelCd>
+      </TrustedCustomerGrp>
+    </AdditionalFilerInformation>
+    <FilingSecurityInformation>
+      <AtSubmissionCreationGrp>
+        <IPAddress>
+          <IPv4AddressTxt>76.122.220.120</IPv4AddressTxt>
+        </IPAddress>
+        <IPPortNum>57374</IPPortNum>
+        <DeviceId>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA</DeviceId>
+        <DeviceTypeCd>1</DeviceTypeCd>
+        <UserAgentTxt>curl/8.4.0</UserAgentTxt>
+        <BrowserLanguageTxt>en-us</BrowserLanguageTxt>
+        <PlatformTxt>iOS</PlatformTxt>
+        <TimeZoneOffsetNum>+240</TimeZoneOffsetNum>
+        <SystemTs>******</SystemTs>
+      </AtSubmissionCreationGrp>
+      <AtSubmissionFilingGrp>
+        <IPAddress>
+          <IPv4AddressTxt>76.122.220.120</IPv4AddressTxt>
+        </IPAddress>
+        <FinalIPPortNum>******</FinalIPPortNum>
+        <DeviceId>AEAEF1FED33281B55BDA9E1D6496D6A12D6085D7</DeviceId>
+        <DeviceTypeCd>1</DeviceTypeCd>
+        <UserAgentTxt>curl/8.4.0</UserAgentTxt>
+        <TimeZoneOffsetNum>-005</TimeZoneOffsetNum>
+        <SystemTs>******</SystemTs>
+      </AtSubmissionFilingGrp>
+      <FederalOriginalSubmissionId>******</FederalOriginalSubmissionId>
+      <FederalOriginalSubmissionIdDt>******</FederalOriginalSubmissionIdDt>
+      <FilingLicenseTypeCd>I</FilingLicenseTypeCd>
+      <TotalPreparationSubmissionTs>0</TotalPreparationSubmissionTs>
+      <TotActiveTimePrepSubmissionTs>0</TotActiveTimePrepSubmissionTs>
+      <AuthenticationReviewCd>5</AuthenticationReviewCd>
+      <VendorControlNum>******</VendorControlNum>
+    </FilingSecurityInformation>
+  </ReturnHeader>
+  <ReturnData documentCnt="6">
+    <IRS1040 documentId="IRS10400001">
+      <IndividualReturnFilingStatusCd>2</IndividualReturnFilingStatusCd>
+      <VirtualCurAcquiredDurTYInd>false</VirtualCurAcquiredDurTYInd>
+      <TotalExemptPrimaryAndSpouseCnt>2</TotalExemptPrimaryAndSpouseCnt>
+      <DependentDetail>
+        <DependentFirstNm>KRONOS</DependentFirstNm>
+        <DependentLastNm>ATHENS</DependentLastNm>
+        <DependentNameControlTxt>ATHE</DependentNameControlTxt>
+        <DependentSSN>300000029</DependentSSN>
+        <DependentRelationshipCd>PARENT</DependentRelationshipCd>
+        <EligibleForODCInd>X</EligibleForODCInd>
+      </DependentDetail>
+      <MoreDependentsInd></MoreDependentsInd>
+      <ChldWhoLivedWithYouCnt>1</ChldWhoLivedWithYouCnt>
+      <OtherDependentsListedCnt>0</OtherDependentsListedCnt>
+      <TotalExemptionsCnt>13</TotalExemptionsCnt>
+      <WagesAmt referenceDocumentId="W20001" referenceDocumentName="IRSW2">50000</WagesAmt>
+      <WagesSalariesAndTipsAmt>50000</WagesSalariesAndTipsAmt>
+      <TaxableInterestAmt>500</TaxableInterestAmt>
+      <SocSecBnftAmt>8000</SocSecBnftAmt>
+      <TaxableSocSecAmt>6800</TaxableSocSecAmt>
+      <TotalAdditionalIncomeAmt>500</TotalAdditionalIncomeAmt>
+      <TotalIncomeAmt>57800</TotalIncomeAmt>
+      <TotalAdjustmentsAmt>1500</TotalAdjustmentsAmt>
+      <AdjustedGrossIncomeAmt>56300</AdjustedGrossIncomeAmt>
+      <TotalItemizedOrStandardDedAmt>27700</TotalItemizedOrStandardDedAmt>
+      <TotalDeductionsAmt>27700</TotalDeductionsAmt>
+      <TaxableIncomeAmt>28600</TaxableIncomeAmt>
+      <TaxAmt>2995</TaxAmt>
+      <TotalTaxBeforeCrAndOthTaxesAmt>2995</TotalTaxBeforeCrAndOthTaxesAmt>
+      <CTCODCAmt>2995</CTCODCAmt>
+      <TotalCreditsAmt>2995</TotalCreditsAmt>
+      <FormW2WithheldTaxAmt>1000</FormW2WithheldTaxAmt>
+      <Form1099WithheldTaxAmt referenceDocumentId="OTHERWITHHOLDING0001" referenceDocumentName="OtherWithholdingStatement">5</Form1099WithheldTaxAmt>
+      <WithholdingTaxAmt>1005</WithholdingTaxAmt>
+      <EarnedIncomeCreditAmt referenceDocumentId="IRSEIC0001" referenceDocumentName="IRS1040ScheduleEIC">1490</EarnedIncomeCreditAmt>
+      <AdditionalChildTaxCreditAmt referenceDocumentId="IRS8812001" referenceDocumentName="IRS1040Schedule8812">6400</AdditionalChildTaxCreditAmt>
+      <RefundableCreditsAmt>7890</RefundableCreditsAmt>
+      <TotalPaymentsAmt>8895</TotalPaymentsAmt>
+      <OverpaidAmt>8895</OverpaidAmt>
+      <RefundAmt>8895</RefundAmt>
+      <OwedAmt>0</OwedAmt>
+      <ThirdPartyDesigneeInd>false</ThirdPartyDesigneeInd>
+      <PrimaryOccupationTxt>God of Thunder</PrimaryOccupationTxt>
+      <SpouseOccupationTxt>stay at home parent</SpouseOccupationTxt>
+      <RefundProductCd>NO FINANCIAL PRODUCT</RefundProductCd>
+    </IRS1040>
+    <IRS1099R documentId="IRS1099R0001">
+      <PayerNameControlTxt>PAYE</PayerNameControlTxt>
+      <PayerName>
+        <BusinessNameLine1Txt>Payer Name</BusinessNameLine1Txt>
+      </PayerName>
+      <PayerUSAddress>
+        <AddressLine1Txt>2030 Pecan Street</AddressLine1Txt>
+        <CityNm>Monroe</CityNm>
+        <StateAbbreviationCd>NC</StateAbbreviationCd>
+        <ZIPCd>05502</ZIPCd>
+      </PayerUSAddress>
+      <PayerEIN>000000008</PayerEIN>
+      <PhoneNum>2025551212</PhoneNum>
+      <RecipientSSN>400000015</RecipientSSN>
+      <RecipientNm>Zeus Thunder</RecipientNm>
+      <RecipientUSAddress>
+        <AddressLine1Txt>2030 Pecan Street</AddressLine1Txt>
+        <CityNm>Monroe</CityNm>
+        <StateAbbreviationCd>NC</StateAbbreviationCd>
+        <ZIPCd>02301</ZIPCd>
+      </RecipientUSAddress>
+      <GrossDistributionAmt>200</GrossDistributionAmt>
+      <TaxableAmt>1000</TaxableAmt>
+      <FederalIncomeTaxWithheldAmt>300</FederalIncomeTaxWithheldAmt>
+      <F1099RDistributionCd>7</F1099RDistributionCd>
+      <F1099RStateLocalTaxGrp>
+        <F1099RStateTaxGrp>
+          <F1099RLocalTaxGrp/>
+        </F1099RStateTaxGrp>
+      </F1099RStateLocalTaxGrp>
+      <F1099RStateLocalTaxGrp>
+        <F1099RStateTaxGrp/>
+      </F1099RStateLocalTaxGrp>
+      <StandardOrNonStandardCd>S</StandardOrNonStandardCd>
+    </IRS1099R>
+    <IRS1099R documentId="IRS1099R0002">
+      <PayerNameControlTxt>PAYE</PayerNameControlTxt>
+      <PayerName>
+        <BusinessNameLine1Txt>Payer 2 Name</BusinessNameLine1Txt>
+        <BusinessNameLine2Txt>Line 2</BusinessNameLine2Txt>
+      </PayerName>
+      <PayerEIN>000000009</PayerEIN>
+      <RecipientSSN>600000013</RecipientSSN>
+      <RecipientNm>Hera Thunder</RecipientNm>
+      <RecipientUSAddress>
+        <AddressLine1Txt>20 Override Street</AddressLine1Txt>
+        <AddressLine2Txt>Line Two</AddressLine2Txt>
+        <CityNm>Monroe</CityNm>
+        <StateAbbreviationCd>NC</StateAbbreviationCd>
+        <ZIPCd>70201</ZIPCd>
+      </RecipientUSAddress>
+      <GrossDistributionAmt>4000</GrossDistributionAmt>
+      <TaxableAmt>3000</TaxableAmt>
+      <EmployeeContributionsAmt>500</EmployeeContributionsAmt>
+      <F1099RStateLocalTaxGrp>
+        <F1099RStateTaxGrp>
+          <StateAbbreviationCd>NC</StateAbbreviationCd>
+          <StateDistributionAmt>2000</StateDistributionAmt>
+          <F1099RLocalTaxGrp>
+            <LocalTaxWithheldAmt>2000</LocalTaxWithheldAmt>
+            <LocalityNm>How Town</LocalityNm>
+            <LocalDistributionAmt>2000</LocalDistributionAmt>
+          </F1099RLocalTaxGrp>
+        </F1099RStateTaxGrp>
+      </F1099RStateLocalTaxGrp>
+      <F1099RStateLocalTaxGrp>
+        <F1099RStateTaxGrp/>
+      </F1099RStateLocalTaxGrp>
+      <StandardOrNonStandardCd>N</StandardOrNonStandardCd>
+    </IRS1099R>
+    <IRS1040Schedule1 documentId="IRS1040S1001">
+      <UnemploymentCompAmt>500</UnemploymentCompAmt>
+      <TotalAdditionalIncomeAmt>500</TotalAdditionalIncomeAmt>
+      <EducatorExpensesAmt>200</EducatorExpensesAmt>
+      <StudentLoanInterestDedAmt>1300</StudentLoanInterestDedAmt>
+      <TotalAdjustmentsAmt>1500</TotalAdjustmentsAmt>
+    </IRS1040Schedule1>
+    <IRS1040Schedule8812 documentName="IRS1040Schedule8812" documentId="IRS8812001">
+      <AdjustedGrossIncomeAmt>56300</AdjustedGrossIncomeAmt>
+      <ModifiedAGIAmt>56300</ModifiedAGIAmt>
+      <QlfyChildUnderAgeSSNCnt>1</QlfyChildUnderAgeSSNCnt>
+      <QlfyChildUnderAgeSSNLimtAmt>8000</QlfyChildUnderAgeSSNLimtAmt>
+      <OtherDependentCnt>0</OtherDependentCnt>
+      <OtherDependentCreditAmt>0</OtherDependentCreditAmt>
+      <InitialCTCODCAmt>11500</InitialCTCODCAmt>
+      <FilingStatusThresholdCd>400000</FilingStatusThresholdCd>
+      <CTCODCOverAGILimitInd>true</CTCODCOverAGILimitInd>
+      <CTCODCAfterAGILimitAmt>11500</CTCODCAfterAGILimitAmt>
+      <ACTCTaxLiabiltyLimitAmt>2995</ACTCTaxLiabiltyLimitAmt>
+      <CTCODCAmt>2995</CTCODCAmt>
+      <ClaimACTCAllFilersGrp>
+        <ACTCBeforeLimitAmt>8505</ACTCBeforeLimitAmt>
+        <QlfyChildUnderAgeSSNCnt>1</QlfyChildUnderAgeSSNCnt>
+        <QlfyChildUnderAgeSSNLimtAmt>6400</QlfyChildUnderAgeSSNLimtAmt>
+        <ACTCAfterLimitAmt>6400</ACTCAfterLimitAmt>
+        <TotalEarnedIncomeAmt>50000</TotalEarnedIncomeAmt>
+        <EarnedIncmMoreThanSpecifiedInd>true</EarnedIncmMoreThanSpecifiedInd>
+        <NetTotalEarnedIncomeAmt>47500</NetTotalEarnedIncomeAmt>
+        <NetEarnedIncomeCalculatedAmt>7125</NetEarnedIncomeCalculatedAmt>
+        <ThreeOrMoreQlfyChildrenInd>true</ThreeOrMoreQlfyChildrenInd>
+        <FromW2Amt>3825</FromW2Amt>
+        <CalcFromW2AndReturnAmt>3825</CalcFromW2AndReturnAmt>
+        <CalcAmtFromRetPlusTaxWhldAmt>1490</CalcAmtFromRetPlusTaxWhldAmt>
+        <CalculatedDifferenceAmt>2335</CalculatedDifferenceAmt>
+        <LargerCalcIncomeOrDiffAmt>7125</LargerCalcIncomeOrDiffAmt>
+      </ClaimACTCAllFilersGrp>
+      <AdditionalChildTaxCreditAmt>6400</AdditionalChildTaxCreditAmt>
+    </IRS1040Schedule8812>
+    <IRSW2 documentName="IRSW2" documentId="W20001">
+      <EmployeeSSN>400000015</EmployeeSSN>
+      <EmployerEIN>001245767</EmployerEIN>
+      <EmployerNameControlTxt>WSF</EmployerNameControlTxt>
+      <EmployerName>
+        <BusinessNameLine1Txt>Wharton State Forest</BusinessNameLine1Txt>
+      </EmployerName>
+      <EmployerUSAddress>
+        <AddressLine1Txt>31 Batsto Road</AddressLine1Txt>
+        <CityNm>Hammonton</CityNm>
+        <StateAbbreviationCd>NJ</StateAbbreviationCd>
+        <ZIPCd>08037</ZIPCd>
+      </EmployerUSAddress>
+      <EmployeeNm>ZEUS L THUNDER</EmployeeNm>
+      <EmployeeUSAddress>
+        <AddressLine1Txt>391 US-206</AddressLine1Txt>
+        <AddressLine2Txt>Unit 73</AddressLine2Txt>
+        <CityNm>Hammonton</CityNm>
+        <StateAbbreviationCd>NJ</StateAbbreviationCd>
+        <ZIPCd>08037</ZIPCd>
+      </EmployeeUSAddress>
+      <WagesAmt>12345</WagesAmt>
+      <WithholdingAmt>1000</WithholdingAmt>
+      <SocialSecurityWagesAmt>12345</SocialSecurityWagesAmt>
+      <SocialSecurityTaxAmt>3100</SocialSecurityTaxAmt>
+      <MedicareWagesAndTipsAmt>12345</MedicareWagesAndTipsAmt>
+      <MedicareTaxWithheldAmt>725</MedicareTaxWithheldAmt>
+      <OtherDeductionsBenefitsGrp>
+        <Desc>414HSUB</Desc>
+        <Amt>250</Amt>
+      </OtherDeductionsBenefitsGrp>
+      <W2StateLocalTaxGrp>
+        <W2StateTaxGrp>
+          <StateAbbreviationCd>NJ</StateAbbreviationCd>
+          <EmployerStateIdNum>12345</EmployerStateIdNum>
+          <StateWagesAmt>12345</StateWagesAmt>
+          <StateIncomeTaxAmt>500</StateIncomeTaxAmt>
+          <W2LocalTaxGrp>
+            <LocalWagesAndTipsAmt>12345</LocalWagesAndTipsAmt>
+            <LocalIncomeTaxAmt>250</LocalIncomeTaxAmt>
+            <LocalityNm>Hammonton</LocalityNm>
+          </W2LocalTaxGrp>
+        </W2StateTaxGrp>
+      </W2StateLocalTaxGrp>
+      <StandardOrNonStandardCd>S</StandardOrNonStandardCd>
+    </IRSW2>
+    <IRSW2 documentName="IRSW2" documentId="W20002">
+      <EmployeeSSN>400000016</EmployeeSSN>
+      <EmployerEIN>001245768</EmployerEIN>
+      <EmployerNameControlTxt>BTB</EmployerNameControlTxt>
+      <EmployerName>
+        <BusinessNameLine1Txt>Brendan T Byrne State Forest</BusinessNameLine1Txt>
+      </EmployerName>
+      <EmployerUSAddress>
+        <AddressLine1Txt>31 Batsto Road</AddressLine1Txt>
+        <CityNm>Hammonton</CityNm>
+        <StateAbbreviationCd>NJ</StateAbbreviationCd>
+        <ZIPCd>08037</ZIPCd>
+      </EmployerUSAddress>
+      <EmployeeNm>ZEUS L THUNDER</EmployeeNm>
+      <EmployeeUSAddress>
+        <AddressLine1Txt>391 US-206</AddressLine1Txt>
+        <AddressLine2Txt>Unit 73</AddressLine2Txt>
+        <CityNm>Hammonton</CityNm>
+        <StateAbbreviationCd>NJ</StateAbbreviationCd>
+        <ZIPCd>08037</ZIPCd>
+      </EmployeeUSAddress>
+      <WagesAmt>50000</WagesAmt>
+      <WithholdingAmt>1000</WithholdingAmt>
+      <SocialSecurityWagesAmt>50000</SocialSecurityWagesAmt>
+      <SocialSecurityTaxAmt>3100</SocialSecurityTaxAmt>
+      <MedicareWagesAndTipsAmt>50000</MedicareWagesAndTipsAmt>
+      <MedicareTaxWithheldAmt>725</MedicareTaxWithheldAmt>
+      <OtherDeductionsBenefitsGrp>
+        <Desc>414HSUB</Desc>
+        <Amt>250</Amt>
+      </OtherDeductionsBenefitsGrp>
+      <W2StateLocalTaxGrp>
+        <W2StateTaxGrp>
+          <StateAbbreviationCd>NJ</StateAbbreviationCd>
+          <EmployerStateIdNum>54321</EmployerStateIdNum>
+          <StateWagesAmt>50000</StateWagesAmt>
+          <StateIncomeTaxAmt>500</StateIncomeTaxAmt>
+          <W2LocalTaxGrp>
+            <LocalWagesAndTipsAmt>50000</LocalWagesAndTipsAmt>
+            <LocalIncomeTaxAmt>250</LocalIncomeTaxAmt>
+            <LocalityNm>Hammonton</LocalityNm>
+          </W2LocalTaxGrp>
+        </W2StateTaxGrp>
+      </W2StateLocalTaxGrp>
+      <StandardOrNonStandardCd>S</StandardOrNonStandardCd>
+    </IRSW2>
+    <OtherWithholdingStatement documentName="OtherWithholdingStatement" documentId="OTHERWITHHOLDING0001">
+      <OtherWithholdingStmt>
+        <WithholdingCd>FORM 1099</WithholdingCd>
+        <EIN>000293117</EIN>
+        <WithholdingAmt>5</WithholdingAmt>
+      </OtherWithholdingStmt>
+    </OtherWithholdingStatement>
+  </ReturnData>
+</Return>

--- a/spec/forms/state_file/nj_retirement_income_source_form_spec.rb
+++ b/spec/forms/state_file/nj_retirement_income_source_form_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe StateFile::NjRetirementIncomeSourceForm do
+  let(:intake) { create(:state_file_nj_intake) }
+  let(:state_file_1099r) { create :state_file1099_r, intake: intake }
+  let(:state_specific_followup) { create :state_file_nj1099_r_followup, state_file1099_r: state_file_1099r }
+  let(:form) { described_class.new(state_specific_followup, form_params) }
+
+  describe "validations" do
+    context "income_source is required" do
+      let(:form_params) do
+        { income_source: nil }
+      end
+
+      it "is invalid" do
+        expect(form.valid?).to eq false
+        expect(form.errors[:income_source]).to include "Can't be blank."
+      end
+    end
+
+    context "when income_source is present" do
+      let(:form_params) do
+        { income_source: :military_pension }
+      end
+
+      it "is valid" do
+        expect(form.valid?).to eq true
+      end
+    end
+  end
+
+  describe ".save" do
+    context "when saving a new county" do
+      let(:form_params) do
+        { income_source: :military_pension }
+      end
+
+      it "saves attributes" do
+        form.save
+        expect(intake.state_file1099_rs[0].state_specific_followup.income_source).to eq "military_pension"
+      end
+    end
+  end
+end

--- a/spec/forms/state_file/nj_retirement_income_source_form_spec.rb
+++ b/spec/forms/state_file/nj_retirement_income_source_form_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe StateFile::NjRetirementIncomeSourceForm do
   end
 
   describe ".save" do
-    context "when saving a new county" do
+    context "when saving an income source" do
       let(:form_params) do
         { income_source: :military_pension }
       end

--- a/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
@@ -119,6 +119,14 @@ describe SubmissionBuilder::Ty2024::States::Nj::NjReturnXml, required_schema: "n
         end
       end
 
+      context "with two 1099Rs" do
+        let(:intake) { create(:state_file_nj_intake, :df_data_2_1099r) }
+        it "does not error" do
+          builder_response = described_class.build(submission)
+          expect(builder_response.errors).not_to be_present
+        end
+      end
+
     end
 
     describe "nj 2450" do

--- a/spec/models/efile_error_spec.rb
+++ b/spec/models/efile_error_spec.rb
@@ -97,6 +97,7 @@ describe 'EfileError' do
       "nj-household-rent-own",
       "nj-ineligible-property-tax",
       "nj-medical-expenses",
+      "nj-retirement-income-source",
       "nj-review",
       "nj-sales-use-tax",
       "nj-tenant-eligibility",

--- a/spec/models/state_file_nj1099_r_followup_spec.rb
+++ b/spec/models/state_file_nj1099_r_followup_spec.rb
@@ -2,9 +2,10 @@
 #
 # Table name: state_file_nj1099_r_followups
 #
-#  id         :bigint           not null, primary key
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id            :bigint           not null, primary key
+#  income_source :integer          default("unfilled"), not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
 #
 require 'rails_helper'
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/79

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Add page to select income source for each 1099-R

## How to test?
- Use Zeus_Two_1099R
- (when running locally) use `Flipper.enable(:show_retirement_ui)` in rails console to enable the UI toggle
- (in heroku) sign into admin hub, then in the heroku app, navigate to `/en/hub/flipper/features` and enable `show_retirement_ui`

## Screenshots (for visual changes)
![image](https://github.com/user-attachments/assets/97124f82-a3df-4b4c-b5b2-acb256abd60d)
![image](https://github.com/user-attachments/assets/5b85bb04-b482-4f57-a644-5f08f8c7accb)

