### PR TITLE
Nj 243 - Add headers to review screen

### DIFF
--- a/app/views/state_file/questions/nj_review/edit.html.erb
+++ b/app/views/state_file/questions/nj_review/edit.html.erb
@@ -142,6 +142,10 @@
     </section>
   <% end %>
 
+  <div class="spacing-below-25">
+    <h2 class="text--body text--bold spacing-below-5"><%=t("state_file.navigation.nj.section_3") %></h2>
+  </div>
+
   <section id="medical_expenses" class="white-group">
     <div class="spacing-below-5">
       <h2 class="text--body text--bold spacing-below-5"><%=t(".medical_expenses") %></h2>
@@ -197,6 +201,10 @@
       </div>
     </section>
   <% end %>
+
+  <div class="spacing-below-25">
+    <h2 class="text--body text--bold spacing-below-5"><%=t("state_file.navigation.nj.section_4", filing_year: current_tax_year) %></h2>
+  </div>
 
   <section id="estimated-tax-payments" class="white-group">
     <div class="spacing-below-5">

--- a/app/views/state_file/questions/nj_review/edit.html.erb
+++ b/app/views/state_file/questions/nj_review/edit.html.erb
@@ -6,7 +6,7 @@
   <% if current_intake.dependents.count(&:under_22?).positive? %>
     <section id="college-dependents" class="white-group">
       <div class="spacing-below-5">
-        <h3 class="text--body text--bold spacing-below-5"><%=t(".college_dependents") %></h2>
+        <h3 class="text--body text--bold spacing-below-5"><%=t(".college_dependents") %></h3>
         <% current_intake.dependents.each do | dependent | %>
           <% if dependent.nj_qualifies_for_college_exemption? %>
             <p><%=dependent.full_name %></p>
@@ -26,7 +26,7 @@
   <% if current_intake.dependents.any? && current_intake.has_health_insurance_requirement_exception? %>
     <section id="missing-health-insurance" class="white-group">
       <div class="spacing-below-5">
-        <h3 class="text--body text--bold spacing-below-5"><%=t(".missing_health_insurance") %></h2>
+        <h3 class="text--body text--bold spacing-below-5"><%=t(".missing_health_insurance") %></h3>
         <% current_intake.dependents.each do | dependent | %>
           <% if dependent.nj_did_not_have_health_insurance_yes? %>
             <p><%=dependent.full_name %></p>
@@ -46,7 +46,7 @@
   <% if current_intake.filing_status_qw? %>
     <section id="year-of-death" class="white-group">
       <div class="spacing-below-5">
-        <h3 class="text--body text--bold spacing-below-5"><%=t(".year_of_death") %></h2>
+        <h3 class="text--body text--bold spacing-below-5"><%=t(".year_of_death") %></h3>
         <p><%=current_intake.spouse_death_year %></p>
 
         <%= link_to StateFile::Questions::NjYearOfDeathController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
@@ -59,7 +59,7 @@
 
   <section id="county-municipality" class="white-group">
     <div class="spacing-below-5">
-      <h3 class="text--body text--bold spacing-below-5"><%=t(".county_municipality", filing_year: current_tax_year) %></h2>
+      <h3 class="text--body text--bold spacing-below-5"><%=t(".county_municipality", filing_year: current_tax_year) %></h3>
       <p><%= t(".county", county: current_intake.county) %></p>
       <p><%=current_intake.municipality_name %></p>
 
@@ -74,11 +74,11 @@
     <section id="disabled_exemption" class="white-group">
       <div class="spacing-below-5">
         <% unless current_intake.primary_disabled_unfilled? %>
-          <h3 class="text--body text--bold spacing-below-5"><%= t(".primary_disabled")  %></h2>
+          <h3 class="text--body text--bold spacing-below-5"><%= t(".primary_disabled")  %></h3>
           <p><%= current_intake.primary_disabled_yes? ? t("general.affirmative") : t("general.negative") %></p>
         <% end %>
         <% unless current_intake.spouse_disabled_unfilled? %>
-          <h3 class="text--body text--bold spacing-below-5"><%= t(".spouse_disabled")  %></h2>
+          <h3 class="text--body text--bold spacing-below-5"><%= t(".spouse_disabled")  %></h3>
           <p><%= current_intake.spouse_disabled_yes? ? t("general.affirmative") : t("general.negative") %></p>
         <% end %>
         <%= link_to StateFile::Questions::NjDisabledExemptionController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
