### PR TITLE
[FYST-1875] 1099R: Use intake.state_code if 1099R's state_code is missing

### DIFF
--- a/app/lib/submission_builder/state1099_r.rb
+++ b/app/lib/submission_builder/state1099_r.rb
@@ -4,7 +4,7 @@ module SubmissionBuilder
 
     def document
       form1099r = @kwargs[:form1099r]
-      state_abbreviation = form1099r.intake.state_code.upcase
+      state_abbreviation = form1099r.intake.state_code.downcase
 
       build_xml_doc("IRS1099R", documentId: "IRS1099R-#{form1099r.id}") do |xml|
         xml.PayerNameControlTxt form1099r.payer_name_control
@@ -36,7 +36,7 @@ module SubmissionBuilder
           xml.F1099RStateLocalTaxGrp do
             xml.F1099RStateTaxGrp do
               xml.StateTaxWithheldAmt form1099r.state_tax_withheld_amount&.round
-              xml.StateAbbreviationCd form1099r.state_code if form1099r.state_code.present?
+              xml.StateAbbreviationCd form1099r.state_code || state_abbreviation
               xml.PayerStateIdNum form1099r.payer_state_identification_number if form1099r.payer_state_identification_number.present?
               xml.StateDistributionAmt form1099r.state_distribution_amount&.round
             end

--- a/app/lib/submission_builder/state1099_r.rb
+++ b/app/lib/submission_builder/state1099_r.rb
@@ -4,7 +4,7 @@ module SubmissionBuilder
 
     def document
       form1099r = @kwargs[:form1099r]
-      state_abbreviation = form1099r.intake.state_code.downcase
+      state_abbreviation = form1099r.intake.state_code.upcase
 
       build_xml_doc("IRS1099R", documentId: "IRS1099R-#{form1099r.id}") do |xml|
         xml.PayerNameControlTxt form1099r.payer_name_control

--- a/spec/lib/submission_builder/state1099_r_spec.rb
+++ b/spec/lib/submission_builder/state1099_r_spec.rb
@@ -47,7 +47,7 @@ describe SubmissionBuilder::State1099R do
           form1099r.update(state_code: nil)
         end
         it "fills in F1099RStateTaxGrp StateAbbreviationCd with intake's state_code" do
-          expect(doc.at("F1099RStateTaxGrp StateAbbreviationCd").text).to eq "#{intake.state_code}"
+          expect(doc.at("F1099RStateTaxGrp StateAbbreviationCd").text).to eq "#{intake.state_code.upcase}"
         end
       end
     end

--- a/spec/lib/submission_builder/state1099_r_spec.rb
+++ b/spec/lib/submission_builder/state1099_r_spec.rb
@@ -41,6 +41,15 @@ describe SubmissionBuilder::State1099R do
         expect(doc.at("F1099RStateTaxGrp StateDistributionAmt").text).to eq "55"
         expect(doc.at("StandardOrNonStandardCd").text).to eq "N"
       end
+
+      context "when 1099R does not have state_code" do
+        before do
+          form1099r.update(state_code: nil)
+        end
+        it "fills in F1099RStateTaxGrp StateAbbreviationCd with intake's state_code" do
+          expect(doc.at("F1099RStateTaxGrp StateAbbreviationCd").text).to eq "#{intake.state_code}"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Similar to https://github.com/codeforamerica/vita-min/pull/5367

## Link to pivotal/JIRA issue
- e.g. https://codeforamerica.atlassian.net/browse/FYST-1875
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Self explanatory
## How to test?
- Describe the testing approach taken to verify the changes, including:
  - Unit/integration/manual tests
  - Test data used
- Specify any relevant testing environments used (e.g., development, staging, demo, Heroku).
- Risk Assessment
  - This hits all states, so if some states _dont_ want this filled out, could be a problem, I suppose.
## Screenshots (for visual changes)
Maher
<img width="575" alt="Screenshot 2025-02-27 at 12 33 48 PM" src="https://github.com/user-attachments/assets/4616c943-1856-46dc-81ee-e136aab7a477" />
