### PR TITLE
FYST-1973 create service to send marketing email to AZ archived intakes filers who have not yet filed for TY24

### DIFF
--- a/app/controllers/state_file/notifications_settings_controller.rb
+++ b/app/controllers/state_file/notifications_settings_controller.rb
@@ -16,7 +16,8 @@ module StateFile
     def matching_intakes(email_address)
       return if email_address.blank?
 
-      StateFile::StateInformationService.state_intake_classes.map { |klass| klass.where(email_address: email_address) }.inject([], :+)
+      intake_classes = StateFile::StateInformationService.state_intake_classes + [StateFileArchivedIntake]
+      intake_classes.map { |klass| klass.where(email_address: email_address) }.inject([], :+)
     end
   end
 end

--- a/app/models/state_file/automated_message/marketing_email.rb
+++ b/app/models/state_file/automated_message/marketing_email.rb
@@ -1,0 +1,23 @@
+module StateFile::AutomatedMessage
+  class MarketingEmail < BaseAutomatedMessage
+    def self.name
+      'messages.state_file.marketing_email'.freeze
+    end
+
+    def self.after_transition_notification?
+      false
+    end
+
+    def self.send_only_once?
+      true
+    end
+
+    def email_subject(**args)
+      I18n.t("messages.state_file.marketing_email.subject", **args)
+    end
+
+    def email_body(**args)
+      I18n.t("messages.state_file.marketing_email.body", **args)
+    end
+  end
+end

--- a/app/models/state_file_archived_intake.rb
+++ b/app/models/state_file_archived_intake.rb
@@ -2,23 +2,24 @@
 #
 # Table name: state_file_archived_intakes
 #
-#  id                    :bigint           not null, primary key
-#  email_address         :string
-#  failed_attempts       :integer          default(0), not null
-#  fake_address_1        :string
-#  fake_address_2        :string
-#  hashed_ssn            :string
-#  locked_at             :datetime
-#  mailing_apartment     :string
-#  mailing_city          :string
-#  mailing_state         :string
-#  mailing_street        :string
-#  mailing_zip           :string
-#  permanently_locked_at :datetime
-#  state_code            :string
-#  tax_year              :integer
-#  created_at            :datetime         not null
-#  updated_at            :datetime         not null
+#  id                      :bigint           not null, primary key
+#  email_address           :string
+#  failed_attempts         :integer          default(0), not null
+#  fake_address_1          :string
+#  fake_address_2          :string
+#  hashed_ssn              :string
+#  locked_at               :datetime
+#  mailing_apartment       :string
+#  mailing_city            :string
+#  mailing_state           :string
+#  mailing_street          :string
+#  mailing_zip             :string
+#  permanently_locked_at   :datetime
+#  state_code              :string
+#  tax_year                :integer
+#  unsubscribed_from_email :boolean          default(FALSE), not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #
 class StateFileArchivedIntake < ApplicationRecord
   has_one_attached :submission_pdf

--- a/app/services/state_file/send_marketing_email_service.rb
+++ b/app/services/state_file/send_marketing_email_service.rb
@@ -1,0 +1,28 @@
+module StateFile
+  class SendMarketingEmailService
+    def self.run
+      message = StateFile::AutomatedMessage::MarketingEmail
+      archived_az_intakes = StateFileArchivedIntake.where(state_code: "az")
+
+      batch_size = 50
+      archived_az_intakes.each_slice(batch_size) do |batch|
+        batch.each do |archived_intake|
+          begin
+            az_intakes_with_matching_ssn_and_import = StateFileAzIntake.where(hashed_ssn: archived_intake.hashed_ssn).where.not(df_data_imported_at: nil)
+            next if az_intakes_with_matching_ssn_and_import.any?
+
+            message_instance = message.new
+            StateFileNotificationEmail.create!(
+              data_source: archived_intake,
+              to: archived_intake.email_address,
+              body: message_instance.email_body,
+              subject: message_instance.email_subject,
+            )
+          rescue => e
+            Sentry.capture_exception(e, extra: { archived_intake_id: archived_intake.id })
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1608,6 +1608,19 @@ en:
           Hello - Thank you for using FileYourStateTaxes! Any issues you may have experienced while using our tool have now been resolved. To continue filing your state taxes, log in here: %{login_link}
 
           Questions? Email us at help@fileyourstatetaxes.org.
+      marketing_email:
+        body: |
+          Hello,
+
+          File your state tax return again for free with FileYourStateTaxes!
+
+          April 15 is right around the corner. Luckily, filing is easier than ever! File your taxes with IRS Direct File and FileYourStateTaxes today.
+
+          Already started? Finish filing before April 15.
+
+          Best,
+          The FileYourStateTaxes team
+        subject: IRS Direct File is back and easier than ever
       post_deadline_reminder:
         email:
           body: |-

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1589,6 +1589,19 @@ es:
           Hola -  ¡Gracias por utilizar FileYourStateTaxes! Cualquier problema que haya experimentado al utilizar nuestra herramienta ya se ha resuelto. Para continuar presentando sus impuestos estatales, inicie sesión aquí: %{login_link}
 
           ¿Preguntas? Envíenos un correo electrónico a help@fileyourstatetaxes.org.