@@ -93,11 +93,11 @@
     <section id="veterans_exemption" class="white-group">
       <div class="spacing-below-5">
         <% unless current_intake.primary_veteran_unfilled? %>
-          <h3 class="text--body text--bold spacing-below-5"><%= t(".primary_veteran")  %></h2>
+          <h3 class="text--body text--bold spacing-below-5"><%= t(".primary_veteran")  %></h3>
           <p><%= current_intake.primary_veteran_yes? ? t("general.affirmative") : t("general.negative") %></p>
         <% end %>
         <% unless current_intake.spouse_veteran_unfilled? %>
-          <h3 class="text--body text--bold spacing-below-5"><%= t(".spouse_veteran")  %></h2>
+          <h3 class="text--body text--bold spacing-below-5"><%= t(".spouse_veteran")  %></h3>
           <p><%= current_intake.spouse_veteran_yes? ? t("general.affirmative") : t("general.negative") %></p>
         <% end %>
         <%= link_to StateFile::Questions::NjVeteransExemptionController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
@@ -111,7 +111,7 @@
   <% if current_intake.state_file1099_rs.length.positive? && Flipper.enabled?(:show_retirement_ui) %>
     <section id="retirement-income-source" class="white-group">
       <div class="spacing-below-5">
-        <h3 class="text--body text--bold spacing-below-25"><%=t(".retirement_income_source") %></h2>
+        <h3 class="text--body text--bold spacing-below-25"><%=t(".retirement_income_source") %></h3>
 
         <% current_intake.state_file1099_rs.each do |state_file1099_r| %>
           <% unless state_file1099_r.state_specific_followup.nil? %>
@@ -148,7 +148,7 @@
 
   <section id="medical_expenses" class="white-group">
     <div class="spacing-below-5">
-      <h3 class="text--body text--bold spacing-below-5"><%=t(".medical_expenses") %></h2>
+      <h3 class="text--body text--bold spacing-below-5"><%=t(".medical_expenses") %></h3>
       <p><%= number_to_currency(current_intake.medical_expenses, precision: 0) %></p>
       <%= link_to StateFile::Questions::NjMedicalExpensesController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
         <%= t(".review_and_edit") %>
@@ -159,18 +159,18 @@
 
   <section id="property-tax" class="white-group">
     <div class="spacing-below-5">
-      <h3 class="text--body text--bold spacing-below-5"><%=t(".property_tax_credit_deduction") %></h2>
+      <h3 class="text--body text--bold spacing-below-5"><%=t(".property_tax_credit_deduction") %></h3>
 
-      <h4 class="text--body spacing-below-5"><%=t(".household_rent_own", filing_year: current_tax_year) %></h3>
+      <h4 class="text--body spacing-below-5"><%=t(".household_rent_own", filing_year: current_tax_year) %></h4>
       <p><%=t(".household_rent_own_#{current_intake.household_rent_own}") unless current_intake.household_rent_own_unfilled? %></p>
 
       <% unless current_intake.property_tax_paid.nil? %>
-        <h4 class="text--body text--bold spacing-below-5"><%= t(".property_tax_paid", filing_year: current_tax_year)  %></h3>
+        <h4 class="text--body text--bold spacing-below-5"><%= t(".property_tax_paid", filing_year: current_tax_year)  %></h4>
         <p><%= number_to_currency(current_intake.property_tax_paid, precision: 0) %></p>
       <% end %>
 
       <% unless current_intake.rent_paid.nil? %>
-        <h4 class="text--body text--bold spacing-below-5"><%=t(".rent_paid", filing_year: current_tax_year) %></h3>
+        <h4 class="text--body text--bold spacing-below-5"><%=t(".rent_paid", filing_year: current_tax_year) %></h4>
         <p><%= number_to_currency(current_intake.rent_paid, precision: 0) %></p>
       <% end %>
 
@@ -184,14 +184,14 @@
   <% unless current_intake.claimed_as_eitc_qualifying_child_unfilled? && current_intake.spouse_claimed_as_eitc_qualifying_child_unfilled? %>
     <section id="eitc_qualifying_child" class="white-group">
       <div class="spacing-below-5">
-        <h3 class="text--body text--bold spacing-below-5"><%=t(".eitc") %></h2>
+        <h3 class="text--body text--bold spacing-below-5"><%=t(".eitc") %></h3>
 
         <% unless current_intake.claimed_as_eitc_qualifying_child_unfilled? %>
