### PR TITLE
Revert "FYST-1288 Fix follow-up behavior for public school page (#5513)"

### DIFF
--- a/app/controllers/flows_controller.rb
+++ b/app/controllers/flows_controller.rb
@@ -665,7 +665,6 @@ class FlowsController < ApplicationController
         email_notification_opt_in: "yes",
         phone_number: "+15005550006",
         sms_notification_opt_in: "yes",
-        made_az322_contributions: "yes",
       )
       status_specific_attributes = case filing_status
                                    when :married_filing_jointly, :married_filing_separately

--- a/app/controllers/state_file/questions/az_charitable_contributions_controller.rb
+++ b/app/controllers/state_file/questions/az_charitable_contributions_controller.rb
@@ -2,6 +2,8 @@ module StateFile
   module Questions
     class AzCharitableContributionsController < QuestionsController
       include ReturnToReviewConcern
+
+      private
     end
   end
 end

--- a/app/controllers/state_file/questions/az_public_school_contributions_controller.rb
+++ b/app/controllers/state_file/questions/az_public_school_contributions_controller.rb
@@ -3,8 +3,6 @@ module StateFile
     class AzPublicSchoolContributionsController < QuestionsController
       include ReturnToReviewConcern
 
-      before_action :set_contribution_count
-
       def self.navigation_actions
         [:index, :new]
       end
@@ -26,20 +24,18 @@ module StateFile
       end
 
       def create
-        @az322_contribution = current_intake.az322_contributions.build
-        @az322_contribution.assign_attributes(az322_contribution_params)
+        @az322_contribution = current_intake.az322_contributions.build(az322_contribution_params)
+        @az322_contributions = current_intake.az322_contributions
+        if @az322_contribution.made_contribution_no?
+          return redirect_to next_path
+        end
 
-        if came_from_old_page || (current_intake.valid?(:az322_form_create) && @az322_contribution.valid?)
+        if current_intake.valid?(:az322) && @az322_contribution.valid?
           @az322_contribution.save
           redirect_to action: :index, return_to_review: params[:return_to_review]
         else
           render :new
         end
-      end
-
-      # remove this after it has been deployed
-      def came_from_old_page
-        params["az322_contribution"].include?("made_contribution") && current_intake.valid? && @az322_contribution.valid?
       end
 
       def edit
@@ -49,6 +45,11 @@ module StateFile
       def update
         @az322_contribution = current_intake.az322_contributions.find(params[:id])
         @az322_contribution.assign_attributes(az322_contribution_params)
+
+        if @az322_contribution.made_contribution_no?
+          @az322_contribution.destroy
+          return redirect_to action: :index, return_to_review: params[:return_to_review]
+        end
 
         if @az322_contribution.valid?
           @az322_contribution.save
@@ -68,22 +69,16 @@ module StateFile
 
       private
 
-      def contributions
-        @contributions ||= current_intake.az322_contributions
-      end
-
-      def set_contribution_count = @contribution_count = contributions.count
-
       def az322_contribution_params
         params.require(:az322_contribution).permit(
+          :made_contribution,
           :school_name,
           :ctds_code,
           :district_name,
           :amount,
           :date_of_contribution_day,
           :date_of_contribution_month,
-          :date_of_contribution_year,
-          state_file_az_intake_attributes: [:made_az322_contributions]
+          :date_of_contribution_year
         )
       end
     end

--- a/app/controllers/state_file/questions/az_qualifying_organization_contributions_controller.rb
+++ b/app/controllers/state_file/questions/az_qualifying_organization_contributions_controller.rb
@@ -90,7 +90,7 @@ module StateFile
         params.require(:az321_contribution).permit(
             :charity_name, :charity_code, :amount,
             :date_of_contribution_day, :date_of_contribution_month,
-            :date_of_contribution_year,
+            :date_of_contribution_year, :made_az321_contributions,
             state_file_az_intake_attributes: [:made_az321_contributions]
           )
       end

--- a/app/forms/state_file/az_charitable_contributions_form.rb
+++ b/app/forms/state_file/az_charitable_contributions_form.rb
@@ -6,6 +6,7 @@ module StateFile
     validates :charitable_cash_amount, presence: true, numericality: { greater_than_or_equal_to: 0 }, allow_blank: false, if: -> { charitable_contributions == "yes" }
     validates :charitable_noncash_amount, presence: true, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 500 }, allow_blank: false, if: -> { charitable_contributions == "yes" }
 
+
     def save
       if charitable_contributions == "no"
         @intake.update(charitable_contributions: "no", charitable_cash_amount: nil, charitable_noncash_amount: nil)

--- a/app/models/az322_contribution.rb
+++ b/app/models/az322_contribution.rb
@@ -7,6 +7,7 @@
 #  ctds_code               :string
 #  date_of_contribution    :date
 #  district_name           :string
+#  made_contribution       :integer          default("unfilled"), not null
 #  school_name             :string
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
@@ -17,17 +18,18 @@
 #  index_az322_contributions_on_state_file_az_intake_id  (state_file_az_intake_id)
 #
 class Az322Contribution < ApplicationRecord
