### PR TITLE
FYST-397 ensure that waiting to load data always proceeds correctly

### DIFF
--- a/app/channels/df_data_transfer_job_channel.rb
+++ b/app/channels/df_data_transfer_job_channel.rb
@@ -1,10 +1,10 @@
 class DfDataTransferJobChannel < ApplicationCable::Channel
   def subscribed
     intake = current_state_file_intake
+    stream_for intake
     if intake.raw_direct_file_data
       DfDataTransferJobChannel.broadcast_job_complete(intake)
     end
-    stream_for intake
   end
 
   def self.broadcast_job_complete(intake)

--- a/spec/channels/df_data_transfer_job_channel_spec.rb
+++ b/spec/channels/df_data_transfer_job_channel_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe DfDataTransferJobChannel, type: :channel do
+  let(:intake) { create(:state_file_az_intake) }
+  before do
+    intake.update(raw_direct_file_data: direct_file_data)
+    stub_connection current_state_file_intake: intake
+  end
+
+  context "without direct file data" do
+    let(:direct_file_data) { nil }
+
+    it 'does not broadcast job complete' do
+      expect do
+        subscribe
+      end.not_to have_broadcasted_to(DfDataTransferJobChannel.broadcasting_for(intake))
+      expect(subscription).to have_stream_for(intake)
+    end
+  end
+
+  context "with direct file data" do
+    let(:direct_file_data) { StateFile::DirectFileApiResponseSampleService.new.old_xml_sample }
+
+    it 'broadcasts job complete' do
+      expect do
+        subscribe
+      end.to have_broadcasted_to(DfDataTransferJobChannel.broadcasting_for(intake)).with(["The job is complete"])
+      expect(subscription).to have_stream_for(intake)
+    end
+  end
+end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/FYST-397

## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?

This is plagiarism from Mike's original description: 

Calls stream_for intake before broadcast_job_complete(intake). broadcast_to(intake, ...) is called by broadcast_job_complete(intake), but won’t do anything until stream_for is called. This should marginally speed up the data transfer page

## How to test?
We've written some tests. They are as good as they can get & don't actually test the problem. But, the [action cable testing documentation](https://github.com/palkan/action-cable-testing) is very limited. 