-          <h4 class="text--body text--bold spacing-below-5"><%=t(".primary_claimed_as_eitc_qualifying_child") %></h3>
+          <h4 class="text--body text--bold spacing-below-5"><%=t(".primary_claimed_as_eitc_qualifying_child") %></h4>
           <p><%=current_intake.claimed_as_eitc_qualifying_child_yes? ? t("general.affirmative") : t("general.negative") %></p>
         <% end %>
         <% unless current_intake.spouse_claimed_as_eitc_qualifying_child_unfilled? %>
-        <h4 class="text--body text--bold spacing-below-5"><%=t(".spouse_claimed_as_eitc_qualifying_child") %></h3>
+        <h4 class="text--body text--bold spacing-below-5"><%=t(".spouse_claimed_as_eitc_qualifying_child") %></h4>
           <p><%=current_intake.spouse_claimed_as_eitc_qualifying_child_yes? ? t("general.affirmative") : t("general.negative") %></p>
         <% end %>
         <%= link_to StateFile::Questions::NjEitcQualifyingChildController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
@@ -208,7 +208,7 @@
 
   <section id="estimated-tax-payments" class="white-group">
     <div class="spacing-below-5">
-      <h3 class="text--body text--bold spacing-below-5"><%=t(".estimated_tax_payments") %></h2>
+      <h3 class="text--body text--bold spacing-below-5"><%=t(".estimated_tax_payments") %></h3>
       <p><%= number_to_currency(current_intake.estimated_tax_payments || 0, precision: 0) %></p>
       <%= link_to StateFile::Questions::NjEstimatedTaxPaymentsController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
         <%= t(".review_and_edit") %>
@@ -219,7 +219,7 @@
 
   <section id="use-tax" class="white-group">
     <div class="spacing-below-5">
-      <h3 class="text--body text--bold spacing-below-5"><%=t(".use_tax_applied") %></h2>
+      <h3 class="text--body text--bold spacing-below-5"><%=t(".use_tax_applied") %></h3>
       <p><%=current_intake.untaxed_out_of_state_purchases_yes? ? t("general.affirmative") : t("general.negative") %></p>
       <% if current_intake.untaxed_out_of_state_purchases_yes? %>
         <p class="text--bold spacing-below-5">
@@ -235,7 +235,7 @@
   </section>
 
   <section class="reveal" id="calculation-details">
-    <h3 class="text--body text--bold spacing-below-5"><button class="reveal__button"><%= t(".reveal.header") %></button></h2>
+    <h3 class="text--body text--bold spacing-below-5"><button class="reveal__button"><%= t(".reveal.header") %></button></h3>
     <div class="reveal__content">
       <% @detailed_return_info.each.with_index do |section, i| %>
         <div>

--- a/app/views/state_file/questions/nj_review/edit.html.erb
+++ b/app/views/state_file/questions/nj_review/edit.html.erb
@@ -6,7 +6,7 @@
   <% if current_intake.dependents.count(&:under_22?).positive? %>
     <section id="college-dependents" class="white-group">
       <div class="spacing-below-5">
-        <h2 class="text--body text--bold spacing-below-5"><%=t(".college_dependents") %></h2>
+        <h3 class="text--body text--bold spacing-below-5"><%=t(".college_dependents") %></h2>
         <% current_intake.dependents.each do | dependent | %>
           <% if dependent.nj_qualifies_for_college_exemption? %>
             <p><%=dependent.full_name %></p>
@@ -26,7 +26,7 @@
   <% if current_intake.dependents.any? && current_intake.has_health_insurance_requirement_exception? %>
     <section id="missing-health-insurance" class="white-group">
       <div class="spacing-below-5">
-        <h2 class="text--body text--bold spacing-below-5"><%=t(".missing_health_insurance") %></h2>
+        <h3 class="text--body text--bold spacing-below-5"><%=t(".missing_health_insurance") %></h2>
         <% current_intake.dependents.each do | dependent | %>
           <% if dependent.nj_did_not_have_health_insurance_yes? %>
             <p><%=dependent.full_name %></p>
@@ -46,7 +46,7 @@
   <% if current_intake.filing_status_qw? %>
     <section id="year-of-death" class="white-group">
       <div class="spacing-below-5">
