### PR TITLE
make analytics data migration skip ny intakes and continue after errors

### DIFF
--- a/db/data/20250312211508_backfill_state_file_analytics_columns.rb
+++ b/db/data/20250312211508_backfill_state_file_analytics_columns.rb
@@ -4,8 +4,11 @@ class BackfillStateFileAnalyticsColumns < ActiveRecord::Migration[7.1]
   def up
     StateFileAnalytics.includes(:record).find_each(batch_size: 100) do |analytics|
       intake = analytics.record
+      next if intake.instance_of?(StateFileNyIntake)
       next unless intake.raw_direct_file_data.present?
       analytics.update(intake.calculator&.analytics_attrs || {})
+    rescue StandardError => e
+      Rails.logger.info("Failed to update analytics for intake #{intake} with error #{e}")
     end
   end
 


### PR DESCRIPTION
Just a small change to work Jenny did to update our state file analytics table, since the migration was breaking in myriad ways on demo