### PR TITLE
GYR1-700 add mixpanel click events for homepage filing options

### DIFF
--- a/app/javascript/lib/mixpanel_event_tracking.js
+++ b/app/javascript/lib/mixpanel_event_tracking.js
@@ -1,5 +1,6 @@
 import "../vendor/navigator.sendbeacon.min.js";
-
+import Rails from "@rails/ujs";
+window.Rails = Rails;
 
 const MixpanelEventTracking = (function () {
     const addClickTrackingToOutboundLinks = function () {

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -12,6 +12,7 @@ import Listeners from "../listeners";
 // but we have things (views, test runner) in the app that require jquery on the window object.
 window.jQuery = $;
 window.$ = $;
+window.Rails = RailsUJS;
 
 RailsUJS.start();
 ActiveStorage.start();

--- a/spec/javascript/lib/mixpanel_event_tracking.spec.js
+++ b/spec/javascript/lib/mixpanel_event_tracking.spec.js
@@ -9,12 +9,6 @@ describe('MixpanelEventTracking', () => {
           <a id="outboundLink" href="https://example.com/">Example link to somewhere radical and new</a>
         `;
     navigator.sendBeacon = jest.fn();
-    window.Rails = {
-      csrfToken: () => {
-      },
-      csrfParam: () => {
-      }
-    }
   });
 
   describe('tracked clicks via [data-track-click]', () => {


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/GYR1-700
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Imported from `@rails/ujs` and set `window.Rails`, per this post: https://www.reddit.com/r/rails/comments/hz9v3y/why_is_the_rails_object_not_defined_in_javascript/
- It seemed maybe nice to have the tests check that this works and it looked to me like the reason this wasn't caught in tests was that the test mocked the Rails object. The thing is, if I remove the mock it fails because it doesn't seem to take `application.js` into account and I don't know how to include that. One way to get it to pass is to import Rails in `mixpanel_event_tracking.js` but that seems redundant
## How to test?
- see above

