### PR TITLE
[FYST-1988] Fix flakey verification_code_controller spec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
           key: parallel-runtime-{{ checksum "/tmp/today" }}
       - run: RAILS_ENV=test bin/shakapacker
       - run:
-          command: bundle exec rspec spec/controllers/state_file/questions/verification_code_controller_spec.rb || touch /tmp/re-run
+          command: bundle exec parallel_rspec -n 12 || touch /tmp/re-run
           environment:
             EAGER_LOAD: 1
             RAILS_CACHE_CLASSES: 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
           key: parallel-runtime-{{ checksum "/tmp/today" }}
       - run: RAILS_ENV=test bin/shakapacker
       - run:
-          command: bundle exec parallel_rspec -n 12 || touch /tmp/re-run
+          command: bundle exec rspec spec/controllers/state_file/questions/verification_code_controller_spec.rb || touch /tmp/re-run
           environment:
             EAGER_LOAD: 1
             RAILS_CACHE_CLASSES: 1

--- a/spec/controllers/state_file/questions/verification_code_controller_spec.rb
+++ b/spec/controllers/state_file/questions/verification_code_controller_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe StateFile::Questions::VerificationCodeController do
         )
         expect(response).to redirect_to(login_location)
         expect(StateFileAzIntake.where(id: intake.id)).to be_empty
-        expect(StateFileIdIntake.find(existing_intake.id).unfinished_intake_ids).to include(intake.id.to_s)
+        expect(existing_intake.reload.unfinished_intake_ids).to include(intake.id.to_s)
       end
 
       context "with the same intake ids" do
@@ -118,7 +118,7 @@ RSpec.describe StateFile::Questions::VerificationCodeController do
           )
           expect(response).to redirect_to(login_location)
           expect(StateFileAzIntake.where(id: intake.id)).to be_empty
-          expect(StateFileIdIntake.find(existing_intake.id).unfinished_intake_ids).to include(intake.id.to_s)
+          expect(existing_intake.reload.unfinished_intake_ids).to include(intake.id.to_s)
         end
       end
     end

--- a/spec/controllers/state_file/questions/verification_code_controller_spec.rb
+++ b/spec/controllers/state_file/questions/verification_code_controller_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe StateFile::Questions::VerificationCodeController do
         )
         expect(response).to redirect_to(login_location)
         expect(StateFileAzIntake.where(id: intake.id)).to be_empty
-        expect(existing_intake.reload.unfinished_intake_ids).to include(intake.id.to_s)
+        expect(StateFileIdIntake.find(existing_intake.id).unfinished_intake_ids).to include(intake.id.to_s)
       end
 
       context "with the same intake ids" do
@@ -118,7 +118,7 @@ RSpec.describe StateFile::Questions::VerificationCodeController do
           )
           expect(response).to redirect_to(login_location)
           expect(StateFileAzIntake.where(id: intake.id)).to be_empty
-          expect(existing_intake.reload.unfinished_intake_ids).to include(intake.id.to_s)
+          expect(StateFileIdIntake.find(existing_intake.id).unfinished_intake_ids).to include(intake.id.to_s)
         end
       end
     end

--- a/spec/controllers/state_file/questions/verification_code_controller_spec.rb
+++ b/spec/controllers/state_file/questions/verification_code_controller_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe StateFile::Questions::VerificationCodeController do
 
       context "with the same intake ids" do
         before do
-          allow(existing_intake).to receive(:id).and_return(intake.id)
+          existing_intake.update(id: intake.id)
         end
 
         it "redirects to login and deletes the existing intake" do

--- a/spec/controllers/state_file/questions/verification_code_controller_spec.rb
+++ b/spec/controllers/state_file/questions/verification_code_controller_spec.rb
@@ -85,7 +85,8 @@ RSpec.describe StateFile::Questions::VerificationCodeController do
       let(:intake) do
         build(:state_file_az_intake, contact_preference: "email", email_address: "someone@example.com", visitor_id: "v1s1t1n9").tap do |intake|
           intake.raw_direct_file_data = nil
-          intake.id = 52322
+          unused_id = ([StateFileAzIntake.last&.id, StateFileIdIntake.last&.id].compact.max || 0) + 1
+          intake.id = unused_id
           intake.save!
         end
       end

--- a/spec/controllers/state_file/questions/verification_code_controller_spec.rb
+++ b/spec/controllers/state_file/questions/verification_code_controller_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe StateFile::Questions::VerificationCodeController do
       let(:intake) do
         build(:state_file_az_intake, contact_preference: "email", email_address: "someone@example.com", visitor_id: "v1s1t1n9").tap do |intake|
           intake.raw_direct_file_data = nil
-          unused_id = ([StateFileAzIntake.last&.id, StateFileIdIntake.last&.id].compact.max || 0) + 1
+          unused_id = ([StateFileAzIntake.last&.id, StateFileIdIntake.last&.id].max || 0) + 1
           intake.id = unused_id
           intake.save!
         end

--- a/spec/controllers/state_file/questions/verification_code_controller_spec.rb
+++ b/spec/controllers/state_file/questions/verification_code_controller_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe StateFile::Questions::VerificationCodeController do
       let(:intake) do
         build(:state_file_az_intake, contact_preference: "email", email_address: "someone@example.com", visitor_id: "v1s1t1n9").tap do |intake|
           intake.raw_direct_file_data = nil
+          intake.id = 52322
           intake.save!
         end
       end
@@ -105,7 +106,7 @@ RSpec.describe StateFile::Questions::VerificationCodeController do
 
       context "with the same intake ids" do
         before do
-          existing_intake.update(id: intake.id)
+          existing_intake.update!(id: intake.id)
         end
 
         it "redirects to login and deletes the existing intake" do


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1988
## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Fixing a test which is actually failing locally when the entire file is run (passes if only the single spec is run)
## How to test?
- Describe the testing approach taken to verify the changes, including:
  - run multiple times in circle ci -- see that it does not fail on the first run (`bundle exec parallel_rspec -n 12 || touch /tmp/re-run`)
- Alternative considered:
  - Tried setting the id to a high number (see the change): https://github.com/codeforamerica/vita-min/pull/5844/commits/081c241adaed2638385ba81eea204eb2ce6780da
  - initially just set the id to something high like Jenny suggested: https://github.com/codeforamerica/vita-min/pull/5751#pullrequestreview-2704377810 but that felt brittle, so added some logic to grab the `last + 1` id from both id/az intakes test db tables. At the end of the day, it felt really odd to update an intake's id like this but difficult to recreate this scenario without it, so decided to go with this approach instead. 