### PR TITLE
FYST-1999 Add redis actioncable connection to prod

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -12,7 +12,8 @@ demo:
   url: <%= ENV["REDIS_URL"] %>
 
 production:
-  adapter: postgresql
+  adapter: <%= ENV["REDIS_URL"].present? ? "redis" : "postgresql" %>
+  url: <%= ENV["REDIS_URL"] %>
 
 test:
   adapter: test

--- a/config/initializers/rack_profiler.rb
+++ b/config/initializers/rack_profiler.rb
@@ -3,7 +3,7 @@ if Rails.env.heroku? || Rails.env.demo? || Rails.env.production?
   Rack::MiniProfiler.config.start_hidden = true
 end
 
-if ENV['MINI_PROFILER_REDIS_URL'].present?
-  Rack::MiniProfiler.config.storage_options = { url: ENV["MINI_PROFILER_REDIS_URL"] }
+if ENV['REDIS_URL'].present?
+  Rack::MiniProfiler.config.storage_options = { url: ENV["REDIS_URL"] }
   Rack::MiniProfiler.config.storage = Rack::MiniProfiler::RedisStore
 end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-1999
## Is PM acceptance required? 
- No - merge after code review approval

## What was done?
- Updated the prod environment configuration in cable.yml to use Redis instead of PostgreSQL for Action Cable. Added fallback configuration for the Redis URL to use postgresql to prevent environment variable errors. This change enables WebSocket communication through Redis in the prod environment. Added a more general name for the redis url is it is no longer just being used for the mini profiler

## How to test?
- Will be testing on production after deployment with following commands: `aptible db:tunnel vita-min-demo-redis` and on a sepate terminal/tab: `redis-cli -u CONNECTION_STRING` and `> monitor`

