### PR TITLE
Nj 320 - Convert w2 box 16 error to warning

### DIFF
--- a/app/controllers/state_file/questions/w2_controller.rb
+++ b/app/controllers/state_file/questions/w2_controller.rb
@@ -15,6 +15,11 @@ module StateFile
       end
 
       def edit
+        if StateFile::StateInformationService.check_box_16(current_state_code)
+          current_intake.confirmed_w2_indexes.append(@w2.w2_index)
+          current_intake.save
+        end
+
         @w2.valid?(:state_file_edit)
       end
 
@@ -23,11 +28,6 @@ module StateFile
       def update
         @w2.assign_attributes(form_params)
         @w2.check_box14_limits = true
-
-        if StateFile::StateInformationService.check_box_16(current_state_code)
-          current_intake.confirmed_w2_indexes.append(@w2.w2_index)
-          current_intake.save
-        end
 
         if @w2.valid?(:state_file_edit)
           @w2.box14_ui_hc_wd = nil

--- a/app/controllers/state_file/questions/w2_controller.rb
+++ b/app/controllers/state_file/questions/w2_controller.rb
@@ -23,10 +23,13 @@ module StateFile
       def update
         @w2.assign_attributes(form_params)
         @w2.check_box14_limits = true
+        @w2.taxpayer_reviewed = true
+        @w2.errors.clear
 
         if @w2.valid?(:state_file_edit)
           @w2.box14_ui_hc_wd = nil
-          @w2.save(context: :state_file_edit)
+          @w2.save(context: [:state_file_edit, :state_file_income_review])
+          binding.pry # w2 is valid in both contexts here, taxpayer_reviewed is true
           redirect_to StateFile::Questions::IncomeReviewController.to_path_helper(return_to_review: params[:return_to_review])
         else
           render :edit

--- a/app/controllers/state_file/questions/w2_controller.rb
+++ b/app/controllers/state_file/questions/w2_controller.rb
@@ -31,7 +31,7 @@ module StateFile
 
         if @w2.valid?(:state_file_edit)
           @w2.box14_ui_hc_wd = nil
-          @w2.save(context: [:state_file_edit, :state_file_income_review])
+          @w2.save(context: :state_file_edit)
           redirect_to StateFile::Questions::IncomeReviewController.to_path_helper(return_to_review: params[:return_to_review])
         else
           render :edit

--- a/app/controllers/state_file/questions/w2_controller.rb
+++ b/app/controllers/state_file/questions/w2_controller.rb
@@ -4,7 +4,7 @@ module StateFile
       before_action :allows_w2_editing, only: [:edit, :update]
       before_action :load_w2
 
-      helper_method :box_14_codes_and_values
+      helper_method :box_14_codes_and_values, :state_wages_invalid?
 
       def self.show?(intake) # only accessed via button, not navigator
         false
@@ -51,6 +51,10 @@ module StateFile
           value = code_name == "uiwfswf" ? @w2.get_box14_ui_overwrite : @w2.send(field_name)
           { code_name:, field_name:, value: }
         end
+      end
+
+      def state_wages_invalid?
+        current_intake.state_wages_invalid?(@w2) if StateFile::StateInformationService.check_box_16(current_state_code)
       end
 
       def load_w2

--- a/app/controllers/state_file/questions/w2_controller.rb
+++ b/app/controllers/state_file/questions/w2_controller.rb
@@ -16,7 +16,7 @@ module StateFile
 
       def edit
         if StateFile::StateInformationService.check_box_16(current_state_code)
-          current_intake.confirmed_w2_indexes.append(@w2.w2_index)
+          current_intake.confirmed_w2_ids.append(@w2.id)
           current_intake.save
         end
 
@@ -54,7 +54,7 @@ module StateFile
       end
 
       def state_wages_invalid?
-        current_intake.state_wages_invalid?(@w2) if StateFile::StateInformationService.check_box_16(current_state_code)
+        StateFile::StateInformationService.check_box_16(current_state_code) && current_intake.state_wages_invalid?(@w2)
       end
 
       def load_w2

--- a/app/controllers/state_file/questions/w2_controller.rb
+++ b/app/controllers/state_file/questions/w2_controller.rb
@@ -23,13 +23,15 @@ module StateFile
       def update
         @w2.assign_attributes(form_params)
         @w2.check_box14_limits = true
-        @w2.taxpayer_reviewed = true
-        @w2.errors.clear
+
+        if StateFile::StateInformationService.check_box_16(current_state_code)
+          current_intake.confirmed_w2_indexes.append(@w2.w2_index)
+          current_intake.save
+        end
 
         if @w2.valid?(:state_file_edit)
           @w2.box14_ui_hc_wd = nil
           @w2.save(context: [:state_file_edit, :state_file_income_review])
-          binding.pry # w2 is valid in both contexts here, taxpayer_reviewed is true
           redirect_to StateFile::Questions::IncomeReviewController.to_path_helper(return_to_review: params[:return_to_review])
         else
           render :edit

--- a/app/models/state_file_nj_intake.rb
+++ b/app/models/state_file_nj_intake.rb
@@ -7,7 +7,7 @@
 #  account_type                                           :integer          default("unfilled"), not null
 #  claimed_as_dep                                         :integer
 #  claimed_as_eitc_qualifying_child                       :integer          default("unfilled"), not null
-#  confirmed_w2_indexes                                   :integer          default([]), is an Array
+#  confirmed_w2_ids                                       :integer          default([]), is an Array
 #  consented_to_sms_terms                                 :integer          default("unfilled"), not null
 #  consented_to_terms_and_conditions                      :integer          default("unfilled"), not null
 #  contact_preference                                     :integer          default("unfilled"), not null
