### PR TITLE
GYR1-673 Updates the form to not accept HEIC directly.

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -37,7 +37,7 @@
 require "mini_magick"
 
 class Document < ApplicationRecord
-  ACCEPTED_FILE_TYPES = [:browser_native_image, :other_image, :document]
+  ACCEPTED_FILE_TYPES = [:browser_native_image, :document]
   has_paper_trail on: [:destroy]
   belongs_to :intake, optional: true
   belongs_to :client, touch: true

--- a/app/views/hub/documents/_form.html.erb
+++ b/app/views/hub/documents/_form.html.erb
@@ -2,9 +2,13 @@
   <%= form_with model: @document, url: url, local: true, method: method, file_upload_enabled: file_upload_enabled, builder: VitaMinFormBuilder do |f| %>
     <h1 class="h2"><%= @title %></h1>
     <% if file_upload_enabled %>
-      <div class="form-group <%= "form-group--error" if @document.errors[:upload].present? %>">
+      <div
+        class="form-group <%= "form-group--error" if @document.errors[:upload].present? %>"
+      >
         <%= f.label(:upload, t("general.select_file"), class: "form-question") %>
-        <%= f.file_field :upload, class: "attachment-upload file-input" %>
+        <%= f.file_field :upload,
+                     class: "attachment-upload file-input",
+                     accept: FileTypeAllowedValidator.mime_types(Document).to_sentence %>
         <% @document.errors[:upload].each do |error_message| %>
           <p class="text--error"><i class="icon-warning"></i>
             <%= error_message %>
@@ -12,17 +16,31 @@
         <% end %>
       </div>
     <% end %>
-    <%= f.vita_min_text_field :display_name, t('hub.documents.display_name'), classes: ["form-width--long"] %>
-    <%= f.cfa_select :document_type, t("general.document_type"), @document_type_options.map { |doc_type| [doc_type.label, doc_type.key] }, include_blank: true %>
-    <%= f.cfa_select :tax_return_id, t("general.tax_return"), @client.tax_returns.map { |tax_return| [tax_return.year, tax_return.id] }, include_blank: true %>
-    <%= f.hub_checkbox :archived, t(".archived_label")%>
+    <%= f.vita_min_text_field :display_name,
+                          t("hub.documents.display_name"),
+                          classes: ["form-width--long"] %>
+    <%= f.cfa_select :document_type,
+                 t("general.document_type"),
+                 @document_type_options.map { |doc_type|
+                   [doc_type.label, doc_type.key]
+                 },
+                 include_blank: true %>
+    <%= f.cfa_select :tax_return_id,
+                 t("general.tax_return"),
+                 @client.tax_returns.map { |tax_return|
+                   [tax_return.year, tax_return.id]
+                 },
+                 include_blank: true %>
+    <%= f.hub_checkbox :archived, t(".archived_label") %>
     <%= f.hidden_field :rotation_angle, id: "rotation-angle" %>
-
 
     <button class="button button--cta" type="submit">
       <%= t("general.save") %>
     </button>
 
-    <%= link_to t("general.cancel"), hub_client_documents_path(client_id: @client), class: "button" %>
+    <%= link_to t("general.cancel"),
+    hub_client_documents_path(client_id: @client),
+    class: "button" %>
   <% end %>
 </div>
+

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -228,7 +228,10 @@ describe Document do
   describe "after_create" do
     include ActiveJob::TestHelper
 
-    context "when the file extension is .heic" do
+    # iOS 18 uses a different codec. We are relying now on safari and MMS to
+    # handle this before it gets to us. For more information, see ticket
+    # GYR1-673
+    xcontext "when the file extension is .heic" do
       before do
         allow(HeicToJpgJob).to receive(:perform_later).and_call_original
       end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -285,6 +285,9 @@ describe Document do
     end
   end
 
+  # iOS 18 uses a different codec. We are relying now on safari and MMS to
+  # handle this before it gets to us. For more information, see ticket
+  # GYR1-673
   xdescribe "#convert_heic_upload_to_jpg!" do
     it "converts a heic attachment to jpg" do
       document = create :document, upload_path: Rails.root.join("spec", "fixtures", "files", "IMG_4851.HEIC")

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -285,7 +285,7 @@ describe Document do
     end
   end
 
-  describe "#convert_heic_upload_to_jpg!" do
+  xdescribe "#convert_heic_upload_to_jpg!" do
     it "converts a heic attachment to jpg" do
       document = create :document, upload_path: Rails.root.join("spec", "fixtures", "files", "IMG_4851.HEIC")
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/GYR1-673
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- We were having failed HEIC image conversions happening due to iOS 18 having a more advanced encoding. Options for updating the library were unsatisfactory (see the engineering notes on the ticket for more information)
- Instead of updating the library, we are now relying on Safari's auto-re-encoding of HEIC images to handle it. On Safari on desktop, and all browsers on iOS mobile (since they are all safari under the hood), we should now receive a JPG instead. iMessage also performs this encoding over MMS

## How to test?
- Use an HEIC image to upload to any of the document forms. It must be taken with iOS 18. A test image will be provided on the ticket.

## Screenshots (for visual changes)
- Before
- After
<img width="662" alt="image" src="https://github.com/user-attachments/assets/35711d7a-fd97-4baf-9764-a32afb62b63a" />
