### PR TITLE
NJ 80 - line 20a taxable retirement income

### DIFF
--- a/app/controllers/state_file/questions/nj_review_controller.rb
+++ b/app/controllers/state_file/questions/nj_review_controller.rb
@@ -8,7 +8,7 @@ module StateFile
           [
             { text_key: '15_wages_salaries_tips', value: line_or_zero(:NJ1040_LINE_15) },
             { text_key: '16a_interest_income', value: line_or_zero(:NJ1040_LINE_16A) },
-            # { text_key: '20a_retirement_income', value: line_or_zero(:NJ1040_LINE_20A) },
+            { text_key: '20a_retirement_income', value: line_or_zero(:NJ1040_LINE_20A) },
             { text_key: '27_total_income', value: line_or_zero(:NJ1040_LINE_27) },
             # { text_key: '28c_retirement_excluded_from_taxation', value: line_or_zero(:NJ1040_LINE_28C) },
             { text_key: '29_nj_gross_income', value: line_or_zero(:NJ1040_LINE_29) },

--- a/app/lib/efile/line_data.yml
+++ b/app/lib/efile/line_data.yml
@@ -876,6 +876,8 @@ NJ1040_LINE_16A:
   label: 'Taxable interest income (Enclose federal Schedule B if over $1,500) (See instructions)'
 NJ1040_LINE_16B:
   label: 'Tax-exempt interest income (Enclose schedule) (See instructions) Do not include on line 16a'
+NJ1040_LINE_20A:
+  label: '20a Taxable pension, annuity, and IRA distributions/withdrawals (See instructions)'
 NJ1040_LINE_27:
   label: '27 Total Income (Add lines 15, 16a, and 20a)'
 NJ1040_LINE_29:

--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -38,6 +38,7 @@ module Efile
         set_line(:NJ1040_LINE_15, :calculate_line_15)
         set_line(:NJ1040_LINE_16A, :calculate_line_16a)
         set_line(:NJ1040_LINE_16B, :calculate_line_16b)
+        set_line(:NJ1040_LINE_20A, :calculate_line_20a)
         set_line(:NJ1040_LINE_27, :calculate_line_27)
         set_line(:NJ1040_LINE_29, :calculate_line_29)
         set_line(:NJ1040_LINE_31, :calculate_line_31)
@@ -317,8 +318,16 @@ module Efile
         calculate_tax_exempt_interest_income if calculate_tax_exempt_interest_income.positive?
       end
 
+      def calculate_line_20a
+        applicable_1099rs = @intake.state_file1099_rs.select do |state_file_1099r|
+          state_file_1099r.state_specific_followup.present? && state_file_1099r.state_specific_followup.income_source_none?
+        end
+
+        applicable_1099rs.sum(&:taxable_amount).round
+      end
+
       def calculate_line_27
-        line_or_zero(:NJ1040_LINE_15) + line_or_zero(:NJ1040_LINE_16A)
+        line_or_zero(:NJ1040_LINE_15) + line_or_zero(:NJ1040_LINE_16A) + line_or_zero(:NJ1040_LINE_20A)
       end
 
       def calculate_line_29

--- a/app/lib/pdf_filler/nj1040_pdf.rb
+++ b/app/lib/pdf_filler/nj1040_pdf.rb
@@ -269,6 +269,23 @@ module PdfFiller
                                                  ]))
       end
 
