### PR TITLE
Nj 290 line 55 includes 1099-R

### DIFF
--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -666,7 +666,7 @@ module Efile
 
       def non_military_1099rs
         @intake.state_file1099_rs.select do |state_file_1099r|
-          state_file_1099r.state_specific_followup.present? && state_file_1099r.state_specific_followup.income_source_none?
+          state_file_1099r.state_specific_followup.present? && state_file_1099r.state_specific_followup.income_source_other?
         end
       end
     end

--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -437,11 +437,11 @@ module Efile
       end
 
       def calculate_line_55
-        return nil if @intake.state_file_w2s.empty? && non_military_1099rs.empty?
+        return nil if @intake.state_file_w2s.empty? && @intake.state_file1099_rs.empty?
 
         (
           @intake.state_file_w2s.sum(&:state_income_tax_amount) +
-          non_military_1099rs.sum(&:state_tax_withheld_amount)
+          @intake.state_file1099_rs.sum(&:state_tax_withheld_amount)
         ).round
       end
 

--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -437,9 +437,12 @@ module Efile
       end
 
       def calculate_line_55
-        return nil if @intake.state_file_w2s.empty?
+        return nil if @intake.state_file_w2s.empty? && non_military_1099rs.empty?
 
-        @intake.state_file_w2s.inject(0) { |sum, w2| sum + w2.state_income_tax_amount }.round
+        (
+          @intake.state_file_w2s.sum(&:state_income_tax_amount) +
+          non_military_1099rs.sum(&:state_tax_withheld_amount)
+        ).round
       end
 
       def calculate_line_56

--- a/app/models/state_file_nj1099_r_followup.rb
+++ b/app/models/state_file_nj1099_r_followup.rb
@@ -11,5 +11,5 @@ class StateFileNj1099RFollowup < ApplicationRecord
 
   has_one :state_file1099_r, inverse_of: :state_specific_followup
 
-  enum income_source: { unfilled: 0, military_pension: 1, military_survivors_benefits: 2, none: 3 }, _prefix: :income_source
+  enum income_source: { unfilled: 0, military_pension: 1, military_survivors_benefits: 2, other: 3 }, _prefix: :income_source
 end

--- a/app/views/state_file/questions/nj_retirement_income_source/edit.html.erb
+++ b/app/views/state_file/questions/nj_retirement_income_source/edit.html.erb
@@ -20,7 +20,7 @@
             collection: [
               { value: :military_pension, label: t(".option_military_pension") },
               { value: :military_survivors_benefits, label: t(".option_military_survivor_benefit") },
-              { value: :none, label: t(".option_none") },
+              { value: :other, label: t(".option_other") },
             ],
           ) %>
     </div>

--- a/app/views/state_file/questions/nj_review/edit.html.erb
+++ b/app/views/state_file/questions/nj_review/edit.html.erb
@@ -127,7 +127,7 @@
                   <% elsif state_file1099_r.state_specific_followup.income_source_military_survivors_benefits? %>
                     <%= t(".retirement_income_source_military_survivor_benefit") %>
                   <% else %>
-                    <%= t(".retirement_income_source_none") %>
+                    <%= t(".retirement_income_source_other") %>
                   <% end %>
                 </b>
               </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3614,7 +3614,7 @@ en:
           label: 'Select the source of this income:'
           option_military_pension: U.S. military pension
           option_military_survivor_benefit: U.S. military survivor's benefits
-          option_none: None of these apply (Choose this if you have a civil service pension or annuity)
+          option_other: None of these apply (Choose this if you have a civil service pension or annuity)
           subtitle: We need more information about this 1099-R.
           taxable_amount_label: 'Taxable Amount:'
           taxpayer_name_label: 'Taxpayer Name:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3650,7 +3650,7 @@ en:
           retirement_income_source_label: 'Source:'
           retirement_income_source_military_pension: U.S. military pension
           retirement_income_source_military_survivor_benefit: U.S. military survivor's benefits