@@ -226,7 +226,7 @@ class StateFileNjIntake < StateFileBaseIntake
 
   def validate_state_specific_w2_requirements(w2)
     super
-    if state_wages_invalid?(w2) && !confirmed_w2_indexes.include?(w2.w2_index)
+    if state_wages_invalid?(w2) && !confirmed_w2_ids.include?(w2.id)
       w2.errors.add(:state_wages_amount, I18n.t("state_file.questions.w2.edit.state_wages_amt_error"))
     end
   end

--- a/app/models/state_file_nj_intake.rb
+++ b/app/models/state_file_nj_intake.rb
@@ -220,11 +220,13 @@ class StateFileNjIntake < StateFileBaseIntake
     (nj_gross_income * 0.02).floor
   end
 
+  def state_wages_invalid?(w2)
+    w2.wages.positive? && (w2.state_wages_amount.nil? || w2.state_wages_amount <= 0)
+  end
+
   def validate_state_specific_w2_requirements(w2)
     super
-    if w2.wages.positive? && 
-       (w2.state_wages_amount.nil? || w2.state_wages_amount <= 0) && 
-       !confirmed_w2_indexes.include?(w2.w2_index)
+    if state_wages_invalid?(w2) && !confirmed_w2_indexes.include?(w2.w2_index)
       w2.errors.add(:state_wages_amount, I18n.t("state_file.questions.w2.edit.state_wages_amt_error"))
     end
   end

--- a/app/models/state_file_nj_intake.rb
+++ b/app/models/state_file_nj_intake.rb
@@ -221,7 +221,9 @@ class StateFileNjIntake < StateFileBaseIntake
 
   def validate_state_specific_w2_requirements(w2)
     super
-    if w2.wages.positive? && (w2.state_wages_amount.nil? || w2.state_wages_amount <= 0)
+    if w2.wages.positive? && 
+       (w2.state_wages_amount.nil? || w2.state_wages_amount <= 0) && 
+       !w2.taxpayer_reviewed
       w2.errors.add(:state_wages_amount, I18n.t("state_file.questions.w2.edit.state_wages_amt_error"))
     end
   end

--- a/app/models/state_file_nj_intake.rb
+++ b/app/models/state_file_nj_intake.rb
@@ -7,6 +7,7 @@
 #  account_type                                           :integer          default("unfilled"), not null
 #  claimed_as_dep                                         :integer
 #  claimed_as_eitc_qualifying_child                       :integer          default("unfilled"), not null
+#  confirmed_w2_indexes                                   :integer          default([]), is an Array
 #  consented_to_sms_terms                                 :integer          default("unfilled"), not null
 #  consented_to_terms_and_conditions                      :integer          default("unfilled"), not null
 #  contact_preference                                     :integer          default("unfilled"), not null
@@ -223,7 +224,7 @@ class StateFileNjIntake < StateFileBaseIntake
     super
     if w2.wages.positive? && 
        (w2.state_wages_amount.nil? || w2.state_wages_amount <= 0) && 
-       !w2.taxpayer_reviewed
+       !confirmed_w2_indexes.include?(w2.w2_index)
       w2.errors.add(:state_wages_amount, I18n.t("state_file.questions.w2.edit.state_wages_amt_error"))
     end
   end

--- a/app/models/state_file_w2.rb
+++ b/app/models/state_file_w2.rb
@@ -29,7 +29,7 @@
 #  index_state_file_w2s_on_state_file_intake  (state_file_intake_type,state_file_intake_id)
 #
 class StateFileW2 < ApplicationRecord
-  attr_accessor :check_box14_limits
+  attr_accessor :check_box14_limits, :taxpayer_reviewed
 
   include XmlMethods
   STATE_TAX_GRP_TEMPLATE = <<~XML
@@ -124,10 +124,8 @@ class StateFileW2 < ApplicationRecord
           errors.add(:local_income_tax_amount, I18n.t("state_file.questions.w2.edit.wages_amt_error", wages_amount: w2.WagesAmt))
           errors.add(:state_income_tax_amount, I18n.t("state_file.questions.w2.edit.wages_amt_error", wages_amount: w2.WagesAmt))
         end
-      else
-        if state_income_tax_amount.present? && state_income_tax_amount > w2.WagesAmt
-          errors.add(:state_income_tax_amount, I18n.t("state_file.questions.w2.edit.wages_amt_error", wages_amount: w2.WagesAmt))
-        end
+      elsif state_income_tax_amount.present? && state_income_tax_amount > w2.WagesAmt
+        errors.add(:state_income_tax_amount, I18n.t("state_file.questions.w2.edit.wages_amt_error", wages_amount: w2.WagesAmt))
       end
     end
   end
@@ -174,7 +172,7 @@ class StateFileW2 < ApplicationRecord
 
   def supported_box14_codes
     box14_codes = StateFile::StateInformationService.w2_supported_box14_codes(state_file_intake.state_code)
-    box14_codes.map{ |code| code[:name] }
+    box14_codes.map { |code| code[:name] }
   end
 
   def validate_box14_limits

--- a/app/models/state_file_w2.rb
+++ b/app/models/state_file_w2.rb
@@ -29,7 +29,7 @@
 #  index_state_file_w2s_on_state_file_intake  (state_file_intake_type,state_file_intake_id)
 #
 class StateFileW2 < ApplicationRecord
-  attr_accessor :check_box14_limits, :taxpayer_reviewed
+  attr_accessor :check_box14_limits
 
   include XmlMethods
   STATE_TAX_GRP_TEMPLATE = <<~XML

--- a/app/services/state_file/state_information_service.rb
+++ b/app/services/state_file/state_information_service.rb
@@ -5,6 +5,7 @@ module StateFile
     GETTER_METHODS = [
       :intake_class,
       :calculator_class,
+      :check_box_16,
       :filing_years,
       :mail_voucher_address,
       :navigation_class,
@@ -25,7 +26,6 @@ module StateFile
       :voucher_form_name,
       :voucher_path,
       :w2_supported_box14_codes,
-      :check_box_16,
       :w2_include_local_income_boxes,
     ].freeze
 
