### PR TITLE
FYST-1790 Fix intake clearing on landing page

### DIFF
--- a/app/controllers/concerns/state_file/state_file_controller_concern.rb
+++ b/app/controllers/concerns/state_file/state_file_controller_concern.rb
@@ -3,7 +3,14 @@ module StateFile
     extend ActiveSupport::Concern
 
     included do
-      helper_method :current_tax_year
+      helper_method :current_tax_year, :current_intake
+    end
+
+    def current_intake
+      StateFile::StateInformationService.active_state_codes
+                                        .lazy
+                                        .map { |c| send("current_state_file_#{c}_intake".to_sym) }
+                                        .find(&:itself)
     end
 
     def current_tax_year

--- a/app/controllers/concerns/state_file/state_file_intake_concern.rb
+++ b/app/controllers/concerns/state_file/state_file_intake_concern.rb
@@ -5,14 +5,7 @@ module StateFile
 
     included do
       before_action :redirect_deprecated_state, :require_state_file_intake_login
-      helper_method :current_intake, :current_state_code, :current_state_name, :card_postscript
-    end
-
-    def current_intake
-      StateFile::StateInformationService.active_state_codes
-                                        .lazy
-                                        .map { |c| send("current_state_file_#{c}_intake".to_sym) }
-                                        .find(&:itself)
+      helper_method :current_state_code, :current_state_name, :card_postscript
     end
 
     def current_state_code

--- a/app/controllers/state_file/landing_page_controller.rb
+++ b/app/controllers/state_file/landing_page_controller.rb
@@ -19,9 +19,7 @@ module StateFile
 
     def update
       all_current_intakes = StateFile::StateInformationService.active_state_codes.map { |c| send("current_state_file_#{c}_intake".to_sym) }.compact
