### PR TITLE
Nj 287 retirement other exclusion

### DIFF
--- a/app/controllers/state_file/questions/nj_review_controller.rb
+++ b/app/controllers/state_file/questions/nj_review_controller.rb
@@ -10,7 +10,7 @@ module StateFile
             { text_key: '16a_interest_income', value: line_or_zero(:NJ1040_LINE_16A) },
             { text_key: '20a_retirement_income', value: line_or_zero(:NJ1040_LINE_20A) },
             { text_key: '27_total_income', value: line_or_zero(:NJ1040_LINE_27) },
-            # { text_key: '28c_retirement_excluded_from_taxation', value: line_or_zero(:NJ1040_LINE_28C) },
+            { text_key: '28c_retirement_excluded_from_taxation', value: line_or_zero(:NJ1040_LINE_28C) },
             { text_key: '29_nj_gross_income', value: line_or_zero(:NJ1040_LINE_29) },
             { text_key: '30_exemptions', value: line_or_zero(:NJ1040_LINE_13) }, # same value for 13 and 30
             { text_key: '31_medical', value: line_or_zero(:NJ1040_LINE_31) },

--- a/app/lib/efile/line_data.yml
+++ b/app/lib/efile/line_data.yml
@@ -882,6 +882,10 @@ NJ1040_LINE_20B:
   label: '20b Excludable pension, annuity, and IRA distributions/withdrawals (See instr)'
 NJ1040_LINE_27:
   label: '27 Total Income (Add lines 15, 16a, and 20a)'
+NJ1040_LINE_28A:
+  label: '28a Pension/Retirement Exclusion (See instructions)'
+NJ1040_LINE_28B:
+  label: '28b Retirement Income Exclusion (See Worksheet D and instructions pages 20–21)'
 NJ1040_LINE_29:
   label: "29 New Jersey Gross Income (Subtract line 28c from line 27) (See instructions)"
 NJ1040_LINE_31:

--- a/app/lib/efile/line_data.yml
+++ b/app/lib/efile/line_data.yml
@@ -886,6 +886,8 @@ NJ1040_LINE_28A:
   label: '28a Pension/Retirement Exclusion (See instructions)'
 NJ1040_LINE_28B:
   label: '28b Retirement Income Exclusion (See Worksheet D and instructions pages 20–21)'
+NJ1040_LINE_28C:
+  label: '28c Total Exclusion Amount (Add lines 28a and 28b)'
 NJ1040_LINE_29:
   label: "29 New Jersey Gross Income (Subtract line 28c from line 27) (See instructions)"
 NJ1040_LINE_31:

--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -253,28 +253,6 @@ module Efile
         line_or_zero(:NJ1040_LINE_12_COUNT) * 1_000
       end
 
-      def calculate_line_15
-        @intake.state_file_w2s.sum do |w2|
-          w2.state_wages_amount.to_i
-        end
-      end
-
-      def calculate_line_20a
-        applicable_1099rs = @intake.state_file1099_rs.select do |state_file_1099r|
-          state_file_1099r.state_specific_followup.present? && state_file_1099r.state_specific_followup.income_source_none?
-        end
-
-        applicable_1099rs.sum(&:taxable_amount).round
-      end
-
-      def calculate_line_27
-        line_or_zero(:NJ1040_LINE_15) + line_or_zero(:NJ1040_LINE_16A) + line_or_zero(:NJ1040_LINE_20A)
-      end
-
-      def calculate_line_28a
-        0
-      end
-
       def line_53c_checkbox
         @intake.eligibility_all_members_health_insurance_yes?
       end
@@ -331,6 +309,12 @@ module Efile
           calculate_line_12
       end
 
+      def calculate_line_15
+        @intake.state_file_w2s.sum do |w2|
+          w2.state_wages_amount.to_i
+        end
+      end
+
       def calculate_line_16a
         @intake.direct_file_data.fed_taxable_income - interest_on_gov_bonds
       end
@@ -339,8 +323,24 @@ module Efile
         calculate_tax_exempt_interest_income if calculate_tax_exempt_interest_income.positive?
       end
 
+      def calculate_line_20a
+        applicable_1099rs = @intake.state_file1099_rs.select do |state_file_1099r|
+          state_file_1099r.state_specific_followup.present? && state_file_1099r.state_specific_followup.income_source_none?
+        end
+
+        applicable_1099rs.sum(&:taxable_amount).round
+      end
+
       def calculate_line_20b
         (non_military_1099rs.sum(&:gross_distribution_amount) - non_military_1099rs.sum(&:taxable_amount)).round
+      end
+
+      def calculate_line_27
+        line_or_zero(:NJ1040_LINE_15) + line_or_zero(:NJ1040_LINE_16A) + line_or_zero(:NJ1040_LINE_20A)
+      end
+
+      def calculate_line_28a
+        0
       end
 
       def calculate_line_28b

--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -324,11 +324,7 @@ module Efile
       end
 
       def calculate_line_20a
-        applicable_1099rs = @intake.state_file1099_rs.select do |state_file_1099r|
-          state_file_1099r.state_specific_followup.present? && state_file_1099r.state_specific_followup.income_source_none?
-        end
-
-        applicable_1099rs.sum(&:taxable_amount).round
+        non_military_1099rs.sum(&:taxable_amount).round
       end
 
       def calculate_line_20b

--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -21,6 +21,7 @@ module Efile
           intake: @intake,
           primary_or_spouse: :spouse
         )
+        @nj_retirement_income_helper = Efile::Nj::NjRetirementIncomeHelper.new(@intake)
       end
 
       def calculate
@@ -343,19 +344,22 @@ module Efile
       end
 
       def calculate_line_28b
-        helper = Efile::Nj::NjRetirementIncomeHelper.new(@intake)
-        return 0 unless helper.eligible?
+        return 0 unless @nj_retirement_income_helper.retirement_exclusion_eligible?(
+          line_or_zero(:NJ1040_LINE_15), 
+          line_or_zero(:NJ1040_LINE_27), 
+          line_or_zero(:NJ1040_LINE_28A))
         
-        total_income = calculate_line_27
-        [helper.calculate_maximum_exclusion(total_income) - calculate_line_28a, helper.total_eligible_nonretirement_income].min
+        total_income = line_or_zero(:NJ1040_LINE_27)
+        [@nj_retirement_income_helper.calculate_maximum_exclusion(total_income) - line_or_zero(:NJ1040_LINE_28A),
+         @nj_retirement_income_helper.total_eligible_nonretirement_income].min
       end
 
       def calculate_line_28c
-        calculate_line_28a + calculate_line_28b
+        line_or_zero(:NJ1040_LINE_28A) + line_or_zero(:NJ1040_LINE_28B)
       end
 
       def calculate_line_29
-        line_or_zero(:NJ1040_LINE_27) - calculate_line_28c
+        line_or_zero(:NJ1040_LINE_27) - line_or_zero(:NJ1040_LINE_28C)
       end
 
       def calculate_line_31

--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -41,6 +41,9 @@ module Efile
         set_line(:NJ1040_LINE_20A, :calculate_line_20a)
         set_line(:NJ1040_LINE_20B, :calculate_line_20b)
         set_line(:NJ1040_LINE_27, :calculate_line_27)
+        set_line(:NJ1040_LINE_28A, :calculate_line_28a)
+        set_line(:NJ1040_LINE_28B, :calculate_line_28b)
+        set_line(:NJ1040_LINE_28C, :calculate_line_28c)
         set_line(:NJ1040_LINE_29, :calculate_line_29)
         set_line(:NJ1040_LINE_31, :calculate_line_31)
         set_line(:NJ1040_LINE_38, :calculate_line_38)
