### PR TITLE
Nj 319 filers below income threshold

### DIFF
--- a/app/controllers/state_file/questions/nj_medical_expenses_controller.rb
+++ b/app/controllers/state_file/questions/nj_medical_expenses_controller.rb
@@ -4,7 +4,7 @@ module StateFile
       include ReturnToReviewConcern
 
       def self.show?(intake)
-        intake.nj_gross_income.positive?
+        !intake.eligibility_made_less_than_threshold?
       end
     end
   end

--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -426,6 +426,8 @@ module Efile
       end
 
       def calculate_line_42
+        return 0 if @intake.eligibility_made_less_than_threshold?
+
         if should_use_property_tax_deduction
           [line_or_zero(:NJ1040_LINE_39) - calculate_property_tax_deduction, 0].max
         else

--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -370,7 +370,7 @@ module Efile
         line_or_zero(:NJ1040_LINE_13) + line_or_zero(:NJ1040_LINE_31)
       end
 
-      def calculate_line_39
+      def calculate_line_39 
         [line_or_zero(:NJ1040_LINE_29) - line_or_zero(:NJ1040_LINE_38), 0].max
       end
 
@@ -426,8 +426,6 @@ module Efile
       end
 
       def calculate_line_42
-        return 0 if @intake.eligibility_made_less_than_threshold?
-
         if should_use_property_tax_deduction
           [line_or_zero(:NJ1040_LINE_39) - calculate_property_tax_deduction, 0].max
         else
@@ -436,6 +434,8 @@ module Efile
       end
 
       def calculate_line_43
+        return 0 if @intake.eligibility_made_less_than_threshold?
+
         should_use_property_tax_deduction ? calculate_tax_liability_with_deduction.round : calculate_tax_liability_without_deduction.round
       end
 

--- a/app/views/state_file/questions/nj_review/edit.html.erb
+++ b/app/views/state_file/questions/nj_review/edit.html.erb
@@ -142,7 +142,7 @@
     </section>
   <% end %>
 
-  <% if current_intake.nj_gross_income.positive? %>
+  <% if !current_intake.eligibility_made_less_than_threshold? %>
     <section id="medical_expenses" class="white-group">
       <div class="spacing-below-5">
         <h2 class="text--body text--bold spacing-below-5"><%=t(".medical_expenses") %></h2>

--- a/spec/controllers/state_file/questions/nj_medical_expenses_controller_spec.rb
+++ b/spec/controllers/state_file/questions/nj_medical_expenses_controller_spec.rb
@@ -28,10 +28,18 @@ RSpec.describe StateFile::Questions::NjMedicalExpensesController do
         end
       end
 
-      context "when nj gross income is greater than zero" do
+      context "when nj gross income is less than or equal to filing threshold" do
+        let(:intake) { create :state_file_nj_intake }
+        it "does not show" do
+          allow_any_instance_of(StateFileNjIntake).to receive(:nj_gross_income).and_return(10_000)
+          expect(described_class.show?(intake)).to eq false
+        end
+      end
+
+      context "when nj gross income is greater than filing threshold" do
         let(:intake) { create :state_file_nj_intake }
         it "shows" do
-          allow_any_instance_of(StateFileNjIntake).to receive(:nj_gross_income).and_return(1)
+          allow_any_instance_of(StateFileNjIntake).to receive(:nj_gross_income).and_return(10_001)
           expect(described_class.show?(intake)).to eq true
         end
       end

--- a/spec/features/state_file/nj/complete_intake_spec.rb
+++ b/spec/features/state_file/nj/complete_intake_spec.rb
@@ -519,7 +519,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
         advance_county_and_municipality
         advance_disabled_exemption(false) # does NOT meet disabled exemption
         advance_veterans_exemption
-        advance_medical_expenses
+        # skips medical expenses page
         choose_household_rent_own("tenant")
         expect_ineligible_page(nil, "income_mfj_qss_hoh")
         expect_page_after_property_tax
