### PR TITLE
Gyr1 519 remove deprecated get ctc statuses from the hub

### DIFF
--- a/app/helpers/tax_return_status_helper.rb
+++ b/app/helpers/tax_return_status_helper.rb
@@ -1,6 +1,6 @@
 module TaxReturnStatusHelper
   def grouped_status_options_for_select
-    TaxReturnStateMachine.available_states_for(role_type: current_user.role_type).map do |stage, statuses|
+    TaxReturnStateMachine.states_to_show_for_client_filter(role_type: current_user.role_type).map do |stage, statuses|
       translated_stage = TaxReturnStatusHelper.stage_translation(stage)
       translated_statuses = statuses.map { |status| [TaxReturnStatusHelper.status_translation(status), status.to_s] }
       [translated_stage, translated_statuses]

--- a/app/state_machines/tax_return_state_machine.rb
+++ b/app/state_machines/tax_return_state_machine.rb
@@ -126,4 +126,11 @@ class TaxReturnStateMachine
     # TODO: Defaulting to 'all' for unknown roles feels bad
     ALLOWABLE_STATES_BY_ROLE.fetch(role_type, STATES_BY_STAGE)
   end
+
+  def self.states_to_show_for_filter(role_type:)
+    available_states = available_states_for(role_type:)
+
+    excluded_states = ["file_fraud_hold", "file_needs_review"]
+    available_states.transform_values { |states| states - excluded_states }
+  end
 end

--- a/app/state_machines/tax_return_state_machine.rb
+++ b/app/state_machines/tax_return_state_machine.rb
@@ -129,7 +129,6 @@ class TaxReturnStateMachine
 
   def self.states_to_show_for_client_filter(role_type:)
     available_states = available_states_for(role_type:)
-
     excluded_states = ["file_fraud_hold", "file_needs_review"]
     available_states.transform_values { |states| states - excluded_states }
   end

--- a/app/state_machines/tax_return_state_machine.rb
+++ b/app/state_machines/tax_return_state_machine.rb
@@ -127,7 +127,7 @@ class TaxReturnStateMachine
     ALLOWABLE_STATES_BY_ROLE.fetch(role_type, STATES_BY_STAGE)
   end
 
-  def self.states_to_show_for_filter(role_type:)
+  def self.states_to_show_for_client_filter(role_type:)
     available_states = available_states_for(role_type:)
 
     excluded_states = ["file_fraud_hold", "file_needs_review"]

--- a/app/views/shared/_client_filters.html.erb
+++ b/app/views/shared/_client_filters.html.erb
@@ -18,7 +18,7 @@
       <div class="select">
         <select name="status" class="select__element" id="status-filter">
           <option value></option>
-          <% TaxReturnStateMachine.available_states_for(role_type: current_user.role_type).each do |stage, statuses| %>
+          <% TaxReturnStateMachine.states_to_show_for_filter(role_type: current_user.role_type).each do |stage, statuses| %>
             <option value="<%= stage %>" <%= filters[:stage] == stage && "selected" %>><%= TaxReturnStatusHelper.stage_translation(stage) %></option>
             <% statuses.each do |status| %>
               <option value="<%= status %>" <%= [status, status.to_s].include?(filters[:status]) && "selected" %>>&emsp;<%= status_translation(status) %></option>

--- a/app/views/shared/_client_filters.html.erb
+++ b/app/views/shared/_client_filters.html.erb
@@ -18,7 +18,7 @@
       <div class="select">
         <select name="status" class="select__element" id="status-filter">
           <option value></option>
-          <% TaxReturnStateMachine.states_to_show_for_filter(role_type: current_user.role_type).each do |stage, statuses| %>
+          <% TaxReturnStateMachine.states_to_show_for_client_filter(role_type: current_user.role_type).each do |stage, statuses| %>
             <option value="<%= stage %>" <%= filters[:stage] == stage && "selected" %>><%= TaxReturnStatusHelper.stage_translation(stage) %></option>
             <% statuses.each do |status| %>
               <option value="<%= status %>" <%= [status, status.to_s].include?(filters[:status]) && "selected" %>>&emsp;<%= status_translation(status) %></option>

