### PR TITLE
[FYST-2000] Update md direct debit behavior post april 15

### DIFF
--- a/app/controllers/state_file/questions/md_taxes_owed_controller.rb
+++ b/app/controllers/state_file/questions/md_taxes_owed_controller.rb
@@ -4,6 +4,33 @@ module StateFile
       def self.form_key
         "state_file/taxes_owed_form"
       end
+
+      def edit
+        super
+        @after_filing_deadline = app_time.in_time_zone(timezone).to_date.after?(md_submission_deadline)
+      end
+
+      private
+
+      def md_payment_deadline
+        @md_payment_deadline ||= StateFile::StateInformationService.payment_deadline_date("md", filing_year: current_year)
+      end
+
+      def md_submission_deadline
+        @md_submission_deadline ||= Date.new(current_year, 4, 15).in_time_zone(timezone).at_midnight
+      end
+
+      def current_year
+        current_tax_year + 1
+      end
+
+      def current_tax_year
+        MultiTenantService.new(:statefile).current_tax_year
+      end
+
+      def timezone
+        StateFile::StateInformationService.timezone(current_intake.state_code)
+      end
     end
   end
 end

--- a/app/controllers/state_file/questions/md_taxes_owed_controller.rb
+++ b/app/controllers/state_file/questions/md_taxes_owed_controller.rb
@@ -1,0 +1,9 @@
+module StateFile
+  module Questions
+    class MdTaxesOwedController < TaxesOwedController
+      def self.form_key
+        "state_file/taxes_owed_form"
+      end
+    end
+  end
+end

--- a/app/lib/navigation/state_file_md_question_navigation.rb
+++ b/app/lib/navigation/state_file_md_question_navigation.rb
@@ -43,7 +43,7 @@ module Navigation
         Navigation::NavigationStep.new(StateFile::Questions::PrimaryStateIdController),
         Navigation::NavigationStep.new(StateFile::Questions::SpouseStateIdController),
         Navigation::NavigationStep.new(StateFile::Questions::MdReviewController),
-        Navigation::NavigationStep.new(StateFile::Questions::TaxesOwedController),
+        Navigation::NavigationStep.new(StateFile::Questions::MdTaxesOwedController),
         Navigation::NavigationStep.new(StateFile::Questions::MdTaxRefundController),
         Navigation::NavigationStep.new(StateFile::Questions::MdHadHealthInsuranceController),
         Navigation::NavigationStep.new(StateFile::Questions::EsignDeclarationController), # creates EfileSubmission and transitions to preparing

--- a/app/views/state_file/questions/md_taxes_owed/_md_bank_details.html.erb
+++ b/app/views/state_file/questions/md_taxes_owed/_md_bank_details.html.erb
@@ -1,0 +1,52 @@
+<div class="white-group">
+  <p class="spacing-below-0"><%= t(".bank_title") %></p>
+  <% if owe_taxes %>
+    <p class="text--small"><%= t(".foreign_accounts_owed") %></p>
+  <% else %>
+    <p class="text--small"><%= t(".foreign_accounts_refund") %></p>
+  <% end %>
+  <div>
+    <% if owe_taxes %>
+      <%= form.hidden_field :app_time, value: app_time %>
+      <%= form.vita_min_money_field(:withdraw_amount, t('.withdraw_amount', owed_amount: taxes_owed), classes: ["form-width--long"]) %>
+      <% if !Flipper.enabled?(:extension_period) %>
+        <div class="date-select">
+          <% year = current_tax_year + 1 %>
+          <%= form.cfa_date_select(
+                :date_electronic_withdrawal,
+                t(".date_withdraw_text",
+                  payment_deadline_date: I18n.l(state_specific_payment_deadline.to_date, format: :medium, locale: locale),
+                  payment_deadline_year: state_specific_payment_deadline.year),
+                options: {
+                  start_year: year,
+                  end_year: year,
+                }
+              ) %>
+        </div>
+      <% else %>
+        <%= form.hidden_field :date_electronic_withdrawal, value: Time.zone.now.to_date %>
+      <% end %>
+    <% end %>
+
+    <%= form.cfa_radio_set(
+          :account_type,
+          label_text: t(".account_type.label"),
+          collection: [
+            { value: :checking, label: t("views.questions.bank_details.account_type.checking") },
+            { value: :savings, label: t("views.questions.bank_details.account_type.savings") },
+          ]
+        )
+    %>
+    <%= form.cfa_input_field(:routing_number, t(".routing_number"), classes: %w[form-width--long disablecopy]) %>
+    <%= form.cfa_input_field(:routing_number_confirmation, t(".confirm_routing_number"), classes: %w[form-width--long disablepaste disablecopy]) %>
+    <%= form.cfa_input_field(:account_number, t(".account_number"), classes: %w[form-width--long disablecopy]) %>
+    <%= form.cfa_input_field(:account_number_confirmation, t(".confirm_account_number"), classes: %w[form-width--long disablepaste disablecopy]) %>
+  </div>
+  <% if owe_taxes && Flipper.enabled?(:extension_period) %>
+    <p>
+      <%= t(".after_deadline_default_withdrawal_info",
+            payment_deadline_date: I18n.l(state_specific_payment_deadline.to_date, format: :medium, locale: locale),
+            payment_deadline_year: state_specific_payment_deadline.year) %>
+    </p>
+  <% end %>
+</div>

