### PR TITLE
unify numericality verification of state tax withheld amount on 1099-Rs

### DIFF
--- a/app/models/state_file1099_r.rb
+++ b/app/models/state_file1099_r.rb
@@ -54,7 +54,6 @@ class StateFile1099R < ApplicationRecord
   # Not adding validations for fields we just copy over from the DF XML, since we have no recourse if they fail
   with_options on: :retirement_income_intake do
     validates :gross_distribution_amount, numericality: { greater_than: 0 }
-    validates_numericality_of :state_tax_withheld_amount, less_than_or_equal_to: BigDecimal(10**10)
     validates :state_distribution_amount,
               numericality: {
                 greater_than_or_equal_to: 0,
@@ -71,6 +70,7 @@ class StateFile1099R < ApplicationRecord
     validates :state_tax_withheld_amount,
               numericality: {
                 greater_than_or_equal_to: 0,
+                less_than_or_equal_to: BigDecimal(10**10),
               },
               presence: {
                 message: proc { I18n.t('forms.errors.no_money_amount') }

--- a/app/models/state_file1099_r.rb
+++ b/app/models/state_file1099_r.rb
@@ -71,6 +71,7 @@ class StateFile1099R < ApplicationRecord
               numericality: {
                 greater_than_or_equal_to: 0,
                 less_than_or_equal_to: BigDecimal(10**10),
+                allow_blank: true
               },
               presence: {
                 message: proc { I18n.t('forms.errors.no_money_amount') }

--- a/app/models/state_file1099_r.rb
+++ b/app/models/state_file1099_r.rb
@@ -57,7 +57,8 @@ class StateFile1099R < ApplicationRecord
     validates :state_distribution_amount,
               numericality: {
                 greater_than_or_equal_to: 0,
-                less_than_or_equal_to: BigDecimal(10**10)
+                less_than_or_equal_to: BigDecimal(10**10),
+                allow_blank: true
               },
               presence: {
                 message: proc { I18n.t('forms.errors.no_money_amount') }


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-2007
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- There were two separate numericality verifications of the state tax withheld amount on 1099-Rs. One (less than a very large number) was only checked on submission of the 1099-R edit form, while the other was checked on both the edit form submission and on the income review page.
- If the form was submitted with the field empty, this was causing both numericality checks to be executed separately and add two different "is not a number" error messages to be displayed alongside the field.
- This PR does two things:
  - Combines the two numericality checks into one, so that both the `< 0` and `> 10**10` cases are checked as part of one verification. This means that they will both be checked on the income review page as well as the edit form submission, which seems fine to me.
  - Adds `allow_blank: true` to the numericality validation, which causes no `is not a number` error to be displayed when the field is left blank. This is because thereis also a `presence` validation that gives a more meaningful message in that case, so we don't need to repeat ourselves.
## How to test?
- Manually verify that the error messages show up correctly on the 1099-R edit page when the field is left blank 
## Screenshots (for visual changes)
- Before
<img width="726" alt="image" src="https://github.com/user-attachments/assets/3f8a1f4c-9e78-4cba-9e7f-8ac717129213" />

- After
<img width="721" alt="image" src="https://github.com/user-attachments/assets/d994eaae-f5b4-40cc-b102-328590de7a52" />