--- a/spec/helpers/tax_return_status_helper_spec.rb
+++ b/spec/helpers/tax_return_status_helper_spec.rb
@@ -32,15 +32,13 @@ describe TaxReturnStatusHelper do
       ],
       [I18n.t("hub.tax_returns.stage.file"),
        [
-         ["Needs review", "file_needs_review"],
          ["Ready to file", "file_ready_to_file"],
          ['E-filed', "file_efiled"],
          ["Filed by mail", "file_mailed"],
          ["Rejected", "file_rejected"],
          ["Accepted", "file_accepted"],
          ["Not filing", "file_not_filing"],
-         ["Hold", "file_hold"],
-         ["ID Check", "file_fraud_hold"]
+         ["Hold", "file_hold"]
        ]
       ]
     ]

--- a/spec/state_machines/tax_return_state_machine_spec.rb
+++ b/spec/state_machines/tax_return_state_machine_spec.rb
@@ -78,6 +78,36 @@ describe TaxReturnStateMachine do
     end
   end
 
+  describe ".states_to_show_for_filter" do
+    context "when role_type is GreeterRole type" do
+      it "only provides limited not including the excluded few" do
+        result = described_class.states_to_show_for_filter(role_type: GreeterRole::TYPE)
+        expect(result.keys.length).to eq 2
+        expect(result.keys.first).to eq "intake"
+        expect(result.keys.last).to eq "file"
+        expect(result["intake"]).to eq [
+                                         "intake_ready",
+                                         "intake_greeter_info_requested",
+                                         "intake_needs_doc_help"
+                                       ]
+        expect(result["file"]).to eq ["file_not_filing", "file_hold"]
+        expect(result.values.flatten).not_to include("file_fraud_hold", "file_needs_review")
+      end
+    end
+
+    context "when role is anything else" do
+      it "provides all statuses except the excluded few" do
+        result = described_class.states_to_show_for_filter(role_type: AdminRole::TYPE)
+
+        expect(result["file"]).to eq ["file_ready_to_file", "file_efiled", "file_mailed", "file_rejected", "file_accepted", "file_not_filing", "file_hold"]
+        expect(result["intake"]).to eq ["intake_in_progress", "intake_ready", "intake_reviewing", "intake_ready_for_call", "intake_info_requested", "intake_greeter_info_requested", "intake_needs_doc_help"]
+        expect(result["prep"]).to eq ["prep_ready_for_prep", "prep_preparing", "prep_info_requested"]
+        expect(result["review"]).to eq ["review_ready_for_qr", "review_reviewing", "review_ready_for_call", "review_signature_requested", "review_info_requested"]
+        expect(result.values.flatten).not_to include("file_fraud_hold", "file_needs_review")
+      end
+    end
+  end
+
   context "transitions" do
     let(:tax_return) { create(:gyr_tax_return) }
 

--- a/spec/state_machines/tax_return_state_machine_spec.rb
+++ b/spec/state_machines/tax_return_state_machine_spec.rb
@@ -78,10 +78,10 @@ describe TaxReturnStateMachine do
     end
   end
 
-  describe ".states_to_show_for_filter" do
+  describe ".states_to_show_for_client_filter" do
     context "when role_type is GreeterRole type" do
       it "only provides limited not including the excluded few" do
-        result = described_class.states_to_show_for_filter(role_type: GreeterRole::TYPE)
+        result = described_class.states_to_show_for_client_filter(role_type: GreeterRole::TYPE)
         expect(result.keys.length).to eq 2
         expect(result.keys.first).to eq "intake"
         expect(result.keys.last).to eq "file"
@@ -97,7 +97,7 @@ describe TaxReturnStateMachine do
 
     context "when role is anything else" do
       it "provides all statuses except the excluded few" do
-        result = described_class.states_to_show_for_filter(role_type: AdminRole::TYPE)
+        result = described_class.states_to_show_for_client_filter(role_type: AdminRole::TYPE)
 
         expect(result["file"]).to eq ["file_ready_to_file", "file_efiled", "file_mailed", "file_rejected", "file_accepted", "file_not_filing", "file_hold"]
         expect(result["intake"]).to eq ["intake_in_progress", "intake_ready", "intake_reviewing", "intake_ready_for_call", "intake_info_requested", "intake_greeter_info_requested", "intake_needs_doc_help"]


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/GYR1-519
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Creates a new method that removes certain status from view in the gyr hub
## How to test?
- Login in as an admin and look at the filters
## Screenshots (for visual changes)
- Before
![Screenshot 2025-03-20 at 1 17 07 PM](https://github.com/user-attachments/assets/dc07fb9f-0047-4ae5-a346-b742f5e06952)

- After
![Screenshot 2025-03-20 at 1 16 33 PM](https://github.com/user-attachments/assets/7d1f9c9b-d661-44ef-9c8a-20b2c1955efa)
