### PR TITLE
[FYST-1971] Sanitize double spaces in W2 Fields to allow bundling

### DIFF
--- a/app/models/state_file_w2.rb
+++ b/app/models/state_file_w2.rb
@@ -29,6 +29,7 @@
 #  index_state_file_w2s_on_state_file_intake  (state_file_intake_type,state_file_intake_id)
 #
 class StateFileW2 < ApplicationRecord
+  include SubmissionBuilder::FormattingMethods
   attr_accessor :check_box14_limits
 
   include XmlMethods
@@ -146,7 +147,7 @@ class StateFileW2 < ApplicationRecord
 
     xml_template = Nokogiri::XML(STATE_TAX_GRP_TEMPLATE)
     xml_template.at(:StateAbbreviationCd).content = state_code&.upcase
-    xml_template.at(:EmployerStateIdNum).content = employer_state_id_num&.delete("\u00AD")
+    xml_template.at(:EmployerStateIdNum).content = sanitize_for_xml(employer_state_id_num.delete("\u00AD")) if employer_state_id_num.present?
     xml_template.at(:StateWagesAmt).content = state_wages_amount&.round
     xml_template.at(:StateIncomeTaxAmt).content = state_income_tax_amount&.round
     xml_template.at(:LocalWagesAndTipsAmt).content = local_wages_and_tips_amount&.round

--- a/app/models/state_file_w2.rb
+++ b/app/models/state_file_w2.rb
@@ -152,7 +152,7 @@ class StateFileW2 < ApplicationRecord
     xml_template.at(:StateIncomeTaxAmt).content = state_income_tax_amount&.round
     xml_template.at(:LocalWagesAndTipsAmt).content = local_wages_and_tips_amount&.round
     xml_template.at(:LocalIncomeTaxAmt).content = local_income_tax_amount&.round
-    xml_template.at(:LocalityNm).content = locality_nm
+    xml_template.at(:LocalityNm).content = sanitize_for_xml(locality_nm)
     delete_blank_nodes(xml_template)
     result = xml_template.at(:W2StateTaxGrp)
     result.nil? ? "" : result.to_xml

--- a/spec/models/state_file_w2_spec.rb
+++ b/spec/models/state_file_w2_spec.rb
@@ -301,6 +301,14 @@ describe StateFileW2 do
         expect(xml.at("EmployerStateIdNum").text).to eq "86 2124319"
       end
     end
+
+    context "when LocalityNm contains consecutive (adjacent) spaces" do
+      it "removes adjacent spaces when generating XML" do
+        w2.locality_nm = "Berry     Fields"
+        xml = Nokogiri::XML(w2.state_tax_group_xml_node)
+        expect(xml.at("LocalityNm").text).to eq "Berry Fields"
+      end
+    end
   end
 
   describe "box14_ui_wf_swf getter override" do

--- a/spec/models/state_file_w2_spec.rb
+++ b/spec/models/state_file_w2_spec.rb
@@ -293,6 +293,14 @@ describe StateFileW2 do
         expect(xml.at("EmployerStateIdNum").text).to eq "862124319"
       end
     end
+
+    context "when EmployerStateIdNum contains consecutive (adjacent) spaces" do
+      it "removes adjacent spaces when generating XML" do
+        w2.employer_state_id_num = "86  2124319"
+        xml = Nokogiri::XML(w2.state_tax_group_xml_node)
+        expect(xml.at("EmployerStateIdNum").text).to eq "86 2124319"
+      end
+    end
   end
 
   describe "box14_ui_wf_swf getter override" do


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1971
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Sanitized EmployerStateIdNum xml node which should trickle down to NJ W2 xml
## How to test?
- Describe the testing approach taken to verify the changes, including:
  - Feels difficult to test this just for NJ given it just renames the node for NJ; feels like overkill to double-sanitize?
  - anyways, checked the xml bundling on `main` vs this branch and saw the employer state id num / locality nm validations disappear
- Risk Assessment
  - Changing this for all states, since we never sanitized this field for any state
  - Realizing that other fields that do not allow double spaces like `LocalityNm` are also not being sanitized, sanitizing `LocalityNm` after talking to Tiffany
## Screenshots (for visual changes)
- Input
<img width="547" alt="Screenshot 2025-03-21 at 9 54 02 AM" src="https://github.com/user-attachments/assets/97e89d20-93a0-43c9-ac2a-60ce54df0f3c" />
<img width="605" alt="Screenshot 2025-03-21 at 10 02 41 AM" src="https://github.com/user-attachments/assets/a98f560d-06fd-4cf3-abfd-c87b92b45080" />

- Before
<img width="555" alt="Screenshot 2025-03-21 at 9 59 15 AM" src="https://github.com/user-attachments/assets/419939c5-4116-44d4-9ac5-3ad2c0945aac" />
<img width="443" alt="Screenshot 2025-03-21 at 10 04 08 AM" src="https://github.com/user-attachments/assets/6b089fc6-a549-4cfa-a048-d829d9d072f8" />

- After
<img width="574" alt="Screenshot 2025-03-21 at 9 53 22 AM" src="https://github.com/user-attachments/assets/43677138-c53e-4df6-b088-e0bf94159769" />
<img width="495" alt="Screenshot 2025-03-21 at 10 04 39 AM" src="https://github.com/user-attachments/assets/a06917e6-3d17-4b03-8aca-0d774dc9740c" />
