### PR TITLE
[FYST-1830] remove the need for the full pdf download url to be in the page params

### DIFF
--- a/app/controllers/state_file/archived_intakes/pdfs_controller.rb
+++ b/app/controllers/state_file/archived_intakes/pdfs_controller.rb
@@ -14,14 +14,14 @@ module StateFile
       end
 
       def index
-        @prior_year_intake = StateFileArchivedIntake.find_by!(email_address: current_request.email_address)
-        @pdf_url = @prior_year_intake.submission_pdf.url(expires_in: pdf_expiration_time, disposition: "inline")
+        @state_code = StateFileArchivedIntake.find_by!(email_address: current_request.email_address).state_code
         create_state_file_access_log("issued_pdf_download_link")
       end
 
       def log_and_redirect
         create_state_file_access_log("client_pdf_download_click")
-        pdf_url = params[:pdf_url]
+        prior_year_intake = StateFileArchivedIntake.find_by!(email_address: current_request.email_address)
+        pdf_url = prior_year_intake.submission_pdf.url(expires_in: pdf_expiration_time, disposition: "inline")
         redirect_to pdf_url
       end
 

--- a/app/controllers/state_file/archived_intakes/pdfs_controller.rb
+++ b/app/controllers/state_file/archived_intakes/pdfs_controller.rb
@@ -22,7 +22,7 @@ module StateFile
         create_state_file_access_log("client_pdf_download_click")
         prior_year_intake = StateFileArchivedIntake.find_by!(email_address: current_request.email_address)
         pdf_url = prior_year_intake.submission_pdf.url(expires_in: pdf_expiration_time, disposition: "inline")
-        redirect_to pdf_url
+        redirect_to pdf_url, allow_other_host: true
       end
 
       private

--- a/app/views/state_file/archived_intakes/pdfs/index.html.erb
+++ b/app/views/state_file/archived_intakes/pdfs/index.html.erb
@@ -6,10 +6,9 @@
   <div class="grid">
     <div class="grid__item question-wrapper">
       <h1 class="h2" id="main-question"><%= @title %></h1>
-      <p><%= t('.subtitle', state: @prior_year_intake.state_code) %></p>
+      <p><%= t('.subtitle', state: @state_code) %></p>
 
       <%= form_with url: state_file_archived_intakes_pdfs_log_and_redirect_path, method: :post, local: true do %>
-        <%= hidden_field_tag :pdf_url, @pdf_url %>
         <button type="submit" class="button button--primary button--wide spacing-below-15 button--icon button--icon--centered">
           <%= image_tag("icons/download.svg", alt: "", style: "filter: invert(1); vertical-align: middle;") %>
           <%= t(".download") %>

--- a/spec/controllers/state_file/archived_intake/pdfs_controller_spec.rb
+++ b/spec/controllers/state_file/archived_intake/pdfs_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe StateFile::ArchivedIntakes::PdfsController, type: :controller do
   let(:email_address) { "test@example.com" }
-  let!(:intake) { create(:state_file_archived_intake, mailing_state: "NY", email_address: email_address) }
+  let!(:intake) { create(:state_file_archived_intake, state_code: "NY", mailing_state: "NY", email_address: email_address) }
   let(:current_request) { create(:state_file_archived_intake_request, email_address: email_address, failed_attempts: 0, state_file_archived_intake: intake) }
   let(:controller_instance) { described_class.new }
   let(:valid_verification_code) { "123456" }
@@ -70,8 +70,7 @@ RSpec.describe StateFile::ArchivedIntakes::PdfsController, type: :controller do
     context "by default" do
       it "renders" do
         get :index
-
-        expect(assigns(:prior_year_intake)).to eq(intake)
+        expect(assigns(:state_code)).to eq(intake.state_code)
         expect(response).to render_template(:index)
       end
     end
@@ -85,94 +84,11 @@ RSpec.describe StateFile::ArchivedIntakes::PdfsController, type: :controller do
     end
 
     it "logs the access event and redirects to the provided pdf_url" do
-      allow_any_instance_of(described_class).to receive(:redirect_to).and_call_original
-
-      post :log_and_redirect, params: { pdf_url: pdf_url }
+      allow_any_instance_of(described_class).to receive(:redirect_to)
+      post :log_and_redirect
 
       expect(controller).to have_received(:create_state_file_access_log).with("client_pdf_download_click")
-      expect(controller).to have_received(:redirect_to).with(pdf_url)
+      expect(controller).to have_received(:redirect_to)
     end
   end
 end
