### PR TITLE
reject actioncable connection on submission confirmation page if there is somehow no current intake, and handle rejection by just showing the download button

### DIFF
--- a/app/channels/state_file_submission_pdf_status_channel.rb
+++ b/app/channels/state_file_submission_pdf_status_channel.rb
@@ -1,7 +1,7 @@
 class StateFileSubmissionPdfStatusChannel < ApplicationCable::Channel
   def subscribed
     @intake = current_state_file_intake
-    if @intake.submission_pdf.attached?
+    if @intake.nil? || @intake.submission_pdf.attached?
       reject
     else
       stream_for @intake

--- a/app/javascript/packs/state_file.js
+++ b/app/javascript/packs/state_file.js
@@ -49,6 +49,14 @@ const actionMap = {
         }, 15000)
       },
 
+      rejected () {
+        this.pdfStatus = 'disconnected'
+        const loadingBlock = document.querySelector('.loading-container')
+        const linkBlock = document.querySelector('.download-link-container')
+        loadingBlock.style.display = "none"
+        linkBlock.style.display = "block"
+      },
+
       disconnected () {
         this.pdfStatus = 'disconnected'
       },

--- a/spec/channels/state_file_submission_pdf_status_channel_spec.rb
+++ b/spec/channels/state_file_submission_pdf_status_channel_spec.rb
@@ -26,6 +26,15 @@ RSpec.describe StateFileSubmissionPdfStatusChannel, type: :channel do
         expect(subscription).to be_rejected
       end
     end
+
+    context "with (somehow) no current intake" do
+      let(:intake) { nil }
+
+      it "does NOT subscribe and does not stream" do
+        subscribe
+        expect(subscription).to be_rejected
+      end
+    end
   end
 
   context "status_update behavior" do


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-2011
## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- We were getting nil back from `current_intake` in the subscription confirmation page's download button's new ActionCable `subscribed` callback. I don't know why this would happen, but this PR handles the nil by rejecting the connection, and changes the JS to immediately show the download button if the ActionCable connection is rejected. This will allow the user to download their PDF whether it's already attached or by having the controller fall back to synchronous generation of the PDF. If `current_intake` is nil from ActionCable's perspective, it's possible that something else will break with the download button, but we should see that pop up elsewhere if so.
## How to test?
- We don't have a repro case, so I don't think we can really do manual acceptance on this.