@@ -71,6 +71,7 @@ module StateFile
       az: {
         intake_class: StateFileAzIntake,
         calculator_class: Efile::Az::Az140Calculator,
+        check_box_16: false,
         filing_years: [2024, 2023],
         mail_voucher_address: "Arizona Department of Revenue<br/>" \
                               "PO Box 29085<br/>" \
@@ -93,12 +94,12 @@ module StateFile
         voucher_form_name: "Form AZ-140V",
         voucher_path: "/pdfs/AZ-140V.pdf",
         w2_supported_box14_codes: [],
-        check_box_16: false,
         w2_include_local_income_boxes: false
       },
       id: {
         intake_class: StateFileIdIntake,
         calculator_class: Efile::Id::Id40Calculator,
+        check_box_16: false,
         filing_years: [2024],
         mail_voucher_address: "Idaho State Tax Commission<br/>" \
                               "PO Box 83784<br/>" \
@@ -121,12 +122,12 @@ module StateFile
         voucher_form_name: "Form ID-VP",
         voucher_path: "/pdfs/idformIDVP-TY2024.pdf",
         w2_supported_box14_codes: [],
-        check_box_16: false,
         w2_include_local_income_boxes: false
       },
       md: {
         intake_class: StateFileMdIntake,
         calculator_class: Efile::Md::Md502Calculator,
+        check_box_16: false,
         filing_years: [2024],
         mail_voucher_address: "Comptroller of Maryland<br/>" \
                               "Payment Processing<br/>" \
@@ -150,12 +151,12 @@ module StateFile
         voucher_form_name: "Form PV",
         voucher_path: "/pdfs/md-pv-TY2024.pdf",
         w2_supported_box14_codes: [{name: "STPICKUP"}],
-        check_box_16: false,
         w2_include_local_income_boxes: true
       },
       nc: {
         intake_class: StateFileNcIntake,
         calculator_class: Efile::Nc::D400Calculator,
+        check_box_16: false,
         filing_years: [2024],
         mail_voucher_address: "North Carolina Department of Revenue<br/>" \
                               "PO Box 25000<br/>" \
@@ -178,12 +179,12 @@ module StateFile
         voucher_form_name: "Form D-400V",
         voucher_path: "https://eservices.dor.nc.gov/vouchers/d400v.jsp?year=2024",
         w2_supported_box14_codes: [],
-        check_box_16: false,
         w2_include_local_income_boxes: false
       },
       nj: {
         intake_class: StateFileNjIntake,
         calculator_class: Efile::Nj::Nj1040Calculator,
+        check_box_16: true,
         filing_years: [2024],
         navigation_class: Navigation::StateFileNjQuestionNavigation,
         review_controller_class: StateFile::Questions::NjReviewController,
@@ -207,12 +208,12 @@ module StateFile
         voucher_form_name: "NJ-1040-V (NJ Gross Income Tax Resident Payment Voucher)",
         voucher_path: "/pdfs/nj1040v-TY2024.pdf",
         w2_supported_box14_codes: [{name: "UI_WF_SWF", limit: 180}, {name: "FLI", limit: 145.26}],
-        check_box_16: true,
         w2_include_local_income_boxes: false
       },
       ny: {
         intake_class: StateFileNyIntake,
         calculator_class: Efile::Ny::It201,
+        check_box_16: false,
         filing_years: [2023],
         mail_voucher_address: "NYS Personal Income Tax<br/>" \
                               "Processing Center<br/>" \
@@ -236,7 +237,6 @@ module StateFile
         voucher_form_name: "Form IT-201-V",
         voucher_path: "/pdfs/it201v_1223.pdf",
         w2_supported_box14_codes: [],
-        check_box_16: false,
         w2_include_local_income_boxes: false
       }
     }.with_indifferent_access)

--- a/app/services/state_file/state_information_service.rb
+++ b/app/services/state_file/state_information_service.rb
@@ -25,6 +25,7 @@ module StateFile
       :voucher_form_name,
       :voucher_path,
       :w2_supported_box14_codes,
+      :check_box_16,
       :w2_include_local_income_boxes,
     ].freeze
 

--- a/app/services/state_file/state_information_service.rb
+++ b/app/services/state_file/state_information_service.rb
@@ -92,6 +92,7 @@ module StateFile
         voucher_form_name: "Form AZ-140V",
         voucher_path: "/pdfs/AZ-140V.pdf",
         w2_supported_box14_codes: [],
+        check_box_16: false,
         w2_include_local_income_boxes: false
       },
       id: {
@@ -119,6 +120,7 @@ module StateFile
         voucher_form_name: "Form ID-VP",
         voucher_path: "/pdfs/idformIDVP-TY2024.pdf",
         w2_supported_box14_codes: [],
+        check_box_16: false,
         w2_include_local_income_boxes: false
       },
       md: {
@@ -147,6 +149,7 @@ module StateFile
         voucher_form_name: "Form PV",
         voucher_path: "/pdfs/md-pv-TY2024.pdf",
         w2_supported_box14_codes: [{name: "STPICKUP"}],
+        check_box_16: false,
         w2_include_local_income_boxes: true
       },
       nc: {
@@ -174,6 +177,7 @@ module StateFile
         voucher_form_name: "Form D-400V",
         voucher_path: "https://eservices.dor.nc.gov/vouchers/d400v.jsp?year=2024",
         w2_supported_box14_codes: [],
+        check_box_16: false,
         w2_include_local_income_boxes: false
       },
       nj: {
@@ -202,6 +206,7 @@ module StateFile
         voucher_form_name: "NJ-1040-V (NJ Gross Income Tax Resident Payment Voucher)",
         voucher_path: "/pdfs/nj1040v-TY2024.pdf",
         w2_supported_box14_codes: [{name: "UI_WF_SWF", limit: 180}, {name: "FLI", limit: 145.26}],
+        check_box_16: true,
         w2_include_local_income_boxes: false
       },
       ny: {
@@ -230,6 +235,7 @@ module StateFile
         voucher_form_name: "Form IT-201-V",
         voucher_path: "/pdfs/it201v_1223.pdf",
         w2_supported_box14_codes: [],
+        check_box_16: false,
         w2_include_local_income_boxes: false
       }
     }.with_indifferent_access)

