### PR TITLE
GYR1-698 Team Assignment module display

### DIFF
--- a/app/presenters/hub/dashboard/team_assignment_presenter.rb
+++ b/app/presenters/hub/dashboard/team_assignment_presenter.rb
@@ -32,20 +32,15 @@ module Hub
 
         @user_count = accessible_users_by_role.count
 
-        accessible_users_by_role.paginate(page: @page, per_page: 5)
+        ordered_users = accessible_users_by_role
+                            .select('users.*, COUNT(tax_returns.id) AS tax_returns_count')
+                            .left_joins(assigned_tax_returns: :client)
+                            .group('users.id, users.name, users.role_type')
+                            .order('tax_returns_count DESC')
+                            .where('clients.filterable_product_year = :product_year OR clients.id IS NULL', product_year: Rails.configuration.product_year)
+
+        ordered_users.paginate(page: @page, per_page: 5)
       end
-
-      def ordered_by_tr_count_users
-        return unless team_assignment_users.present?
-
-        team_assignment_users
-          .select('users.*, COUNT(tax_returns.id) AS tax_returns_count')
-          .left_joins(assigned_tax_returns: :client)
-          .group('users.id, users.name, users.role_type')
-          .order('tax_returns_count DESC')
-          .where('clients.filterable_product_year = :product_year OR clients.id IS NULL', product_year: Rails.configuration.product_year)
-      end
-
     end
   end
 end

--- a/app/presenters/hub/dashboard/team_assignment_presenter.rb
+++ b/app/presenters/hub/dashboard/team_assignment_presenter.rb
@@ -33,11 +33,10 @@ module Hub
         @user_count = accessible_users_by_role.count
 
         ordered_users = accessible_users_by_role
-                            .select('users.*, COUNT(tax_returns.id) AS tax_returns_count')
+                            .select("users.*, COUNT(CASE WHEN clients.filterable_product_year = '#{Rails.configuration.product_year}' THEN tax_returns.id ELSE NULL END) AS tax_returns_count")
                             .left_joins(assigned_tax_returns: :client)
                             .group('users.id, users.name, users.role_type')
                             .order('tax_returns_count DESC')
-                            .where('clients.filterable_product_year = :product_year OR clients.id IS NULL', product_year: Rails.configuration.product_year)
 
         ordered_users.paginate(page: @page, per_page: 5)
       end

--- a/app/views/hub/dashboard/_team_assignment_content.html.erb
+++ b/app/views/hub/dashboard/_team_assignment_content.html.erb
@@ -1,6 +1,5 @@
 <% p = presenter.team_assignment_presenter %>
-<% users = p.team_assignment_users %>
-<% ordered_users = p.ordered_by_tr_count_users %>
+<% ordered_users = p.team_assignment_users %>
   <h2><%= t("hub.dashboard.show.team_assignment.title") %></h2>
 
   <table>
@@ -41,14 +40,14 @@
     </tbody>
   </table>
 
-  <% if users.present? %>
+  <% if ordered_users.present? %>
     <div class="paging">
       <div class="user-count">
         <% start_user = ((p.page.to_i - 1) * 5) + 1 %>
         <% end_user = [start_user + 4, p.user_count].min %>
         <%= t("hub.dashboard.show.team_assignment.pager", start_range: start_user, end_range: end_user, total: p.user_count) %>
       </div>
-      <div><%= js_will_paginate users,
+      <div><%= js_will_paginate ordered_users,
                              previous_label: "<i class='icon icon-keyboard_arrow_left'></i><span class='hide-on-mobile'>Previous 5</span>",
                              next_label: "<span class='hide-on-mobile'>Next 5</span><i class='icon icon-keyboard_arrow_right'></i>",
                              inner_window: 0,

--- a/spec/presenters/hub/team_assignment_presenter_spec.rb
+++ b/spec/presenters/hub/team_assignment_presenter_spec.rb
@@ -34,20 +34,31 @@ describe Hub::Dashboard::TeamAssignmentPresenter do
       let(:selected_model) { coalition_lead.role.coalition }
 
       it "returns no users" do
