### PR TITLE
NJ 274 - a11y fix, buttons have role link

### DIFF
--- a/app/helpers/vita_min_form_builder.rb
+++ b/app/helpers/vita_min_form_builder.rb
@@ -478,6 +478,7 @@ class VitaMinFormBuilder < Cfa::Styleguide::CfaFormBuilder
   def submit(value, options = {})
     options[:data] ||= {}
     options[:data][:disable_with] = value
+    options[:role] = "link"
     super(value, **options)
   end
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/274#issue-2813739879

## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Fix to be compliant with [WCAG 3.2.4: Consistent Identification (Level AA)](https://w3.org/TR/WCAG21#consistent-identification) 
- Currently, we use button styling for both links and buttons. This can be confusing to users, as it's unclear that the "Submit" and "Continue" buttons will take them to the next page when they are coded as `button` elements rather than `a` elements

```
<a
    class="button button--primary button--wide" 
    id="firstCta" href="/en/questions/contact-preference">
    Continue
</a>
```
and

```
<input 
    type="submit" name="commit" 
    value="Continue" 
    class="button button--primary button--wide" 
    data-disable-with="Continue">
```

While one way to solve this is to change all Continue and Submit buttons to <a> tags, but that felt too disruptive to a code-base of this size. Instead, I implemented the alternate solution of using the `role="link"` attribute to input/button elements to signify that the button will link out to a different page. I did this by modifying the shared component in the VitaMin form builder library.

## How to test?
- navigate to `notifications-preference` screen or any screen with a continue or submit button that takes you to the next page and inspect HTML to validate that there is now a `role="link"` attribute on any input element.

## Screenshots (for visual changes)
- Before
<img width="1511" alt="image" src="https://github.com/user-attachments/assets/20861641-6f53-4df6-b4ef-8c4aee424f92" />

- After (role attribute on the input element)
<img width="1506" alt="image" src="https://github.com/user-attachments/assets/9be23547-2c2b-4117-9f95-6315c638e048" />
