### PR TITLE
NJ 299 - check for nil values when summing line 55

### DIFF
--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -468,7 +468,7 @@ module Efile
         return nil if @intake.state_file_w2s.empty? && @intake.state_file1099_rs.empty?
 
         (
-          @intake.state_file_w2s.sum(&:state_income_tax_amount) +
+          @intake.state_file_w2s.sum{ |item| item.state_income_tax_amount || 0} +
           @intake.state_file1099_rs.sum(&:state_tax_withheld_amount)
         ).round
       end

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -1738,6 +1738,19 @@ describe Efile::Nj::Nj1040Calculator do
         expect(instance.lines[:NJ1040_LINE_55].value).to eq nil
       end
     end
+
+    context "with nil state_income_tax_amount for W2" do
+      let(:intake) { create(:state_file_nj_intake, :df_data_many_w2s)}
+
+      before do
+        intake.state_file_w2s.first&.update(state_income_tax_amount: nil)
+      end
+
+      it "sums up all relevant values without error" do
+        instance.calculate
+        expect(instance.lines[:NJ1040_LINE_55].value).to eq(1500)
+      end
+    end
   end
 
   describe 'line 57 - estimated tax payments' do


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/299

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!
- No - merge after code review approval

## What was done?
Don't have line 55 fail if state income tax amt is nil

## How to test?
Can't be tested end-to-end because of CFA fix 

