### PR TITLE
[TBE-141] Save the matching intakes search as it's getting refined

### DIFF
--- a/app/controllers/state_file/questions/verification_code_controller.rb
+++ b/app/controllers/state_file/questions/verification_code_controller.rb
@@ -55,8 +55,8 @@ module StateFile
         state_intake_classes.each do |intake_class|
           key = intake.contact_preference == "text" ? :phone_number : :email_address
           search = intake_class.where.not(raw_direct_file_data: nil) # has a successful df import...
-          search.where(key => intake[key]) # ...using the same contact info
-          search.where.not(id: intake.id) if intake_class == intake.class # ...unless it's literally the same intake
+          search = search.where(key => intake[key]) # ...using the same contact info
+          search = search.where.not(id: intake.id) if intake_class == intake.class # ...unless it's literally the same intake
 
           existing_intake = search.first
           return existing_intake if existing_intake

--- a/spec/controllers/state_file/questions/verification_code_controller_spec.rb
+++ b/spec/controllers/state_file/questions/verification_code_controller_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe StateFile::Questions::VerificationCodeController do
           )
         )
         expect(response).to redirect_to(login_location)
+        expect(StateFileAzIntake.where(id: intake.id)).to be_empty
       end
     end
 
@@ -97,6 +98,7 @@ RSpec.describe StateFile::Questions::VerificationCodeController do
           )
         )
         expect(response).to redirect_to(login_location)
+        expect(StateFileAzIntake.where(id: intake.id)).to be_empty
       end
     end
 
@@ -119,6 +121,7 @@ RSpec.describe StateFile::Questions::VerificationCodeController do
       it "redirects to the next path" do
         post :update, params: { state_file_verification_code_form: { verification_code: token[0] }}
         expect(response).to redirect_to(questions_code_verified_path)
+        expect(intake.reload).not_to be_destroyed
       end
     end
   end

--- a/spec/controllers/state_file/questions/verification_code_controller_spec.rb
+++ b/spec/controllers/state_file/questions/verification_code_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe StateFile::Questions::VerificationCodeController do
+  let!(:first_existing_intake) { create(:state_file_az_intake, email_address: "hellodarkness@myoldfriend.org") }
   before do
     sign_in intake
   end

--- a/spec/controllers/state_file/questions/verification_code_controller_spec.rb
+++ b/spec/controllers/state_file/questions/verification_code_controller_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe StateFile::Questions::VerificationCodeController do
-  let!(:first_existing_intake) { create(:state_file_az_intake, email_address: "hellodarkness@myoldfriend.org") }
+  # making sure this one doesn't match
+  let!(:first_existing_intake) { create(:state_file_az_intake, email_address: "shouldntmatchanything@please.org") }
   before do
     sign_in intake
   end

--- a/spec/controllers/state_file/questions/verification_code_controller_spec.rb
+++ b/spec/controllers/state_file/questions/verification_code_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe StateFile::Questions::VerificationCodeController do
-  # making sure this one doesn't match
-  let!(:first_existing_intake) { create(:state_file_az_intake, email_address: "shouldntmatchanything@please.org") }
   before do
     sign_in intake
   end
@@ -56,6 +54,8 @@ RSpec.describe StateFile::Questions::VerificationCodeController do
   end
 
   describe "#update" do
+    # making sure this one doesn't match
+    let!(:existing_intake_with_df_data) { create(:state_file_az_intake, email_address: "shouldntmatchanything@please.org", raw_direct_file_data: "something") }
     context "with an intake matching an existing intake in the same state" do
       let!(:existing_intake) { create(:state_file_az_intake, contact_preference: "email", email_address: "someone@example.com") }
       let(:intake) do


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/TBE-141
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Save off the query as it's getting more refined; i think what was happening was that the search was just returning the first intake that does not have a direct file data, and in the specs this wasn't surfacing b/c we clean up the intake every time the tests run
- The Oops error occurs after `validate_token` runs and redirects to `:create` action (no idea _why_ create action runs, instead of a more elegant offboarding -- it might be that the `ClientLoginsController` is kind of from legacy code from CTC?)
## How to test?
- Describe the testing approach taken to verify the changes, including:
  - We should revamp the tests to expose the issue better in the controller specs.. to fix up demo I think we need to patch it to unblock releases (as i know NJ wants to release today); maybe make a followup story. I added a `existing_intake_with_df_data` in the second commit of this PR to demonstrate how the error manifests, but I wonder if we need a more robust re-write
    - funny thing is that even with the re-write, the tests pass in the "match" scenarios (although it matched incorrectly) b/c the login hash is based on the **current** intake, not the existing intake. The test fails for the non-matching one b/c it ends up matching when it doesnt expect to and goes to `login` path instead of the plain `code-verified` path (for intakes with no existing matches)