### PR TITLE
FYST-1809 bounce from page when there is no request

### DIFF
--- a/app/controllers/state_file/archived_intakes/archived_intake_controller.rb
+++ b/app/controllers/state_file/archived_intakes/archived_intake_controller.rb
@@ -30,7 +30,7 @@ module StateFile
       end
 
       def is_request_locked
-        if current_request.access_locked? || current_archived_intake&.permanently_locked_at.present?
+        if current_request.nil? || current_request.access_locked? || current_archived_intake&.permanently_locked_at.present?
           redirect_to state_file_archived_intakes_verification_error_path
         end
       end

--- a/spec/controllers/state_file/archived_intake/archived_intake_controller_spec.rb
+++ b/spec/controllers/state_file/archived_intake/archived_intake_controller_spec.rb
@@ -88,5 +88,57 @@ describe StateFile::ArchivedIntakes::ArchivedIntakeController, type: :controller
         end
       end
     end
+
+    describe '#is_request_locked' do
+      before do
+        allow(controller).to receive(:current_request).and_return(request_instance)
+        allow(controller).to receive(:current_archived_intake).and_return(archived_intake)
+      end
+
+      context 'when the request is nil' do
+        before do
+          allow(controller).to receive(:current_request).and_return(nil)
+        end
+
+        it 'redirects to verification error page' do
+          expect(controller).to receive(:redirect_to).with(state_file_archived_intakes_verification_error_path)
+          controller.is_request_locked
+        end
+      end
+
+      context 'when the request is locked' do
+        before do
+          allow(request_instance).to receive(:access_locked?).and_return(true)
+        end
+
+        it 'redirects to verification error page' do
+          expect(controller).to receive(:redirect_to).with(state_file_archived_intakes_verification_error_path)
+          controller.is_request_locked
+        end
+      end
+
+      context 'when the archived intake is permanently locked' do
+        before do
+          allow(archived_intake).to receive(:permanently_locked_at).and_return(Time.current)
+        end
+
+        it 'redirects to verification error page' do
+          expect(controller).to receive(:redirect_to).with(state_file_archived_intakes_verification_error_path)
+          controller.is_request_locked
+        end
+      end
+
+      context 'when the request is valid and not locked' do
+        before do
+          allow(request_instance).to receive(:access_locked?).and_return(false)
+          allow(archived_intake).to receive(:permanently_locked_at).and_return(nil)
+        end
+
+        it 'does not redirect' do
+          expect(controller).not_to receive(:redirect_to)
+          controller.is_request_locked
+        end
+      end
+    end
   end
 end

--- a/spec/controllers/state_file/archived_intake/email_address_controller_spec.rb
+++ b/spec/controllers/state_file/archived_intake/email_address_controller_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe StateFile::ArchivedIntakes::EmailAddressController, type: :contro
   before do
     Flipper.enable(:get_your_pdf)
   end
+
   describe "GET #edit" do
     it "renders the edit template with a new EmailAddressForm" do
       get :edit
@@ -23,9 +24,9 @@ RSpec.describe StateFile::ArchivedIntakes::EmailAddressController, type: :contro
     end
 
     context "when the form is valid" do
-      context "and a archived intake exists with the email address" do
+      context "and an archived intake exists with the email address" do
         let!(:archived_intake) { create :state_file_archived_intake, email_address: valid_email_address }
-        it "creates an access log create a request and redirects to the verification code page" do
+        it "creates an access log, creates a request, and redirects to the verification code page" do
           post :update, params: {
             state_file_archived_intakes_email_address_form: { email_address: valid_email_address }
           }
@@ -46,8 +47,8 @@ RSpec.describe StateFile::ArchivedIntakes::EmailAddressController, type: :contro
         end
       end
 
-      context "and a archived does not exist with the email address" do
-        it "creates an access log create a request and redirects to the verification code page" do
+      context "and an archived intake does not exist with the email address" do
+        it "creates an access log, creates a request, and redirects to the verification code page" do
           post :update, params: {
             state_file_archived_intakes_email_address_form: { email_address: valid_email_address }
           }
