### PR TITLE
[FYST-1926] Return to income_review if current step was at retirement_income

### DIFF
--- a/app/models/state_file_base_intake.rb
+++ b/app/models/state_file_base_intake.rb
@@ -418,7 +418,7 @@ class StateFileBaseIntake < ApplicationRecord
       StateFile::Questions::ReturnStatusController
     else
       step_name = current_step.split('/').last
-      if step_name == "w2"
+      if ["w2", "retirement-income"].include?(step_name)
         StateFile::Questions::IncomeReviewController
       else
         "StateFile::Questions::#{step_name.underscore.camelize}Controller".constantize

--- a/spec/models/state_file_base_intake_spec.rb
+++ b/spec/models/state_file_base_intake_spec.rb
@@ -259,6 +259,14 @@ describe StateFileBaseIntake do
         expect(intake.controller_for_current_step).to eq StateFile::Questions::IncomeReviewController
       end
     end
+
+    context "step is retirement_income" do
+      let(:current_step) { "/en/questions/retirement-income" }
+
+      it "returns the income review controller" do
+        expect(intake.controller_for_current_step).to eq StateFile::Questions::IncomeReviewController
+      end
+    end
   end
 
   describe "#sum_1099_r_followup_type_for_filer" do


### PR DESCRIPTION
co-authored with @tahsinaislam 

## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1926
- Sentry: https://codeforamerica.sentry.io/issues/6391479077/?referrer=sentry-issues-glance
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Borrowed logic from w2 where if user was at a specific income form edit page, we route them back to the income-review page instead (https://github.com/codeforamerica/vita-min/pull/5551)
- In a similar manner, retirement_income edit/show need an id. I think we get a 500 instead of 404 here b/c of `load_warnings` method which attempts to look up values on a `@state_file1099_r` that is `nil`, although the Sentry error instead throws: `No route matches {:action=>"edit", :controller=>"state_file/questions/retirement_income", :locale=>:en} (ActionController::UrlGenerationError)`
## How to test?
- Describe the testing approach taken to verify the changes, including:
  - Unit/manual tests
  - Test data used: any persona that has 1099R that could be edited/shown (All states except NC can edit/North Carolina can _show_ the income form, if they are on this page at the time of logging out, they should also not be stuck on 500 page)