### PR TITLE
[FYST-1881] Make html consistent between az and id review of 1099 r subtractions

### DIFF
--- a/app/views/state_file/questions/id_review/edit.html.erb
+++ b/app/views/state_file/questions/id_review/edit.html.erb
@@ -2,20 +2,6 @@
 <% content_for :card do %>
   <%= render "state_file/questions/shared/review_header" %>
 
-  <% if Flipper.enabled?(:show_retirement_ui) && current_intake.calculator.line_or_zero(:ID39R_B_LINE_8e).positive? %>
-    <div id="qualified-retirement-benefits-deduction" class="white-group">
-      <div class="spacing-below-5">
-        <p class="text--bold spacing-below-5"><%= t(".qualified_retirement_benefits_deduction") %></p>
-        <p class="text spacing-below-2"><%= t(".qualified_retirement_benefits_deduction_explain") %></p>
-
-        <p class="text--bold spacing-below-5"><%= t(".qualified_disabled_retirement_benefits") %></p>
-        <p><%= number_to_currency(current_intake.calculator.line_or_zero(:ID39R_B_LINE_8f), precision: 2) %></p>
-        <% id_disability_or_retirement_link = current_intake.has_filer_between_62_and_65_years_old? ? StateFile::Questions::IdDisabilityController.to_path_helper(return_to_review: "y") : StateFile::Questions::IdRetirementAndPensionIncomeController.to_path_helper(return_to_review: "y", index: 0) %>
-        <%= link_to t("general.review_and_edit"), id_disability_or_retirement_link, class: "button--small" %>
-      </div>
-    </div>
-  <% end %>
-
   <section class="review-section">
     <div class="spacing-below-25">
       <h2 class="text--body text--bold spacing-below-5"><%=t("state_file.questions.shared.review_header.state_details_title") %></h2>

--- a/app/views/state_file/questions/shared/_id_retirement_income_deductions_review_header.html.erb
+++ b/app/views/state_file/questions/shared/_id_retirement_income_deductions_review_header.html.erb
@@ -1,4 +1,4 @@
-<% if Flipper.enabled?(:show_retirement_ui) && current_intake.calculator.line_or_zero(:ID39R_B_LINE_8e).positive? %>
+<% if current_intake.calculator.line_or_zero(:ID39R_B_LINE_8e).positive? %>
   <div id="qualified-retirement-benefits-deduction" class="white-group">
     <div class="spacing-below-5">
       <p class="text--bold spacing-below-5"><%= t(".qualified_retirement_benefits_deduction") %></p>

--- a/app/views/state_file/questions/shared/_id_retirement_income_deductions_review_header.html.erb
+++ b/app/views/state_file/questions/shared/_id_retirement_income_deductions_review_header.html.erb
@@ -1,0 +1,14 @@
+<% if Flipper.enabled?(:show_retirement_ui) && current_intake.calculator.line_or_zero(:ID39R_B_LINE_8e).positive? %>
+  <div id="qualified-retirement-benefits-deduction" class="white-group">
+    <div class="spacing-below-5">
+      <p class="text--bold spacing-below-5"><%= t(".qualified_retirement_benefits_deduction") %></p>
+      <p class="text spacing-below-2"><%= t(".qualified_retirement_benefits_deduction_explain") %></p>
+
+      <p class="text--bold spacing-below-5"><%= t(".qualified_disabled_retirement_benefits") %></p>
+      <p><%= number_to_currency(current_intake.calculator.line_or_zero(:ID39R_B_LINE_8f), precision: 2) %></p>
+      <% id_disability_or_retirement_link = current_intake.has_filer_between_62_and_65_years_old? ? StateFile::Questions::IdDisabilityController.to_path_helper(return_to_review: "y") : StateFile::Questions::IdRetirementAndPensionIncomeController.to_path_helper(return_to_review: "y", index: 0) %>
+      <%= link_to t("general.review_and_edit"), id_disability_or_retirement_link, class: "button--small" %>
+    </div>
+  </div>
+<% end %>
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3074,9 +3074,6 @@ en:
           no_donations_selected: "<strong>No donations selected</strong>"
           permanent_building_fund_tax: Permanent Building Fund Tax
           purchases_without_sales_tax: Purchases without paying sales tax
-          qualified_disabled_retirement_benefits: Qualified disabled retirement benefits
-          qualified_retirement_benefits_deduction: Qualified Retirement Benefits Deduction
-          qualified_retirement_benefits_deduction_explain: These allow people to deduct all or a portion of their retirement income from their taxes.
           voluntary_charitable_donations: Voluntary Charitable Donations
       id_sales_use_tax:
         edit:
@@ -4062,6 +4059,10 @@ en:
           subtitle: These allow people to deduct all or a portion of their retirement income from their taxes.
           title: Arizona retirement income deductions
           uniformed_services: Retired or retainer pay of the uniformed services of the United States