-  self.ignored_columns = [:made_contribution]
-
   date_accessor :date_of_contribution
 
   belongs_to :state_file_az_intake
-  accepts_nested_attributes_for :state_file_az_intake, update_only: true
 
-  validates :school_name, presence: true
-  validates :ctds_code, presence: true, format: { with: /\A\d{9}\z/, message: -> (_object, _data) { I18n.t("validators.ctds_code") }}
-  validates :district_name, presence: true
-  validates :amount, presence: true, numericality: { greater_than: 0 }
+  enum made_contribution: { unfilled: 0, yes: 1, no: 2 }, _prefix: :made_contribution
+
+  validates_inclusion_of :made_contribution, in: ['yes', 'no'], message: ->(_object, _data) { I18n.t("errors.messages.blank") }
+  validates :school_name, presence: true, if: -> { made_contribution == "yes" }
+  validates :ctds_code, presence: true, format: { with: /\A\d{9}\z/, message: -> (_object, _data) { I18n.t("validators.ctds_code") }}, if: -> { made_contribution == "yes" }
+  validates :district_name, presence: true, if: -> { made_contribution == "yes" }
+  validates :amount, presence: true, numericality: { greater_than: 0 }, if: -> { made_contribution == "yes" }
+
   validates :date_of_contribution,
             inclusion: {
               in: TAX_YEAR.beginning_of_year..TAX_YEAR.end_of_year

--- a/app/models/state_file_az_intake.rb
+++ b/app/models/state_file_az_intake.rb
@@ -37,7 +37,6 @@
 #  locale                                 :string           default("en")
 #  locked_at                              :datetime
 #  made_az321_contributions               :integer          default("unfilled"), not null
-#  made_az322_contributions               :integer          default("unfilled"), not null
 #  message_tracker                        :jsonb
 #  payment_or_deposit_type                :integer          default("unfilled"), not null
 #  phone_number                           :string
@@ -104,15 +103,13 @@ class StateFileAzIntake < StateFileBaseIntake
   enum eligibility_married_filing_separately: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_married_filing_separately
   enum eligibility_529_for_non_qual_expense: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_529_for_non_qual_expense
   enum made_az321_contributions: { unfilled: 0, yes: 1, no: 2 }, _prefix: :made_az321_contributions
-  enum made_az322_contributions: { unfilled: 0, yes: 1, no: 2 }, _prefix: :made_az322_contributions
   enum eligibility_lived_in_state: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_lived_in_state
   enum eligibility_out_of_state_income: { unfilled: 0, yes: 1, no: 2 }, _prefix: :eligibility_out_of_state_income
 
   validates :made_az321_contributions, inclusion: { in: ["yes", "no"]}, on: :az321_form_create
-  validates :made_az322_contributions, inclusion: { in: ["yes", "no"]}, on: :az322_form_create
   validates :az321_contributions, length: { maximum: 10 }
-  validates :az322_contributions, length: { maximum: 10 }
 
+  validates :az322_contributions, length: { maximum: 10 }, on: :az322
   def federal_dependent_count_under_17
     self.dependents.select{ |dependent| dependent.under_17? }.length
   end

--- a/app/views/state_file/questions/az_public_school_contributions/_form.html.erb
+++ b/app/views/state_file/questions/az_public_school_contributions/_form.html.erb
@@ -1,5 +1,4 @@
 <% @main_heading = t("state_file.questions.az_public_school_contributions.edit.title_html") %>
-<% show_yes_no = @contribution_count == 0 %>
 
 <% content_for :page_title, ActionView::Base.full_sanitizer.sanitize(@main_heading) %>
 <% content_for :card do %>
@@ -10,42 +9,40 @@
     <% end %>
 
     <div class="question-with-follow-up">
-      <% if show_yes_no %>
-        <div class="question-with-follow-up__question">
-          <div class="white-group">
-            <%= f.fields_for(:state_file_az_intake) do |ff| %>
-              <%= ff.cfa_radio_set(
-                    :made_az322_contributions,
-                    label_text: t('.made_az322_contributions', count: current_intake.filer_count, year: current_tax_year),
-                    collection: [
-                      { value: :yes, label: t('general.affirmative'), input_html: { "data-follow-up": "#contribution-details", } },
-                      { value: :no, label: t('general.negative') }
-                    ]
-                  ) %>
-            <% end %>
-          </div>
-          <div class="reveal">
-            <button class="reveal__button"><%= t('.which_qualify') %></button>
-            <div class="reveal__content">
-              <ul>
-                <% t(".qualifying_list").each do |list_item| %>
-                  <li><%= list_item %></li>
-                <% end %>
-              </ul>
-              <p><%= t(".more_details_html") %></p>
-            </div>
-          </div>
-
-          <div class="reveal">
-            <button class="reveal__button"><%= t(".donations_this_year", current_year: current_tax_year + 1) %></button>
-            <div class="reveal__content">
-              <p><%= t(".donations_this_year_details_html", current_year: current_tax_year + 1) %></p>
-            </div>
-          </div>
+      <div class="question-with-follow-up__question">
+        <div class="white-group">
+          <%= f.cfa_radio_set(
+                :made_contribution,
+                label_text: t('state_file.questions.az_public_school_contributions.edit.made_contribution', count: current_intake.filer_count, year: current_tax_year),
+                collection: [
+                  { value: :yes, label: t('general.affirmative'), input_html: { "data-follow-up": "#contribution-details" } },
+                  { value: :no, label: t('general.negative') }
+                ]
+              )
+          %>
         </div>
-      <% end %>
+      </div>
 
-      <div class="<%= "question-with-follow-up__follow-up" if show_yes_no %>" id="contribution-details">
+      <div class="reveal">
+        <button class="reveal__button"><%= t('.which_qualify') %></button>
+        <div class="reveal__content">
+          <ul>
+            <% t(".qualifying_list").each do |list_item| %>
+              <li><%= list_item %></li>
+            <% end %>
+          </ul>
+          <p><%= t(".more_details_html") %></p>
+        </div>
+      </div>
+
+      <div class="reveal">
+        <button class="reveal__button"><%= t(".donations_this_year", current_year: current_tax_year + 1) %></button>
+        <div class="reveal__content">
+          <p><%= t(".donations_this_year_details_html", current_year: current_tax_year + 1) %></p>
+        </div>
+      </div>
+
+      <div class="question-with-follow-up__follow-up" id="contribution-details">
         <div class="white-group">
           <p class="form-question spacing-below-25"><%= t('state_file.questions.az_public_school_contributions.edit.additional_info') %></p>
           <div class="form-group-tight">
@@ -85,6 +82,6 @@
       </div>
     </div>
 
-    <%= f.submit t("general.continue"), class: "button button--primary button--wide" %>
+    <%= f.submit t("general.continue"), :class => "button button--primary button--wide" %>
   <% end %>
 <% end %>

--- a/app/views/state_file/questions/az_qualifying_organization_contributions/_form.html.erb
+++ b/app/views/state_file/questions/az_qualifying_organization_contributions/_form.html.erb
@@ -1,10 +1,10 @@
 <% @main_heading_no_html = strip_tags(t('.main_heading_html')) %>
-<% show_yes_no = @contribution_count == 0 %>
+<% show_yes_no = @contribution_count == 0  %>
 
 <% content_for :page_title, @main_heading_no_html %>
 
 <% content_for :card do %>
-  <%= form_with(model: @contribution, url: { action: @contribution.persisted? ? :update : :create }, local: true, builder: VitaMinFormBuilder, html: { class: 'form-card form-card--long' }) do |f| %>
+  <%= form_with( model: @contribution, url: { action: @contribution.persisted? ? :update : :create }, local: true, builder: VitaMinFormBuilder, html: { class: 'form-card form-card--long' }) do |f| %>
     <div class="question-with-follow-up">
       <% if show_yes_no %>
         <div class="question-with-follow-up__question">
@@ -26,14 +26,14 @@
       <div class="<%= "question-with-follow-up__follow-up" if show_yes_no %>" id="contribution-details">
         <div class="white-group">
           <p class="form-question spacing-below-25">
-            <%= t('.question_header') %>
+          <%= t('.question_header') %>
           </p>
           <div class="form-group-tight">
             <%= f.cfa_input_field(:charity_name, t('.charity_name'), classes: ["form-width--long"]) %>
             <%= f.cfa_input_field(:charity_code, t('.charity_code'), classes: ["form-width--long"]) %>
             <%= f.vita_min_money_field(:amount, t('.amount', filing_year: current_tax_year), classes: ["form-width--long"]) %>
             <div class="date-select">
-              <%= f.cfa_date_select(:date_of_contribution, t('.date_of_contribution', filing_year: current_tax_year), options: { start_year: current_tax_year, end_year: current_tax_year }) %>
+              <%= f.cfa_date_select( :date_of_contribution, t('.date_of_contribution', filing_year: current_tax_year), options: { start_year: current_tax_year, end_year: current_tax_year }) %>
             </div>
           </div>
         </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2308,6 +2308,9 @@ en:
           ctds_code: School Code/CTDS
           date_of_contribution: Date of payment in %{year}
           district_name: School District Name
+          made_contribution:
+            one: Did you pay any fees or make any qualified cash donation to an Arizona public school in %{year}?
+            other: Did you or your spouse pay any fees or make any qualified cash donation to an Arizona public school in %{year}?
           school_name: School Name
           school_name_help_text: Please use the official school name
           title_html: You might be eligible for the <a href="https://azdor.gov/sites/default/files/2023-03/PUBLICATION_guideline-public-school-ECA-tax-credit.pdf" target="_blank">Arizona Public School Credit</a>!
@@ -2317,9 +2320,6 @@ en:
             FileYourStateTaxes only allows you to add payment to the corresponding tax period.
             <br/><br/>
             You can report any donations made in %{current_year} in next year’s tax return.
-          made_az322_contributions:
-            one: Did you pay any fees or make any qualified cash donation to an Arizona public school in %{year}?
-            other: Did you or your spouse pay any fees or make any qualified cash donation to an Arizona public school in %{year}?
           more_details_html: Visit the <a href="https://azdor.gov/sites/default/files/2023-03/PUBLICATION_guideline-public-school-ECA-tax-credit.pdf" target="_blank">Arizona Department of Revenue Guide</a> for more details.
           qualifying_list:
           - Extracurricular Activities

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2257,6 +2257,10 @@ es:
           ctds_code: Código de la escuela/CTDS
           date_of_contribution: Fecha del pago en %{year}
           district_name: Nombre del distrito escolar
+          made_contribution:
+            many: "¿Pagaste tarifas o hiciste contribuciones en efectivo a una escuela pública en %{year}? No incluyas cantidades reclamadas en la declaración de impuestos del año pasado."
+            one: "¿Pagaste tarifas o hiciste contribuciones en efectivo a una escuela pública en %{year}? No incluyas cantidades reclamadas en la declaración de impuestos del año pasado."
+            other: "¿Tú o tu cónyuge pagaron alguna tarifa o donaron dinero a una escuela pública de Arizona en  %{year}?"
           school_name: Nombre de la escuela
           school_name_help_text: Por favor ingresa el nombre oficial
           title_html: ¡Podrías ser elegible para el <a href="https://azdor.gov/sites/default/files/2023-03/PUBLICATION_guideline-public-school-ECA-tax-credit.pdf" target="_blank">crédito tributario de las escuelas públicas de Arizona! </a>!
@@ -2266,10 +2270,6 @@ es:
             FileYourStateTaxes sólo te permite agregar donaciones del período fiscal correspondiente.
             <br/><br/>
             Puedes reportar cualquier donación hecha en %{current_year} en la declaración de impuestos del próximo año.
-          made_az322_contributions:
-            many: "¿Pagaste tarifas o hiciste contribuciones en efectivo a una escuela pública en %{year}? No incluyas cantidades reclamadas en la declaración de impuestos del año pasado."
-            one: "¿Pagaste tarifas o hiciste contribuciones en efectivo a una escuela pública en %{year}? No incluyas cantidades reclamadas en la declaración de impuestos del año pasado."
-            other: "¿Tú o tu cónyuge pagaron alguna tarifa o donaron dinero a una escuela pública de Arizona en  %{year}?"
           more_details_html: Visita el <a href="https://azdor.gov/sites/default/files/2023-03/PUBLICATION_guideline-public-school-ECA-tax-credit.pdf" target="_blank">Departamento de Ingresos de Arizona</a>para más detalles.
           qualifying_list:
           - Actividades extracurriculares

--- a/db/migrate/20250130234706_add_school_contributions_to_state_file_az_intake.rb
+++ b/db/migrate/20250130234706_add_school_contributions_to_state_file_az_intake.rb
@@ -1,5 +1,0 @@
-class AddSchoolContributionsToStateFileAzIntake < ActiveRecord::Migration[7.1]
-  def change
-    add_column :state_file_az_intakes, :made_az322_contributions, :integer, default: 0, null: false
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_30_234706) do
+ActiveRecord::Schema[7.1].define(version: 2025_01_24_172223) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -1854,7 +1854,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_30_234706) do
     t.string "locale", default: "en"
     t.datetime "locked_at"
     t.integer "made_az321_contributions", default: 0, null: false