--- a/app/views/state_file/questions/w2/edit.html.erb
+++ b/app/views/state_file/questions/w2/edit.html.erb
@@ -35,6 +35,11 @@
       <div class="form-question spacing-below-25">
         <%= f.vita_min_money_field(:state_wages_amount, t(".box16_html"), classes: ["form-width--long"]) %>
       </div>
+      <% if StateFile::StateInformationService.check_box_16(current_state_code) %>
+        <div class="notice--warning spacing-above-5">
+          <p><%= t(".nj_box_16_warning") %></p>
+        </div>
+      <% end %>
       <div class="form-question spacing-below-25">
         <%= f.vita_min_money_field(:state_income_tax_amount, t(".box17_html"), classes: ["form-width--long"]) %>
       </div>

--- a/app/views/state_file/questions/w2/edit.html.erb
+++ b/app/views/state_file/questions/w2/edit.html.erb
@@ -37,7 +37,7 @@
       </div>
       <% if state_wages_invalid? %>
         <div class="notice--warning spacing-above-5">
-          <p><%= t(".nj_box_16_warning") %></p>
+          <p><%= t(".box16_warning_nj") %></p>
         </div>
       <% end %>
       <div class="form-question spacing-below-25">

--- a/app/views/state_file/questions/w2/edit.html.erb
+++ b/app/views/state_file/questions/w2/edit.html.erb
@@ -35,7 +35,7 @@
       <div class="form-question spacing-below-25">
         <%= f.vita_min_money_field(:state_wages_amount, t(".box16_html"), classes: ["form-width--long"]) %>
       </div>
-      <% if StateFile::StateInformationService.check_box_16(current_state_code) %>
+      <% if state_wages_invalid? %>
         <div class="notice--warning spacing-above-5">
           <p><%= t(".nj_box_16_warning") %></p>
         </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4292,6 +4292,7 @@ en:
           box14_ui_wf_swf_html: "<strong>UI/WF/SWF</strong>"
           box15_html: "<strong>Box 15,</strong> Employer’s state ID number"
           box16_html: "<strong>Box 16,</strong> State wages, tips, etc."
+          box16_warning_nj: 'Warning: If this is incorrect, you could end up underpaying state taxes. If box 16 has a number in it, enter that number here. If it''s blank or 0, click "Chat with us" and let''s make sure this is correct.'
           box17_html: "<strong>Box 17,</strong> State income tax"
           box18_html: "<strong>Box 18,</strong> Local wages, tips, etc."
           box19_html: "<strong>Box 19,</strong> Local income tax"
@@ -4306,7 +4307,6 @@ en:
           state_income_tax_amt_error: Cannot be greater than State wages and tips.
           state_wages_amt_error: Please enter State wages and tips
           wages_amt_error: Total income tax cannot be greater than $%{wages_amount}
-          nj_box_16_warning: ⚠️ If Box 16 has a number in it, enter that number here. If it's blank or 0, click "Chat with us" and let's make sure this is correct.
           what_is_box14_md: What could be in Box 14?
           what_is_box14_nj: What should I put in these Box 14 fields?
       waiting_to_load_data:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4306,7 +4306,7 @@ en:
           state_income_tax_amt_error: Cannot be greater than State wages and tips.
           state_wages_amt_error: Please enter State wages and tips
           wages_amt_error: Total income tax cannot be greater than $%{wages_amount}
-          nj_box_16_warning: ⚠️ If Box 16 has a number in it, enter that number here. If it’s blank or 0, click "Chat with us” and let’s make sure this is correct.
+          nj_box_16_warning: ⚠️ If Box 16 has a number in it, enter that number here. If it's blank or 0, click "Chat with us" and let's make sure this is correct.
           what_is_box14_md: What could be in Box 14?
           what_is_box14_nj: What should I put in these Box 14 fields?
       waiting_to_load_data:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4306,6 +4306,8 @@ en:
           state_income_tax_amt_error: Cannot be greater than State wages and tips.
           state_wages_amt_error: Please enter State wages and tips
           wages_amt_error: Total income tax cannot be greater than $%{wages_amount}
+          nj_box_16_warning: Are you sure box 16 is $0 on every copy of your W-2? To avoid any issues or penalties, please review.
+          nj_box_16_helper_text: On your transferred federal return, you entered $0. Confirm this is accurate by checking box 16 is $0 on every copy of your W-2.
           what_is_box14_md: What could be in Box 14?
           what_is_box14_nj: What should I put in these Box 14 fields?
       waiting_to_load_data:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4306,8 +4306,7 @@ en:
           state_income_tax_amt_error: Cannot be greater than State wages and tips.
           state_wages_amt_error: Please enter State wages and tips
           wages_amt_error: Total income tax cannot be greater than $%{wages_amount}