@@ -249,6 +252,28 @@ module Efile
         line_or_zero(:NJ1040_LINE_12_COUNT) * 1_000
       end
 
+      def calculate_line_15
+        @intake.state_file_w2s.sum do |w2|
+          w2.state_wages_amount.to_i
+        end
+      end
+
+      def calculate_line_20a
+        applicable_1099rs = @intake.state_file1099_rs.select do |state_file_1099r|
+          state_file_1099r.state_specific_followup.present? && state_file_1099r.state_specific_followup.income_source_none?
+        end
+
+        applicable_1099rs.sum(&:taxable_amount).round
+      end
+
+      def calculate_line_27
+        line_or_zero(:NJ1040_LINE_15) + line_or_zero(:NJ1040_LINE_16A) + line_or_zero(:NJ1040_LINE_20A)
+      end
+
+      def calculate_line_28a
+        0
+      end
+
       def line_53c_checkbox
         @intake.eligibility_all_members_health_insurance_yes?
       end
@@ -305,12 +330,6 @@ module Efile
           calculate_line_12
       end
 
-      def calculate_line_15
-        @intake.state_file_w2s.sum do |w2|
-          w2.state_wages_amount.to_i
-        end
-      end
-
       def calculate_line_16a
         @intake.direct_file_data.fed_taxable_income - interest_on_gov_bonds
       end
@@ -319,20 +338,24 @@ module Efile
         calculate_tax_exempt_interest_income if calculate_tax_exempt_interest_income.positive?
       end
 
-      def calculate_line_20a
-        non_military_1099rs.sum(&:taxable_amount).round
-      end
-
       def calculate_line_20b
         (non_military_1099rs.sum(&:gross_distribution_amount) - non_military_1099rs.sum(&:taxable_amount)).round
       end
 
-      def calculate_line_27
-        line_or_zero(:NJ1040_LINE_15) + line_or_zero(:NJ1040_LINE_16A) + line_or_zero(:NJ1040_LINE_20A)
+      def calculate_line_28b
+        helper = Efile::Nj::NjRetirementIncomeHelper.new(@intake)
+        return 0 unless helper.eligible?
+        
+        total_income = calculate_line_27
+        [helper.calculate_maximum_exclusion(total_income) - calculate_line_28a, helper.total_eligible_nonretirement_income].min
+      end
+
+      def calculate_line_28c
+        calculate_line_28a + calculate_line_28b
       end
 
       def calculate_line_29
-        line_or_zero(:NJ1040_LINE_27)
+        line_or_zero(:NJ1040_LINE_27) - calculate_line_28c
       end
 
       def calculate_line_31

--- a/app/lib/efile/nj/nj_retirement_income_helper.rb
+++ b/app/lib/efile/nj/nj_retirement_income_helper.rb
@@ -29,22 +29,23 @@ module Efile
       end
 
       def primary_62_and_older?
-        @intake.calculate_age(@intake.primary_birth_date, inclusive_of_jan_1: true) >= 62
+        @intake.calculate_age(@intake.primary_birth_date, inclusive_of_jan_1: false) >= 62
       end
 
       def spouse_62_and_older?
-        @intake.calculate_age(@intake.spouse_birth_date, inclusive_of_jan_1: true) >= 62 
+        @intake.calculate_age(@intake.spouse_birth_date, inclusive_of_jan_1: false) >= 62 
       end
 
-      def eligible?
+      def retirement_exclusion_eligible?(line_15, line_27, line_28a)
         if @intake.spouse_birth_date.present?
-          return false unless spouse_62_and_older? || primary_62_and_older?
+          spouse_or_primary_is_age_eligible = spouse_62_and_older? || primary_62_and_older?
+          return false unless spouse_or_primary_is_age_eligible
         elsif !primary_62_and_older?
           return false
         end
-        return false if @intake.calculator.lines[:NJ1040_LINE_15].value > 3_000
-        return false if @intake.calculator.lines[:NJ1040_LINE_27].value > 150_000
-        return false if @intake.calculator.lines[:NJ1040_LINE_28A].value > calculate_maximum_exclusion(@intake.calculator.lines[:NJ1040_LINE_27].value)
+        return false if line_15 > 3_000
+        return false if line_27 > 150_000
+        return false if line_28a > calculate_maximum_exclusion(line_27)
 
         true
       end

--- a/app/lib/efile/nj/nj_retirement_income_helper.rb
+++ b/app/lib/efile/nj/nj_retirement_income_helper.rb
@@ -19,10 +19,10 @@ module Efile
             total_income += w2.state_wages_amount.to_i
           end
         end
-        @intake.direct_file_json_data.interest_reports.each do |form1099|
-          sanitized_recipient_tin = form1099.recipient_tin.tr("-", "")
+        @intake.direct_file_json_data.interest_reports.each do |interest_report|
+          sanitized_recipient_tin = interest_report.recipient_tin.delete("-")
           if sanitized_recipient_tin.in?(eligible_ssn)
-            total_income += form1099.interest_on_government_bonds.to_i
+            total_income += (interest_report.amount_1099&.round || 0) + (interest_report.amount_no_1099&.round || 0)
           end
         end
         total_income

