### PR TITLE
Added a concept of default values to forms. Also includes using models &

### DIFF
--- a/app/forms/concerns/form_attributes.rb
+++ b/app/forms/concerns/form_attributes.rb
@@ -11,7 +11,7 @@ module FormAttributes
       default_attrs = self.class.scoped_defaults.values.reduce(&:merge)
 
       self.class.scoped_attributes.values.flatten.each do |attribute_string|
-        next unless send(attribute_string).nil?
+        next unless send(attribute_string).blank?
         send("#{attribute_string}=", default_attrs&.fetch(attribute_string, nil))
       end
     end

--- a/app/forms/concerns/form_attributes.rb
+++ b/app/forms/concerns/form_attributes.rb
@@ -5,8 +5,8 @@ module FormAttributes
     extend AutoStripAttributes
     class_attribute :attribute_names
 
-    def initialize
-      super
+    def initialize(*args, **kwargs)
+      super(*args, **kwargs)
 
       default_attrs = self.class.scoped_defaults.values.reduce(&:merge)
 

--- a/app/forms/concerns/form_attributes.rb
+++ b/app/forms/concerns/form_attributes.rb
@@ -4,20 +4,46 @@ module FormAttributes
   included do
     extend AutoStripAttributes
     class_attribute :attribute_names
+
+    def initialize
+      super
+
+      default_attrs = self.class.scoped_defaults.values.reduce(&:merge)
+
+      self.class.scoped_attributes.values.flatten.each do |attribute_string|
+        next unless send(attribute_string).nil?
+        send("#{attribute_string}=", default_attrs&.fetch(attribute_string, nil))
+      end
+    end
   end
 
   class_methods do
-    def set_attributes_for(model, *attributes)
+    def set_attributes_for(model, *attributes, **options)
+      if options[:defaults].present?
+        scoped_defaults[model] = options[:defaults].compact
+      elsif model.respond_to?(:column_defaults)
+        scoped_defaults[model] = model.column_defaults
+          .compact
+          .transform_keys(&:to_sym)
+          .slice(*attributes)
+      end
+
       scoped_attributes[model] = attributes
+
       self.attribute_names = scoped_attributes.values.flatten
       attribute_strings = Attributes.new(attributes).to_s
 
       attr_accessor(*attribute_strings)
+
       auto_strip_attributes *attribute_strings, virtual: true
     end
 
     def before_validation_squish(*attributes)
       auto_strip_attributes *attributes, virtual: true, squish: true
+    end
+
+    def scoped_defaults
+      @scoped_defaults ||= {}
     end
 
     def scoped_attributes

--- a/app/forms/hub/update_13614c_form_page1.rb
+++ b/app/forms/hub/update_13614c_form_page1.rb
@@ -1,6 +1,6 @@
 module Hub
   class Update13614cFormPage1 < ClientForm
-    set_attributes_for :intake,
+    set_attributes_for Intake::GyrIntake,
                        :primary_first_name,
                        :primary_last_name,
                        :primary_middle_initial,
@@ -107,7 +107,7 @@ module Hub
     def save
       return false unless valid?
 
-      modified_attributes = attributes_for(:intake)
+      modified_attributes = attributes_for(Intake::GyrIntake)
                               .except(:primary_birth_date_year, :primary_birth_date_month, :primary_birth_date_day, :spouse_birth_date_year, :spouse_birth_date_month, :spouse_birth_date_day)
                               .merge(
                                 primary_birth_date: parse_date_params(primary_birth_date_year, primary_birth_date_month, primary_birth_date_day),
@@ -115,21 +115,6 @@ module Hub
                               )
       modified_attributes[:ever_married] = modified_attributes.delete(:never_married) == "yes" ? "no" : "yes"
       modified_attributes[:dependents_attributes] = formatted_dependents_attributes
