### PR TITLE
NJ 285 - return error if state_wages is 0 but wages is present

### DIFF
--- a/app/controllers/state_file/questions/income_review_controller.rb
+++ b/app/controllers/state_file/questions/income_review_controller.rb
@@ -22,9 +22,9 @@ module StateFile
 
       def update
         if current_intake.allows_w2_editing? && @w2s.any? do |w2|
-            w2.check_box14_limits = true
-            !w2.valid?(:state_file_edit)
-          end
+             w2.check_box14_limits = true
+             !w2.valid?(:state_file_edit)
+           end
           flash[:alert] = I18n.t("state_file.questions.income_review.edit.invalid_w2")
           render :edit
         else
@@ -35,6 +35,8 @@ module StateFile
       private
 
       def should_show_warning?(w2, w2_count_for_filer)
+        return true if w2.wages.present? && !w2.state_wages_amount.positive?
+
         return false if StateFile::StateInformationService
           .w2_supported_box14_codes(w2.state_file_intake.state_code)
           .none? { |code| code[:name] == "UI_WF_SWF" || code[:name] == "FLI" }

--- a/app/controllers/state_file/questions/income_review_controller.rb
+++ b/app/controllers/state_file/questions/income_review_controller.rb
@@ -35,7 +35,7 @@ module StateFile
       private
 
       def should_show_warning?(w2, w2_count_for_filer)
-        return true if w2.wages.present? && !w2.state_wages_amount.positive?
+        return true if w2.wages.positive? && !w2.state_wages_amount.positive?
 
         return false if StateFile::StateInformationService
           .w2_supported_box14_codes(w2.state_file_intake.state_code)

--- a/app/models/state_file_w2.rb
+++ b/app/models/state_file_w2.rb
@@ -54,7 +54,7 @@ class StateFileW2 < ApplicationRecord
   with_options on: :state_file_edit do
     validates :employer_state_id_num, length: { maximum: 16, message: ->(_object, _data) { I18n.t('state_file.questions.w2.edit.employer_state_id_error') } }
     validates :state_wages_amount, numericality: { greater_than_or_equal_to: 0 }, if: -> { state_wages_amount.present? }
-    validates :state_wages_amount, numericality: { greater_than: 0 }, if: -> { wages.present? }
+    validates :state_wages_amount, numericality: { greater_than: 0 }, if: -> { wages.positive? }
     validates :state_income_tax_amount, numericality: { greater_than_or_equal_to: 0 }, if: -> { state_income_tax_amount.present? }
     validates :local_wages_and_tips_amount, numericality: { greater_than_or_equal_to: 0 }, if: -> { local_wages_and_tips_amount.present? && StateFile::StateInformationService.w2_include_local_income_boxes(state_file_intake.state_code) }
     validates :local_income_tax_amount, numericality: { greater_than_or_equal_to: 0 }, if: -> { local_income_tax_amount.present? && StateFile::StateInformationService.w2_include_local_income_boxes(state_file_intake.state_code) }

--- a/app/models/state_file_w2.rb
+++ b/app/models/state_file_w2.rb
@@ -54,6 +54,7 @@ class StateFileW2 < ApplicationRecord
   with_options on: :state_file_edit do
     validates :employer_state_id_num, length: { maximum: 16, message: ->(_object, _data) { I18n.t('state_file.questions.w2.edit.employer_state_id_error') } }
     validates :state_wages_amount, numericality: { greater_than_or_equal_to: 0 }, if: -> { state_wages_amount.present? }
+    validates :state_wages_amount, numericality: { greater_than: 0 }, if: -> { wages.present? }
     validates :state_income_tax_amount, numericality: { greater_than_or_equal_to: 0 }, if: -> { state_income_tax_amount.present? }
     validates :local_wages_and_tips_amount, numericality: { greater_than_or_equal_to: 0 }, if: -> { local_wages_and_tips_amount.present? && StateFile::StateInformationService.w2_include_local_income_boxes(state_file_intake.state_code) }
     validates :local_income_tax_amount, numericality: { greater_than_or_equal_to: 0 }, if: -> { local_income_tax_amount.present? && StateFile::StateInformationService.w2_include_local_income_boxes(state_file_intake.state_code) }
