### PR TITLE
GYR1-698 Fix teams module arrow bug

### DIFF
--- a/app/presenters/hub/dashboard/team_assignment_presenter.rb
+++ b/app/presenters/hub/dashboard/team_assignment_presenter.rb
@@ -32,13 +32,17 @@ module Hub
 
         @user_count = accessible_users_by_role.count
 
-        ordered_users = accessible_users_by_role
-                            .select("users.*, COUNT(CASE WHEN clients.filterable_product_year = '#{Rails.configuration.product_year}' THEN tax_returns.id ELSE NULL END) AS tax_returns_count")
-                            .left_joins(assigned_tax_returns: :client)
-                            .group('users.id, users.name, users.role_type')
-                            .order('tax_returns_count DESC')
+        accessible_users_by_role.paginate(page: @page, per_page: 5)
+      end
 
-        ordered_users.paginate(page: @page, per_page: 5)
+      def ordered_by_tr_count_users
+        return unless team_assignment_users.present?
+
+        team_assignment_users
+          .select("users.*, COUNT(CASE WHEN clients.filterable_product_year = '#{Rails.configuration.product_year}' THEN tax_returns.id ELSE NULL END) AS tax_returns_count")
+          .left_joins(assigned_tax_returns: :client)
+          .group('users.id, users.name, users.role_type')
+          .order('tax_returns_count DESC')
       end
     end
   end

--- a/app/views/hub/dashboard/_team_assignment_content.html.erb
+++ b/app/views/hub/dashboard/_team_assignment_content.html.erb
@@ -1,5 +1,6 @@
 <% p = presenter.team_assignment_presenter %>
-<% ordered_users = p.team_assignment_users %>
+<% users = p.team_assignment_users %>
+<% ordered_users = p.ordered_by_tr_count_users %>
   <h2><%= t("hub.dashboard.show.team_assignment.title") %></h2>
 
   <table>
@@ -40,14 +41,14 @@
     </tbody>
   </table>
 
-  <% if ordered_users.present? %>
+  <% if users.present? %>
     <div class="paging">
       <div class="user-count">
         <% start_user = ((p.page.to_i - 1) * 5) + 1 %>
         <% end_user = [start_user + 4, p.user_count].min %>
         <%= t("hub.dashboard.show.team_assignment.pager", start_range: start_user, end_range: end_user, total: p.user_count) %>
       </div>
-      <div><%= js_will_paginate ordered_users,
+      <div><%= js_will_paginate users,
                              previous_label: "<i class='icon icon-keyboard_arrow_left'></i><span class='hide-on-mobile'>Previous 5</span>",
                              next_label: "<span class='hide-on-mobile'>Next 5</span><i class='icon icon-keyboard_arrow_right'></i>",
                              inner_window: 0,

--- a/spec/presenters/hub/team_assignment_presenter_spec.rb
+++ b/spec/presenters/hub/team_assignment_presenter_spec.rb
@@ -40,15 +40,15 @@ describe Hub::Dashboard::TeamAssignmentPresenter do
 
     context "when selecting an org" do
       it "shows org leads, team members and site coordinators belonging to selected org or child sites and their number of assigned tax returns in desc order" do
-        expect(subject.team_assignment_users).to eq [site_coordinator, team_member, org_lead, other_team_member]
+        expect(subject.ordered_by_tr_count_users).to eq [site_coordinator, team_member, org_lead, other_team_member]
       end
 
       context "when there are tax returns with archived clients" do
         it "doesn't count their tax returns" do
           create(:gyr_tax_return, assigned_user: site_coordinator, client: create(:client, filterable_product_year: 2023))
 
-          expect(subject.team_assignment_users.first.tax_returns_count).to eq 2
-          expect(subject.team_assignment_users.first).to eq site_coordinator
+          expect(subject.ordered_by_tr_count_users.first.tax_returns_count).to eq 2
+          expect(subject.ordered_by_tr_count_users.first).to eq site_coordinator
         end
       end
 
@@ -56,9 +56,9 @@ describe Hub::Dashboard::TeamAssignmentPresenter do
         it "returns 0 for their count of tax returns" do
           create(:gyr_tax_return, assigned_user: other_team_member, client: create(:client, filterable_product_year: 2023))
 
-          expect(subject.team_assignment_users).to eq [site_coordinator, team_member, org_lead, other_team_member]
-          expect(subject.team_assignment_users[3]).to eq other_team_member
-          expect(subject.team_assignment_users[3].tax_returns_count).to eq 0
+          expect(subject.ordered_by_tr_count_users).to eq [site_coordinator, team_member, org_lead, other_team_member]
+          expect(subject.ordered_by_tr_count_users[3]).to eq other_team_member
+          expect(subject.ordered_by_tr_count_users[3].tax_returns_count).to eq 0
         end
       end
 
@@ -66,7 +66,7 @@ describe Hub::Dashboard::TeamAssignmentPresenter do
         it "doesn't include them in the user group" do
           create(:user, role: (create :team_member_role, sites: [site]), suspended_at: Time.now)
 
-          expect(subject.team_assignment_users).to eq [site_coordinator, team_member, org_lead, other_team_member]
+          expect(subject.ordered_by_tr_count_users).to eq [site_coordinator, team_member, org_lead, other_team_member]
         end
       end
     end
@@ -75,7 +75,7 @@ describe Hub::Dashboard::TeamAssignmentPresenter do
       let(:selected_model) { other_org }
 
       it "doesn't show users from the other org" do
-        expect(subject.team_assignment_users).to eq [other_org_lead, other_site_coordinator]
+        expect(subject.ordered_by_tr_count_users).to eq [other_org_lead, other_site_coordinator]
       end
     end
   end
@@ -85,7 +85,7 @@ describe Hub::Dashboard::TeamAssignmentPresenter do
 
     context "when selecting an organization in the drop down" do
       it "shows team members, org leads, site coordinators under that selected org or its child sites and their number of assigned tax returns in desc order" do
-        expect(subject.team_assignment_users).to eq [site_coordinator, team_member, org_lead, other_team_member]
+        expect(subject.ordered_by_tr_count_users).to eq [site_coordinator, team_member, org_lead, other_team_member]
       end
     end
 
@@ -93,7 +93,7 @@ describe Hub::Dashboard::TeamAssignmentPresenter do
       let(:selected_model) { site }
 
       it "shows team members, org leads, site coordinators under that site or with its parent org" do
-        expect(subject.team_assignment_users).to eq [site_coordinator, team_member, org_lead]
+        expect(subject.ordered_by_tr_count_users).to eq [site_coordinator, team_member, org_lead]
       end
     end
   end
@@ -105,7 +105,7 @@ describe Hub::Dashboard::TeamAssignmentPresenter do
       let(:selected_model) { site }
 
       it "Site coordinators and team members that are assigned to selected site" do
-        expect(subject.team_assignment_users).to eq [site_coordinator, team_member]
+        expect(subject.ordered_by_tr_count_users).to eq [site_coordinator, team_member]
       end
     end
   end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/GYR1-698
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Separated the teams presenter methods in order to paginate properly through all the users in the teams module 
## How to test?
- Update the presenter unit tests

## Screenshots (for visual changes)
- Before
<img width="610" alt="Screenshot 2025-03-24 at 2 40 27 PM" src="https://github.com/user-attachments/assets/d7f9536f-27bc-4898-9f56-6bd701b7b9c5" />

- After
<img width="611" alt="Screenshot 2025-03-24 at 2 39 59 PM" src="https://github.com/user-attachments/assets/1d2c4e58-86e7-4d0c-a0b2-e87cc37aa797" />