--- a/app/views/state_file/questions/md_taxes_owed/_md_bank_details.html.erb
+++ b/app/views/state_file/questions/md_taxes_owed/_md_bank_details.html.erb
@@ -10,7 +10,7 @@
       <%= form.hidden_field :app_time, value: app_time %>
       <%= form.vita_min_money_field(:withdraw_amount, t('.withdraw_amount', owed_amount: taxes_owed), classes: ["form-width--long"]) %>
       <% if @after_filing_deadline %>
-        <%= form.hidden_field :date_electronic_withdrawal, value: @md_payment_deadline %>
+        <%= form.hidden_field :date_electronic_withdrawal, value: DateTime.current %>
       <% else %>
         <div class="date-select">
           <% year = current_tax_year + 1 %>

--- a/app/views/state_file/questions/md_taxes_owed/_md_bank_details.html.erb
+++ b/app/views/state_file/questions/md_taxes_owed/_md_bank_details.html.erb
@@ -9,7 +9,9 @@
     <% if owe_taxes %>
       <%= form.hidden_field :app_time, value: app_time %>
       <%= form.vita_min_money_field(:withdraw_amount, t('.withdraw_amount', owed_amount: taxes_owed), classes: ["form-width--long"]) %>
-      <% if !Flipper.enabled?(:extension_period) %>
+      <% if @after_filing_deadline %>
+        <%= form.hidden_field :date_electronic_withdrawal, value: @md_payment_deadline %>
+      <% else %>
         <div class="date-select">
           <% year = current_tax_year + 1 %>
           <%= form.cfa_date_select(
@@ -23,8 +25,6 @@
                 }
               ) %>
         </div>
-      <% else %>
-        <%= form.hidden_field :date_electronic_withdrawal, value: Time.zone.now.to_date %>
       <% end %>
     <% end %>
 
@@ -42,7 +42,7 @@
     <%= form.cfa_input_field(:account_number, t(".account_number"), classes: %w[form-width--long disablecopy]) %>
     <%= form.cfa_input_field(:account_number_confirmation, t(".confirm_account_number"), classes: %w[form-width--long disablepaste disablecopy]) %>
   </div>
-  <% if owe_taxes && Flipper.enabled?(:extension_period) %>
+  <% if @after_filing_deadline %>
     <p>
       <%= t(".after_deadline_default_withdrawal_info",
             payment_deadline_date: I18n.l(state_specific_payment_deadline.to_date, format: :medium, locale: locale),

--- a/app/views/state_file/questions/md_taxes_owed/edit.html.erb
+++ b/app/views/state_file/questions/md_taxes_owed/edit.html.erb
@@ -21,7 +21,9 @@
                 },
                 {
                   value: :mail,
-                  label: t(".pay_mail_online_html")
+                  label: t(".pay_mail_online_html",
+                           tax_payment_info_url: StateFile::StateInformationService.tax_payment_info_url(current_state_code),
+                           tax_payment_info_text: StateFile::StateInformationService.tax_payment_info_text(current_state_code))
                 }
               ]
             ) %>

--- a/app/views/state_file/questions/md_taxes_owed/edit.html.erb
+++ b/app/views/state_file/questions/md_taxes_owed/edit.html.erb
@@ -29,7 +29,7 @@
       <div class="question-with-follow-up__follow-up" id="pay-from-bank">
         <div class="question-with-follow-up">
           <div class="question-with-follow-up__question">
-            <%= render partial: 'state_file/questions/nc_tax_refund/nc_bank_details', locals: { form: f, owe_taxes: true } %>
+            <%= render partial: 'md_bank_details', locals: { form: f, owe_taxes: true } %>
           </div>
         </div>
       </div>