-          retirement_income_source_none: Neither U.S. military pension nor U.S. military survivor's benefits
+          retirement_income_source_other: Neither U.S. military pension nor U.S. military survivor's benefits
           retirement_income_source_taxable_amount_label: 'Taxable Amount:'
           retirement_income_source_taxpayer_name_label: 'Taxpayer Name:'
           reveal:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3586,7 +3586,7 @@ es:
           label: 'Select the source of this income:'
           option_military_pension: U.S. military pension
           option_military_survivor_benefit: U.S. military survivor's benefits
-          option_none: None of these apply (Choose this if you have a civil service pension or annuity)
+          option_other: None of these apply (Choose this if you have a civil service pension or annuity)
           subtitle: We need more information about this 1099-R.
           taxable_amount_label: 'Taxable Amount:'
           taxpayer_name_label: 'Taxpayer Name:'
@@ -3622,7 +3622,7 @@ es:
           retirement_income_source_label: 'Source:'
           retirement_income_source_military_pension: U.S. military pension
           retirement_income_source_military_survivor_benefit: U.S. military survivor's benefits
-          retirement_income_source_none: Neither U.S. military pension nor U.S. military survivor's benefits
+          retirement_income_source_other: Neither U.S. military pension nor U.S. military survivor's benefits
           retirement_income_source_taxable_amount_label: 'Taxable Amount:'
           retirement_income_source_taxpayer_name_label: 'Taxpayer Name:'
           reveal:

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -1607,8 +1607,8 @@ describe Efile::Nj::Nj1040Calculator do
 
     context 'when has only 1099-Rs' do
       let(:intake) { create(:state_file_nj_intake, :df_data_minimal)}
-      let!(:state_file_1099r) { create :state_file1099_r, intake: intake, state_tax_withheld_amount: 100 }
-      let!(:state_specific_followup) { create :state_file_nj1099_r_followup, state_file1099_r: state_file_1099r, income_source: :none }
+      let!(:state_file_1099r) { create :state_file1099_r, intake: intake, state_tax_withheld_amount: 100.1 }
+      let!(:state_specific_followup) { create :state_file_nj1099_r_followup, state_file1099_r: state_file_1099r, income_source: :other }
     
       it 'sets line 55 to total income tax withheld, rounded' do
         intake.reload
@@ -1619,8 +1619,8 @@ describe Efile::Nj::Nj1040Calculator do
 
     context 'when has both w2s and 1099-Rs' do
       let(:intake) { create(:state_file_nj_intake, :df_data_many_w2s)}
-      let!(:state_file_1099r) { create :state_file1099_r, intake: intake, state_tax_withheld_amount: 100 }
-      let!(:state_specific_followup) { create :state_file_nj1099_r_followup, state_file1099_r: state_file_1099r, income_source: :none }
+      let!(:state_file_1099r) { create :state_file1099_r, intake: intake, state_tax_withheld_amount: 100.1 }
+      let!(:state_specific_followup) { create :state_file_nj1099_r_followup, state_file1099_r: state_file_1099r, income_source: :other }
 
       it 'sets line 55 to total income tax withheld, rounded' do
         intake.reload

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -1608,7 +1608,7 @@ describe Efile::Nj::Nj1040Calculator do
     context 'when has only 1099-Rs' do
       let(:intake) { create(:state_file_nj_intake, :df_data_minimal)}
       let!(:state_file_1099r) { create :state_file1099_r, intake: intake, state_tax_withheld_amount: 100.1 }
-      let!(:state_specific_followup) { create :state_file_nj1099_r_followup, state_file1099_r: state_file_1099r, income_source: :other }
+      let!(:state_specific_followup) { create :state_file_nj1099_r_followup, state_file1099_r: state_file_1099r, income_source: :military_pension }
     
       it 'sets line 55 to total income tax withheld, rounded' do
         intake.reload

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -535,9 +535,9 @@ describe Efile::Nj::Nj1040Calculator do
     end
 
     context 'when all 1099-Rs are applicable (non-military)' do