-          nj_box_16_warning: Are you sure box 16 is $0 on every copy of your W-2? To avoid any issues or penalties, please review.
-          nj_box_16_helper_text: On your transferred federal return, you entered $0. Confirm this is accurate by checking box 16 is $0 on every copy of your W-2.
+          nj_box_16_warning: ⚠️ If Box 16 has a number in it, enter that number here. If it’s blank or 0, click "Chat with us” and let’s make sure this is correct.
           what_is_box14_md: What could be in Box 14?
           what_is_box14_nj: What should I put in these Box 14 fields?
       waiting_to_load_data:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4278,6 +4278,7 @@ es:
           box14_ui_wf_swf_html: "<strong>UI/WF/SWF</strong>"
           box15_html: "<strong>Casilla 15,</strong> Número de identificación estatal del empleador"
           box16_html: "<strong>Casilla 16</strong>, Salarios estatales, propinas, etc."
+          box16_warning_nj: 'Advertencia: Si esto es incorrecto, podrías terminar pagando menos impuestos estatales de lo que te corresponde. Si la casilla 16 tiene un número, ingresa ese número aquí. Si está en blanco o tiene un 0, haz clic en el chat para verificar si esto es correcto.'
           box17_html: "<strong>Casilla 17</strong>, Impuesto estatal sobre los ingresos"
           box18_html: "<strong>Box 18,</strong> Local wages, tips, etc."
           box19_html: "<strong>Box 19,</strong> Local income tax"

--- a/db/migrate/20250313183732_add_nj_validated_w2_ids_column.rb
+++ b/db/migrate/20250313183732_add_nj_validated_w2_ids_column.rb
@@ -1,0 +1,5 @@
+class AddNjValidatedW2IdsColumn < ActiveRecord::Migration[7.1]
+  def change
+    add_column :state_file_nj_intakes, :confirmed_w2_indexes, :integer, array: true, default: []
+  end
+end

--- a/db/migrate/20250313183732_add_nj_validated_w2_ids_column.rb
+++ b/db/migrate/20250313183732_add_nj_validated_w2_ids_column.rb
@@ -1,5 +1,5 @@
 class AddNjValidatedW2IdsColumn < ActiveRecord::Migration[7.1]
   def change
-    add_column :state_file_nj_intakes, :confirmed_w2_indexes, :integer, array: true, default: []
+    add_column :state_file_nj_intakes, :confirmed_w2_ids, :integer, array: true, default: []
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2306,7 +2306,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_13_183732) do
     t.string "bank_name"
     t.integer "claimed_as_dep"
     t.integer "claimed_as_eitc_qualifying_child", default: 0, null: false
-    t.integer "confirmed_w2_indexes", default: [], array: true
+    t.integer "confirmed_w2_ids", default: [], array: true
     t.integer "consented_to_sms_terms", default: 0, null: false
     t.integer "consented_to_terms_and_conditions", default: 0, null: false
     t.integer "contact_preference", default: 0, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_04_145229) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_13_183732) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -2306,6 +2306,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_04_145229) do
     t.string "bank_name"
     t.integer "claimed_as_dep"
     t.integer "claimed_as_eitc_qualifying_child", default: 0, null: false
+    t.integer "confirmed_w2_indexes", default: [], array: true
     t.integer "consented_to_sms_terms", default: 0, null: false
     t.integer "consented_to_terms_and_conditions", default: 0, null: false
     t.integer "contact_preference", default: 0, null: false

--- a/spec/controllers/state_file/questions/w2_controller_spec.rb
+++ b/spec/controllers/state_file/questions/w2_controller_spec.rb
@@ -83,6 +83,7 @@ RSpec.describe StateFile::Questions::W2Controller do
       context "with NJ invalid state wages" do
         before do
           allow_any_instance_of(StateFileNjIntake).to receive(:state_wages_invalid?).and_return true
+          
         end
 
         it "adds w2 index to the list of verified W2s and removes the state_wages_amount error when user opens the page" do
@@ -94,6 +95,7 @@ RSpec.describe StateFile::Questions::W2Controller do
           state_file_w2.valid?(:state_file_edit)
           expect(intake.reload.confirmed_w2_ids).to eq [state_file_w2.id]
           expect(state_file_w2.errors).not_to include(:state_wages_amount)
+          expect(response.body).to have_text(I18n.t("state_file.questions.w2.edit.nj_box_16_warning"))
         end
       end
 
@@ -108,6 +110,7 @@ RSpec.describe StateFile::Questions::W2Controller do
           get :edit, params: params
           expect(intake.reload.confirmed_w2_ids).to eq [state_file_w2.id]
           expect(state_file_w2.errors).not_to include(:state_wages_amount)
+          expect(response.body).not_to have_text(I18n.t("state_file.questions.w2.edit.nj_box_16_warning"))
         end
       end
 

--- a/spec/controllers/state_file/questions/w2_controller_spec.rb
+++ b/spec/controllers/state_file/questions/w2_controller_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe StateFile::Questions::W2Controller do
           state_file_w2.valid?(:state_file_edit)
           expect(intake.reload.confirmed_w2_ids).to eq [state_file_w2.id]
           expect(state_file_w2.errors).not_to include(:state_wages_amount)
-          expect(response.body).to have_text(I18n.t("state_file.questions.w2.edit.nj_box_16_warning"))
+          expect(response.body).to have_text(I18n.t("state_file.questions.w2.edit.box16_warning_nj"))
         end
       end
 
@@ -110,7 +110,7 @@ RSpec.describe StateFile::Questions::W2Controller do
           get :edit, params: params
           expect(intake.reload.confirmed_w2_ids).to eq [state_file_w2.id]
           expect(state_file_w2.errors).not_to include(:state_wages_amount)
-          expect(response.body).not_to have_text(I18n.t("state_file.questions.w2.edit.nj_box_16_warning"))
+          expect(response.body).not_to have_text(I18n.t("state_file.questions.w2.edit.box16_warning_nj"))
         end
       end
 

