### PR TITLE
FYST-1751 Show NJ clients data import failed page instead of oops page when import fails

### DIFF
--- a/app/controllers/state_file/questions/post_data_transfer_controller.rb
+++ b/app/controllers/state_file/questions/post_data_transfer_controller.rb
@@ -3,13 +3,13 @@ module StateFile
     class PostDataTransferController < QuestionsController
       def edit
         super
+        if current_intake&.df_data_import_succeeded_at.nil?
+          redirect_to StateFilePagesController.to_path_helper(action: :data_import_failed) and return
+        end
         # Redirect to offboarding here if not eligible
         if current_intake&.has_disqualifying_eligibility_answer? ||
            current_intake&.disqualifying_df_data_reason.present?
           redirect_to next_path and return
-        end
-        if current_intake&.df_data_import_succeeded_at.nil?
-          redirect_to StateFilePagesController.to_path_helper(action: :data_import_failed) and return
         end
         StateFileEfileDeviceInfo.find_or_create_by!(
           event_type: "initial_creation",

--- a/spec/controllers/state_file/questions/post_data_transfer_controller_spec.rb
+++ b/spec/controllers/state_file/questions/post_data_transfer_controller_spec.rb
@@ -53,10 +53,25 @@ RSpec.describe StateFile::Questions::PostDataTransferController do
     end
 
     context "with federal data which we could not import successfully" do
-      it "redirects to the offboard screen" do
+      before do
         intake.update(df_data_import_succeeded_at: nil)
+      end
+
+      it "redirects to the offboard screen" do
         response = get :edit
         expect(response).to redirect_to(StateFile::StateFilePagesController.to_path_helper(action: "data_import_failed"))
+      end
+
+      context "with disqualifying reason" do
+        let(:intake) { create :state_file_nj_intake }
+        before do
+          allow_any_instance_of(DirectFileData).to receive(:filing_status).and_return(nil)
+        end
+
+        it "should redirect to offborad screen" do
+          response = get :edit
+          expect(response).to redirect_to(StateFile::StateFilePagesController.to_path_helper(action: "data_import_failed"))
+        end
       end
     end
 

--- a/spec/controllers/state_file/questions/post_data_transfer_controller_spec.rb
+++ b/spec/controllers/state_file/questions/post_data_transfer_controller_spec.rb
@@ -62,13 +62,13 @@ RSpec.describe StateFile::Questions::PostDataTransferController do
         expect(response).to redirect_to(StateFile::StateFilePagesController.to_path_helper(action: "data_import_failed"))
       end
 
-      context "with disqualifying reason" do
+      context "for New Jersey which does calculations with imported direct_file_data" do
         let(:intake) { create :state_file_nj_intake }
         before do
           allow_any_instance_of(DirectFileData).to receive(:filing_status).and_return(nil)
         end
 
-        it "should redirect to offborad screen" do
+        it "redirects to offboard screen" do
           response = get :edit
           expect(response).to redirect_to(StateFile::StateFilePagesController.to_path_helper(action: "data_import_failed"))
         end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1751
- Sentry: https://codeforamerica.sentry.io/issues/6271169563/?project=1880327&referrer=issue-stream&statsPeriod=14d&stream_index=0
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- We were attempting to check the eligibility of the intake when it was not successfully imported. We should redirect to `data_import_failed` page before we check whether the intake is eligible or not. NJ is the only state that uses the calculator to determine whether the intake is eligible or not -- which is why we only saw these errors for two of NJ intakes.
- For all 9 events, this was the case, I did not see any odd issues regarding jumping around on the landing page

## How to test?
- Describe the testing approach taken to verify the changes, including:
  - Unit tests
  - I don't know how to reproduce this in demo/prod since we'd have to initiate a failed import somehow

## Followups
 NJ intake 1689 & NJ Intake 1968 both had failed imports, we will likely want to reach out to DF about it