### PR TITLE
[GYR1-694] Add spacing CSS around refund due elements (Hub 14-C p2)

### DIFF
--- a/app/views/hub/clients/edit_13614c_form_page1.html.erb
+++ b/app/views/hub/clients/edit_13614c_form_page1.html.erb
@@ -114,7 +114,7 @@
           <div class="grid__item width-one-whole">
             <p class="form-question"><%= "#{t(".fields.refund_payment_method")}" %></p>
           </div>
-          <div class="grid__item width-one-whole">
+          <div class="grid__item width-one-whole" style="display: flex; justify-content: space-between;">
             <%= f.cfa_select(:refund_direct_deposit, t(".fields.refund_payment_method_direct_deposit"), yes_no_options_for_select) %>
             <%= f.cfa_select(:refund_check_by_mail, t(".fields.refund_check_by_mail"), yes_no_options_for_select) %>
             <%= f.cfa_select(:savings_split_refund, t(".fields.refund_payment_method_split"), yes_no_options_for_select) %>


### PR DESCRIPTION
## Link to Jira issue

- https://codeforamerica.atlassian.net/browse/GYR1-694

## Is PM acceptance required?

- Yes - don't merge until JIRA issue is accepted!

## What was done?

Just added some spacing CSS so that the "refund due" elements (Hub editable 14-C 
page 1) are spaced apart more.

## How to test?

Just visually confirm the spacing looks OK when:
- zooming in and out (using the browser's zoom functionality)
- try it in a couple different browsers (e.g., LibreWolf and Safari)

## Screenshots (for visual changes)

- Before:

![image](https://github.com/user-attachments/assets/cad14861-e4fd-44d2-8fd1-0a9aa984f142)

- After:

<img width="1081" alt="image" src="https://github.com/user-attachments/assets/e63238ed-5705-4420-aa70-1558158a857b" />