+        id_retirement_income_deductions_review_header:
+          qualified_disabled_retirement_benefits: Qualified disabled retirement benefits
+          qualified_retirement_benefits_deduction: Qualified Retirement Benefits Deduction
+          qualified_retirement_benefits_deduction_explain: These allow people to deduct all or a portion of their retirement income from their taxes.
         review_header:
           income_details: Income Details
           income_forms_collected: 'Income form(s) collected:'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3043,9 +3043,6 @@ es:
           no_donations_selected: "<strong>No hay donaciones seleccionadas</strong>"
           permanent_building_fund_tax: Impuesto sobre el Fondo de Edificios Permanentes
           purchases_without_sales_tax: Compras sin pagar impuesto de ventas
-          qualified_disabled_retirement_benefits: Beneficios calificados de jubilación para personas con discapacidad
-          qualified_retirement_benefits_deduction: Deducción por Beneficios Calificados de Jubilación
-          qualified_retirement_benefits_deduction_explain: Estos permiten a las personas deducir de sus impuestos la totalidad o una parte de sus ingresos por jubilación.
           voluntary_charitable_donations: Donaciones caritativas voluntarias
       id_sales_use_tax:
         edit:
@@ -4048,6 +4045,10 @@ es:
           subtitle: These allow people to deduct all or a portion of their retirement income from their taxes.
           title: Arizona retirement income deductions
           uniformed_services: Retired or retainer pay of the uniformed services of the United States
+        id_retirement_income_deductions_review_header:
+          qualified_disabled_retirement_benefits: Beneficios calificados de jubilación para personas con discapacidad
+          qualified_retirement_benefits_deduction: Deducción por Beneficios Calificados de Jubilación
+          qualified_retirement_benefits_deduction_explain: Estos permiten a las personas deducir de sus impuestos la totalidad o una parte de sus ingresos por jubilación.
         review_header:
           income_details: Detalles de ingresos
           income_forms_collected: 'Formulario(s) de ingresos recogidos:'

--- a/spec/features/state_file/review_page_spec.rb
+++ b/spec/features/state_file/review_page_spec.rb
@@ -383,8 +383,8 @@ RSpec.feature "Completing a state file intake", active_job: true, js: true do
             expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
             within "#qualified-retirement-benefits-deduction" do
               expect(page).to have_text I18n.t("state_file.questions.shared.id_retirement_income_deductions_review_header.qualified_retirement_benefits_deduction")
-              expect(page).to have_text I18n.t("state_file.questions.id_review.edit.qualified_retirement_benefits_deduction_explain")
-              expect(page).to have_text I18n.t("state_file.questions.id_review.edit.qualified_disabled_retirement_benefits")
+              expect(page).to have_text I18n.t("state_file.questions.shared.id_retirement_income_deductions_review_header.qualified_retirement_benefits_deduction_explain")
+              expect(page).to have_text I18n.t("state_file.questions.shared.id_retirement_income_deductions_review_header.qualified_disabled_retirement_benefits")
               expect(page).to have_text "$250.00"
 
               click_on I18n.t("general.review_and_edit")

--- a/spec/features/state_file/review_page_spec.rb
+++ b/spec/features/state_file/review_page_spec.rb
@@ -382,7 +382,7 @@ RSpec.feature "Completing a state file intake", active_job: true, js: true do
 
             expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
             within "#qualified-retirement-benefits-deduction" do
-              expect(page).to have_text I18n.t("state_file.questions.id_review.edit.qualified_retirement_benefits_deduction")
+              expect(page).to have_text I18n.t("state_file.questions.shared.id_retirement_income_deductions_review_header.qualified_retirement_benefits_deduction")
               expect(page).to have_text I18n.t("state_file.questions.id_review.edit.qualified_retirement_benefits_deduction_explain")
               expect(page).to have_text I18n.t("state_file.questions.id_review.edit.qualified_disabled_retirement_benefits")
               expect(page).to have_text "$250.00"
@@ -405,9 +405,9 @@ RSpec.feature "Completing a state file intake", active_job: true, js: true do
 
             expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
             within "#qualified-retirement-benefits-deduction" do
-              expect(page).to have_text I18n.t("state_file.questions.id_review.edit.qualified_retirement_benefits_deduction")
-              expect(page).to have_text I18n.t("state_file.questions.id_review.edit.qualified_retirement_benefits_deduction_explain")
-              expect(page).to have_text I18n.t("state_file.questions.id_review.edit.qualified_disabled_retirement_benefits")
+              expect(page).to have_text I18n.t("state_file.questions.shared.id_retirement_income_deductions_review_header.qualified_retirement_benefits_deduction")
+              expect(page).to have_text I18n.t("state_file.questions.shared.id_retirement_income_deductions_review_header.qualified_retirement_benefits_deduction_explain")
+              expect(page).to have_text I18n.t("state_file.questions.shared.id_retirement_income_deductions_review_header.qualified_disabled_retirement_benefits")
               expect(page).to have_text "$200.00" # $50 less eligible
             end
           end
