### PR TITLE
NJ 235 - fix calculator negative value bug

### DIFF
--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -360,7 +360,7 @@ module Efile
       end
 
       def calculate_line_29
-        line_or_zero(:NJ1040_LINE_27) - line_or_zero(:NJ1040_LINE_28C)
+        [line_or_zero(:NJ1040_LINE_27) - line_or_zero(:NJ1040_LINE_28C), 0].max
       end
 
       def calculate_line_31
@@ -376,7 +376,7 @@ module Efile
       end
 
       def calculate_line_39
-        line_or_zero(:NJ1040_LINE_29) - line_or_zero(:NJ1040_LINE_38)
+        [line_or_zero(:NJ1040_LINE_29) - line_or_zero(:NJ1040_LINE_38), 0].max
       end
 
       def is_ineligible_or_unsupported_for_property_tax_credit
@@ -659,9 +659,7 @@ module Efile
 
       def calculate_line_80
         if line_or_zero(:NJ1040_LINE_68).positive?
-          # Line 78 is always 0 now
-          # When implemented we will have to make sure this doesn't become negative
-          return line_or_zero(:NJ1040_LINE_68) - line_or_zero(:NJ1040_LINE_78)
+          return [line_or_zero(:NJ1040_LINE_68) - line_or_zero(:NJ1040_LINE_78), 0].max
         end
         0
       end

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -724,19 +724,17 @@ describe Efile::Nj::Nj1040Calculator do
   describe 'line 29 - gross income' do
     let(:intake) { create(:state_file_nj_intake) }
 
-    it 'sets line 29 to the sum of all state wage amounts minus 28c' do
-      allow(instance).to receive(:calculate_line_15).and_return 50_000
-      allow(instance).to receive(:calculate_line_16a).and_return 1_000
-      allow(instance).to receive(:calculate_line_28c).and_return 3_000
+    it 'sets line 29 to line 27 minus line 28c' do
+      allow(instance).to receive(:calculate_line_27).and_return 3_000
+      allow(instance).to receive(:calculate_line_28c).and_return 1_000
       instance.calculate
-      expect(instance.lines[:NJ1040_LINE_29].value).to eq(48_000)
+      expect(instance.lines[:NJ1040_LINE_29].value).to eq(2_000)
     end
 
-    context 'when 28c is larger than 29' do
+    context 'when 28c is larger than line 27' do
       it 'sets line 29 to zero' do
-        allow(instance).to receive(:calculate_line_15).and_return 1_000
-        allow(instance).to receive(:calculate_line_16a).and_return 1_000
-        allow(instance).to receive(:calculate_line_28c).and_return 2_001
+        allow(instance).to receive(:calculate_line_27).and_return 1_000
+        allow(instance).to receive(:calculate_line_28c).and_return 1_001
         instance.calculate
         expect(instance.lines[:NJ1040_LINE_29].value).to eq(0)
       end

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -731,6 +731,16 @@ describe Efile::Nj::Nj1040Calculator do
       instance.calculate
       expect(instance.lines[:NJ1040_LINE_29].value).to eq(48_000)
     end
+
+    context 'when 28c is larger than 29' do
+      it 'sets line 29 to zero' do
+        allow(instance).to receive(:calculate_line_15).and_return 1_000
+        allow(instance).to receive(:calculate_line_16a).and_return 1_000
+        allow(instance).to receive(:calculate_line_28c).and_return 2_001
+        instance.calculate
+        expect(instance.lines[:NJ1040_LINE_29].value).to eq(0)
+      end
+    end
   end
 
   describe 'line 31 - medical expenses' do
@@ -800,6 +810,15 @@ describe Efile::Nj::Nj1040Calculator do
     it 'sets line 39 to line 29 gross income minus line 38 total exemptions/deductions' do
       expected_total = instance.lines[:NJ1040_LINE_29].value - instance.lines[:NJ1040_LINE_38].value
       expect(instance.lines[:NJ1040_LINE_39].value).to eq(expected_total)
+    end
+
+    context 'when line 38 is larger than line 29' do
+      it 'sets line 39 to zero' do
+        allow(instance).to receive(:calculate_line_29).and_return 1_000
+        allow(instance).to receive(:calculate_line_38).and_return 1_001
+        instance.calculate
+        expect(instance.lines[:NJ1040_LINE_39].value).to eq(0)
+      end
     end
   end
 
@@ -2428,6 +2447,15 @@ describe Efile::Nj::Nj1040Calculator do
       allow(instance).to receive(:calculate_line_78).and_return 10
       instance.calculate
       expect(instance.lines[:NJ1040_LINE_80].value).to eq(20)
+    end
+
+    context 'when line 78 is larger than line 68' do
+      it 'sets line 80 to zero' do
+        allow(instance).to receive(:calculate_line_68).and_return 1_000
+        allow(instance).to receive(:calculate_line_78).and_return 1_001
+        instance.calculate
+        expect(instance.lines[:NJ1040_LINE_80].value).to eq(0)
+      end
     end
   end
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://github.com/newjersey/affordability-pm/issues/235#issue-2763737917

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Problem reported was that review screen contained a negative value for "NJ taxable income" (see screenshot)
- Looked in the calculator and we were allowing negative values for many of the subtractions.
- Added checks for all subtraction calculations in the NJ calculator. If line value was negative, set it to zero instead

## How to test?
- Use Eastern Goldfinch persona continue to end of the flow and look at NJ taxable income on the review screen


## Screenshots (for visual changes)
- Before
![image](https://github.com/user-attachments/assets/4e43bea7-5b9e-4b9b-93d9-ac9cdcdd03a0)

- After
![image](https://github.com/user-attachments/assets/93f2146f-03b9-48ad-af34-899c790a90f8)
