### PR TITLE
Added role="button" tags to state_file links

### DIFF
--- a/app/views/state_file/landing_page/edit.html.erb
+++ b/app/views/state_file/landing_page/edit.html.erb
@@ -26,7 +26,7 @@
                 <%= t(".#{@state_code}.supported_by") %>
               </div>
             </div>
-            <%= link_to StateFile::StateFilePagesController.to_path_helper(action: :login_options), class: "button button--primary button--wide", id: "firstCta" do %>
+            <%= link_to StateFile::StateFilePagesController.to_path_helper(action: :login_options), class: "button button--primary button--wide", role: "button", id: "firstCta" do %>
               <%= t(".download_your_record") %>
             <% end %>
           <% else %>
@@ -48,7 +48,7 @@
             <% if @user_name.present? %>
               <p class="h2"><%= t(".welcome_back", user_name: @user_name) %></p>
               <p class="h2"><%= t(".continue", state_name: @state_name) %></p>
-              <%= link_to StateFile::StateFilePagesController.to_path_helper(action: :login_options), class: "button button--primary button--wide", id: "firstCta" do %>
+              <%= link_to StateFile::StateFilePagesController.to_path_helper(action: :login_options), class: "button button--primary button--wide", role: "button", id: "firstCta" do %>
                 <%= t("general.sign_in") %>
               <% end %>
               <%= form_with model: @form, url: { action: :update }, local: true, method: :put, builder: VitaMinFormBuilder, id: "start-again-form" do |f| %>

--- a/app/views/state_file/questions/az_qualifying_organization_contributions/index.html.erb
+++ b/app/views/state_file/questions/az_qualifying_organization_contributions/index.html.erb
@@ -55,7 +55,7 @@
   <%= button_to(StateFile::Questions::AzQualifyingOrganizationContributionsController.to_path_helper(action: :new), params: { return_to_review: params[:return_to_review] }, class: "button button--wide spacing-below-10", method: :get, disabled: (@contribution_count >= 10)) do %>
     <%= t('.add_another') %>
   <% end %>
-  <%= link_to(next_path, class: "button button--primary button--wide") do %>
+  <%= link_to(next_path, class: "button button--primary button--wide", role: "button") do %>
     <%= t('general.continue') %>
   <% end %>
 

--- a/app/views/state_file/questions/eligible/edit.html.erb
+++ b/app/views/state_file/questions/eligible/edit.html.erb
@@ -31,7 +31,7 @@
     </div>
   <% end %>
 
-  <%= link_to next_path, class: "button button--primary button--wide", id: "firstCta" do %>
+  <%= link_to next_path, class: "button button--primary button--wide", role: "button", id: "firstCta" do %>
     <%= t("general.continue") %>
   <% end %>
 <% end %>

--- a/app/views/state_file/questions/md_pension_exclusion_offboarding/edit.html.erb
+++ b/app/views/state_file/questions/md_pension_exclusion_offboarding/edit.html.erb
@@ -35,7 +35,7 @@
     </div>
 
   </div>
-  <%= link_to next_path, class: "button button--primary button--wide", id: "firstCta" do %>
+  <%= link_to next_path, class: "button button--primary button--wide", role: "button", id: "firstCta" do %>
     <%= t("general.continue") %>
   <% end %>
 <% end %>

--- a/app/views/state_file/questions/post_data_transfer/edit.html.erb
+++ b/app/views/state_file/questions/post_data_transfer/edit.html.erb
@@ -9,7 +9,7 @@
   </div>
   <h1 class="h2" id="main-question"><%= title %></h1>
   <p><%= t(".subtitle", state_name: current_state_name) %></p>
-  <%= link_to t("general.continue"), next_path, class: "button button--wide button--primary text--centered" %>
+  <%= link_to t("general.continue"), next_path, class: "button button--wide button--primary text--centered", role: "button" %>
 
   <% unless acts_like_production? %>
     <%=

--- a/app/views/state_file/questions/retirement_income/show.html.erb
+++ b/app/views/state_file/questions/retirement_income/show.html.erb
@@ -27,5 +27,5 @@
       </div>
     </div>
   </dl>
-  <%= link_to t('general.continue'), questions_income_review_path(return_to_review: params[:return_to_review]), class: "button button--primary button--wide text--centered" %>
+  <%= link_to t('general.continue'), questions_income_review_path(return_to_review: params[:return_to_review]), class: "button button--primary button--wide text--centered", role: "button" %>
 <% end %>

--- a/app/views/state_file/questions/return_status/edit.html.erb
+++ b/app/views/state_file/questions/return_status/edit.html.erb
@@ -7,7 +7,7 @@
   <% end %>
 
   <% if !@error&.auto_wait || app_time.after?(Rails.configuration.state_file_end_of_in_progress_intakes) && @submission_to_show.present? %>
