### PR TITLE
[FYST-1553] Fix links to return to a previous page which were breaking when the language is changed

### DIFF
--- a/app/controllers/concerns/state_file/eligibility_offboarding_concern.rb
+++ b/app/controllers/concerns/state_file/eligibility_offboarding_concern.rb
@@ -4,7 +4,17 @@ module StateFile
     # to the eligibility offboarding page if given a disqualifying answer
     extend ActiveSupport::Concern
 
+    included do
+      before_action :clear_offboarded_from, only: :edit
+    end
+
     private
+
+    def clear_offboarded_from
+      if session[:offboarded_from].present?
+        session.delete(:offboarded_from)
+      end
+    end
 
     def offboarding_path
       StateFile::Questions::EligibilityOffboardingController.to_path_helper

--- a/app/controllers/state_file/questions/eligibility_offboarding_controller.rb
+++ b/app/controllers/state_file/questions/eligibility_offboarding_controller.rb
@@ -17,7 +17,7 @@ module StateFile
       end
 
       def set_prev_path
-        @prev_path = session.delete(:offboarded_from)
+        @prev_path = session[:offboarded_from]
       end
 
       def prev_path

--- a/app/lib/navigation/state_file_md_question_navigation.rb
+++ b/app/lib/navigation/state_file_md_question_navigation.rb
@@ -5,6 +5,7 @@ module Navigation
     SECTIONS = [
       Navigation::NavigationSection.new("state_file.navigation.section_1", [
         Navigation::NavigationStep.new(StateFile::Questions::MdEligibilityFilingStatusController),
+        Navigation::NavigationStep.new(StateFile::Questions::EligibilityOffboardingController, false),
         Navigation::NavigationStep.new(StateFile::Questions::EligibleController),
       ]),
       Navigation::NavigationSection.new("state_file.navigation.section_2", [

--- a/spec/controllers/concerns/state_file/eligibility_offboarding_concern_spec.rb
+++ b/spec/controllers/concerns/state_file/eligibility_offboarding_concern_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe StateFile::EligibilityOffboardingConcern, type: :controller do
     def index
       redirect_to next_path
     end
+
+    def edit; end
   end
 
   let(:intake) { create(:state_file_az_intake) }

--- a/spec/controllers/state_file/questions/eligibility_offboarding_controller_spec.rb
+++ b/spec/controllers/state_file/questions/eligibility_offboarding_controller_spec.rb
@@ -61,7 +61,6 @@ RSpec.describe StateFile::Questions::EligibilityOffboardingController do
             get :edit
 
             expect(Nokogiri::HTML.parse(response.body)).to have_link(href: eligibility_controller_path)
-            expect(session[:offboarded_from]).to be_nil
           end
         end
 
@@ -72,7 +71,6 @@ RSpec.describe StateFile::Questions::EligibilityOffboardingController do
             get :edit
 
             expect(Nokogiri::HTML.parse(response.body)).to have_link(href: default_controller_path)
-            expect(session[:offboarded_from]).to be_nil
           end
         end
       end

--- a/spec/controllers/state_file/questions/eligibility_offboarding_controller_spec.rb
+++ b/spec/controllers/state_file/questions/eligibility_offboarding_controller_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe StateFile::Questions::EligibilityOffboardingController do
         get :edit
 
         expect(Nokogiri::HTML.parse(response.body)).to have_link(href: offboarded_from_path)
-        expect(session[:offboarded_from]).to be_nil
       end
     end
 

--- a/spec/controllers/state_file/questions/eligibility_offboarding_controller_spec.rb
+++ b/spec/controllers/state_file/questions/eligibility_offboarding_controller_spec.rb
@@ -18,66 +18,59 @@ RSpec.describe StateFile::Questions::EligibilityOffboardingController do
   end
 
   describe "#edit" do
+    render_views
     before do
       sign_in intake
     end
 
-    context "NJ specific content" do
-      # az does not utilize eligiblity_offboarding_controller in its flow
-      StateFile::StateInformationService.active_state_codes.excluding("az", "ny", "nj").each do |state_code|
-        render_views
+    context "with offboarded_from set in the session" do
+      let(:intake) { create :state_file_id_intake }
+      let(:offboarded_from_path) do
+        StateFile::Questions::IdEligibilityResidenceController.to_path_helper
+      end
+      before do
+        session[:offboarded_from] = offboarded_from_path
+      end
 
-        let(:intake) { create "state_file_#{state_code}_intake".to_sym }
+      it "uses the correct prev_path for the Go back button" do
+        get :edit
 
-        it "#{state_code} does not show NJ-specific content" do
-          get :edit
-          expect(response.body).to include("Visit our FAQ")
-          expect(response.body).not_to include("Get connected now")
-        end
+        expect(Nokogiri::HTML.parse(response.body)).to have_link(href: offboarded_from_path)
+        expect(session[:offboarded_from]).to be_nil
       end
     end
 
-    # For NJ, two controllers can lead to the ineligible offboarding controller -- so we still have an issue where if the
-    # locale changes, session[:offboarded_from] will be `nil` and they will have an inactive Go back button.
-    [
-      ["id", StateFile::Questions::IdEligibilityResidenceController],
-      ["md", StateFile::Questions::MdEligibilityFilingStatusController],
-      ["nc", StateFile::Questions::NcEligibilityController],
-      ["nj", StateFile::Questions::NjEligibilityHealthInsuranceController],
-      ["nj", StateFile::Questions::NjRetirementWarningController, StateFile::Questions::NjEligibilityHealthInsuranceController]
-    ].each do |state_code, eligibility_controller, default_eligibility_controller|
-      context "#{state_code} with eligibility controller #{eligibility_controller}" do
-        render_views
+    context "AZ" do
+      let(:intake) { create :state_file_az_intake }
 
-        let(:intake) { create "state_file_#{state_code}_intake".to_sym }
-        let(:eligibility_controller_path) { eligibility_controller.to_path_helper }
+      it "does not show NJ-specific content" do
+        get :edit
+        expect(response.body).to include("Visit our FAQ")
+        expect(response.body).not_to include("Get connected now")
+      end
+    end
 
-        context "with offboarded_from set in the session" do
-          before do
-            session[:offboarded_from] = eligibility_controller_path
-          end
+    context "ID" do
+      let(:intake) { create :state_file_id_intake }
 
-          it "uses the correct prev_path for the Go back button" do
-            get :edit
+      it "does not show NJ-specific content" do
+        get :edit
+        expect(response.body).to include("Visit our FAQ")
+        expect(response.body).not_to include("Get connected now")
+      end
+    end
 
-            expect(Nokogiri::HTML.parse(response.body)).to have_link(href: eligibility_controller_path)
-          end
-        end
+    context "MD" do
+      let(:intake) { create :state_file_md_intake }
 
-        context "without offboarded_from set in the session" do
-          let(:default_controller_path) { default_eligibility_controller ? default_eligibility_controller.to_path_helper : eligibility_controller_path }
-
-          it "uses the default prev_path for the Go back button (controller right before offboarding controller in flow)" do
-            get :edit
-
-            expect(Nokogiri::HTML.parse(response.body)).to have_link(href: default_controller_path)
-          end
-        end
+      it "does not show NJ-specific content" do
+        get :edit
+        expect(response.body).to include("Visit our FAQ")
+        expect(response.body).not_to include("Get connected now")
       end
     end
 
     context "NJ" do
-      render_views
       let(:intake) { create :state_file_nj_intake }
   
       it "shows NJ-specific content" do

--- a/spec/controllers/state_file/questions/eligibility_offboarding_controller_spec.rb
+++ b/spec/controllers/state_file/questions/eligibility_offboarding_controller_spec.rb
@@ -18,59 +18,68 @@ RSpec.describe StateFile::Questions::EligibilityOffboardingController do
   end
 
   describe "#edit" do
-    render_views
     before do
       sign_in intake
     end
 
-    context "with offboarded_from set in the session" do
-      let(:intake) { create :state_file_id_intake }
-      let(:offboarded_from_path) do
-        StateFile::Questions::IdEligibilityResidenceController.to_path_helper
-      end
-      before do
-        session[:offboarded_from] = offboarded_from_path
-      end
+    context "NJ specific content" do
+      # az does not utilize eligiblity_offboarding_controller in its flow
+      StateFile::StateInformationService.active_state_codes.excluding("az", "ny", "nj").each do |state_code|
+        render_views
 
-      it "uses the correct prev_path for the Go back button" do
-        get :edit
+        let(:intake) { create "state_file_#{state_code}_intake".to_sym }
 
-        expect(Nokogiri::HTML.parse(response.body)).to have_link(href: offboarded_from_path)
-        expect(session[:offboarded_from]).to be_nil
+        it "#{state_code} does not show NJ-specific content" do
+          get :edit
+          expect(response.body).to include("Visit our FAQ")
+          expect(response.body).not_to include("Get connected now")
+        end
       end
     end
 
-    context "AZ" do
-      let(:intake) { create :state_file_az_intake }
-  
-      it "does not show NJ-specific content" do
-        get :edit
-        expect(response.body).to include("Visit our FAQ")
-        expect(response.body).not_to include("Get connected now")
+    # For NJ, two controllers can lead to the ineligible offboarding controller -- so we still have an issue where if the
+    # locale changes, session[:offboarded_from] will be `nil` and they will have an inactive Go back button.
+    [
+      ["id", StateFile::Questions::IdEligibilityResidenceController],
+      ["md", StateFile::Questions::MdEligibilityFilingStatusController],
+      ["nc", StateFile::Questions::NcEligibilityController],
+      ["nj", StateFile::Questions::NjEligibilityHealthInsuranceController],
+      ["nj", StateFile::Questions::NjRetirementWarningController, StateFile::Questions::NjEligibilityHealthInsuranceController]
+    ].each do |state_code, eligibility_controller, default_eligibility_controller|
+      context "#{state_code} with eligibility controller #{eligibility_controller}" do
+        render_views
+
+        let(:intake) { create "state_file_#{state_code}_intake".to_sym }
+        let(:eligibility_controller_path) { eligibility_controller.to_path_helper }
+
+        context "with offboarded_from set in the session" do
+          before do
+            session[:offboarded_from] = eligibility_controller_path
+          end
+
+          it "uses the correct prev_path for the Go back button" do
+            get :edit
+
+            expect(Nokogiri::HTML.parse(response.body)).to have_link(href: eligibility_controller_path)
+            expect(session[:offboarded_from]).to be_nil
+          end
+        end
+
+        context "without offboarded_from set in the session" do
+          let(:default_controller_path) { default_eligibility_controller ? default_eligibility_controller.to_path_helper : eligibility_controller_path }
+
+          it "uses the default prev_path for the Go back button (controller right before offboarding controller in flow)" do
+            get :edit
+
+            expect(Nokogiri::HTML.parse(response.body)).to have_link(href: default_controller_path)
+            expect(session[:offboarded_from]).to be_nil
+          end
+        end
       end
     end
-  
-    context "ID" do
-      let(:intake) { create :state_file_id_intake }
-  
-      it "does not show NJ-specific content" do
-        get :edit
-        expect(response.body).to include("Visit our FAQ")
-        expect(response.body).not_to include("Get connected now")
-      end
-    end
-  
-    context "MD" do
-      let(:intake) { create :state_file_md_intake }
-  
-      it "does not show NJ-specific content" do
-        get :edit
-        expect(response.body).to include("Visit our FAQ")
-        expect(response.body).not_to include("Get connected now")
-      end
-    end
-  
+
     context "NJ" do
+      render_views
       let(:intake) { create :state_file_nj_intake }
   
       it "shows NJ-specific content" do

--- a/spec/controllers/state_file/questions/id_eligibility_residence_controller_spec.rb
+++ b/spec/controllers/state_file/questions/id_eligibility_residence_controller_spec.rb
@@ -2,10 +2,6 @@ require 'rails_helper'
 
 RSpec.describe StateFile::Questions::IdEligibilityResidenceController do
   describe "eligibility_offboarding_concern" do
-    # use the eligibility_offboarding_concern shared example if the page
-    # should redirect to the state file eligibility offboarding page
-    # when it receives a disqualifying answer.
-    # requires one example each of eligible_params & ineligible_params
     it_behaves_like :eligibility_offboarding_concern, intake_factory: :state_file_id_intake do
       let(:eligible_params) do
         {

--- a/spec/controllers/state_file/questions/id_eligibility_residence_controller_spec.rb
+++ b/spec/controllers/state_file/questions/id_eligibility_residence_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe StateFile::Questions::IdEligibilityResidenceController do
-  describe "#update" do
+  describe "eligibility_offboarding_concern" do
     # use the eligibility_offboarding_concern shared example if the page
     # should redirect to the state file eligibility offboarding page
     # when it receives a disqualifying answer.

--- a/spec/controllers/state_file/questions/md_eligibility_filing_status_controller_spec.rb
+++ b/spec/controllers/state_file/questions/md_eligibility_filing_status_controller_spec.rb
@@ -17,10 +17,6 @@ describe StateFile::Questions::MdEligibilityFilingStatusController do
   end
 
   describe "eligibility_offboarding_concern" do
-    # the disqualifying param here is permanent_address_outside_md but this is set in the form based on:
-    # * whether they are using the address from DF
-    # * if so, whether that address is in MD
-    # so we have to mock the DF data
     it_behaves_like :eligibility_offboarding_concern, intake_factory: :state_file_md_intake do
       let(:eligible_params) do
         {

--- a/spec/controllers/state_file/questions/md_eligibility_filing_status_controller_spec.rb
+++ b/spec/controllers/state_file/questions/md_eligibility_filing_status_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe StateFile::Questions::MdPermanentAddressController do
+describe StateFile::Questions::MdEligibilityFilingStatusController do
   let(:intake) { create :state_file_md_intake }
   before do
     sign_in intake
@@ -12,7 +12,7 @@ describe StateFile::Questions::MdPermanentAddressController do
     it "succeeds" do
       get :edit
       expect(response).to be_successful
-      expect(response_html).to have_text "Did you live at this address"
+      expect(response_html).to have_text I18n.t("state_file.questions.md_eligibility_filing_status.edit.title", year: MultiTenantService.statefile.current_tax_year)
     end
   end
 
@@ -23,19 +23,23 @@ describe StateFile::Questions::MdPermanentAddressController do
     # so we have to mock the DF data
     it_behaves_like :eligibility_offboarding_concern, intake_factory: :state_file_md_intake do
       let(:eligible_params) do
-        allow_any_instance_of(DirectFileData).to receive(:mailing_state).and_return "MD"
         {
-          state_file_md_permanent_address_form: {
-            confirmed_permanent_address: "yes",
+          state_file_md_eligibility_filing_status_form: {
+            eligibility_filing_status_mfj: "yes",
+            eligibility_homebuyer_withdrawal: "no",
+            eligibility_homebuyer_withdrawal_mfj: "no",
+            eligibility_home_different_areas: "no"
           }
         }
       end
 
       let(:ineligible_params) do
-        allow_any_instance_of(DirectFileData).to receive(:mailing_state).and_return "NC"
         {
-          state_file_md_permanent_address_form: {
-            confirmed_permanent_address: "yes",
+          state_file_md_eligibility_filing_status_form: {
+            eligibility_filing_status_mfj: "yes",
+            eligibility_homebuyer_withdrawal: "yes",
+            eligibility_homebuyer_withdrawal_mfj: "yes",
+            eligibility_home_different_areas: "no"
           }
         }
       end

--- a/spec/controllers/state_file/questions/nc_eligibility_controller_spec.rb
+++ b/spec/controllers/state_file/questions/nc_eligibility_controller_spec.rb
@@ -2,10 +2,6 @@ require 'rails_helper'
 
 RSpec.describe StateFile::Questions::NcEligibilityController do
   describe "eligibility_offboarding concern" do
-    # use the eligibility_offboarding_concern shared example if the page
-    # should redirect to the state file eligibility offboarding page
-    # when it receives a disqualifying answer.
-    # requires one example each of eligible_params & ineligible_params
     it_behaves_like :eligibility_offboarding_concern, intake_factory: :state_file_nc_intake do
       let(:eligible_params) do
         {

--- a/spec/controllers/state_file/questions/nc_eligibility_controller_spec.rb
+++ b/spec/controllers/state_file/questions/nc_eligibility_controller_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe StateFile::Questions::NcEligibilityController do
+  describe "eligibility_offboarding concern" do
+    # use the eligibility_offboarding_concern shared example if the page
+    # should redirect to the state file eligibility offboarding page
+    # when it receives a disqualifying answer.
+    # requires one example each of eligible_params & ineligible_params
+    it_behaves_like :eligibility_offboarding_concern, intake_factory: :state_file_nc_intake do
+      let(:eligible_params) do
+        {
+          state_file_nc_eligibility_form: {
+            nc_eligiblity_none: "yes",
+            eligibility_ed_loan_cancelled: "unfilled",
+            eligibility_ed_loan_emp_payment: "no",
+          }
+        }
+      end
+
+      let(:ineligible_params) do
+        {
+          state_file_nc_eligibility_form: {
+            nc_eligiblity_none: "unfilled",
+            eligibility_ed_loan_cancelled: "yes",
+            eligibility_ed_loan_emp_payment: "no",
+          }
+        }
+      end
+    end
+  end
+end

--- a/spec/controllers/state_file/questions/nc_eligibility_out_of_state_income_controller_spec.rb
+++ b/spec/controllers/state_file/questions/nc_eligibility_out_of_state_income_controller_spec.rb
@@ -2,10 +2,6 @@ require 'rails_helper'
 
 RSpec.describe StateFile::Questions::NcEligibilityController do
   describe "#update" do
-    # use the eligibility_offboarding_concern shared example if the page
-    # should redirect to the state file eligibility offboarding page
-    # when it receives a disqualifying answer.
-    # requires one example each of eligible_params & ineligible_params
     it_behaves_like :eligibility_offboarding_concern, intake_factory: :state_file_nc_intake do
       let(:eligible_params) do
         {

--- a/spec/controllers/state_file/questions/nj_eligibility_health_insurance_controller_spec.rb
+++ b/spec/controllers/state_file/questions/nj_eligibility_health_insurance_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe StateFile::Questions::NjEligibilityHealthInsuranceController do
-  describe "#update" do
+  describe "eligiblity_offboarding_concern" do
     it_behaves_like :eligibility_offboarding_concern, intake_factory: :state_file_nj_intake do
       let(:eligible_params) do
         {
@@ -19,7 +19,9 @@ RSpec.describe StateFile::Questions::NjEligibilityHealthInsuranceController do
         }
       end
     end
+  end
 
+  describe "#update" do
     context "when taxpayer checks no, but is eligible" do
       let(:intake) { create :state_file_nj_intake, :df_data_mfj_both_claimed_dep }
       let(:form_params) do

--- a/spec/controllers/state_file/questions/nj_retirement_warning_controller_spec.rb
+++ b/spec/controllers/state_file/questions/nj_retirement_warning_controller_spec.rb
@@ -85,10 +85,6 @@ RSpec.describe StateFile::Questions::NjRetirementWarningController do
   end
 
   describe "eligibility_offboarding_concern" do
-    # the disqualifying param here is permanent_address_outside_md but this is set in the form based on:
-    # * whether they are using the address from DF
-    # * if so, whether that address is in MD
-    # so we have to mock the DF data
     it_behaves_like :eligibility_offboarding_concern, intake_factory: :state_file_nj_intake do
       let(:eligible_params) do
         {

--- a/spec/controllers/state_file/questions/nj_retirement_warning_controller_spec.rb
+++ b/spec/controllers/state_file/questions/nj_retirement_warning_controller_spec.rb
@@ -83,4 +83,28 @@ RSpec.describe StateFile::Questions::NjRetirementWarningController do
       end
     end
   end
+
+  describe "eligibility_offboarding_concern" do
+    # the disqualifying param here is permanent_address_outside_md but this is set in the form based on:
+    # * whether they are using the address from DF
+    # * if so, whether that address is in MD
+    # so we have to mock the DF data
+    it_behaves_like :eligibility_offboarding_concern, intake_factory: :state_file_nj_intake do
+      let(:eligible_params) do
+        {
+          state_file_nj_retirement_warning_form: {
+            eligibility_retirement_warning_continue: "yes",
+          }
+        }
+      end
+
+      let(:ineligible_params) do
+        {
+          state_file_nj_retirement_warning_form: {
+            eligibility_retirement_warning_continue: "no",
+          }
+        }
+      end
+    end
+  end
 end

--- a/spec/features/switching_locale_spec.rb
+++ b/spec/features/switching_locale_spec.rb
@@ -54,7 +54,7 @@ RSpec.feature "Switching Locale" do
         end
 
         click_on "Regresa para corregirlo."
-        expect(page).to have_text I18n.t("state_file.questions.id_eligibility_residence.edit.title", filing_year: filing_year, locale: 'es')
+        expect(page).to have_text I18n.t("state_file.questions.id_eligibility_residence.edit.title", filing_year: filing_year)
       end
     end
 
@@ -91,7 +91,7 @@ RSpec.feature "Switching Locale" do
         end
 
         click_on "Regresa para corregirlo."
-        expect(page).to have_text I18n.t("state_file.questions.md_eligibility_filing_status.edit.title", year: filing_year, locale: "es")
+        expect(page).to have_text I18n.t("state_file.questions.md_eligibility_filing_status.edit.title", year: filing_year)
       end
 
       scenario "from the md_permanent_address controller" do
@@ -137,7 +137,7 @@ RSpec.feature "Switching Locale" do
           click_on "Español"
         end
         click_on "Regresa para corregirlo."
-        expect(page).to have_text I18n.t("state_file.questions.md_permanent_address.edit.title", filing_year: filing_year, locale: "es")
+        expect(page).to have_text I18n.t("state_file.questions.md_permanent_address.edit.title", filing_year: filing_year)
       end
     end
 
@@ -167,7 +167,7 @@ RSpec.feature "Switching Locale" do
         end
 
         click_on "Regresa para corregirlo."
-        expect(page).to have_text I18n.t("state_file.questions.nc_eligibility.edit.title", filing_year: filing_year, locale: "es")
+        expect(page).to have_text I18n.t("state_file.questions.nc_eligibility.edit.title", filing_year: filing_year)
       end
     end
   end

--- a/spec/features/switching_locale_spec.rb
+++ b/spec/features/switching_locale_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Switching Locale" do
+  include StateFileIntakeHelper
 
   scenario "client switches between Spanish and English versions of website using the header link" do
     visit root_path
@@ -14,5 +15,160 @@ RSpec.feature "Switching Locale" do
       click_on "English"
     end
     expect(page).to have_content(I18n.t("views.public_pages.home.header", locale: :en))
+  end
+
+  context "from eligibility offboarding pages, when client switches between Spanish and English" do
+    before do
+      allow_any_instance_of(Routes::StateFileDomain).to receive(:matches?).and_return(true)
+    end
+
+    context "ID" do
+      scenario "from the id_eligibility_residence_controller" do
+        visit "/en"
+        click_on "Start Test ID"
+
+        expect(page).to have_text I18n.t("state_file.landing_page.edit.id.title")
+        click_on I18n.t('general.get_started'), id: "firstCta"
+
+        expect(page).to have_text I18n.t("state_file.questions.id_eligibility_residence.edit.title", filing_year: filing_year)
+        expect(page).to have_text I18n.t("state_file.questions.id_eligibility_residence.edit.emergency_rental_assistance", filing_year: filing_year)
+        expect(page).to have_text I18n.t("state_file.questions.id_eligibility_residence.edit.withdrew_msa_fthb", filing_year: filing_year)
+
+        find_by_id('state_file_id_eligibility_residence_form_eligibility_withdrew_msa_fthb_yes').click
+        find_by_id('state_file_id_eligibility_residence_form_eligibility_emergency_rental_assistance_yes').click
+        click_on I18n.t("general.continue")
+
+        expect(page).to have_text I18n.t("state_file.questions.eligibility_offboarding.edit.title.default")
+        click_on "Go back to correct."
+
+        expect(page).to have_text I18n.t("state_file.questions.id_eligibility_residence.edit.title", filing_year: filing_year)
+
+        find_by_id('state_file_id_eligibility_residence_form_eligibility_withdrew_msa_fthb_yes').click
+        find_by_id('state_file_id_eligibility_residence_form_eligibility_emergency_rental_assistance_yes').click
+        click_on I18n.t("general.continue")
+
+        expect(page).to have_text I18n.t("state_file.questions.eligibility_offboarding.edit.title.default")
+
+        within(".main-header") do
+          click_on "Español"
+        end
+
+        click_on "Regresa para corregirlo."
+        expect(page).to have_text I18n.t("state_file.questions.id_eligibility_residence.edit.title", filing_year: filing_year, locale: 'es')
+      end
+    end
+
+    context "MD" do
+      scenario "from the md_eligibility_filing_status controller" do
+        visit "/en"
+        click_on "Start Test MD"
+
+        expect(page).to have_text I18n.t("state_file.landing_page.edit.md.title")
+        click_on I18n.t('general.get_started'), id: "firstCta"
+
+        expect(page).to have_text I18n.t("state_file.questions.md_eligibility_filing_status.edit.title", year: filing_year)
+        click_on I18n.t("general.continue")
+
+        expect(page).to have_text I18n.t("state_file.questions.md_eligibility_filing_status.edit.title", year: filing_year)
+        choose I18n.t("general.affirmative"), id: "state_file_md_eligibility_filing_status_form_eligibility_filing_status_mfj_yes"
+        choose I18n.t("general.affirmative"), id: "state_file_md_eligibility_filing_status_form_eligibility_homebuyer_withdrawal_mfj_yes"
+        choose I18n.t("general.affirmative"), id: "state_file_md_eligibility_filing_status_form_eligibility_home_different_areas_yes"
+        click_on I18n.t("general.continue")
+
+        expect(page).to have_text I18n.t("state_file.questions.eligibility_offboarding.edit.title.default")
+        click_on "Go back to correct."
+
+        expect(page).to have_text I18n.t("state_file.questions.md_eligibility_filing_status.edit.title", year: filing_year)
+        choose I18n.t("general.affirmative"), id: "state_file_md_eligibility_filing_status_form_eligibility_filing_status_mfj_yes"
+        choose I18n.t("general.affirmative"), id: "state_file_md_eligibility_filing_status_form_eligibility_homebuyer_withdrawal_mfj_yes"
+        choose I18n.t("general.affirmative"), id: "state_file_md_eligibility_filing_status_form_eligibility_home_different_areas_yes"
+        click_on I18n.t("general.continue")
+
+        expect(page).to have_text I18n.t("state_file.questions.eligibility_offboarding.edit.title.default")
+
+        within(".main-header") do
+          click_on "Español"
+        end
+
+        click_on "Regresa para corregirlo."
+        expect(page).to have_text I18n.t("state_file.questions.md_eligibility_filing_status.edit.title", year: filing_year, locale: "es")
+      end
+
+      scenario "from the md_permanent_address controller" do
+        visit "/en"
+        click_on "Start Test MD"
+
+        expect(page).to have_text I18n.t("state_file.landing_page.edit.md.title")
+        click_on I18n.t('general.get_started'), id: "firstCta"
+
+        expect(page).to have_text I18n.t("state_file.questions.md_eligibility_filing_status.edit.title", year: filing_year)
+        click_on I18n.t("general.continue")
+
+        step_through_eligibility_screener(us_state: "md")
+
+        step_through_initial_authentication(contact_preference: :email)
+
+        check "Email"
+        check "Text message"
+        fill_in "Your phone number", with: "+12025551212"
+        click_on "Continue"
+
+        expect(page).to have_text I18n.t('state_file.questions.sms_terms.edit.title')
+        click_on I18n.t("general.accept")
+
+        expect(page).to have_text I18n.t('state_file.questions.terms_and_conditions.edit.title')
+        click_on I18n.t("state_file.questions.terms_and_conditions.edit.accept")
+
+        step_through_df_data_transfer("Transfer Frodo hoh cdcc")
+
+        expect(page).to have_text I18n.t("state_file.questions.md_permanent_address.edit.title", filing_year: filing_year)
+        choose I18n.t("general.affirmative")
+        click_on I18n.t("general.continue")
+
+        expect(page).to have_text I18n.t("state_file.questions.eligibility_offboarding.edit.title.default")
+        click_on "Go back to correct."
+
+        expect(page).to have_text I18n.t("state_file.questions.md_permanent_address.edit.title", filing_year: filing_year)
+        choose I18n.t("general.affirmative")
+        click_on I18n.t("general.continue")
+
+        expect(page).to have_text I18n.t("state_file.questions.eligibility_offboarding.edit.title.default")
+        within(".main-header") do
+          click_on "Español"
+        end
+        click_on "Regresa para corregirlo."
+        expect(page).to have_text I18n.t("state_file.questions.md_permanent_address.edit.title", filing_year: filing_year, locale: "es")
+      end
+    end
+
+    context "NC" do
+      scenario "from nc_eligibility controller" do
+        visit "/en"
+        click_on "Start Test NC"
+
+        expect(page).to have_text I18n.t("state_file.landing_page.edit.nc.title")
+        click_on I18n.t('general.get_started'), id: "firstCta"
+
+        expect(page).to have_text I18n.t("state_file.questions.nc_eligibility.edit.title", filing_year: filing_year)
+        check I18n.t("state_file.questions.nc_eligibility.edit.eligibility_ed_loan_emp_payment")
+        click_on I18n.t("general.continue")
+
+        expect(page).to have_text I18n.t("state_file.questions.eligibility_offboarding.edit.title.default")
+        click_on "Go back to correct."
+
+        expect(page).to have_text I18n.t("state_file.questions.nc_eligibility.edit.title", filing_year: filing_year)
+        check I18n.t("state_file.questions.nc_eligibility.edit.eligibility_ed_loan_cancelled")
+        click_on I18n.t("general.continue")
+
+        expect(page).to have_text I18n.t("state_file.questions.eligibility_offboarding.edit.title.default")
+
+        within(".main-header") do
+          click_on "Español"
+        end
+
+        click_on "Regresa para corregirlo."
+        expect(page).to have_text I18n.t("state_file.questions.nc_eligibility.edit.title", filing_year: filing_year, locale: "es")
+      end
+    end
   end
 end

--- a/spec/support/shared_examples/eligibility_offboarding_concern.rb
+++ b/spec/support/shared_examples/eligibility_offboarding_concern.rb
@@ -1,12 +1,25 @@
 require "rails_helper"
 
 shared_examples :eligibility_offboarding_concern do |intake_factory:|
+  before do
+    sign_in create(intake_factory)
+  end
+
+  describe "#edit" do
+    context "if session has offboarded_from" do
+      before do
+        session[:offboarded_from] = "somewhere over the rainbow"
+      end
+
+      it "should delete the session offboarded_from data" do
+        get :edit
+        expect(session[:offboarded_from]).to be_nil
+      end
+    end
+  end
+
   # requires ineligible_params and eligible_params to be defined
   describe "#next_path" do
-    before do
-      sign_in create(intake_factory)
-    end
-
     context "with eligible params" do
       it "does not redirect to the eligibility offboarding page" do
         post :update, params: eligible_params


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1553
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Most states have one eligibility controller and one offboarding controller
  - MD & NJ have two eligibility screening controllers which can both lead to offboarding
    - MD: `md_eligibility_filing_status` & `md_permanent_address` pages
    - NJ: `NjEligibilityHealthInsuranceController`, `NjRetirementWarningController`
  - Less important:
     - NY also does too (we will ignore them for now)
     - AZ does not utilize the offboarding controller at all
- When the language is changed on the `eligibility_offboarding_controller`, the `session[:offboarded_from]` param which saves which controller to go back to is lost (i.e. for NJ, `NjRetirementWarningController` can lead to offboarding page, but it will "go back" to `NjEligibilityHealthInsuranceController` b/c that's the controller before it, which is the default behavior if no `offboarded_from` param exists)
- `session[:offboarded_from]` gets deleted at the offboarding controller when the page renders❗
```
        def set_prev_path
        @prev_path = session.delete(:offboarded_from)
      end
````
- I guess the solution is to _not_ delete it at the offboarding controller (is it a problem if we never delete it?) -- so I'm opting to delete it when the user returns (before `edit` action) to the one of the eligibility controllers, since `session[:offboarded_from]` value can be set again from the `next_path`. It is possible for the client to keep this in their session if they nav away from this screen without going back to one of the eligibility controllers, but if they hit the eligibility screen again, they'll have to re-set this value.

## How to test?
- Describe the testing approach taken to verify the changes, including:
  - Unit/integration/manual tests
  - Test data used:
    - MD: Frodo hoh to test the permanent address offboarding page; any other persona works for the other eligiblity page
    - NJ: I didn't test these as I'm not certain of which persons to use to get into these offboarding experiences, but did test the controllers & have reasonable expectation they will be fine
    - For all states (except AZ which doesn't have offboarding) make sure that the "Go back to correct" button actually does go back to one of the eligibility pages it came from.
- Risk Assessment
  - After the language changes, the `offboarded_from` data still persists a link back to the original language, instead of the language being currently shown on the page. If there's a way to elegantly change the url of the link, I'll prefer to do that. I'm not even sure exactly what would be desired from product perspective, so probably need a conversation if we want to make it happen.
  - Probably want NJ team to review some of this as I didn't test this locally for their flow.
## Screenshots (for visual changes)
- Before
**English: see link at the bottom left corner**
<img width="885" alt="Screenshot 2025-03-11 at 10 50 07 PM" src="https://github.com/user-attachments/assets/f1a85b6e-374f-430b-a1de-0f688d3d4eec" />

**Spanish: see link at the bottom left corner**
<img width="878" alt="Screenshot 2025-03-11 at 10 50 14 PM" src="https://github.com/user-attachments/assets/c6043207-eeb9-49f6-848d-69d2740bde3d" />

- After
**English: see link at the bottom left corner**
<img width="880" alt="Screenshot 2025-03-11 at 10 47 54 PM" src="https://github.com/user-attachments/assets/d179843c-6510-4c6c-ae61-71a3de354603" />

**Spanish: see link at the bottom left corner**
<img width="888" alt="Screenshot 2025-03-11 at 10 47 49 PM" src="https://github.com/user-attachments/assets/ce61dc9f-2f6e-4c4c-8c22-7effe33f78a0" />