--- a/app/lib/efile/nj/nj_retirement_income_helper.rb
+++ b/app/lib/efile/nj/nj_retirement_income_helper.rb
@@ -1,0 +1,90 @@
+module Efile
+  module Nj
+    class NjRetirementIncomeHelper
+      def initialize(intake)
+        @intake = intake
+      end
+
+      def total_eligible_nonretirement_income
+        total_income = 0
+        eligible_ssn = []
+        if primary_62_and_older?
+          eligible_ssn.push(@intake.primary.ssn)
+        end
+        if @intake.spouse_birth_date.present? && spouse_62_and_older?
+          eligible_ssn.push(@intake.spouse.ssn)
+        end
+        @intake.state_file_w2s.each do |w2|
+          if w2.employee_ssn.in?(eligible_ssn)
+            total_income += w2.state_wages_amount.to_i
+          end
+        end
+        @intake.direct_file_json_data.interest_reports.each do |form1099|
+          sanitized_recipient_tin = form1099.recipient_tin.tr("-", "")
+          if sanitized_recipient_tin.in?(eligible_ssn)
+            total_income += form1099.interest_on_government_bonds.to_i
+          end
+        end
+        total_income
+      end
+
+      def primary_62_and_older?
+        @intake.calculate_age(@intake.primary_birth_date, inclusive_of_jan_1: true) >= 62
+      end
+
+      def spouse_62_and_older?
+        @intake.calculate_age(@intake.spouse_birth_date, inclusive_of_jan_1: true) >= 62 
+      end
+
+      def eligible?
+        if @intake.spouse_birth_date.present?
+          return false unless spouse_62_and_older? || primary_62_and_older?
+        elsif !primary_62_and_older?
+          return false
+        end
+        return false if @intake.calculator.lines[:NJ1040_LINE_15].value > 3_000
+        return false if @intake.calculator.lines[:NJ1040_LINE_27].value > 150_000
+        return false if @intake.calculator.lines[:NJ1040_LINE_28A].value > calculate_maximum_exclusion(@intake.calculator.lines[:NJ1040_LINE_27].value)
+
+        true
+      end
+
+      def calculate_maximum_exclusion(total_income)
+        if @intake.filing_status_mfs?
+          case total_income
+          when 0..100_000
+            50_000
+          when 100_001..125_000
+            (0.25 * total_income).round
+          when 125_001..150_000
+            (0.125 * total_income).round
+          else
+            0
+          end
+        elsif @intake.filing_status_mfj?
+          case total_income
+          when 0..100_000
+            100_000
+          when 100_001..125_000
+            (0.5 * total_income).round
+          when 125_001..150_000
+            (0.25 * total_income).round
+          else
+            0
+          end
+        else
+          case total_income
+          when 0..100_000
+            75_000
+          when 100_001..125_000
+            (0.375 * total_income).round
+          when 125_001..150_000
+            (0.1875 * total_income).round
+          else
+            0
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/pdf_filler/nj1040_pdf.rb
+++ b/app/lib/pdf_filler/nj1040_pdf.rb
@@ -273,35 +273,36 @@ module PdfFiller
       if @xml_document.at("PensAnnuitAndIraWithdraw")
         taxable_retirement_income = @xml_document.at("PensAnnuitAndIraWithdraw").text.to_i
         answers.merge!(insert_digits_into_fields(taxable_retirement_income, [
-          "141",
-          "140",
-          "139",
-          "138",
-          "137",
-          "136",
-          "undefined_56",
-          "undefined_55",
-          "undefined_54",
-          "20a"
-        ]))
+                                                   "141",
+                                                   "140",
+                                                   "139",
+                                                   "138",
+                                                   "137",
+                                                   "136",
+                                                   "undefined_56",
+                                                   "undefined_55",
+                                                   "undefined_54",
+                                                   "20a"
+                                                 ]))
       end
 
       # line 20b
       if @xml_document.at("TaxExemptPensAnnuit")
         excludable_retirement_income = @xml_document.at("TaxExemptPensAnnuit").text.to_i
         answers.merge!(insert_digits_into_fields(excludable_retirement_income, [
-          "146",
-          "undefined_59",
-          "145",
-          "144",
-          "undefined_58",
-          "143",
-          "142",
-          "undefined_57",
-          "20b"
-        ]))
+                                                   "146",
+                                                   "undefined_59",
+                                                   "145",
+                                                   "144",
+                                                   "undefined_58",
+                                                   "143",
+                                                   "142",
+                                                   "undefined_57",
+                                                   "20b"
+                                                 ]))
       end
 
+      # line 27
       if @xml_document.at("TotalIncome").present?
         total_income = @xml_document.at("TotalIncome").text.to_i
         answers.merge!(insert_digits_into_fields(total_income, [
@@ -316,6 +317,51 @@ module PdfFiller
                                                    "183",
                                                    "27",
                                                    "263"
+                                                 ]))
+      end
+
+      # line 28a
+      if @xml_document.at("PensionExclusion").present?
+        other_retirement_income_exclusion = @xml_document.at("PensionExclusion").text.to_i
+        answers.merge!(insert_digits_into_fields(other_retirement_income_exclusion, [
+                                                   "193",
+                                                   "undefined_82",
+                                                   "192",
+                                                   "191",
+                                                   "undefined_81",
+                                                   "190",
+                                                   "189",
+                                                   "28a"
+                                                 ]))
+      end
+
+      # line 28b
+      if @xml_document.at("OtherRetireIncomeExclus").present?
+        other_retirement_income_exclusion = @xml_document.at("OtherRetireIncomeExclus").text.to_i
+        answers.merge!(insert_digits_into_fields(other_retirement_income_exclusion, [
+                                                   "198",
+                                                   "undefined_84",
+                                                   "197",
+                                                   "196",
+                                                   "undefined_83",
+                                                   "195",
+                                                   "194",
+                                                   "28b"
+                                                 ]))
+      end
+
+      # line 28c
+      if @xml_document.at("TotalExclusionAmount").present?
+        other_retirement_income_exclusion = @xml_document.at("TotalExclusionAmount").text.to_i
+        answers.merge!(insert_digits_into_fields(other_retirement_income_exclusion, [
+                                                   "203",
+                                                   "undefined_86",
+                                                   "202",
+                                                   "201",
+                                                   "undefined_85",
+                                                   "200",
+                                                   "199",
+                                                   "28c"
                                                  ]))
       end
 

--- a/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
+++ b/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
@@ -137,15 +137,15 @@ module SubmissionBuilder
                     xml.TotalIncome calculated_fields.fetch(:NJ1040_LINE_27)
                   end
 
-                  if calculated_fields.fetch(:NJ1040_LINE_28A).positive? && Flipper.enabled?(:show_retirement_ui)
+                  if calculated_fields.fetch(:NJ1040_LINE_28A).positive?
                     xml.PensionExclusion calculated_fields.fetch(:NJ1040_LINE_28A)
                   end
 
-                  if calculated_fields.fetch(:NJ1040_LINE_28B).positive? && Flipper.enabled?(:show_retirement_ui)
+                  if calculated_fields.fetch(:NJ1040_LINE_28B).positive?
                     xml.OtherRetireIncomeExclus calculated_fields.fetch(:NJ1040_LINE_28B)
                   end
 
-                  if calculated_fields.fetch(:NJ1040_LINE_28C).positive? && Flipper.enabled?(:show_retirement_ui)
+                  if calculated_fields.fetch(:NJ1040_LINE_28C).positive?
                     xml.TotalExclusionAmount calculated_fields.fetch(:NJ1040_LINE_28C)
                   end
 

--- a/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
+++ b/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
@@ -137,6 +137,18 @@ module SubmissionBuilder
                     xml.TotalIncome calculated_fields.fetch(:NJ1040_LINE_27)
                   end
 
+                  if calculated_fields.fetch(:NJ1040_LINE_28A).positive? && Flipper.enabled?(:show_retirement_ui)
+                    xml.PensionExclusion calculated_fields.fetch(:NJ1040_LINE_28A)
+                  end
+
+                  if calculated_fields.fetch(:NJ1040_LINE_28B).positive? && Flipper.enabled?(:show_retirement_ui)
+                    xml.OtherRetireIncomeExclus calculated_fields.fetch(:NJ1040_LINE_28B)
+                  end
+
+                  if calculated_fields.fetch(:NJ1040_LINE_28C).positive? && Flipper.enabled?(:show_retirement_ui)
+                    xml.TotalExclusionAmount calculated_fields.fetch(:NJ1040_LINE_28C)
+                  end
+
                   if calculated_fields.fetch(:NJ1040_LINE_29).positive?
                     xml.GrossIncome calculated_fields.fetch(:NJ1040_LINE_29)
                   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3648,6 +3648,7 @@ en:
             16a_interest_income: Interest income
             20a_retirement_income: Retirement income
             27_total_income: Total income
+            28c_retirement_excluded_from_taxation: Retirement income excluded from Taxation
             29_nj_gross_income: New Jersey Gross Income
             30_exemptions: Exemptions (based on the size of your family, disability status, veteran status)
             31_medical: Medical expenses deducted

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3620,6 +3620,7 @@ es:
             16a_interest_income: Ingreso total
             20a_retirement_income: Retirement income
             27_total_income: Ingreso total
+            28c_retirement_excluded_from_taxation: Ingresos de jubilación excluidos del impuesto
             29_nj_gross_income: Ingreso Bruto de New Jersey
             30_exemptions: Exenciones (según el tamaño de tu familia, estado de discapacidad, estado de veterano/a de guerra)
             31_medical: Gastos médicos deducidos