+      # line 20a
+      if @xml_document.at("PensAnnuitAndIraWithdraw") && Flipper.enabled?(:show_retirement_ui)
+        retirement_income = @xml_document.at("PensAnnuitAndIraWithdraw").text.to_i
+        answers.merge!(insert_digits_into_fields(retirement_income, [
+          "141",
+          "140",
+          "139",
+          "138",
+          "137",
+          "136",
+          "undefined_56",
+          "undefined_55",
+          "undefined_54",
+          "20a"
+        ]))
+      end
+
       if @xml_document.at("TotalIncome").present?
         total_income = @xml_document.at("TotalIncome").text.to_i
         answers.merge!(insert_digits_into_fields(total_income, [

--- a/app/lib/pdf_filler/nj1040_pdf.rb
+++ b/app/lib/pdf_filler/nj1040_pdf.rb
@@ -270,7 +270,7 @@ module PdfFiller
       end
 
       # line 20a
-      if @xml_document.at("PensAnnuitAndIraWithdraw") && Flipper.enabled?(:show_retirement_ui)
+      if @xml_document.at("PensAnnuitAndIraWithdraw")
         retirement_income = @xml_document.at("PensAnnuitAndIraWithdraw").text.to_i
         answers.merge!(insert_digits_into_fields(retirement_income, [
           "141",

--- a/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
+++ b/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
@@ -124,6 +124,10 @@ module SubmissionBuilder
                   if calculated_fields.fetch(:NJ1040_LINE_16B)&.positive?
                     xml.TaxexemptInterestIncome calculated_fields.fetch(:NJ1040_LINE_16B)
                   end
+
+                  if calculated_fields.fetch(:NJ1040_LINE_20A)&.positive? && Flipper.enabled?(:show_retirement_ui)
+                    xml.PensAnnuitAndIraWithdraw calculated_fields.fetch(:NJ1040_LINE_20A)
+                  end
                   
                   if calculated_fields.fetch(:NJ1040_LINE_27).positive?
                     xml.TotalIncome calculated_fields.fetch(:NJ1040_LINE_27)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3618,6 +3618,7 @@ en:
           reveal:
             15_wages_salaries_tips: Wages, salaries, tips
             16a_interest_income: Interest income
+            20a_retirement_income: Retirement income
             27_total_income: Total income
             29_nj_gross_income: New Jersey Gross Income
             30_exemptions: Exemptions (based on the size of your family, disability status, veteran status)

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3553,6 +3553,7 @@ es:
           reveal:
             15_wages_salaries_tips: Salarios, sueldos, propinas
             16a_interest_income: Ingreso total
+            20a_retirement_income: Retirement income
             27_total_income: Ingreso total
             29_nj_gross_income: Ingreso Bruto de New Jersey
             30_exemptions: Exenciones (según el tamaño de tu familia, estado de discapacidad, estado de veterano/a de guerra)

--- a/spec/controllers/state_file/questions/nj_retirement_income_source_controller_spec.rb
+++ b/spec/controllers/state_file/questions/nj_retirement_income_source_controller_spec.rb
@@ -22,6 +22,14 @@ RSpec.describe StateFile::Questions::NjRetirementIncomeSourceController do
         expect(described_class.show?(intake)).to eq true
       end
     end
+
+    context "when show_retirement_ui flag is disabled" do
+      let(:intake) { create :state_file_nj_intake, :df_data_2_1099r }
+      it "does not show" do
+        allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(false)
+        expect(described_class.show?(intake)).to eq false
+      end
+    end
   end
 
   describe "#edit" do

--- a/spec/factories/state_file_nj_intakes.rb
+++ b/spec/factories/state_file_nj_intakes.rb
@@ -159,10 +159,6 @@ FactoryBot.define do
       end
     end
 
-    trait :with_1099_rs_synced do
-      after(:create, &:synchronize_df_1099_rs_to_database)
-    end
-
     trait :df_data_2_w2s do
       raw_direct_file_data { StateFile::DirectFileApiResponseSampleService.new.read_xml('nj_zeus_two_w2s') }
       raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nj_zeus_two_w2s') }

--- a/spec/factories/state_file_nj_intakes.rb
+++ b/spec/factories/state_file_nj_intakes.rb
@@ -159,6 +159,10 @@ FactoryBot.define do
       end
     end
 
+    trait :with_1099_rs_synced do
+      after(:create, &:synchronize_df_1099_rs_to_database)
+    end
+
     trait :df_data_2_w2s do
       raw_direct_file_data { StateFile::DirectFileApiResponseSampleService.new.read_xml('nj_zeus_two_w2s') }
       raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nj_zeus_two_w2s') }

--- a/spec/features/state_file/nj/complete_intake_spec.rb
+++ b/spec/features/state_file/nj/complete_intake_spec.rb
@@ -278,7 +278,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
 
       click_on I18n.t("state_file.questions.nj_review.edit.reveal.header")
       amounts_in_calculation_details = page.all(:xpath, '//*[contains(@class,"main-content-inner")]/section[last()]//p[contains(text(),"$")]')
-      expect(amounts_in_calculation_details.count).to eq(19)
+      expect(amounts_in_calculation_details.count).to eq(20)
       expect(page).to be_axe_clean
       continue
 

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -520,14 +520,60 @@ describe Efile::Nj::Nj1040Calculator do
     end
   end
 
+  describe 'line 20a - taxable retirement income' do
+    let(:intake) { create(:state_file_nj_intake) }
+    let!(:state_file_1099r_1) { create :state_file1099_r, intake: intake, taxable_amount: 300 }
+    let!(:state_file_1099r_2) { create :state_file1099_r, intake: intake, taxable_amount: 100.55 }
+    let!(:state_file_1099r_3) { create :state_file1099_r, intake: intake, taxable_amount: 500 }
+    let!(:state_specific_followup_1) { create :state_file_nj1099_r_followup, state_file1099_r: state_file_1099r_1, income_source: income_source_1 }
+    let!(:state_specific_followup_2) { create :state_file_nj1099_r_followup, state_file1099_r: state_file_1099r_2, income_source: income_source_2 }
+    let!(:state_specific_followup_3) { create :state_file_nj1099_r_followup, state_file1099_r: state_file_1099r_3, income_source: income_source_3 }
+
+    before do
+      intake.reload
+      instance.calculate
+    end
+
+    context 'when all 1099-Rs are applicable (non-military)' do
+      let(:income_source_1) { :none }
+      let(:income_source_2) { :none }
+      let(:income_source_3) { :none }
+
+      it 'sets line 20a to the sum of all 1099-Rs, rounded' do
+        expect(instance.lines[:NJ1040_LINE_20A].value).to eq(901)
+      end
+    end
+
+    context 'when some 1099-Rs are military pension or survivor benefits' do
+      let(:income_source_1) { :military_pension }
+      let(:income_source_2) { :military_survivors_benefits }
+      let(:income_source_3) { :none }
+
+      it 'does not include military pension / survivor benefits in line 20a sum' do
+        expect(instance.lines[:NJ1040_LINE_20A].value).to eq(500)
+      end
+    end
+
+    context 'when all 1099-Rs are military pension or survivor benefits' do
+      let(:income_source_1) { :military_pension }
+      let(:income_source_2) { :military_survivors_benefits }
+      let(:income_source_3) { :military_pension }
+
+      it 'line 20a sums to zero' do
+        expect(instance.lines[:NJ1040_LINE_20A].value).to eq(0)
+      end
+    end
+  end
+
   describe 'line 27 - total income' do
     let(:intake) { create(:state_file_nj_intake) }
 
-    it 'sets line 27 to the sum of all state wage amounts' do
+    it 'sets line 27 to the sum of all state wage amounts plus line 20a (taxable retirement income)' do
       allow(instance).to receive(:calculate_line_15).and_return 50_000
       allow(instance).to receive(:calculate_line_16a).and_return 1_000
+      allow(instance).to receive(:calculate_line_20a).and_return 3_000
       instance.calculate
-      expect(instance.lines[:NJ1040_LINE_27].value).to eq(51_000)
+      expect(instance.lines[:NJ1040_LINE_27].value).to eq(54_000)
     end
   end
 

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -1039,6 +1039,54 @@ RSpec.describe PdfFiller::Nj1040Pdf do
       end
     end
 
+    describe "line 20a - retirement income" do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)
+      end
+
+      context "when taxpayer has retirement income $12,345,678" do
+        it "fills in the total income boxes in the PDF on line 27 with the rounded value" do
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_20a).and_return 12_345_678
+
+          # millions
+          expect(pdf_fields["20a"]).to eq "1"
+          expect(pdf_fields["undefined_54"]).to eq "2"
+          # thousands
+          expect(pdf_fields["undefined_55"]).to eq "3"
+          expect(pdf_fields["undefined_56"]).to eq "4"
+          expect(pdf_fields["136"]).to eq "5"
+          # hundreds
+          expect(pdf_fields["137"]).to eq "6"
+          expect(pdf_fields["138"]).to eq "7"
+          expect(pdf_fields["139"]).to eq "8"
+          # decimals
+          expect(pdf_fields["140"]).to eq "0"
+          expect(pdf_fields["141"]).to eq "0"
+        end
+      end
+
+      context "when taxpayer provides retirement income of 0" do
+        it "does not fill in any of the boxes on line 20a" do
+        allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_20a).and_return 0
+
+          # millions
+          expect(pdf_fields["20a"]).to eq ""
+          expect(pdf_fields["undefined_54"]).to eq ""
+          # thousands
+          expect(pdf_fields["undefined_55"]).to eq ""
+          expect(pdf_fields["undefined_56"]).to eq ""
+          expect(pdf_fields["136"]).to eq ""
+          # hundreds
+          expect(pdf_fields["137"]).to eq ""
+          expect(pdf_fields["138"]).to eq ""
+          expect(pdf_fields["139"]).to eq ""
+          # decimals
+          expect(pdf_fields["140"]).to eq ""
+          expect(pdf_fields["141"]).to eq ""
+        end
+      end
+    end
+
     describe "line 27 - total income" do
       context "when taxpayer provides total income with the sum 200,000" do
         let(:submission) {

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -1039,13 +1039,37 @@ RSpec.describe PdfFiller::Nj1040Pdf do
       end
     end
 
+    describe "disabled show_retirement_ui flag" do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(false)
+      end
+
+      it "does not fill in any of the boxes on line 20a even when there is a value" do
+        allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_20a).and_return 12_345_678
+        # millions
+        expect(pdf_fields["20a"]).to eq ""
+        expect(pdf_fields["undefined_54"]).to eq ""
+        # thousands
+        expect(pdf_fields["undefined_55"]).to eq ""
+        expect(pdf_fields["undefined_56"]).to eq ""
+        expect(pdf_fields["136"]).to eq ""
+        # hundreds
+        expect(pdf_fields["137"]).to eq ""
+        expect(pdf_fields["138"]).to eq ""
+        expect(pdf_fields["139"]).to eq ""
+        # decimals
+        expect(pdf_fields["140"]).to eq ""
+        expect(pdf_fields["141"]).to eq ""
+      end
+    end
+
     describe "line 20a - retirement income" do
       before do
         allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)
       end
 
       context "when taxpayer has retirement income $12,345,678" do
-        it "fills in the total income boxes in the PDF on line 27 with the rounded value" do
+        it "fills in the total income boxes in the PDF on line 20a with the rounded value" do
           allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_20a).and_return 12_345_678
 
           # millions

--- a/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
@@ -422,6 +422,17 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
       end
     end
 
+    describe "disabled show_retirement_ui flag" do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(false)
+      end
+
+      it "does not show line 20a PensAnnuitAndIraWithdraw even when there is a value" do
+        allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_20a).and_return 300
+        expect(xml.at("PensAnnuitAndIraWithdraw")).to eq(nil)
+      end
+    end
+
     describe "retirement income - line 20a" do
       before do
         allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)

