### PR TITLE
Nj 249 bugfix non nj

### DIFF
--- a/app/views/state_file/questions/data_transfer_offboarding/edit.html.erb
+++ b/app/views/state_file/questions/data_transfer_offboarding/edit.html.erb
@@ -13,15 +13,11 @@
     <p><%= vita_introduction %></p>
   <% end %>
 
-  <% if current_state_code == "nj" %>
-    <% vita_link = I18n.locale == :en ? StateFile::StateInformationService.vita_link_en(current_state_code) : StateFile::StateInformationService.vita_link_es(current_state_code) %>
-    <% if vita_link.present? %>
-      <p><%= link_to t("state_file.questions.eligible.faq_link"), state_faq_path(us_state: current_state_code) %></p>
-      <%= link_to(vita_link, class: "button button--primary button--wide spacing-below-15", target: "_blank", rel: "noopener noreferrer") do %>
-        <%= t('state_file.questions.eligible.vita_option.connect_to_vita') %>
-      <% end %>
-    <% end %>
-  <% end %>
+  <% vita_link_key = "state_file.questions.eligible.vita_option.connect_to_vita.#{current_state_code}" %>
+  <% vita_link_href = StateFile::StateInformationService.send("vita_link_#{I18n.locale}", current_state_code) %>
+  <% faq_link_href = state_faq_path(us_state: current_state_code) %>
+  <% vita_link = t(vita_link_key, faq_link_href: faq_link_href, vita_link_href: vita_link_href, default: '') %>
+  <%= vita_link.html_safe if vita_link.present? %>
 
   <%= render 'state_file/questions/eligible/other_filing_options' %>
 <% end %>

--- a/app/views/state_file/questions/data_transfer_offboarding/edit.html.erb
+++ b/app/views/state_file/questions/data_transfer_offboarding/edit.html.erb
@@ -13,6 +13,7 @@
     <p><%= vita_introduction %></p>
   <% end %>
 
+  <% # i18n-tasks-use t('state_file.questions.eligible.vita_option.connect_to_vita.nj') # hint for the i18n linter that, yes, we are using this key (sometimes) %>
   <% vita_link_key = "state_file.questions.eligible.vita_option.connect_to_vita.#{current_state_code}" %>
   <% vita_link_href = StateFile::StateInformationService.send("vita_link_#{I18n.locale}", current_state_code) %>
   <% faq_link_href = state_faq_path(us_state: current_state_code) %>

--- a/app/views/state_file/questions/data_transfer_offboarding/edit.html.erb
+++ b/app/views/state_file/questions/data_transfer_offboarding/edit.html.erb
@@ -13,11 +13,13 @@
     <p><%= vita_introduction %></p>
   <% end %>
 
-  <% vita_link = I18n.locale == :en ? StateFile::StateInformationService.vita_link_en(current_state_code) : StateFile::StateInformationService.vita_link_es(current_state_code) %>
-  <% if vita_link.present? %>
-    <p><%= link_to t("state_file.questions.eligible.faq_link"), state_faq_path(us_state: current_state_code) %></p>
-    <%= link_to(vita_link, class: "button button--primary button--wide spacing-below-15", target: "_blank", rel: "noopener noreferrer") do %>
-      <%= t('state_file.questions.eligible.vita_option.connect_to_vita') %>
+  <% if current_state_code == "nj" %>
+    <% vita_link = I18n.locale == :en ? StateFile::StateInformationService.vita_link_en(current_state_code) : StateFile::StateInformationService.vita_link_es(current_state_code) %>
+    <% if vita_link.present? %>
+      <p><%= link_to t("state_file.questions.eligible.faq_link"), state_faq_path(us_state: current_state_code) %></p>
+      <%= link_to(vita_link, class: "button button--primary button--wide spacing-below-15", target: "_blank", rel: "noopener noreferrer") do %>
+        <%= t('state_file.questions.eligible.vita_option.connect_to_vita') %>
+      <% end %>
     <% end %>
   <% end %>
 

--- a/app/views/state_file/questions/eligibility_offboarding/edit.html.erb
+++ b/app/views/state_file/questions/eligibility_offboarding/edit.html.erb
@@ -16,17 +16,19 @@
     <p><%= vita_introduction %></p>
   <% end %>
 
