### PR TITLE
Add md address validation for PO boxes

### DIFF
--- a/app/forms/state_file/md_permanent_address_form.rb
+++ b/app/forms/state_file/md_permanent_address_form.rb
@@ -1,5 +1,6 @@
 module StateFile
   class MdPermanentAddressForm < QuestionsForm
+    include StateFile::PatternMatchingHelper
     set_attributes_for :intake,
                        :confirmed_permanent_address,
                        :permanent_street,
@@ -8,13 +9,16 @@ module StateFile
                        :permanent_zip,
                        :permanent_address_outside_md
 
-    validates :confirmed_permanent_address, presence: true
-    validates :permanent_street, presence: true, irs_street_address_type: { maximum: nil }, if: -> { confirmed_permanent_address == "no" }
+    validates :confirmed_permanent_address, presence: true, unless: -> { @intake.direct_file_address_is_po_box? }
     validates :permanent_apartment, irs_street_address_type: { maximum: nil }
-    validates :permanent_city, presence: true, irs_street_address_type: { maximum: nil }, if: -> { confirmed_permanent_address == "no" }
-    validates :permanent_zip, presence: true, zip_code: { zip_code_lengths: [5, 9, 12].freeze }, if: -> { confirmed_permanent_address == "no" }
     validate :permanent_street_is_not_po_box, if: -> { permanent_street.present? }
     validate :permanent_apartment_is_not_po_box, if: -> { permanent_apartment.present? }
+
+    with_options if: -> { collect_new_address? } do
+      validates :permanent_street, presence: true, irs_street_address_type: { maximum: nil }
+      validates :permanent_city, presence: true, irs_street_address_type: { maximum: nil }
+      validates :permanent_zip, presence: true, zip_code: { zip_code_lengths: [5, 9, 12].freeze }
+    end
 
     def initialize(intake = nil, params = nil)
       if params[:confirmed_permanent_address] == "yes"
@@ -26,15 +30,15 @@ module StateFile
     end
 
     def save
-      attributes_from_direct_file = if confirmed_permanent_address == "yes"
+      attributes_from_direct_file = if collect_new_address?
+                                      {}
+                                    else
                                       {
                                         permanent_city: @intake.direct_file_data.mailing_city,
                                         permanent_street: @intake.direct_file_data.mailing_street,
                                         permanent_apartment: @intake.direct_file_data.mailing_apartment,
                                         permanent_zip: @intake.direct_file_data.mailing_zip,
                                       }
-                                    else
-                                      {}
                                     end
       attributes_from_direct_file[:permanent_address_outside_md] = @intake.direct_file_data.mailing_state != 'MD' && confirmed_permanent_address == "yes" ? "yes" : "no"
       attributes_from_form = attributes_for(:intake).except(:permanent_zip).merge({ permanent_zip: permanent_zip&.delete('-') })
@@ -43,20 +47,16 @@ module StateFile
 
     private
 
+    def collect_new_address?
+      confirmed_permanent_address == "no" || @intake.direct_file_address_is_po_box?
+    end
+
     def permanent_street_is_not_po_box
       errors.add(:permanent_street, I18n.t("forms.errors.address_is_not_po_box", tax_year: MultiTenantService.statefile.current_tax_year)) if contains_po_box(permanent_street)
     end
 
     def permanent_apartment_is_not_po_box
       errors.add(:permanent_apartment, I18n.t("forms.errors.address_is_not_po_box", tax_year: MultiTenantService.statefile.current_tax_year)) if contains_po_box(permanent_apartment)
-    end
-
-    def contains_po_box(address)
-      return false if address.blank?
-
-      # Regex tested at https://regex101.com/r/4b22vr/1
-      pattern = /(?i)p(?:[.\s]*)o(?:[.\s]*)(?:b(?:[.\s]*)(?:o(?:[.\s]*)x)?)?/
-      address.match?(pattern)
     end
   end
 end

--- a/app/forms/state_file/md_permanent_address_form.rb
+++ b/app/forms/state_file/md_permanent_address_form.rb
@@ -13,6 +13,8 @@ module StateFile
     validates :permanent_apartment, irs_street_address_type: { maximum: nil }
     validates :permanent_city, presence: true, irs_street_address_type: { maximum: nil }, if: -> { confirmed_permanent_address == "no" }
     validates :permanent_zip, presence: true, zip_code: { zip_code_lengths: [5, 9, 12].freeze }, if: -> { confirmed_permanent_address == "no" }
+    validate :permanent_street_is_not_po_box, if: -> { permanent_street.present? }
+    validate :permanent_apartment_is_not_po_box, if: -> { permanent_apartment.present? }
 
     def initialize(intake = nil, params = nil)
       if params[:confirmed_permanent_address] == "yes"