@@ -530,7 +530,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
         advance_county_and_municipality
         advance_disabled_exemption(false) # does NOT meet disabled exemption
         advance_veterans_exemption
-        advance_medical_expenses
+        # skips medical expenses page
         choose_household_rent_own("both")
         expect_ineligible_page(nil, "income_mfj_qss_hoh")
         expect_page_after_property_tax

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -1339,7 +1339,7 @@ describe Efile::Nj::Nj1040Calculator do
     end
   end
 
-  describe 'calculate line 42 when filer is at or below threshold' do
+  describe 'calculate line 43 when filer is at or below threshold' do
     [
       { traits: [:single], line_29_total_income: 9_999 },
       { traits: [:single], line_29_total_income: 10_000 },
@@ -1361,7 +1361,7 @@ describe Efile::Nj::Nj1040Calculator do
         end
         it "returns 0" do
           instance.calculate
-          expect(instance.lines[:NJ1040_LINE_42].value).to eq(0)
+          expect(instance.lines[:NJ1040_LINE_43].value).to eq(0)
         end
       end
     end

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -1339,6 +1339,34 @@ describe Efile::Nj::Nj1040Calculator do
     end
   end
 
+  describe 'calculate line 42 when filer is at or below threshold' do
+    [
+      { traits: [:single], line_29_total_income: 9_999 },
+      { traits: [:single], line_29_total_income: 10_000 },
+      { traits: [:head_of_household], line_29_total_income: 19_999 },
+      { traits: [:head_of_household], line_29_total_income: 20_000 },
+      { traits: [:qualifying_widow], line_29_total_income: 19_999 },
+      { traits: [:qualifying_widow], line_29_total_income: 20_000 },
+      { traits: [:married_filing_jointly], line_29_total_income: 19_999 },
+      { traits: [:married_filing_jointly], line_29_total_income: 20_000 },
+      { traits: [:married_filing_separately], line_29_total_income: 9_999 },
+      { traits: [:married_filing_separately], line_29_total_income: 10_000 },
+    ].each do |test_case|
+      context "when filing with #{test_case}" do
+        before do
+          allow(intake).to receive(:nj_gross_income).and_return test_case[:line_29_total_income]
+        end
+        let(:intake) do
+          create(:state_file_nj_intake, *test_case[:traits])
+        end
+        it "returns 0" do
+          instance.calculate
+          expect(instance.lines[:NJ1040_LINE_42].value).to eq(0)
+        end
+      end
+    end
+  end
+
   describe 'lines 41, 42, 43, 56 - property tax deduction' do
     context 'when without_deduction - with_deduction >= $50' do
       let(:intake) {


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://github.com/newjersey/affordability-pm/issues/319

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- If a taxpayer has a NJ gross income <= the filing threshold, NJ does not require them to pay any taxes
  - Update Line 43 logic to reflect this
  - Remove medical exemption screen for these filers as claiming deductions will not be applicable to them, they are not paying any taxes

## How to test?
- Use Danny Devito persona
- Edit W2 state wages to 10,000 or less
- Go through property tax eligibility
- Validate that medical expenses controller does not appear
- Validate on Review Screen that medical expenses does not appear
- Validate that tax liability in PDF on lines 43 and 79 are 0
- Validate that XML <NetBalanceDue> is 0
- If eligible for property tax credit, ensure that it is present on line 56 and included in the refund amount

## Screenshots (for visual changes)
- Before
- After
<img width="548" alt="image" src="https://github.com/user-attachments/assets/99f85cb8-342f-46b7-9e6a-b2496b1d82cb" />
<img width="551" alt="image" src="https://github.com/user-attachments/assets/aca6ca0f-23b8-4da6-8c6c-2ee339e24464" />
<img width="550" alt="image" src="https://github.com/user-attachments/assets/3826946e-ee30-417f-9107-dabf3793641f" />
<img width="1495" alt="image" src="https://github.com/user-attachments/assets/95941fa6-977b-4ef2-940d-f3876bb53e5f" />

