### PR TITLE
[FYST-2021]  Send notifications regardless of verification for pre_deadline_reminder

### DIFF
--- a/app/models/state_file_base_intake.rb
+++ b/app/models/state_file_base_intake.rb
@@ -40,6 +40,7 @@ class StateFileBaseIntake < ApplicationRecord
     where.not(raw_direct_file_data: nil)
          .where(federal_submission_id: nil)
   }
+
   scope :messaging_eligible, lambda {
     where(<<~SQL)
       (
@@ -51,6 +52,20 @@ class StateFileBaseIntake < ApplicationRecord
       (
         email_address IS NOT NULL
         AND email_notification_opt_in = 1
+        AND email_address_verified_at IS NOT NULL
+      )
+    SQL
+  }
+
+  scope :has_verified_contact_info, lambda {
+    where(<<~SQL)
+      (
+        phone_number IS NOT NULL
+        AND phone_number_verified_at IS NOT NULL
+      )
+      OR
+      (
+        email_address IS NOT NULL
         AND email_address_verified_at IS NOT NULL
       )
     SQL

--- a/app/services/state_file/send_pre_deadline_reminder_service.rb
+++ b/app/services/state_file/send_pre_deadline_reminder_service.rb
@@ -29,7 +29,7 @@ module StateFile
           StateFile::MessagingService.new(
             message: StateFile::AutomatedMessage::PreDeadlineReminder,
             intake: intake
-          ).send_message
+          ).send_message(require_verification: false)
         end
       end
     end

--- a/app/services/state_file/send_pre_deadline_reminder_service.rb
+++ b/app/services/state_file/send_pre_deadline_reminder_service.rb
@@ -11,6 +11,7 @@ module StateFile
         intakes_to_notify += class_object.left_joins(:efile_submissions)
                                          .where(efile_submissions: { id: nil })
                                          .where.not(df_data_imported_at: nil)
+                                         .has_verified_contact_info
                                          .select do |intake|
                                             if intake.message_tracker.present? && intake.message_tracker["messages.state_file.finish_return"]
                                               finish_return_msg_sent_time = Time.parse(intake.message_tracker["messages.state_file.finish_return"])

--- a/app/services/state_file/send_pre_deadline_reminder_service.rb
+++ b/app/services/state_file/send_pre_deadline_reminder_service.rb
@@ -11,7 +11,6 @@ module StateFile
         intakes_to_notify += class_object.left_joins(:efile_submissions)
                                          .where(efile_submissions: { id: nil })
                                          .where.not(df_data_imported_at: nil)
-                                         .messaging_eligible
                                          .select do |intake|
                                             if intake.message_tracker.present? && intake.message_tracker["messages.state_file.finish_return"]
                                               finish_return_msg_sent_time = Time.parse(intake.message_tracker["messages.state_file.finish_return"])

--- a/spec/models/state_file_az_intake_spec.rb
+++ b/spec/models/state_file_az_intake_spec.rb
@@ -451,14 +451,14 @@ describe StateFileAzIntake do
   end
 
   describe "#has_verified_contact_info scope" do
-    context "when there is an intake with a phone_number, sms_notification_opt_in is yes and phone_number_verified_at is present" do
+    context "when there is an intake with a phone_number and phone_number_verified_at is present" do
       let!(:intake) { create(:state_file_az_intake, phone_number: "+14155551212", phone_number_verified_at: Time.now) }
       it "includes the intake in the scope" do
         expect(StateFileAzIntake.has_verified_contact_info).to include(intake)
       end
     end
 
-    context "when there is an intake with a email_address, email_notification_opt_in is yes and email_address_verified_at is present" do
+    context "when there is an intake with a email_address and email_address_verified_at is present" do
       let!(:intake) { create(:state_file_az_intake, email_address: "email@example.com", email_address_verified_at: Time.now) }
       it "includes the intake in the scope" do
         expect(StateFileAzIntake.has_verified_contact_info).to include(intake)

--- a/spec/models/state_file_az_intake_spec.rb
+++ b/spec/models/state_file_az_intake_spec.rb
@@ -450,6 +450,30 @@ describe StateFileAzIntake do
     end
   end
 
+  describe "#has_verified_contact_info scope" do
+    context "when there is an intake with a phone_number, sms_notification_opt_in is yes and phone_number_verified_at is present" do
+      let!(:intake) { create(:state_file_az_intake, phone_number: "+14155551212", phone_number_verified_at: Time.now) }
+      it "includes the intake in the scope" do
+        expect(StateFileAzIntake.has_verified_contact_info).to include(intake)
+      end
+    end
+
+    context "when there is an intake with a email_address, email_notification_opt_in is yes and email_address_verified_at is present" do
+      let!(:intake) { create(:state_file_az_intake, email_address: "email@example.com", email_address_verified_at: Time.now) }
+      it "includes the intake in the scope" do
+        expect(StateFileAzIntake.has_verified_contact_info).to include(intake)
+      end
+    end
+
+    context "when there is are intake that contact methods are not verified" do
+      let!(:phone_intake) { create(:state_file_az_intake, email_address: "email@example.com", email_address_verified_at: nil) }
+      let!(:email_intake) { create(:state_file_az_intake, phone_number: "+14155551212", phone_number_verified_at: nil) }
+      it "excludes the intake in the scope" do
+        expect(StateFileAzIntake.has_verified_contact_info).not_to include(phone_intake, email_intake)
+      end
+    end
+  end
+
   describe "#no_prior_message_history_of scope" do
     let!(:intake_with_finish_return_message) { create(:state_file_az_intake, message_tracker: {"messages.state_file.finish_return" => "2024-11-06 21:14:49 UTC"}) }
     let!(:intake_with_welcome_message) { create(:state_file_az_intake, message_tracker: {"messages.state_file.welcome" => "2024-11-06 21:14:49 UTC"}) }

--- a/spec/services/state_file/messaging_service_spec.rb
+++ b/spec/services/state_file/messaging_service_spec.rb
@@ -104,8 +104,8 @@ describe StateFile::MessagingService do
     end
   end
 
-  context "when has email and phone number notifications" do
-    it "should send a message if the number is verified" do
+  context "when required_verification is false" do
+    it "should send email and phone notifications" do
       intake.update(email_address_verified_at: nil)
       intake.update(phone_number_verified_at: nil)
       expect {

--- a/spec/services/state_file/messaging_service_spec.rb
+++ b/spec/services/state_file/messaging_service_spec.rb
@@ -104,6 +104,17 @@ describe StateFile::MessagingService do
     end
   end
 
+  context "when has email and phone number notifications" do
+    it "should send a message if the number is verified" do
+      intake.update(email_address_verified_at: nil)
+      intake.update(phone_number_verified_at: nil)
+      expect {
+        messaging_service.send_message(require_verification: false)
+      }.to change(StateFileNotificationEmail, :count).by(1)
+      .and change(StateFileNotificationTextMessage, :count).by(1)
+    end
+  end
+
   context "when message is an after_transition_notification" do
     let(:message) { StateFile::AutomatedMessage::Rejected }
     let!(:messaging_service) { described_class.new(message: message, intake: intake, submission: efile_submission, body_args: { return_status_link: "link.com" }) }

--- a/spec/tasks/send_pre_deadline_reminder_service_spec.rb
+++ b/spec/tasks/send_pre_deadline_reminder_service_spec.rb
@@ -36,10 +36,13 @@ describe 'state_file:pre_deadline_reminder' do
            phone_number_verified_at: 5.minutes.ago
   }
   let!(:nc_intake_with_unverified_text_notifications_and_df_import) {
-    create :state_file_az_intake,
+    create :state_file_nc_intake,
            df_data_imported_at: 2.minutes.ago,
            phone_number: "+15551115511",
-           sms_notification_opt_in: 1
+           sms_notification_opt_in: "yes",
+           email_address: 'test@example.com',
+           email_address_verified_at: 5.minutes.ago,
+           email_notification_opt_in: "no"
   }
   let!(:nc_intake_submitted) {
     create :state_file_nc_intake,

--- a/spec/tasks/send_pre_deadline_reminder_service_spec.rb
+++ b/spec/tasks/send_pre_deadline_reminder_service_spec.rb
@@ -35,6 +35,12 @@ describe 'state_file:pre_deadline_reminder' do
            sms_notification_opt_in: 1,
            phone_number_verified_at: 5.minutes.ago
   }
+  let!(:nc_intake_with_unverified_text_notifications_and_df_import) {
+    create :state_file_az_intake,
+           df_data_imported_at: 2.minutes.ago,
+           phone_number: "+15551115511",
+           sms_notification_opt_in: 1
+  }
   let!(:nc_intake_submitted) {
     create :state_file_nc_intake,
            df_data_imported_at: 2.minutes.ago,
@@ -67,9 +73,10 @@ describe 'state_file:pre_deadline_reminder' do
 
     Rake::Task['state_file:pre_deadline_reminder'].execute
 
-    expect(StateFile::MessagingService).to have_received(:new).exactly(2).times
+    expect(StateFile::MessagingService).to have_received(:new).exactly(3).times
     expect(StateFile::MessagingService).to have_received(:new).with(message: StateFile::AutomatedMessage::PreDeadlineReminder, intake: az_intake_with_email_notifications_and_df_import)
     expect(StateFile::MessagingService).to have_received(:new).with(message: StateFile::AutomatedMessage::PreDeadlineReminder, intake: nc_intake_with_text_notifications_and_df_import)
+    expect(StateFile::MessagingService).to have_received(:new).with(message: StateFile::AutomatedMessage::PreDeadlineReminder, intake: nc_intake_with_unverified_text_notifications_and_df_import)
     expect(StateFile::MessagingService).not_to have_received(:new).with(message: StateFile::AutomatedMessage::PreDeadlineReminder, intake: az_intake_has_received_reminder)
     expect(StateFile::MessagingService).not_to have_received(:new).with(message: StateFile::AutomatedMessage::PreDeadlineReminder, intake: md_intake_disqualifying_df_data)
   end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. https://codeforamerica.atlassian.net/browse/FYST-2021
## Is PM acceptance required? (delete one)
We can only test this on demo since the heroku environment only allows for email notifications

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
* send notifications regardless of verification for pre_deadline_reminder
* add scope to verify that email or phone is verified