### PR TITLE
FYST-1934 Change SocialSecurityNumberValidator to allow SSN/ITINs to start with 9

### DIFF
--- a/app/validators/social_security_number_validator.rb
+++ b/app/validators/social_security_number_validator.rb
@@ -1,6 +1,6 @@
 class SocialSecurityNumberValidator < ActiveModel::EachValidator
-  REAL_SSN_REGEX = /\A(?!(000|666|9))\d{3}-?(?!00)\d{2}-?(?!0000)\d{4}\z/ # Real SSNS cannot have 00 in 4th and 5th position
-  LOOSE_SSN_REGEX = /\A(?!(000|666|9))\d{3}-?\d{2}-?(?!0000)\d{4}\z/
+  REAL_SSN_REGEX = /\A(?!(000|666))\d{3}-?(?!00)\d{2}-?(?!0000)\d{4}\z/ # Real SSNS cannot have 00 in 4th and 5th position
+  LOOSE_SSN_REGEX = /\A(?!(000|666))\d{3}-?\d{2}-?(?!0000)\d{4}\z/
 
   def validate_each(record, attr_name, value)
     regex = Rails.env.production? ? REAL_SSN_REGEX : LOOSE_SSN_REGEX

--- a/spec/forms/ssn_itin_form_spec.rb
+++ b/spec/forms/ssn_itin_form_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe SsnItinForm do
   let(:intake) { create :intake }
   let(:valid_params) do
     {
-        primary_ssn: "123456789",
-        primary_ssn_confirmation: "123456789",
+        primary_ssn: "900500011",
+        primary_ssn_confirmation: "900500011",
         primary_tin_type: "ssn"
       }
   end
@@ -66,7 +66,7 @@ RSpec.describe SsnItinForm do
       form.save
       intake.reload
 
-      expect(intake.primary.ssn).to eq "123456789"
+      expect(intake.primary.ssn).to eq "900500011"
       expect(intake.primary.tin_type).to eq "ssn"
     end
   end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1934
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Update the SSN/ITIN validator to allow numbers to start with a 9
## How to test?
- Updated one form that uses the validator to have an example ITIN that starts with 9 (taken from Atticus fixture)