-
-=begin
-
-RSpec.describe StateFile::ArchivedIntakes::MailingAddressValidationController, type: :controller do
-  describe "GET #edit" do
-    context "when the request is not locked" do
-      before do
-        allow(current_request).to receive(:access_locked?).and_return(false)
-      end
-
-      it "renders the edit template with a new MailingAddressValidationForm" do
-        get :edit
-
-        expect(assigns(:form)).to be_a(StateFile::ArchivedIntakes::MailingAddressValidationForm)
-        expect(response).to render_template(:edit)
-      end
-    end
-
-    it "redirect to root if code verification was not completed" do
-      session[:code_verified] = nil
-      session[:ssn_verified] = true
-      get :edit
-
-      expect(response).to redirect_to(root_path)
-      expect(StateFileArchivedIntakeAccessLog.last.event_type).to eq("unauthorized_mailing_attempt")
-    end
-
-    it "redirect to root if ssn verification was not completed" do
-      session[:code_verified] = true
-      session[:ssn_verified] = nil
-      get :edit
-
-      expect(response).to redirect_to(root_path)
-      expect(StateFileArchivedIntakeAccessLog.last.event_type).to eq("unauthorized_mailing_attempt")
-    end
-  end
-
-  describe "PATCH #update" do
-    context "with a valid chosen address" do
-      it "creates an access log and redirects to the download page" do
-        post :update, params: {
-          state_file_archived_intakes_mailing_address_validation_form: { selected_address: intake.full_address, addresses: current_request.address_challenge_set}
-        }
-        expect(assigns(:form)).to be_valid
-
-        access_log = StateFileArchivedIntakeAccessLog.last
-        expect(access_log.state_file_archived_intake_request).to eq(current_request)
-        expect(access_log.event_type).to eq("correct_mailing_address")
-        expect(session[:mailing_verified]).to eq(true)
-
-        expect(response).to redirect_to(state_file_archived_intakes_pdfs_path)
-      end
-    end
-
-    context "with an invalid chosen address" do
-      it "creates an access log and redirects to the root path and locks the request" do
-        post :update, params: {
-          state_file_archived_intakes_mailing_address_validation_form: { selected_address: current_request.fake_address_1, addresses: current_request.address_challenge_set}
-        }
-        expect(assigns(:form)).not_to be_valid
-
-        access_log = StateFileArchivedIntakeAccessLog.last
-        expect(access_log.state_file_archived_intake_request).to eq(current_request)
-        expect(access_log.event_type).to eq("incorrect_mailing_address")
-        expect(session[:mailing_verified]).to eq(nil)
-        expect(current_request.access_locked?).to eq(true)
-        expect(response).to redirect_to(state_file_archived_intakes_verification_error_path)
-      end
-    end
-
-    context "without a chosen address" do
-      it "creates an access log and redirects to the root path" do
-        post :update, params: {
-        }
-        expect(assigns(:form)).not_to be_valid
-
-        expect(response).to render_template(:edit)
-      end
-    end
-  end
-end
-=end

--- a/spec/controllers/state_file/archived_intake/pdfs_controller_spec.rb
+++ b/spec/controllers/state_file/archived_intake/pdfs_controller_spec.rb
@@ -78,17 +78,19 @@ RSpec.describe StateFile::ArchivedIntakes::PdfsController, type: :controller do
 
   describe "POST #log_and_redirect" do
     let(:pdf_url) { "https://example.com/test.pdf" }
+    let(:mock_pdf) { spy }
 
     before do
       allow(controller).to receive(:create_state_file_access_log)
+      allow_any_instance_of(StateFileArchivedIntake).to receive(:submission_pdf).and_return(mock_pdf)
+      allow(mock_pdf).to receive(:url).and_return(pdf_url)
     end
 
     it "logs the access event and redirects to the provided pdf_url" do
-      allow_any_instance_of(described_class).to receive(:redirect_to)
       post :log_and_redirect
 
       expect(controller).to have_received(:create_state_file_access_log).with("client_pdf_download_click")
-      expect(controller).to have_received(:redirect_to)
+      expect(response).to redirect_to(pdf_url)
     end
   end
 end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
[FYST-1830](https://codeforamerica.atlassian.net/browse/FYST-1830)

## Is PM acceptance required? (delete one)
Yes - don't merge until JIRA issue is accepted! Needs to be tested on demo prior to release.

## What was done?
Shifts when in the flow the signed URL is generated. Before, the signed URL to the PDF was being generated in the action that rendered the 'download your pdf' button, and being passed as a param to a controller action that would log the activity and redirect to the URL. This flow exposed the signed PDF URL in the logs, and also created an avenue to siphon the signed url out of the client.

This PR moves the url generation to the end of the flow instead. Now there's no need for a param to hold the url between page loads; we log the request, generate the signed url, and redirect the client.

## How to test?
- Go through the GetYourPDF flow. Should be no noted difference in the client experience
- Inspect the logs (or ask eng to) to validate that the signed PDF url doesn't appear in the logged params
- Validate the appropriate access logs are created for each step in the retrieval



[FYST-1830]: https://codeforamerica.atlassian.net/browse/FYST-1830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