+      marketing_email:
+        body: |
+          Hello,
+
+          File your state tax return again for free with FileYourStateTaxes!
+
+          April 15 is right around the corner. Luckily, filing is easier than ever! File your taxes with IRS Direct File and FileYourStateTaxes today.
+
+          Already started? Finish filing before April 15.
+
+          Best,
+          The FileYourStateTaxes team
+        subject: IRS Direct File is back and easier than ever
       post_deadline_reminder:
         email:
           body: |-

--- a/db/migrate/20250402233714_add_unsubscribed_from_email_to_state_file_archived_intakes.rb
+++ b/db/migrate/20250402233714_add_unsubscribed_from_email_to_state_file_archived_intakes.rb
@@ -1,0 +1,5 @@
+class AddUnsubscribedFromEmailToStateFileArchivedIntakes < ActiveRecord::Migration[7.1]
+  def change
+    add_column :state_file_archived_intakes, :unsubscribed_from_email, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_14_183447) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_02_233714) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -1846,6 +1846,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_14_183447) do
     t.datetime "permanently_locked_at"
     t.string "state_code"
     t.integer "tax_year"
+    t.boolean "unsubscribed_from_email", default: false, null: false
     t.datetime "updated_at", null: false
   end
 

--- a/lib/tasks/state_file.rake
+++ b/lib/tasks/state_file.rake
@@ -15,6 +15,10 @@ namespace :state_file do
     StateFile::SendPostDeadlineReminderService.run
   end
 
+  task send_marketing_email: :environment do
+    StateFile::SendMarketingEmailService.run
+  end
+
   task backfill_intake_submission_pdfs: :environment do
     batch_size = 5
     intake_types = StateFile::StateInformationService.state_intake_classes

--- a/spec/controllers/state_file/notifications_settings_controller_spec.rb
+++ b/spec/controllers/state_file/notifications_settings_controller_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe StateFile::NotificationsSettingsController do
     render_views
 
     let!(:intake) { create :state_file_ny_intake, email_address: "unsubscribe_me@example.com", unsubscribed_from_email: false }
+    let!(:archived_intake) { create :state_file_archived_intake, email_address: "unsubscribe_me@example.com", unsubscribed_from_email: false }
     let(:verifier) { ActiveSupport::MessageVerifier.new(Rails.application.secret_key_base) }
     let(:signed_email) { verifier.generate("unsubscribe_me@example.com") }
     let(:signed_email_without_intake) { verifier.generate("rando@example.com") }
@@ -13,6 +14,7 @@ RSpec.describe StateFile::NotificationsSettingsController do
       get :unsubscribe_from_emails, params: { email_address: signed_email }
 
       expect(intake.reload.unsubscribed_from_email).to eq true
+      expect(archived_intake.reload.unsubscribed_from_email).to eq true
       expect(response.body).to include state_file_subscribe_to_emails_path(email_address: signed_email)
     end
 

--- a/spec/factories/state_file_archived_intakes.rb
+++ b/spec/factories/state_file_archived_intakes.rb
@@ -2,23 +2,24 @@
 #
 # Table name: state_file_archived_intakes
 #
-#  id                    :bigint           not null, primary key
-#  email_address         :string
-#  failed_attempts       :integer          default(0), not null
-#  fake_address_1        :string
-#  fake_address_2        :string
-#  hashed_ssn            :string
-#  locked_at             :datetime
-#  mailing_apartment     :string
-#  mailing_city          :string
-#  mailing_state         :string
-#  mailing_street        :string
-#  mailing_zip           :string
-#  permanently_locked_at :datetime
-#  state_code            :string
-#  tax_year              :integer
-#  created_at            :datetime         not null
-#  updated_at            :datetime         not null
+#  id                      :bigint           not null, primary key
+#  email_address           :string
+#  failed_attempts         :integer          default(0), not null
+#  fake_address_1          :string
+#  fake_address_2          :string
+#  hashed_ssn              :string
+#  locked_at               :datetime
+#  mailing_apartment       :string
+#  mailing_city            :string
+#  mailing_state           :string
+#  mailing_street          :string
+#  mailing_zip             :string
+#  permanently_locked_at   :datetime
+#  state_code              :string
+#  tax_year                :integer
+#  unsubscribed_from_email :boolean          default(FALSE), not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #
 FactoryBot.define do
   factory :state_file_archived_intake do

--- a/spec/models/state_file_archived_intake_spec.rb
+++ b/spec/models/state_file_archived_intake_spec.rb
@@ -2,23 +2,24 @@
 #
 # Table name: state_file_archived_intakes
 #