-        <h2 class="text--body text--bold spacing-below-5"><%=t(".year_of_death") %></h2>
+        <h3 class="text--body text--bold spacing-below-5"><%=t(".year_of_death") %></h2>
         <p><%=current_intake.spouse_death_year %></p>
 
         <%= link_to StateFile::Questions::NjYearOfDeathController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
@@ -59,7 +59,7 @@
 
   <section id="county-municipality" class="white-group">
     <div class="spacing-below-5">
-      <h2 class="text--body text--bold spacing-below-5"><%=t(".county_municipality", filing_year: current_tax_year) %></h2>
+      <h3 class="text--body text--bold spacing-below-5"><%=t(".county_municipality", filing_year: current_tax_year) %></h2>
       <p><%= t(".county", county: current_intake.county) %></p>
       <p><%=current_intake.municipality_name %></p>
 
@@ -74,11 +74,11 @@
     <section id="disabled_exemption" class="white-group">
       <div class="spacing-below-5">
         <% unless current_intake.primary_disabled_unfilled? %>
-          <h2 class="text--body text--bold spacing-below-5"><%= t(".primary_disabled")  %></h2>
+          <h3 class="text--body text--bold spacing-below-5"><%= t(".primary_disabled")  %></h2>
           <p><%= current_intake.primary_disabled_yes? ? t("general.affirmative") : t("general.negative") %></p>
         <% end %>
         <% unless current_intake.spouse_disabled_unfilled? %>
-          <h2 class="text--body text--bold spacing-below-5"><%= t(".spouse_disabled")  %></h2>
+          <h3 class="text--body text--bold spacing-below-5"><%= t(".spouse_disabled")  %></h2>
           <p><%= current_intake.spouse_disabled_yes? ? t("general.affirmative") : t("general.negative") %></p>
         <% end %>
         <%= link_to StateFile::Questions::NjDisabledExemptionController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
@@ -93,11 +93,11 @@
     <section id="veterans_exemption" class="white-group">
       <div class="spacing-below-5">
         <% unless current_intake.primary_veteran_unfilled? %>
-          <h2 class="text--body text--bold spacing-below-5"><%= t(".primary_veteran")  %></h2>
+          <h3 class="text--body text--bold spacing-below-5"><%= t(".primary_veteran")  %></h2>
           <p><%= current_intake.primary_veteran_yes? ? t("general.affirmative") : t("general.negative") %></p>
         <% end %>
         <% unless current_intake.spouse_veteran_unfilled? %>
-          <h2 class="text--body text--bold spacing-below-5"><%= t(".spouse_veteran")  %></h2>
+          <h3 class="text--body text--bold spacing-below-5"><%= t(".spouse_veteran")  %></h2>
           <p><%= current_intake.spouse_veteran_yes? ? t("general.affirmative") : t("general.negative") %></p>
         <% end %>
         <%= link_to StateFile::Questions::NjVeteransExemptionController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
@@ -111,7 +111,7 @@
   <% if current_intake.state_file1099_rs.length.positive? && Flipper.enabled?(:show_retirement_ui) %>
     <section id="retirement-income-source" class="white-group">
       <div class="spacing-below-5">
-        <h2 class="text--body text--bold spacing-below-25"><%=t(".retirement_income_source") %></h2>
+        <h3 class="text--body text--bold spacing-below-25"><%=t(".retirement_income_source") %></h2>
 
         <% current_intake.state_file1099_rs.each do |state_file1099_r| %>
           <% unless state_file1099_r.state_specific_followup.nil? %>
@@ -148,7 +148,7 @@
 
   <section id="medical_expenses" class="white-group">
     <div class="spacing-below-5">
-      <h2 class="text--body text--bold spacing-below-5"><%=t(".medical_expenses") %></h2>
+      <h3 class="text--body text--bold spacing-below-5"><%=t(".medical_expenses") %></h2>
       <p><%= number_to_currency(current_intake.medical_expenses, precision: 0) %></p>
       <%= link_to StateFile::Questions::NjMedicalExpensesController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
         <%= t(".review_and_edit") %>
@@ -159,18 +159,18 @@
 
   <section id="property-tax" class="white-group">
     <div class="spacing-below-5">
-      <h2 class="text--body text--bold spacing-below-5"><%=t(".property_tax_credit_deduction") %></h2>
+      <h3 class="text--body text--bold spacing-below-5"><%=t(".property_tax_credit_deduction") %></h2>
 