--- a/app/views/state_file/questions/md_taxes_owed/edit.html.erb
+++ b/app/views/state_file/questions/md_taxes_owed/edit.html.erb
@@ -1,0 +1,44 @@
+<% content_for :page_title, t(".page_title") %>
+<% content_for :card do %>
+  <h1 class="h2">
+    <%= t(".title_html", owed_amount: taxes_owed, state_name: current_state_name) %>
+  </h1>
+  <p><%= t('.subtitle_html') %></p>
+
+  <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
+    <div class="question-with-follow-up">
+      <div class="question-with-follow-up__question white-group">
+        <div class="spacing-below-10">
+          <p><%= t('.subtitle') %></p>
+        </div>
+        <%= f.cfa_radio_set(
+              :payment_or_deposit_type,
+              collection: [
+                {
+                  value: :direct_deposit,
+                  label: t(".pay_bank"),
+                  input_html: { "data-follow-up": "#pay-from-bank" }
+                },
+                {
+                  value: :mail,
+                  label: t(".pay_mail_online_html")
+                }
+              ]
+            ) %>
+      </div>
+      <div class="question-with-follow-up__follow-up" id="pay-from-bank">
+        <div class="question-with-follow-up">
+          <div class="question-with-follow-up__question">
+            <%= render partial: 'state_file/questions/nc_tax_refund/nc_bank_details', locals: { form: f, owe_taxes: true } %>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <%= f.continue %>
+  <% end %>
+<% end %>
+
+<% content_for :script do %>
+  <%= render 'shared/disable_copy_paste' %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4244,7 +4244,7 @@ en:
           mail: By mail (slower)
           page_title: Good news, you're getting a tax refund. How would you like to receive your refund?
           title_html: Good news, you're getting a %{state_name} state tax refund of <strong>$%{refund_amount}.</strong>
-      taxes_owed:
+      md_taxes_owed:
         edit:
           more_tax_information_nj_html: <p><a href="https://www.nj.gov/treasury/taxation/payments-notices.shtml" target="_blank" rel="noopener nofollow">Here is more information about tax due dates and payment methods.</a></p>
           page_title: You owe state taxes. How would you like to pay?
@@ -4252,6 +4252,22 @@ en:
           pay_mail_online_html: Pay by mail or online at <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a>
           subtitle: How would you like to pay?
           subtitle_html: For more information about tax due dates and payment methods, visit <a target="_blank" rel="noopener nofollow" href="https://marylandtaxes.gov/">Marylandtaxes.gov</a>
+          title_html: You owe <strong>$%{owed_amount}</strong> in %{state_name} state taxes.
+          underpayment_notice_nj_html: |-
+            <p> This can happen for many reasons, but common ones are: </p>
+            <ul class="list--bulleted">
+              <li>if there weren’t enough taxes withheld from your paycheck (you may want to discuss with your employer for future years), or</li>
+              <li>if you haven’t made enough in estimated tax payments.</li>
+            </ul>
+            <p>You might be charged interest on what you owe. If that applies to you, you will get a notice from the State of New Jersey Division of Taxation in the mail.</p>
+            <p><strong>You should definitely continue with this filing. The sooner you file, the less you will eventually have to pay in penalties.</strong></p>
+      taxes_owed:
+        edit:
+          more_tax_information_nj_html: <p><a href="https://www.nj.gov/treasury/taxation/payments-notices.shtml" target="_blank" rel="noopener nofollow">Here is more information about tax due dates and payment methods.</a></p>
+          page_title: You owe state taxes. How would you like to pay?
+          pay_bank: Pay directly from your checking or savings account (direct debit)
+          pay_mail_online_html: Pay by mail or online at <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a>
+          subtitle: How would you like to pay?
           title_html: You owe <strong>$%{owed_amount}</strong> in %{state_name} state taxes.
           underpayment_notice_nj_html: |-
             <p> This can happen for many reasons, but common ones are: </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3349,6 +3349,27 @@ en:
           last_name: Last Name
           middle_initial: Middle Initial
           suffix: Suffix