-      let(:income_source_1) { :none }
-      let(:income_source_2) { :none }
-      let(:income_source_3) { :none }
+      let(:income_source_1) { :other }
+      let(:income_source_2) { :other }
+      let(:income_source_3) { :other }
 
       it 'sets line 20a to the sum of all 1099-Rs taxable amount, rounded' do
         expect(instance.lines[:NJ1040_LINE_20A].value).to eq(901)
@@ -547,7 +547,7 @@ describe Efile::Nj::Nj1040Calculator do
     context 'when some 1099-Rs are military pension or survivor benefits' do
       let(:income_source_1) { :military_pension }
       let(:income_source_2) { :military_survivors_benefits }
-      let(:income_source_3) { :none }
+      let(:income_source_3) { :other }
 
       it 'does not include military pension / survivor benefits in line 20a sum' do
         expect(instance.lines[:NJ1040_LINE_20A].value).to eq(500)
@@ -580,9 +580,9 @@ describe Efile::Nj::Nj1040Calculator do
     end
 
     context 'when all 1099-Rs are applicable (non-military)' do
-      let(:income_source_1) { :none }
-      let(:income_source_2) { :none }
-      let(:income_source_3) { :none }
+      let(:income_source_1) { :other }
+      let(:income_source_2) { :other }
+      let(:income_source_3) { :other }
 
       it 'sets line 20a to the sum of all 1099-Rs gross distribution amount minus taxable amount, rounded' do
         expected = 300 # 1200.01 - 900.50 = 299.51, rounded
@@ -593,7 +593,7 @@ describe Efile::Nj::Nj1040Calculator do
     context 'when some 1099-Rs are military pension or survivor benefits' do
       let(:income_source_1) { :military_pension }
       let(:income_source_2) { :military_survivors_benefits }
-      let(:income_source_3) { :none }
+      let(:income_source_3) { :other }
 
       it 'does not include military pension / survivor benefits in line 20b' do
         expect(instance.lines[:NJ1040_LINE_20B].value).to eq(100)

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -1617,6 +1617,18 @@ describe Efile::Nj::Nj1040Calculator do
       end
     end
 
+    # Remove when Flipper :show_retirement_ui is permanently enabled
+    context 'when has 1099-R and source is unknown' do
+      let(:intake) { create(:state_file_nj_intake, :df_data_minimal)}
+      let!(:state_file_1099r) { create :state_file1099_r, intake: intake, state_tax_withheld_amount: 100.1 }
+    
+      it 'sets line 55 to total income tax withheld, rounded' do
+        intake.reload
+        instance.calculate
+        expect(instance.lines[:NJ1040_LINE_55].value).to eq 100
+      end
+    end
+
     context 'when has both w2s and 1099-Rs' do
       let(:intake) { create(:state_file_nj_intake, :df_data_many_w2s)}
       let!(:state_file_1099r) { create :state_file1099_r, intake: intake, state_tax_withheld_amount: 100.1 }

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -1607,33 +1607,25 @@ describe Efile::Nj::Nj1040Calculator do
 
     context 'when has only 1099-Rs' do
       let(:intake) { create(:state_file_nj_intake, :df_data_minimal)}