-  <% vita_link = I18n.locale == :en ? StateFile::StateInformationService.vita_link_en(current_state_code) : StateFile::StateInformationService.vita_link_es(current_state_code) %>
-  <% if vita_link.present? %>
-    <p><%= link_to t("state_file.questions.eligible.faq_link"), state_faq_path(us_state: current_state_code), target: "_blank", rel: "noopener noreferrer" %></p>
-    <%= link_to(vita_link, class: "button button--primary button--wide spacing-below-25", target: "_blank", rel: "noopener noreferrer") do %>
-      <%= t('state_file.questions.eligible.vita_option.connect_to_vita') %>
+  <% if current_state_code == "nj" %>
+    <% vita_link = I18n.locale == :en ? StateFile::StateInformationService.vita_link_en(current_state_code) : StateFile::StateInformationService.vita_link_es(current_state_code) %>
+    <% if vita_link.present? %>
+      <p><%= link_to t("state_file.questions.eligible.faq_link"), state_faq_path(us_state: current_state_code), target: "_blank", rel: "noopener noreferrer" %></p>
+      <%= link_to(vita_link, class: "button button--primary button--wide spacing-below-25", target: "_blank", rel: "noopener noreferrer") do %>
+        <%= t('state_file.questions.eligible.vita_option.connect_to_vita') %>
+      <% end %>
     <% end %>
   <% end %>
 
   <%= render 'state_file/questions/eligible/other_filing_options' %>
 
-  <% unless vita_link.present? %>
+  <% unless current_state_code == "nj" %>
     <p class="spacing-above-35"><%= link_to t("state_file.questions.eligible.vita_option.vita_link"), @vita_link, target: "_blank", rel: "noopener noreferrer" %></p>
     <p><%= link_to t("state_file.questions.eligible.faq_link"), state_faq_path(us_state: current_state_code), target: "_blank", rel: "noopener noreferrer" %></p>
   <% end %>

--- a/app/views/state_file/questions/eligibility_offboarding/edit.html.erb
+++ b/app/views/state_file/questions/eligibility_offboarding/edit.html.erb
@@ -16,19 +16,15 @@
     <p><%= vita_introduction %></p>
   <% end %>
 
-  <% if current_state_code == "nj" %>
-    <% vita_link = I18n.locale == :en ? StateFile::StateInformationService.vita_link_en(current_state_code) : StateFile::StateInformationService.vita_link_es(current_state_code) %>
-    <% if vita_link.present? %>
-      <p><%= link_to t("state_file.questions.eligible.faq_link"), state_faq_path(us_state: current_state_code), target: "_blank", rel: "noopener noreferrer" %></p>
-      <%= link_to(vita_link, class: "button button--primary button--wide spacing-below-25", target: "_blank", rel: "noopener noreferrer") do %>
-        <%= t('state_file.questions.eligible.vita_option.connect_to_vita') %>
-      <% end %>
-    <% end %>
-  <% end %>
+  <% vita_link_key = "state_file.questions.eligible.vita_option.connect_to_vita.#{current_state_code}" %>
+  <% vita_link_href = StateFile::StateInformationService.send("vita_link_#{I18n.locale}", current_state_code) %>
+  <% faq_link_href = state_faq_path(us_state: current_state_code) %>
+  <% vita_link = t(vita_link_key, faq_link_href: faq_link_href, vita_link_href: vita_link_href, default: '') %>
+  <%= vita_link.html_safe if vita_link.present? %>
 
   <%= render 'state_file/questions/eligible/other_filing_options' %>
 
-  <% unless current_state_code == "nj" %>
+  <% unless vita_link.present? %>
     <p class="spacing-above-35"><%= link_to t("state_file.questions.eligible.vita_option.vita_link"), @vita_link, target: "_blank", rel: "noopener noreferrer" %></p>
     <p><%= link_to t("state_file.questions.eligible.faq_link"), state_faq_path(us_state: current_state_code), target: "_blank", rel: "noopener noreferrer" %></p>
   <% end %>