--- a/spec/factories/state_file_nj_intakes.rb
+++ b/spec/factories/state_file_nj_intakes.rb
@@ -264,7 +264,7 @@ FactoryBot.define do
       raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nj_sinatra_qss') }
       filing_status { "qualifying_widow" }
     end
-
+    
     trait :df_data_taxes_owed do
       raw_direct_file_data { StateFile::DirectFileApiResponseSampleService.new.read_xml('nj_jones_mfj') }
       raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nj_jones_mfj') }

--- a/spec/factories/state_file_nj_intakes.rb
+++ b/spec/factories/state_file_nj_intakes.rb
@@ -264,7 +264,7 @@ FactoryBot.define do
       raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nj_sinatra_qss') }
       filing_status { "qualifying_widow" }
     end
-    
+
     trait :df_data_taxes_owed do
       raw_direct_file_data { StateFile::DirectFileApiResponseSampleService.new.read_xml('nj_jones_mfj') }
       raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nj_jones_mfj') }
@@ -327,6 +327,20 @@ FactoryBot.define do
 
     trait :primary_over_65 do
       primary_birth_date { Date.new(1900, 1, 1) }
+    end
+
+    trait :primary_over_62 do
+      primary_birth_date { Date.new(MultiTenantService.new(:statefile).current_tax_year - 62, 12, 31) }
+    end
+
+    trait :primary_under_62 do
+      primary_birth_date { Date.new(MultiTenantService.new(:statefile).current_tax_year - 61, 1, 1) }
+    end
+
+    trait :mfj_spouse_over_62 do
+      filing_status { "married_filing_jointly" }
+      spouse_birth_date { Date.new(MultiTenantService.new(:statefile).current_tax_year - 62, 12, 31) }
+      spouse_ssn { "123456789" }
     end
 
     trait :mfj_spouse_over_65 do

--- a/spec/features/state_file/nj/complete_intake_spec.rb
+++ b/spec/features/state_file/nj/complete_intake_spec.rb
@@ -279,7 +279,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
 
       click_on I18n.t("state_file.questions.nj_review.edit.reveal.header")
       amounts_in_calculation_details = page.all(:xpath, '//*[contains(@class,"main-content-inner")]/section[last()]//p[contains(text(),"$")]')
-      expect(amounts_in_calculation_details.count).to eq(20)
+      expect(amounts_in_calculation_details.count).to eq(21)
       expect(page).to be_axe_clean
       continue
 
@@ -570,7 +570,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
         expect_municipality_question_exists
 
         # unselect county
-        within find('#county-question') do
+        within find_by_id('county-question') do
           select I18n.t('general.select_prompt')
         end
         expect_county_question_exists
@@ -581,7 +581,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
         advance_to_start_of_intake("Minimal", expect_income_review: false)
 
         select "Atlantic"
-        within find('#municipality-question') do
+        within find_by_id('municipality-question') do
           expect(page.all("option").length).to eq(24) # 23 municipalities + 1 "- Select -"
           expect(page).to have_text "Absecon City"
           expect(page).to have_text "Atlantic City"
@@ -590,7 +590,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
         end
 
         select "Mercer"
-        within find('#municipality-question') do
+        within find_by_id('municipality-question') do
           expect(page.all("option").length).to eq(13) # 12 municipalities + 1 "- Select -"
           expect(page).to have_text "East Windsor Township"
           expect(page).to have_text "Hopewell Township"
@@ -603,10 +603,10 @@ RSpec.feature "Completing a state file intake", active_job: true do
 
         select "Atlantic"
         select "Absecon City"
-        expect(find("#state_file_nj_county_municipality_form_municipality_code").value).to eq("0101")
+        expect(find_by_id('state_file_nj_county_municipality_form_municipality_code').value).to eq("0101")
 
         select "Mercer"
-        expect(find("#state_file_nj_county_municipality_form_municipality_code").value).to eq("")
+        expect(find_by_id('state_file_nj_county_municipality_form_municipality_code').value).to eq("")
       end
 
     end

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -623,12 +623,58 @@ describe Efile::Nj::Nj1040Calculator do
     end
   end
 
+  describe 'line 28b - other retirement income exclusion' do
+    let(:intake) { create(:state_file_nj_intake) }
+
+    context 'when taxpayer is ineligible' do
+      it 'sets line 28b to 0' do
+        allow_any_instance_of(Efile::Nj::NjRetirementIncomeHelper).to receive(:eligible?).and_return false
+        instance.calculate
+        expect(instance.lines[:NJ1040_LINE_28B].value).to eq(0)
+      end
+    end
+
+    context 'when taxpayer is eligible' do
+      context 'when maximum_exclusion minus 28a is greater than total_eligible_nonretirement_income' do
+        it 'sets line 28b to total_eligible_nonretirement_income' do
+          allow_any_instance_of(Efile::Nj::NjRetirementIncomeHelper).to receive(:eligible?).and_return true
+          allow_any_instance_of(Efile::Nj::NjRetirementIncomeHelper).to receive(:total_eligible_nonretirement_income).and_return 1_000
+          allow_any_instance_of(Efile::Nj::NjRetirementIncomeHelper).to receive(:calculate_maximum_exclusion).and_return 50_000
+          allow(instance).to receive(:calculate_line_28a).and_return 0
+          instance.calculate
+          expect(instance.lines[:NJ1040_LINE_28B].value).to eq(1000)
+        end
+      end
+
+      context 'when maximum_exclusion minus 28a is less than total_eligible_nonretirement_income' do
+        it 'sets line 28b to maximum_exclusion minus 28a' do
+          allow_any_instance_of(Efile::Nj::NjRetirementIncomeHelper).to receive(:eligible?).and_return true
+          allow_any_instance_of(Efile::Nj::NjRetirementIncomeHelper).to receive(:total_eligible_nonretirement_income).and_return 100_000
+          allow_any_instance_of(Efile::Nj::NjRetirementIncomeHelper).to receive(:calculate_maximum_exclusion).and_return 50_000
+          allow(instance).to receive(:calculate_line_28a).and_return 0
+          instance.calculate
+          expect(instance.lines[:NJ1040_LINE_28B].value).to eq(50_000)
+        end
+      end
+    end
+  end
+
+  describe 'line 28c - total exclusion amount' do
+    it 'sets line 28c to 28a plus 28b' do
+      allow(instance).to receive(:calculate_line_28a).and_return 1_000
+      allow(instance).to receive(:calculate_line_28b).and_return 2_000
+      instance.calculate
+      expect(instance.lines[:NJ1040_LINE_28C].value).to eq(3_000)
+    end
+  end
+
   describe 'line 29 - gross income' do
     let(:intake) { create(:state_file_nj_intake) }
 
-    it 'sets line 29 to the sum of all state wage amounts' do
+    it 'sets line 29 to the sum of all state wage amounts minus 28c' do
       allow(instance).to receive(:calculate_line_15).and_return 50000
       allow(instance).to receive(:calculate_line_16a).and_return 1_000
+      allow(instance).to receive(:calculate_line_28c).and_return 0
       instance.calculate
       expect(instance.lines[:NJ1040_LINE_29].value).to eq(51_000)
     end
@@ -1721,8 +1767,7 @@ describe Efile::Nj::Nj1040Calculator do
         contribution_2 = instance.excess_ui_wf_swf_max - 2
 
         first_w2.update_attribute(:box14_ui_wf_swf, contribution_1)
