### PR TITLE
Revert "GYR1-667 Add mg subdomain to email domain config"

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -6,9 +6,9 @@ Rails.application.configure do
   config.ctc_url = "https://www.getctc.org"
   config.gyr_url = "https://www.getyourrefund.org"
   config.statefile_url = "https://www.fileyourstatetaxes.org"
-  ctc_email_from_domain = "mg.getctc.org"
-  gyr_email_from_domain = "mg.getyourrefund.org"
-  statefile_email_from_domain = "mg.fileyourstatetaxes.org"
+  ctc_email_from_domain = "getctc.org"
+  gyr_email_from_domain = "getyourrefund.org"
+  statefile_email_from_domain = "fileyourstatetaxes.org"
   config.email_from = {
     default: {
       ctc: "hello@#{ctc_email_from_domain}",


### PR DESCRIPTION
Reverts codeforamerica/vita-min#5557. 

At the moment, we are discussing additional options.