--- a/app/views/state_file/questions/eligibility_offboarding/edit.html.erb
+++ b/app/views/state_file/questions/eligibility_offboarding/edit.html.erb
@@ -16,6 +16,7 @@
     <p><%= vita_introduction %></p>
   <% end %>
 
+  <% # i18n-tasks-use t('state_file.questions.eligible.vita_option.connect_to_vita.nj') # hint for the i18n linter that, yes, we are using this key (sometimes) %>
   <% vita_link_key = "state_file.questions.eligible.vita_option.connect_to_vita.#{current_state_code}" %>
   <% vita_link_href = StateFile::StateInformationService.send("vita_link_#{I18n.locale}", current_state_code) %>
   <% faq_link_href = state_faq_path(us_state: current_state_code) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2852,7 +2852,16 @@ en:
               default: What are my free state filing options?
               nj: Learn more about the VITA process
         vita_option:
-          connect_to_vita: Get connected now
+          connect_to_vita:
+            nj: |
+              <p>
+                <a href="%{faq_link_href}" target="_blank" rel="noopener noreferrer">
+                  Visit our FAQ
+                </a>
+              </p>
+              <a href="%{vita_link_href}" target="_blank" rel="noopener noreferrer" class="button button--primary button--wide spacing-below-25">
+                Get connected now
+              </a>
           vita_introduction:
             nj: You can file your state taxes for free with help from IRS-certified Volunteer Income Tax Assistance (VITA) tax preparers at Simplify CT.
           vita_link: Get started with VITA now

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2819,7 +2819,16 @@ es:
               default: "¿Qué opciones gratuitas tengo para declarar mis impuestos estatales?"
               nj: Lee más sobre el proceso de VITA
         vita_option:
-          connect_to_vita: Conéctate ahora
+          connect_to_vita:
+            nj: |
+              <p>
+                <a href="%{faq_link_href}" target="_blank" rel="noopener noreferrer">
+                  Visita nuestras Preguntas Frecuentes
+                </a>
+              </p>
+              <a href="%{vita_link_href}" target="_blank" rel="noopener noreferrer" class="button button--primary button--wide spacing-below-25">
+                Conéctate ahora
+              </a>
           vita_introduction:
             nj: Puedes presentar tus impuestos estatales de forma gratuita con la ayuda de preparadores de impuestos voluntarios certificados por el IRS del programa Volunteer Income Tax Assistance (VITA por las siglas en inglés) en Simplify CT.
           vita_link: Comienza con VITA ahora

--- a/spec/controllers/state_file/questions/data_transfer_offboarding_controller_spec.rb
+++ b/spec/controllers/state_file/questions/data_transfer_offboarding_controller_spec.rb
@@ -22,5 +22,40 @@ RSpec.describe StateFile::Questions::DataTransferOffboardingController do
         expect(subject.ineligible_reason).to be_nil
       end
     end
+
+    shared_examples "check for NJ-specific content" do |current_state_code, show_nj_content|
+      let(:intake) { create "state_file_#{current_state_code}_intake" }
+      render_views
+      before do
+        sign_in intake
+      end
+
+      it "checks for NJ-specific content" do
+        get :edit
+        if show_nj_content
+          expect(response.body).to have_text I18n.t("state_file.questions.eligible.vita_option.connect_to_vita")
+          expect(response.body).to have_text I18n.t("state_file.questions.eligible.vita_option.vita_introduction.nj")
+        else
+          expect(response.body).not_to have_text I18n.t("state_file.questions.eligible.vita_option.connect_to_vita")
+          expect(response.body).not_to have_text I18n.t("state_file.questions.eligible.vita_option.vita_introduction.nj")
+        end
+      end
+    end
+
+    context "AZ" do
+      it_behaves_like "check for NJ-specific content", "az", false
+    end
+
+    context "ID" do
+      it_behaves_like "check for NJ-specific content", "id", false
+    end
+
+    context "MD" do
+      it_behaves_like "check for NJ-specific content", "md", false
+    end
+
+    context "NJ" do
+      it_behaves_like "check for NJ-specific content", "nj", true
+    end
   end
 end