+      md_taxes_owed:
+        edit:
+          page_title: You owe state taxes. How would you like to pay?
+          pay_bank: Pay directly from your checking or savings account (direct debit)
+          pay_mail_online_html: Pay by mail or online at <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a>
+          subtitle: How would you like to pay?
+          subtitle_html: For more information about tax due dates and payment methods, visit <a target="_blank" rel="noopener nofollow" href="https://marylandtaxes.gov/">Marylandtaxes.gov</a>
+          title_html: You owe <strong>$%{owed_amount}</strong> in %{state_name} state taxes.
+        md_bank_details:
+          account_number: Account number
+          account_type:
+            label: Bank Account Type
+          after_deadline_default_withdrawal_info: Because you are submitting your return on or after %{payment_deadline_date}, %{payment_deadline_year}, the state will withdraw your payment as soon as they process your return.
+          bank_title: 'Please provide your bank account details:'
+          confirm_account_number: Confirm Account Number
+          confirm_routing_number: Confirm Routing Number
+          date_withdraw_text: 'When would you like the funds withdrawn from your account? (Must be on or before %{payment_deadline_date}, %{payment_deadline_year}):'
+          foreign_accounts_owed: International ACH payments are not allowed.
+          foreign_accounts_refund: International ACH direct deposit refunds are not allowed.
+          routing_number: Routing Number
+          withdraw_amount: How much do you authorize to be withdrawn from your account? (Your total amount due is $%{owed_amount}.)
       md_two_income_subtractions:
         edit:
           description: In order to know if you qualify and calculate the subtraction, we need more information about the student loan interest deduction you took on your federal tax return.
@@ -4244,36 +4265,6 @@ en:
           mail: By mail (slower)
           page_title: Good news, you're getting a tax refund. How would you like to receive your refund?
           title_html: Good news, you're getting a %{state_name} state tax refund of <strong>$%{refund_amount}.</strong>
-      md_taxes_owed:
-        md_bank_details:
-          account_number: Account number
-          account_type:
-            label: Bank Account Type
-          after_deadline_default_withdrawal_info: Because you are submitting your return on or after %{payment_deadline_date}, %{payment_deadline_year}, the state will withdraw your payment as soon as they process your return.
-          bank_title: 'Please provide your bank account details:'
-          confirm_account_number: Confirm Account Number
-          confirm_routing_number: Confirm Routing Number
-          date_withdraw_text: 'When would you like the funds withdrawn from your account? (Must be on or before %{payment_deadline_date}, %{payment_deadline_year}):'
-          foreign_accounts_owed: International ACH payments are not allowed.
-          foreign_accounts_refund: International ACH direct deposit refunds are not allowed.
-          routing_number: Routing Number
-          withdraw_amount: How much do you authorize to be withdrawn from your account? (Your total amount due is $%{owed_amount}.)
-        edit:
-          more_tax_information_nj_html: <p><a href="https://www.nj.gov/treasury/taxation/payments-notices.shtml" target="_blank" rel="noopener nofollow">Here is more information about tax due dates and payment methods.</a></p>
-          page_title: You owe state taxes. How would you like to pay?
-          pay_bank: Pay directly from your checking or savings account (direct debit)
-          pay_mail_online_html: Pay by mail or online at <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a>
-          subtitle: How would you like to pay?
-          subtitle_html: For more information about tax due dates and payment methods, visit <a target="_blank" rel="noopener nofollow" href="https://marylandtaxes.gov/">Marylandtaxes.gov</a>
-          title_html: You owe <strong>$%{owed_amount}</strong> in %{state_name} state taxes.
-          underpayment_notice_nj_html: |-
-            <p> This can happen for many reasons, but common ones are: </p>
-            <ul class="list--bulleted">
-              <li>if there weren’t enough taxes withheld from your paycheck (you may want to discuss with your employer for future years), or</li>
-              <li>if you haven’t made enough in estimated tax payments.</li>
-            </ul>
-            <p>You might be charged interest on what you owe. If that applies to you, you will get a notice from the State of New Jersey Division of Taxation in the mail.</p>
-            <p><strong>You should definitely continue with this filing. The sooner you file, the less you will eventually have to pay in penalties.</strong></p>
       taxes_owed:
         edit:
           more_tax_information_nj_html: <p><a href="https://www.nj.gov/treasury/taxation/payments-notices.shtml" target="_blank" rel="noopener nofollow">Here is more information about tax due dates and payment methods.</a></p>
@@ -4281,6 +4272,7 @@ en:
           pay_bank: Pay directly from your checking or savings account (direct debit)
           pay_mail_online_html: Pay by mail or online at <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a>
           subtitle: How would you like to pay?