@@ -418,9 +418,9 @@ RSpec.feature "Completing a state file intake", active_job: true, js: true do
 
           expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
           within "#qualified-retirement-benefits-deduction" do
-            expect(page).to have_text I18n.t("state_file.questions.id_review.edit.qualified_retirement_benefits_deduction")
-            expect(page).to have_text I18n.t("state_file.questions.id_review.edit.qualified_retirement_benefits_deduction_explain")
-            expect(page).to have_text I18n.t("state_file.questions.id_review.edit.qualified_disabled_retirement_benefits")
+            expect(page).to have_text I18n.t("state_file.questions.shared.id_retirement_income_deductions_review_header.qualified_retirement_benefits_deduction")
+            expect(page).to have_text I18n.t("state_file.questions.shared.id_retirement_income_deductions_review_header.qualified_retirement_benefits_deduction_explain")
+            expect(page).to have_text I18n.t("state_file.questions.shared.id_retirement_income_deductions_review_header.qualified_disabled_retirement_benefits")
             expect(page).to have_text "$250.00"
 
             click_on I18n.t("general.review_and_edit")
@@ -441,9 +441,9 @@ RSpec.feature "Completing a state file intake", active_job: true, js: true do
 
           expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
           within "#qualified-retirement-benefits-deduction" do
-            expect(page).to have_text I18n.t("state_file.questions.id_review.edit.qualified_retirement_benefits_deduction")
-            expect(page).to have_text I18n.t("state_file.questions.id_review.edit.qualified_retirement_benefits_deduction_explain")
-            expect(page).to have_text I18n.t("state_file.questions.id_review.edit.qualified_disabled_retirement_benefits")
+            expect(page).to have_text I18n.t("state_file.questions.shared.id_retirement_income_deductions_review_header.qualified_retirement_benefits_deduction")
+            expect(page).to have_text I18n.t("state_file.questions.shared.id_retirement_income_deductions_review_header.qualified_retirement_benefits_deduction_explain")
+            expect(page).to have_text I18n.t("state_file.questions.shared.id_retirement_income_deductions_review_header.qualified_disabled_retirement_benefits")
             expect(page).to have_text "$200.00" # $50 less eligible
           end
         end
@@ -460,9 +460,9 @@ RSpec.feature "Completing a state file intake", active_job: true, js: true do
 
           expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
           within "#qualified-retirement-benefits-deduction" do
-            expect(page).to have_text I18n.t("state_file.questions.id_review.edit.qualified_retirement_benefits_deduction")
-            expect(page).to have_text I18n.t("state_file.questions.id_review.edit.qualified_retirement_benefits_deduction_explain")
-            expect(page).to have_text I18n.t("state_file.questions.id_review.edit.qualified_disabled_retirement_benefits")
+            expect(page).to have_text I18n.t("state_file.questions.shared.id_retirement_income_deductions_review_header.qualified_retirement_benefits_deduction")
+            expect(page).to have_text I18n.t("state_file.questions.shared.id_retirement_income_deductions_review_header.qualified_retirement_benefits_deduction_explain")
+            expect(page).to have_text I18n.t("state_file.questions.shared.id_retirement_income_deductions_review_header.qualified_disabled_retirement_benefits")
             expect(page).to have_text "$250.00"
 
             click_on I18n.t("general.review_and_edit")
@@ -473,7 +473,7 @@ RSpec.feature "Completing a state file intake", active_job: true, js: true do
           click_on I18n.t("general.continue")
 
           expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
-          expect(page).not_to have_text I18n.t("state_file.questions.id_review.edit.qualified_retirement_benefits_deduction")
+          expect(page).not_to have_text I18n.t("state_file.questions.shared.id_retirement_income_deductions_review_header.qualified_retirement_benefits_deduction")
         end
       end
     end
@@ -483,7 +483,7 @@ RSpec.feature "Completing a state file intake", active_job: true, js: true do
       visit "/questions/id-review"
 
       expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
-      expect(page).not_to have_text(I18n.t("state_file.questions.id_review.edit.qualified_retirement_benefits_deduction"))
+      expect(page).not_to have_text(I18n.t("state_file.questions.shared.id_retirement_income_deductions_review_header.qualified_retirement_benefits_deduction"))
     end
   end
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1881
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Moved the html for id retirement card from id_review to review_header to be consistent with az approach. I think it's in the `Income Details` section of the review, so feels like it should be in the same area. 
## How to test?
- Describe the testing approach taken to verify the changes, including:
  - Tests should still pass
- Specify any relevant testing environments used (e.g., development, staging, demo, Heroku).
- Use pangolin (must answer disabled: yes), potato_mfj who have eligible 1099Rs

## Screenshots (for visual changes)
looks the same
<img width="590" alt="Screenshot 2025-02-28 at 11 05 18 AM" src="https://github.com/user-attachments/assets/231eafc8-9adf-4689-827e-a57f48274e7e" />