@@ -98,10 +99,8 @@ class StateFileW2 < ApplicationRecord
           errors.add(:local_income_tax_amount, I18n.t("state_file.questions.w2.edit.wages_amt_error", wages_amount: w2.WagesAmt))
           errors.add(:state_income_tax_amount, I18n.t("state_file.questions.w2.edit.wages_amt_error", wages_amount: w2.WagesAmt))
         end
-      else
-        if state_income_tax_amount.present? && state_income_tax_amount > w2.WagesAmt
-          errors.add(:state_income_tax_amount, I18n.t("state_file.questions.w2.edit.wages_amt_error", wages_amount: w2.WagesAmt))
-        end
+      elsif state_income_tax_amount.present? && state_income_tax_amount > w2.WagesAmt
+        errors.add(:state_income_tax_amount, I18n.t("state_file.questions.w2.edit.wages_amt_error", wages_amount: w2.WagesAmt))
       end
     end
   end

--- a/spec/models/state_file_w2_spec.rb
+++ b/spec/models/state_file_w2_spec.rb
@@ -108,6 +108,7 @@ describe StateFileW2 do
     end
 
     it "permits state_wages_amt to be blank if state_income_tax_amt is blank" do
+      w2.wages = 0
       w2.state_wages_amount = 0
       w2.state_income_tax_amount = 0
       expect(w2).to be_valid(:state_file_edit)
@@ -120,6 +121,7 @@ describe StateFileW2 do
     end
 
     it "permits state_wages_amt to be blank if state_income_tax_amt is blank" do
+      w2.wages = 0
       w2.employer_state_id_num = nil
       w2.state_wages_amount = 0
       w2.state_income_tax_amount = 0
@@ -164,9 +166,9 @@ describe StateFileW2 do
         w2.check_box14_limits = true
         allow(StateFile::StateInformationService).to receive(:w2_supported_box14_codes)
           .and_return([
-            { name: "UI_WF_SWF", limit: 179.78 },
-            { name: "FLI", limit: 145.26 }
-          ])
+                        { name: "UI_WF_SWF", limit: 179.78 },
+                        { name: "FLI", limit: 145.26 }
+                      ])
       end
   
       it "is invalid when box14_ui_wf_swf exceeds the state limit" do
@@ -263,9 +265,9 @@ describe StateFileW2 do
       before do
         allow(StateFile::StateInformationService).to receive(:w2_supported_box14_codes)
           .and_return([
-            { name: "UI_WF_SWF", limit: 179.78 },
-            { name: "FLI", limit: 145.26 }
-          ])
+                        { name: "UI_WF_SWF", limit: 179.78 },
+                        { name: "FLI", limit: 145.26 }
+                      ])
       end
 
       it "returns the correct limit for a valid name" do


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://github.com/newjersey/affordability-pm/issues/285

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Added validation to record to ensure that w2 is not valid if wages is present but state_wages is 0
- Added warning to W2 screen if federal wages is non-zero but state wages is 0.

## How to test?
- Devito Single
  - During W2 import, change XML
  - Set StateWagesAmt (Box 16) to 0 
  - Set StateIncomeTaxAmt (Box 17) to 0. If this is not done, the record will be invalid for the wrong reason (because it expects Box 17 to be less than Box 16)
  - Validate that warning exists and that you are unable to continue with the W2 submission.

## Screenshots (for visual changes)
- Before
- After

<img width="676" alt="image" src="https://github.com/user-attachments/assets/e020c990-4078-4edd-9466-a219c6e2c5ee" />

<img width="776" alt="image" src="https://github.com/user-attachments/assets/61f67e3e-c39c-4cbe-95b9-e612cfbb42b3" />
Warning appears

<img width="1231" alt="image" src="https://github.com/user-attachments/assets/df885ee6-ea64-47d8-aea4-ced2f7b87c4d" />
When attempting to submit without correcting

<img width="763" alt="image" src="https://github.com/user-attachments/assets/88968f02-eac8-4f8d-aeb9-15598ddca4dd" />
StateWagesAmount is now required to be greater than 0 when saving a W2