--- a/spec/controllers/state_file/questions/w2_controller_spec.rb
+++ b/spec/controllers/state_file/questions/w2_controller_spec.rb
@@ -75,6 +75,71 @@ RSpec.describe StateFile::Questions::W2Controller do
 
       expect(response.body).to include(state_file_w2.employer_state_id_num)
     end
+
+    context "NJ intake" do
+      let(:intake) { create(:state_file_nj_intake) }
+      let!(:state_file_w2) { create :state_file_w2, state_file_intake: intake, box14_ui_hc_wd: 10 }
+
+      context "with NJ invalid state wages" do
+        before do
+          allow_any_instance_of(StateFileNjIntake).to receive(:state_wages_invalid?).and_return true
+        end
+
+        it "adds w2 index to the list of verified W2s and removes the state_wages_amount error when user opens the page" do
+          expect(state_file_w2.valid?(:state_file_edit)).to eq false
+          expect(intake.confirmed_w2_ids.size).to eq 0
+          expect(state_file_w2.errors).to include(:state_wages_amount)
+          get :edit, params: params
+          state_file_w2.reload
+          state_file_w2.valid?(:state_file_edit)
+          expect(intake.reload.confirmed_w2_ids).to eq [state_file_w2.id]
+          expect(state_file_w2.errors).not_to include(:state_wages_amount)
+        end
+      end
+
+      context "with NJ valid state wages" do
+        before do
+          allow_any_instance_of(StateFileNjIntake).to receive(:state_wages_invalid?).and_return false
+        end
+
+        it "adds w2 id to the list of verified W2s" do
+          expect(intake.confirmed_w2_ids.size).to eq 0
+          expect(state_file_w2.errors).not_to include(:state_wages_amount)
+          get :edit, params: params
+          expect(intake.reload.confirmed_w2_ids).to eq [state_file_w2.id]
+          expect(state_file_w2.errors).not_to include(:state_wages_amount)
+        end
+      end
+
+    end
+
+    context "non NJ intake" do
+      StateFile::StateInformationService.active_state_codes.excluding("nj").each do |state_code|
+        let(:intake) { create("state_file_#{state_code}_intake".to_sym) }
+        let!(:state_file_w2) { create :state_file_w2, state_file_intake: intake, box14_ui_hc_wd: 10 }
+        let(:params) do
+          {
+            id: state_file_w2.id,
+            state_file_w2: {
+              employer_state_id_num: "12345",
+              box14_stpickup: 230,
+              wages: 100,
+              state_wages_amount: 0,
+              state_income_tax_amount: 0,
+              local_wages_and_tips_amount: 40,
+              local_income_tax_amount: 0,
+              locality_nm: "Boopville"
+            }
+          }
+        end
+  
+        it "does not show an error if state wages is 0 and federal wages is nonzero" do
+          get :edit, params: params
+          expect(subject.state_wages_invalid?).to eq false
+          expect(state_file_w2.errors).not_to include(:state_wages_amount)
+        end
+      end
+    end
   end
 
   describe "#update" do
@@ -95,41 +160,6 @@ RSpec.describe StateFile::Questions::W2Controller do
         expect(state_file_w2.locality_nm).to eq "BOOPVILLE"
 
         expect(response).to redirect_to(StateFile::Questions::IncomeReviewController.to_path_helper)
-      end
-
-      context "NJ intake" do
-        let(:intake) { create(:state_file_nj_intake) }
-
-        it "adds w2 index to the list of verified W2s" do
-          post :update, params: params
-          expect(intake.reload.confirmed_w2_indexes).to eq [1]
-        end
-
-        context "with NJ state wages amount error" do
-          let!(:state_file_w2) { create :state_file_w2, state_file_intake: intake, box14_ui_hc_wd: 10 }
-          let(:params) do
-            {
-              id: state_file_w2.id,
-              state_file_w2: {
-                employer_state_id_num: "12345",
-                state_wages_amount: 0,
-                state_income_tax_amount: 0,
-                box14_ui_wf_swf: 0,
-                box14_fli: 0
-              }
-            }
-          end
-          before do
-            state_file_w2.errors.add(:state_wages_amount, I18n.t("state_file.questions.w2.edit.state_wages_amt_error"))
-          end
-  
-          it "removes the state_wages_amount error when user updates the page" do
-            post :update, params: params
-            state_file_w2.reload
-            expect(state_file_w2.valid?(:state_file_edit)).to eq true
-            expect(state_file_w2.errors.size).to eq 0
-          end
-        end
       end
 
       context "with MD Box 14 fields" do

--- a/spec/controllers/state_file/questions/w2_controller_spec.rb
+++ b/spec/controllers/state_file/questions/w2_controller_spec.rb
@@ -93,34 +93,42 @@ RSpec.describe StateFile::Questions::W2Controller do
         expect(state_file_w2.local_wages_and_tips_amount).to eq 40
         expect(state_file_w2.local_income_tax_amount).to eq 30
         expect(state_file_w2.locality_nm).to eq "BOOPVILLE"
-        expect(state_file_w2.taxpayer_reviewed).to eq true
 
         expect(response).to redirect_to(StateFile::Questions::IncomeReviewController.to_path_helper)
       end
 
-      context "with NJ state wages amount error" do
+      context "NJ intake" do
         let(:intake) { create(:state_file_nj_intake) }
-        let!(:state_file_w2) { create :state_file_w2, state_file_intake: intake, box14_ui_hc_wd: 10 }
-        let(:params) do
-          {
-            id: state_file_w2.id,
-            state_file_w2: {
-              employer_state_id_num: "12345",
-              state_wages_amount: 0,
-              state_income_tax_amount: 0,
-              box14_ui_wf_swf: 0,
-              box14_fli: 0
-            }
-          }
-        end
-        before do
-          state_file_w2.errors.add(:state_wages_amount, I18n.t("state_file.questions.w2.edit.state_wages_amt_error"))
+
+        it "adds w2 index to the list of verified W2s" do
+          post :update, params: params
+          expect(intake.reload.confirmed_w2_indexes).to eq [1]
         end
 
