### PR TITLE
[FYST-1709] Incorrect SMS verification code causes phone number to disappear

### DIFF
--- a/app/controllers/state_file/intake_logins_controller.rb
+++ b/app/controllers/state_file/intake_logins_controller.rb
@@ -17,6 +17,7 @@ module StateFile
       if @form.valid?
         intake_classes = client_login_service.intake_classes
         @records = intake_classes.map { |intake_class| @form.filter_records(intake_class) }.flatten
+
         if @records.blank?
           @form.errors.add(@contact_method, I18n.t("state_file.intake_logins.new.#{@contact_method}.not_found_html"))
           render :new and return

--- a/app/controllers/state_file/questions/verification_code_controller.rb
+++ b/app/controllers/state_file/questions/verification_code_controller.rb
@@ -39,6 +39,7 @@ module StateFile
           track_question_answer
           redirect_to(next_path)
         else
+          @contact_info = params[:state_file_verification_code_form][:contact_info]
           after_update_failure
           track_validation_error
           render :edit

--- a/app/controllers/state_file/questions/verification_code_controller.rb
+++ b/app/controllers/state_file/questions/verification_code_controller.rb
@@ -39,7 +39,7 @@ module StateFile
           track_question_answer
           redirect_to(next_path)
         else
-          @contact_info = params[:state_file_verification_code_form][:contact_info]
+          @contact_info = params.dig(:state_file_verification_code_form, :contact_info)
           after_update_failure
           track_validation_error
           render :edit

--- a/app/views/state_file/questions/verification_code/edit.html.erb
+++ b/app/views/state_file/questions/verification_code/edit.html.erb
@@ -4,8 +4,9 @@
   <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
     <h1 class="h2" id="main-question"><%= title %></h1>
     <p><%= t(".subtitle_html") %></p>
+    <%= f.hidden_field(:contact_info, value: @contact_info) %>
     <div class="white-group">
-        <%= f.cfa_input_field(:verification_code, t(".verification_code_label"), classes: ["form-width--long"]) %>
+      <%= f.cfa_input_field(:verification_code, t(".verification_code_label"), classes: ["form-width--long"]) %>
     </div>
     <%= f.submit t(".action"), class: "button button--primary button--wide spacing-below-15"%>
   <% end %>

--- a/spec/controllers/state_file/questions/verification_code_controller_spec.rb
+++ b/spec/controllers/state_file/questions/verification_code_controller_spec.rb
@@ -119,5 +119,19 @@ RSpec.describe StateFile::Questions::VerificationCodeController do
         expect(response).to redirect_to(questions_code_verified_path)
       end
     end
+
+    context "with an invalid form" do
+      let(:intake) { create(:state_file_az_intake, contact_preference: "email", email_address: "someone@example.com", visitor_id: "v1s1t1n9") }
+
+      it "renders the edit page" do
+        post :update, params: { state_file_verification_code_form: { verification_code: "invalid" }}
+        expect(response).to render_template(:edit)
+      end
+
+      it "sets @contact_info to the contact info" do
+        post :update, params: { state_file_verification_code_form: { verification_code: "invalid", contact_info: "someone@example.com" }}
+        expect(assigns(:contact_info)).to eq "someone@example.com"
+      end
+    end
   end
 end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/FYST-1709

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Submit and pass back contact info when there is an error verifying login code. Contact info is displayed as phone number on the error page
## How to test?
- Attempt to log in with sms
- enter an incorrect code
- verify phone number is still present

## Screenshots (for visual changes)
<img width="627" alt="Screenshot 2025-03-10 at 12 30 16 PM" src="https://github.com/user-attachments/assets/f99581b5-6dd5-4db7-820b-750b1a5235ee" />
