### PR TITLE
FYST-1876 MD Two income subtraction calculation fix

### DIFF
--- a/app/lib/efile/md/two_income_subtraction_worksheet.rb
+++ b/app/lib/efile/md/two_income_subtraction_worksheet.rb
@@ -48,7 +48,7 @@ module Efile
         unemployment_income = @direct_file_json_data.form_1099gs
           .select { |form_1099g| form_1099g.recipient_tin.delete("-") == filer_ssn }
           .sum { |form_1099g| (form_1099g.amount - form_1099g.amount_paid_back_for_benefits_in_tax_year).round }
-        
+
         wage_income +
           interest_income +
           retirement_income +

--- a/app/lib/efile/md/two_income_subtraction_worksheet.rb
+++ b/app/lib/efile/md/two_income_subtraction_worksheet.rb
@@ -48,7 +48,6 @@ module Efile
         unemployment_income = @direct_file_json_data.form_1099gs
           .select { |form_1099g| form_1099g.recipient_tin.delete("-") == filer_ssn }
           .sum { |form_1099g| (form_1099g.amount - form_1099g.amount_paid_back_for_benefits_in_tax_year).round }
-
         wage_income +
           interest_income +
           retirement_income +
@@ -93,10 +92,9 @@ module Efile
       def calculate_line_4(primary_or_spouse)
         cdc_expenses = (@direct_file_data.total_qualifying_dependent_care_expenses_or_limit_amt || 0) / 2
 
-        # NOTE: Stub alert - this data relies on 1099R followup questions, which have been deprioritized
-        pension_exclusion = 0
-        military_retirement_exclusion = 0
-
+        pension_exclusion = primary_or_spouse == :primary ? line_or_zero(:MD502R_LINE_11A) : line_or_zero(:MD502R_LINE_11B)
+        military_retirement_exclusion = primary_or_spouse == :primary ? line_or_zero(:MD502_SU_LINE_U_PRIMARY) : line_or_zero(:MD502_SU_LINE_U_SPOUSE)
+        
         cdc_expenses +
           pension_exclusion +
           military_retirement_exclusion

--- a/app/lib/efile/md/two_income_subtraction_worksheet.rb
+++ b/app/lib/efile/md/two_income_subtraction_worksheet.rb
@@ -48,6 +48,7 @@ module Efile
         unemployment_income = @direct_file_json_data.form_1099gs
           .select { |form_1099g| form_1099g.recipient_tin.delete("-") == filer_ssn }
           .sum { |form_1099g| (form_1099g.amount - form_1099g.amount_paid_back_for_benefits_in_tax_year).round }
+        
         wage_income +
           interest_income +
           retirement_income +
@@ -94,7 +95,7 @@ module Efile
 
         pension_exclusion = primary_or_spouse == :primary ? line_or_zero(:MD502R_LINE_11A) : line_or_zero(:MD502R_LINE_11B)
         military_retirement_exclusion = primary_or_spouse == :primary ? line_or_zero(:MD502_SU_LINE_U_PRIMARY) : line_or_zero(:MD502_SU_LINE_U_SPOUSE)
-        
+
         cdc_expenses +
           pension_exclusion +
           military_retirement_exclusion

--- a/spec/lib/efile/md/two_income_subtraction_worksheet_spec.rb
+++ b/spec/lib/efile/md/two_income_subtraction_worksheet_spec.rb
@@ -365,6 +365,48 @@ describe Efile::Md::TwoIncomeSubtractionWorksheet do
         expect(instance.lines[:MD_TWO_INCOME_WK_LINE_4_B].value).to eq(100)
       end
     end
+
+    context "return has pension exclusion" do
+      before do
+        allow_any_instance_of(Efile::Md::Md502RCalculator).to receive(:calculate_line_11a).and_return(500)
+        allow_any_instance_of(Efile::Md::Md502RCalculator).to receive(:calculate_line_11b).and_return(300)
+      end
+
+      it "calculates the state subtraction amount for primary and spouse" do
+        main_calculator.calculate
+        expect(instance.lines[:MD_TWO_INCOME_WK_LINE_4_A].value).to eq(500)
+        expect(instance.lines[:MD_TWO_INCOME_WK_LINE_4_B].value).to eq(300)
+      end
+    end
+
+    context "return has military retirement exclusion" do
+      before do
+        allow_any_instance_of(Efile::Md::Md502SuCalculator).to receive(:calculate_line_u_primary).and_return(400)
+        allow_any_instance_of(Efile::Md::Md502SuCalculator).to receive(:calculate_line_u_spouse).and_return(200)
+      end
+
+      it "calculates the state subtraction amount for primary and spouse" do
+        main_calculator.calculate
+        expect(instance.lines[:MD_TWO_INCOME_WK_LINE_4_A].value).to eq(400)
+        expect(instance.lines[:MD_TWO_INCOME_WK_LINE_4_B].value).to eq(200)
+      end
+    end
+
+    context "return has all possible subtractions" do
+      before do
+        intake.direct_file_data.total_qualifying_dependent_care_expenses_or_limit_amt = 200
+        allow_any_instance_of(Efile::Md::Md502RCalculator).to receive(:calculate_line_11a).and_return(500)
+        allow_any_instance_of(Efile::Md::Md502RCalculator).to receive(:calculate_line_11b).and_return(300)
+        allow_any_instance_of(Efile::Md::Md502SuCalculator).to receive(:calculate_line_u_primary).and_return(400)
+        allow_any_instance_of(Efile::Md::Md502SuCalculator).to receive(:calculate_line_u_spouse).and_return(200)
+      end
+
+      it "calculates the combined state subtraction amount for primary and spouse" do
+        main_calculator.calculate
+        expect(instance.lines[:MD_TWO_INCOME_WK_LINE_4_A].value).to eq(1000) # 100 + 500 + 400
+        expect(instance.lines[:MD_TWO_INCOME_WK_LINE_4_B].value).to eq(600)  # 100 + 300 + 200
+      end
+    end
   end
 
   describe "#calculate_line_5" do

--- a/spec/lib/efile/md/two_income_subtraction_worksheet_spec.rb
+++ b/spec/lib/efile/md/two_income_subtraction_worksheet_spec.rb
@@ -403,8 +403,8 @@ describe Efile::Md::TwoIncomeSubtractionWorksheet do
 
       it "calculates the combined state subtraction amount for primary and spouse" do
         main_calculator.calculate
-        expect(instance.lines[:MD_TWO_INCOME_WK_LINE_4_A].value).to eq(1000) # 100 + 500 + 400
-        expect(instance.lines[:MD_TWO_INCOME_WK_LINE_4_B].value).to eq(600)  # 100 + 300 + 200
+        expect(instance.lines[:MD_TWO_INCOME_WK_LINE_4_A].value).to eq(100 + 500 + 400)
+        expect(instance.lines[:MD_TWO_INCOME_WK_LINE_4_B].value).to eq(100 + 300 + 200)
       end
     end
   end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/FYST-1876

## Is PM acceptance required?
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
The worksheet calculations had stubbed values for the military and pension amounts. This was filled in with the appropriate values

## How to test?
- Added in units tests for worksheet calculator 