+          subtitle_html: For more information about tax due dates and payment methods, visit <a target="_blank" rel="noopener nofollow" href="https://marylandtaxes.gov/">Marylandtaxes.gov</a>
           title_html: You owe <strong>$%{owed_amount}</strong> in %{state_name} state taxes.
           underpayment_notice_nj_html: |-
             <p> This can happen for many reasons, but common ones are: </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4245,6 +4245,19 @@ en:
           page_title: Good news, you're getting a tax refund. How would you like to receive your refund?
           title_html: Good news, you're getting a %{state_name} state tax refund of <strong>$%{refund_amount}.</strong>
       md_taxes_owed:
+        md_bank_details:
+          account_number: Account number
+          account_type:
+            label: Bank Account Type
+          after_deadline_default_withdrawal_info: Because you are submitting your return on or after %{payment_deadline_date}, %{payment_deadline_year}, the state will withdraw your payment as soon as they process your return.
+          bank_title: 'Please provide your bank account details:'
+          confirm_account_number: Confirm Account Number
+          confirm_routing_number: Confirm Routing Number
+          date_withdraw_text: 'When would you like the funds withdrawn from your account? (Must be on or before %{payment_deadline_date}, %{payment_deadline_year}):'
+          foreign_accounts_owed: International ACH payments are not allowed.
+          foreign_accounts_refund: International ACH direct deposit refunds are not allowed.
+          routing_number: Routing Number
+          withdraw_amount: How much do you authorize to be withdrawn from your account? (Your total amount due is $%{owed_amount}.)
         edit:
           more_tax_information_nj_html: <p><a href="https://www.nj.gov/treasury/taxation/payments-notices.shtml" target="_blank" rel="noopener nofollow">Here is more information about tax due dates and payment methods.</a></p>
           page_title: You owe state taxes. How would you like to pay?

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4230,7 +4230,7 @@ es:
           mail: Por correo (más lento)
           page_title: Buenas noticias, recibirás un reembolso de impuestos. ¿Cómo te gustaría recibirlo?
           title_html: Buenas noticias, recibirás un reembolso de impuestos del estado de %{state_name} de <strong>$%{refund_amount}.</strong>
-      taxes_owed:
+      md_taxes_owed:
         edit:
           more_tax_information_nj_html: <p><a href="https://www.nj.gov/treasury/taxation/payments-notices.shtml" target="_blank" rel="noopener nofollow">Aquí hay más información sobre las fechas de vencimiento de impuestos y los modos de pago.</a></p>
           page_title: Debes impuestos estatales. ¿Cómo te gustaría pagar?
@@ -4238,6 +4238,22 @@ es:
           pay_mail_online_html: Por correo o en línea en <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a>
           subtitle: "¿Cómo te gustaría pagar?"
           subtitle_html: Para obtener más información sobre las fechas de vencimiento de impuestos y los métodos de pago, visita <a target="_blank" rel="noopener nofollow" href="https://marylandtaxes.gov/">Marylandtaxes.gov</a>
+          title_html: Debes <strong>$%{owed_amount}</strong> en impuestos estatales de %{state_name}.
+          underpayment_notice_nj_html: |-
+            <p>Esto puede suceder por muchas razones, las más comunes son:</p>
+            <ul class="list--bulleted">
+              <li>Porque no se retuvieron suficientes impuestos de tu cheque/recibo de pago (paycheck) (podrías charlar esto con tu empleador/a para los próximos años), o</li>
+              <li>Porque no hiciste suficientes pagos de impuestos estimados.</li>
+            </ul>
+            <p>Es posible que te cobren intereses sobre lo que debes. Si este es tu caso, recibirás un aviso de la División de Impuestos del Estado de New Jersey por correo.</p>
+            <p><strong>Definitivamente debes continuar con esta declaración de impuestos. Cuanto antes lo hagas, menos tendrás que pagar en multas.</strong></p>
+      taxes_owed:
+        edit:
+          more_tax_information_nj_html: <p><a href="https://www.nj.gov/treasury/taxation/payments-notices.shtml" target="_blank" rel="noopener nofollow">Aquí hay más información sobre las fechas de vencimiento de impuestos y los modos de pago.</a></p>
+          page_title: Debes impuestos estatales. ¿Cómo te gustaría pagar?
+          pay_bank: Directamente desde tu cuenta corriente o de ahorros (débito directo)
+          pay_mail_online_html: Por correo o en línea en <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a>
+          subtitle: "¿Cómo te gustaría pagar?"
           title_html: Debes <strong>$%{owed_amount}</strong> en impuestos estatales de %{state_name}.
           underpayment_notice_nj_html: |-
             <p>Esto puede suceder por muchas razones, las más comunes son:</p>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4231,6 +4231,19 @@ es:
           page_title: Buenas noticias, recibirás un reembolso de impuestos. ¿Cómo te gustaría recibirlo?
           title_html: Buenas noticias, recibirás un reembolso de impuestos del estado de %{state_name} de <strong>$%{refund_amount}.</strong>
       md_taxes_owed:
+        md_bank_details:
+          account_number: Número de cuenta
+          account_type:
+            label: Tipo de cuenta bancaria
+          after_deadline_default_withdrawal_info: Debido a que está presentando su declaración el o después del %{payment_deadline_date}, %{payment_deadline_year}, el estado retirará su pago tan pronto como procesen su declaración.
+          bank_title: 'Por favor, comparte los detalles de tu cuenta bancaria:'
+          confirm_account_number: Confirma el número de cuenta
+          confirm_routing_number: Confirma el número de ruta bancaria (routing number)
+          date_withdraw_text: "¿Cuándo te gustaría que se retiren los fondos de tu cuenta? (debe ser antes o en el día del %{payment_deadline_date} de %{payment_deadline_year}):"
+          foreign_accounts_owed: No están permitidos los depósitos directos internacionales.
+          foreign_accounts_refund: No están permitidos los depósitos directos internacionales.
+          routing_number: Número de ruta bancaria (routing number)
+          withdraw_amount: "¿Cuánto autorizas que sea retirado de tu cuenta? (La cantidad total que debes es $%{owed_amount}.)"
         edit:
           more_tax_information_nj_html: <p><a href="https://www.nj.gov/treasury/taxation/payments-notices.shtml" target="_blank" rel="noopener nofollow">Aquí hay más información sobre las fechas de vencimiento de impuestos y los modos de pago.</a></p>
           page_title: Debes impuestos estatales. ¿Cómo te gustaría pagar?

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3319,6 +3319,27 @@ es:
           last_name: Apellido
           middle_initial: Inicial del segundo nombre
           suffix: Sufijo
+      md_taxes_owed:
+        edit:
+          page_title: Debes impuestos estatales. ¿Cómo te gustaría pagar?
+          pay_bank: Directamente desde tu cuenta corriente o de ahorros (débito directo)
+          pay_mail_online_html: Por correo o en línea en <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a>
+          subtitle: "¿Cómo te gustaría pagar?"
+          subtitle_html: Para obtener más información sobre las fechas de vencimiento de impuestos y los métodos de pago, visita <a target="_blank" rel="noopener nofollow" href="https://marylandtaxes.gov/">Marylandtaxes.gov</a>
+          title_html: Debes <strong>$%{owed_amount}</strong> en impuestos estatales de %{state_name}.
+        md_bank_details:
+          account_number: Número de cuenta
+          account_type:
+            label: Tipo de cuenta bancaria
+          after_deadline_default_withdrawal_info: Debido a que está presentando su declaración el o después del %{payment_deadline_date}, %{payment_deadline_year}, el estado retirará su pago tan pronto como procesen su declaración.
+          bank_title: 'Por favor, comparte los detalles de tu cuenta bancaria:'
+          confirm_account_number: Confirma el número de cuenta
+          confirm_routing_number: Confirma el número de ruta bancaria (routing number)
+          date_withdraw_text: "¿Cuándo te gustaría que se retiren los fondos de tu cuenta? (debe ser antes o en el día del %{payment_deadline_date} de %{payment_deadline_year}):"
+          foreign_accounts_owed: No están permitidos los depósitos directos internacionales.
+          foreign_accounts_refund: No están permitidos los depósitos directos internacionales.
+          routing_number: Número de ruta bancaria (routing number)
+          withdraw_amount: "¿Cuánto autorizas que sea retirado de tu cuenta? (La cantidad total que debes es $%{owed_amount}.)"
       md_two_income_subtractions:
         edit:
           description: Para saber si calificas y calcular la resta, necesitamos más información sobre la deducción de intereses de préstamos estudiantiles que se aplicó a tu declaración de impuestos federales.
@@ -4230,36 +4251,6 @@ es:
           mail: Por correo (más lento)
           page_title: Buenas noticias, recibirás un reembolso de impuestos. ¿Cómo te gustaría recibirlo?
           title_html: Buenas noticias, recibirás un reembolso de impuestos del estado de %{state_name} de <strong>$%{refund_amount}.</strong>
