### PR TITLE
Remove "go back" button on the data-transfer-offboarding page

### DIFF
--- a/app/controllers/state_file/questions/data_transfer_offboarding_controller.rb
+++ b/app/controllers/state_file/questions/data_transfer_offboarding_controller.rb
@@ -21,6 +21,10 @@ module StateFile
 
       private
 
+      def prev_path
+        nil
+      end
+
       def card_postscript; end
 
     end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. https://codeforamerica.atlassian.net/browse/FYST-1268
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- made prev path nil so the go back button would disappear 
## How to test?
- Start an AZ intake, choose any persona then edit the filing status to be married filing separately 
- check if the go back button is on the `questions/data-transfer-offboarding` page
## Screenshots (for visual changes)
- Before
<img width="903" alt="Screenshot 2025-03-13 at 7 41 41 PM" src="https://github.com/user-attachments/assets/47c199b6-0739-42e9-aacd-abe923d492d8" />

- After
<img width="877" alt="Screenshot 2025-03-13 at 7 41 19 PM" src="https://github.com/user-attachments/assets/6cd0abe1-9d38-43ab-8575-5d4c58b941e0" />
