### PR TITLE
Fyst 1905 md disability proof not saving correctly

### DIFF
--- a/app/controllers/state_file/questions/md_pension_exclusion_offboarding_controller.rb
+++ b/app/controllers/state_file/questions/md_pension_exclusion_offboarding_controller.rb
@@ -3,7 +3,7 @@ module StateFile
     class MdPensionExclusionOffboardingController < QuestionsController
       include OtherOptionsLinksConcern
       def self.show?(intake)
-        Flipper.enabled?(:show_retirement_ui) && intake.filing_status_mfj? && intake.state_file1099_rs.present? && intake.has_filer_under_65? && intake.filer_disabled? && intake.no_proof_of_disability_submitted?
+        Flipper.enabled?(:show_retirement_ui) && intake.state_file1099_rs.present? && intake.has_filer_under_65? && intake.filer_disabled? && intake.no_proof_of_disability_submitted?
       end
     end
   end

--- a/app/views/state_file/questions/md_permanently_disabled/edit.html.erb
+++ b/app/views/state_file/questions/md_permanently_disabled/edit.html.erb
@@ -35,20 +35,10 @@
 
       <div class="question-with-follow-up__follow-up" id="primary-disability-proof">
         <div class="white-group">
-          <div class="question-with-follow-up">
-            <div class="question-with-follow-up__question">
-                <% show_disability_warning =  !current_intake.filing_status_mfj? ? "#disability-warning" : nil %>
-                <%= f.cfa_radio_set(:primary_proof_of_disability_submitted, label_text: t(".primary_proof_question_html"), collection: [
-                  { value: "yes", label: t("general.affirmative") },
-                  { value: "no", label: t("general.negative"), input_html: { "data-follow-up": show_disability_warning }},
-                ]) %>
-              </div>
-            <div class="question-with-follow-up__follow-up" id="disability-warning">
-                <div class="notice">
-                  <p><%= t(".unfortunately_dont_support_html", path: questions_md_pension_exclusion_offboarding_path) %></p>
-                </div>
-              </div>
-          </div>
+          <%= f.cfa_radio_set(:primary_proof_of_disability_submitted, label_text: t(".primary_proof_question_html"), collection: [
+            { value: "yes", label: t("general.affirmative") },
+            { value: "no", label: t("general.negative") },
+          ]) %>
         </div>
       </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3221,7 +3221,6 @@ en:
           spouse_proof_question_html: Has <strong>your spouse</strong> provided proof of your disability for the  <a href="https://www.marylandtaxes.gov/individual/income/filing/pension-exclusion.php">Maryland Pension Exclusion</a> in the previous tax years?
           title: Are you totally and permanently disabled?
           title_spouse: Are you or your spouse totally and permanently disabled?
-          unfortunately_dont_support_html: Unfortunately, our service doesn’t support the Maryland Pension Exclusion if you haven’t provided proof of your disability in a previous tax year.<br><br> If you want to claim the pension exclusion, <a href='%{path}'>learn more here</a>.
           why: Why are you asking this?
           why_explained_1: The Maryland Pension Exclusion can save you hundreds to thousands of dollars in state and local taxes by reducing your taxable retirement income. If you are over 65, you automatically qualify for the pension exclusion.
           why_explained_2_html: If you are under 65 and want to claim the pension exclusion, you <strong>must have attached a certification from a qualified physician stating the nature of your impairment and that you are totally disabled to a previously filed tax return</strong>.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3191,7 +3191,6 @@ es:
           spouse_proof_question_html: ¿Ha presentado prueba de <strong>tu cónyuge</strong> discapacidad para <a href="https://www.marylandtaxes.gov/individual/income/filing/pension-exclusion.php">la Exclusión de Pensiones de Maryland </a> en años fiscales anteriores?
           title: "¿Estás total y permanentemente discapacitado?"
           title_spouse: "¿Tú o tu cónyuge están total y permanentemente discapacitados?"
-          unfortunately_dont_support_html: Desafortunadamente, nuestro servicio no puede incluir la Exclusión de Pensiones de Maryland si no has presentado prueba de tu discapacidad en un año fiscal anterior.<br><br> Si quieres reclamar la exclusión de pensiones, <a href='%{path}'>obtén más información aquí</a>.
           why: "¿Por qué están preguntando esto?"
           why_explained_1: La Exclusión de Pensiones de Maryland puede ahorrarte cientos a miles de dólares en impuestos estatales y locales al reducir la cantidad de impuestos que deberás pagar de tus ingresos de jubilación. Si tú tienen más de 65 años, califican automáticamente para la exclusión de pensiones.
           why_explained_2_html: Si tú tienen menos de 65 años y deseas reclamar la exclusión de pensiones utilizando este servicio, tú haber <strong>adjuntado una certificación de un médico calificado que indique la naturaleza de su discapacidad y que tú estén totalmente discapacitados a una declaración de impuestos presentada anteriormente</strong>.

--- a/spec/controllers/state_file/questions/md_pension_exclusion_offboarding_controller_spec.rb
+++ b/spec/controllers/state_file/questions/md_pension_exclusion_offboarding_controller_spec.rb
@@ -1,103 +1,67 @@
 require "rails_helper"
 
 RSpec.describe StateFile::Questions::MdPensionExclusionOffboardingController do
-  let(:intake) { create(:state_file_md_intake, :with_spouse) }
-  let!(:state_file1099_r) { create(:state_file1099_r, intake: intake) }
-
-  before do
-    allow(Flipper).to receive(:enabled?).and_call_original
-    allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)
-  end
 
   describe "#show?" do
