### PR TITLE
NJ 340 - reduce W2 box 16 amount from DF import when greater than DB max

### DIFF
--- a/app/models/state_file_base_intake.rb
+++ b/app/models/state_file_base_intake.rb
@@ -172,6 +172,7 @@ class StateFileBaseIntake < ApplicationRecord
   def synchronize_df_w2s_to_database
     direct_file_data.w2s.each_with_index do |direct_file_w2, i|
       state_file_w2 = state_file_w2s.where(w2_index: i).first || state_file_w2s.build
+      db_numeric_max = 9_999_999_999.99
       box_14_values = {}
       direct_file_w2.w2_box14.each do |deduction|
         box_14_values[deduction[:other_description]] = deduction[:other_amount]
@@ -190,7 +191,7 @@ class StateFileBaseIntake < ApplicationRecord
         local_wages_and_tips_amount: direct_file_w2.LocalWagesAndTipsAmt,
         locality_nm: direct_file_w2.LocalityNm,
         state_income_tax_amount: direct_file_w2.StateIncomeTaxAmt,
-        state_wages_amount: direct_file_w2.StateWagesAmt,
+        state_wages_amount: [direct_file_w2.StateWagesAmt, db_numeric_max].min,
         state_file_intake: self,
         wages: direct_file_w2.WagesAmt,
         w2_index: i,

--- a/spec/factories/state_file_nj_intakes.rb
+++ b/spec/factories/state_file_nj_intakes.rb
@@ -180,6 +180,11 @@ FactoryBot.define do
       raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nj_irs_test_w2_with_missing_info') }
     end
 
+    trait :df_data_irs_test_box_16_large do
+      raw_direct_file_data { StateFile::DirectFileApiResponseSampleService.new.read_xml('nj_irs_test_box_16_more_than_10_digits') }
+      raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nj_irs_test_box_16_more_than_10_digits') }
+    end
+
     trait :df_data_many_w2s do
       raw_direct_file_data { StateFile::DirectFileApiResponseSampleService.new.read_xml('nj_zeus_many_w2s') }
       raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('nj_zeus_many_w2s') }

--- a/spec/fixtures/state_file/fed_return_jsons/nj/irs_test_box_16_more_than_10_digits.json
+++ b/spec/fixtures/state_file/fed_return_jsons/nj/irs_test_box_16_more_than_10_digits.json
@@ -1,0 +1,30 @@
+{
+  "familyAndHousehold": [],
+  "filers": [
+    {
+      "lastName": "Lucky",
+      "firstName": "Tess",
+      "middleInitial": "L",
+      "tin": "400-00-6306",
+      "dateOfBirth": "1998-06-23",
+      "suffix": null,
+      "isPrimaryFiler": true,
+      "ssnNotValidForEmployment": null
+    }
+  ],
+  "form1099Gs": [],
+  "interestReports": [
+    {
+      "has1099": true,
+      "taxExemptAndTaxCreditBondCusipNo": null,
+      "interestOnGovernmentBonds": "0.00",
+      "taxExemptInterest": "0.00",
+      "payerTin": null,
+      "recipientTin": "400-00-6306",
+      "payer": "Clothing Investments",
+      "taxWithheld": "0.00",
+      "1099Amount": "100.00",
+      "no1099Amount": null
+    }
+  ]
+}