-      <h3 class="text--body spacing-below-5"><%=t(".household_rent_own", filing_year: current_tax_year) %></h3>
+      <h4 class="text--body spacing-below-5"><%=t(".household_rent_own", filing_year: current_tax_year) %></h3>
       <p><%=t(".household_rent_own_#{current_intake.household_rent_own}") unless current_intake.household_rent_own_unfilled? %></p>
 
       <% unless current_intake.property_tax_paid.nil? %>
-        <h3 class="text--body text--bold spacing-below-5"><%= t(".property_tax_paid", filing_year: current_tax_year)  %></h3>
+        <h4 class="text--body text--bold spacing-below-5"><%= t(".property_tax_paid", filing_year: current_tax_year)  %></h3>
         <p><%= number_to_currency(current_intake.property_tax_paid, precision: 0) %></p>
       <% end %>
 
       <% unless current_intake.rent_paid.nil? %>
-        <h3 class="text--body text--bold spacing-below-5"><%=t(".rent_paid", filing_year: current_tax_year) %></h3>
+        <h4 class="text--body text--bold spacing-below-5"><%=t(".rent_paid", filing_year: current_tax_year) %></h3>
         <p><%= number_to_currency(current_intake.rent_paid, precision: 0) %></p>
       <% end %>
 
@@ -184,14 +184,14 @@
   <% unless current_intake.claimed_as_eitc_qualifying_child_unfilled? && current_intake.spouse_claimed_as_eitc_qualifying_child_unfilled? %>
     <section id="eitc_qualifying_child" class="white-group">
       <div class="spacing-below-5">
-        <h2 class="text--body text--bold spacing-below-5"><%=t(".eitc") %></h2>
+        <h3 class="text--body text--bold spacing-below-5"><%=t(".eitc") %></h2>
 
         <% unless current_intake.claimed_as_eitc_qualifying_child_unfilled? %>
-          <h3 class="text--body text--bold spacing-below-5"><%=t(".primary_claimed_as_eitc_qualifying_child") %></h3>
+          <h4 class="text--body text--bold spacing-below-5"><%=t(".primary_claimed_as_eitc_qualifying_child") %></h3>
           <p><%=current_intake.claimed_as_eitc_qualifying_child_yes? ? t("general.affirmative") : t("general.negative") %></p>
         <% end %>
         <% unless current_intake.spouse_claimed_as_eitc_qualifying_child_unfilled? %>
-        <h3 class="text--body text--bold spacing-below-5"><%=t(".spouse_claimed_as_eitc_qualifying_child") %></h3>
+        <h4 class="text--body text--bold spacing-below-5"><%=t(".spouse_claimed_as_eitc_qualifying_child") %></h3>
           <p><%=current_intake.spouse_claimed_as_eitc_qualifying_child_yes? ? t("general.affirmative") : t("general.negative") %></p>
         <% end %>
         <%= link_to StateFile::Questions::NjEitcQualifyingChildController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
@@ -208,7 +208,7 @@
 
   <section id="estimated-tax-payments" class="white-group">
     <div class="spacing-below-5">
-      <h2 class="text--body text--bold spacing-below-5"><%=t(".estimated_tax_payments") %></h2>
+      <h3 class="text--body text--bold spacing-below-5"><%=t(".estimated_tax_payments") %></h2>
       <p><%= number_to_currency(current_intake.estimated_tax_payments || 0, precision: 0) %></p>
       <%= link_to StateFile::Questions::NjEstimatedTaxPaymentsController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
         <%= t(".review_and_edit") %>
@@ -219,7 +219,7 @@
 
   <section id="use-tax" class="white-group">
     <div class="spacing-below-5">
-      <h2 class="text--body text--bold spacing-below-5"><%=t(".use_tax_applied") %></h2>
+      <h3 class="text--body text--bold spacing-below-5"><%=t(".use_tax_applied") %></h2>
       <p><%=current_intake.untaxed_out_of_state_purchases_yes? ? t("general.affirmative") : t("general.negative") %></p>
       <% if current_intake.untaxed_out_of_state_purchases_yes? %>
         <p class="text--bold spacing-below-5">
@@ -235,7 +235,7 @@
   </section>
 
   <section class="reveal" id="calculation-details">
-    <h2 class="text--body text--bold spacing-below-5"><button class="reveal__button"><%= t(".reveal.header") %></button></h2>
+    <h3 class="text--body text--bold spacing-below-5"><button class="reveal__button"><%= t(".reveal.header") %></button></h2>
     <div class="reveal__content">
       <% @detailed_return_info.each.with_index do |section, i| %>
         <div>