@@ -24,16 +26,37 @@ module StateFile
     end
 
     def save
-      attributes_from_direct_file = confirmed_permanent_address == "yes" ?
+      attributes_from_direct_file = if confirmed_permanent_address == "yes"
                                       {
                                         permanent_city: @intake.direct_file_data.mailing_city,
                                         permanent_street: @intake.direct_file_data.mailing_street,
                                         permanent_apartment: @intake.direct_file_data.mailing_apartment,
                                         permanent_zip: @intake.direct_file_data.mailing_zip,
-                                      } : {}
+                                      }
+                                    else
+                                      {}
+                                    end
       attributes_from_direct_file[:permanent_address_outside_md] = @intake.direct_file_data.mailing_state != 'MD' && confirmed_permanent_address == "yes" ? "yes" : "no"
       attributes_from_form = attributes_for(:intake).except(:permanent_zip).merge({ permanent_zip: permanent_zip&.delete('-') })
       @intake.update(attributes_from_form.merge(attributes_from_direct_file))
+    end
+
+    private
+
+    def permanent_street_is_not_po_box
+      errors.add(:permanent_street, I18n.t("forms.errors.address_is_not_po_box", tax_year: MultiTenantService.statefile.current_tax_year)) if contains_po_box(permanent_street)
+    end
+
+    def permanent_apartment_is_not_po_box
+      errors.add(:permanent_apartment, I18n.t("forms.errors.address_is_not_po_box", tax_year: MultiTenantService.statefile.current_tax_year)) if contains_po_box(permanent_apartment)
+    end
+
+    def contains_po_box(address)
+      return false if address.blank?
+
+      # Regex tested at https://regex101.com/r/4b22vr/1
+      pattern = /(?i)p(?:[.\s]*)o(?:[.\s]*)(?:b(?:[.\s]*)(?:o(?:[.\s]*)x)?)?/
+      address.match?(pattern)
     end
   end
 end

--- a/app/helpers/state_file/pattern_matching_helper.rb
+++ b/app/helpers/state_file/pattern_matching_helper.rb
@@ -3,7 +3,7 @@ module StateFile
     def contains_po_box(address)
       return false if address.blank?
 
-      # Regex tested at https://regex101.com/r/4b22vr/1
+      # Regex tested at https://regex101.com/r/SksZmO/1
       pattern = /(?i)p(?:[.\s]*)o(?:[.\s]*)(?:b(?:[.\s]*)(?:o(?:[.\s]*)x)?)?/
       address.match?(pattern)
     end

--- a/app/helpers/state_file/pattern_matching_helper.rb
+++ b/app/helpers/state_file/pattern_matching_helper.rb
@@ -1,0 +1,11 @@
+module StateFile
+  module PatternMatchingHelper
+    def contains_po_box(address)
+      return false if address.blank?
+
+      # Regex tested at https://regex101.com/r/4b22vr/1
+      pattern = /(?i)p(?:[.\s]*)o(?:[.\s]*)(?:b(?:[.\s]*)(?:o(?:[.\s]*)x)?)?/
+      address.match?(pattern)
+    end
+  end
+end

--- a/app/models/state_file_md_intake.rb
+++ b/app/models/state_file_md_intake.rb
@@ -113,6 +113,7 @@
 #
 class StateFileMdIntake < StateFileBaseIntake
   include MdResidenceCountyConcern
+  include StateFile::PatternMatchingHelper
 
   encrypts :account_number, :routing_number, :raw_direct_file_data, :raw_direct_file_intake_data
 
@@ -271,5 +272,11 @@ class StateFileMdIntake < StateFileBaseIntake
 
   def should_warn_about_pension_exclusion?
     eligible_1099rs.present? && has_filer_under_65?
+  end
+
+  def direct_file_address_is_po_box?
+    return false if direct_file_data.blank?
+
+    contains_po_box(direct_file_data&.mailing_street) || contains_po_box(direct_file_data&.mailing_apartment)
   end
 end

--- a/app/models/state_file_md_intake.rb
+++ b/app/models/state_file_md_intake.rb
@@ -282,6 +282,6 @@ class StateFileMdIntake < StateFileBaseIntake
   def direct_file_address_is_po_box?
     return false if direct_file_data.blank?
 
-    contains_po_box(direct_file_data&.mailing_street) || contains_po_box(direct_file_data&.mailing_apartment)
+    contains_po_box(direct_file_data.mailing_street) || contains_po_box(direct_file_data.mailing_apartment)
   end
 end