--- a/spec/fixtures/state_file/fed_return_xmls/nj/irs_test_box_16_more_than_10_digits.xml
+++ b/spec/fixtures/state_file/fed_return_xmls/nj/irs_test_box_16_more_than_10_digits.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Return xmlns="http://www.irs.gov/efile" xmlns:efile="http://www.irs.gov/efile" returnVersion="2024v4.0">
+  <ReturnHeader binaryAttachmentCnt="0">
+    <TaxYr>2024</TaxYr>
+    <TaxPeriodBeginDt>2024-01-01</TaxPeriodBeginDt>
+    <TaxPeriodEndDt>2024-12-31</TaxPeriodEndDt>
+    <SoftwareVersionNum>dcf46c78</SoftwareVersionNum>
+    <ReturnTypeCd>1040</ReturnTypeCd>
+    <Filer>
+      <PrimarySSN>400006306</PrimarySSN>
+      <NameLine1Txt>TESS L&lt;LUCKY</NameLine1Txt>
+      <PrimaryNameControlTxt>LUCK</PrimaryNameControlTxt>
+      <USAddress>
+        <AddressLine1Txt>456 Walnut Grove Dr</AddressLine1Txt>
+        <CityNm>Mercerville</CityNm>
+        <StateAbbreviationCd>NJ</StateAbbreviationCd>
+        <ZIPCd>08619</ZIPCd>
+      </USAddress>
+      <PhoneNum>2015559876</PhoneNum>
+    </Filer>
+    <AdditionalFilerInformation>
+      <AtSubmissionFilingGrp>
+        <EmailAddressTxt>test-user+40000630-6e20-4822-b2a3-5bccb310ca7f@directfile.test</EmailAddressTxt>
+      </AtSubmissionFilingGrp>
+    </AdditionalFilerInformation>
+  </ReturnHeader>
+  <ReturnData documentCnt="5">
+    <IRS1040 documentId="IRS10400001">
+      <PECFPrimaryInd>X</PECFPrimaryInd>
+      <IndividualReturnFilingStatusCd>1</IndividualReturnFilingStatusCd>
+      <VirtualCurAcquiredDurTYInd>false</VirtualCurAcquiredDurTYInd>
+      <TotalExemptPrimaryAndSpouseCnt>1</TotalExemptPrimaryAndSpouseCnt>
+      <ChldWhoLivedWithYouCnt>0</ChldWhoLivedWithYouCnt>
+      <OtherDependentsListedCnt>0</OtherDependentsListedCnt>
+      <TotalExemptionsCnt>1</TotalExemptionsCnt>
+      <WagesAmt referenceDocumentId="W20001 W20002" referenceDocumentName="IRSW2">50565</WagesAmt>
+      <WagesSalariesAndTipsAmt>50565</WagesSalariesAndTipsAmt>
+      <TaxableInterestAmt>100</TaxableInterestAmt>
+      <TotalIncomeAmt>50665</TotalIncomeAmt>
+      <AdjustedGrossIncomeAmt>50665</AdjustedGrossIncomeAmt>
+      <TotalItemizedOrStandardDedAmt>14600</TotalItemizedOrStandardDedAmt>
+      <TotalDeductionsAmt>14600</TotalDeductionsAmt>
+      <TaxableIncomeAmt>36065</TaxableIncomeAmt>
+      <TaxAmt>4097</TaxAmt>
+      <TotalTaxBeforeCrAndOthTaxesAmt>4097</TotalTaxBeforeCrAndOthTaxesAmt>
+      <TaxLessCreditsAmt>4097</TaxLessCreditsAmt>
+      <TotalTaxAmt>4097</TotalTaxAmt>
+      <FormW2WithheldTaxAmt>2500</FormW2WithheldTaxAmt>
+      <WithholdingTaxAmt>2500</WithholdingTaxAmt>
+      <TotalPaymentsAmt>2500</TotalPaymentsAmt>
+      <OwedAmt>1597</OwedAmt>
+      <ThirdPartyDesigneeInd>true</ThirdPartyDesigneeInd>
+      <ThirdPartyDesigneeNm>Designee Dude</ThirdPartyDesigneeNm>
+      <ThirdPartyDesigneePhoneNum>2015554332</ThirdPartyDesigneePhoneNum>
+      <ThirdPartyDesigneePIN>25252</ThirdPartyDesigneePIN>
+      <PrimaryOccupationTxt>Gambler</PrimaryOccupationTxt>
+      <RefundProductCd>NO FINANCIAL PRODUCT</RefundProductCd>
+    </IRS1040>
+    <IRS1040ScheduleLEP documentId="LEP005">
+      <PersonNm>Tess L Lucky</PersonNm>
+      <SSN>400006306</SSN>
+      <LanguagePreferenceCd>015</LanguagePreferenceCd>
+    </IRS1040ScheduleLEP>
+    <IRS9000 documentId="IRS90004">
+      <PersonNm>Tess L Lucky</PersonNm>
+      <SSN>400006306</SSN>
+      <AlternativeMediaCd>01</AlternativeMediaCd>
+    </IRS9000>
+    <IRSW2 documentId="W20001" documentName="IRSW2">
+      <EmployeeSSN>400006306</EmployeeSSN>
+      <EmployerEIN>221236333</EmployerEIN>
+      <EmployerNameControlTxt>WEAR</EmployerNameControlTxt>
+      <EmployerName>
+        <BusinessNameLine1Txt>Wearable Garments</BusinessNameLine1Txt>
+      </EmployerName>
+      <EmployerUSAddress>
+        <AddressLine1Txt>1 Clothing St</AddressLine1Txt>
+        <CityNm>Fairfield</CityNm>
+        <StateAbbreviationCd>CT</StateAbbreviationCd>
+        <ZIPCd>06510</ZIPCd>
+      </EmployerUSAddress>
+      <EmployeeNm>Tess L Lucky</EmployeeNm>
+      <EmployeeUSAddress>
+        <AddressLine1Txt>456 Walnut Grove Dr</AddressLine1Txt>
+        <CityNm>Mercerville</CityNm>
+        <StateAbbreviationCd>NJ</StateAbbreviationCd>
+        <ZIPCd>08619</ZIPCd>
+      </EmployeeUSAddress>
+      <WagesAmt>40565</WagesAmt>
+      <WithholdingAmt>2000</WithholdingAmt>
+      <SocialSecurityWagesAmt>40565</SocialSecurityWagesAmt>
+      <SocialSecurityTaxAmt>1000</SocialSecurityTaxAmt>
+      <MedicareWagesAndTipsAmt>40565</MedicareWagesAndTipsAmt>
+      <MedicareTaxWithheldAmt>500</MedicareTaxWithheldAmt>
+      <W2StateLocalTaxGrp>
+        <W2StateTaxGrp>
+          <StateAbbreviationCd>NJ</StateAbbreviationCd>
+          <EmployerStateIdNum>654321</EmployerStateIdNum>
+          <StateWagesAmt>10000000000</StateWagesAmt>
+          <StateIncomeTaxAmt>400</StateIncomeTaxAmt>
+          <W2LocalTaxGrp/>
+        </W2StateTaxGrp>
+      </W2StateLocalTaxGrp>
+      <StandardOrNonStandardCd>S</StandardOrNonStandardCd>
+    </IRSW2>
+  </ReturnData>
+</Return>