--- a/spec/features/state_file/nj/complete_intake_spec.rb
+++ b/spec/features/state_file/nj/complete_intake_spec.rb
@@ -261,11 +261,21 @@ RSpec.feature "Completing a state file intake", active_job: true do
 
       expect(page).to be_axe_clean.within "main"
 
-      groups = page.all(:css, '.white-group').count
-      h2s = page.all(:css, 'h2').count
-      expect(groups).to eq(h2s - 2)
-      # total should be h2s -1 to account for the h2 reveal button
-      # there's also an extra h2 in the veteran exemption box
+      household_details_h3s = 2 + dependents_dob
+      income_details_h3s = 0
+      dependents_attending_college_h3s = 1
+      where_you_lived_as_of_dec_31_h3s = 1
+      disability_exemption_h3s = 1
+      veterans_exemption_h3s = 2
+      medical_expenses_h3s = 1
+      property_tax_h3s = 1
+      payments_made_h3s = 1
+      use_tax_h3s = 1
+      reveal_h3 = 1
+      total_expected_h3s = household_details_h3s + income_details_h3s + dependents_attending_college_h3s + where_you_lived_as_of_dec_31_h3s + disability_exemption_h3s + veterans_exemption_h3s + medical_expenses_h3s + property_tax_h3s + payments_made_h3s + use_tax_h3s + reveal_h3
+
+      h3s = page.all(:css, 'h3').count
+      expect(total_expected_h3s).to eq(h3s)
 
       edit_buttons = page.all(:css, '.white-group a')
       edit_buttons_count = edit_buttons.count
@@ -569,7 +579,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
         expect_municipality_question_exists
 
         # unselect county
-        within find('#county-question') do
+        within find_by_id('county-question') do
           select I18n.t('general.select_prompt')
         end
         expect_county_question_exists
@@ -580,7 +590,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
         advance_to_start_of_intake("Minimal", expect_income_review: false)
 
         select "Atlantic"
-        within find('#municipality-question') do
+        within find_by_id('municipality-question') do
           expect(page.all("option").length).to eq(24) # 23 municipalities + 1 "- Select -"
           expect(page).to have_text "Absecon City"
           expect(page).to have_text "Atlantic City"
@@ -589,7 +599,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
         end
 
         select "Mercer"
-        within find('#municipality-question') do
+        within find_by_id('municipality-question') do
           expect(page.all("option").length).to eq(13) # 12 municipalities + 1 "- Select -"
           expect(page).to have_text "East Windsor Township"
           expect(page).to have_text "Hopewell Township"
@@ -602,10 +612,10 @@ RSpec.feature "Completing a state file intake", active_job: true do
 
         select "Atlantic"
         select "Absecon City"
-        expect(find("#state_file_nj_county_municipality_form_municipality_code").value).to eq("0101")
+        expect(find_by_id('state_file_nj_county_municipality_form_municipality_code').value).to eq("0101")
 
         select "Mercer"
-        expect(find("#state_file_nj_county_municipality_form_municipality_code").value).to eq("")
+        expect(find_by_id('state_file_nj_county_municipality_form_municipality_code').value).to eq("")
       end
 
     end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/243

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Add "Deductions and Credits" and "Your 2024 Taxes" Headers to NJ review screen to match content doc:https://docs.google.com/document/d/1I3IAqk1xYehwF3iJEw0hBUXLmD3db4rM_Ivm7HBfnbo/edit?tab=t.0#heading=h.buaa78ggxvdj
- Update headers so that the hierarchy is correctly maintained
  - Note that the [abstract header](https://github.com/codeforamerica/vita-min/blob/c75ad162f29742abd773e98eba6e566608530ea3/app/views/state_file/questions/shared/_abstract_review_header.html.erb) used has h2 headings, so the titles of each deduction/credit need to be set to h3.

## How to test?
- Navigate to nj_review, validate that the headings appear correctly in english and spanish

## Screenshots (for visual changes)
- Before
<img width="572" alt="image" src="https://github.com/user-attachments/assets/d0577075-f552-49f7-ab83-1b797d6b2d24" />


- After
<img width="430" alt="image" src="https://github.com/user-attachments/assets/ab0b6e76-a63b-4439-a995-8577c31efb50" />