### PR TITLE
[GYR1-665] Fix typos in the "Continue where you left off" message

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1475,7 +1475,7 @@ en:
           Your Tax Team at GetYourRefund
         subject: 'GetYourRefund: You have a submission in progress'
       sms:
-        body: Hello <<Client.PreferredName>> you haven''t completed providing the information we need to prepare your taxes at GetYourRefund. Continue where you left off here <<Client.LoginLink>>. Your Client ID is <<Client.ClientId>>. If you have any questions, please reply to this message.
+        body: Hello <<Client.PreferredName>>, you haven't completed providing the information we need to prepare your taxes at GetYourRefund. Continue where you left off here <<Client.LoginLink>>. Your Client ID is <<Client.ClientId>>. If you have any questions, please reply to this message.
     intercom_forwarding:
       email:
         body: This conversation has been forwarded to GetYourRefund.org's customer service specialists. You should expect to see a message from them at a different email shortly.


### PR DESCRIPTION
## Link to Jira issue

- https://codeforamerica.atlassian.net/browse/GYR1-665

## Is PM acceptance required?

- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main

## What was done?

Fixed two typos. Screenshot:

<img width="1309" alt="Screenshot 2025-02-06 at 3 28 07 PM" src="https://github.com/user-attachments/assets/8e73f2a0-9b3f-4832-ad61-0a072a78cfc9" />

## How to test?

I'm not 100% certain how to test 🫠  (it involves generating a notification), but the fix was trivial and not sure we really need to test here.