-        second_w2.update_attribute(:box14_ui_wf_swf, contribution_2)
-        second_w2.update_attribute(:box14_ui_hc_wd, 1)
+        second_w2.update_attribute(:box14_ui_hc_wd, contribution_2)
         instance.calculate
 
         expected_sum = (contribution_1 + contribution_2 - instance.excess_ui_wf_swf_max).round

--- a/spec/lib/efile/nj/nj_retirement_income_helper_spec.rb
+++ b/spec/lib/efile/nj/nj_retirement_income_helper_spec.rb
@@ -3,23 +3,35 @@ require 'rails_helper'
 RSpec.describe Efile::Nj::NjRetirementIncomeHelper do
   describe ".calculate_maximum_exclusion" do
     [
-      { total_income: 99_000, expected: 75_000 },
-      { traits: [:head_of_household], total_income: 99_000, expected: 75_000 },
-      { traits: [:qualifying_widow], total_income: 99_000, expected: 75_000 },
-      { traits: [:married_filing_jointly], total_income: 99_000, expected: 100_000 },
-      { traits: [:married_filing_separately], total_income: 99_000, expected: 50_000 },
+      { total_income: 100_000, expected: 75_000 },
+      { traits: [:head_of_household], total_income: 100_000, expected: 75_000 },
+      { traits: [:qualifying_widow], total_income: 100_000, expected: 75_000 },
+      { traits: [:married_filing_jointly], total_income: 100_000, expected: 100_000 },
+      { traits: [:married_filing_separately], total_income: 100_000, expected: 50_000 },
 
-      { total_income: 120_000, expected: 45_000 },
-      { traits: [:head_of_household], total_income: 120_000, expected: 45_000 },
-      { traits: [:qualifying_widow], total_income: 120_000, expected: 45_000 },
-      { traits: [:married_filing_jointly], total_income: 120_000, expected: 60_000 },
-      { traits: [:married_filing_separately], total_income: 120_000, expected: 30_000 },
+      { total_income: 100_001, expected: 37_500 },
+      { traits: [:head_of_household], total_income: 100_001, expected: 37_500 },
+      { traits: [:qualifying_widow], total_income: 100_001, expected: 37_500 },
+      { traits: [:married_filing_jointly], total_income: 100_001, expected: 50_001 },
+      { traits: [:married_filing_separately], total_income: 100_001, expected: 25_000 },
 
-      { total_income: 130_000, expected: 24_375 },
-      { traits: [:head_of_household], total_income: 130_000, expected: 24_375 },
-      { traits: [:qualifying_widow], total_income: 130_000, expected: 24_375 },
-      { traits: [:married_filing_jointly], total_income: 130_000, expected: 32_500 },
-      { traits: [:married_filing_separately], total_income: 130_000, expected: 16_250 },
+      { total_income: 125_000, expected: 46_875 },
+      { traits: [:head_of_household], total_income: 125_000, expected: 46_875 },
+      { traits: [:qualifying_widow], total_income: 125_000, expected: 46_875 },
+      { traits: [:married_filing_jointly], total_income: 125_000, expected: 62_500 },
+      { traits: [:married_filing_separately], total_income: 125_000, expected: 31_250 },
+
+      { total_income: 125_001, expected: 23_438 },
+      { traits: [:head_of_household], total_income: 125_001, expected: 23_438 },
+      { traits: [:qualifying_widow], total_income: 125_001, expected: 23_438 },
+      { traits: [:married_filing_jointly], total_income: 125_001, expected: 31_250 },
+      { traits: [:married_filing_separately], total_income: 125_001, expected: 15_625 },
+
+      { total_income: 150_000, expected: 28_125 },
+      { traits: [:head_of_household], total_income: 150_000, expected: 28_125 },
+      { traits: [:qualifying_widow], total_income: 150_000, expected: 28_125 },
+      { traits: [:married_filing_jointly], total_income: 150_000, expected: 37_500 },
+      { traits: [:married_filing_separately], total_income: 150_000, expected: 18_750 },
 
       { total_income: 150_001, expected: 0 },
       { traits: [:head_of_household], total_income: 150_001, expected: 0 },
@@ -39,14 +51,14 @@ RSpec.describe Efile::Nj::NjRetirementIncomeHelper do
       end
     end
 
-    describe ".eligible?" do
+    describe ".retirement_exclusion_eligible?" do
       [
-        { traits: [:mfj_spouse_over_65], total_income: 99_000, earned_income: 3000, line_28a: 0, expected: true },
-        { traits: [:primary_over_65], total_income: 99_000, earned_income: 3000, line_28a: 0, expected: true },
-        { total_income: 99_000, earned_income: 3000, line_28a: 0, expected: false },
-        { traits: [:primary_over_65], total_income: 160_000, earned_income: 3000, line_28a: 0, expected: false },
-        { traits: [:primary_over_65], total_income: 99_000, earned_income: 4000, line_28a: 0, expected: false },
-        { traits: [:primary_over_65], total_income: 99_000, earned_income: 4000, line_28a: 100_000, expected: false },
+        { traits: [:mfj_spouse_over_62], line_15: 3_000, line_27: 150_000, line_28a: 37_500, expected: true },
+        { traits: [:primary_over_62], line_15: 3_000, line_27: 150_000, line_28a: 28_125, expected: true },
+        { traits: [:primary_under_62], line_15: 3_000, line_27: 150_000, line_28a: 28_125, expected: false },
+        { traits: [:primary_over_62], line_15: 3_000, line_27: 150_001, line_28a: 0, expected: false },
+        { traits: [:primary_over_62], line_15: 3_001, line_27: 99_999, line_28a: 0, expected: false },
+        { traits: [:primary_over_62], line_15: 3_000, line_27: 150_000, line_28a: 100_000, expected: false },
       ].each do |test_case|
         context "when filing with #{test_case}" do
           let(:intake) do
@@ -58,16 +70,18 @@ RSpec.describe Efile::Nj::NjRetirementIncomeHelper do
               intake: intake
             )
           end
+          let(:helper) do
+            Efile::Nj::NjRetirementIncomeHelper.new(intake)
+          end
           before do
-            allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_15).and_return(test_case[:earned_income])
-            allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_27).and_return(test_case[:total_income])
+            allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_15).and_return(test_case[:line_15])
+            allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_27).and_return(test_case[:line_27])
             allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_28a).and_return(test_case[:line_28a])
             instance.calculate
           end
-  
+
           it "returns #{test_case[:expected]}" do
-            helper = Efile::Nj::NjRetirementIncomeHelper.new(intake)
-            result = helper.eligible?
+            result = helper.retirement_exclusion_eligible?(test_case[:line_15], test_case[:line_27], test_case[:line_28a])
             expect(result).to eq(test_case[:expected])
           end
         end
@@ -75,7 +89,10 @@ RSpec.describe Efile::Nj::NjRetirementIncomeHelper do
     end
 
     describe ".total_eligible_nonretirement_income" do
-      def setup_income_data(intake)
+      let(:helper) do
+        Efile::Nj::NjRetirementIncomeHelper.new(intake)
+      end
+      before do
         primary_ssn = 400000015
         spouse_ssn = 123456789
         first_w2 = intake.state_file_w2s.first 
@@ -91,41 +108,33 @@ RSpec.describe Efile::Nj::NjRetirementIncomeHelper do
         second_1099_int.amount_no_1099 = 4_000
       end
       context "when primary and spouse are both over 62" do