-        it "removes the state_wages_amount error when user updates the page" do
-          post :update, params: params
-          binding.pry # after the update action is complete, w2.taxpayer_reviewed is nil here
-          expect(state_file_w2.reload.errors).to eq []
+        context "with NJ state wages amount error" do
+          let!(:state_file_w2) { create :state_file_w2, state_file_intake: intake, box14_ui_hc_wd: 10 }
+          let(:params) do
+            {
+              id: state_file_w2.id,
+              state_file_w2: {
+                employer_state_id_num: "12345",
+                state_wages_amount: 0,
+                state_income_tax_amount: 0,
+                box14_ui_wf_swf: 0,
+                box14_fli: 0
+              }
+            }
+          end
+          before do
+            state_file_w2.errors.add(:state_wages_amount, I18n.t("state_file.questions.w2.edit.state_wages_amt_error"))
+          end
+  
+          it "removes the state_wages_amount error when user updates the page" do
+            post :update, params: params
+            state_file_w2.reload
+            expect(state_file_w2.valid?(:state_file_edit)).to eq true
+            expect(state_file_w2.errors.size).to eq 0
+          end
         end
       end
 

--- a/spec/factories/state_file_nj_intakes.rb
+++ b/spec/factories/state_file_nj_intakes.rb
@@ -7,6 +7,7 @@
 #  account_type                                           :integer          default("unfilled"), not null
 #  claimed_as_dep                                         :integer
 #  claimed_as_eitc_qualifying_child                       :integer          default("unfilled"), not null
+#  confirmed_w2_indexes                                   :integer          default([]), is an Array
 #  consented_to_sms_terms                                 :integer          default("unfilled"), not null
 #  consented_to_terms_and_conditions                      :integer          default("unfilled"), not null
 #  contact_preference                                     :integer          default("unfilled"), not null

--- a/spec/factories/state_file_nj_intakes.rb
+++ b/spec/factories/state_file_nj_intakes.rb
@@ -7,7 +7,7 @@
 #  account_type                                           :integer          default("unfilled"), not null
 #  claimed_as_dep                                         :integer
 #  claimed_as_eitc_qualifying_child                       :integer          default("unfilled"), not null
-#  confirmed_w2_indexes                                   :integer          default([]), is an Array
+#  confirmed_w2_ids                                       :integer          default([]), is an Array
 #  consented_to_sms_terms                                 :integer          default("unfilled"), not null
 #  consented_to_terms_and_conditions                      :integer          default("unfilled"), not null
 #  contact_preference                                     :integer          default("unfilled"), not null

--- a/spec/models/state_file_nj_intake_spec.rb
+++ b/spec/models/state_file_nj_intake_spec.rb
@@ -305,6 +305,23 @@ RSpec.describe StateFileNjIntake, type: :model do
       expect(w2).to be_valid
       expect(w2.errors[:state_wages_amount]).not_to be_present
     end
+
+    it "permits state_wages_amount to be 0 if w2.WagesAmt is non-zero and taxpayer has reviewed the w2" do
+      w2.taxpayer_reviewed = true
+      w2.state_wages_amount = 0
+      w2.state_income_tax_amount = 0
+      intake.validate_state_specific_w2_requirements(w2)
+      expect(w2.errors[:state_wages_amount]).not_to be_present
+      expect(w2.valid?(:state_file_income_review)).to eq true
+    end
+
+    it "does not permit state_wages_amount to be 0 if w2.WagesAmt is non-zero and taxpayer has not reviewed the w2" do
+      w2.taxpayer_reviewed = false
+      w2.state_wages_amount = 0
+      intake.validate_state_specific_w2_requirements(w2)
+      expect(w2.errors[:state_wages_amount]).to be_present
+      expect(w2.valid?(:state_file_edit)).to eq false
+    end
   end
 
   describe "#medical_expenses_threshold" do

--- a/spec/models/state_file_nj_intake_spec.rb
+++ b/spec/models/state_file_nj_intake_spec.rb
@@ -7,7 +7,7 @@
 #  account_type                                           :integer          default("unfilled"), not null
 #  claimed_as_dep                                         :integer
 #  claimed_as_eitc_qualifying_child                       :integer          default("unfilled"), not null
-#  confirmed_w2_indexes                                   :integer          default([]), is an Array
+#  confirmed_w2_ids                                       :integer          default([]), is an Array
 #  consented_to_sms_terms                                 :integer          default("unfilled"), not null
 #  consented_to_terms_and_conditions                      :integer          default("unfilled"), not null
 #  contact_preference                                     :integer          default("unfilled"), not null
@@ -318,7 +318,7 @@ RSpec.describe StateFileNjIntake, type: :model do
     end
 
     context "taxpayer has reviewed the w2" do
-      let(:intake) { create :state_file_nj_intake, confirmed_w2_indexes: [0]}
+      let(:intake) { create :state_file_nj_intake, confirmed_w2_ids: [w2.id]}
 
       it "permits state_wages_amount to be 0 if w2.WagesAmt is non-zero" do
         w2.taxpayer_reviewed = true

--- a/spec/models/state_file_nj_intake_spec.rb
+++ b/spec/models/state_file_nj_intake_spec.rb
@@ -285,6 +285,7 @@ RSpec.describe StateFileNjIntake, type: :model do
   end
 
   describe "#validate_state_specific_w2_requirements" do
