### PR TITLE
Revert "NJ 285 - return error if state_wages is 0 but wages is present (#5542)"

### DIFF
--- a/app/controllers/state_file/questions/income_review_controller.rb
+++ b/app/controllers/state_file/questions/income_review_controller.rb
@@ -45,8 +45,6 @@ module StateFile
       end
 
       def should_show_warning?(w2, w2_count_for_filer)
-        return true if w2.wages.positive? && !w2.state_wages_amount.positive?
-
         return false if StateFile::StateInformationService
           .w2_supported_box14_codes(w2.state_file_intake.state_code)
           .none? { |code| code[:name] == "UI_WF_SWF" || code[:name] == "FLI" }

--- a/app/models/state_file_w2.rb
+++ b/app/models/state_file_w2.rb
@@ -54,7 +54,6 @@ class StateFileW2 < ApplicationRecord
   with_options on: :state_file_edit do
     validates :employer_state_id_num, length: { maximum: 16, message: ->(_object, _data) { I18n.t('state_file.questions.w2.edit.employer_state_id_error') } }
     validates :state_wages_amount, numericality: { greater_than_or_equal_to: 0 }, if: -> { state_wages_amount.present? }
-    validates :state_wages_amount, numericality: { greater_than: 0 }, if: -> { wages.positive? }
     validates :state_income_tax_amount, numericality: { greater_than_or_equal_to: 0 }, if: -> { state_income_tax_amount.present? }
     validates :local_wages_and_tips_amount, numericality: { greater_than_or_equal_to: 0 }, if: -> { local_wages_and_tips_amount.present? && StateFile::StateInformationService.w2_include_local_income_boxes(state_file_intake.state_code) }
     validates :local_income_tax_amount, numericality: { greater_than_or_equal_to: 0 }, if: -> { local_income_tax_amount.present? && StateFile::StateInformationService.w2_include_local_income_boxes(state_file_intake.state_code) }
@@ -99,8 +98,10 @@ class StateFileW2 < ApplicationRecord
           errors.add(:local_income_tax_amount, I18n.t("state_file.questions.w2.edit.wages_amt_error", wages_amount: w2.WagesAmt))
           errors.add(:state_income_tax_amount, I18n.t("state_file.questions.w2.edit.wages_amt_error", wages_amount: w2.WagesAmt))
         end
-      elsif state_income_tax_amount.present? && state_income_tax_amount > w2.WagesAmt
-        errors.add(:state_income_tax_amount, I18n.t("state_file.questions.w2.edit.wages_amt_error", wages_amount: w2.WagesAmt))
+      else
+        if state_income_tax_amount.present? && state_income_tax_amount > w2.WagesAmt
+          errors.add(:state_income_tax_amount, I18n.t("state_file.questions.w2.edit.wages_amt_error", wages_amount: w2.WagesAmt))
+        end
       end
     end
   end

--- a/spec/models/state_file_w2_spec.rb
+++ b/spec/models/state_file_w2_spec.rb
@@ -108,7 +108,6 @@ describe StateFileW2 do
     end
 
     it "permits state_wages_amt to be blank if state_income_tax_amt is blank" do
-      w2.wages = 0
       w2.state_wages_amount = 0
       w2.state_income_tax_amount = 0
       expect(w2).to be_valid(:state_file_edit)
@@ -121,7 +120,6 @@ describe StateFileW2 do
     end
 
     it "permits state_wages_amt to be blank if state_income_tax_amt is blank" do
-      w2.wages = 0
       w2.employer_state_id_num = nil
       w2.state_wages_amount = 0
       w2.state_income_tax_amount = 0
@@ -166,9 +164,9 @@ describe StateFileW2 do
         w2.check_box14_limits = true
         allow(StateFile::StateInformationService).to receive(:w2_supported_box14_codes)
           .and_return([
-                        { name: "UI_WF_SWF", limit: 179.78 },
-                        { name: "FLI", limit: 145.26 }
-                      ])
+            { name: "UI_WF_SWF", limit: 179.78 },
+            { name: "FLI", limit: 145.26 }
+          ])
       end
   
       it "is invalid when box14_ui_wf_swf exceeds the state limit" do
@@ -273,9 +271,9 @@ describe StateFileW2 do
       before do
         allow(StateFile::StateInformationService).to receive(:w2_supported_box14_codes)
           .and_return([
-                        { name: "UI_WF_SWF", limit: 179.78 },
-                        { name: "FLI", limit: 145.26 }
-                      ])
+            { name: "UI_WF_SWF", limit: 179.78 },
+            { name: "FLI", limit: 145.26 }
+          ])
       end
 
       it "returns the correct limit for a valid name" do


### PR DESCRIPTION
This reverts commit ac80996e8c9f2609c6b8656b151c44937c60cd37. ([PR #5542](https://github.com/codeforamerica/vita-min/pull/5542))

## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1793
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- The change made in PR #5542 was intended to be NJ-specific, but was implemented for everyone. This reverts it so that we can get a client unstuck ASAP, and it will be re-implemented as an NJ-specific change in a future PR.
## How to test?
- Go through the flow for any/all states with a persona that has W2s, and enter (either in the XML editor, or on the W2 editing screen, or both) 0 or blank in the state wages field, and verify that you can continue (unless state tax is > 0)

