### PR TITLE
turn on show_retirement_ui flipper flag in review page spec to be more like prod

### DIFF
--- a/spec/features/state_file/review_page_spec.rb
+++ b/spec/features/state_file/review_page_spec.rb
@@ -6,6 +6,10 @@ RSpec.feature "Completing a state file intake", active_job: true, js: true do
 
   before do
     allow_any_instance_of(Routes::StateFileDomain).to receive(:matches?).and_return(true)
+
+    # Turn on 1099-R support to be more like prod
+    allow(Flipper).to receive(:enabled?).and_call_original
+    allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)
   end
 
   StateFile::StateInformationService.active_state_codes.without("ny").each do |state_code|


### PR DESCRIPTION
## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Previously, the review page spec didn't enable the `show_retirement_ui` flipper flag, which has now been turned on in prod for a while and is likely to stay on forever.
- Because of this, our automated tests failed to catch a change in another PR which would have caused the review page to crash for all NJ filers.
- Weirdly, we _ already do_ test 1099-R editing behavior in the review page spec - it seems like we may have been inconsistent in what was hidden behind the feature flag?
## How to test?
- As long as the review spec continues to pass, this change should be harmless
