### PR TITLE
NJ 329 - content updates for use tax and property tax

### DIFF
--- a/app/controllers/state_file/questions/nj_ineligible_property_tax_controller.rb
+++ b/app/controllers/state_file/questions/nj_ineligible_property_tax_controller.rb
@@ -4,6 +4,7 @@ module StateFile
       include ReturnToReviewConcern
 
       helper_method :ineligible_reason
+      helper_method :determine_reason
       helper_method :on_home_or_rental
 
       def determine_reason

--- a/app/views/state_file/questions/nj_ineligible_property_tax/edit.html.erb
+++ b/app/views/state_file/questions/nj_ineligible_property_tax/edit.html.erb
@@ -16,6 +16,10 @@
   <% end  %>
   <p><%= t(".continue_text") %></p>
 
+  <% if determine_reason === "neither" %>
+    <p><%= t(".housing_assistance_html") %></p>
+  <% end %>
+
   <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
     <% if params[:on_home_or_rental].present? %>
       <%= hidden_field_tag "on_home_or_rental", params[:on_home_or_rental] %>

--- a/app/views/state_file/questions/nj_sales_use_tax/edit.html.erb
+++ b/app/views/state_file/questions/nj_sales_use_tax/edit.html.erb
@@ -13,8 +13,8 @@
               :untaxed_out_of_state_purchases,
               label_text: t('.use_tax_radio_label'),
               collection: [
-                { value: :yes, label: t("general.affirmative"), input_html: { "data-follow-up": "#sut-method-field" } },
                 { value: :no, label: t(".no_text") },
+                { value: :yes, label: t("general.affirmative"), input_html: { "data-follow-up": "#sut-method-field" } },
               ],
               legend_class: "sr-only"
             )

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3623,8 +3623,8 @@ en:
       nj_ineligible_property_tax:
         edit:
           continue_text: Click "Continue" to keep working on your taxes.
-          housing_assistance_html: (If you are interested in housing assistance, please call 211 or <a href="https://www.nj.gov/dca/dhcr/offices/housing_assistance.shtml" target="_blank" rel="noopener nofollow">visit the New Jersey Department of Community Affairs page on Housing Assistance</a>.)
           go_back_link: Go back to correct.
+          housing_assistance_html: (If you are interested in housing assistance, please call 211 or <a href="https://www.nj.gov/dca/dhcr/offices/housing_assistance.shtml" target="_blank" rel="noopener nofollow">visit the New Jersey Department of Community Affairs page on Housing Assistance</a>.)
           mistake_text: Is this a mistake?
           on_home: on the home you lived in and owned.
           on_rental: on the home you lived in and rented.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3569,7 +3569,7 @@ en:
           helper_description_html: |
             <ul class="list--bulleted">
               <li>You are a disabled veteran with a 100% exemption from property taxes on your main home; or if</li>
-              <li>You made P.I.L.O.T. (Payments-In-Lieu-of-Tax) payments</li>
+              <li>You made P.I.L.O.T. (Payments-In-Lieu-of-Tax) payments; or if</li>
               <li><a href="https://www.nj.gov/treasury/taxation/questions/propertyd2.shtml" target="_blank" rel="noopener nofollow">Another reason applies</a></li>
             </ul>
           helper_header: 'Leave first box unchecked if:'
@@ -3622,7 +3622,8 @@ en:
           title: You may qualify for a Property Tax Deduction or Credit on your main home, whether you owned or rented it.
       nj_ineligible_property_tax:
         edit:
-          continue_text: Click continue to keep working on your taxes.
+          continue_text: Click "Continue" to keep working on your taxes.
+          housing_assistance_html: (If you are interested in housing assistance, please call 211 or <a href="https://www.nj.gov/dca/dhcr/offices/housing_assistance.shtml" target="_blank" rel="noopener nofollow">visit the New Jersey Department of Community Affairs page on Housing Assistance</a>.)
           go_back_link: Go back to correct.
           mistake_text: Is this a mistake?
           on_home: on the home you lived in and owned.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3595,8 +3595,8 @@ es:
       nj_ineligible_property_tax:
         edit:
           continue_text: Haz clic en "Continuar" para seguir trabajando en tus impuestos.
-          housing_assistance_html: (Si te interesa la asistencia de vivienda, llama al 211 o <a href="https://www.nj.gov/dca/dhcr/offices/housing_assistance.shtml" target="_blank" rel="noopener nofollow">visita la página del Departamento de Asuntos Comunitarios de New Jersey sobre Asistencia de Vivienda</a>.)
           go_back_link: Corregir.