-    <%= link_to t('.download_state_return_pdf'), StateFile::Questions::SubmissionPdfsController.to_path_helper(action: :show, id: @submission_to_show.id), class: "button button--primary button--wide spacing-above-60" %>
+    <%= link_to t('.download_state_return_pdf'), StateFile::Questions::SubmissionPdfsController.to_path_helper(action: :show, id: @submission_to_show.id), class: "button button--primary button--wide spacing-above-60", role: "button" %>
   <% end %>
 
   <% if show_xml? %>

--- a/app/views/state_file/questions/shared/_review_footer.html.erb
+++ b/app/views/state_file/questions/shared/_review_footer.html.erb
@@ -1,3 +1,3 @@
-<%= link_to next_path, class: "button button--primary button--wide spacing-above-15" do %>
+<%= link_to next_path, class: "button button--primary button--wide spacing-above-15", role: "button" do %>
   <%= t("general.continue") %>
 <% end %>

--- a/app/views/state_file/questions/submission_confirmation/edit.html.erb
+++ b/app/views/state_file/questions/submission_confirmation/edit.html.erb
@@ -38,7 +38,7 @@
 
   <%= render partial: "state_file/questions/submission_confirmation/#{current_state_code}_additional_content" rescue nil %>
 
-  <%= link_to t(".download_state_return_pdf"), StateFile::Questions::SubmissionPdfsController.to_path_helper(action: :show, id: current_intake.latest_submission), class: "button button--primary button--wide" %>
+  <%= link_to t(".download_state_return_pdf"), StateFile::Questions::SubmissionPdfsController.to_path_helper(action: :show, id: current_intake.latest_submission), class: "button button--primary button--wide", role: "button" %>
 
   <% if show_xml? %>
     <p>

--- a/app/views/state_file/questions/unemployment/index.html.erb
+++ b/app/views/state_file/questions/unemployment/index.html.erb
@@ -26,7 +26,7 @@
   <%= link_to(next_path, class: "button button--primary button--wide spacing-below-10") do %>
     <%= t('general.continue') %>
   <% end %>
-  <%= link_to(StateFile::Questions::UnemploymentController.to_path_helper(action: :new, return_to_review: params[:return_to_review]), class: "button button--wide") do %>
+  <%= link_to(StateFile::Questions::UnemploymentController.to_path_helper(action: :new, return_to_review: params[:return_to_review]), class: "button button--wide", role: "button") do %>
     <%= t('.add_another') %>
   <% end %>
 <% end %>

--- a/app/views/state_file/questions/w2/show.html.erb
+++ b/app/views/state_file/questions/w2/show.html.erb
@@ -48,5 +48,5 @@
     </dl>
   </div>
 
-  <%= link_to t('general.continue'), questions_income_review_path(return_to_review: params[:return_to_review]), class: "button button--primary button--wide text--centered" %>
+  <%= link_to t('general.continue'), questions_income_review_path(return_to_review: params[:return_to_review]), class: "button button--primary button--wide text--centered", role: "button" %>
 <% end %>

--- a/app/views/state_file/state_file_pages/about_page.html.erb
+++ b/app/views/state_file/state_file_pages/about_page.html.erb
@@ -29,7 +29,7 @@
     <% else %>
       <div>
         <%= t(".closed_subheader_html") %>
-        <%= link_to StateFile::StateFilePagesController.to_path_helper(action: :login_options), class: "button button--primary button--wide", id: "firstCta" do %>
+        <%= link_to StateFile::StateFilePagesController.to_path_helper(action: :login_options), class: "button button--primary button--wide", role: "button", id: "firstCta" do %>
           <%= t("general.sign_in") %>
         <% end %>
       </div>

--- a/app/views/state_file/state_file_pages/archived_intakes_verification_error.html.erb
+++ b/app/views/state_file/state_file_pages/archived_intakes_verification_error.html.erb
@@ -12,7 +12,7 @@
         <li><a href="https://www.tax.ny.gov/help/contact/get-copy-of-return.htm"><%= t("state_file.archived_intakes.verification_error.ny_dor") %></a></li>
       </ul>
     </div>
-    <%= link_to root_path, class: "button button--primary button--wide text--centered spacing-above-25" do %>
+    <%= link_to root_path, class: "button button--primary button--wide text--centered spacing-above-25", role: "button" do %>
       <%=t("state_file.archived_intakes.verification_error.return_to_home") %>
     <% end %>
   </div>


### PR DESCRIPTION
## Link to pivotal/JIRA issue
(visible to CFA) https://github.com/newjersey/accessibility-pm/issues/14
(OOI internal) https://github.com/newjersey/affordability-pm/issues/274

## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Change all state_file occurences of link_to elements styled as button--wide to have role="button"

## How to test?
- Step through flow, validate that all Continue buttons are either `<input type="submit">` or `<a role="button">` elements.

## Screenshots (for visual changes)
Videos illustrate how a button="role" element appear to users using a screen reader, and how this creates consistency between <input type="submit"> and <a role="button"> elements

https://github.com/user-attachments/assets/3402315d-be17-4e24-8204-7a9fddc96295

https://github.com/user-attachments/assets/7f3cfdec-773c-4cdd-93b7-6b78a54f076e


