### PR TITLE
add w2 show page

### DIFF
--- a/app/assets/stylesheets/_state-file.scss
+++ b/app/assets/stylesheets/_state-file.scss
@@ -366,12 +366,24 @@
       list-style-type: disc;
       padding-left: 2rem;
       margin: 1rem 0;
+
+      .unbulleted {
+        list-style-type: none;
+      }
     }
 
     li {
       font-size: 1.6rem;
       line-height: 2.4rem;
       margin-bottom: 0.5rem;
+    }
+
+    dt {
+      font-size: 1.3rem;
+    }
+
+    dd {
+      margin-left: 0;
     }
   }
 

--- a/app/controllers/state_file/questions/w2_controller.rb
+++ b/app/controllers/state_file/questions/w2_controller.rb
@@ -12,9 +12,10 @@ module StateFile
       end
 
       def edit
-        @state_code = current_state_code
         @w2.valid?(:state_file_edit)
       end
+
+      def show; end
 
       def update
         @w2.assign_attributes(form_params)

--- a/app/views/state_file/questions/income_review/edit.html.erb
+++ b/app/views/state_file/questions/income_review/edit.html.erb
@@ -7,11 +7,11 @@
   <% if @w2s.present? %>
     <div class="white-group" id="w2s">
       <h2 class="text--body text--bold spacing-below-0"><%= t(".w2s_title") %></h2>
-      <% if current_intake.allows_w2_editing? %>
-        <% @w2s.each do |w2| %>
-          <div class="spacing-above-25">
-            <p class="text--bold spacing-below-5"><%= w2.employee_name %></p>
-            <p class="spacing-below-5"><%= w2.employer_name %></p>
+      <% @w2s.each do |w2| %>
+        <div class="spacing-above-25">
+          <p class="text--bold spacing-below-5"><%= w2.employee_name %></p>
+          <p class="spacing-below-5"><%= w2.employer_name %></p>
+          <% if current_intake.allows_w2_editing? %>
             <%= link_to t(".review_and_edit_state_info"),
                         StateFile::Questions::W2Controller.to_path_helper(
                           action: :edit,
@@ -20,17 +20,22 @@
                         ),
                         class: "button--small"
             %>
-          </div>
-          <% if @w2_warnings[w2.id] %>
-            <div class="notice--warning spacing-above-5">
-              <p><%= t(".warning") %></p>
-            </div>
+            <% if @w2_warnings[w2.id] %>
+              <div class="notice--warning spacing-above-5">
+                <p><%= t(".warning") %></p>
+              </div>
+            <% end %>
+          <% else %>
+            <%= link_to t(".review_state_info"),
+                        StateFile::Questions::W2Controller.to_path_helper(
+                          action: :show,
+                          id: w2.id,
+                          return_to_review: params[:return_to_review]
+                        ),
+                        class: "button--small"
+            %>
           <% end %>
-        <% end %>
-      <% else %>
-        <p class="text--grey-bold spacing-above-15 spacing-below-0">
-          <%= t(".no_info_needed") %>
-        </p>
+        </div>
       <% end %>
     </div>
   <% end %>

--- a/app/views/state_file/questions/retirement_income/show.html.erb
+++ b/app/views/state_file/questions/retirement_income/show.html.erb
@@ -7,18 +7,25 @@
     <%= hidden_field_tag "return_to_review", params[:return_to_review] %>
   <% end %>
 
-  <div class="white-group spacing-below-35" >
-    <div class="form-group spacing-below-25">
-      <p class="form-question"><strong><%= @state_file1099_r.recipient_name %></strong></p>
-      <p class="form-question"><%= @state_file1099_r.payer_name %></p>
+  <dl>
+    <div class="white-group spacing-below-35">
+      <div class="spacing-below-25">
+        <dt class="form-question"><strong><%= @state_file1099_r.recipient_name %></strong></dt>
+        <dd class="form-question"><%= @state_file1099_r.payer_name %></dd>
+      </div>
+      <div class="spacing-below-25">
+        <dt><%= t("state_file.questions.retirement_income.edit.box14_html") %></dt>
+        <dd>$<%= @state_file1099_r.state_tax_withheld_amount %></dd>
+      </div>
+      <div class="spacing-below-25">
+        <dt><%= t("state_file.questions.retirement_income.edit.box15_html") %></dt>
+        <dd><%= current_state_code.upcase %><%= @state_file1099_r.payer_state_identification_number %></dd>
+      </div>
+      <div class="spacing-below-25">
+        <dt><%= t("state_file.questions.retirement_income.edit.box16_html") %></dt>
+        <dd>$<%= @state_file1099_r.state_distribution_amount %></dd>
+      </div>
     </div>