-    t.integer "made_az322_contributions", default: 0, null: false
     t.jsonb "message_tracker", default: {}
     t.integer "payment_or_deposit_type", default: 0, null: false
     t.string "phone_number"

--- a/spec/controllers/state_file/questions/az_public_school_contributions_controller_spec.rb
+++ b/spec/controllers/state_file/questions/az_public_school_contributions_controller_spec.rb
@@ -27,25 +27,9 @@ RSpec.describe StateFile::Questions::AzPublicSchoolContributionsController do
   end
 
   describe "#new" do
-    render_views
-
     it "builds a new contribution" do
       get :new
       expect(assigns(:az322_contribution)).to be_a_new(Az322Contribution)
-    end
-
-    context "showing the yes/no question" do
-      it "shows when there are no contributions" do
-        get :new
-        expect(response.body).to include I18n.t("state_file.questions.az_public_school_contributions.form.made_az322_contributions", count: intake.filer_count, year: MultiTenantService.new(:statefile).current_tax_year)
-      end
-
-      it "does not show when there are contributions" do
-        create(:az322_contribution, state_file_az_intake: intake)
-
-        get :new
-        expect(response.body).not_to include I18n.t("state_file.questions.az_public_school_contributions.form.made_az322_contributions", count: intake.filer_count, year: MultiTenantService.new(:statefile).current_tax_year)
-      end
     end
   end
 
