### PR TITLE
FYST-1765 Notification emails not switching to spanish

### DIFF
--- a/app/forms/state_file/notification_preferences_form.rb
+++ b/app/forms/state_file/notification_preferences_form.rb
@@ -17,6 +17,7 @@ module StateFile
 
       if is_first_time_setup
         messaging_service = StateFile::MessagingService.new(
+          locale: I18n.locale,
           message: StateFile::AutomatedMessage::Welcome,
           intake: @intake,
           sms: sms_notification_opt_in == "yes",

--- a/app/services/state_file/after_transition_messaging_service.rb
+++ b/app/services/state_file/after_transition_messaging_service.rb
@@ -70,14 +70,15 @@ module StateFile
     def send_efile_submission_successful_submission_message
       message = StateFile::AutomatedMessage::SuccessfulSubmission
       submitted_key = @intake.efile_submissions.count > 1 ? "resubmitted" : "submitted"
-      submitted_or_resubmitted = I18n.t("messages.state_file.successful_submission.email.#{submitted_key}", locale: (@intake.locale || "en"))
+      submitted_or_resubmitted = I18n.t("messages.state_file.successful_submission.email.#{submitted_key}", locale: I18n.locale)
       body_args = { return_status_link: return_status_link, submitted_or_resubmitted: submitted_or_resubmitted }
 
       StateFile::MessagingService.new(
         intake: @intake,
         submission: @submission,
         message: message,
-        body_args: body_args
+        body_args: body_args,
+        locale: I18n.locale
       ).send_message(require_verification: false)
     end
 

--- a/spec/forms/state_file/notification_preferences_form_spec.rb
+++ b/spec/forms/state_file/notification_preferences_form_spec.rb
@@ -234,7 +234,8 @@ RSpec.describe StateFile::NotificationPreferencesForm do
             intake: intake,
             sms: false,
             email: true,
-            body_args: { intake_id: intake.id }
+            body_args: { intake_id: intake.id },
+            locale: :en
           )
           form.save
         end
@@ -255,7 +256,8 @@ RSpec.describe StateFile::NotificationPreferencesForm do
             intake: intake,
             sms: true,
             email: false,
-            body_args: { intake_id: intake.id }
+            body_args: { intake_id: intake.id },
+            locale: :en
           )
           form.save
         end
@@ -278,7 +280,8 @@ RSpec.describe StateFile::NotificationPreferencesForm do
             intake: intake,
             sms: true,
             email: true,
-            body_args: { intake_id: intake.id }
+            body_args: { intake_id: intake.id },
+            locale: :en
           )
           form.save
         end

--- a/spec/services/state_file/after_transition_messaging_service_spec.rb
+++ b/spec/services/state_file/after_transition_messaging_service_spec.rb
@@ -144,6 +144,11 @@ describe StateFile::AfterTransitionMessagingService do
   end
 
   describe "#send_efile_submission_successful_submission_message" do
+    before do
+      allow(StateFile::MessagingService).to receive(:new).with(intake: intake, submission: efile_submission, message: message, body_args: body_args, locale: :en).and_return(sf_messaging_service)
+      allow(StateFile::MessagingService).to receive(:new).with(intake: intake, submission: efile_submission, message: message).and_return(sf_messaging_service)
+    end
+
     let(:message) { StateFile::AutomatedMessage::SuccessfulSubmission }
 
     context "intake has only one submission" do
@@ -156,7 +161,7 @@ describe StateFile::AfterTransitionMessagingService do
                                                          .and change(StateFileNotificationTextMessage, :count).by(1)
 
         expect(efile_submission.message_tracker).to include "messages.state_file.successful_submission"
-        expect(StateFile::MessagingService).to have_received(:new).with(intake: intake, submission: efile_submission, message: message, body_args: body_args)
+        expect(StateFile::MessagingService).to have_received(:new).with(intake: intake, submission: efile_submission, message: message, body_args: body_args, locale: :en)
       end
     end
 
@@ -171,7 +176,7 @@ describe StateFile::AfterTransitionMessagingService do
                                                          .and change(StateFileNotificationTextMessage, :count).by(1)
 
         expect(efile_submission.message_tracker).to include "messages.state_file.successful_submission"
-        expect(StateFile::MessagingService).to have_received(:new).with(intake: intake, submission: efile_submission, message: message, body_args: body_args)
+        expect(StateFile::MessagingService).to have_received(:new).with(intake: intake, submission: efile_submission, message: message, body_args: body_args, locale: :en)
       end
     end
   end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/FYST-1765

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Fix the locale for welcome and successful submission messages to look for the locale of the intake as it currently is so that the messages are in spanish like how we do for the footer and verification code controller
- We used to look at intake.local for the submission message, but the intake.local is set as soon as the the intake is created, but a user can change the locale during the intake to spanish, and the intake.locale will not reflect this once an intake is created. 
- To keep the messaging consistent with the locale the user is at, I18.locale is used instead of intake.locale

## How to test?
- Updated the tests for welcome message and submission message 

## Screenshots (for visual changes)
- Before - body of the message did not match the footer because the footer looked at current locale while body looked for intake.locale which was set early in the intake flow
<img width="649" alt="Screenshot 2025-02-06 at 3 25 36 PM" src="https://github.com/user-attachments/assets/612de02c-1cd7-4471-aaad-cec4be9b260a" />

- After
<img width="711" alt="Screenshot 2025-02-06 at 3 24 01 PM" src="https://github.com/user-attachments/assets/a3d3e9f1-4b86-4387-8aa0-80f7f153fd99" />
