### PR TITLE
[FYST-2002] 1099R XML: Sanitize payer_state_identification_number to match schema validations

### DIFF
--- a/app/lib/submission_builder/state1099_r.rb
+++ b/app/lib/submission_builder/state1099_r.rb
@@ -45,7 +45,7 @@ module SubmissionBuilder
             xml.F1099RStateTaxGrp do
               xml.StateTaxWithheldAmt form1099r.state_tax_withheld_amount&.round
               xml.StateAbbreviationCd form1099r.state_code || state_abbreviation
-              xml.PayerStateIdNum form1099r.payer_state_identification_number if form1099r.payer_state_identification_number.present?
+              xml.PayerStateIdNum sanitize_for_xml(form1099r.payer_state_identification_number) if form1099r.payer_state_identification_number.present?
               xml.StateDistributionAmt form1099r.state_distribution_amount&.round
             end
           end

--- a/spec/lib/submission_builder/state1099_r_spec.rb
+++ b/spec/lib/submission_builder/state1099_r_spec.rb
@@ -71,6 +71,16 @@ describe SubmissionBuilder::State1099R do
           expect(doc.at("RecipientUSAddress")).to be_nil
         end
       end
+
+      context "when 1099R has payer_state_identification_number with trailing/adjacent/leading spaces" do
+        before do
+          form1099r.update(payer_state_identification_number: "  AZ 123  22 ")
+        end
+
+        it "should remove trailing & leading spaces and leave only a single space if there are multiple adjacent spaces" do
+          expect(doc.at("F1099RStateTaxGrp PayerStateIdNum").text).to eq "AZ 123 22"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-2002
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Sanitizing to fit `TextType` validations for this field
## How to test?
- Describe the testing approach taken to verify the changes, including:
  - Unit/integration/manual tests
  - Test data used: AZ/MD personas with 1099R, then manipulate the employer state id number field (box 15) to put leading/adjacent/trailing spaces & make sure that does not lead to failures bundling
- Specify any relevant testing environments used (e.g., development, staging, demo, Heroku).
## Screenshots (for visual changes)
- Before 
<img width="1136" alt="Screenshot 2025-03-31 at 3 57 43 PM" src="https://github.com/user-attachments/assets/80f8052f-b84a-4267-97d8-7d27e4026a0a" />
<img width="368" alt="Screenshot 2025-03-31 at 3 57 54 PM" src="https://github.com/user-attachments/assets/97410cdf-798e-41e6-84ed-1cb0543decc4" />

- After
<img width="436" alt="Screenshot 2025-03-31 at 3 58 36 PM" src="https://github.com/user-attachments/assets/22f1d3f3-de33-479f-b2d8-39f3c0506d83" />
<img width="404" alt="Screenshot 2025-03-31 at 3 58 39 PM" src="https://github.com/user-attachments/assets/2830a7d6-51f0-4068-a3bb-7730a50a5ab7" />