-        expect(subject.ordered_by_tr_count_users).to eq nil
+        expect(subject.team_assignment_users).to eq nil
       end
     end
 
     context "when selecting an org" do
       it "shows org leads, team members and site coordinators belonging to selected org or child sites and their number of assigned tax returns in desc order" do
-        expect(subject.ordered_by_tr_count_users).to eq [site_coordinator, team_member, org_lead, other_team_member]
+        expect(subject.team_assignment_users).to eq [site_coordinator, team_member, org_lead, other_team_member]
       end
 
       context "when there are tax returns with archived clients" do
         it "doesn't count their tax returns" do
           create(:gyr_tax_return, assigned_user: site_coordinator, client: create(:client, filterable_product_year: 2023))
 
-          expect(subject.ordered_by_tr_count_users.first.tax_returns_count).to eq 2
+          expect(subject.team_assignment_users.first.tax_returns_count).to eq 2
+          expect(subject.team_assignment_users.first).to eq site_coordinator
+        end
+      end
+
+      context "when the team member only has archived clients" do
+        it "returns 0 for their count of tax returns" do
+          create(:gyr_tax_return, assigned_user: other_team_member, client: create(:client, filterable_product_year: 2023))
+
+          expect(subject.team_assignment_users).to eq [site_coordinator, team_member, org_lead, other_team_member]
+          expect(subject.team_assignment_users[3]).to eq other_team_member
+          expect(subject.team_assignment_users[3].tax_returns_count).to eq 0
         end
       end
 
@@ -55,7 +66,7 @@ describe Hub::Dashboard::TeamAssignmentPresenter do
         it "doesn't include them in the user group" do
           create(:user, role: (create :team_member_role, sites: [site]), suspended_at: Time.now)
 
-          expect(subject.ordered_by_tr_count_users).to eq [site_coordinator, team_member, org_lead, other_team_member]
+          expect(subject.team_assignment_users).to eq [site_coordinator, team_member, org_lead, other_team_member]
         end
       end
     end
@@ -64,7 +75,7 @@ describe Hub::Dashboard::TeamAssignmentPresenter do
       let(:selected_model) { other_org }
 
       it "doesn't show users from the other org" do
-        expect(subject.ordered_by_tr_count_users).to eq [other_org_lead, other_site_coordinator]
+        expect(subject.team_assignment_users).to eq [other_org_lead, other_site_coordinator]
       end
     end
   end
@@ -74,7 +85,7 @@ describe Hub::Dashboard::TeamAssignmentPresenter do
 
     context "when selecting an organization in the drop down" do
       it "shows team members, org leads, site coordinators under that selected org or its child sites and their number of assigned tax returns in desc order" do
-        expect(subject.ordered_by_tr_count_users).to eq [site_coordinator, team_member, org_lead, other_team_member]
+        expect(subject.team_assignment_users).to eq [site_coordinator, team_member, org_lead, other_team_member]
       end
     end
 
@@ -82,7 +93,7 @@ describe Hub::Dashboard::TeamAssignmentPresenter do
       let(:selected_model) { site }
 
       it "shows team members, org leads, site coordinators under that site or with its parent org" do
-        expect(subject.ordered_by_tr_count_users).to eq [site_coordinator, team_member, org_lead]
+        expect(subject.team_assignment_users).to eq [site_coordinator, team_member, org_lead]
       end
     end
   end
@@ -94,7 +105,7 @@ describe Hub::Dashboard::TeamAssignmentPresenter do
       let(:selected_model) { site }
 
       it "Site coordinators and team members that are assigned to selected site" do
-        expect(subject.ordered_by_tr_count_users).to eq [site_coordinator, team_member]
+        expect(subject.team_assignment_users).to eq [site_coordinator, team_member]
       end
     end
   end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/GYR1-698

## Is PM acceptance required?
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Combined methods for the teams modules presenter so the pagination and users shown are consistent
- Updated query for ordering users to no exclude users if they have a client/tax return from a prior year but instead count that older tax return as zero

## How to test?
- Updated presenter tests for the teams module in the dashboard

## Screenshots (for visual changes)
- Before
- After
