### PR TITLE
Show orgs with parent coalitions on hub/organization page

### DIFF
--- a/app/presenters/hub/organizations_presenter.rb
+++ b/app/presenters/hub/organizations_presenter.rb
@@ -7,8 +7,13 @@ module Hub
       accessible_organizations = Organization.accessible_by(current_ability)
       @organizations = accessible_organizations.includes(:child_sites).with_computed_client_count.load
       @coalitions = Coalition.accessible_by(current_ability)
-      @state_routing_targets = StateRoutingTarget.where(target: accessible_organizations).or(StateRoutingTarget.where(target: @coalitions)).load.group_by(&:state_abbreviation)
+      coalition_parents_of_dependent_orgs = accessible_organizations.where.not(coalition_id: nil).reorder(nil).distinct.pluck(:coalition_id)
+      @state_routing_targets = StateRoutingTarget.where(target: accessible_organizations)
+                                                 .or(StateRoutingTarget.where(target: @coalitions))
+                                                 .or(StateRoutingTarget.where(target_id: coalition_parents_of_dependent_orgs))
+                                                 .distinct.load.group_by(&:state_abbreviation)
     end
+
 
     Capacity = Struct.new(:current_count, :total_capacity) do
       def initialize(current_count = 0, total_capacity = 0)
@@ -17,9 +22,20 @@ module Hub
     end
 
     def accessible_entities_for(state)
-      @state_routing_targets[state]&.map do |target|
-        target.target_type == "Coalition" ? coalition(target.target_id) : organization(target.target_id)
-      end
+      return [] unless @state_routing_targets[state]
+
+      @state_routing_targets[state].flat_map do |srt|
+        case srt.target_type
+        when Coalition::TYPE
+          if (coalition_obj = coalition(srt.target_id))
+            coalition_obj
+          else
+            srt.target.organizations&.filter_map { |org| organization(org.id) }
+          end
+        when Organization::TYPE, VitaPartner::TYPE
+          organization(srt.target_id)
+        end
+      end.compact.uniq
     end
 
     # use instead of coalition.organizations in the view so that we're not loading organizations 2x

--- a/app/views/hub/coalitions/edit.html.erb
+++ b/app/views/hub/coalitions/edit.html.erb
@@ -2,6 +2,7 @@
 <% content_for :page_title, @title %>
 <% content_for :card do %>
   <div class="slab slab--padded">
+    <%= link_to t("general.all_organizations"), hub_organizations_path %>
     <div class="grid">
       <div class="grid-item width-one-half">
         <%= render "hub/coalitions/form", url: hub_coalition_path(id: @coalition.id), http_method: :patch %>

--- a/app/views/hub/organizations/index.html.erb
+++ b/app/views/hub/organizations/index.html.erb
@@ -6,12 +6,12 @@
       <h1 class="h1"><%= title %></h1>
       <div>
         <% if can? :create, VitaPartner %>
-          <%= link_to t("hub.organizations.index.add_organization"), new_hub_organization_path, class: "button"%>
+          <%= link_to t("hub.organizations.index.add_organization"), new_hub_organization_path, class: "button spacing-below-15"%>
         <% end %>
       </div>
       <div>
         <% if can? :create, Coalition %>
-          <%= link_to t("hub.organizations.index.add_coalition"), new_hub_coalition_path, class: "button"%>
+          <%= link_to t("hub.organizations.index.add_coalition"), new_hub_coalition_path, class: "button  spacing-below-25"%>
         <% end %>
       </div>
     </div>
@@ -24,7 +24,7 @@
           <% end %>
         <% else %>
           <% if @presenter.state_routing_targets.length > 0 %>
-            <%= @presenter.state_routing_targets.values.flatten.each do |state_routing_target| %>
+            <% @presenter.state_routing_targets.values.flatten.each do |state_routing_target| %>
               <%= render "state", state_abbreviation: state_routing_target.state_abbreviation, state_name: state_routing_target.full_state_name%>
             <% end %>
           <% else %>

--- a/app/views/hub/sites/edit.html.erb
+++ b/app/views/hub/sites/edit.html.erb
@@ -1,8 +1,11 @@
-<% @title = @site.name %>
+<% @title = "Edit #{@site.name}" %>
 <% content_for :page_title, @title %>
 <% content_for :card do %>
   <section class="slab slab--padded">
-    <%= link_to(@site.parent_organization.name, edit_hub_organization_path(id: @site.parent_organization)) %>
+    <p><%= link_to t("general.all_organizations"), hub_organizations_path %></p>
+
+    <p class="grid spacing-below-0"><%= link_to(@site.parent_organization.name, edit_hub_organization_path(id: @site.parent_organization)) %></p>
+
     <div class="grid">
       <div class="grid--item width-one-half">
         <%= render "form", url: hub_site_path(id: @site.id), http_method: :patch %>

--- a/spec/presenters/hub/organizations_presenter_spec.rb
+++ b/spec/presenters/hub/organizations_presenter_spec.rb
@@ -134,5 +134,30 @@ describe Hub::OrganizationsPresenter do
         end
       end
     end
+
+    context "with organizations that have a parent coalition" do
+      let(:user) { create :organization_lead_user, organization: org }
+      let!(:org) { create :organization, coalition: create(:coalition), capacity_limit: 300 }
+
+      before do
+        create :state_routing_target, target: org.coalition, state_abbreviation: "NC"
+        create :state_routing_target, target: org.coalition, state_abbreviation: "NY"
+      end
+
+      it "shows the organization but not the coalition" do
+        expect(subject.accessible_entities_for("NC")).to eq [org]
+        expect(subject.accessible_entities_for("NY")).to eq [org]
+      end
+
+      it "returns state capacities for org" do
+        capacity = subject.state_capacity("NC")
+        expect(capacity.current_count).to eq 0
+        expect(capacity.total_capacity).to eq 300
+
+        capacity = subject.state_capacity("NY")
+        expect(capacity.current_count).to eq 0
+        expect(capacity.total_capacity).to eq 300
+      end
+    end
   end
 end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. [link](https://codeforamerica.atlassian.net/browse/GYR1-542?atlOrigin=eyJpIjoiZDYzYmMxNjBlN2JmNDhiNmJmZjI2MzQ3MGUxMjM0ZDAiLCJwIjoiaiJ9)
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Show organizations that have a parent coalition to organization leads 
## How to test?
1. go to heroku hub
4. login as org lead (`skywalker@example.com`)
3. go to the `/hub/organizations` page
4. See if you can see your org that has a parent coalition
## Screenshots (for visual changes)
- Before
- After