--- a/spec/controllers/state_file/questions/data_transfer_offboarding_controller_spec.rb
+++ b/spec/controllers/state_file/questions/data_transfer_offboarding_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe StateFile::Questions::DataTransferOffboardingController do
   describe "#edit" do
     let(:intake) { create :state_file_az_intake, filing_status: filing_status }
     let(:filing_status) { :single }
-
+    render_views
     before do
       sign_in intake
     end
@@ -23,39 +23,40 @@ RSpec.describe StateFile::Questions::DataTransferOffboardingController do
       end
     end
 
-    shared_examples "check for NJ-specific content" do |current_state_code, show_nj_content|
-      let(:intake) { create "state_file_#{current_state_code}_intake" }
-      render_views
-      before do
-        sign_in intake
-      end
-
-      it "checks for NJ-specific content" do
-        get :edit
-        if show_nj_content
-          expect(response.body).to have_text I18n.t("state_file.questions.eligible.vita_option.connect_to_vita")
-          expect(response.body).to have_text I18n.t("state_file.questions.eligible.vita_option.vita_introduction.nj")
-        else
-          expect(response.body).not_to have_text I18n.t("state_file.questions.eligible.vita_option.connect_to_vita")
-          expect(response.body).not_to have_text I18n.t("state_file.questions.eligible.vita_option.vita_introduction.nj")
-        end
-      end
-    end
-
     context "AZ" do
-      it_behaves_like "check for NJ-specific content", "az", false
+      let(:intake) { create :state_file_az_intake }
+  
+      it "does not show NJ-specific content" do
+        get :edit
+        expect(response.body).not_to include("Get connected now")
+      end
     end
-
+  
     context "ID" do
-      it_behaves_like "check for NJ-specific content", "id", false
+      let(:intake) { create :state_file_id_intake }
+  
+      it "does not show NJ-specific content" do
+        get :edit
+        expect(response.body).not_to include("Get connected now")
+      end
     end
-
+  
     context "MD" do
-      it_behaves_like "check for NJ-specific content", "md", false
+      let(:intake) { create :state_file_md_intake }
+  
+      it "does not show NJ-specific content" do
+        get :edit
+        expect(response.body).not_to include("Get connected now")
+      end
     end
-
+  
     context "NJ" do
-      it_behaves_like "check for NJ-specific content", "nj", true
+      let(:intake) { create :state_file_nj_intake }
+  
+      it "shows NJ-specific content" do
+        get :edit
+        expect(response.body).to include("Get connected now")
+      end
     end
   end
 end

--- a/spec/controllers/state_file/questions/eligibility_offboarding_controller_spec.rb
+++ b/spec/controllers/state_file/questions/eligibility_offboarding_controller_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe StateFile::Questions::EligibilityOffboardingController do
         session[:offboarded_from] = offboarded_from_path
       end
 
-
       it "uses the correct prev_path for the Go back button" do
         get :edit
 
@@ -39,42 +38,35 @@ RSpec.describe StateFile::Questions::EligibilityOffboardingController do
       end
     end
 
-    context "AZ" do
-      let(:intake) { create :state_file_az_intake }
+    shared_examples "check for NJ-specific content" do |current_state_code, show_nj_content|
+      let(:intake) { create "state_file_#{current_state_code}_intake" }
       render_views
       before do
         sign_in intake
       end
-      it "does not show NJ-specific content" do
+
+      it "checks for NJ-specific content" do
         get :edit
-        expect(response.body).not_to have_text I18n.t("state_file.questions.eligible.vita_option.connect_to_vita")   
+        if show_nj_content
+          expect(response.body).to have_text I18n.t("state_file.questions.eligible.vita_option.connect_to_vita")
+          expect(response.body).to have_text I18n.t("state_file.questions.eligible.vita_option.vita_introduction.nj")
+        else
+          expect(response.body).not_to have_text I18n.t("state_file.questions.eligible.vita_option.connect_to_vita")
+          expect(response.body).not_to have_text I18n.t("state_file.questions.eligible.vita_option.vita_introduction.nj")
+        end
       end
