### PR TITLE
GYR1-667 Add mg subdomain to email domain config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -6,9 +6,9 @@ Rails.application.configure do
   config.ctc_url = "https://www.getctc.org"
   config.gyr_url = "https://www.getyourrefund.org"
   config.statefile_url = "https://www.fileyourstatetaxes.org"
-  ctc_email_from_domain = "getctc.org"
-  gyr_email_from_domain = "getyourrefund.org"
-  statefile_email_from_domain = "fileyourstatetaxes.org"
+  ctc_email_from_domain = "mg.getctc.org"
+  gyr_email_from_domain = "mg.getyourrefund.org"
+  statefile_email_from_domain = "mg.fileyourstatetaxes.org"
   config.email_from = {
     default: {
       ctc: "hello@#{ctc_email_from_domain}",


### PR DESCRIPTION
## Link to Jira issue

- https://codeforamerica.atlassian.net/browse/GYR1-667

## Is PM acceptance required?

- No -- but let's have someone spot-check this after deploying to Prod.

**Reminder**: merge main into this branch and get green tests before merging to main

## What was done?

- Added `mg.` as a subdomain to the email domain configuration in 
  `production.rb` for all three Tax apps -- GYR, FYST, and CTC. This brings 
  things in line with the configuration in Mailgun currently (screenshot follows 
  with pertinent highlighted inside an orange rectangle):

<img width="665" alt="tax-domains-in-mailgun" src="https://github.com/user-attachments/assets/7d8d9fa0-4d79-41f8-802b-c75adb921b2b" />

The purpose here is to fix the DKIM failures we're seeing that we suspect are 
the cause of some automated emails going into users' spam folders.

## How to test?

- Try out the password reset feature on production on both GYR and 
  FYST (or ask a PM to do it) to send an automated email to yourself. Steps:
  - Send a password reset email to yourself.
  - When viewing the email's details in the Gmail web client, client on the 
    "three-vertical-dots" button (right-hand-side at top of email), and select 
    "Show Original".
  - Confirm in the table (just below the "Original Message" title) that DKIM 
    shows as `'PASS' with domain mg.getyourrefund.org`.
-  Beyond that, PM needs to reach out to screeners/partners to ask them to 
   keep an eye on things -- specifically, whether they observe (or hear about) 
   any 'password reset' mails continuing to end up in folk's spam foldes.