-
-      # we are getting null violations from the database; the below lines fix that.
-      modified_attributes[:multiple_states] ||= 'unfilled'
-      modified_attributes[:primary_owned_or_held_any_digital_currencies] ||= 'unfilled'
-      modified_attributes[:spouse_issued_identity_pin] ||= 'unfilled'
-      modified_attributes[:spouse_owned_or_held_any_digital_currencies] ||= 'unfilled'
-      modified_attributes[:balance_pay_from_bank] ||= 'unfilled'
-      modified_attributes[:presidential_campaign_fund_donation] ||= 'unfilled'
-      modified_attributes[:receive_written_communication] ||= 'unfilled'
-      modified_attributes[:savings_split_refund] ||= 'unfilled'
-      modified_attributes[:register_to_vote] ||= 'unfilled'
-      modified_attributes[:primary_visa] ||= 'unfilled'
-      modified_attributes[:spouse_visa] ||= 'unfilled'
-      modified_attributes[:refund_other_cb] ||= 'unfilled'
-      modified_attributes[:married_for_all_of_tax_year] ||= 'unfilled'
 
       @client.intake.update(modified_attributes)
       @client.touch(:last_13614c_update_at)

--- a/spec/forms/concerns/form_attributes_spec.rb
+++ b/spec/forms/concerns/form_attributes_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe FormAttributes do
         expect(attributes).to be_empty
       end
 
-      it 'should create initialize with nil if defaults are not passed' do
+      it 'should initialize with nil if defaults are not passed' do
         attributes = subject.attributes_for(:without_defaults)
         expect(attributes).to match(attribute_one: nil, attribute_two: nil)
       end

--- a/spec/forms/concerns/form_attributes_spec.rb
+++ b/spec/forms/concerns/form_attributes_spec.rb
@@ -1,7 +1,28 @@
 require 'rails_helper'
 
 class ExampleModel