-#  id                    :bigint           not null, primary key
-#  email_address         :string
-#  failed_attempts       :integer          default(0), not null
-#  fake_address_1        :string
-#  fake_address_2        :string
-#  hashed_ssn            :string
-#  locked_at             :datetime
-#  mailing_apartment     :string
-#  mailing_city          :string
-#  mailing_state         :string
-#  mailing_street        :string
-#  mailing_zip           :string
-#  permanently_locked_at :datetime
-#  state_code            :string
-#  tax_year              :integer
-#  created_at            :datetime         not null
-#  updated_at            :datetime         not null
+#  id                      :bigint           not null, primary key
+#  email_address           :string
+#  failed_attempts         :integer          default(0), not null
+#  fake_address_1          :string
+#  fake_address_2          :string
+#  hashed_ssn              :string
+#  locked_at               :datetime
+#  mailing_apartment       :string
+#  mailing_city            :string
+#  mailing_state           :string
+#  mailing_street          :string
+#  mailing_zip             :string
+#  permanently_locked_at   :datetime
+#  state_code              :string
+#  tax_year                :integer
+#  unsubscribed_from_email :boolean          default(FALSE), not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #
 require 'rails_helper'
 

--- a/spec/services/state_file/send_marketing_email_service_spec.rb
+++ b/spec/services/state_file/send_marketing_email_service_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe StateFile::SendMarketingEmailService do
+  describe ".run" do
+    let!(:az_intake_with_import) { create :state_file_az_intake, hashed_ssn: "123456789", df_data_imported_at: Date.new(MultiTenantService.new(:statefile).current_tax_year, 2, 1) }
+    let!(:archived_az_intake_returned) { create :state_file_archived_intake, state_code: "az", hashed_ssn: "123456789" }
+
+    let!(:archived_ny_intake) { create :state_file_archived_intake, state_code: "ny" }
+
+    let!(:az_intake_without_import) { create :state_file_az_intake, hashed_ssn: "987654321", df_data_imported_at: nil }
+    let!(:archived_az_intake_returned_no_import) { create :state_file_archived_intake, hashed_ssn: "987654321" }
+
+    let!(:archived_az_intake_not_returned) { create :state_file_archived_intake, state_code: "az" }
+
+    it "sends a message to the archived AZ intakes and not the archived NY intakes" do
+      StateFile::SendMarketingEmailService.run
+
+      expect(StateFileNotificationEmail.where(data_source: archived_az_intake_not_returned).count).to eq 0
+      expect(StateFileNotificationEmail.where(data_source: archived_ny_intake).count).to eq 0
+      expect(StateFileNotificationEmail.where(data_source: archived_az_intake_returned_no_import).count).to eq 1
+      expect(StateFileNotificationEmail.where(data_source: archived_az_intake_not_returned).count).to eq 1
+    end
+  end
+end

--- a/spec/services/state_file/send_marketing_email_service_spec.rb
+++ b/spec/services/state_file/send_marketing_email_service_spec.rb
@@ -8,14 +8,16 @@ describe StateFile::SendMarketingEmailService do
     let!(:archived_ny_intake) { create :state_file_archived_intake, state_code: "ny" }
 
     let!(:az_intake_without_import) { create :state_file_az_intake, hashed_ssn: "987654321", df_data_imported_at: nil }
-    let!(:archived_az_intake_returned_no_import) { create :state_file_archived_intake, hashed_ssn: "987654321" }
+    let!(:archived_az_intake_returned_no_import) { create :state_file_archived_intake, state_code: "az", hashed_ssn: "987654321" }
 
     let!(:archived_az_intake_not_returned) { create :state_file_archived_intake, state_code: "az" }
 
     it "sends a message to the archived AZ intakes and not the archived NY intakes" do
-      StateFile::SendMarketingEmailService.run
+      expect {
+        StateFile::SendMarketingEmailService.run
+      }.to change(StateFileNotificationEmail, :count).by(2)
 
-      expect(StateFileNotificationEmail.where(data_source: archived_az_intake_not_returned).count).to eq 0
+      expect(StateFileNotificationEmail.where(data_source: archived_az_intake_returned).count).to eq 0
       expect(StateFileNotificationEmail.where(data_source: archived_ny_intake).count).to eq 0
       expect(StateFileNotificationEmail.where(data_source: archived_az_intake_returned_no_import).count).to eq 1
       expect(StateFileNotificationEmail.where(data_source: archived_az_intake_not_returned).count).to eq 1


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1973
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted?

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Added service to send email to archived intakes from AZ that don't have a corresponding this year AZ intake with the same ssn and successful data import
## How to test?
- Added unit test for service. Should test in demo probably
## Screenshots (for visual changes)
test email from heroku
<img width="1181" alt="image" src="https://github.com/user-attachments/assets/ec8ec66c-42b4-4471-a885-15a631f15957" />