+          housing_assistance_html: (Si te interesa la asistencia de vivienda, llama al 211 o <a href="https://www.nj.gov/dca/dhcr/offices/housing_assistance.shtml" target="_blank" rel="noopener nofollow">visita la página del Departamento de Asuntos Comunitarios de New Jersey sobre Asistencia de Vivienda</a>.)
           mistake_text: "¿Es esto un error?"
           on_home: en la vivienda en la que viviste y fuiste dueño/a.
           on_rental: en la vivienda que alquilaste.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3541,7 +3541,7 @@ es:
           helper_description_html: |
             <ul class="list--bulleted">
               <li>Eres un/a veterano/a discapacitado/a con una exención del 100% de los impuestos sobre la propiedad en tu vivienda principal; o si</li>
-              <li>Realizaste Pagos en Lugar de Impuestos (P.I.L.O.T. por las siglas en inglés)</li>
+              <li>Realizaste Pagos en Lugar de Impuestos (P.I.L.O.T. por las siglas en inglés); o si</li>
               <li><a href="https://www.nj.gov/treasury/taxation/questions/propertyd2.shtml" target="_blank" rel="noopener nofollow">Otros motivos (en inglés)</a></li>
             </ul>
           helper_header: Deja la casilla anterior sin marcar si
@@ -3594,7 +3594,8 @@ es:
           title: Puedes calificar para una Deducción o Crédito por impuestos sobre la propiedad en tu vivienda principal, ya sea que la hayas comprado o alquilado.
       nj_ineligible_property_tax:
         edit:
-          continue_text: Haz clic en continuar para seguir trabajando en tus impuestos.
+          continue_text: Haz clic en "Continuar" para seguir trabajando en tus impuestos.
+          housing_assistance_html: (Si te interesa la asistencia de vivienda, llama al 211 o <a href="https://www.nj.gov/dca/dhcr/offices/housing_assistance.shtml" target="_blank" rel="noopener nofollow">visita la página del Departamento de Asuntos Comunitarios de New Jersey sobre Asistencia de Vivienda</a>.)
           go_back_link: Corregir.
           mistake_text: "¿Es esto un error?"
           on_home: en la vivienda en la que viviste y fuiste dueño/a.

--- a/spec/controllers/state_file/questions/nj_ineligible_property_tax_controller_spec.rb
+++ b/spec/controllers/state_file/questions/nj_ineligible_property_tax_controller_spec.rb
@@ -163,6 +163,24 @@ RSpec.describe StateFile::Questions::NjIneligiblePropertyTaxController do
       expect(response).to be_successful
     end
 
+    context 'when reason is not neither' do
+      let(:intake) { create :state_file_nj_intake, household_rent_own: "own" }
+      it 'does not show housing_assistance text' do
+        allow(Efile::Nj::NjPropertyTaxEligibility).to receive(:ineligible?).and_return true
+        get :edit
+        expect(response.body).not_to include(I18n.t("state_file.questions.nj_ineligible_property_tax.edit.housing_assistance_html"))
+      end
+    end
+
+    context 'when reason is neither' do
+      let(:intake) { create :state_file_nj_intake, household_rent_own: "neither" }
+      it 'shows housing_assistance text' do
+        allow(Efile::Nj::NjPropertyTaxEligibility).to receive(:ineligible?).and_return false
+        get :edit
+        expect(response.body).to include(I18n.t("state_file.questions.nj_ineligible_property_tax.edit.housing_assistance_html"))
+      end
+    end
+
     context 'when reason is not income' do
       let(:intake) { create :state_file_nj_intake, household_rent_own: "neither" }
       it 'shows mistake text' do


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/329

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Rearrange radio options for use tax ("no" should come first)
- Content update for reveal on homeowner eligibility screen
- Add housing assistance text to property tax ineligibility screen if reason is "neither"

## How to test?
Any persona

## Screenshots (for visual changes)
![image](https://github.com/user-attachments/assets/8cec3862-7d83-4764-96dc-e3d76df564a1)
![image](https://github.com/user-attachments/assets/488fdf3a-b857-41c5-aaf1-88cde0330560)
![image](https://github.com/user-attachments/assets/b2b2fd37-4675-4e7c-b27e-3bf0086c08ed)
