### PR TITLE
Disable on click to prevent multiple clicks

### DIFF
--- a/app/views/shared/_client_filters.html.erb
+++ b/app/views/shared/_client_filters.html.erb
@@ -135,7 +135,7 @@
     <hr>
 
     <div>
-      <%= submit_tag t("hub.clients.index.filter"), class: "button button--cta", name: nil %>
+      <%= submit_tag t("hub.clients.index.filter"), class: "button button--cta", name: nil, data: { disable_with: t('hub.clients.index.filter') } %>
       <% if filters.values.any? %>
         <%= link_to t("hub.clients.index.clear_filters"), { column: @sort_column, order: @sort_order, clear: true }, class: "button button--danger", name: "clear" %>
       <% end %>


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1981
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- This disables a button after clicking it so that it cannot be clicked multiple times. The filter button submits a form that performs a pretty resource intensive query that can take down the site in some circumstances. This, while not fixing the root issue, should make the problem less common.

## How to test?
- Log into the hub
- Click 'All Clients'
- Click 'filter'
- Observe button is disabled and unclickable after the first time
- Wait for page load
- Click into any filter input and hit enter
- Note the button is disabled and unclickable

## Screenshots (for visual changes)
- Before
- After
