### PR TITLE
FYST-2003 update pre deadline reminder fyst notification behavior

### DIFF
--- a/app/models/state_file/automated_message/pre_deadline_reminder.rb
+++ b/app/models/state_file/automated_message/pre_deadline_reminder.rb
@@ -10,7 +10,7 @@ module StateFile::AutomatedMessage
     end
 
     def self.send_only_once?
-      true
+      false
     end
 
     def sms_body(**args)

--- a/app/services/state_file/send_pre_deadline_reminder_service.rb
+++ b/app/services/state_file/send_pre_deadline_reminder_service.rb
@@ -7,12 +7,10 @@ module StateFile
       cutoff_time_ago = HOURS_AGO.hours.ago
       intakes_to_notify = []
 
-      StateFile::StateInformationService.state_intake_classes.each do |class_object|
+      StateFile::StateInformationService.state_intake_classes.excluding(StateFileNyIntake).each do |class_object|
         intakes_to_notify += class_object.left_joins(:efile_submissions)
                                          .where(efile_submissions: { id: nil })
-                                         .where.not(email_address: nil)
-                                         .where.not(email_address_verified_at: nil)
-                                         .where(unsubscribed_from_email: false)
+                                         .messaging_eligible
                                          .where("#{class_object.name.underscore.pluralize}.message_tracker #> '{messages.state_file.pre_deadline_reminder}' IS NULL")
                                          .select do |intake|
                                             if intake.message_tracker.present? && intake.message_tracker["messages.state_file.finish_return"]

--- a/app/services/state_file/send_pre_deadline_reminder_service.rb
+++ b/app/services/state_file/send_pre_deadline_reminder_service.rb
@@ -1,6 +1,6 @@
 module StateFile
   class SendPreDeadlineReminderService
-    BATCH_SIZE = 10
+    BATCH_SIZE = 1_000
     HOURS_AGO = 24
 
     def self.run
@@ -11,7 +11,6 @@ module StateFile
         intakes_to_notify += class_object.left_joins(:efile_submissions)
                                          .where(efile_submissions: { id: nil })
                                          .messaging_eligible
-                                         .where("#{class_object.name.underscore.pluralize}.message_tracker #> '{messages.state_file.pre_deadline_reminder}' IS NULL")
                                          .select do |intake|
                                             if intake.message_tracker.present? && intake.message_tracker["messages.state_file.finish_return"]
                                               finish_return_msg_sent_time = Time.parse(intake.message_tracker["messages.state_file.finish_return"])

--- a/crontab
+++ b/crontab
@@ -9,5 +9,7 @@
 */10 * * * 1-6 bundle exec rake efile:poll_and_get_acknowledgments
 0 */2 * * * bundle exec rake state_file:reminder_to_finish_state_return
 0 19 23 4 * bundle exec rake state_file:post_deadline_reminder
+0 18 05 4 * bundle exec rake state_file:pre_deadline_reminder
+0 18 15 4 * bundle exec rake state_file:pre_deadline_reminder
 0 21 23 4 * bundle exec rake send_reject_resolution_reminder_notifications:send
 0 21 27 10 * bundle exec rake users:suspend_non_admins

--- a/lib/tasks/state_file.rake
+++ b/lib/tasks/state_file.rake
@@ -6,7 +6,7 @@ namespace :state_file do
   end
 
   task pre_deadline_reminder: :environment do
-    return unless DateTime.now.year == 2024
+    return unless DateTime.now.year == 2025
     StateFile::SendPreDeadlineReminderService.run
   end
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. https://codeforamerica.atlassian.net/browse/FYST-2003

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
  * add cron tab dates for 4/05/2025 and 4/15/25
  * update pre_deadline_reminder to filter out NY and also use scope for messaging eligible
  *  remove pre_deadline_reminder query for checking if the email has been sent before
  * allow pre_deadline_reminder message to be sent more than once
  * update associated tests as well

- Alternatives considered
## How to test?
* rspec test for the service 
* queried demo (204 intakes) and prod (7,646 intakes) 