### PR TITLE
NJ 338 - Added federal extension checkbox to NJ PDF

### DIFF
--- a/app/lib/pdf_filler/nj1040_pdf.rb
+++ b/app/lib/pdf_filler/nj1040_pdf.rb
@@ -100,7 +100,10 @@ module PdfFiller
         
         # signature fields
         'Date1_es_:signer:date': @xml_document.at("ReturnHeaderState Filer Primary DateSigned")&.text,
-        'Date2_es_:signer:date': @xml_document.at("ReturnHeaderState Filer Secondary DateSigned")&.text
+        'Date2_es_:signer:date': @xml_document.at("ReturnHeaderState Filer Secondary DateSigned")&.text,
+
+        # Federal extension payment checkbox
+        'Check Box18': Flipper.enabled?(:extension_period) && @submission.data_source.paid_federal_extension_payments_yes? ? "Yes" : "Off"
       }
 
       dependents = get_dependents

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -1041,6 +1041,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
 
     describe "disabled show_retirement_ui flag" do
       before do
+        allow(Flipper).to receive(:enabled?).and_call_original
         allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(false)
       end
 
@@ -1099,6 +1100,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
 
     describe "line 20a - taxable retirement income" do
       before do
+        allow(Flipper).to receive(:enabled?).and_call_original
         allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)
       end
 
@@ -1147,6 +1149,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
 
     describe "line 20b - excludable retirement income" do
       before do
+        allow(Flipper).to receive(:enabled?).and_call_original
         allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)
       end
 
@@ -1243,6 +1246,7 @@ RSpec.describe PdfFiller::Nj1040Pdf do
 
     describe "line 28a - Pension/Retirement Exclusion" do
       before do
+        allow(Flipper).to receive(:enabled?).and_call_original
         allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)
       end
 
@@ -2616,5 +2620,42 @@ RSpec.describe PdfFiller::Nj1040Pdf do
         end
       end
     end
+
+    describe "federal extension payments" do
+      context 'when feature flag is disabled' do
+        before do
+          allow(Flipper).to receive(:enabled?).and_call_original
+          allow(Flipper).to receive(:enabled?).with(:extension_period).and_return(false)
+        end
+
+        it 'does not check the box' do
+          expect(pdf_fields["Check Box18"]).to eq "Off"
+        end
+      end
+
+      context 'when feature flag is enabled' do
+        before do
+          allow(Flipper).to receive(:enabled?).and_call_original
+          allow(Flipper).to receive(:enabled?).with(:extension_period).and_return(true)
+        end
+
+        context "when taxpayer has paid federal extension payments" do
+          let(:intake) { create(:state_file_nj_intake, paid_federal_extension_payments: "yes") }
+  
+          it "checks the box" do
+            expect(pdf_fields["Check Box18"]).to eq "Yes"
+          end
+        end
+  
+        context "when taxpayer has not paid federal extension payments" do
+          let(:intake) { create(:state_file_nj_intake, paid_federal_extension_payments: "no") }
+  
+          it "does not check the box" do
+            expect(pdf_fields["Check Box18"]).to eq "Off"
+          end
+        end
+      end
+    end
+
   end
 end

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -2623,6 +2623,8 @@ RSpec.describe PdfFiller::Nj1040Pdf do
 
     describe "federal extension payments" do
       context 'when feature flag is disabled' do
+        let(:intake) { create(:state_file_nj_intake, paid_federal_extension_payments: "yes") }
+
         before do
           allow(Flipper).to receive(:enabled?).and_call_original
           allow(Flipper).to receive(:enabled?).with(:extension_period).and_return(false)


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://github.com/newjersey/affordability-pm/issues/338#issue-2983009669

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- NJ doesn't have an XML schema field for the federal extension checkbox
- Decided to still fill in the PDF field if the user says they made federal extension payments so the user is not confused: see https://njcio.slack.com/archives/C07GYAQ4E1E/p1744293998466119

## How to test?
- Set extension_period feature flag
- Answer Yes when asked if you paid NJ extension payments
- Confirm in PDF that the checkbox is selected

## Screenshots (for visual changes)
- Before
- After
<img width="983" alt="image" src="https://github.com/user-attachments/assets/7e547155-55e6-4efd-ade9-16e34fd2843a" />