-        let(:intake) { create(:state_file_nj_intake, :df_data_one_dep, :primary_over_65, :mfj_spouse_over_65) }
+        let(:intake) { create(:state_file_nj_intake, :df_data_one_dep, :primary_over_62, :mfj_spouse_over_62) }
 
         it 'sums both spouse and primary wages in total eligible income' do
-          setup_income_data(intake)
-          helper = Efile::Nj::NjRetirementIncomeHelper.new(intake)
           expect(helper.total_eligible_nonretirement_income).to eq(7_000)
         end
       end
 
       context "when only primary is over 62" do
-        let(:intake) { create(:state_file_nj_intake, :df_data_one_dep, :primary_over_65) }
+        let(:intake) { create(:state_file_nj_intake, :df_data_one_dep, :primary_over_62) }
 
         it 'sums only primary wages in total eligible income' do
-          setup_income_data(intake)
-          helper = Efile::Nj::NjRetirementIncomeHelper.new(intake)
           expect(helper.total_eligible_nonretirement_income).to eq(3_000)
         end
       end
 
       context "when only spouse is over 62" do
-        let(:intake) { create(:state_file_nj_intake, :df_data_one_dep, :mfj_spouse_over_65) }
+        let(:intake) { create(:state_file_nj_intake, :df_data_one_dep, :mfj_spouse_over_62) }
 
         it 'sums only spouse wages in total eligible income' do
-          setup_income_data(intake)
-          helper = Efile::Nj::NjRetirementIncomeHelper.new(intake)
           expect(helper.total_eligible_nonretirement_income).to eq(4_000)
         end
       end
 
       context "when neither primary or spouse is over 62" do
-        let(:intake) { create(:state_file_nj_intake, :df_data_one_dep) }
+        let(:intake) { create(:state_file_nj_intake, :df_data_one_dep, :primary_under_62) }
 
         it 'sums neither filers wages in total eligible income' do
-          setup_income_data(intake)
-          helper = Efile::Nj::NjRetirementIncomeHelper.new(intake)
           expect(helper.total_eligible_nonretirement_income).to eq(0)
         end
       end

--- a/spec/lib/efile/nj/nj_retirement_income_helper_spec.rb
+++ b/spec/lib/efile/nj/nj_retirement_income_helper_spec.rb
@@ -1,0 +1,132 @@
+require 'rails_helper'
+
+RSpec.describe Efile::Nj::NjRetirementIncomeHelper do
+  describe ".calculate_maximum_exclusion" do
+    [
+      { total_income: 99_000, expected: 75_000 },
+      { traits: [:head_of_household], total_income: 99_000, expected: 75_000 },
+      { traits: [:qualifying_widow], total_income: 99_000, expected: 75_000 },
+      { traits: [:married_filing_jointly], total_income: 99_000, expected: 100_000 },
+      { traits: [:married_filing_separately], total_income: 99_000, expected: 50_000 },
+
+      { total_income: 120_000, expected: 45_000 },
+      { traits: [:head_of_household], total_income: 120_000, expected: 45_000 },
+      { traits: [:qualifying_widow], total_income: 120_000, expected: 45_000 },
+      { traits: [:married_filing_jointly], total_income: 120_000, expected: 60_000 },
+      { traits: [:married_filing_separately], total_income: 120_000, expected: 30_000 },
+
+      { total_income: 130_000, expected: 24_375 },
+      { traits: [:head_of_household], total_income: 130_000, expected: 24_375 },
+      { traits: [:qualifying_widow], total_income: 130_000, expected: 24_375 },
+      { traits: [:married_filing_jointly], total_income: 130_000, expected: 32_500 },
+      { traits: [:married_filing_separately], total_income: 130_000, expected: 16_250 },
+
+      { total_income: 150_001, expected: 0 },
+      { traits: [:head_of_household], total_income: 150_001, expected: 0 },
+      { traits: [:qualifying_widow], total_income: 150_001, expected: 0 },
+      { traits: [:married_filing_jointly], total_income: 150_001, expected: 0 },
+      { traits: [:married_filing_separately], total_income: 150_001, expected: 0 },
+    ].each do |test_case|
+      context "when filing with #{test_case}" do
+        let(:intake) do
+          create(:state_file_nj_intake, *test_case[:traits])
+        end
+        it "returns #{test_case[:expected]}" do
+          helper = Efile::Nj::NjRetirementIncomeHelper.new(intake)
+          result = helper.calculate_maximum_exclusion(test_case[:total_income])
+          expect(result).to eq(test_case[:expected])
+        end
+      end
+    end
+
+    describe ".eligible?" do
+      [
+        { traits: [:mfj_spouse_over_65], total_income: 99_000, earned_income: 3000, line_28a: 0, expected: true },
+        { traits: [:primary_over_65], total_income: 99_000, earned_income: 3000, line_28a: 0, expected: true },
+        { total_income: 99_000, earned_income: 3000, line_28a: 0, expected: false },
+        { traits: [:primary_over_65], total_income: 160_000, earned_income: 3000, line_28a: 0, expected: false },
+        { traits: [:primary_over_65], total_income: 99_000, earned_income: 4000, line_28a: 0, expected: false },
+        { traits: [:primary_over_65], total_income: 99_000, earned_income: 4000, line_28a: 100_000, expected: false },
+      ].each do |test_case|
+        context "when filing with #{test_case}" do
+          let(:intake) do
+            create(:state_file_nj_intake, *test_case[:traits])
+          end
+          let(:instance) do
+            Efile::Nj::Nj1040Calculator.new(
+              year: MultiTenantService.statefile.current_tax_year,
+              intake: intake
+            )
+          end
+          before do
+            allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_15).and_return(test_case[:earned_income])
+            allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_27).and_return(test_case[:total_income])
+            allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_28a).and_return(test_case[:line_28a])
+            instance.calculate
+          end
+  
+          it "returns #{test_case[:expected]}" do
+            helper = Efile::Nj::NjRetirementIncomeHelper.new(intake)
+            result = helper.eligible?
+            expect(result).to eq(test_case[:expected])
+          end
+        end
+      end
+    end
+
+    describe ".total_eligible_nonretirement_income" do
+      def setup_income_data(intake)
+        primary_ssn = 400000015
+        spouse_ssn = 123456789
+        first_w2 = intake.state_file_w2s.first 
+        first_w2.update_attribute(:employee_ssn, primary_ssn)
+        first_w2.update_attribute(:state_wages_amount, 1_000)
+        first_1099_int = intake.direct_file_json_data.interest_reports.first
+        first_1099_int.recipient_tin = primary_ssn.to_s
+        first_1099_int.interest_on_government_bonds = 2_000
+        second_1099_int = intake.direct_file_json_data.interest_reports.second
+        second_1099_int.recipient_tin = spouse_ssn.to_s
+        second_1099_int.interest_on_government_bonds = 4_000
+      end
+      context "when primary and spouse are both over 62" do
+        let(:intake) { create(:state_file_nj_intake, :df_data_one_dep, :primary_over_65, :mfj_spouse_over_65) }
+
+        it 'sums both spouse and primary wages in total eligible income' do
+          setup_income_data(intake)
+          helper = Efile::Nj::NjRetirementIncomeHelper.new(intake)
+          expect(helper.total_eligible_nonretirement_income).to eq(7_000)
+        end
+      end
+
+      context "when only primary is over 62" do
+        let(:intake) { create(:state_file_nj_intake, :df_data_one_dep, :primary_over_65) }
+
+        it 'sums only primary wages in total eligible income' do
+          setup_income_data(intake)
+          helper = Efile::Nj::NjRetirementIncomeHelper.new(intake)
+          expect(helper.total_eligible_nonretirement_income).to eq(3_000)
+        end
+      end
+
+      context "when only spouse is over 62" do
+        let(:intake) { create(:state_file_nj_intake, :df_data_one_dep, :mfj_spouse_over_65) }
+
+        it 'sums only spouse wages in total eligible income' do
+          setup_income_data(intake)
+          helper = Efile::Nj::NjRetirementIncomeHelper.new(intake)
+          expect(helper.total_eligible_nonretirement_income).to eq(4_000)
+        end
+      end
+
+      context "when neither primary or spouse is over 62" do
+        let(:intake) { create(:state_file_nj_intake, :df_data_one_dep) }
+
+        it 'sums neither filers wages in total eligible income' do
+          setup_income_data(intake)
+          helper = Efile::Nj::NjRetirementIncomeHelper.new(intake)
+          expect(helper.total_eligible_nonretirement_income).to eq(0)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/efile/nj/nj_retirement_income_helper_spec.rb
+++ b/spec/lib/efile/nj/nj_retirement_income_helper_spec.rb
@@ -83,10 +83,12 @@ RSpec.describe Efile::Nj::NjRetirementIncomeHelper do
         first_w2.update_attribute(:state_wages_amount, 1_000)
         first_1099_int = intake.direct_file_json_data.interest_reports.first
         first_1099_int.recipient_tin = primary_ssn.to_s