--- a/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
@@ -359,9 +359,9 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
 
       context "when w2 wages exist" do
         it "includes the sum in WagesSalariesTips item" do
-          expected_sum = 50000 + 50000 + 50000 + 50000
-          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_15).and_return expected_sum
-          expect(xml.at("WagesSalariesTips").text).to eq(expected_sum.to_s)
+          expected = 200_000
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_15).and_return expected
+          expect(xml.at("WagesSalariesTips").text).to eq(expected.to_s)
         end
       end
     end
@@ -422,15 +422,32 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
       end
     end
 
+    describe "retirement income - line 20a" do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)
+      end
+
+      context "when applicable retirement income exists" do
+        it "fills PensAnnuitAndIraWithdraw with the values from calculator" do
+          expected_total = 30_000
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_20a).and_return expected_total
+          expect(xml.at("PensAnnuitAndIraWithdraw").text).to eq(expected_total.to_s)
+        end
+      end
+
+      context "when filer does not have applicable retirement income" do
+        it "does not include TotalIncome in the XML" do
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_20a).and_return 0
+          expect(xml.at("PensAnnuitAndIraWithdraw")).to eq(nil)
+        end
+      end
+    end
+
     describe "total income - line 27" do
       context "when filer submits w2 wages" do
-        it "fills TotalIncome with the values from Line 15 and line 16A" do
-          expected_line_15_w2_wages = 200_000
-          expected_line_16a = 500
-          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_15).and_return expected_line_15_w2_wages
-          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_16a).and_return expected_line_16a
-          expected_total = expected_line_15_w2_wages + expected_line_16a
-          expect(xml.at("WagesSalariesTips").text).to eq(expected_line_15_w2_wages.to_s)
+        it "fills TotalIncome with the values from calculator" do
+          expected_total = 150_000
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_27).and_return expected_total
           expect(xml.at("TotalIncome").text).to eq(expected_total.to_s)
         end
       end
