### PR TITLE
Switch h2 tag on landing page reveal to p tag

### DIFF
--- a/app/views/ctc/questions/w2s/edit.html.erb
+++ b/app/views/ctc/questions/w2s/edit.html.erb
@@ -8,9 +8,7 @@
 
   <div class="spacing-above-15 spacing-below-60">
     <div class="reveal">
-      <p>
-        <button class="reveal__button" data-track-click="w2_havent_received_reveal"><%= t("views.ctc.questions.w2s.reveal.title") %></button>
-      </p>
+      <button class="reveal__button" data-track-click="w2_havent_received_reveal"><%= t("views.ctc.questions.w2s.reveal.title") %></button>
       <div class="reveal__content">
         <p class="text--line-breaks"><%= t("views.ctc.questions.w2s.reveal.content_html") %></p>
       </div>

--- a/app/views/state_file/landing_page/edit.html.erb
+++ b/app/views/state_file/landing_page/edit.html.erb
@@ -59,12 +59,10 @@
               <% end %>
             <% else %>
               <div class="reveal">
-                <p>
-                  <button class="reveal__button">
-                    <% # i18n-tasks-use t('state_file.landing_page.edit.help_text_title') # hint for the i18n linter that, yes, we are using this key (sometimes) %>
-                    <%= t(".#{@state_code}.help_text_title", default: :'.help_text_title') %>
-                  </button>
-                </p>
+                <button class="reveal__button">
+                  <% # i18n-tasks-use t('state_file.landing_page.edit.help_text_title') # hint for the i18n linter that, yes, we are using this key (sometimes) %>
+                  <%= t(".#{@state_code}.help_text_title", default: :'.help_text_title') %>
+                </button>
                 <div class="reveal__content">
                   <% # i18n-tasks-use t('state_file.landing_page.edit.help_text_html') # hint for the i18n linter that, yes, we are using this key (sometimes) %>
                   <%= t(".#{@state_code}.help_text_html", default: :'.help_text_html', filing_year: current_tax_year) %>

--- a/app/views/state_file/landing_page/edit.html.erb
+++ b/app/views/state_file/landing_page/edit.html.erb
@@ -59,12 +59,12 @@
               <% end %>
             <% else %>
               <div class="reveal">
-                <h2 class="text--body text--bold spacing-below-5">
+                <p>
                   <button class="reveal__button">
                     <% # i18n-tasks-use t('state_file.landing_page.edit.help_text_title') # hint for the i18n linter that, yes, we are using this key (sometimes) %>
                     <%= t(".#{@state_code}.help_text_title", default: :'.help_text_title') %>
                   </button>
-                </h2>
+                </p>
                 <div class="reveal__content">
                   <% # i18n-tasks-use t('state_file.landing_page.edit.help_text_html') # hint for the i18n linter that, yes, we are using this key (sometimes) %>
                   <%= t(".#{@state_code}.help_text_html", default: :'.help_text_html', filing_year: current_tax_year) %>

--- a/app/views/state_file/questions/eligible/_nj_credits_unsupported.html.erb
+++ b/app/views/state_file/questions/eligible/_nj_credits_unsupported.html.erb
@@ -1,5 +1,5 @@
 <div class="reveal">
-  <p><button class="reveal__button"><%= t("state_file.questions.eligible.edit.credits_not_supported")%></button></p>
+  <button class="reveal__button"><%= t("state_file.questions.eligible.edit.credits_not_supported")%></button>
 
   <div class="reveal__content">
     <div class="spacing-below-25">

--- a/app/views/state_file/questions/eligible/edit.html.erb
+++ b/app/views/state_file/questions/eligible/edit.html.erb
@@ -22,7 +22,7 @@
     <%= render partial: "state_file/questions/eligible/#{current_state_code}_credits_unsupported" %>
 
     <div class="reveal">
-      <p><button class="reveal__button"><%= t('.not_supported') %></button></p>
+      <button class="reveal__button"><%= t('.not_supported') %></button>
       <div class="reveal__content">
         <div>
           <%= render partial: "state_file/questions/eligible/vita_option" %>

--- a/app/views/state_file/questions/phone_number/edit.html.erb
+++ b/app/views/state_file/questions/phone_number/edit.html.erb
@@ -12,7 +12,7 @@
       <%= f.submit t(".action"), class: "button button--primary button--wide spacing-below-15" %>
     <% end %>
   <div class="reveal">
-    <p><button class="reveal__button"><%= t('.messaging_details') %></button></p>
+    <button class="reveal__button"><%= t('.messaging_details') %></button>
     <div class="reveal__content">
       <p><%= t('.message_body_one') %></p>
       <p><%= t('.message_body_two_html') %></p>

--- a/app/views/state_file/questions/submission_confirmation/_nj_additional_content.html.erb
+++ b/app/views/state_file/questions/submission_confirmation/_nj_additional_content.html.erb
@@ -4,7 +4,7 @@
     <p><%= current_intake.filing_status_mfj? ? t('.body_mfj_html') : t('.body_html') %></p>
   </div>
   <div class="reveal">
-  <p><button class="reveal__button"><%= t('.veterans_reveal') %></button></p>
+  <button class="reveal__button"><%= t('.veterans_reveal') %></button>
   <div class="reveal__content">
     <p><%= t('.veterans_reveal_html') %></p>
   </div>

--- a/app/views/state_file/questions/unemployment/_form.html.erb
+++ b/app/views/state_file/questions/unemployment/_form.html.erb
@@ -106,7 +106,7 @@
         </div>
 
         <div class="reveal">
-          <p><button class="reveal__button"><%= t('state_file.questions.unemployment.edit.information_html') %></button></p>
+          <button class="reveal__button"><%= t('state_file.questions.unemployment.edit.information_html') %></button>
           <div class="reveal__content"><%= t('state_file.questions.unemployment.edit.information_content_html') %></div>
         </div>
       </div>


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://github.com/newjersey/affordability-pm/issues/318
- CFA visible: https://github.com/newjersey/accessibility-pm/issues/41

## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Remove header tag from reveal and replace with p tag

## How to test?
- check the console after clicking "Start NJ" or any other state, verify that tag for reveal is no longer a h2 tag

## Screenshots (for visual changes)
- Before
<img width="810" alt="image" src="https://github.com/user-attachments/assets/48350cdc-4007-42e2-8b14-4c5cb0db8c80" />

- After
<img width="810" alt="image" src="https://github.com/user-attachments/assets/589b6c69-b38a-41f7-a67a-378df34d9ee3" />

