### PR TITLE
NJ 145 - update medical expenses to remove default and allow nil

### DIFF
--- a/app/forms/state_file/nj_medical_expenses_form.rb
+++ b/app/forms/state_file/nj_medical_expenses_form.rb
@@ -4,12 +4,10 @@ module StateFile
                        :medical_expenses
 
     validates_numericality_of :medical_expenses, message: I18n.t("validators.not_a_number"), if: -> { medical_expenses.present? }
-    validates :medical_expenses, presence: true, allow_blank: false, numericality: { greater_than_or_equal_to: 0 }
+    validates :medical_expenses, allow_blank: true, numericality: { greater_than_or_equal_to: 0 }
                    
     def save
-      unless medical_expenses.nil?
-        @intake.update(attributes_for(:intake))
-      end
+      @intake.update(attributes_for(:intake))
     end
   end
 end

--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -365,7 +365,8 @@ module Efile
 
       def calculate_line_31
         two_percent_gross = line_or_zero(:NJ1040_LINE_29) * 0.02
-        difference_with_med_expenses = @intake.medical_expenses - two_percent_gross
+        medical_expenses = @intake.medical_expenses || 0
+        difference_with_med_expenses = medical_expenses - two_percent_gross
         rounded_difference = difference_with_med_expenses.round
         return rounded_difference if rounded_difference.positive?
         nil

--- a/app/models/state_file_nj_intake.rb
+++ b/app/models/state_file_nj_intake.rb
@@ -44,7 +44,7 @@
 #  last_sign_in_ip                                        :inet
 #  locale                                                 :string           default("en")
 #  locked_at                                              :datetime
-#  medical_expenses                                       :decimal(12, 2)   default(0.0), not null
+#  medical_expenses                                       :decimal(12, 2)
 #  message_tracker                                        :jsonb
 #  municipality_code                                      :string
 #  municipality_name                                      :string

--- a/app/views/state_file/questions/nj_review/edit.html.erb
+++ b/app/views/state_file/questions/nj_review/edit.html.erb
@@ -146,7 +146,7 @@
     <section id="medical_expenses" class="white-group">
       <div class="spacing-below-5">
         <h2 class="text--body text--bold spacing-below-5"><%=t(".medical_expenses") %></h2>
-        <p><%= number_to_currency(current_intake.medical_expenses, precision: 0) %></p>
+        <p><%= number_to_currency(current_intake.medical_expenses || 0, precision: 0) %></p>
         <%= link_to StateFile::Questions::NjMedicalExpensesController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
           <%= t(".review_and_edit") %>
           <span class="sr-only"><%= t(".medical_expenses") %></span>

--- a/db/migrate/20250403171411_remove_medical_expenses_default_on_nj_intake.rb
+++ b/db/migrate/20250403171411_remove_medical_expenses_default_on_nj_intake.rb
@@ -1,0 +1,6 @@
+class RemoveMedicalExpensesDefaultOnNjIntake < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :state_file_nj_intakes, :medical_expenses, true
+    change_column_default :state_file_nj_intakes, :medical_expenses, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_02_190355) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_03_171411) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -2375,7 +2375,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_02_190355) do
     t.inet "last_sign_in_ip"
     t.string "locale", default: "en"
     t.datetime "locked_at"
-    t.decimal "medical_expenses", precision: 12, scale: 2, default: "0.0", null: false
+    t.decimal "medical_expenses", precision: 12, scale: 2
     t.jsonb "message_tracker", default: {}
     t.string "municipality_code"
     t.string "municipality_name"

--- a/spec/factories/state_file_nj_intakes.rb
+++ b/spec/factories/state_file_nj_intakes.rb
@@ -44,7 +44,7 @@
 #  last_sign_in_ip                                        :inet
 #  locale                                                 :string           default("en")
 #  locked_at                                              :datetime
-#  medical_expenses                                       :decimal(12, 2)   default(0.0), not null
+#  medical_expenses                                       :decimal(12, 2)
 #  message_tracker                                        :jsonb
 #  municipality_code                                      :string
 #  municipality_name                                      :string

--- a/spec/forms/state_file/nj_medical_expenses_form_spec.rb
+++ b/spec/forms/state_file/nj_medical_expenses_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe StateFile::NjMedicalExpensesForm do
   describe "validations" do
     let(:form) { described_class.new(intake, params) }
 
-    it_behaves_like :nj_money_field_concern, field: :medical_expenses do
+    it_behaves_like :nj_money_field_concern, field: :medical_expenses, can_be_empty: true do
       let(:form_params) do
         { medical_expenses: money_field_value }
       end
@@ -15,7 +15,7 @@ RSpec.describe StateFile::NjMedicalExpensesForm do
 
   describe ".save" do
     let(:intake) {
-      create :state_file_nj_intake, medical_expenses: 0
+      create :state_file_nj_intake, medical_expenses: nil
     }
     let(:form) { described_class.new(intake, valid_params) }
 

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -796,6 +796,15 @@ describe Efile::Nj::Nj1040Calculator do
         expect(instance.lines[:NJ1040_LINE_38].value).to eq(1000)
       end
     end
+
+    context 'when medical expenses is nil' do
+      let(:gross_income) { 10_000 }
+      let(:medical_expenses) { nil }
+
+      it 'treats medical expenses as 0' do
+        expect(instance.lines[:NJ1040_LINE_31].value).to eq(nil)
+      end
+    end
   end
 
   describe 'line 38 - total exemptions/deductions' do

--- a/spec/models/state_file_nj_intake_spec.rb
+++ b/spec/models/state_file_nj_intake_spec.rb
@@ -44,7 +44,7 @@
 #  last_sign_in_ip                                        :inet
 #  locale                                                 :string           default("en")
 #  locked_at                                              :datetime
-#  medical_expenses                                       :decimal(12, 2)   default(0.0), not null
+#  medical_expenses                                       :decimal(12, 2)
 #  message_tracker                                        :jsonb
 #  municipality_code                                      :string
 #  municipality_name                                      :string


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/145

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Update medical expenses in database so it no longer defaults to 0
- allow user to continue without entering a value
- treat a nil value as 0

## How to test?
any persona

## Screenshots (for visual changes)
![image](https://github.com/user-attachments/assets/fd7fa2d5-da00-40ed-81be-4c2a952b412e)