-  # This was copied from OutgoingEmail to have a real example, but not literally tie to an existing model (which may change)
+  # This was copied from OutgoingEmail to have a real example, but not literally
+  # tie to an existing model (which may change)
+  def self.column_defaults
+    {
+      "id" => nil,
+      "body" => "some body text",
+      "client_id" => nil,
+      "created_at" => nil,
+      "mailgun_status" => "sending",
+      "message_id" => nil,
+      "sent_at" => nil,
+      "subject" => nil,
+      "to" => nil,
+      "updated_at" => nil,
+      "user_id" => nil
+    }
+  end
+end
+
+class SecondExampleModel
+  # This was copied from OutgoingEmail to have a real example, but not literally
+  # tie to an existing model (which may change)
   def self.column_defaults
     {
       "id" => nil,
@@ -48,6 +69,9 @@ class ModelExampleForm
     defaults: {
       mailgun_status: "not_sent",
     }
+
+  set_attributes_for SecondExampleModel,
+    :body
 end
 
 class MixedExampleForm

--- a/spec/forms/concerns/form_attributes_spec.rb
+++ b/spec/forms/concerns/form_attributes_spec.rb
@@ -74,9 +74,6 @@ class ModelExampleForm
     :body
 end
 
-class MixedExampleForm
-  include FormAttributes
-end
 
 RSpec.describe FormAttributes do
   describe "#set_attributes_for" do

--- a/spec/forms/concerns/form_attributes_spec.rb
+++ b/spec/forms/concerns/form_attributes_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+class ExampleModel
+  # This was copied from OutgoingEmail to have a real example, but not literally tie to an existing model (which may change)
+  def self.column_defaults
+    {
+      "id" => nil,
+      "body" => "some body text",
+      "client_id" => nil,
+      "created_at" => nil,
+      "mailgun_status" => "sending",
+      "message_id" => nil,
+      "sent_at" => nil,
+      "subject" => nil,
+      "to" => nil,
+      "updated_at" => nil,
+      "user_id" => nil
+    }
+  end
+end
+
+class SymbolExampleForm
+  include ActiveModel::Model
+  include ActiveModel::Validations::Callbacks
+  include FormAttributes
+
+  set_attributes_for :empty
+  set_attributes_for :without_defaults, :attribute_one, :attribute_two
+  set_attributes_for :with_defaults,
+    :default_attribute_one,
+    :default_attribute_two,
+    :default_attribute_three,
+    defaults: {
+      default_attribute_one: 'foo',
+      default_attribute_two: 'bar',
+    }
+end
+
+class ModelExampleForm
+  include ActiveModel::Model
+  include ActiveModel::Validations::Callbacks
+  include FormAttributes
+
+  set_attributes_for ExampleModel,
+    :body,
+    :client_id,
+    :mailgun_status,
+    defaults: {
+      mailgun_status: "not_sent",
+    }
+end
+
+class MixedExampleForm
+  include FormAttributes
+end
+
+RSpec.describe FormAttributes do
+  describe "#set_attributes_for" do
+    context "when passing a symbol" do
+      subject { SymbolExampleForm.new }
+
+      it 'should create an empty hash by default' do
+        attributes = subject.attributes_for(:empty)
+        expect(attributes).to be_a Hash
+        expect(attributes).to be_empty
+      end
+
+      it 'should create initialize with nil if defaults are not passed' do
+        attributes = subject.attributes_for(:without_defaults)
+        expect(attributes.keys).to eq [:attribute_one, :attribute_two]
+        expect(attributes.values).to be_all nil
+      end
+
+      it 'should initialize with defaults when defaults are passed' do
+        attributes = subject.attributes_for(:with_defaults)
+        expect(attributes.keys).to eq [:default_attribute_one, :default_attribute_two, :default_attribute_three]
+        expect(attributes[:default_attribute_one]).to eq 'foo'
+        expect(attributes[:default_attribute_two]).to eq 'bar'
+        expect(attributes[:default_attribute_three]).to be_nil
+      end
+
+      it 'should create an hash for each symbol passed' do
+        [:without_defaults, :empty, :with_defaults].each do |attribute|
+          expect(subject.attributes_for(attribute)).to be_a Hash
+        end
+      end
+    end
+
+    context "when passing a model" do
+      subject { ModelExampleForm.new }
+
+      it 'should only create defaults where column defaults exist' do
+        attributes = subject.attributes_for(ExampleModel)
+
+        expect(attributes[:body]).to eq 'some body text'
+        expect(subject.body).to eq 'some body text'
+
+        expect(attributes[:client_id]).to be_nil
+        expect(subject.client_id).to be_nil
+      end
+
+      it 'should not use column defaults when a defaults hash is specified' do
+        expect(subject.mailgun_status).not_to eq 'sending'
+        expect(subject.mailgun_status).to eq 'not_sent'
+      end
+    end
+  end
+end

--- a/spec/forms/concerns/form_attributes_spec.rb
+++ b/spec/forms/concerns/form_attributes_spec.rb
@@ -88,16 +88,16 @@ RSpec.describe FormAttributes do
 
       it 'should create initialize with nil if defaults are not passed' do
         attributes = subject.attributes_for(:without_defaults)
-        expect(attributes.keys).to eq [:attribute_one, :attribute_two]
-        expect(attributes.values).to be_all nil
+        expect(attributes).to match(attribute_one: nil, attribute_two: nil)
       end
 
       it 'should initialize with defaults when defaults are passed' do
         attributes = subject.attributes_for(:with_defaults)
-        expect(attributes.keys).to eq [:default_attribute_one, :default_attribute_two, :default_attribute_three]
-        expect(attributes[:default_attribute_one]).to eq 'foo'
-        expect(attributes[:default_attribute_two]).to eq 'bar'
-        expect(attributes[:default_attribute_three]).to be_nil
+        expect(attributes).to match(
+          default_attribute_one: 'foo',
+          default_attribute_two: 'bar',
+          default_attribute_three: nil,
+        )
       end
 
       it 'should create an hash for each symbol passed' do


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- No JIRA ticket
## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
When you use a form's `set_attributes_for` on fields with defaults and don't set a value, you can get database level failures. This provides two possible fixes; either:
  a. Specifically provide a `defaults` dictionary or
  b. Use a model rather than a symbol for the first argument to `set_attributes_for`

When doing the latter, we inspect the `column_defaults` on the model and populate the default values with which we initialize the form, so they will never be nil without being explicitly set to nil.

This behavior is opt in and uses new arguments and reflection on the model. It should change no other behavior.

This resolves issues like the ones seen on [update_13614c_form_page1](https://github.com/codeforamerica/vita-min/blob/7409348c052b5440b8d387d59a7ceee946291c9c/app/forms/hub/update_13614c_form_page1.rb#L108-L117).

It will also set us up well for a default `QuestionsForm#save` method; if all keys are models, then we can assume that their respective attributes are available and we can save it out.

## How to test?
- It's pretty high touch. Doing basically anything in the application will either succeed or fail.
- There's a chance that this will need to be touched up a little more when it gets first used, I didn't really want to explicitly change any forms, but I look forward to playing with it in the future.

## Screenshots (for visual changes)
- Before
- After
