### PR TITLE
GYR1-696 Hide updates in the menu for dates older than 2025

### DIFF
--- a/app/views/hub/components/_menu_item.html.erb
+++ b/app/views/hub/components/_menu_item.html.erb
@@ -4,6 +4,6 @@
   <%= image_tag(icon_path) %>
   <div>
     <p><%= item_label %></p>
-    <%= render 'shared/unread_icon', flag: true if current_user.notifications.pluck(:read).any?(false) && item_label == "My Updates" %>
+    <%= render 'shared/unread_icon', flag: true if current_user.notifications.where('created_at >= ?', Date.new(Rails.configuration.product_year)).pluck(:read).any?(false) && item_label == "My Updates" %>
   </div>
 </a>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1984,14 +1984,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_14_183447) do
   end
 
   create_table "state_file_id1099_r_followups", force: :cascade do |t|
-    t.integer "civil_service_account_number", default: 0, null: false
     t.datetime "created_at", null: false
     t.integer "eligible_income_source", default: 0, null: false
-    t.integer "firefighter_frf", default: 0, null: false
-    t.integer "firefighter_persi", default: 0, null: false
-    t.integer "income_source", default: 0, null: false
-    t.integer "police_persi", default: 0, null: false
-    t.integer "police_retirement_fund", default: 0, null: false
     t.datetime "updated_at", null: false
   end
 
@@ -2001,7 +1995,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_14_183447) do
     t.decimal "american_red_cross_fund_donation", precision: 12, scale: 2
     t.string "bank_name"
     t.decimal "childrens_trust_fund_donation", precision: 12, scale: 2
-    t.datetime "clicked_to_file_with_other_service_at"
     t.integer "consented_to_sms_terms", default: 0, null: false
     t.integer "consented_to_terms_and_conditions", default: 0, null: false
     t.integer "contact_preference", default: 0, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1984,8 +1984,14 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_14_183447) do
   end
 
   create_table "state_file_id1099_r_followups", force: :cascade do |t|
+    t.integer "civil_service_account_number", default: 0, null: false
     t.datetime "created_at", null: false
     t.integer "eligible_income_source", default: 0, null: false
+    t.integer "firefighter_frf", default: 0, null: false
+    t.integer "firefighter_persi", default: 0, null: false
+    t.integer "income_source", default: 0, null: false
+    t.integer "police_persi", default: 0, null: false
+    t.integer "police_retirement_fund", default: 0, null: false
     t.datetime "updated_at", null: false
   end
 
@@ -1995,6 +2001,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_14_183447) do
     t.decimal "american_red_cross_fund_donation", precision: 12, scale: 2
     t.string "bank_name"
     t.decimal "childrens_trust_fund_donation", precision: 12, scale: 2
+    t.datetime "clicked_to_file_with_other_service_at"
     t.integer "consented_to_sms_terms", default: 0, null: false
     t.integer "consented_to_terms_and_conditions", default: 0, null: false
     t.integer "contact_preference", default: 0, null: false


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. https://codeforamerica.atlassian.net/browse/ABCD-123
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Updated query for how notification alerts are shown in the main menu of the hub to make sure unread notification from before the current year is not shown. Now the blue dot next to the notifications is not shown if there are unread notification only from the prior years

## How to test?
- This can be tested on demo

## Screenshots (for visual changes)
- Before
![Screenshot 2025-03-20 at 11 13 11 AM](https://github.com/user-attachments/assets/1b325cae-514f-4da3-a957-9d5fe5e098ad)

- After
<img width="1344" alt="Screenshot 2025-03-20 at 2 08 57 PM" src="https://github.com/user-attachments/assets/66eab881-6b46-418d-8def-eff8adbf9385" />
