### PR TITLE
[FYST-1715] NC County: Update error message if no county selected

### DIFF
--- a/app/forms/state_file/nc_county_form.rb
+++ b/app/forms/state_file/nc_county_form.rb
@@ -2,12 +2,12 @@ module StateFile
   class NcCountyForm < QuestionsForm
     set_attributes_for :intake, :residence_county, :moved_after_hurricane_helene, :county_during_hurricane_helene
 
-    validates :residence_county, presence: true, inclusion: { in: StateFileNcIntake::COUNTIES.keys }
+    validates :residence_county, inclusion: { in: StateFileNcIntake::COUNTIES.keys, message: I18n.t("forms.errors.nc_county.county.presence") }
     with_options unless: -> { NcResidenceCountyConcern.designated_hurricane_county?(residence_county) } do
       validates :moved_after_hurricane_helene, presence: true
     end
     with_options if: -> { moved_after_hurricane_helene == "yes" } do
-      validates :county_during_hurricane_helene, presence: true, inclusion: { in: StateFileNcIntake::COUNTIES.keys }
+      validates :county_during_hurricane_helene, inclusion: { in: StateFileNcIntake::COUNTIES.keys,  message: I18n.t("forms.errors.nc_county.county.presence") }
     end
 
     def save

--- a/app/forms/state_file/nc_county_form.rb
+++ b/app/forms/state_file/nc_county_form.rb
@@ -7,7 +7,7 @@ module StateFile
       validates :moved_after_hurricane_helene, presence: true
     end
     with_options if: -> { moved_after_hurricane_helene == "yes" } do
-      validates :county_during_hurricane_helene, inclusion: { in: StateFileNcIntake::COUNTIES.keys,  message: I18n.t("forms.errors.nc_county.county.presence") }
+      validates :county_during_hurricane_helene, inclusion: { in: StateFileNcIntake::COUNTIES.keys, message: I18n.t("forms.errors.nc_county.county.presence") }
     end
 
     def save

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -265,6 +265,9 @@ en:
           presence: Please select a county
         subdivision_code:
           presence: Please select a political subdivision
+      nc_county:
+        county:
+          presence: Please select a county
       nc_eligibility_form:
         at_most_one_option_selected: You must either select none or the above options
       need_exactly_one_communication_method: Please enter only one form of contact.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -265,6 +265,9 @@ es:
           presence: Por favor seleccione un condado
         subdivision_code:
           presence: Por favor seleccione una subdivisión política
+      nc_county:
+        county:
+          presence: Por favor seleccione un condado
       nc_eligibility_form:
         at_most_one_option_selected: Debe seleccionar ninguna o las opciones anteriores.
       need_exactly_one_communication_method: Ingrese solo una forma de contacto.

--- a/spec/forms/state_file/nc_county_form_spec.rb
+++ b/spec/forms/state_file/nc_county_form_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe StateFile::NcCountyForm, type: :model do
 
-  describe "simple validations" do
+  describe "residence_county validations" do
     let(:intake) { create :state_file_nc_intake }
     let(:form) { described_class.new(intake, params) }
     let(:params) {
@@ -10,14 +10,14 @@ RSpec.describe StateFile::NcCountyForm, type: :model do
     }
     let(:residence_county) { nil }
 
-    context "when resident_county is not provided" do
+    context "when residence_county is not provided" do
       it "is invalid" do
         expect(form.valid?).to be false
         expect(form.errors[:residence_county]).to eq([I18n.t("forms.errors.nc_county.county.presence")])
       end
     end
 
-    context "when resident_county is not included" do
+    context "when residence_county is not included" do
       let(:residence_county) { "120" }
       it "is invalid" do
         expect(form.valid?).to be false
@@ -25,7 +25,7 @@ RSpec.describe StateFile::NcCountyForm, type: :model do
       end
     end
 
-    context "when resident_county is included and provided" do
+    context "when residence_county is included and provided" do
       let(:residence_county) { "003" }
       it "is valid" do
         expect(form.valid?).to be true

--- a/spec/forms/state_file/nc_county_form_spec.rb
+++ b/spec/forms/state_file/nc_county_form_spec.rb
@@ -3,8 +3,34 @@ require 'rails_helper'
 RSpec.describe StateFile::NcCountyForm, type: :model do
 
   describe "simple validations" do
-    it { should validate_presence_of :residence_county }
-    it { should validate_inclusion_of(:residence_county).in_array(StateFileNcIntake::COUNTIES.keys) }
+    let(:intake) { create :state_file_nc_intake }
+    let(:form) { described_class.new(intake, params) }
+    let(:params) {
+      { residence_county: residence_county }
+    }
+    let(:residence_county) { nil }
+
+    context "when resident_county is not provided" do
+      it "is invalid" do
+        expect(form.valid?).to be false
+        expect(form.errors[:residence_county]).to eq([I18n.t("forms.errors.nc_county.county.presence")])
+      end
+    end
+
+    context "when resident_county is not included" do
+      let(:residence_county) { "120" }
+      it "is invalid" do
+        expect(form.valid?).to be false
+        expect(form.errors[:residence_county]).to eq([I18n.t("forms.errors.nc_county.county.presence")])
+      end
+    end
+
+    context "when resident_county is included and provided" do
+      let(:residence_county) { "003" }
+      it "is valid" do
+        expect(form.valid?).to be true
+      end
+    end
   end
 
   describe "#save" do
@@ -54,6 +80,7 @@ RSpec.describe StateFile::NcCountyForm, type: :model do
             intake = create(:state_file_nc_intake)
             form = described_class.new(intake, params)
             expect(form.valid?).to be false
+            expect(form.errors[:county_during_hurricane_helene]).to eq([I18n.t("forms.errors.nc_county.county.presence")])
           end
         end
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1715
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Copied implementation from MD County selection
- Removed `presence` check which had its built-in "can't be blank" error message
- Since `nil` or `""` is not included in the list of counties, it'll be able to use the new message. There is no way that a user could send an invalid county param (besides sending an API request built manually somehow?) but if they did, they would get the same error
## How to test?
- Describe the testing approach taken to verify the changes, including:
  - Unit tests
  - Test data used: Any NC persona should work
## Screenshots (for visual changes)
- Before
![image](https://github.com/user-attachments/assets/91c4b8a2-e0c8-4532-8270-a2ac2fa19ee1)

- After
<img width="653" alt="Screenshot 2025-03-07 at 10 38 17 AM" src="https://github.com/user-attachments/assets/f9daee65-d3e9-4097-a95f-d3b3a7ad6ead" />

<img width="674" alt="Screenshot 2025-03-07 at 10 02 17 AM" src="https://github.com/user-attachments/assets/806637e5-f229-49e5-9b3b-f192e263efdb" />