-        first_1099_int.interest_on_government_bonds = 2_000
+        first_1099_int.amount_1099 = 2_000
+        first_1099_int.amount_no_1099 = nil
         second_1099_int = intake.direct_file_json_data.interest_reports.second
         second_1099_int.recipient_tin = spouse_ssn.to_s
-        second_1099_int.interest_on_government_bonds = 4_000
+        second_1099_int.amount_1099 = nil
+        second_1099_int.amount_no_1099 = 4_000
       end
       context "when primary and spouse are both over 62" do
         let(:intake) { create(:state_file_nj_intake, :df_data_one_dep, :primary_over_65, :mfj_spouse_over_65) }

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -1226,10 +1226,6 @@ RSpec.describe PdfFiller::Nj1040Pdf do
     end
 
     describe "line 28a - Pension/Retirement Exclusion" do
-      before do
-        allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)
-      end
-      
       context "when taxpayer has pension/retirement income exclusion with 123_456" do
         it "fills in the PDF line 28a boxes with the rounded value" do
           allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_28a).and_return 123_456
@@ -1250,10 +1246,6 @@ RSpec.describe PdfFiller::Nj1040Pdf do
     end
 
     describe "line 28b - Other Retirement Income Exclusion" do
-      before do
-        allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)
-      end
-      
       context "when taxpayer has exclusion with 123_456" do
         it "fills in the PDF line 28b boxes with the rounded value" do
           allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_28b).and_return 123_456
@@ -1274,10 +1266,6 @@ RSpec.describe PdfFiller::Nj1040Pdf do
     end
 
     describe "line 28c - Total Retirement Income Exclusion" do
-      before do
-        allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)
-      end
-      
       context "when taxpayer has total retirement income exclusion with 123_456" do
         it "fills in the PDF line 28c boxes with the rounded value" do
           allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_28c).and_return 123_456

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -1226,6 +1226,24 @@ RSpec.describe PdfFiller::Nj1040Pdf do
     end
 
     describe "line 28a - Pension/Retirement Exclusion" do
+      context "when taxpayer has pension/retirement income exclusion with 0" do
+        it "does not fill in the PDF line 28a boxes" do
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_28a).and_return 0
+
+          # thousands
+          expect(pdf_fields["28a"]).to eq ""
+          expect(pdf_fields["189"]).to eq ""
+          expect(pdf_fields["190"]).to eq ""
+          # hundreds
+          expect(pdf_fields["undefined_81"]).to eq ""
+          expect(pdf_fields["191"]).to eq ""
+          expect(pdf_fields["192"]).to eq ""
+          # decimals
+          expect(pdf_fields["undefined_82"]).to eq ""
+          expect(pdf_fields["193"]).to eq ""
+        end
+      end
+
       context "when taxpayer has pension/retirement income exclusion with 123_456" do
         it "fills in the PDF line 28a boxes with the rounded value" do
           allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_28a).and_return 123_456
@@ -1246,6 +1264,24 @@ RSpec.describe PdfFiller::Nj1040Pdf do
     end
 
     describe "line 28b - Other Retirement Income Exclusion" do
+      context "when taxpayer has exclusion with 0" do
+        it "does not fill in the PDF line 28b boxes" do
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_28b).and_return 0
+
+          # thousands
+          expect(pdf_fields["28b"]).to eq ""
+          expect(pdf_fields["194"]).to eq ""
+          expect(pdf_fields["195"]).to eq ""
+          # hundreds
+          expect(pdf_fields["undefined_83"]).to eq ""
+          expect(pdf_fields["196"]).to eq ""
+          expect(pdf_fields["197"]).to eq ""
+          # decimals
+          expect(pdf_fields["undefined_84"]).to eq ""
+          expect(pdf_fields["198"]).to eq ""
+        end
+      end
+
       context "when taxpayer has exclusion with 123_456" do
         it "fills in the PDF line 28b boxes with the rounded value" do
           allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_28b).and_return 123_456
@@ -1266,6 +1302,24 @@ RSpec.describe PdfFiller::Nj1040Pdf do
     end
 
     describe "line 28c - Total Retirement Income Exclusion" do
+      context "when taxpayer has total retirement income exclusion with 0" do
+        it "does not fill in the PDF line 28c boxes" do
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_28c).and_return 0
+
+          # thousands
+          expect(pdf_fields["28c"]).to eq ""
+          expect(pdf_fields["199"]).to eq ""
+          expect(pdf_fields["200"]).to eq ""
+          # hundreds
+          expect(pdf_fields["undefined_85"]).to eq ""
+          expect(pdf_fields["201"]).to eq ""
+          expect(pdf_fields["202"]).to eq ""
+          # decimals
+          expect(pdf_fields["undefined_86"]).to eq ""
+          expect(pdf_fields["203"]).to eq ""
+        end
+      end
+
       context "when taxpayer has total retirement income exclusion with 123_456" do
         it "fills in the PDF line 28c boxes with the rounded value" do
           allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_28c).and_return 123_456

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -1109,7 +1109,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
 
       context "when taxpayer has taxable retirement income of 0" do
         it "does not fill in any of the boxes on line 20a" do
-        allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_20a).and_return 0
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_20a).and_return 0
 
           # millions
           expect(pdf_fields["20a"]).to eq ""
@@ -1221,6 +1221,78 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           # decimals
           expect(pdf_fields["undefined_80"]).to eq ""
           expect(pdf_fields["188"]).to eq ""
