### PR TITLE
FYST-1972 include locale as arg to user_messsage so the hub page can manually set it

### DIFF
--- a/app/controllers/hub/state_file/automated_messages_controller.rb
+++ b/app/controllers/hub/state_file/automated_messages_controller.rb
@@ -55,7 +55,7 @@ module Hub::StateFile
       email = StateFileNotificationEmail.new(to: "example@example.com",
                                              body: replaced_body,
                                              subject: subject)
-      message = StateFile::NotificationMailer.user_message(notification_email: email)
+      message = StateFile::NotificationMailer.user_message(notification_email: email, locale: locale)
       ActionMailer::Base.preview_interceptors.each do |interceptor|
         interceptor.previewing_email(message)
       end

--- a/app/mailers/state_file/notification_mailer.rb
+++ b/app/mailers/state_file/notification_mailer.rb
@@ -1,8 +1,9 @@
 module StateFile
   class NotificationMailer < ApplicationMailer
-    def user_message(notification_email:)
+    def user_message(notification_email:, locale: nil)
       service = MultiTenantService.new(:statefile)
       @body = notification_email.body
+      @locale = locale || I18n.locale
       attachments.inline['logo.png'] = service.email_logo
 
       verifier = ActiveSupport::MessageVerifier.new(Rails.application.secret_key_base)
@@ -13,7 +14,7 @@ module StateFile
           host: MultiTenantService.new(:statefile).host,
           controller: "state_file/notifications_settings",
           action: :unsubscribe_from_emails,
-          locale: I18n.locale,
+          locale: @locale,
           _recall: {},
           email_address: signed_email
         }

--- a/app/views/state_file/notification_mailer/user_message.html.erb
+++ b/app/views/state_file/notification_mailer/user_message.html.erb
@@ -6,4 +6,4 @@
   <% end %>
 <% end %>
 <br />
-<%= auto_link(t(".unsubscribe", unsubscribe_link: @unsubscribe_link)) %>
+<%= auto_link(t(".unsubscribe", unsubscribe_link: @unsubscribe_link, locale: @locale)) %>


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1972
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Add locale as an instance variable to NotificationMailer#user_message so that it can be passed in manually instead of relying on `I18n.locale` for the unsubscribe copy. We manually set locale when rendering previews of automated messages in the hub and want to see all of the copy in each locale respectively.
## How to test?
- Attempted to write a unit test on the automated messages controller but since the emails are rendered in an iframe it was too complicated
- Tested manually to see that 1) emails continue to have the correct locale for all of the copy and 2) the hub page displays the right locale for all parts of each message
## Screenshots (for visual changes)
- Before
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/891f6739-9a2b-475a-b131-196b4c0cd09b" />

- After
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/4ea393fe-b002-4a5a-a6f6-144d1c368c90" />