@@ -446,13 +463,9 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
     describe "gross income - line 29" do
       context "when filer submits w2 wages" do
         it "fills TotalIncome with the value from Line 15" do
-          expected_line_15_w2_wages = 200_000
-          expected_line_16a = 500
-          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_15).and_return expected_line_15_w2_wages
-          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_16a).and_return expected_line_16a
-          expected_total = expected_line_15_w2_wages + expected_line_16a
-          expect(xml.at("WagesSalariesTips").text).to eq(expected_line_15_w2_wages.to_s)
-          expect(xml.at("GrossIncome").text).to eq(expected_total.to_s)
+          expected = 200_000
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_29).and_return expected
+          expect(xml.at("GrossIncome").text).to eq(expected.to_s)
         end
       end
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/80

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- add calculation for line 20a (based on income source) & display in XML/PDF
- control XML/PDF based on Flipper retirement UI
- Update calculation for line 27 to include line 20a in sum
- clean up a bit of XML tests to avoid duplicating logic with calculator tests

## How to test?
Use persona with 1099-Rs (zeus two 1099r)
Don't forget to enable Flipper flag

## Screenshots (for visual changes)
![image](https://github.com/user-attachments/assets/38c76abb-f7a1-43a7-bdff-9580207a4026)
![image](https://github.com/user-attachments/assets/60590da2-bc75-4235-94d3-a93ed5ae777e)
