### PR TITLE
FYST-1826 Fix 502SU bug where the calculation was referring to the primary as opposed to spouse

### DIFF
--- a/app/lib/efile/md/md502_su_calculator.rb
+++ b/app/lib/efile/md/md502_su_calculator.rb
@@ -25,7 +25,7 @@ module Efile
 
       def calculate_military_per_filer(filer)
         age_benefits = @intake.is_filer_55_and_older?(filer) ? 20_000 : 12_500
-        [@intake.sum_1099_r_followup_type_for_filer(:primary, :service_type_military?), age_benefits].min
+        [@intake.sum_1099_r_followup_type_for_filer(filer, :service_type_military?), age_benefits].min
       end
 
       def calculate_public_safety_employee(filer)

--- a/spec/fixtures/state_file/fed_return_jsons/md/dorothy_mfj_1099_r.json
+++ b/spec/fixtures/state_file/fed_return_jsons/md/dorothy_mfj_1099_r.json
@@ -3,7 +3,7 @@
   "filers": [
     {
       "lastName": "Deaveraux",
-      "dateOfBirth": "1960-10-05",
+      "dateOfBirth": "1971-10-05",
       "suffix": null,
       "isPrimaryFiler": true,
       "firstName": "Blanche",

--- a/spec/fixtures/state_file/fed_return_jsons/md/dorothy_mfj_1099_r.json
+++ b/spec/fixtures/state_file/fed_return_jsons/md/dorothy_mfj_1099_r.json
@@ -3,7 +3,7 @@
   "filers": [
     {
       "lastName": "Deaveraux",
-      "dateOfBirth": "1971-10-05",
+      "dateOfBirth": "1960-10-05",
       "suffix": null,
       "isPrimaryFiler": true,
       "firstName": "Blanche",

--- a/spec/lib/efile/md/md502_su_calculator_spec.rb
+++ b/spec/lib/efile/md/md502_su_calculator_spec.rb
@@ -30,37 +30,36 @@ describe Efile::Md::Md502SuCalculator do
   end
 
   describe "#calculate_military_per_filer" do
-    context "when the taxable amount is higher than the age benefit amount" do
-      before do
-        allow_any_instance_of(StateFileMdIntake).to receive(:sum_1099_r_followup_type_for_filer).and_return 30_000
-        allow_any_instance_of(StateFileMdIntake).to receive(:is_filer_55_and_older?).and_return is_55_and_older
-      end
+    [:primary, :spouse].each do |filer|
+      context "when the taxable amount is higher than the age benefit amount" do
+        before do
+          allow_any_instance_of(StateFileMdIntake).to receive(:sum_1099_r_followup_type_for_filer).with(filer, :service_type_military?).and_return 30_000
+          allow_any_instance_of(StateFileMdIntake).to receive(:is_filer_55_and_older?).with(filer).and_return is_55_and_older
+        end
 
-      context "when the filer is older than 55" do
-        let(:is_55_and_older) { true }
-        it "returns 20,000" do
-          expect(instance.calculate_military_per_filer(:primary)).to eq(20_000)
-          expect(instance.calculate_military_per_filer(:spouse)).to eq(20_000)
+        context "when the filer is older than 55" do
+          let(:is_55_and_older) { true }
+          it "returns 20,000" do
+            expect(instance.calculate_military_per_filer(filer)).to eq(20_000)
+          end
+        end
+
+        context "when the filer is younger than 55" do
+          let(:is_55_and_older) { false }
+          it "returns 12,500" do
+            expect(instance.calculate_military_per_filer(filer)).to eq(12_500)
+          end
         end
       end
 
-      context "when the filer is younger than 55" do
-        let(:is_55_and_older) { false }
-        it "returns 12,500" do
-          expect(instance.calculate_military_per_filer(:primary)).to eq(12_500)
-          expect(instance.calculate_military_per_filer(:spouse)).to eq(12_500)
+      context "when the taxable amount is lower than the age benefit amount" do
+        before do
+          allow_any_instance_of(StateFileMdIntake).to receive(:sum_1099_r_followup_type_for_filer).with(filer, :service_type_military?).and_return 10_000
+          allow_any_instance_of(StateFileMdIntake).to receive(:is_filer_55_and_older?).with(filer).and_return false
         end
-      end
-    end
-
-    context "when the taxable amount is lower than the age benefit amount" do
-      before do
-        allow_any_instance_of(StateFileMdIntake).to receive(:sum_1099_r_followup_type_for_filer).and_return 10_000
-        allow_any_instance_of(StateFileMdIntake).to receive(:is_filer_55_and_older?).and_return false
-      end
-      it "returns the taxable amount" do
-        expect(instance.calculate_military_per_filer(:primary)).to eq(10_000)
-        expect(instance.calculate_military_per_filer(:spouse)).to eq(10_000)
+        it "returns the taxable amount" do
+          expect(instance.calculate_military_per_filer(filer)).to eq(10_000)
+        end
       end
     end
   end


### PR DESCRIPTION


## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/FYST-1826

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
For Line 502SU line u, I hard coded the filer to `:primary` and so the calculations for the spouse were also for the primary. I changed that & made the tests more specific to only receive the correct value.

