### PR TITLE
Fix MD address XML bug when DF address is PO Box

### DIFF
--- a/app/helpers/state_file/pattern_matching_helper.rb
+++ b/app/helpers/state_file/pattern_matching_helper.rb
@@ -3,8 +3,8 @@ module StateFile
     def contains_po_box(address)
       return false if address.blank?
 
-      # Regex tested at https://regex101.com/r/SksZmO/1
-      pattern = /(?i)p(?:[.\s]*)o(?:[.\s]*)(?:b(?:[.\s]*)(?:o(?:[.\s]*)x)?)?/
+      # Regex tested at https://regex101.com/r/V64RgG/1
+      pattern = /(?i)\bp(?:[.\s]*)o(?:[.\s]*)(?:b(?:[.\s]*)(?:o(?:[.\s]*)x)?)?\b/
       address.match?(pattern)
     end
   end

--- a/app/lib/submission_builder/ty2024/states/md/documents/md502.rb
+++ b/app/lib/submission_builder/ty2024/states/md/documents/md502.rb
@@ -45,12 +45,12 @@ class SubmissionBuilder::Ty2024::States::Md::Documents::Md502 < SubmissionBuilde
         xml.CityTownOrTaxingArea @intake.political_subdivision
       end
       xml.MarylandAddress do
-        if @intake.confirmed_permanent_address_yes?
+        if @intake.confirmed_permanent_address_yes? && !@intake.direct_file_address_is_po_box?
           extract_apartment_from_mailing_street(xml)
           xml.CityNm sanitize_for_xml(@intake.direct_file_data.mailing_city, 20)
           xml.StateAbbreviationCd @intake.direct_file_data.mailing_state.upcase
           xml.ZIPCd sanitize_zipcode(@intake.direct_file_data.mailing_zip)
-        elsif @intake.confirmed_permanent_address_no?
+        elsif @intake.confirmed_permanent_address_no? || @intake.direct_file_address_is_po_box?
           xml.AddressLine1Txt sanitize_for_xml(@intake.permanent_street, 30)
           xml.AddressLine2Txt sanitize_for_xml(@intake.permanent_apartment, 30) if @intake.permanent_apartment.present?
           xml.CityNm sanitize_for_xml(@intake.permanent_city, 20)


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. https://codeforamerica.atlassian.net/browse/FYST-1985
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Since we don't ask confirmed permanent address question anymore if the DF address in MD is a PO box then we need to check if the DF address is PO box when we create the efile submission
## How to test?
1. Use heroku
2. start a new MD state file intake
3. Use Ray_dependent 
4. Enter new address on md-permanent-address
5. Keep note of new address 
6. Continue & submit return
7. Go to the hub and check the XML output

