### PR TITLE
changed NJ intake to has_many analytics

### DIFF
--- a/app/jobs/state_file/create_nj_analytics_record_job.rb
+++ b/app/jobs/state_file/create_nj_analytics_record_job.rb
@@ -2,7 +2,7 @@ module StateFile
   class CreateNjAnalyticsRecordJob < ApplicationJob
     def perform(submission_id)
       submission = EfileSubmission.find(submission_id)
-      nj_analytics = submission.data_source.create_state_file_nj_analytics!
+      nj_analytics = StateFileNjAnalytics.create(state_file_nj_intake: submission.data_source)
       nj_analytics&.update(nj_analytics.calculated_fields)
     end
 

--- a/app/models/state_file_nj_intake.rb
+++ b/app/models/state_file_nj_intake.rb
@@ -114,7 +114,7 @@
 class StateFileNjIntake < StateFileBaseIntake
   self.ignored_columns += ["primary_signature_pin", "spouse_signature_pin"]
   encrypts :account_number, :routing_number, :raw_direct_file_data, :raw_direct_file_intake_data
-  has_one :state_file_nj_analytics
+  has_many :state_file_nj_analytics
 
   enum household_rent_own: { unfilled: 0, rent: 1, own: 2, neither: 3, both: 4 }, _prefix: :household_rent_own
 

--- a/spec/jobs/state_file/create_nj_analytics_record_job_spec.rb
+++ b/spec/jobs/state_file/create_nj_analytics_record_job_spec.rb
@@ -11,5 +11,16 @@ describe StateFile::CreateNjAnalyticsRecordJob do
       submitted_intake.reload
       expect(submitted_intake.state_file_nj_analytics).to be_present
     end
+
+    context "when multiple submissions exist" do
+      let!(:submission_2) { create :efile_submission, :for_state, data_source: submitted_intake }
+      it "allows multiple NJ analytics records to be attached to one intake" do
+        expect(submitted_intake.state_file_nj_analytics).not_to be_present
+        described_class.perform_now(submission.id)
+        submitted_intake.reload
+        described_class.perform_now(submission_2.id)
+        expect(submitted_intake.state_file_nj_analytics.size).to eq 2
+      end
+    end
   end
 end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://github.com/newjersey/affordability-pm/issues/281

## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Added ability to attach multiple analytics records to one intake. This is important since we want 1 analytics record per SUBMISSION, rather than per intake.
- Example of when this is relevant:
  - Taxpayer submits their return
  - It gets rejected by the IRS
  - Taxpayer updates their return and resubmits
  - It gets accepted by the IRS
- This will result in 2 submissions associated with the intake.

## How to test?
- run tests in `vita-min/spec/jobs/state_file/create_nj_analytics_record_job_spec.rb`

## Screenshots (for visual changes)
- Before
- After