-      if all_current_intakes.present?
-        all_current_intakes.each { |intake| sign_out intake }
-      end
+      all_current_intakes.each { |intake| sign_out intake }
       intake = StateInformationService.intake_class(params[:us_state]).new(
         visitor_id: cookies.encrypted[:visitor_id],
         source: session[:source],

--- a/app/controllers/state_file/landing_page_controller.rb
+++ b/app/controllers/state_file/landing_page_controller.rb
@@ -18,7 +18,10 @@ module StateFile
     end
 
     def update
-      sign_out current_intake if current_intake.present?
+      all_current_intakes = StateFile::StateInformationService.active_state_codes.map { |c| send("current_state_file_#{c}_intake".to_sym) }.compact
+      if all_current_intakes.present?
+        all_current_intakes.each { |intake| sign_out intake }
+      end
       intake = StateInformationService.intake_class(params[:us_state]).new(
         visitor_id: cookies.encrypted[:visitor_id],
         source: session[:source],

--- a/app/controllers/state_file/landing_page_controller.rb
+++ b/app/controllers/state_file/landing_page_controller.rb
@@ -18,9 +18,14 @@ module StateFile
     end
 
     def update
-      all_current_intakes = StateFile::StateInformationService.active_state_codes.map { |c| send("current_state_file_#{c}_intake".to_sym) }.compact
-      if all_current_intakes.present?
-        all_current_intakes.each { |intake| sign_out intake }
+      if acts_like_production?
+        current_state_intake = send("current_state_file_#{params[:us_state]}_intake".to_sym)
+        sign_out current_state_intake if current_state_intake.present?
+      else
+        all_current_intakes = StateFile::StateInformationService.active_state_codes.map { |c| send("current_state_file_#{c}_intake".to_sym) }.compact
+        if all_current_intakes.present?
+          all_current_intakes.each { |intake| sign_out intake }
+        end
       end
       intake = StateInformationService.intake_class(params[:us_state]).new(
         visitor_id: cookies.encrypted[:visitor_id],

--- a/app/controllers/state_file/landing_page_controller.rb
+++ b/app/controllers/state_file/landing_page_controller.rb
@@ -18,14 +18,9 @@ module StateFile
     end
 
     def update
-      if acts_like_production?
-        current_state_intake = send("current_state_file_#{params[:us_state]}_intake".to_sym)
-        sign_out current_state_intake if current_state_intake.present?
-      else
-        all_current_intakes = StateFile::StateInformationService.active_state_codes.map { |c| send("current_state_file_#{c}_intake".to_sym) }.compact
-        if all_current_intakes.present?
-          all_current_intakes.each { |intake| sign_out intake }
-        end
+      all_current_intakes = StateFile::StateInformationService.active_state_codes.map { |c| send("current_state_file_#{c}_intake".to_sym) }.compact
+      if all_current_intakes.present?
+        all_current_intakes.each { |intake| sign_out intake }
       end
       intake = StateInformationService.intake_class(params[:us_state]).new(
         visitor_id: cookies.encrypted[:visitor_id],

--- a/spec/controllers/concerns/state_file/state_file_controller_concern_spec.rb
+++ b/spec/controllers/concerns/state_file/state_file_controller_concern_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe StateFile::StateFileControllerConcern, type: :controller do
+  controller(ApplicationController) do
+    include StateFile::StateFileControllerConcern
+
+    def index
+      head :ok
+    end
+  end
+
+  describe "helper methods" do
+    let(:az_intake) { create(:state_file_az_intake) }
+
+    describe "#current_intake" do
+      context "when there is a logged in intake" do
+        before { sign_in az_intake }
+
+        it "returns that intake" do
+          expect(subject.current_intake).to eq az_intake
+        end
+
+        context "when there are multiple logged in intakes" do
+          before { sign_in create(:state_file_md_intake) }
+
+          it "returns the first logged in intake it can find" do
+            expect(subject.current_intake).to eq az_intake
+          end
+        end
+      end
+
+      context "when there is not a logged in intake" do
+        it "returns nil" do
+          expect(subject.current_intake).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/state_file/landing_page_controller_spec.rb
+++ b/spec/controllers/state_file/landing_page_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe StateFile::LandingPageController do
-  StateFile::StateInformationService.active_state_codes.excluding(:ny).each do |state_code|
+  StateFile::StateInformationService.active_state_codes.excluding("ny").each do |state_code|
     describe "#update" do
       it_behaves_like :start_intake_concern, intake_class: StateFile::StateInformationService.intake_class(state_code) do
         let(:valid_params) do

--- a/spec/support/shared_examples/start_intake_concern.rb
+++ b/spec/support/shared_examples/start_intake_concern.rb
@@ -20,49 +20,39 @@ shared_examples :start_intake_concern do |intake_class:|
     end
 
     context "with existing intakes in the session" do
-      let(:existing_intake) do
-        create(intake_class.name.underscore)
-      end
-      let(:existing_oos_intake) do
-        intake_classes = StateFile::StateInformationService.state_intake_classes.excluding(StateFileNyIntake)
-        other_intake_class_index = intake_classes.find_index(intake_class) - 1
-        other_intake_class = intake_classes[other_intake_class_index]
-        create(other_intake_class.name.underscore)
-      end
-
       before do
         sign_in existing_intake
-        sign_in existing_oos_intake
       end
 
-      context "in production" do
-        before do
-          allow(Rails).to receive(:env).and_return("production".inquiry)
+      context "with an in-state intake" do
+        let(:existing_intake) do
+          create(intake_class.name.underscore)
         end
 
-        it "replaces the existing in-state intake and does not clear the out of state intakes" do
+        it "replaces the existing in-state intake and clears other intakes" do
           post :update, params: valid_params
           logged_in_intakes = StateFile::StateInformationService.state_intake_classes.map do |klass|
             subject.send("current_#{klass.name.underscore}")
           end.compact
           expect(logged_in_intakes).not_to include existing_intake
-          expect(logged_in_intakes).to include existing_oos_intake
           expect(logged_in_intakes).to include intake_class.send(:last)
         end
       end
 
-      context "in any other environment" do
-        before do
-          allow(Rails).to receive(:env).and_return("demo".inquiry)
+      context "with an out-of-state intake" do
+        let(:existing_intake) do
+          intake_classes = StateFile::StateInformationService.state_intake_classes.excluding(StateFileNyIntake)
+          other_intake_class_index = intake_classes.find_index(intake_class) - 1
+          other_intake_class = intake_classes[other_intake_class_index]
+          create(other_intake_class.name.underscore)
         end
 
-        it "replaces the existing in-state intake and clears the out of state intakes" do
+        it "replaces the existing in-state intake and clears other intakes" do
           post :update, params: valid_params
           logged_in_intakes = StateFile::StateInformationService.state_intake_classes.map do |klass|
             subject.send("current_#{klass.name.underscore}")
           end.compact
           expect(logged_in_intakes).not_to include existing_intake
-          expect(logged_in_intakes).not_to include existing_oos_intake
           expect(logged_in_intakes).to include intake_class.send(:last)
         end
       end

--- a/spec/support/shared_examples/start_intake_concern.rb
+++ b/spec/support/shared_examples/start_intake_concern.rb
@@ -28,7 +28,7 @@ shared_examples :start_intake_concern do |intake_class:|
 
       it "replaces the existing intake in the session with a new one" do
         post :update, params: valid_params
-        logged_in_intake = intake_class.find(session["warden.user.#{intake_class.name.underscore}.key"].first.first)
+        logged_in_intake = subject.send("current_#{intake_class.name.underscore}")
         expect(logged_in_intake).not_to eq existing_intake
         expect(logged_in_intake).to eq intake_class.send(:last)
       end
@@ -47,8 +47,7 @@ shared_examples :start_intake_concern do |intake_class:|
       it "replaces the existing intake in the session with a new one" do
         post :update, params: valid_params
         logged_in_intakes = StateFile::StateInformationService.state_intake_classes.map do |klass|
-          intake_id = session["warden.user.#{klass.name.underscore}.key"]&.first&.first
-          intake_id.present? ? klass.find(intake_id) : nil
+          subject.send("current_#{klass.name.underscore}")
         end.compact
         expect(logged_in_intakes).not_to include existing_intake
         expect(logged_in_intakes).to include intake_class.send(:last)

--- a/spec/support/shared_examples/start_intake_concern.rb
+++ b/spec/support/shared_examples/start_intake_concern.rb
@@ -28,8 +28,30 @@ shared_examples :start_intake_concern do |intake_class:|
 
       it "replaces the existing intake in the session with a new one" do
         post :update, params: valid_params
-        intake = intake_class.find(session["warden.user.#{intake_class.name.underscore}.key"].first.first)
-        expect(intake).not_to eq existing_intake
+        logged_in_intake = intake_class.find(session["warden.user.#{intake_class.name.underscore}.key"].first.first)
+        expect(logged_in_intake).not_to eq existing_intake
+        expect(logged_in_intake).to eq intake_class.send(:last)
+      end
+    end
+
+    context "with an existing intake from another state" do
+      let(:existing_intake) do
+        intake_classes = StateFile::StateInformationService.state_intake_classes.excluding(StateFileNyIntake)
+        other_intake_class_index = intake_classes.find_index(intake_class) - 1
+        other_intake_class = intake_classes[other_intake_class_index]
+        create(other_intake_class.name.underscore)
+      end
+
+      before { sign_in existing_intake }
+
+      it "replaces the existing intake in the session with a new one" do
+        post :update, params: valid_params
+        logged_in_intakes = StateFile::StateInformationService.state_intake_classes.map do |klass|
+          intake_id = session["warden.user.#{klass.name.underscore}.key"]&.first&.first
+          intake_id.present? ? klass.find(intake_id) : nil
+        end.compact
+        expect(logged_in_intakes).not_to include existing_intake
+        expect(logged_in_intakes).to include intake_class.send(:last)
       end
     end
   end

--- a/spec/support/shared_examples/start_intake_concern.rb
+++ b/spec/support/shared_examples/start_intake_concern.rb
@@ -19,30 +19,21 @@ shared_examples :start_intake_concern do |intake_class:|
       expect(intake.referrer).to eq "https://www.goggles.com/get-tax-refund"
     end
 
-    context "with an existing intake in the session" do
+    context "with existing intakes in the session, one in-state and one out-of-state" do
       let(:existing_intake) do
         create(intake_class.name.underscore)
       end
-
-      before { sign_in existing_intake }
-
-      it "replaces the existing intake in the session with a new one" do
-        post :update, params: valid_params
-        logged_in_intake = subject.send("current_#{intake_class.name.underscore}")
-        expect(logged_in_intake).not_to eq existing_intake
-        expect(logged_in_intake).to eq intake_class.send(:last)
-      end
-    end
-
-    context "with an existing intake from another state" do
-      let(:existing_intake) do
+      let(:existing_oos_intake) do
         intake_classes = StateFile::StateInformationService.state_intake_classes.excluding(StateFileNyIntake)
         other_intake_class_index = intake_classes.find_index(intake_class) - 1
         other_intake_class = intake_classes[other_intake_class_index]
         create(other_intake_class.name.underscore)
       end
 
-      before { sign_in existing_intake }
+      before do
+        sign_in existing_intake
+        sign_in existing_oos_intake
+      end
 
       it "replaces the existing intake in the session with a new one" do
         post :update, params: valid_params
@@ -50,6 +41,7 @@ shared_examples :start_intake_concern do |intake_class:|
           subject.send("current_#{klass.name.underscore}")
         end.compact
         expect(logged_in_intakes).not_to include existing_intake
+        expect(logged_in_intakes).not_to include existing_oos_intake
         expect(logged_in_intakes).to include intake_class.send(:last)
       end
     end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1790
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- the code in landing page controller that is ostensibly supposed to clear the current intake has i guess never been doing that because it did not have access to the `current_intake` method for state file (just the one in application controller, which returned nothing). for in-state cases this didn't matter because logging in the same type of record would replace the old one.
- after several passes at this (not intentional, oops) i landed on this:
  - in production, it will log out in-state intakes only
  - in other environments, it will look for every type of state intake and log it out
- you can kind of see the journey i went on by looking at the individual commits
## How to test?
- updated the shared example to test the out of state case in different environments