### PR TITLE
FYST-1974 NC w2 and 1099r editing: add flipper flag to turn editing back on

### DIFF
--- a/app/models/state_file_nc_intake.rb
+++ b/app/models/state_file_nc_intake.rb
@@ -153,11 +153,11 @@ class StateFileNcIntake < StateFileBaseIntake
   end
 
   def allows_w2_editing?
-    false
+    Flipper.enabled?(:nc_flip_flop)
   end
 
   def allows_1099_r_editing?
-    false
+    Flipper.enabled?(:nc_flip_flop)
   end
 
   def check_nra_status?

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -8,6 +8,7 @@ end
 # This structure is borrowed from https://github.com/department-of-veterans-affairs/vets-api/blob/247c84c0226d4cc90477b96a46107c6bace62bd5/config/initializers/flipper.rb
 # Make sure that each feature we reference in code is present in the UI, as long as we have a Database already
 begin
+  Flipper.disable :nc_flip_flop unless Flipper.exist?(:nc_flip_flop)
   Flipper.disable :show_retirement_ui unless Flipper.exist?(:show_retirement_ui)
   Flipper.disable :sms_notifications unless Flipper.exist?(:sms_notifications)
   Flipper.disable :hub_dashboard unless Flipper.exist?(:hub_dashboard)

--- a/spec/controllers/state_file/questions/income_review_controller_spec.rb
+++ b/spec/controllers/state_file/questions/income_review_controller_spec.rb
@@ -467,4 +467,34 @@ RSpec.describe StateFile::Questions::IncomeReviewController do
       expect(efile_device_info.reload.device_id).to eq "ABC123"
     end
   end
+
+  # TEMP: remove when flipper flag goes away
+  context "links to edit forms vs show them" do
+    let(:intake) { create(:state_file_nc_intake) }
+    let!(:state_file_w2) { create :state_file_w2, state_file_intake: intake }
+    let!(:state_file_1099r) { create(:state_file1099_r, intake: intake) }
+
+    context "when flipper flag is enabled" do
+      before do
+        allow(Flipper).to receive(:enabled?).and_call_original
+        allow(Flipper).to receive(:enabled?).with(:nc_flip_flop).and_return(true)
+      end
+
+      it "shows links to edit w2s and 1099Rs" do
+        get :edit, params: params
+
+        expect(response.body).to have_link(href: edit_w2_path(id: state_file_w2.id))
+        expect(response.body).to have_link(href: edit_retirement_income_path(id: state_file_1099r.id))
+      end
+    end
+
+    context "when flipper flag is disabled" do
+      it "shows links to show w2s and 1099Rs" do
+        get :edit, params: params
+
+        expect(response.body).to have_link(href: w2_path(id: state_file_w2.id))
+        expect(response.body).to have_link(href: retirement_income_path(id: state_file_1099r.id))
+      end
+    end
+  end
 end

--- a/spec/controllers/state_file/questions/w2_controller_spec.rb
+++ b/spec/controllers/state_file/questions/w2_controller_spec.rb
@@ -239,6 +239,35 @@ RSpec.describe StateFile::Questions::W2Controller do
           }.to raise_error(NoMethodError)
         end
       end
+
+      # TEMP: remove when flipper flag goes away
+      context "when the intake's w2s are not editable" do
+        let(:intake) { create :state_file_nc_intake }
+        let!(:state_file_w2) { create :state_file_w2, state_file_intake: intake, w2_index: 1, employer_state_id_num: "23456" }
+
+        context "flipper flag is enabled" do
+          before do
+            allow(Flipper).to receive(:enabled?).and_call_original
+            allow(Flipper).to receive(:enabled?).with(:nc_flip_flop).and_return(true)
+          end
+
+          it "updates the w2 information and redirects to the income review page" do
+            post :update, params: params
+
+            state_file_w2.reload
+            expect(state_file_w2.employer_state_id_num).to eq "12345"
+          end
+        end
+
+        context "flipper flag is disabled" do
+          it "does not updates the w2 information" do
+            post :update, params: params
+
+            state_file_w2.reload
+            expect(state_file_w2.employer_state_id_num).to eq "23456"
+          end
+        end
+      end
     end
 
     context "with invalid params" do


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1974
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Hide turning editing back on behind a flipper flag
## How to test?
- added unit tests for w2, 1099r, and income review controllers for flag on and flag off cases
## Screenshots (for visual changes)
- Before
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/0b408ec5-75d7-4908-81fd-9f03de4318cb" />
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/0a57be90-a4ca-41f3-ae27-0e199bc6d22c" />
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/42fc4c3b-5c02-4455-b190-11b7424d1496" />

- After
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/73754ed8-02b8-47fc-92dd-f9ac71328783" />
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/9f9eb659-bf2a-4f59-8ecf-fa42ea14b84d" />
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/5e51af08-c9ff-4c7b-a4ee-6424e44caec1" />