-    <span class="form-question"><%= t("state_file.questions.retirement_income.edit.box14_html") %></span>
-    <p class="text-25">$<%= @state_file1099_r.state_tax_withheld_amount %></p>
-    <span class="form-question"><%= t("state_file.questions.retirement_income.edit.box15_html") %></span>
-    <p class="text-25"><%= current_state_code.upcase %><%= @state_file1099_r.payer_state_identification_number %></p>
-    <span class="form-question"><%= t("state_file.questions.retirement_income.edit.box16_html") %></span>
-    <p class="text-25 spacing-below-0">$<%= @state_file1099_r.state_distribution_amount %></p>
-  </div>
-
+  </dl>
   <%= link_to t('general.continue'), questions_income_review_path(return_to_review: params[:return_to_review]), class: "button button--primary button--wide text--centered" %>
 <% end %>

--- a/app/views/state_file/questions/w2/edit.html.erb
+++ b/app/views/state_file/questions/w2/edit.html.erb
@@ -51,7 +51,7 @@
           <%= f.vita_min_money_field(:local_income_tax_amount, t(".box19_html"), classes: ["form-width--long"]) %>
         </div>
         <div class="form-question spacing-below-25 ny-w2-locality-nm">
-          <%= f.cfa_input_field(:locality_nm, t(".box20_locality_name"), classes: ["form-width--long"]) %>
+          <%= f.cfa_input_field(:locality_nm, t(".box20_locality_name_html"), classes: ["form-width--long"]) %>
         </div>
       <% end %>
     </div>

--- a/app/views/state_file/questions/w2/show.html.erb
+++ b/app/views/state_file/questions/w2/show.html.erb
@@ -1,0 +1,57 @@
+<% content_for :card do %>
+  <h1 class="form-question"><%= t("state_file.questions.w2.edit.instructions_1_html", employer: @w2.employer_name) %></h1>
+  <div class="white-group spacing-below-35">
+    <p class="text--bold spacing-below-5"><%= @w2.employee_name %></p>
+    <p class="spacing-below-25"><%= @w2.employer_name %></p>
+
+    <dl>
+      <% if @box14_codes.present? %>
+        <p class="text--small spacing-below-0"><%= t("state_file.questions.w2.edit.box14_html") %></p>
+        <ul>
+          <% @box14_codes.each do |code| %>
+            <li class="list--padded unbulleted">
+              <div class="spacing-below-25">
+                <% field_name = "box14_#{code['name'].downcase}" %>
+                <% value = if code['name'] == "UIWFSWF"
+                             @w2.get_box14_ui_overwrite
+                           else
+                             @w2.send(field_name)
+                           end %>
+                <dt><%= t("state_file.questions.w2.edit.box14_#{code['name'].downcase}_html") %></dt>
+                <dd>$<%= value %></dd>
+              </div>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+      <div class="spacing-below-25">
+        <dt><%= t("state_file.questions.w2.edit.box15_html") %></dt>
+        <dd><%= @w2.employer_state_id_num %></dd>
+      </div>
+      <div class="spacing-below-25">
+        <dt><%= t("state_file.questions.w2.edit.box16_html") %></dt>
+        <dd>$<%= @w2.state_wages_amount %></dd>
+      </div>
+      <div class="spacing-below-25">
+        <dt><%= t("state_file.questions.w2.edit.box17_html") %></dt>
+        <dd>$<%= @w2.state_income_tax_amount %></dd>
+      </div>
+      <% if StateFile::StateInformationService.w2_include_local_income_boxes(current_state_code) %>
+        <div class="spacing-below-25">
+          <dt><%= t("state_file.questions.w2.edit.box18_html") %></dt>
+          <dd>$<%= @w2.local_wages_and_tips_amount %></dd>
+        </div>
+        <div class="spacing-below-25">
+          <dt><%= t("state_file.questions.w2.edit.box19_html") %></dt>
+          <dd>$<%= @w2.local_income_tax_amount %></dd>
+        </div>
+        <div class="spacing-below-25">
+          <dt><%= t("state_file.questions.w2.edit.box20_locality_name_html") %></dt>
+          <dd><%= @w2.locality_nm %></dd>
+        </div>
+      <% end %>
+    </dl>
+  </div>
+
+  <%= link_to t('general.continue'), questions_income_review_path(return_to_review: params[:return_to_review]), class: "button button--primary button--wide text--centered" %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4316,7 +4316,7 @@ en:
           box17_html: "<strong>Box 17,</strong> State income tax"
           box18_html: "<strong>Box 18,</strong> Local wages, tips, etc."
           box19_html: "<strong>Box 19,</strong> Local income tax"