-      let!(:state_file_1099r) { create :state_file1099_r, intake: intake, state_tax_withheld_amount: 100.1 }
-      let!(:state_specific_followup) { create :state_file_nj1099_r_followup, state_file1099_r: state_file_1099r, income_source: :military_pension }
-    
+      let!(:state_file_1099r_1) { create :state_file1099_r, intake: intake, state_tax_withheld_amount: 10.1 }
+      let!(:state_specific_followup_1) { create :state_file_nj1099_r_followup, state_file1099_r: state_file_1099r_1, income_source: :military_pension }
+      let!(:state_file_1099r_2) { create :state_file1099_r, intake: intake, state_tax_withheld_amount: 30.1 }
+      let!(:state_specific_followup_2) { create :state_file_nj1099_r_followup, state_file1099_r: state_file_1099r_2, income_source: :military_survivors_benefits }
+      let!(:state_file_1099r_3) { create :state_file1099_r, intake: intake, state_tax_withheld_amount: 80.1 }
+      let!(:state_specific_followup_3) { create :state_file_nj1099_r_followup, state_file1099_r: state_file_1099r_3, income_source: :other }
+      let!(:state_file_1099r_4) { create :state_file1099_r, intake: intake, state_tax_withheld_amount: 210.1 }
+      
       it 'sets line 55 to total income tax withheld, rounded' do
         intake.reload
         instance.calculate
-        expect(instance.lines[:NJ1040_LINE_55].value).to eq 100
-      end
-    end
-
-    # Remove when Flipper :show_retirement_ui is permanently enabled
-    context 'when has 1099-R and source is unknown' do
-      let(:intake) { create(:state_file_nj_intake, :df_data_minimal)}
-      let!(:state_file_1099r) { create :state_file1099_r, intake: intake, state_tax_withheld_amount: 100.1 }
-    
-      it 'sets line 55 to total income tax withheld, rounded' do
-        intake.reload
-        instance.calculate
-        expect(instance.lines[:NJ1040_LINE_55].value).to eq 100
+        expect(instance.lines[:NJ1040_LINE_55].value).to eq 330
       end
     end
 
     context 'when has both w2s and 1099-Rs' do
       let(:intake) { create(:state_file_nj_intake, :df_data_many_w2s)}
       let!(:state_file_1099r) { create :state_file1099_r, intake: intake, state_tax_withheld_amount: 100.1 }
-      let!(:state_specific_followup) { create :state_file_nj1099_r_followup, state_file1099_r: state_file_1099r, income_source: :other }
-
+      
       it 'sets line 55 to total income tax withheld, rounded' do
         intake.reload
         instance.calculate

--- a/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
@@ -881,17 +881,19 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
     end
 
     describe "total income tax withheld - line 55" do
-      context 'when has w2s' do
+      context 'when has tax withheld' do
         before do
           allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_55).and_return 12_345
         end
-        it 'sets TaxWithheld to sum of state_income_tax_amount' do
+        it 'sets TaxWithheld to total of tax withheld' do
           expect(xml.at("TaxWithheld").text).to eq(12_345.to_s)
         end
       end
 
-      context 'when no w2s' do
-        let(:intake) { create(:state_file_nj_intake, :df_data_minimal)}
+      context 'when no tax withheld' do
+        before do
+          allow_any_instance_of(Efile::Nj::Nj1040Calculator).to receive(:calculate_line_55).and_return nil
+        end
         it 'sets TaxWithheld to nil' do
           expect(xml.at("TaxWithheld")).to eq(nil)
         end


### PR DESCRIPTION
## Link to pivotal/JIRA issue

https://github.com/newjersey/affordability-pm/issues/290

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Tests to check for W2s and 1099-Rs with taxes withheld
- There will eventually be more types of forms to be added in Line 55, but for now we only support these
- I also renamed `none` to `other` in the `income_source` enum of `state_file_nj1099_r_followup`, which feels more accurate

## How to test?
- Use `bog turtle`, which has 2000 withheld from W2 and 1000 withheld from 1099-R
- You'll have to adjust the UI Box 14 amount under the limit after you import
- It doesn't matter if Flipper is on for `show_retirement_ui` or not, or which income source you choose for the 1099-R. All withholdings count!
- XML and PDF show 3000 total withheld

## Screenshots (for visual changes)

<img width="365" alt="image" src="https://github.com/user-attachments/assets/bdc7e22b-f506-4b90-8109-11f24babb9e8" />

<img width="741" alt="image" src="https://github.com/user-attachments/assets/04d85b72-e4a5-41c8-8858-9f6beb6144c6" />


