### PR TITLE
verify that an existing intake's contact preference is the same as the communication channel a user is using to log in

### DIFF
--- a/app/controllers/state_file/questions/verification_code_controller.rb
+++ b/app/controllers/state_file/questions/verification_code_controller.rb
@@ -54,8 +54,10 @@ module StateFile
         state_intake_classes = StateFile::StateInformationService.state_intake_classes.without(StateFileNyIntake)
         state_intake_classes.each do |intake_class|
           key = intake.contact_preference == "text" ? :phone_number : :email_address
-          search = intake_class.where.not(raw_direct_file_data: nil) # has a successful df import...
-          search = search.where(key => intake[key]) # ...using the same contact info
+          search = intake_class
+                     .where.not(raw_direct_file_data: nil) # has a successful df import...
+                     .where(contact_preference: intake.contact_preference) # ...used the same login method
+                     .where(key => intake[key]) # ...with the same contact info
           search = search.where.not(id: intake.id) if intake_class == intake.class # ...unless it's literally the same intake
 
           existing_intake = search.first
@@ -67,10 +69,10 @@ module StateFile
 
       def redirect_into_login(intake, existing_intake)
         contact_info = (
-          if intake.contact_preference == "email"
-            intake.email_address
+          if existing_intake.contact_preference == "email"
+            existing_intake.email_address
           else
-            intake.phone_number
+            existing_intake.phone_number
           end
         )
         hashed_verification_code = VerificationCodeService.hash_verification_code_with_contact_info(


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1949
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Although there can be two pieces of contact information on an intake, we only ever verify that the user controls and can access one of them, when we send a verification code via that channel and allow them proceed after they enter it into the site. This selected channel is called `contact_preference` in the code (though I'd like a later refactor to rename it or alias it to `login_method`). Since a user who has entered & verified the contact info corresponding to their contact preference could (mistakenly or otherwise) then enter contact info into the other channel that they don't control or can't access, we should only allow users to subsequently access that intake who log in using the same contact info as is on that intake corresponding to its contact preference.
- That sure is a mess of words! Here's an example of what we're trying to prevent:
  - User A with email `user_a@example.com` and phone number `123-555-1234` comes to FYST and selects "text" as their contact preference. They receive a verification code on their phone, enter it on the site and proceed.
  - User A then says that they'd like to receive notifications via email, but mistakenly enters their email as `user_b@example.com`. They continue through the app, since we don't verify the contact info they entered for notifications
  - User B with email `user_b@example.com` then attempts to use FYST, selects "email" as their contact preference, and enters their email address correctly. Before this change, we would have prompted them to log into User A's intake because the email addresses on the intakes match. After this change, we will not, because their contact preferences don't match
## How to test?
- Unit test added
- Manual testing: 
  - Go through the example flow described above and verify that you aren't prompted to log in as the second user
  - Do the same thing on demo and verify that you are prompted to log in there