+    end
+
+    context "AZ" do
+      it_behaves_like "check for NJ-specific content", "az", false
     end
 
     context "MD" do
-      let(:intake) { create :state_file_md_intake }
-      render_views
-      before do
-        sign_in intake
-      end
-      it "does not show NJ-specific content" do
-        get :edit
-        
-        expect(response.body).not_to have_text I18n.t("state_file.questions.eligible.vita_option.connect_to_vita") 
-      end
+      it_behaves_like "check for NJ-specific content", "md", false
     end
 
     context "NJ" do
-      let(:intake) { create :state_file_nj_intake }
-      render_views
-      before do
-        sign_in intake
-      end
-      it "shows NJ-specific content" do
-        get :edit
-        expect(response.body).to have_text I18n.t("state_file.questions.eligible.vita_option.connect_to_vita")
-        expect(response.body).to have_text I18n.t("state_file.questions.eligible.vita_option.vita_introduction.nj")
-      end
+      it_behaves_like "check for NJ-specific content", "nj", true
     end
   end
 end

--- a/spec/controllers/state_file/questions/eligibility_offboarding_controller_spec.rb
+++ b/spec/controllers/state_file/questions/eligibility_offboarding_controller_spec.rb
@@ -18,15 +18,17 @@ RSpec.describe StateFile::Questions::EligibilityOffboardingController do
   end
 
   describe "#edit" do
+    render_views
+    before do
+      sign_in intake
+    end
+
     context "with offboarded_from set in the session" do
       let(:intake) { create :state_file_id_intake }
-
-      render_views
       let(:offboarded_from_path) do
         StateFile::Questions::IdEligibilityResidenceController.to_path_helper
       end
       before do
-        sign_in intake
         session[:offboarded_from] = offboarded_from_path
       end
 
@@ -38,39 +40,40 @@ RSpec.describe StateFile::Questions::EligibilityOffboardingController do
       end
     end
 
-    shared_examples "check for NJ-specific content" do |current_state_code, show_nj_content|
-      let(:intake) { create "state_file_#{current_state_code}_intake" }
-      render_views
-      before do
-        sign_in intake
-      end
-
-      it "checks for NJ-specific content" do
-        get :edit
-        if show_nj_content
-          expect(response.body).to have_text I18n.t("state_file.questions.eligible.vita_option.connect_to_vita")
-          expect(response.body).to have_text I18n.t("state_file.questions.eligible.vita_option.vita_introduction.nj")
-        else
-          expect(response.body).not_to have_text I18n.t("state_file.questions.eligible.vita_option.connect_to_vita")
-          expect(response.body).not_to have_text I18n.t("state_file.questions.eligible.vita_option.vita_introduction.nj")
-        end
-      end
-    end
-
     context "AZ" do
-      it_behaves_like "check for NJ-specific content", "az", false
+      let(:intake) { create :state_file_az_intake }
+  
+      it "does not show NJ-specific content" do
+        get :edit
+        expect(response.body).not_to include("Get connected now")
+      end
     end
-
+  
     context "ID" do
-      it_behaves_like "check for NJ-specific content", "id", false
+      let(:intake) { create :state_file_id_intake }
+  
+      it "does not show NJ-specific content" do
+        get :edit
+        expect(response.body).not_to include("Get connected now")
+      end
     end
-
+  
     context "MD" do
-      it_behaves_like "check for NJ-specific content", "md", false
+      let(:intake) { create :state_file_md_intake }
+  
+      it "does not show NJ-specific content" do
+        get :edit
+        expect(response.body).not_to include("Get connected now")
+      end
     end
-
+  
     context "NJ" do
-      it_behaves_like "check for NJ-specific content", "nj", true
+      let(:intake) { create :state_file_nj_intake }
+  
+      it "shows NJ-specific content" do
+        get :edit
+        expect(response.body).to include("Get connected now")
+      end
     end
   end
 end

--- a/spec/controllers/state_file/questions/eligibility_offboarding_controller_spec.rb
+++ b/spec/controllers/state_file/questions/eligibility_offboarding_controller_spec.rb
@@ -61,6 +61,10 @@ RSpec.describe StateFile::Questions::EligibilityOffboardingController do
       it_behaves_like "check for NJ-specific content", "az", false
     end
 