-      md_taxes_owed:
-        md_bank_details:
-          account_number: Número de cuenta
-          account_type:
-            label: Tipo de cuenta bancaria
-          after_deadline_default_withdrawal_info: Debido a que está presentando su declaración el o después del %{payment_deadline_date}, %{payment_deadline_year}, el estado retirará su pago tan pronto como procesen su declaración.
-          bank_title: 'Por favor, comparte los detalles de tu cuenta bancaria:'
-          confirm_account_number: Confirma el número de cuenta
-          confirm_routing_number: Confirma el número de ruta bancaria (routing number)
-          date_withdraw_text: "¿Cuándo te gustaría que se retiren los fondos de tu cuenta? (debe ser antes o en el día del %{payment_deadline_date} de %{payment_deadline_year}):"
-          foreign_accounts_owed: No están permitidos los depósitos directos internacionales.
-          foreign_accounts_refund: No están permitidos los depósitos directos internacionales.
-          routing_number: Número de ruta bancaria (routing number)
-          withdraw_amount: "¿Cuánto autorizas que sea retirado de tu cuenta? (La cantidad total que debes es $%{owed_amount}.)"
-        edit:
-          more_tax_information_nj_html: <p><a href="https://www.nj.gov/treasury/taxation/payments-notices.shtml" target="_blank" rel="noopener nofollow">Aquí hay más información sobre las fechas de vencimiento de impuestos y los modos de pago.</a></p>
-          page_title: Debes impuestos estatales. ¿Cómo te gustaría pagar?
-          pay_bank: Directamente desde tu cuenta corriente o de ahorros (débito directo)
-          pay_mail_online_html: Por correo o en línea en <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a>
-          subtitle: "¿Cómo te gustaría pagar?"
-          subtitle_html: Para obtener más información sobre las fechas de vencimiento de impuestos y los métodos de pago, visita <a target="_blank" rel="noopener nofollow" href="https://marylandtaxes.gov/">Marylandtaxes.gov</a>
-          title_html: Debes <strong>$%{owed_amount}</strong> en impuestos estatales de %{state_name}.
-          underpayment_notice_nj_html: |-
-            <p>Esto puede suceder por muchas razones, las más comunes son:</p>
-            <ul class="list--bulleted">
-              <li>Porque no se retuvieron suficientes impuestos de tu cheque/recibo de pago (paycheck) (podrías charlar esto con tu empleador/a para los próximos años), o</li>
-              <li>Porque no hiciste suficientes pagos de impuestos estimados.</li>
-            </ul>
-            <p>Es posible que te cobren intereses sobre lo que debes. Si este es tu caso, recibirás un aviso de la División de Impuestos del Estado de New Jersey por correo.</p>
-            <p><strong>Definitivamente debes continuar con esta declaración de impuestos. Cuanto antes lo hagas, menos tendrás que pagar en multas.</strong></p>
       taxes_owed:
         edit:
           more_tax_information_nj_html: <p><a href="https://www.nj.gov/treasury/taxation/payments-notices.shtml" target="_blank" rel="noopener nofollow">Aquí hay más información sobre las fechas de vencimiento de impuestos y los modos de pago.</a></p>
@@ -4267,6 +4258,7 @@ es:
           pay_bank: Directamente desde tu cuenta corriente o de ahorros (débito directo)
           pay_mail_online_html: Por correo o en línea en <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a>
           subtitle: "¿Cómo te gustaría pagar?"
+          subtitle_html: Para obtener más información sobre las fechas de vencimiento de impuestos y los métodos de pago, visita <a target="_blank" rel="noopener nofollow" href="https://marylandtaxes.gov/">Marylandtaxes.gov</a>
           title_html: Debes <strong>$%{owed_amount}</strong> en impuestos estatales de %{state_name}.
           underpayment_notice_nj_html: |-
             <p>Esto puede suceder por muchas razones, las más comunes son:</p>

--- a/spec/controllers/state_file/questions/md_taxes_owed_controller_spec.rb
+++ b/spec/controllers/state_file/questions/md_taxes_owed_controller_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+describe StateFile::Questions::MdTaxesOwedController do
+
+  let(:intake) { create :state_file_md_owed_intake }
+
+  before do
+    sign_in intake, scope: :state_file_md_intake
+  end
+
+  describe '#edit' do
+    render_views
+    it 'succeeds' do
+      get :edit
+      expect(response).to be_successful
+      expect(response_html).to have_text "You owe"
+    end
+  end
+end

