### PR TITLE
NJ 316 - accessibility SC412 back arrow is read aloud

### DIFF
--- a/app/assets/stylesheets/templates/_question.scss
+++ b/app/assets/stylesheets/templates/_question.scss
@@ -6,7 +6,7 @@
     display: block;
     a {
       &:before {
-        content:'←';
+        content:'←' / '';
         padding-right: .5rem;
       }
       font-size: 1.6rem;


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/accessibility-pm/issues/16

## Is PM acceptance required? (delete one)
- No - merge after code review approval

## What was done?
Add empty alt text to left-arrow pseudo-element on back button, so that it is flagged as decorative content and not read aloud by screen readers

## How to test?
use voiceover or similar

## Screenshots (use audio)
BEFORE:

https://github.com/user-attachments/assets/972b2267-2060-464e-83e5-c33f3c85e503

AFTER:

https://github.com/user-attachments/assets/67b04570-f393-4d54-9efc-261a647a7d5a