+        end
+      end
+    end
+
+    describe "line 28a - Pension/Retirement Exclusion" do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)
+      end
+      
+      context "when taxpayer has pension/retirement income exclusion with 123_456" do
+        it "fills in the PDF line 28a boxes with the rounded value" do
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_28a).and_return 123_456
+
+          # thousands
+          expect(pdf_fields["28a"]).to eq "1"
+          expect(pdf_fields["189"]).to eq "2"
+          expect(pdf_fields["190"]).to eq "3"
+          # hundreds
+          expect(pdf_fields["undefined_81"]).to eq "4"
+          expect(pdf_fields["191"]).to eq "5"
+          expect(pdf_fields["192"]).to eq "6"
+          # decimals
+          expect(pdf_fields["undefined_82"]).to eq "0"
+          expect(pdf_fields["193"]).to eq "0"
+        end
+      end
+    end
+
+    describe "line 28b - Other Retirement Income Exclusion" do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)
+      end
+      
+      context "when taxpayer has exclusion with 123_456" do
+        it "fills in the PDF line 28b boxes with the rounded value" do
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_28b).and_return 123_456
+
+          # thousands
+          expect(pdf_fields["28b"]).to eq "1"
+          expect(pdf_fields["194"]).to eq "2"
+          expect(pdf_fields["195"]).to eq "3"
+          # hundreds
+          expect(pdf_fields["undefined_83"]).to eq "4"
+          expect(pdf_fields["196"]).to eq "5"
+          expect(pdf_fields["197"]).to eq "6"
+          # decimals
+          expect(pdf_fields["undefined_84"]).to eq "0"
+          expect(pdf_fields["198"]).to eq "0"
+        end
+      end
+    end
+
+    describe "line 28c - Total Retirement Income Exclusion" do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)
+      end
+      
+      context "when taxpayer has total retirement income exclusion with 123_456" do
+        it "fills in the PDF line 28c boxes with the rounded value" do
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_28c).and_return 123_456
+
+          # thousands
+          expect(pdf_fields["28c"]).to eq "1"
+          expect(pdf_fields["199"]).to eq "2"
+          expect(pdf_fields["200"]).to eq "3"
+          # hundreds
+          expect(pdf_fields["undefined_85"]).to eq "4"
+          expect(pdf_fields["201"]).to eq "5"
+          expect(pdf_fields["202"]).to eq "6"
+          # decimals
+          expect(pdf_fields["undefined_86"]).to eq "0"
+          expect(pdf_fields["203"]).to eq "0"
         end
       end
     end

--- a/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
@@ -497,6 +497,55 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
       end
     end
 
+    describe "Other Retirement Income Exclusion - line 28a" do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)
+      end
+
+      context "when filer is eligible" do
+        it 'sets PensionExclusion to the line 28a value' do
+          expected = 5_000
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_28a).and_return expected
+          expect(xml.at("PensionExclusion").text).to eq(expected.to_s)
+        end
+      end
+    end
+
+    describe "Other Retirement Income Exclusion - line 28b" do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)
+      end
+      
+      context "when filer is eligible" do
+        it 'sets OtherRetireIncomeExclus to the line 28b value' do
+          expected = 1_000
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_28b).and_return expected
+          expect(xml.at("OtherRetireIncomeExclus").text).to eq(expected.to_s)
+        end
+      end
+
+      context "when filer is ineligible" do
+        it "does not include TotalIncome in the XML" do
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_28b).and_return 0
+          expect(xml.at("OtherRetireIncomeExclus")).to eq(nil)
+        end
+      end
+    end
+
+    describe "Other Retirement Income Exclusion - line 28c" do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)
+      end
+
+      context "when filer is eligible" do
+        it 'sets TotalExclusionAmount to the line 28c value' do
+          expected = 2_000
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_28c).and_return expected
+          expect(xml.at("TotalExclusionAmount").text).to eq(expected.to_s)
+        end
+      end
+    end
+
     describe "gross income - line 29" do
       context "when filer submits w2 wages" do
         it "fills TotalIncome with the value from Line 15" do

--- a/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
@@ -498,17 +498,24 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
     end
 
     describe "Other Retirement Income Exclusion - line 28a" do
-      context "when filer is eligible" do
+      context "when line 28a has a value" do
         it 'sets PensionExclusion to the line 28a value' do
           expected = 5_000
           allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_28a).and_return expected
           expect(xml.at("PensionExclusion").text).to eq(expected.to_s)
         end
       end
+
+      context "when line 28a is 0" do
+        it 'does not set the PensionExclusion value in the XML' do
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_28a).and_return 0
+          expect(xml.at("PensionExclusion")).to be_nil
+        end
+      end
     end
 
     describe "Other Retirement Income Exclusion - line 28b" do
-      context "when filer is eligible" do
+      context "when line 28b has a value" do
         it 'sets OtherRetireIncomeExclus to the line 28b value' do
           expected = 1_000
           allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_28b).and_return expected
@@ -516,7 +523,7 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
         end
       end
 
-      context "when filer is ineligible" do
+      context "wwhen line 28b is 0" do
         it "does not include TotalIncome in the XML" do
           allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_28b).and_return 0
           expect(xml.at("OtherRetireIncomeExclus")).to eq(nil)
@@ -525,11 +532,18 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
     end
 
     describe "Other Retirement Income Exclusion - line 28c" do
-      context "when filer is eligible" do
+      context "when line 28c has a value" do
         it 'sets TotalExclusionAmount to the line 28c value' do
           expected = 2_000
           allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_28c).and_return expected
           expect(xml.at("TotalExclusionAmount").text).to eq(expected.to_s)
+        end
+      end
+
+      context "when Line 28c is 0" do
+        it 'does not set the TotalExclusionAmount value in the XML' do
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_28c).and_return 0
+          expect(xml.at("TotalExclusionAmount")).to be_nil
         end
       end
     end

--- a/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
@@ -498,10 +498,6 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
     end
 
     describe "Other Retirement Income Exclusion - line 28a" do
-      before do
-        allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)
-      end
-
       context "when filer is eligible" do
         it 'sets PensionExclusion to the line 28a value' do
           expected = 5_000
@@ -512,10 +508,6 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
     end
 
     describe "Other Retirement Income Exclusion - line 28b" do
-      before do
-        allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)
-      end
-      
       context "when filer is eligible" do
         it 'sets OtherRetireIncomeExclus to the line 28b value' do
           expected = 1_000
@@ -533,10 +525,6 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
     end
 
     describe "Other Retirement Income Exclusion - line 28c" do
-      before do
-        allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)
-      end
-
       context "when filer is eligible" do
         it 'sets TotalExclusionAmount to the line 28c value' do
           expected = 2_000


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://github.com/newjersey/affordability-pm/issues/287

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
Added the following lines for retirement income calculation

28A - always static 0 for now
28B - see ticket for details
28C - sum 28A and 28B
29 - update logic to subtract 28C

## How to test?
- Manual testing in Heroku
  - Springsteen MFJ, edit W2 so StateLocalWages is <= 3000. 1099-INT belongs to spouse, who is <62, so expect that income to be filtered out, while W2 wages are correctly included in line 28b.

## Screenshots (for visual changes)
- Before
- After
XML contains fields
<img width="1400" alt="image" src="https://github.com/user-attachments/assets/c9c92328-950f-4d16-955b-b6bce352e741" />

PDF contains fields
<img width="945" alt="image" src="https://github.com/user-attachments/assets/3058de31-e501-423b-a952-e3a4c4595a7c" />

WITHOUT modifying W2 XML to 3000, Springsteen MFJ is ineligible for the exclusion and the fields are not shown in the final return XML.

<img width="654" alt="image" src="https://github.com/user-attachments/assets/40e8ec47-c892-4f43-9d70-0b3693ad18cb" />

AND the fields are blank in the PDF

<img width="996" alt="image" src="https://github.com/user-attachments/assets/83ae30de-83a0-4535-b769-9645fc940d3e" />
