### PR TITLE
[FYST-1838] No longer check eligibility when calcing tax withheld for Idaho 1099r forms

### DIFF
--- a/app/lib/efile/id/id40_calculator.rb
+++ b/app/lib/efile/id/id40_calculator.rb
@@ -254,11 +254,7 @@ module Efile
         @intake.state_file_w2s.sum { |item| item.state_income_tax_amount.round } +
           @intake.state_file1099_gs.sum { |item| item.state_income_tax_withheld_amount.round } +
           @intake.state_file1099_rs.sum do |item|
-            if item.state_specific_followup&.eligible_income_source_yes?
-              item.state_tax_withheld_amount.round || 0
-            else
-              0
-            end
+            item.state_tax_withheld_amount.round || 0
           end
       end
 

--- a/spec/factories/state_file_id_intakes.rb
+++ b/spec/factories/state_file_id_intakes.rb
@@ -200,7 +200,7 @@ FactoryBot.define do
 
     trait :with_ineligible_1099r_income do
       after(:create) do |intake|
-        create(:state_file1099_r, intake: intake, taxable_amount: 2000) do |form_1099r|
+        create(:state_file1099_r, intake: intake, taxable_amount: 2000, state_tax_withheld_amount: 200) do |form_1099r|
           create(:state_file_id1099_r_followup, state_file1099_r: form_1099r, eligible_income_source: "no")
         end
       end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1838

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- I just removed eligibility checks in the calculator and added a test

## How to test?
- Navigate through the flow for ID, selecting Grey for your persona
- At the end, download the PDF and check that line 46 is 1300

## Screenshots (for visual changes)
- Before
- After
<img width="727" alt="image" src="https://github.com/user-attachments/assets/3a42047e-ce8a-400c-8d2c-250aaee8e3c2" />