--- a/app/views/state_file/questions/md_permanent_address/edit.html.erb
+++ b/app/views/state_file/questions/md_permanent_address/edit.html.erb
@@ -4,37 +4,40 @@
 <% content_for :card do %>
   <h1 class="h2"><%= title %></h1>
 
-  <p>
-    <%= t('.mark_no_hint_html', filing_year: current_tax_year) %>
-  </p>
-
   <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
     <% if params[:return_to_review].present? %>
       <%= hidden_field_tag "return_to_review", params[:return_to_review] %>
     <% end %>
     <div class="question-with-follow-up spacing-below-15">
-      <div class="question-with-follow-up__question">
-        <div class="white-group">
-          <div class="form-question spacing-below-15">
-            <div class="text--bold"><%=t(".address_header") %></div>
-            <div><%= current_intake.direct_file_data.mailing_street %> <%= current_intake.direct_file_data.mailing_apartment %></div>
-            <div><%= current_intake.direct_file_data.mailing_city %>, <%= current_intake.direct_file_data.mailing_state %> <%= current_intake.direct_file_data.mailing_zip %></div>
-          </div>
-          <div>
-            <%=
-              f.cfa_radio_set(
-                :confirmed_permanent_address,
-                collection: [
-                  { value: :yes, label: t("general.affirmative") },
-                  { value: :no, label: t("general.negative"), input_html: { "data-follow-up": "#permanent-address-fields" } },
-                ]
-              )
-            %>
+      <% if current_intake.direct_file_address_is_po_box? %>
+        <p class="spacing-below-15"><%= t(".df_address_is_po_box.p1") %></p>
+        <p class="spacing-below-0"><strong>PO Box 123</strong></p>
+        <p class="spacing-below-15"><strong>Baltimore, MD 21201</strong></p>
+        <p><%= t(".df_address_is_po_box.p2", tax_year: current_tax_year) %></p>
+      <% else %>
+        <p><%= t('.mark_no_hint_html', filing_year: current_tax_year) %></p>
+        <div class="question-with-follow-up__question">
+          <div class="white-group">
+            <div class="form-question spacing-below-15">
+              <div class="text--bold"><%= t(".address_header") %></div>
+              <div><%= current_intake.direct_file_data.mailing_street %> <%= current_intake.direct_file_data.mailing_apartment %></div>
+              <div><%= current_intake.direct_file_data.mailing_city %>, <%= current_intake.direct_file_data.mailing_state %> <%= current_intake.direct_file_data.mailing_zip %></div>
+            </div>
+            <div>
+              <%=
+                f.cfa_radio_set(
+                  :confirmed_permanent_address,
+                  collection: [
+                    { value: :yes, label: t("general.affirmative") },
+                    { value: :no, label: t("general.negative"), input_html: { "data-follow-up": "#permanent-address-fields" } },
+                  ]
+                )
+              %>
+            </div>
           </div>
         </div>
-      </div>
-
-      <div class="question-with-follow-up__follow-up" id="permanent-address-fields">
+      <% end %>
+      <div class=<%= "question-with-follow-up__follow-up" unless current_intake.direct_file_address_is_po_box? %> id="permanent-address-fields">
         <div class="white-group">
           <div class="form-question spacing-below-10">
             <%= t(".where_did_you_live", filing_year: current_tax_year) %>

--- a/app/views/state_file/questions/md_permanent_address/edit.html.erb
+++ b/app/views/state_file/questions/md_permanent_address/edit.html.erb
@@ -11,8 +11,8 @@
     <div class="question-with-follow-up spacing-below-15">
       <% if current_intake.direct_file_address_is_po_box? %>
         <p class="spacing-below-15"><%= t(".df_address_is_po_box.p1") %></p>
-        <p class="spacing-below-0"><strong>PO Box 123</strong></p>
-        <p class="spacing-below-15"><strong>Baltimore, MD 21201</strong></p>
+        <p class="spacing-below-0"><strong><%= "#{current_intake&.direct_file_data&.mailing_street} #{current_intake&.direct_file_data&.mailing_apartment}" %></strong></p>
+        <p class="spacing-below-15"><strong><%= "#{current_intake&.direct_file_data&.mailing_city}, #{current_intake&.direct_file_data&.mailing_state} #{current_intake&.direct_file_data&.mailing_zip}" %></strong></p>
         <p><%= t(".df_address_is_po_box.p2", tax_year: current_tax_year) %></p>
       <% else %>
         <p><%= t('.mark_no_hint_html', filing_year: current_tax_year) %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -265,6 +265,7 @@ en:
           presence: Please select a county
         subdivision_code:
           presence: Please select a political subdivision