-    context "when they have no 1099Rs in their DF XML" do
-      before { allow(intake).to receive(:state_file1099_rs).and_return([]) }
+    [:single, :married_filing_jointly].each do |filing_status|
+      context "filing status #{filing_status}" do
+        context "when all conditions are met" do
+          let(:intake) { create(:state_file_md_intake) }
+          let!(:state_file1099_r) { create(:state_file1099_r, intake: intake) }
 
-      it "does not show" do
-        expect(described_class.show?(intake)).to eq false
-      end
-    end
-
-    context "not mfj" do
-      let(:intake) { create(:state_file_md_intake) }
-
-      it "does not show" do
-        expect(described_class.show?(intake)).to eq false
-      end
-    end
-
-    context "when they have 1099Rs in their DF XML" do
-      context "when a filer is disabled" do
-        before do
-          allow(intake).to receive(:filer_disabled?).and_return(true)
-        end
-        context "has a disabled filer under 65" do
           before do
+            allow(Flipper).to receive(:enabled?).and_call_original
+            allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)
+
+            allow(intake).to receive(:filing_status).and_return(filing_status)
+            allow(intake).to receive(:filer_disabled?).and_return(true)
             allow(intake).to receive(:has_filer_under_65?).and_return(true)
+            allow(intake).to receive(:no_proof_of_disability_submitted?).and_return(true)
           end
 
-          context "has no proof of disability" do
-            before do
-              allow(intake).to receive(:no_proof_of_disability_submitted?).and_return(true)
-            end
-
-            it "shows" do
-              expect(described_class.show?(intake)).to eq true
-            end
+          it "shows" do
+            expect(described_class.show?(intake)).to eq true
           end
 
-          context "has proof of disability" do
-            before do
-              allow(intake).to receive(:no_proof_of_disability_submitted?).and_return(false)
-            end
+          context "except the flipper flag is not set to true" do
+            before { allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(false) }
 
-            it "shows" do
-              expect(described_class.show?(intake)).to eq false
-            end
-          end
-        end
-
-        context "does not have a filer under 65" do
-          before do
-            allow(intake).to receive(:has_filer_under_65?).and_return(false)
-          end
-
-          context "has no proof of disability" do
-            before do
-              allow(intake).to receive(:no_proof_of_disability_submitted?).and_return(true)
-            end
-
-            it "shows" do
+            it "does not show" do
               expect(described_class.show?(intake)).to eq false
             end
           end
 
-          context "has proof of disability" do
-            it "shows" do
+          context "except filer is not disabled" do
+            before { allow(intake).to receive(:filer_disabled?).and_return(false) }
+
+            it "does not show" do
               expect(described_class.show?(intake)).to eq false
             end
           end
-        end
-      end
 
-      context "when no filers are disabled" do
-        before do
-          allow(intake).to receive(:filer_disabled?).and_return(false)
-        end
+          context "except no filer is under 65" do
+            before { allow(intake).to receive(:has_filer_under_65?).and_return(false) }
 
-        it "shows" do
-          expect(described_class.show?(intake)).to eq false
-        end
-      end
+            it "does not show" do
+              expect(described_class.show?(intake)).to eq false
+            end
+          end
 
-      context "when the flipper flag is not enabled " do
-        before do
-          allow(Flipper).to receive(:enabled?).and_call_original
-          allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(false)
-        end
+          context "except proof of disability has been submitted for all disabled filers" do
+            before { allow(intake).to receive(:no_proof_of_disability_submitted?).and_return(false) }
 
-        it "shows" do
-          expect(described_class.show?(intake)).to eq false
+            it "does not show" do
+              expect(described_class.show?(intake)).to eq false
+            end
+          end
+
+          context "except there are no 1099-Rs" do
+            before { allow(intake).to receive(:state_file1099_rs).and_return([]) }
+
+            it "does not show" do
+              expect(described_class.show?(intake)).to eq false
+            end
+          end
         end
       end
     end

--- a/spec/controllers/state_file/questions/md_permanently_disabled_controller_spec.rb
+++ b/spec/controllers/state_file/questions/md_permanently_disabled_controller_spec.rb
@@ -150,7 +150,6 @@ RSpec.describe StateFile::Questions::MdPermanentlyDisabledController do
             html = Nokogiri::HTML.parse(response.body)
 
             expect(html.at_css("input[data-follow-up='#primary-disability-proof']")).to be_present
-            expect(html.to_s).to include('data-follow-up="#disability-warning"')
             expect(html.at_css("input[data-follow-up='#spouse-disability-proof']")).not_to be_present
             expect(html.at_css("input[data-follow-up='#both-disability-proof']")).not_to be_present
           end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1905
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- When users clicked through to the softboarding page, any selections they had made on the `md-permanently-disabled` page were discarded because they never clicked Continue to submit the form.
- This removes the warning box (and the included link to the softboarding page), and instead makes non-mfj filers go through the same flow as mfj filers, where the softboarding page is shown after the `md-permanently-disabled` page if they satisfy the conditions (filer under 65, permanently disabled, no proof of disability submitted)
- Alternatives considered were to submit the form when clicking the link to the softboarding page, but I estimated that would be more awkward to implement
## How to test?
- Several of the examples in the `md_pension_exclusion_offboarding_controller_spec` controller test weren't actually testing anything (in that you could change their `before` or `let` expressions to set the opposite value and the tests would still pass. To address this, I changed the test so that it sets all necessary preconditions for the page to show, verifies that it does show, and then verifies that it doesn't show when each of the preconditions is individually set to false.
## Screenshots (for visual changes)
- Before
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/062e2c53-494b-4507-8762-6cb3f89227f7" />

- After
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/6a278405-1b71-44f4-b901-43047c5f6e48" />