### PR TITLE
FYST-1192 Remove button height

### DIFF
--- a/app/assets/stylesheets/_state-file.scss
+++ b/app/assets/stylesheets/_state-file.scss
@@ -388,7 +388,6 @@
     border-radius: 0.4rem;
     font-size: 2.2rem;
     font-weight: 700;
-    height: 6rem;
     letter-spacing: 0;
     line-height: 2.5rem;
     padding: 1.6rem 2.4rem;

--- a/app/views/state_file/questions/initiate_data_transfer/_data_transfer_buttons.html.erb
+++ b/app/views/state_file/questions/initiate_data_transfer/_data_transfer_buttons.html.erb
@@ -1,5 +1,5 @@
 <% if @fake_data_transfer_link.present? %>
-  <%= link_to @fake_data_transfer_link.to_s, class: "button button--primary button--icon button--full-width", id: "firstCta" do %>
+  <%= link_to @fake_data_transfer_link.to_s, class: "button button--primary button--icon button--full-width spacing-below-15", id: "firstCta" do %>
     <%= image_tag("icons/link-white.svg", alt: "") %>
     <%= t(".from_fake_df_page") %>
   <% end %>


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1192
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Spanish text overflowed the text/email notification buttons (and also maybe on the data transfer button?)
- Story didn't specify how to fix this so I just removed the button height. As far as I can tell the buttons all look the same except the ones with overflowing text
## How to test?
- Visually? Might be good to do a sweep of the website to make sure the buttons don't look terrible
## Screenshots (for visual changes)
- Before
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/51d26bdd-f536-46d5-a877-808806891faf" />
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/2343b53f-95cd-4c2a-8c9c-8b97734af9bc" />

- After
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/efa38b38-1b20-4fee-95d1-9ab6f920c7cb" />
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/29ee29bc-470d-46c0-a4da-1999aeecada0" />
