### PR TITLE
FYST-1999 Move actioncable to redis on demo

### DIFF
--- a/app/channels/df_data_transfer_job_channel.rb
+++ b/app/channels/df_data_transfer_job_channel.rb
@@ -8,7 +8,6 @@ class DfDataTransferJobChannel < ApplicationCable::Channel
   end
 
   def self.broadcast_job_complete(intake)
-    binding.pry
     broadcast_to(intake, ["The job is complete"])
   end
 end

--- a/app/channels/df_data_transfer_job_channel.rb
+++ b/app/channels/df_data_transfer_job_channel.rb
@@ -8,6 +8,7 @@ class DfDataTransferJobChannel < ApplicationCable::Channel
   end
 
   def self.broadcast_job_complete(intake)
+    binding.pry
     broadcast_to(intake, ["The job is complete"])
   end
 end

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -8,12 +8,11 @@ heroku:
   adapter: postgresql
 
 demo:
-  adapter: redis
-  url: <%= ENV.fetch("MINI_PROFILER_REDIS_URL", "redis://localhost:6379/0") %>
+  adapter: <%= ENV["REDIS_URL"].present? ? "redis" : "postgresql" %>
+  url: <%= ENV.fetch("REDIS_URL") %>
 
 production:
-  adapter: redis
-  url: <%= ENV.fetch("MINI_PROFILER_REDIS_URL", "redis://localhost:6379/0") %>
+  adapter: postgresql
 
 test:
   adapter: test

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -9,7 +9,7 @@ heroku:
 
 demo:
   adapter: <%= ENV["REDIS_URL"].present? ? "redis" : "postgresql" %>
-  url: <%= ENV.fetch("REDIS_URL") %>
+  url: <%= ENV["REDIS_URL"] %>
 
 production:
   adapter: postgresql

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -12,7 +12,8 @@ demo:
   url: <%= ENV.fetch("MINI_PROFILER_REDIS_URL", "redis://localhost:6379/0") %>
 
 production:
-  adapter: postgresql
+  adapter: redis
+  url: <%= ENV.fetch("MINI_PROFILER_REDIS_URL", "redis://localhost:6379/0") %>
 
 test:
   adapter: test


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1999

## Is PM acceptance required? 
- No - merge after code review approval

## What was done?
- Updated the prod environment configuration in cable.yml to use Redis instead of PostgreSQL for Action Cable. Added fallback configuration for the Redis URL to prevent environment variable errors. This change enables WebSocket communication through Redis in the demo environment
- This is a follow up to this [PR](https://github.com/codeforamerica/vita-min/pull/5893) where the demo config was updated
