### PR TITLE
[FYST-1082] Add previous path to w2 and 1099R controllers

### DIFF
--- a/app/controllers/state_file/questions/retirement_income_controller.rb
+++ b/app/controllers/state_file/questions/retirement_income_controller.rb
@@ -1,6 +1,11 @@
 module StateFile
   module Questions
     class RetirementIncomeController < QuestionsController
+
+      def prev_path
+        StateFile::Questions::IncomeReviewController.to_path_helper(return_to_review: params[:return_to_review])
+      end
+      
       def edit
         @state_file1099_r = current_intake.state_file1099_rs.find(params[:id])
       end

--- a/app/controllers/state_file/questions/w2_controller.rb
+++ b/app/controllers/state_file/questions/w2_controller.rb
@@ -6,7 +6,11 @@ module StateFile
       def self.show?(intake) # only accessed via button, not navigator
         false
       end
-      
+
+      def prev_path
+        StateFile::Questions::IncomeReviewController.to_path_helper(return_to_review: params[:return_to_review])
+      end
+
       def edit
         @state_code = current_state_code
       end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/FYST-1082

## What was done? 
Add previous path to w2 and 1099R controllers. 1099G already has a back button.

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## Screenshots (for visual changes)

<img width="641" alt="Screenshot 2025-02-05 at 3 34 04 PM" src="https://github.com/user-attachments/assets/cd61d60e-b086-401e-8587-40084b8179ce" />
<img width="631" alt="Screenshot 2025-02-05 at 3 35 09 PM" src="https://github.com/user-attachments/assets/24ec040b-918e-49a1-bc5b-8244c1a7c390" />
