### PR TITLE
[FYST-1950] Fix flakey specs on circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
           key: parallel-runtime-{{ checksum "/tmp/today" }}
       - run: RAILS_ENV=test bin/shakapacker
       - run:
-          command: bundle exec rspec spec/features/state_file/review_page_spec.rb || touch /tmp/re-run
+          command: bundle exec rspec spec/features/state_file/* || touch /tmp/re-run
           environment:
             EAGER_LOAD: 1
             RAILS_CACHE_CLASSES: 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
           key: parallel-runtime-{{ checksum "/tmp/today" }}
       - run: RAILS_ENV=test bin/shakapacker
       - run:
-          command: bundle exec parallel_rspec -n 12 || touch /tmp/re-run
+          command: bundle exec rspec spec/features/state_file/review_page_spec.rb || touch /tmp/re-run
           environment:
             EAGER_LOAD: 1
             RAILS_CACHE_CLASSES: 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
           key: parallel-runtime-{{ checksum "/tmp/today" }}
       - run: RAILS_ENV=test bin/shakapacker
       - run:
-          command: bundle exec rspec spec/features/state_file/* || touch /tmp/re-run
+          command: bundle exec parallel_rspec -n 12 || touch /tmp/re-run
           environment:
             EAGER_LOAD: 1
             RAILS_CACHE_CLASSES: 1

--- a/app/forms/state_file/md_eligibility_filing_status_form.rb
+++ b/app/forms/state_file/md_eligibility_filing_status_form.rb
@@ -4,8 +4,8 @@ module StateFile
 
     validates :eligibility_filing_status_mfj, presence: true
     validates :eligibility_homebuyer_withdrawal_mfj, presence: true, if: -> { eligibility_filing_status_mfj == "yes" }
-    validates :eligibility_homebuyer_withdrawal, presence: true, unless: -> { eligibility_filing_status_mfj == "yes" }
     validates :eligibility_home_different_areas, presence: true, if: -> { eligibility_filing_status_mfj == "yes" }
+    validates :eligibility_homebuyer_withdrawal, presence: true, unless: -> { eligibility_filing_status_mfj == "yes" }
 
     def save
       @intake.update(attributes_for(:intake))

--- a/spec/controllers/questions/mailing_address_controller_spec.rb
+++ b/spec/controllers/questions/mailing_address_controller_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Questions::MailingAddressController do
       end
 
       it "enqueues a job to generate F13614cPdf" do
-        expect(GenerateF13614cPdfJob).to receive(:perform_later).with(intake.client.id, "Preliminary 13614-C.pdf")
+        expect(GenerateF13614cPdfJob).to receive(:perform_later).with(intake.id, "Preliminary 13614-C.pdf")
 
         subject.after_update_success
       end

--- a/spec/features/state_file/review_page_spec.rb
+++ b/spec/features/state_file/review_page_spec.rb
@@ -127,64 +127,6 @@ RSpec.feature "Completing a state file intake", active_job: true, js: true do
     end
   end
 
-  context "AZ" do
-    it "allows user to navigate to az public school contributions page, edit a contribution form, and then navigate back to final review page, and then to 1099r edit page and back", required_schema: "az" do
-      Flipper.enable(:show_retirement_ui)
-      state_code = "az"
-      set_up_intake_and_associated_records(state_code)
-
-      intake = StateFile::StateInformationService.intake_class(state_code).last
-
-      create :az322_contribution, state_file_az_intake: intake
-
-      visit "/questions/#{state_code}-review"
-
-      # Final review page
-      expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
-      within "#public-school-contributions" do
-        click_on I18n.t("general.edit")
-      end
-
-      # public school contribution review page edit navigates to public school contribution index page
-      expect(page).to have_text(I18n.t('state_file.questions.az_public_school_contributions.index.title'))
-      click_on I18n.t("general.continue")
-
-      # Back on final review page
-      expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
-      within "#public-school-contributions" do
-        click_on I18n.t("general.edit")
-      end
-
-      # click Edit on the public school contribution index page (there's only one)
-      click_on I18n.t("general.edit")
-
-      # public school contribution edit page
-      expect(page).to have_text strip_html_tags(I18n.t("state_file.questions.az_public_school_contributions.edit.title_html"))
-      fill_in strip_html_tags(I18n.t("state_file.questions.az_public_school_contributions.edit.school_name")), with: "beepboop"
-      click_on I18n.t("general.continue")
-
-      # takes them to the az public school contributions index page first
-      expect(page).to have_text strip_html_tags(I18n.t("state_file.questions.az_public_school_contributions.index.title"))
-      expect(page).to have_text ("beepboop")
-      click_on "Continue"
-
-      # Back on final review page
-      expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
-
-      # 1099R edit page
-      within "#retirement-income-subtractions" do
-        click_on I18n.t("general.edit")
-      end
-
-      expect(page).to have_text intake.state_file1099_rs.first.payer_name
-      choose I18n.t("state_file.questions.az_retirement_income_subtraction.edit.uniformed_services")
-      click_on I18n.t("general.continue")
-
-      # Back on final review page
-      expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
-    end
-  end
-
   context "NC" do
     before do
       allow(Flipper).to receive(:enabled?).and_call_original
@@ -249,6 +191,64 @@ RSpec.feature "Completing a state file intake", active_job: true, js: true do
         expect(page).to have_text "Boone Community Garden"
         expect(page).to have_text I18n.t("state_file.questions.shared.nc_retirement_income_deductions_review_header.none_apply")
       end
+    end
+  end
+
+  context "AZ" do
+    it "allows user to navigate to az public school contributions page, edit a contribution form, and then navigate back to final review page, and then to 1099r edit page and back", required_schema: "az" do
+      Flipper.enable(:show_retirement_ui)
+      state_code = "az"
+      set_up_intake_and_associated_records(state_code)
+
+      intake = StateFile::StateInformationService.intake_class(state_code).last
+
+      create :az322_contribution, state_file_az_intake: intake
+
+      visit "/questions/#{state_code}-review"
+
+      # Final review page
+      expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
+      within "#public-school-contributions" do
+        click_on I18n.t("general.edit")
+      end
+
+      # public school contribution review page edit navigates to public school contribution index page
+      expect(page).to have_text(I18n.t('state_file.questions.az_public_school_contributions.index.title'))
+      click_on I18n.t("general.continue")
+
+      # Back on final review page
+      expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
+      within "#public-school-contributions" do
+        click_on I18n.t("general.edit")
+      end
+
+      # click Edit on the public school contribution index page (there's only one)
+      click_on I18n.t("general.edit")
+
+      # public school contribution edit page
+      expect(page).to have_text strip_html_tags(I18n.t("state_file.questions.az_public_school_contributions.edit.title_html"))
+      fill_in strip_html_tags(I18n.t("state_file.questions.az_public_school_contributions.edit.school_name")), with: "beepboop"
+      click_on I18n.t("general.continue")
+
+      # takes them to the az public school contributions index page first
+      expect(page).to have_text strip_html_tags(I18n.t("state_file.questions.az_public_school_contributions.index.title"))
+      expect(page).to have_text ("beepboop")
+      click_on "Continue"
+
+      # Back on final review page
+      expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
+
+      # 1099R edit page
+      within "#retirement-income-subtractions" do
+        click_on I18n.t("general.edit")
+      end
+
+      expect(page).to have_text intake.state_file1099_rs.first.payer_name
+      choose I18n.t("state_file.questions.az_retirement_income_subtraction.edit.uniformed_services")
+      click_on I18n.t("general.continue")
+
+      # Back on final review page
+      expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
     end
   end
 

--- a/spec/features/state_file/review_page_spec.rb
+++ b/spec/features/state_file/review_page_spec.rb
@@ -128,17 +128,19 @@ RSpec.feature "Completing a state file intake", active_job: true, js: true do
   end
 
   context "AZ" do
+    before do
+      allow(Flipper).to receive(:enabled?).and_call_original
+      allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)
+    end
+
     it "allows user to navigate to az public school contributions page, edit a contribution form, and then navigate back to final review page, and then to 1099r edit page and back", required_schema: "az" do
-      Flipper.enable(:show_retirement_ui)
       state_code = "az"
       set_up_intake_and_associated_records(state_code)
 
       intake = StateFile::StateInformationService.intake_class(state_code).last
 
       create :az322_contribution, state_file_az_intake: intake
-
       visit "/questions/#{state_code}-review"
-
       # Final review page
       expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
       within "#public-school-contributions" do

--- a/spec/features/state_file/review_page_spec.rb
+++ b/spec/features/state_file/review_page_spec.rb
@@ -208,6 +208,17 @@ RSpec.feature "Completing a state file intake", active_job: true, js: true do
 
       # Final review page
       expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
+      # 1099R edit page
+      within "#retirement-income-subtractions" do
+        click_on I18n.t("general.edit")
+      end
+
+      expect(page).to have_text intake.state_file1099_rs.first.payer_name
+      choose I18n.t("state_file.questions.az_retirement_income_subtraction.edit.uniformed_services")
+      click_on I18n.t("general.continue")
+
+      # Back on final review page
+      expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
       within "#public-school-contributions" do
         click_on I18n.t("general.edit")
       end
@@ -234,18 +245,6 @@ RSpec.feature "Completing a state file intake", active_job: true, js: true do
       expect(page).to have_text strip_html_tags(I18n.t("state_file.questions.az_public_school_contributions.index.title"))
       expect(page).to have_text ("beepboop")
       click_on "Continue"
-
-      # Back on final review page
-      expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
-
-      # 1099R edit page
-      within "#retirement-income-subtractions" do
-        click_on I18n.t("general.edit")
-      end
-
-      expect(page).to have_text intake.state_file1099_rs.first.payer_name
-      choose I18n.t("state_file.questions.az_retirement_income_subtraction.edit.uniformed_services")
-      click_on I18n.t("general.continue")
 
       # Back on final review page
       expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")

--- a/spec/features/state_file/review_page_spec.rb
+++ b/spec/features/state_file/review_page_spec.rb
@@ -208,17 +208,6 @@ RSpec.feature "Completing a state file intake", active_job: true, js: true do
 
       # Final review page
       expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
-      # 1099R edit page
-      within "#retirement-income-subtractions" do
-        click_on I18n.t("general.edit")
-      end
-
-      expect(page).to have_text intake.state_file1099_rs.first.payer_name
-      choose I18n.t("state_file.questions.az_retirement_income_subtraction.edit.uniformed_services")
-      click_on I18n.t("general.continue")
-
-      # Back on final review page
-      expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
       within "#public-school-contributions" do
         click_on I18n.t("general.edit")
       end
@@ -245,6 +234,18 @@ RSpec.feature "Completing a state file intake", active_job: true, js: true do
       expect(page).to have_text strip_html_tags(I18n.t("state_file.questions.az_public_school_contributions.index.title"))
       expect(page).to have_text ("beepboop")
       click_on "Continue"
+
+      # Back on final review page
+      expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
+
+      # 1099R edit page
+      within "#retirement-income-subtractions" do
+        click_on I18n.t("general.edit")
+      end
+
+      expect(page).to have_text intake.state_file1099_rs.first.payer_name
+      choose I18n.t("state_file.questions.az_retirement_income_subtraction.edit.uniformed_services")
+      click_on I18n.t("general.continue")
 
       # Back on final review page
       expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")

--- a/spec/features/state_file/review_page_spec.rb
+++ b/spec/features/state_file/review_page_spec.rb
@@ -127,6 +127,64 @@ RSpec.feature "Completing a state file intake", active_job: true, js: true do
     end
   end
 
+  context "AZ" do
+    it "allows user to navigate to az public school contributions page, edit a contribution form, and then navigate back to final review page, and then to 1099r edit page and back", required_schema: "az" do
+      Flipper.enable(:show_retirement_ui)
+      state_code = "az"
+      set_up_intake_and_associated_records(state_code)
+
+      intake = StateFile::StateInformationService.intake_class(state_code).last
+
+      create :az322_contribution, state_file_az_intake: intake
+
+      visit "/questions/#{state_code}-review"
+
+      # Final review page
+      expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
+      within "#public-school-contributions" do
+        click_on I18n.t("general.edit")
+      end
+
+      # public school contribution review page edit navigates to public school contribution index page
+      expect(page).to have_text(I18n.t('state_file.questions.az_public_school_contributions.index.title'))
+      click_on I18n.t("general.continue")
+
+      # Back on final review page
+      expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
+      within "#public-school-contributions" do
+        click_on I18n.t("general.edit")
+      end
+
+      # click Edit on the public school contribution index page (there's only one)
+      click_on I18n.t("general.edit")
+
+      # public school contribution edit page
+      expect(page).to have_text strip_html_tags(I18n.t("state_file.questions.az_public_school_contributions.edit.title_html"))
+      fill_in strip_html_tags(I18n.t("state_file.questions.az_public_school_contributions.edit.school_name")), with: "beepboop"
+      click_on I18n.t("general.continue")
+
+      # takes them to the az public school contributions index page first
+      expect(page).to have_text strip_html_tags(I18n.t("state_file.questions.az_public_school_contributions.index.title"))
+      expect(page).to have_text ("beepboop")
+      click_on "Continue"
+
+      # Back on final review page
+      expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
+
+      # 1099R edit page
+      within "#retirement-income-subtractions" do
+        click_on I18n.t("general.edit")
+      end
+
+      expect(page).to have_text intake.state_file1099_rs.first.payer_name
+      choose I18n.t("state_file.questions.az_retirement_income_subtraction.edit.uniformed_services")
+      click_on I18n.t("general.continue")
+
+      # Back on final review page
+      expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
+    end
+  end
+
   context "NC" do
     before do
       allow(Flipper).to receive(:enabled?).and_call_original
@@ -191,64 +249,6 @@ RSpec.feature "Completing a state file intake", active_job: true, js: true do
         expect(page).to have_text "Boone Community Garden"
         expect(page).to have_text I18n.t("state_file.questions.shared.nc_retirement_income_deductions_review_header.none_apply")
       end
-    end
-  end
-
-  context "AZ" do
-    it "allows user to navigate to az public school contributions page, edit a contribution form, and then navigate back to final review page, and then to 1099r edit page and back", required_schema: "az" do
-      Flipper.enable(:show_retirement_ui)
-      state_code = "az"
-      set_up_intake_and_associated_records(state_code)
-
-      intake = StateFile::StateInformationService.intake_class(state_code).last
-
-      create :az322_contribution, state_file_az_intake: intake
-
-      visit "/questions/#{state_code}-review"
-
-      # Final review page
-      expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
-      within "#public-school-contributions" do
-        click_on I18n.t("general.edit")
-      end
-
-      # public school contribution review page edit navigates to public school contribution index page
-      expect(page).to have_text(I18n.t('state_file.questions.az_public_school_contributions.index.title'))
-      click_on I18n.t("general.continue")
-
-      # Back on final review page
-      expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
-      within "#public-school-contributions" do
-        click_on I18n.t("general.edit")
-      end
-
-      # click Edit on the public school contribution index page (there's only one)
-      click_on I18n.t("general.edit")
-
-      # public school contribution edit page
-      expect(page).to have_text strip_html_tags(I18n.t("state_file.questions.az_public_school_contributions.edit.title_html"))
-      fill_in strip_html_tags(I18n.t("state_file.questions.az_public_school_contributions.edit.school_name")), with: "beepboop"
-      click_on I18n.t("general.continue")
-
-      # takes them to the az public school contributions index page first
-      expect(page).to have_text strip_html_tags(I18n.t("state_file.questions.az_public_school_contributions.index.title"))
-      expect(page).to have_text ("beepboop")
-      click_on "Continue"
-
-      # Back on final review page
-      expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
-
-      # 1099R edit page
-      within "#retirement-income-subtractions" do
-        click_on I18n.t("general.edit")
-      end
-
-      expect(page).to have_text intake.state_file1099_rs.first.payer_name
-      choose I18n.t("state_file.questions.az_retirement_income_subtraction.edit.uniformed_services")
-      click_on I18n.t("general.continue")
-
-      # Back on final review page
-      expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
     end
   end
 

--- a/spec/forms/state_file/md_eligibility_filing_status_form_spec.rb
+++ b/spec/forms/state_file/md_eligibility_filing_status_form_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+RSpec.describe StateFile::MdEligibilityFilingStatusForm do
+  let(:intake) {
+    build :state_file_md_intake,
+          eligibility_filing_status_mfj: "unfilled",
+          eligibility_homebuyer_withdrawal_mfj: "unfilled",
+          eligibility_homebuyer_withdrawal: "unfilled",
+          eligibility_home_different_areas: "unfilled"
+  }
+
+  describe "validations" do
+    let(:filing_status_mfj) { nil }
+    let(:withdrawal_mfj) { nil }
+    let(:home_different_areas) { nil }
+    let(:withdrawal) { nil }
+    let(:params) {
+      {
+        eligibility_filing_status_mfj: filing_status_mfj,
+        eligibility_homebuyer_withdrawal_mfj: withdrawal_mfj,
+        eligibility_home_different_areas: home_different_areas,
+        eligibility_homebuyer_withdrawal: withdrawal
+      }
+    }
+    before do
+      @form = described_class.new(intake, params)
+      @form.valid?
+    end
+
+    context "when eligibility_filing_status_mfj is not present" do
+      it "should show form error" do
+        expect(@form.errors[:eligibility_filing_status_mfj]).to eq ["Can't be blank."]
+      end
+    end
+
+    context "when eligibility_filing_status_mfj is present" do
+      context "when yes" do
+        let(:filing_status_mfj) { "yes" }
+
+        context "valid when all required attributes provided" do
+          let(:withdrawal_mfj) { "yes" }
+          let(:home_different_areas) { "no" }
+
+          it "is valid" do
+            expect(@form.errors).to be_empty
+          end
+        end
+
+        context "invalid when required attributes are missing" do
+          it "is invalid" do
+            expect(@form.errors[:eligibility_filing_status_mfj]).not_to be_present
+            expect(@form.errors[:eligibility_homebuyer_withdrawal_mfj]).to be_present
+            expect(@form.errors[:eligibility_home_different_areas]).to be_present
+            expect(@form.errors[:eligibility_homebuyer_withdrawal]).not_to be_present
+          end
+        end
+      end
+
+      context "when no" do
+        let(:filing_status_mfj) { "no" }
+
+        context "valid when all required attributes provided" do
+          let(:withdrawal) { "yes" }
+
+          it "is valid" do
+            expect(@form.errors).to be_empty
+          end
+        end
+
+        context "invalid when required attributes are missing" do
+          context "invalid when required attributes are missing" do
+            it "is invalid" do
+              expect(@form.errors[:eligibility_filing_status_mfj]).not_to be_present
+              expect(@form.errors[:eligibility_homebuyer_withdrawal_mfj]).not_to be_present
+              expect(@form.errors[:eligibility_home_different_areas]).not_to be_present
+              expect(@form.errors[:eligibility_homebuyer_withdrawal]).to be_present
+            end
+          end
+        end
+      end
+
+    end
+  end
+
+  describe "#save" do
+    let(:valid_params) do
+      {
+        eligibility_filing_status_mfj: "yes",
+        eligibility_homebuyer_withdrawal_mfj: "no",
+        eligibility_home_different_areas: "no",
+      }
+    end
+
+    it "saves the answers to the intake" do
+      form = described_class.new(intake, valid_params)
+      form.save
+      intake.reload
+      expect(intake.eligibility_filing_status_mfj_yes?).to eq true
+      expect(intake.eligibility_home_different_areas_no?).to eq true
+      expect(intake.eligibility_homebuyer_withdrawal_mfj_no?).to eq true
+    end
+  end
+end

--- a/spec/support/helpers/state_file_intake_helper.rb
+++ b/spec/support/helpers/state_file_intake_helper.rb
@@ -46,9 +46,6 @@ module StateFileIntakeHelper
       expect(page).to have_text I18n.t("state_file.questions.eligible.id_credits_unsupported.change_in_filing_status")
     when "md"
       expect(page).to have_text I18n.t("state_file.questions.md_eligibility_filing_status.edit.title", year: filing_year)
-      click_on I18n.t("general.continue")
-
-      expect(page).to have_text I18n.t("state_file.questions.md_eligibility_filing_status.edit.title", year: filing_year)
       choose I18n.t("general.affirmative"), id: "state_file_md_eligibility_filing_status_form_eligibility_filing_status_mfj_yes"
       choose I18n.t("general.negative"), id: "state_file_md_eligibility_filing_status_form_eligibility_homebuyer_withdrawal_mfj_no"
       choose I18n.t("general.negative"), id: "state_file_md_eligibility_filing_status_form_eligibility_home_different_areas_no"


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1950
## Is PM acceptance required? (delete one)
- No - merge after code review approval

Fixing the most frequent offenders on circle ci flakey runs
<img width="1679" alt="Screenshot 2025-03-27 at 2 29 09 PM" src="https://github.com/user-attachments/assets/7671ef29-f1d8-48d2-bec3-1811c132767a" />

Notes left on relevant code.
Specs fixed:

```
spec/features/state_file/review_page_spec.rb
spec/controllers/questions/mailing_address_controller_spec.rb
```
[verification_controller_spec was fixed here](https://github.com/codeforamerica/vita-min/pull/5844)
