### PR TITLE
[FYST-1994] Remove Box 15 conditional presence validation 

### DIFF
--- a/app/models/state_file1099_r.rb
+++ b/app/models/state_file1099_r.rb
@@ -63,7 +63,7 @@ class StateFile1099R < ApplicationRecord
               presence: {
                 message: proc { I18n.t('forms.errors.no_money_amount') }
               }
-    validates :payer_state_identification_number, presence: true, length: { maximum: 16 }, if: -> { state_tax_withheld_amount&.positive? }
+    validates :payer_state_identification_number, length: { maximum: 16 }
   end
 
   with_options on: [:income_review, :retirement_income_intake] do

--- a/spec/models/state_file1099_r_spec.rb
+++ b/spec/models/state_file1099_r_spec.rb
@@ -152,16 +152,6 @@ RSpec.describe StateFile1099R do
       end
 
       context "payer_state_identification_number" do
-        it "validates present when has state_tax_withheld_amount" do
-          state_file1099_r.state_tax_withheld_amount = 0
-          state_file1099_r.payer_state_identification_number = nil
-          expect(state_file1099_r.valid?(context)).to eq true
-
-          state_file1099_r.state_tax_withheld_amount = 20
-          state_file1099_r.payer_state_identification_number = nil
-          expect(state_file1099_r.valid?(context)).to eq false
-        end
-
         it "validates <= 16 digits" do
           state_file1099_r.payer_state_identification_number = "1231578123"
           expect(state_file1099_r.valid?(context)).to eq true


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1994
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Removed `presence` check 
- Also make sure we check the length < 16 in all cases, if `payer_state_identification_number` is given... previously we weren't validating if `state_withheld_tax_amount` was not positive 😢 
## How to test?
- Describe the testing approach taken to verify the changes, including:
  - Removed tests
  - Any fixtures utilizing 1099Rs - try to leave `payer_state_identification_number` (box 15) blank & it should let you (regardless values on box 14); it should still check if the characters are <= 16 characters
- Risk Assessment
  - Checked xml to see that this change wouldn't impact anything 
## Screenshots (for visual changes)
- Before 
<img width="610" alt="Screenshot 2025-03-31 at 11 31 00 AM" src="https://github.com/user-attachments/assets/211870a6-d3a9-4d27-867d-2502c9d40216" />
<img width="582" alt="Screenshot 2025-03-31 at 11 33 08 AM" src="https://github.com/user-attachments/assets/396505ce-ffed-4b00-8af2-bb04adf44ed9" />


- After
<img width="559" alt="Screenshot 2025-03-31 at 11 30 37 AM" src="https://github.com/user-attachments/assets/53a14462-1d05-487b-9885-6e9b54b72c39" />
<img width="646" alt="Screenshot 2025-03-31 at 11 33 29 AM" src="https://github.com/user-attachments/assets/c83c083d-04d9-43ad-a5b2-4145289ab0cc" />
