### PR TITLE
FYST-1866-nc-correct-retirement-subtraction-card-text-on-final-review-screen

### DIFF
--- a/app/views/state_file/questions/nc_review/edit.html.erb
+++ b/app/views/state_file/questions/nc_review/edit.html.erb
@@ -23,6 +23,9 @@
                     <% if followup.bailey_settlement_from_retirement_plan_yes? %>
                       <li><%= t(".bailey_settlement_from_retirement_plan") %></li>
                     <% end %>
+                    <% if !followup.bailey_settlement_from_retirement_plan_yes? && !followup.bailey_settlement_at_least_five_years_yes? %>
+                      <li><%= t(".none_apply") %></li>
+                    <% end %>
                   <% elsif followup.income_source_uniformed_services? %>
                     <li><%= t(".retirement_income_source_uniformed_services") %></li>
                     <% if followup.uniformed_services_retired_yes? %>

--- a/app/views/state_file/questions/nc_review/edit.html.erb
+++ b/app/views/state_file/questions/nc_review/edit.html.erb
@@ -23,9 +23,6 @@
                     <% if followup.bailey_settlement_from_retirement_plan_yes? %>
                       <li><%= t(".bailey_settlement_from_retirement_plan") %></li>
                     <% end %>
-                    <% if !followup.bailey_settlement_from_retirement_plan_yes? && !followup.bailey_settlement_from_retirement_plan_yes? %>
-                      <li><%= t(".none_apply") %></li>
-                    <% end %>
                   <% elsif followup.income_source_uniformed_services? %>
                     <li><%= t(".retirement_income_source_uniformed_services") %></li>
                     <% if followup.uniformed_services_retired_yes? %>


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1866
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!
**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Removes an unnecessary if statement that was adding "none apply" when "Retirement benefits as part of the Bailey Settlement" was already shown.
## How to test?
- Follow recreation steps in the Jira ticket.
## Screenshots (for visual changes)
- Before
<img width="789" alt="Screenshot 2025-02-26 at 1 49 41 PM" src="https://github.com/user-attachments/assets/35aba4aa-2746-4aea-8f9e-63579a82f5f5" />

- After
<img width="790" alt="Screenshot 2025-02-26 at 1 48 17 PM" src="https://github.com/user-attachments/assets/260bf4de-ffe0-488d-af4e-23b1be2c1b48" />