--- a/spec/features/state_file/md_taxes_owed_spec.rb
+++ b/spec/features/state_file/md_taxes_owed_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+RSpec.feature "MD Taxes Owed" do
+  before do
+    allow(Flipper).to receive(:enabled?).and_call_original
+  end
+
+  context "before the tax deadline (extension_period flipper is off)" do
+    before do
+      allow(Flipper).to receive(:enabled?).with(:extension_period).and_return(false)
+    end
+
+    scenario "can select a payment date" do
+      intake = create :state_file_md_intake, :taxes_owed
+      login_as intake, scope: :state_file_intake
+
+      visit "/questions/md-taxes-owed"
+
+      expect(page).to have_text "You owe $123 in Maryland state taxes."
+      click_on "Pay directly from your checking or savings account (direct debit)"
+
+      # Check that date select is visible
+      expect(page).to have_text "When would you like the funds withdrawn from your account?"
+      expect(page).to have_css(".date-select")
+
+      # Fill in bank details & select a date
+      fill_in "Your total amount due is $123.", with: "100"
+      select "January", from: "state_file_md_taxes_owed_form[date_electronic_withdrawal(2i)]"
+      select "3", from: "state_file_md_taxes_owed_form[date_electronic_withdrawal(3i)]"
+      select (Time.now.year + 1).to_s, from: "state_file_md_taxes_owed_form[date_electronic_withdrawal(1i)]"
+      choose "Checking"
+      fill_in "Routing Number", with: "123456789"
+      fill_in "Confirm Routing Number", with: "123456789"
+      fill_in "Account number", with: "987654321"
+      fill_in "Confirm Account Number", with: "987654321"
+
+      click_on "Continue"
+
+      intake.reload
+      expect(intake.direct_debit_date.strftime("%Y-%m-%d")).to eq Date.new(Time.now.year + 1, 1, 3).strftime("%Y-%m-%d")
+      expect(intake.payment_or_deposit_type).to eq "direct_deposit"
+    end
+  end
+
+  context "after the tax deadline (extension_period flipper is on)" do
+    before do
+      allow(Flipper).to receive(:enabled?).with(:extension_period).and_return(true)
+    end
+
+    scenario "cannot select a payment date and it defaults to today" do
+      intake = create :state_file_md_intake, :taxes_owed
+      login_as intake, scope: :state_file_intake
+
+      visit "/questions/md-taxes-owed"
+
+      expect(page).to have_text "You owe $123 in Maryland state taxes."
+      click_on "Pay directly from your checking or savings account (direct debit)"
+
+      # Check that date select is NOT visible and informational text IS visible
+      expect(page).not_to have_text "When would you like the funds withdrawn from your account?"
+      expect(page).not_to have_css(".date-select")
+      expect(page).to have_text "Because you are submitting your return on or after"
+
+      # Fill in bank details
+      fill_in "Your total amount due is $123.", with: "100"
+      choose "Checking"
+      fill_in "Routing Number", with: "123456789"
+      fill_in "Confirm Routing Number", with: "123456789"
+      fill_in "Account number", with: "987654321"
+      fill_in "Confirm Account Number", with: "987654321"
+
+      click_on "Continue"
+
+      intake.reload
+      # The hidden field sets the date to Time.zone.now.to_date
+      expect(intake.direct_debit_date.strftime("%Y-%m-%d")).to eq Time.zone.now.to_date.strftime("%Y-%m-%d")
+      expect(intake.payment_or_deposit_type).to eq "direct_deposit"
+    end
+  end
+end

--- a/spec/models/efile_error_spec.rb
+++ b/spec/models/efile_error_spec.rb
@@ -77,6 +77,7 @@ describe 'EfileError' do
       "md-retirement-income-subtraction",
       "md-review",
       "md-tax-refund",
+      "md-taxes-owed",
       "md-two-income-subtractions",
       "nc-county",
       "nc-eligibility",


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/FYST-2000

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- hardcode a April 15th at midnight deadline for setting a payment date when md state taxes are owed
- Set default to 
## How to test?
- Use session toggle to update the app time to after the april 15th deadline for md
- Start a md intake, selecting a personal that owes taxes (like Drum or Frank rollover)
- Verify that a date is not editable on the taxes owed screen

## Screenshots (for visual changes)
- After
<img width="1051" alt="Screenshot 2025-04-08 at 3 08 02 PM" src="https://github.com/user-attachments/assets/ddedbb65-fbb8-4f81-9f27-894fd7c7cdb9" />
