### PR TITLE
FYST-1841-remove-pya-sign-in-button-from-homepage

### DIFF
--- a/app/controllers/state_file/archived_intakes/archived_intake_controller.rb
+++ b/app/controllers/state_file/archived_intakes/archived_intake_controller.rb
@@ -1,6 +1,7 @@
 module StateFile
   module ArchivedIntakes
     class ArchivedIntakeController < ApplicationController
+      layout "state_file"
       before_action :check_feature_flag
       def current_request
         request = StateFileArchivedIntakeRequest.where("ip_address = ? AND LOWER(email_address) = LOWER(?)", ip_for_irs, session[:email_address]).first

--- a/app/views/state_file/state_file_pages/about_page.html.erb
+++ b/app/views/state_file/state_file_pages/about_page.html.erb
@@ -55,7 +55,7 @@
 <% end %>
 
 <% if Flipper.enabled?(:get_your_pdf) %>
-  <div data-testid="get-your-pdf-sign-in">
+  <div data-testid="get-your-pdf-sign-in" class="spacing-below-25">
       <%= t(".looking_for_return_html", link: state_file_archived_intakes_edit_email_address_path )%>
   </div>
 <% end %>

--- a/app/views/state_file/state_file_pages/about_page.html.erb
+++ b/app/views/state_file/state_file_pages/about_page.html.erb
@@ -56,9 +56,6 @@
 
 <% if Flipper.enabled?(:get_your_pdf) %>
   <div data-testid="get-your-pdf-sign-in">
-      <%= t(".looking_for_return_html")%>
-        <div class = "spacing-above-10">
-          <%= link_to t("general.sign_in"), state_file_archived_intakes_edit_email_address_path, class: "button button--primary button--wide" %>
-        </div>
+      <%= t(".looking_for_return_html", link: state_file_archived_intakes_edit_email_address_path )%>
   </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4259,7 +4259,7 @@ en:
         faq_prior_year_returns: Visit our FAQ for questions about prior year returns
         header: A free state filing service for taxpayers using IRS Direct File
         helper_heading_html: "<strong>How does this service work? </strong>"
-        looking_for_return_html: "<strong>Looking for your 2023 Arizona or New York State Tax Return?</strong> Sign in to download a copy of your state return."
+        looking_for_return_html: "<strong>Looking for your 2023 Arizona or New York State Tax Return?</strong> <a href='%{link}'>Sign in</a> to download a copy of your state return."
         section1_html: |
           <ol class="list--numbered"  style="padding-left: 2rem">
             <li>First, file and submit your federal return with <a target="_blank" rel="nofollow noopener" href="https://directfile.irs.gov/?utm_source=CA-Nonprofit&utm_medium=email&utm_campaign=gyr&utm_id=directfile&utm_content=QRcode">IRS Direct File</a> before using this service.</li>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4245,7 +4245,7 @@ es:
         faq_prior_year_returns: Visita nuestra sección de preguntas frecuentes si tienes dudas sobre declaraciones de años anteriores.
         header: Un servicio sin costo para declarar los impuestos estatales para las personas que usaron IRS Direct File
         helper_heading_html: "<strong>¿Cómo funciona este servicio?</strong>"
-        looking_for_return_html: "<strong>¿Necesitas tu declaración de impuestos de Arizona o Nueva York de 2023?</strong>"
+        looking_for_return_html: "<strong>¿Necesitas tu declaración de impuestos de Arizona o Nueva York de 2023?</strong> <a href='%{link}'>Inicia sesión</a> para descargar una copia de tu declaración estatal."
         section1_html: |
           <ol class="list--numbered" style="padding-left: 2rem">
             <li>Primero, presenta y envía tu declaración federal con el servicio <a target="_blank" rel="nofollow noopener" href="https://directfile.irs.gov/?utm_source=CA-Nonprofit&utm_medium=email&utm_campaign=gyr&utm_id=directfile&utm_content=QRcode">Direct File del IRS</a> antes de usar este servicio.</li>


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1841
- ## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Updates copy for PYA on the home page
- PYA pages now use the statefile layout for meta properties
## How to test?
- Go to about page and checkout the change
- inspect page and look at meta properties within the PYA flow
## Screenshots (for visual changes)
- Before
![Screenshot 2025-02-21 at 1 09 29 PM](https://github.com/user-attachments/assets/189cf5b4-47a7-4074-b533-89355790b5ed)
- After
<img width="1512" alt="Screenshot 2025-02-21 at 5 22 48 PM" src="https://github.com/user-attachments/assets/87e0a553-fc13-41cf-a71a-1f84765c9ee4" />