+    context "ID" do
+      it_behaves_like "check for NJ-specific content", "id", false
+    end
+
     context "MD" do
       it_behaves_like "check for NJ-specific content", "md", false
     end

--- a/spec/controllers/state_file/questions/eligibility_offboarding_controller_spec.rb
+++ b/spec/controllers/state_file/questions/eligibility_offboarding_controller_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe StateFile::Questions::EligibilityOffboardingController do
   end
 
   describe "#edit" do
-    let(:intake) { create :state_file_id_intake }
-
     context "with offboarded_from set in the session" do
+      let(:intake) { create :state_file_id_intake }
+
       render_views
       let(:offboarded_from_path) do
         StateFile::Questions::IdEligibilityResidenceController.to_path_helper
@@ -36,6 +36,44 @@ RSpec.describe StateFile::Questions::EligibilityOffboardingController do
 
         expect(Nokogiri::HTML.parse(response.body)).to have_link(href: offboarded_from_path)
         expect(session[:offboarded_from]).to be_nil
+      end
+    end
+
+    context "AZ" do
+      let(:intake) { create :state_file_az_intake }
+      render_views
+      before do
+        sign_in intake
+      end
+      it "does not show NJ-specific content" do
+        get :edit
+        expect(response.body).not_to have_text I18n.t("state_file.questions.eligible.vita_option.connect_to_vita")   
+      end
+    end
+
+    context "MD" do
+      let(:intake) { create :state_file_md_intake }
+      render_views
+      before do
+        sign_in intake
+      end
+      it "does not show NJ-specific content" do
+        get :edit
+        
+        expect(response.body).not_to have_text I18n.t("state_file.questions.eligible.vita_option.connect_to_vita") 
+      end
+    end
+
+    context "NJ" do
+      let(:intake) { create :state_file_nj_intake }
+      render_views
+      before do
+        sign_in intake
+      end
+      it "shows NJ-specific content" do
+        get :edit
+        expect(response.body).to have_text I18n.t("state_file.questions.eligible.vita_option.connect_to_vita")
+        expect(response.body).to have_text I18n.t("state_file.questions.eligible.vita_option.vita_introduction.nj")
       end
     end
   end

--- a/spec/controllers/state_file/questions/eligibility_offboarding_controller_spec.rb
+++ b/spec/controllers/state_file/questions/eligibility_offboarding_controller_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe StateFile::Questions::EligibilityOffboardingController do
   
       it "does not show NJ-specific content" do
         get :edit
+        expect(response.body).to include("Visit our FAQ")
         expect(response.body).not_to include("Get connected now")
       end
     end
@@ -54,6 +55,7 @@ RSpec.describe StateFile::Questions::EligibilityOffboardingController do
   
       it "does not show NJ-specific content" do
         get :edit
+        expect(response.body).to include("Visit our FAQ")
         expect(response.body).not_to include("Get connected now")
       end
     end
@@ -63,6 +65,7 @@ RSpec.describe StateFile::Questions::EligibilityOffboardingController do
   
       it "does not show NJ-specific content" do
         get :edit
+        expect(response.body).to include("Visit our FAQ")
         expect(response.body).not_to include("Get connected now")
       end
     end
@@ -72,6 +75,7 @@ RSpec.describe StateFile::Questions::EligibilityOffboardingController do
   
       it "shows NJ-specific content" do
         get :edit
+        expect(response.body).to include("Visit our FAQ")
         expect(response.body).to include("Get connected now")
       end
     end


### PR DESCRIPTION
## Link to pivotal/JIRA issue

Followup to
https://github.com/codeforamerica/vita-min/pull/5495

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- The check for NJ content was checking on info in the StateInformationService that was present in other states and thus the new NJ-specific button was appearing in other states
- I added tests to the two related controllers that verified that NJ content was NOT showing for those states. (These tests failed before the implementation code in the PR, meaning the issue was reproduced).

## How to test?
- For NJ, use a persona like Streep and select that not all had health insurance (just one of the many ineligibility reasons)
- For AZ, MD, etc., steps TBD


