### PR TITLE
NJ 304 - do not show medical expenses when gross income is zero

### DIFF
--- a/app/controllers/state_file/questions/nj_medical_expenses_controller.rb
+++ b/app/controllers/state_file/questions/nj_medical_expenses_controller.rb
@@ -2,6 +2,10 @@ module StateFile
   module Questions
     class NjMedicalExpensesController < QuestionsController
       include ReturnToReviewConcern
+
+      def self.show?(intake)
+        intake.nj_gross_income.positive?
+      end
     end
   end
 end

--- a/app/models/state_file_nj_intake.rb
+++ b/app/models/state_file_nj_intake.rb
@@ -154,8 +154,11 @@ class StateFileNjIntake < StateFileBaseIntake
   enum tenant_shared_rent_not_spouse: { unfilled: 0, yes: 1, no: 2}, _prefix: :tenant_shared_rent_not_spouse
   enum tenant_same_home_spouse: { unfilled: 0, yes: 1, no: 2}, _prefix: :tenant_same_home_spouse
 
+  def nj_gross_income
+    calculator.lines[:NJ1040_LINE_29].value
+  end
+
   def calculate_sales_use_tax
-    nj_gross_income = calculator.lines[:NJ1040_LINE_29].value
     calculator.calculate_use_tax(nj_gross_income)
   end
 
@@ -178,7 +181,6 @@ class StateFileNjIntake < StateFileBaseIntake
   end
 
   def eligibility_made_less_than_threshold?
-    nj_gross_income = calculator.lines[:NJ1040_LINE_29].value
     threshold = self.filing_status_single? || self.filing_status_mfs? ? 10_000 : 20_000
     nj_gross_income <= threshold
   end
@@ -214,7 +216,6 @@ class StateFileNjIntake < StateFileBaseIntake
   end
 
   def medical_expenses_threshold
-    nj_gross_income = calculator.lines[:NJ1040_LINE_29].value
     (nj_gross_income * 0.02).floor
   end
 

--- a/app/views/state_file/questions/nj_review/edit.html.erb
+++ b/app/views/state_file/questions/nj_review/edit.html.erb
@@ -142,16 +142,19 @@
     </section>
   <% end %>
 
-  <section id="medical_expenses" class="white-group">
-    <div class="spacing-below-5">
-      <h2 class="text--body text--bold spacing-below-5"><%=t(".medical_expenses") %></h2>
-      <p><%= number_to_currency(current_intake.medical_expenses, precision: 0) %></p>
-      <%= link_to StateFile::Questions::NjMedicalExpensesController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
-        <%= t(".review_and_edit") %>
-        <span class="sr-only"><%= t(".medical_expenses") %></span>
-      <% end %>
-    </div>
-  </section>
+  <% if current_intake.nj_gross_income.positive? %>
+    <section id="medical_expenses" class="white-group">
+      <div class="spacing-below-5">
+        <h2 class="text--body text--bold spacing-below-5"><%=t(".medical_expenses") %></h2>
+        <p><%= number_to_currency(current_intake.medical_expenses, precision: 0) %></p>
+        <%= link_to StateFile::Questions::NjMedicalExpensesController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
+          <%= t(".review_and_edit") %>
+          <span class="sr-only"><%= t(".medical_expenses") %></span>
+        <% end %>
+      </div>
+    </section>
+  <% end %>
+
 
   <section id="property-tax" class="white-group">
     <div class="spacing-below-5">

--- a/spec/controllers/state_file/questions/nj_medical_expenses_controller_spec.rb
+++ b/spec/controllers/state_file/questions/nj_medical_expenses_controller_spec.rb
@@ -19,6 +19,24 @@ RSpec.describe StateFile::Questions::NjMedicalExpensesController do
       expect(response.body).to have_text "$246"
     end
 
+    describe "#show?" do
+      context "when nj gross income is zero" do
+        let(:intake) { create :state_file_nj_intake }
+        it "does not show" do
+          allow_any_instance_of(StateFileNjIntake).to receive(:nj_gross_income).and_return(0)
+          expect(described_class.show?(intake)).to eq false
+        end
+      end
+
+      context "when nj gross income is greater than zero" do
+        let(:intake) { create :state_file_nj_intake }
+        it "shows" do
+          allow_any_instance_of(StateFileNjIntake).to receive(:nj_gross_income).and_return(1)
+          expect(described_class.show?(intake)).to eq true
+        end
+      end
+    end
+
     describe "#update" do 
       context "when a user has medical expenses" do
         let(:form_params) {

--- a/spec/features/state_file/nj/complete_intake_spec.rb
+++ b/spec/features/state_file/nj/complete_intake_spec.rb
@@ -460,7 +460,6 @@ RSpec.feature "Completing a state file intake", active_job: true do
         advance_county_and_municipality
         advance_disabled_exemption(true) # disabled exemption
         advance_veterans_exemption
-        advance_medical_expenses
         choose_household_rent_own("homeowner")
         select_homeowner_eligibility(["homeowner_home_subject_to_property_taxes"])
         # skips property tax paid page
@@ -472,7 +471,6 @@ RSpec.feature "Completing a state file intake", active_job: true do
         advance_county_and_municipality
         advance_disabled_exemption(true) # disabled exemption
         advance_veterans_exemption
-        advance_medical_expenses
         choose_household_rent_own("tenant")
         select_tenant_eligibility(["tenant_home_subject_to_property_taxes"])
         # skips rent paid page
@@ -484,7 +482,6 @@ RSpec.feature "Completing a state file intake", active_job: true do
         advance_county_and_municipality
         advance_disabled_exemption(true) # disabled exemption
         advance_veterans_exemption
-        advance_medical_expenses
         choose_household_rent_own("both")
         select_homeowner_eligibility(["homeowner_home_subject_to_property_taxes"])
         # skips property tax paid page
@@ -497,7 +494,6 @@ RSpec.feature "Completing a state file intake", active_job: true do
         advance_county_and_municipality
         advance_disabled_exemption(true) # disabled exemption
         advance_veterans_exemption
-        advance_medical_expenses
         choose_household_rent_own("both")
         select_homeowner_eligibility([])
         expect_ineligible_page("on_home", "property_taxes")
@@ -513,7 +509,6 @@ RSpec.feature "Completing a state file intake", active_job: true do
         advance_county_and_municipality
         advance_disabled_exemption(false) # does NOT meet disabled exemption
         advance_veterans_exemption
-        advance_medical_expenses
         choose_household_rent_own("homeowner")
         expect_ineligible_page(nil, "income_single_mfs")
         expect_page_after_property_tax


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/304

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Hide medical expenses screen if gross income is zero
- Hide medical expenses on review page if gross income is zero

## How to test?
- use any persona with income, and any persona without