--- a/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/nj_return_xml_spec.rb
@@ -119,6 +119,14 @@ describe SubmissionBuilder::Ty2024::States::Nj::NjReturnXml, required_schema: "n
         end
       end
 
+      context 'with IRS test when w2 box 16 is greater than database max of 10^10' do
+        let(:intake) { create(:state_file_nj_intake, :df_data_irs_test_box_16_large) }
+        it "sets StateWagesAmt to 9999999999.99 (rounded)" do
+          expect(build_response.document.at("NJW2").text).not_to eq(nil)
+          expect(xml.document.at('NJW2 StateWagesAmt').text).to eq("10000000000")
+        end
+      end
+
       context "with two 1099Rs" do
         let(:intake) { create(:state_file_nj_intake, :df_data_2_1099r) }
         it "does not error" do

--- a/spec/models/state_file_base_intake_spec.rb
+++ b/spec/models/state_file_base_intake_spec.rb
@@ -182,6 +182,15 @@ describe StateFileBaseIntake do
       expect(w2.box14_ui_hc_wd).to eq 140.00
       expect(w2.box14_ui_wf_swf).to eq 180.00
     end
+
+    context "when W2 StateWagesAmt greater than database max of 10^10" do
+      it "sets state_wages_amount to maximum $9,999,999,999.99" do
+        intake = create(:state_file_nj_intake, :df_data_irs_test_box_16_large)
+        intake.synchronize_df_w2s_to_database
+        w2 = intake.state_file_w2s.first
+        expect(w2.state_wages_amount).to eq 9_999_999_999.99
+      end
+    end
   end
 
   describe "#timedout?" do


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/340

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- If state wages amount received from DF is >$9,999,999,999.99, overwrite it to $9,999,999,999.99
- Note that the $9,999,999,999.99 amount will be rounded to an even 10,000,000,000 in the submitted NJ return XML because of our rounding rules. No matter what the DF original value was (be it 10,000,000,000 or anything else) it will get submitted as the rounded 10mil if the user does not edit it on the income editing screen. Because this is a rounding thing on the submission side, it doesn't cause any database error in the app)

## How to test?
Use newly created NJ persona `Irs test box 16 more than 10 digits`
(note that this fix will apply to all states, not just NJ though)

## Screenshots (for visual changes)

**W2 XML in DirectFile fake data:**
![image](https://github.com/user-attachments/assets/19dfb257-49f3-4101-b958-706402bcee7d)

**After importing into FYST:**
![image](https://github.com/user-attachments/assets/4bd68494-493f-4dde-824f-8536c9f8c9d5)

**In NJ Return XML:**
![image](https://github.com/user-attachments/assets/f24b5513-45d6-4fb9-b84f-d2c5ba93b9a2)