-          box20_locality_name: "<strong>Box 20,</strong> Locality name"
+          box20_locality_name_html: "<strong>Box 20,</strong> Locality name"
           employer_state_id_error: EIN cannot be more than 16 characters.
           instructions_1_html: Please review your job (W-2) details for <strong>%{employer}</strong>
           local_income_tax_amt_error: Cannot be greater than local wages and tips.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4302,7 +4302,7 @@ es:
           box17_html: "<strong>Casilla 17</strong>, Impuesto estatal sobre los ingresos"
           box18_html: "<strong>Box 18,</strong> Local wages, tips, etc."
           box19_html: "<strong>Box 19,</strong> Local income tax"
-          box20_locality_name: "<strong>Box 20,</strong> Locality name"
+          box20_locality_name_html: "<strong>Box 20,</strong> Locality name"
           employer_state_id_error: El EIN no puede tener más de 16 caracteres.
           instructions_1_html: Por favor revisa los detalles de tu trabajo (W-2) para <strong>%{employer}</strong>
           local_income_tax_amt_error: No puede ser mayor que los salarios y propinas locales.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -608,7 +608,7 @@ Rails.application.routes.draw do
 
       match("/questions/pending-federal-return", action: :edit, controller: "state_file/questions/pending_federal_return", via: :get)
       match("/questions/pending_federal_return", action: :edit, controller: "state_file/questions/pending_federal_return", via: :get)
-      resources :w2, only: [:edit, :update], module: 'state_file/questions', path: 'questions/w2'
+      resources :w2, only: [:show, :edit, :update], module: 'state_file/questions', path: 'questions/w2'
 
       active_state_codes.each do |code|
         navigation_class = StateFile::StateInformationService.navigation_class(code)


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1874
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Added a w2 show page and link to it from the income review page on states that don't allow w2 editing (only NC right now)
- Edited the recently-added 1099-R to more closely match its designs, using the same semantic html structure as the w2 show page 
- I used [`<dl>, <dt>, <dd>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl) for the show pages' HTML, as this was the closest I could fine to a "right answer" on how to structure read-only labeled numerical/textual data in a way that would be interpreted correctly by accessibility tools. I tried it out with a screen reader and, at least on mac, it didn't seem to have any benefit over just putting everything in `<p>` tags, but maybe it's better in some way I don't know how to assess. Typical accessibility tools like `<label>` and `aria-labeledby` are only available on input elements, so I couldn't use those unless I changed the HTML to use readonly input fields instead of normal tags, which I felt was not the intent of the page.
## How to test?
- Go through the NC flow for a persona with some w2s and verify that they show up on the income review page, can be clicked and that doing so goes to a non-interactive page where the w2 info can be viewed, and that the continue and back buttons work as expected
- Verify that the 1099-R show pages in NC still work
- Try adding `/edit` to the URL of a w2 page while going through the NC flow and verify that it redirects you to the income review page
## Screenshots (for visual changes)
### Income Review
#### Before
<img width="988" alt="image" src="https://github.com/user-attachments/assets/8d552584-7efe-4b37-963a-df6e6fb0e25a" />

#### After
<img width="964" alt="image" src="https://github.com/user-attachments/assets/11ce16e8-d4a8-4d23-a260-bb98cff27164" />

### W2 show screen
<img width="946" alt="image" src="https://github.com/user-attachments/assets/0ddb03d9-8391-4c2f-86a1-4b8237b79a7d" />
