### PR TITLE
Add payer_name2 column to 1099R to pass on values to xml

### DIFF
--- a/app/lib/submission_builder/state1099_r.rb
+++ b/app/lib/submission_builder/state1099_r.rb
@@ -11,6 +11,7 @@ module SubmissionBuilder
         if form1099r.payer_name.present?
           xml.PayerName do
             xml.BusinessNameLine1Txt sanitize_for_xml(form1099r.payer_name.tr('-', ' '), 75)
+            xml.BusinessNameLine2Txt sanitize_for_xml(form1099r.payer_name2&.tr('-', ' '), 75)
           end
           xml.PayerUSAddress do
             xml.AddressLine1Txt sanitize_for_xml(form1099r.payer_address_line1, 35) if form1099r.payer_address_line1.present?

--- a/app/models/df_1099r_accessor.rb
+++ b/app/models/df_1099r_accessor.rb
@@ -2,6 +2,7 @@ class Df1099rAccessor < DfXmlAccessor
   SELECTORS = {
     payer_name_control: "PayerNameControlTxt",
     payer_name: "PayerName BusinessNameLine1Txt",
+    payer_name2: "PayerName BusinessNameLine2Txt",
     payer_address_line1: "PayerUSAddress AddressLine1Txt",
     payer_address_line2: "PayerUSAddress AddressLine2Txt",
     payer_city_name: "PayerUSAddress CityNm",

--- a/app/models/state_file1099_r.rb
+++ b/app/models/state_file1099_r.rb
@@ -14,6 +14,7 @@
 #  payer_city_name                    :string
 #  payer_identification_number        :string
 #  payer_name                         :string
+#  payer_name2                        :string
 #  payer_name_control                 :string
 #  payer_state_code                   :string
 #  payer_state_identification_number  :string

--- a/app/views/state_file/questions/federal_info/_df_1099r.html.erb
+++ b/app/views/state_file/questions/federal_info/_df_1099r.html.erb
@@ -7,6 +7,7 @@
     <table>
       <%= f.state_file_nested_xml_field :payer_name_control %>
       <%= f.state_file_nested_xml_field :payer_name %>
+      <%= f.state_file_nested_xml_field :payer_name2 %>
       <%= f.state_file_nested_xml_field :payer_address_line1 %>
       <%= f.state_file_nested_xml_field :payer_address_line2 %>
       <%= f.state_file_nested_xml_field :payer_city_name %>

--- a/db/migrate/20250226234403_add_payer_name2_to_state_file1099_rs.rb
+++ b/db/migrate/20250226234403_add_payer_name2_to_state_file1099_rs.rb
@@ -1,0 +1,5 @@
+class AddPayerName2ToStateFile1099Rs < ActiveRecord::Migration[7.1]
+  def change
+    add_column :state_file1099_rs, :payer_name2, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_21_220547) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_26_234403) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -1729,6 +1729,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_21_220547) do
     t.string "payer_city_name"
     t.string "payer_identification_number"
     t.string "payer_name"
+    t.string "payer_name2"
     t.string "payer_name_control"
     t.string "payer_state_code"
     t.string "payer_state_identification_number"

--- a/spec/factories/state_file1099_rs.rb
+++ b/spec/factories/state_file1099_rs.rb
@@ -14,6 +14,7 @@
 #  payer_city_name                    :string
 #  payer_identification_number        :string
 #  payer_name                         :string
+#  payer_name2                        :string
 #  payer_name_control                 :string
 #  payer_state_code                   :string
 #  payer_state_identification_number  :string

--- a/spec/lib/submission_builder/state1099_r_spec.rb
+++ b/spec/lib/submission_builder/state1099_r_spec.rb
@@ -20,6 +20,7 @@ describe SubmissionBuilder::State1099R do
       it "generates xml with the right values" do
         expect(doc.at("PayerNameControlTxt").text).to eq "DORO"
         expect(doc.at("PayerName BusinessNameLine1Txt").text).to eq "Dorothy Red"
+        expect(doc.at("PayerName BusinessNameLine2Txt").text).to eq ""
         expect(doc.at("PayerUSAddress AddressLine1Txt").text).to eq "123 Sesame ST"
         expect(doc.at("PayerUSAddress AddressLine2Txt").text).to eq "Apt 202"
         expect(doc.at("PayerUSAddress CityNm").text).to eq "Long Island"

--- a/spec/models/state_file1099_r_spec.rb
+++ b/spec/models/state_file1099_r_spec.rb
@@ -14,6 +14,7 @@
 #  payer_city_name                    :string
 #  payer_identification_number        :string
 #  payer_name                         :string
+#  payer_name2                        :string
 #  payer_name_control                 :string
 #  payer_state_code                   :string
 #  payer_state_identification_number  :string


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1872
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Passing on `PayerName BusinessNameLine2Txt` from df to state 1099R xml, also `PayerName BusinessNameLine2Txt`
- Because we synchronize 1099Rs to the db & then pull the data from the database, we need to add the new column for `payer_name2`
- I added it to the federal info controller, although I'm not sure if it's necessary it felt weird to omit it since `payer_name` is there
## How to test?
- Describe the testing approach taken to verify the changes, including:
  - Unit/integration/manual tests
  - Test data used: 
    - Test with AZ persona: [Grand_income_1099Rval](https://docs.google.com/document/d/1q35-QfpnKtyYwe9omWO1C9DAAdaQUv3R7Lfp27QAJvQ/edit?tab=t.0#heading=h.6dbtxxbo27dm)
    - Test with MD persona: [Maher_all_income](https://docs.google.com/document/d/1zuWQ5_f_F_F5wO-IBggbzLsizzgqN05gvWGbrc3SsEk/edit?tab=t.0#heading=h.ubik9ri0s1f0)
- Specify any relevant testing environments used: development, use heroku in QA testing