@@ -55,9 +39,7 @@ RSpec.describe StateFile::Questions::AzPublicSchoolContributionsController do
     let(:params) do
       {
         az322_contribution: {
-          state_file_az_intake_attributes: {
-            made_az322_contributions: "yes",
-          },
+          made_contribution: 'yes',
           school_name: 'School A',
           ctds_code: '123456789',
           district_name: 'District A',
@@ -76,7 +58,6 @@ RSpec.describe StateFile::Questions::AzPublicSchoolContributionsController do
 
       expect(response).to redirect_to(action: :index)
 
-      expect(intake.reload.made_az322_contributions).to eq "yes"
       contribution = Az322Contribution.last
       expect(contribution.state_file_az_intake).to eq intake
       expect(contribution.school_name).to eq 'School A'
@@ -101,89 +82,36 @@ RSpec.describe StateFile::Questions::AzPublicSchoolContributionsController do
       }.not_to change(intake.az322_contributions, :count)
     end
 
-    context "with invalid params" do
-      render_views
-
-      context "yes/no question" do
-        it 'should not create the contribution when made_az322_contributions is missing' do
-          expect {
-            put :create, params: {
-              az322_contribution: {
-                state_file_az_intake_attributes: {
-                  made_az322_contributions: nil,
-                },
-                school_name: 'School A',
-                ctds_code: '123456789',
-                district_name: 'District A',
-                amount: 100,
-                date_of_contribution_month: '8',
-                date_of_contribution_day: "12",
-                date_of_contribution_year: Rails.configuration.statefile_current_tax_year
-              }
-            }
-          }.not_to change(Az321Contribution, :count)
-
-          expect(response).to render_template :new
-        end
+    context "when 'no' was selected for made_contribution" do
+      before do
+        params[:az322_contribution][:made_contribution] = 'no'
       end
 
-      context "contribution is invalid" do
-        let(:invalid_params) do
-          {
-            az322_contribution: {
-              state_file_az_intake_attributes: {
-                made_az322_contributions: "yes",
-              },
-              school_name: 'School A',
-              ctds_code: '123456789',
-              district_name: 'District A',
-              amount: 0, # must have amount
-              date_of_contribution_month: '8',
-              date_of_contribution_day: "12",
-              date_of_contribution_year: Rails.configuration.statefile_current_tax_year
-            }
-          }
-        end
-
-        it "renders new with validation errors" do
-          expect do
-            post :create, params: invalid_params
-          end.not_to change(Az322Contribution, :count)
-
-          expect(response).to render_template(:new)
-          expect(response.body).to include "must be greater than 0"
-        end
+      it "creates nothing" do
+        expect do
+          post :create, params: params
+        end.not_to change(Az322Contribution, :count)
       end
     end
 
-    context "DEPRECATED BEHAVIOR; keep tests until page is changed on prod" do
-      # missing state_file_az_intake_attributes/made_az322_contributions
-      let(:params) do
+    context "with invalid params" do
+      render_views
+
+      let(:invalid_params) do
         {
           az322_contribution: {
-            made_contribution: 'yes',
-            school_name: 'School A',
-            ctds_code: '123456789',
-            district_name: 'District A',
-            amount: 100,
-            date_of_contribution_month: '8',
-            date_of_contribution_day: "12",
-            date_of_contribution_year: Rails.configuration.statefile_current_tax_year
+            made_contribution: nil,
           }
         }
       end
 
-      it "creates a new contribution linked to the current intake and redirects to the index" do
+      it "renders new with validation errors" do
         expect do
-          post :create, params: params
-        end.to change(Az322Contribution, :count).by 1
+          post :create, params: invalid_params
+        end.not_to change(Az322Contribution, :count)
 
-        expect(response).to redirect_to(action: :index)
-
-        contribution = Az322Contribution.last
-        expect(contribution.state_file_az_intake).to eq intake
-        expect(contribution.school_name).to eq 'School A'
-        expect(contribution.amount).to eq 100
+        expect(response).to render_template(:new)
+        expect(response.body).to include "Can't be blank"
       end
     end
   end
@@ -206,6 +134,7 @@ RSpec.describe StateFile::Questions::AzPublicSchoolContributionsController do
       {
         id: contribution.id,
         az322_contribution: {
+          made_contribution: 'yes',
           school_name: 'New School',
           ctds_code: '123456789',
           district_name: 'District A',
@@ -223,6 +152,20 @@ RSpec.describe StateFile::Questions::AzPublicSchoolContributionsController do
 
       contribution.reload
       expect(contribution.school_name).to eq 'New School'
+    end
+
+    context "when 'no' was selected for made_contribution" do
+      before do
+        params[:az322_contribution][:made_contribution] = 'no'
+      end
+
+      it "deletes the contribution" do
+        expect do
+          post :update, params: params
+        end.to change(Az322Contribution, :count).by(-1)
+
+        expect { contribution.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
     end
 
     context "with invalid params" do
@@ -246,32 +189,6 @@ RSpec.describe StateFile::Questions::AzPublicSchoolContributionsController do
         expect(response).to render_template(:edit)
         expect(response.body).to include "Can't be blank"
         expect(response.body).to include "School Code/CTDS must be a 9 digit number"
-      end
-    end
-
-    context "DEPRECATED BEHAVIOR; keep tests until page is changed on prod" do
-      let(:params) do
-        {
-          id: contribution.id,
-          az322_contribution: {
-            made_contribution: 'yes',
-            school_name: 'New School',
-            ctds_code: '123456789',
-            district_name: 'District A',
-            amount: 100,
-            date_of_contribution_month: '8',
-            date_of_contribution_day: "12",
-            date_of_contribution_year: Rails.configuration.statefile_current_tax_year.to_s
-          }
-        }
-      end
-
-      it "updates the contribution and redirects to the index" do
-        post :update, params: params
-        expect(response).to redirect_to(action: :index)
-
-        contribution.reload
-        expect(contribution.school_name).to eq 'New School'
       end
     end
   end

--- a/spec/controllers/state_file/questions/az_qualifying_organization_contributions_controller_spec.rb
+++ b/spec/controllers/state_file/questions/az_qualifying_organization_contributions_controller_spec.rb
@@ -10,12 +10,14 @@ RSpec.describe StateFile::Questions::AzQualifyingOrganizationContributionsContro
   end
 
   describe ".show?" do
+
     context "when the intake has charitable contributions" do
       before do
         intake.charitable_contributions_yes!
       end
 
       context "when the intake has cash contributions" do
+
         before do
           intake.update(charitable_cash_amount: 1)
         end
@@ -27,6 +29,7 @@ RSpec.describe StateFile::Questions::AzQualifyingOrganizationContributionsContro
       end
 
       context "when the intake does not have cash contributions" do
+
         before do
           intake.update(charitable_cash_amount: 0)
         end
@@ -34,7 +37,9 @@ RSpec.describe StateFile::Questions::AzQualifyingOrganizationContributionsContro
         it "does not show" do
           expect(described_class).not_to be_show(intake)
         end
+
       end
+
     end
 
     context "when the intake does not have charitable contributions" do
@@ -46,6 +51,7 @@ RSpec.describe StateFile::Questions::AzQualifyingOrganizationContributionsContro
         expect(described_class).not_to be_show(intake)
       end
     end
+
   end
 
   describe "#index" do
@@ -102,7 +108,7 @@ RSpec.describe StateFile::Questions::AzQualifyingOrganizationContributionsContro
   end
 
   describe "edit" do
-    let(:contribution) { create(:az321_contribution, state_file_az_intake: intake) }
+    let(:contribution) { create(:az321_contribution, state_file_az_intake: intake)}
 
     it 'should render information about the contribution' do
       get :edit, params: { id: contribution.id }
@@ -270,7 +276,7 @@ RSpec.describe StateFile::Questions::AzQualifyingOrganizationContributionsContro
   end
 
   describe "destroy" do
-    let!(:contribution) { create(:az321_contribution, state_file_az_intake: intake) }
+    let!(:contribution) { create(:az321_contribution, state_file_az_intake: intake)}
 
     it 'should delete the contribution when valid' do
       expect {

--- a/spec/factories/az322_contributions.rb
+++ b/spec/factories/az322_contributions.rb
@@ -7,6 +7,7 @@
 #  ctds_code               :string
 #  date_of_contribution    :date
 #  district_name           :string
+#  made_contribution       :integer          default("unfilled"), not null
 #  school_name             :string
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
@@ -21,6 +22,7 @@ FactoryBot.define do
     date_of_contribution_year { Rails.configuration.statefile_current_tax_year }
     date_of_contribution_month { "3" }
     date_of_contribution_day { "4" }
+    made_contribution { "yes" }
     ctds_code { "100206038" }
     school_name { "Schublic Pool" }
     district_name { "Dool Schistrict" }

--- a/spec/factories/state_file_az_intakes.rb
+++ b/spec/factories/state_file_az_intakes.rb
@@ -37,7 +37,6 @@
 #  locale                                 :string           default("en")
 #  locked_at                              :datetime
 #  made_az321_contributions               :integer          default("unfilled"), not null
-#  made_az322_contributions               :integer          default("unfilled"), not null
 #  message_tracker                        :jsonb
 #  payment_or_deposit_type                :integer          default("unfilled"), not null
 #  phone_number                           :string
@@ -177,9 +176,7 @@ FactoryBot.define do
     end
 
     trait :with_az322_contributions do
-      made_az322_contributions { "yes" }
-
-      after(:create) do |intake|
+      after(:build) do |intake|
         create(:az322_contribution,
                date_of_contribution: "#{Rails.configuration.statefile_current_tax_year}-03-04",
                ctds_code: '123456789',

--- a/spec/forms/state_file/az_charitable_contributions_form_spec.rb
+++ b/spec/forms/state_file/az_charitable_contributions_form_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe StateFile::AzCharitableContributionsForm do
       end
 
       it "Requires all contributions to be numeric" do
-        form = described_class.new(intake, params.merge({ charitable_cash_amount: "a10", charitable_noncash_amount: "b20" }))
+        form = described_class.new(intake, params.merge({ charitable_cash_amount: "a10", charitable_noncash_amount: "b20"}))
         expect(form).not_to be_valid
         expect(form.errors).to include :charitable_cash_amount
         expect(form.errors).to include :charitable_noncash_amount
@@ -40,9 +40,9 @@ RSpec.describe StateFile::AzCharitableContributionsForm do
       context "when non cash contributions exceed 500" do
         let(:params) do
           super().merge({
-                          charitable_cash_amount: 100,
-                          charitable_noncash_amount: 600,
-                        })
+            charitable_cash_amount: 100,
+            charitable_noncash_amount: 600,
+          })
         end
 
         it "returns false" do
@@ -53,6 +53,8 @@ RSpec.describe StateFile::AzCharitableContributionsForm do
       end
     end
   end
+
+
 
   describe "#save" do
     let(:intake) { create :state_file_az_intake }
@@ -93,7 +95,7 @@ RSpec.describe StateFile::AzCharitableContributionsForm do
   end
 
   describe "going back and saying no to charitable contributions" do
-    let(:intake) { create :state_file_az_intake, charitable_cash_amount: 100, charitable_noncash_amount: 100 }
+    let(:intake) { create :state_file_az_intake, charitable_cash_amount: 100, charitable_noncash_amount: 100}
     let(:valid_params) do
       {
         charitable_contributions: "no",

--- a/spec/lib/pdf_filler/az322_pdf_spec.rb
+++ b/spec/lib/pdf_filler/az322_pdf_spec.rb
@@ -3,15 +3,11 @@ require 'rails_helper'
 RSpec.describe PdfFiller::Az322Pdf do
   include PdfSpecHelper
 
-  let(:submission) do
-    create :efile_submission,
-           tax_return: nil,
-           data_source: create(:state_file_az_intake, :with_az322_contributions)
-  end
+  let(:submission) { create :efile_submission, tax_return: nil, data_source: create(:state_file_az_intake, :with_az322_contributions) }
   let(:pdf) { described_class.new(submission) }
 
   describe '#hash_for_pdf', required_schema: "az" do
-    let!(:pdf_fields) { filled_in_values(described_class.new(submission.reload).output_file.path) }
+    let!(:pdf_fields) { filled_in_values(described_class.new(submission).output_file.path) }
     it 'uses field names that exist in the pdf' do
       missing_fields = pdf.hash_for_pdf.keys.map(&:to_s) - pdf_fields.keys
       expect(missing_fields).to eq([])

--- a/spec/models/az322_contribution_spec.rb
+++ b/spec/models/az322_contribution_spec.rb
@@ -7,6 +7,7 @@
 #  ctds_code               :string
 #  date_of_contribution    :date
 #  district_name           :string
+#  made_contribution       :integer          default("unfilled"), not null
 #  school_name             :string
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
@@ -21,122 +22,140 @@ require 'rails_helper'
 describe 'Az322Contribution' do
   let(:intake) { create(:state_file_az_intake) }
 
-  let(:az) { Az322Contribution.new(state_file_az_intake: intake) }
-
-  describe "#school_name" do
+  describe "#made_contributions" do
     it 'should validate presence' do
-      az.school_name = nil
+      az = Az322Contribution.new(state_file_az_intake: intake, made_contribution: nil)
       az.valid?
-      expect(az.errors[:school_name]).not_to be_empty
+      expect(az.errors[:made_contribution]).not_to be_empty
 
-      az.school_name = 'Hopscotch School'
+      az.made_contribution = 'yes'
       az.valid?
-      expect(az.errors[:school_name]).to be_empty
+      expect(az.errors[:made_contribution]).to be_empty
+
+      az.made_contribution = 'gobble'
+      az.valid?
+      expect(az.errors[:made_contribution]).not_to be_empty
     end
   end
 
-  describe "#ctds_code" do
-    it 'should validate presence' do
-      az.ctds_code = nil
-      az.valid?
-      expect(az.errors[:ctds_code]).not_to be_empty
+  context "made_contributions is true" do
+    let(:az) { Az322Contribution.new(state_file_az_intake: intake, made_contribution: 'yes') }
 
-      az.ctds_code = '123456789'
-      az.valid?
-      expect(az.errors[:ctds_code]).to be_empty
+    describe "#school_name" do
+      it 'should validate presence' do
+        az.school_name = nil
+        az.valid?
+        expect(az.errors[:school_name]).not_to be_empty
 
-      az.ctds_code = '12345678'
-      az.valid?
-      expect(az.errors[:ctds_code]).not_to be_empty
-
-      az.ctds_code = 'fffffffff'
-      az.valid?
-      expect(az.errors[:ctds_code]).not_to be_empty
-    end
-  end
-
-  describe "#district_name" do
-    it 'should validate presence' do
-      az.district_name = nil
-      az.valid?
-      expect(az.errors[:district_name]).not_to be_empty
-
-      az.district_name = 'Sesame District'
-      az.valid?
-      expect(az.errors[:district_name]).to be_empty
-    end
-  end
-
-  describe "#amount" do
-    it 'should validate presence' do
-      az.amount = nil
-      az.valid?
-      expect(az.errors[:amount]).to eq(["Can't be blank.", "is not a number"])
-
-      az.amount = 0
-      az.valid?
-      expect(az.errors[:amount]).to eq(["must be greater than 0"])
-
-      az.amount = 1
-      az.valid?
-      expect(az.errors[:amount]).to be_empty
-      expect(az.amount).to eq(1)
-    end
-  end
-
-  describe '#date_of_contribution' do
-    it 'should be valid in the current tax year' do
-      az.date_of_contribution_year = Rails.configuration.statefile_current_tax_year
-
-      az.valid?
-
-      expect(az.errors[:date_of_contribution]).to be_empty
+        az.school_name = 'Hopscotch School'
+        az.valid?
+        expect(az.errors[:school_name]).to be_empty
+      end
     end
 
-    it 'should be invalid in the previous year' do
-      az.date_of_contribution_year = Rails.configuration.statefile_current_tax_year - 1
+    describe "#ctds_code" do
+      it 'should validate presence' do
+        az.ctds_code = nil
+        az.valid?
+        expect(az.errors[:ctds_code]).not_to be_empty
 
-      az.valid?
+        az.ctds_code = '123456789'
+        az.valid?
+        expect(az.errors[:ctds_code]).to be_empty
 
-      expect(az.errors[:date_of_contribution]).not_to be_empty
+        az.ctds_code = '12345678'
+        az.valid?
+        expect(az.errors[:ctds_code]).not_to be_empty
+
+        az.ctds_code = 'fffffffff'
+        az.valid?
+        expect(az.errors[:ctds_code]).not_to be_empty
+      end
     end
 
-    it 'should be invalid in the next year' do
-      az.date_of_contribution_year = Rails.configuration.statefile_current_tax_year + 1
+    describe "#district_name" do
+      it 'should validate presence' do
+        az.district_name = nil
+        az.valid?
+        expect(az.errors[:district_name]).not_to be_empty
 
-      az.valid?
-
-      expect(az.errors[:date_of_contribution]).not_to be_empty
+        az.district_name = 'Sesame District'
+        az.valid?
+        expect(az.errors[:district_name]).to be_empty
+      end
     end
 
-    it 'should be valid when a correct date is provided' do
-      current_tax_year = Rails.configuration.statefile_current_tax_year
+    describe "#amount" do
+      it 'should validate presence' do
+        az.amount = nil
+        az.valid?
+        expect(az.errors[:amount]).to eq(["Can't be blank.", "is not a number"])
 
-      az.date_of_contribution_year = current_tax_year
-      az.date_of_contribution_day = 12
-      az.date_of_contribution_month = 5
+        az.amount = 0
+        az.valid?
+        expect(az.errors[:amount]).to eq(["must be greater than 0"])
 
-      az.valid?
-
-      expect(az.errors[:date_of_contribution]).to be_empty
-
-      az.restore_attributes
-
-      expect(az.date_of_contribution).to be_nil
-
-      az.date_of_contribution = "#{current_tax_year}-05-12"
-
-      az.valid?
-
-      expect(az.errors[:date_of_contribution]).to be_empty
+        az.amount = 1
+        az.valid?
+        expect(az.errors[:amount]).to be_empty
+        expect(az.amount).to eq(1)
+      end
     end
 
-    it 'should be invalid when nonsense is provided' do
-      az.date_of_contribution = "foo"
+    describe '#date_of_contribution' do
+      it 'should be valid in the current tax year' do
+        az.date_of_contribution_year = Rails.configuration.statefile_current_tax_year
 
-      az.valid?
+        az.valid?
 
-      expect(az.errors[:date_of_contribution]).not_to be_empty
+        expect(az.errors[:date_of_contribution]).to be_empty
+      end
+
+      it 'should be invalid in the previous year' do
+        az.date_of_contribution_year = Rails.configuration.statefile_current_tax_year - 1
+
+        az.valid?
+
+        expect(az.errors[:date_of_contribution]).not_to be_empty
+      end
+
+      it 'should be invalid in the next year' do
+        az.date_of_contribution_year = Rails.configuration.statefile_current_tax_year + 1
+
+        az.valid?
+
+        expect(az.errors[:date_of_contribution]).not_to be_empty
+      end
+
+      it 'should be valid when a correct date is provided' do
+        current_tax_year = Rails.configuration.statefile_current_tax_year
+
+        az.date_of_contribution_year = current_tax_year
+        az.date_of_contribution_day = 12
+        az.date_of_contribution_month = 5
+
+        az.valid?
+
+        expect(az.errors[:date_of_contribution]).to be_empty
+
+        az.restore_attributes
+
+        expect(az.date_of_contribution).to be_nil
+
+        az.date_of_contribution = "#{current_tax_year}-05-12"
+
+        az.valid?
+
+        expect(az.errors[:date_of_contribution]).to be_empty
+      end
+
+      it 'should be invalid when nonsense is provided' do
+        az.date_of_contribution = "foo"
+
+        az.valid?
+
+        expect(az.errors[:date_of_contribution]).not_to be_empty
+      end
     end
   end
 end

--- a/spec/models/state_file_az_intake_spec.rb
+++ b/spec/models/state_file_az_intake_spec.rb
@@ -37,7 +37,6 @@
 #  locale                                 :string           default("en")
 #  locked_at                              :datetime
 #  made_az321_contributions               :integer          default("unfilled"), not null
-#  made_az322_contributions               :integer          default("unfilled"), not null
 #  message_tracker                        :jsonb
 #  payment_or_deposit_type                :integer          default("unfilled"), not null
 #  phone_number                           :string


### PR DESCRIPTION
This reverts commit 4bb14f841df3dae871bd8473a393474500bf947c.

We found that you cannot advance past the AZ school credits page if you answer "no" to the initial question. We are reverting the whole feature for now and will revisit when we have more time so as not to block any filers on this page.