### PR TITLE
NJ 302 - round w2 state wages sum for line 15

### DIFF
--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -230,9 +230,7 @@ module Efile
       end
 
       def calculate_line_10_count
-        @intake.dependents.count do |dependent|
-          dependent.qualifying_child
-        end
+        @intake.dependents.count(&:qualifying_child)
       end
 
       def calculate_line_10_exemption
@@ -310,9 +308,7 @@ module Efile
       end
 
       def calculate_line_15
-        @intake.state_file_w2s.sum do |w2|
-          w2.state_wages_amount.to_i
-        end
+        @intake.state_file_w2s.sum(&:state_wages_amount).round
       end
 
       def calculate_line_16a

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -478,6 +478,14 @@ describe Efile::Nj::Nj1040Calculator do
         expected_sum = 50000 + 50000 + 50000 + 50000
         expect(instance.lines[:NJ1040_LINE_15].value).to eq(expected_sum)
       end
+
+      it "rounds to nearest whole number" do
+        w2 = intake.state_file_w2s.first
+        w2.update_attribute(:state_wages_amount, 50000.51)
+        instance.calculate
+        expected = 200_001 # 50000.51 + 50000 + 50000 + 50000
+        expect(instance.lines[:NJ1040_LINE_15].value).to eq expected
+      end
     end
   end
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/302

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Round the calculation for line 15

## How to test?
- use any persona with multiple W2s [ex. Superman]
- on one W2, update Box 16 W2 amount to be 15000.75
- on the second W2, update box 16 W2 amount to be 10001
- Expected Outcomes: Line 15 wages is 15000.75 + 10001 = 25,001.75, which rounds to 25,002

## Screenshots (for visual changes)
![image](https://github.com/user-attachments/assets/5440532d-ece4-4751-a471-9ad305153d5b)
![image](https://github.com/user-attachments/assets/0919af7d-c55b-4852-bf2c-d0dd66908b0e)