@@ -68,6 +69,7 @@ RSpec.describe StateFile::ArchivedIntakes::EmailAddressController, type: :contro
         end
       end
     end
+
     context "when the form is invalid" do
       it "renders the edit template" do
         post :update, params: {

--- a/spec/controllers/state_file/archived_intake/identification_number_controller_spec.rb
+++ b/spec/controllers/state_file/archived_intake/identification_number_controller_spec.rb
@@ -25,25 +25,16 @@ RSpec.describe StateFile::ArchivedIntakes::IdentificationNumberController, type:
   end
 
   describe "GET #edit" do
+    it_behaves_like 'archived intake request locked', action: :edit, method: :get do
+      let(:request_instance) { intake_request }
+      let(:archived_intake) { existing_archived_intake }
+    end
+
     it "renders the edit template with a new IdentificationNumberForm" do
       get :edit
 
       expect(assigns(:form)).to be_a(StateFile::ArchivedIntakes::IdentificationNumberForm)
       expect(response).to render_template(:edit)
-    end
-
-    it "redirects to the lockout path when the request is locked" do
-      intake_request.lock_access!
-      get :edit
-
-      expect(response).to redirect_to(state_file_archived_intakes_verification_error_path)
-    end
-
-    it "redirects to the lockout path when the request is permantly locked" do
-      archived_intake.update(permanently_locked_at: Time.now)
-      get :edit
-
-      expect(response).to redirect_to(state_file_archived_intakes_verification_error_path)
     end
 
     it "redirect to root if code verification was not completed" do

--- a/spec/controllers/state_file/archived_intake/mailing_address_validation_controller_spec.rb
+++ b/spec/controllers/state_file/archived_intake/mailing_address_validation_controller_spec.rb
@@ -1,9 +1,8 @@
 require "rails_helper"
 
 RSpec.describe StateFile::ArchivedIntakes::MailingAddressValidationController, type: :controller do
-  let(:intake) { create(:state_file_archived_intake, mailing_state: "NY") }
-  let(:current_request) { create(:state_file_archived_intake_request, email_address:email_address, failed_attempts: 0, state_file_archived_intake: intake) }
-  let(:controller_instance) { described_class.new }
+  let(:archived_intake) { create(:state_file_archived_intake, mailing_state: "NY") }
+  let(:current_request) { create(:state_file_archived_intake_request, email_address: email_address, failed_attempts: 0, state_file_archived_intake: archived_intake) }
   let(:email_address) { "test@example.com" }
   let(:valid_verification_code) { "123456" }
   let(:invalid_verification_code) { "654321" }
@@ -17,15 +16,11 @@ RSpec.describe StateFile::ArchivedIntakes::MailingAddressValidationController, t
   end
 
   describe "GET #edit" do
+    it_behaves_like 'archived intake request locked', action: :edit, method: :get
+
     context "when the request is locked" do
       before do
         allow(current_request).to receive(:access_locked?).and_return(true)
-      end
-
-      it "redirects to error page" do
-        get :edit
-
-        expect(response).to redirect_to(state_file_archived_intakes_verification_error_path)
       end
     end
 
@@ -42,7 +37,7 @@ RSpec.describe StateFile::ArchivedIntakes::MailingAddressValidationController, t
       end
     end
 
-    it "redirect to root if code verification was not completed" do
+    it "redirects to root if code verification was not completed" do
       session[:code_verified] = nil
       session[:ssn_verified] = true
       get :edit
@@ -51,7 +46,7 @@ RSpec.describe StateFile::ArchivedIntakes::MailingAddressValidationController, t
       expect(StateFileArchivedIntakeAccessLog.last.event_type).to eq("unauthorized_mailing_attempt")
     end
 
-    it "redirect to root if ssn verification was not completed" do
+    it "redirects to root if ssn verification was not completed" do
       session[:code_verified] = true
       session[:ssn_verified] = nil
       get :edit
@@ -65,7 +60,7 @@ RSpec.describe StateFile::ArchivedIntakes::MailingAddressValidationController, t
     context "with a valid chosen address" do
       it "creates an access log and redirects to the download page" do
         post :update, params: {
-          state_file_archived_intakes_mailing_address_validation_form: { selected_address: intake.full_address, addresses: current_request.address_challenge_set}
+          state_file_archived_intakes_mailing_address_validation_form: { selected_address: archived_intake.full_address, addresses: current_request.address_challenge_set}
         }
         expect(assigns(:form)).to be_valid
 
@@ -79,7 +74,7 @@ RSpec.describe StateFile::ArchivedIntakes::MailingAddressValidationController, t
     end
 
     context "with an invalid chosen address" do
-      it "creates an access log and redirects to the root path and locks the request" do
+      it "creates an access log, locks the request, and redirects to the verification error path" do
         post :update, params: {
           state_file_archived_intakes_mailing_address_validation_form: { selected_address: current_request.fake_address_1, addresses: current_request.address_challenge_set}
         }
@@ -89,15 +84,14 @@ RSpec.describe StateFile::ArchivedIntakes::MailingAddressValidationController, t
         expect(access_log.state_file_archived_intake_request).to eq(current_request)
         expect(access_log.event_type).to eq("incorrect_mailing_address")
         expect(session[:mailing_verified]).to eq(nil)
-        expect(intake.permanently_locked_at).to be_present
+        expect(archived_intake.permanently_locked_at).to be_present
         expect(response).to redirect_to(state_file_archived_intakes_verification_error_path)
       end
     end
 
     context "without a chosen address" do
-      it "creates an access log and redirects to the root path" do
-        post :update, params: {
-        }
+      it "creates an access log and re-renders the edit template" do
+        post :update, params: {}
         expect(assigns(:form)).not_to be_valid
 
         expect(response).to render_template(:edit)

--- a/spec/controllers/state_file/archived_intake/pdfs_controller_spec.rb
+++ b/spec/controllers/state_file/archived_intake/pdfs_controller_spec.rb
@@ -2,9 +2,8 @@ require "rails_helper"
 
 RSpec.describe StateFile::ArchivedIntakes::PdfsController, type: :controller do
   let(:email_address) { "test@example.com" }
-  let!(:intake) { create(:state_file_archived_intake, state_code: "NY", mailing_state: "NY", email_address: email_address) }
-  let(:current_request) { create(:state_file_archived_intake_request, email_address: email_address, failed_attempts: 0, state_file_archived_intake: intake) }
-  let(:controller_instance) { described_class.new }
+  let!(:archived_intake) { create(:state_file_archived_intake, state_code: "NY", mailing_state: "NY", email_address: email_address) }
+  let(:current_request) { create(:state_file_archived_intake_request, email_address: email_address, failed_attempts: 0, state_file_archived_intake: archived_intake) }
   let(:valid_verification_code) { "123456" }
   let(:invalid_verification_code) { "654321" }
 
@@ -19,58 +18,12 @@ RSpec.describe StateFile::ArchivedIntakes::PdfsController, type: :controller do
   end
 
   describe "GET #index" do
-    context "request is locked" do
-      before do
-        allow(current_request).to receive(:access_locked?).and_return(true)
-      end
-
-      it "redirects to error page" do
-        get :index
-
-        expect(response).to redirect_to(state_file_archived_intakes_verification_error_path)
-      end
-    end
-
-    context "email address is not verified" do
-      before do
-        session[:code_verified] = nil
-      end
-
-      it "redirects to the email verification page" do
-        get :index
-
-        expect(response).to redirect_to(state_file_archived_intakes_verification_error_path)
-      end
-    end
-
-    context "ssn is not verified" do
-      before do
-        session[:ssn_verified] = nil
-      end
-
-      it "redirects to the ssn verification page" do
-        get :index
-
-        expect(response).to redirect_to(state_file_archived_intakes_verification_error_path)
-      end
-    end
-
-    context "mailing address is not verified" do
-      before do
-        session[:mailing_verified] = nil
-      end
-
-      it "redirects to the ssn verification page" do
-        get :index
-
-        expect(response).to redirect_to(state_file_archived_intakes_verification_error_path)
-      end
-    end
+    it_behaves_like 'archived intake request locked', action: :index, method: :get
 
     context "by default" do
       it "renders" do
         get :index
-        expect(assigns(:state_code)).to eq(intake.state_code)
+        expect(assigns(:state_code)).to eq(archived_intake.state_code)
         expect(response).to render_template(:index)
       end
     end

--- a/spec/controllers/state_file/archived_intake/verification_code_controller_spec.rb
+++ b/spec/controllers/state_file/archived_intake/verification_code_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe StateFile::ArchivedIntakes::VerificationCodeController, type: :controller do
   let!(:archived_intake) { build(:state_file_archived_intake) }
-  let(:current_request) { create(:state_file_archived_intake_request, email_address:email_address, failed_attempts: 0, state_file_archived_intake: archived_intake) }
+  let(:current_request) { create(:state_file_archived_intake_request, email_address: email_address, failed_attempts: 0, state_file_archived_intake: archived_intake) }
   let(:email_address) { "test@example.com" }
   let(:valid_verification_code) { "123456" }
   let(:invalid_verification_code) { "654321" }
@@ -14,17 +14,7 @@ RSpec.describe StateFile::ArchivedIntakes::VerificationCodeController, type: :co
   end
 
   describe "GET #edit" do
-    context "when the request is locked" do
-      before do
-        allow(current_request).to receive(:access_locked?).and_return(true)
-      end
-
-      it "redirects to the root path" do
-        get :edit
-
-        expect(response).to redirect_to(state_file_archived_intakes_verification_error_path)
-      end
-    end
+    it_behaves_like 'archived intake request locked', action: :edit, method: :get
 
     context "when the request is not locked" do
       before do

--- a/spec/support/shared_examples/is_request_locked.rb
+++ b/spec/support/shared_examples/is_request_locked.rb
@@ -1,0 +1,40 @@
+RSpec.shared_examples 'archived intake request locked' do |action:, method: :get, params: {}|
+  context 'when the request is nil' do
+    before { allow(controller).to receive(:current_request).and_return(nil) }
+
+    it 'redirects to verification error page' do
+      send(method, action, params: params)
+      expect(response).to redirect_to(state_file_archived_intakes_verification_error_path)
+    end
+  end
+
+  context 'when the request is locked' do
+    before { allow(current_request).to receive(:access_locked?).and_return(true) }
+
+    it 'redirects to verification error page' do
+      send(method, action, params: params)
+      expect(response).to redirect_to(state_file_archived_intakes_verification_error_path)
+    end
+  end
+
+  context 'when the archived intake is permanently locked' do
+    before { allow(archived_intake).to receive(:permanently_locked_at).and_return(Time.current) }
+
+    it 'redirects to verification error page' do
+      send(method, action, params: params)
+      expect(response).to redirect_to(state_file_archived_intakes_verification_error_path)
+    end
+  end
+
+  context 'when the request is valid and not locked' do
+    before do
+      allow(current_request).to receive(:access_locked?).and_return(false)
+      allow(archived_intake).to receive(:permanently_locked_at).and_return(nil)
+    end
+
+    it 'does not redirect' do
+      send(method, action, params: params)
+      expect(response).not_to be_redirect
+    end
+  end
+end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1809
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Right now if the URL is typed for any of our archived state file pages an error is thrown. This will stop that from happening so we can focus on the real errors.
- this does not solve all the IP related issues, see https://www.notion.so/cfa/PYA-accounts-Refactor-1a1373fd79b280a294fbc549d30a9345
## How to test?
- Specify any relevant testing environments used (e.g., development, staging, demo, Heroku).
-  try navigate to `/en/state_file/archived_intakes/verification_code/edit` without entering an email first.
- Risk Assessment
  - We could be bouncing people who are encountering whatever the unsolved problem is. But we are also logging that.