+    let(:intake) { create :state_file_nj_intake }
     let(:w2) {
       create(:state_file_w2,
              employer_state_id_num: "001245788",
@@ -295,20 +296,12 @@ RSpec.describe StateFileNjIntake, type: :model do
              state_file_intake: intake,
              state_income_tax_amount: 600,
              state_wages_amount: 8000,
-             w2_index: 0
-      )
+             wages: 1000
+            )
     }
     context "taxpayer has not reviewed the w2" do
-      let(:intake) { create :state_file_nj_intake }
 
-      it "permits state_wages_amount to be greater than w2.WagesAmt" do
-        w2.state_wages_amount = 1000000
-        intake.validate_state_specific_w2_requirements(w2)
-        expect(w2).to be_valid
-        expect(w2.errors[:state_wages_amount]).not_to be_present
-      end
-
-      it "does not permit state_wages_amount to be 0 if w2.WagesAmt is non-zero and taxpayer has not reviewed the w2" do
+      it "does not permit state_wages_amount to be 0 if federal wages is non-zero" do
         w2.taxpayer_reviewed = false
         w2.state_wages_amount = 0
         intake.validate_state_specific_w2_requirements(w2)
@@ -318,9 +311,10 @@ RSpec.describe StateFileNjIntake, type: :model do
     end
 
     context "taxpayer has reviewed the w2" do
-      let(:intake) { create :state_file_nj_intake, confirmed_w2_ids: [w2.id]}
-
-      it "permits state_wages_amount to be 0 if w2.WagesAmt is non-zero" do
+      before do
+        intake.confirmed_w2_ids = [w2.id]
+      end
+      it "permits state_wages_amount to be 0 if federal wages is non-zero" do
         w2.taxpayer_reviewed = true
         w2.state_wages_amount = 0
         w2.state_income_tax_amount = 0

--- a/spec/models/state_file_nj_intake_spec.rb
+++ b/spec/models/state_file_nj_intake_spec.rb
@@ -296,6 +296,7 @@ RSpec.describe StateFileNjIntake, type: :model do
              state_file_intake: intake,
              state_income_tax_amount: 600,
              state_wages_amount: 8000,
+             w2_index: 0,
              wages: 1000
             )
     }

--- a/spec/models/state_file_w2_spec.rb
+++ b/spec/models/state_file_w2_spec.rb
@@ -97,12 +97,20 @@ describe StateFileW2 do
 
     context "NJ" do
       let(:intake) { create :state_file_nj_intake }
-      it "permits state_wages_amount to be zero if wages is positive" do
-        w2.taxpayer_reviewed = true
+      it "permits state_wages_amount to be zero if wages is positive and w2 has been visited" do
+        intake.confirmed_w2_ids = [w2.id]
         w2.wages = 10
         w2.state_wages_amount = 0
         w2.state_income_tax_amount = 0
         expect(w2).to be_valid(:state_file_edit)
+      end
+
+      it "does not permit state_wages_amount to be zero if wages is positive and w2 has NOT been visited" do
+        intake.confirmed_w2_ids = []
+        w2.wages = 10
+        w2.state_wages_amount = 0
+        w2.state_income_tax_amount = 0
+        expect(w2).not_to be_valid(:state_file_edit)
       end
 
       it "does not permit state_wages_amount to be nil if wages is positive" do

--- a/spec/models/state_file_w2_spec.rb
+++ b/spec/models/state_file_w2_spec.rb
@@ -97,10 +97,12 @@ describe StateFileW2 do
 
     context "NJ" do
       let(:intake) { create :state_file_nj_intake }
-      it "does not permit state_wages_amount to be zero if wages is positive" do
+      it "permits state_wages_amount to be zero if wages is positive" do
+        w2.taxpayer_reviewed = true
         w2.wages = 10
         w2.state_wages_amount = 0
-        expect(w2).not_to be_valid(:state_file_edit)
+        w2.state_income_tax_amount = 0
+        expect(w2).to be_valid(:state_file_edit)
       end
 
       it "does not permit state_wages_amount to be nil if wages is positive" do
@@ -209,9 +211,9 @@ describe StateFileW2 do
         w2.check_box14_limits = true
         allow(StateFile::StateInformationService).to receive(:w2_supported_box14_codes)
           .and_return([
-            { name: "UI_WF_SWF", limit: NjTestConstHelper::UI_WF_SWF_AT_LIMIT },
-            { name: "FLI", limit: NjTestConstHelper::FLI_AT_LIMIT }
-          ])
+                        { name: "UI_WF_SWF", limit: NjTestConstHelper::UI_WF_SWF_AT_LIMIT },
+                        { name: "FLI", limit: NjTestConstHelper::FLI_AT_LIMIT }
+                      ])
       end
   
       it "is invalid when box14_ui_wf_swf exceeds the state limit" do
@@ -316,9 +318,9 @@ describe StateFileW2 do
       before do
         allow(StateFile::StateInformationService).to receive(:w2_supported_box14_codes)
           .and_return([
-            { name: "UI_WF_SWF", limit: NjTestConstHelper::UI_WF_SWF_AT_LIMIT },
-            { name: "FLI", limit: NjTestConstHelper::FLI_AT_LIMIT }
-          ])
+                        { name: "UI_WF_SWF", limit: NjTestConstHelper::UI_WF_SWF_AT_LIMIT },
+                        { name: "FLI", limit: NjTestConstHelper::FLI_AT_LIMIT }
+                      ])
       end
 
       it "returns the correct limit for a valid name" do


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://github.com/newjersey/affordability-pm/issues/320
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!


**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- For NJ, allow state wage to be 0 even if federal wages are nonzero, as long as user visits the W2 edit screen

## How to test?
- Use bad W2s persona
- Validate that you cannot proceed past income review before editing individual w2s

## Screenshots (for visual changes)
- Before
- After