+      address_is_not_po_box: A PO box cannot be listed as your physical address. Please enter where you lived on December 31, %{tax_year}
       nc_county:
         county:
           presence: Please select a county

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -246,6 +246,7 @@ en:
       whole_number: must be a whole number
   forms:
     errors:
+      address_is_not_po_box: A PO box cannot be listed as your physical address. Please enter where you lived on December 31, %{tax_year}
       at_least_one_year: Please pick at least one year.
       general: Please fix indicated errors before continuing.
       healthcare:
@@ -265,7 +266,6 @@ en:
           presence: Please select a county
         subdivision_code:
           presence: Please select a political subdivision
-      address_is_not_po_box: A PO box cannot be listed as your physical address. Please enter where you lived on December 31, %{tax_year}
       nc_county:
         county:
           presence: Please select a county
@@ -3209,6 +3209,9 @@ en:
           address_header: Address
           apartment_number_label: Apartment/Unit Number
           city_label: City
+          df_address_is_po_box:
+            p1: 'The address we have on file for you is a PO Box:'
+            p2: Since a PO Box cannot be listed as your physical address, we need you to tell us where you lived on December 31, %{tax_year}.
           follow_up_help_text: PO Boxes are not accepted
           mark_no_hint_html: Mark &quot;no&quot; if the address listed is a PO Box <strong>or</strong> if you lived at a different address on December 31, %{filing_year}.
           state_label: State

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -246,6 +246,7 @@ es:
       whole_number: Debe ser un número entero
   forms:
     errors:
+      address_is_not_po_box: A PO box cannot be listed as your physical address. Please enter where you lived on December 31, %{tax_year}
       at_least_one_year: Por favor, elija al menos un año.
       general: Por favor, corrija los errores indicados antes de continuar.
       healthcare:
@@ -3178,6 +3179,9 @@ es:
           address_header: Dirección
           apartment_number_label: Número de apartamento/unidad
           city_label: Cuidad
+          df_address_is_po_box:
+            p1: 'The address we have on file for you is a PO Box:'
+            p2: Since a PO Box cannot be listed as your physical address, we need you to tell us where you lived on December 31, %{tax_year}.
           follow_up_help_text: No se aceptan PO Boxes
           mark_no_hint_html: Marca “no” si la dirección que aparece es un PO Box <strong>o</strong> si vivías en una dirección distinta el 31 de diciembre de %{filing_year}.
           state_label: Estado

--- a/spec/models/state_file_md_intake_spec.rb
+++ b/spec/models/state_file_md_intake_spec.rb
@@ -698,4 +698,35 @@ RSpec.describe StateFileMdIntake, type: :model do
       end
     end
   end
+
+  describe "#direct_file_address_is_po_box?" do
+    let(:intake) { create :state_file_md_intake }
+
+    context "if there is not direct file data" do
+      before do
+        intake.raw_direct_file_data = nil
+      end
+      it "returns false" do
+        expect(intake.direct_file_address_is_po_box?).to eq(false)
+      end
+    end
+
+    context "if the mailing street is a po box" do
+      before do
+        intake.direct_file_data.mailing_street = "PO Box 123"
+      end
+      it "returns true" do
+        expect(intake.direct_file_address_is_po_box?).to eq(true)
+      end
+    end
+
+    context "if the mailing apartment is a po box" do
+      before do
+        intake.direct_file_data.mailing_apartment = "PO Box 555"
+      end
+      it "returns true" do
+        expect(intake.direct_file_address_is_po_box?).to eq(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. https://codeforamerica.atlassian.net/browse/FYST-1531
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Added PO box validation for Maryland FYST filers so that users can't add an address with a PO box and if they have a PO box address from direct file we force them to add a new non-PO box address
## How to test?
- test two cases through Heroku:
1. go through the Maryland flow with a DF test case that has a normal valid address and check the street and apartment address for PO box addresses

> Any of these variations should fail:
> Po Box
> 
> po box
> 
> PO Box
> 
> PO BOX
> 
> P.O. BOX
> 
> P.O. Box
> 
> p.o. box
> 
> P.o. box 
> 
> P.o. Box 
> 
> POB
> 
> POBox
> 
> pobox
> 
> P.O.Box

2. Go through the maryland flow and change the direct file street or apartment address with PO box and see if it requires you to provide an address on the address page 
## Screenshots (for visual changes)
<img width="675" alt="Screenshot 2025-03-20 at 1 21 13 PM" src="https://github.com/user-attachments/assets/c8265ea5-be5e-4309-a427-b66646490010" />
