### PR TITLE
FYST-1676 restrict nj hub efile submissions to only show count of nj submissions

### DIFF
--- a/app/controllers/hub/state_file/efile_submissions_controller.rb
+++ b/app/controllers/hub/state_file/efile_submissions_controller.rb
@@ -65,7 +65,8 @@ module Hub
       end
 
       def state_counts
-        @efile_submission_state_counts = EfileSubmission.statefile_state_counts(except: %w[new resubmitted ready_to_resubmit], nj: current_user.state_file_nj_staff?)
+        intake_classes = current_user.state_file_nj_staff? ? "StateFileNjIntake" : ::StateFile::StateInformationService.state_intake_class_names.excluding("StateFileNjIntake").join("','")
+        @efile_submission_state_counts = EfileSubmission.statefile_state_counts(except: %w[new resubmitted ready_to_resubmit], intake_classes: intake_classes)
         respond_to :js
       end
 

--- a/app/controllers/hub/state_file/efile_submissions_controller.rb
+++ b/app/controllers/hub/state_file/efile_submissions_controller.rb
@@ -23,7 +23,6 @@ module Hub
 
         @efile_submissions = @efile_submissions.includes(:efile_submission_transitions).reorder(created_at: :desc).paginate(page: params[:page], per_page: 30)
         @efile_submissions = @efile_submissions.in_state(params[:status]) if params[:status].present?
-
       end
 
       def show
@@ -66,7 +65,7 @@ module Hub
       end
 
       def state_counts
-        @efile_submission_state_counts = EfileSubmission.statefile_state_counts(except: %w[new resubmitted ready_to_resubmit])
+        @efile_submission_state_counts = EfileSubmission.statefile_state_counts(except: %w[new resubmitted ready_to_resubmit], nj: current_user.state_file_nj_staff?)
         respond_to :js
       end
 

--- a/app/lib/seeder.rb
+++ b/app/lib/seeder.rb
@@ -113,6 +113,11 @@ class Seeder
     additional_user.update(name: "Lea Amidala Organa", password: strong_shared_password)
     additional_user.update(role: OrganizationLeadRole.create(organization: first_org)) if additional_user.role_type != OrganizationLeadRole::TYPE
 
+    # nj user
+    nj_user = User.where(email: "stew@example.com").first_or_initialize
+    nj_user.update(name: "Stewart Stringbean", password: strong_shared_password)
+    nj_user.update(role: StateFileNjStaffRole.create) if nj_user.role_type != StateFileNjStaffRole::TYPE
+
     if Rails.configuration.google_login_enabled
       pairs_file_data = YAML.safe_load(File.read(Rails.root.join(".pairs")))
       admin_names = pairs_file_data["pairs"]

--- a/app/models/efile_submission.rb
+++ b/app/models/efile_submission.rb
@@ -77,15 +77,9 @@ class EfileSubmission < ApplicationRecord
     result.except(*except)
   end
 
-  def self.statefile_state_counts(except: [], nj: false)
+  def self.statefile_state_counts(except: [], intake_classes: StateFile::StateInformationService.state_intake_class_names.join("','"))
     result = {}
     EfileSubmissionStateMachine.states.each { |state| result[state] = 0 }
-    intake_classes = case nj
-             when true
-               "StateFileNjIntake"
-             when false
-               StateFile::StateInformationService.state_intake_class_names.excluding("StateFileNjIntake").join("','")
-             end
     ActiveRecord::Base.connection.execute(<<~SQL).each { |row| result[row['to_state']] = row['count'] }
       SELECT to_state, COUNT(*) FROM "efile_submissions"
       LEFT OUTER JOIN efile_submission_transitions AS most_recent_efile_submission_transition ON (


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1676
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- The counts at the top of the efile submissions page were for all types of efile submissions but they should instead be either all states except nj (when logged in as admin) and only nj (when logged in as nj staff)
- Added an argument to the method that returns counts
- I tried 2 different implementations that can be found in commits 1 and 2 respectively. Please weigh in.
## How to test?
- Added a test to the controller with different users logged in
## Screenshots (for visual changes)
- Before
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/028efc43-3f63-4986-966f-13818fb35f75" />
when you click on the 1 transmitted:
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/c32fd771-2de1-4605-9e09-041c022fd23d" />

- After
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/49dec900-e55d-4b21-8669-4063b7ad0501" />

