### PR TITLE
NJ 336 - Added headers to review screen

### DIFF
--- a/app/views/state_file/questions/nj_review/edit.html.erb
+++ b/app/views/state_file/questions/nj_review/edit.html.erb
@@ -6,7 +6,7 @@
   <% if current_intake.state_file1099_rs.length.positive? && Flipper.enabled?(:show_retirement_ui) %>
     <section id="retirement-income-source" class="white-group">
       <div class="spacing-below-5">
-        <h2 class="text--body text--bold spacing-below-25"><%=t(".retirement_income_source") %></h2>
+        <h3 class="text--body text--bold spacing-below-25"><%=t(".retirement_income_source") %></h3>
 
         <% current_intake.state_file1099_rs.each do |state_file1099_r| %>
           <% unless state_file1099_r.state_specific_followup.nil? %>
@@ -37,30 +37,41 @@
     </section>
   <% end %>
 
-  <% if current_intake.dependents.count(&:under_22?).positive? %>
-    <section id="college-dependents" class="white-group">
+  <div class="spacing-below-25">
+    <h2 class="text--body text--bold spacing-below-5"><%=t(".more_household_details") %></h2>
+  </div>
+
+  <% if current_intake.filing_status_qw? %>
+    <section id="year-of-death" class="white-group">
       <div class="spacing-below-5">
-        <h2 class="text--body text--bold spacing-below-5"><%=t(".college_dependents") %></h2>
-        <% current_intake.dependents.each do | dependent | %>
-          <% if dependent.nj_qualifies_for_college_exemption? %>
-            <p><%=dependent.full_name %></p>
-          <% end %>
-        <% end %>
-        <% if current_intake.dependents.all? { |dependent| !dependent.nj_qualifies_for_college_exemption? } %>
-          <p><%= t(".college_dependents_none") %></p>
-        <% end %>
-        <%= link_to StateFile::Questions::NjCollegeDependentsExemptionController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
+        <h3 class="text--body text--bold spacing-below-5"><%=t(".year_of_death") %></h3>
+        <p><%=current_intake.spouse_death_year %></p>
+
+        <%= link_to StateFile::Questions::NjYearOfDeathController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
           <%= t(".review_and_edit") %>
-          <span class="sr-only"><%= t(".college_dependents") %></span>
+          <span class="sr-only"><%= t(".year_of_death") %></span>
         <% end %>
       </div>
     </section>
   <% end %>
 
+  <section id="county-municipality" class="white-group">
+    <div class="spacing-below-5">
+      <h3 class="text--body text--bold spacing-below-5"><%=t(".county_municipality", filing_year: current_tax_year) %></h3>
+      <p><%= t(".county", county: current_intake.county) %></p>
+      <p><%=current_intake.municipality_name %></p>
+
+      <%= link_to StateFile::Questions::NjCountyMunicipalityController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
+        <%= t(".review_and_edit") %>
+        <span class="sr-only"><%= t(".county_municipality") %></span>
+      <% end %>
+    </div>
+  </section>
+
   <% if current_intake.dependents.any? && current_intake.has_health_insurance_requirement_exception? %>
     <section id="missing-health-insurance" class="white-group">
       <div class="spacing-below-5">
-        <h2 class="text--body text--bold spacing-below-5"><%=t(".missing_health_insurance") %></h2>
+        <h3 class="text--body text--bold spacing-below-5"><%=t(".missing_health_insurance") %></h3>
         <% current_intake.dependents.each do | dependent | %>
           <% if dependent.nj_did_not_have_health_insurance_yes? %>
             <p><%=dependent.full_name %></p>
@@ -77,42 +88,19 @@
     </section>
   <% end %>
 
-  <% if current_intake.filing_status_qw? %>
-    <section id="year-of-death" class="white-group">
-      <div class="spacing-below-5">
-        <h2 class="text--body text--bold spacing-below-5"><%=t(".year_of_death") %></h2>
-        <p><%=current_intake.spouse_death_year %></p>
-
-        <%= link_to StateFile::Questions::NjYearOfDeathController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
-          <%= t(".review_and_edit") %>
-          <span class="sr-only"><%= t(".year_of_death") %></span>
-        <% end %>
-      </div>
-    </section>
-  <% end %>
-
-  <section id="county-municipality" class="white-group">
-    <div class="spacing-below-5">
-      <h2 class="text--body text--bold spacing-below-5"><%=t(".county_municipality", filing_year: current_tax_year) %></h2>
-      <p><%= t(".county", county: current_intake.county) %></p>
-      <p><%=current_intake.municipality_name %></p>
-
-      <%= link_to StateFile::Questions::NjCountyMunicipalityController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
-        <%= t(".review_and_edit") %>
-        <span class="sr-only"><%= t(".county_municipality") %></span>
-      <% end %>
-    </div>
-  </section>
+  <div class="spacing-below-25">
+    <h2 class="text--body text--bold spacing-below-5"><%=t("state_file.navigation.nj.section_3") %></h2>
+  </div>
 
   <% if !current_intake.primary_disabled_unfilled? || !current_intake.spouse_disabled_unfilled? %>
     <section id="disabled_exemption" class="white-group">
       <div class="spacing-below-5">
         <% unless current_intake.primary_disabled_unfilled? %>
-          <h2 class="text--body text--bold spacing-below-5"><%= t(".primary_disabled")  %></h2>
+          <h3 class="text--body text--bold spacing-below-5"><%= t(".primary_disabled")  %></h3>
           <p><%= current_intake.primary_disabled_yes? ? t("general.affirmative") : t("general.negative") %></p>
         <% end %>
         <% unless current_intake.spouse_disabled_unfilled? %>
-          <h2 class="text--body text--bold spacing-below-5"><%= t(".spouse_disabled")  %></h2>
+          <h3 class="text--body text--bold spacing-below-5"><%= t(".spouse_disabled")  %></h3>
           <p><%= current_intake.spouse_disabled_yes? ? t("general.affirmative") : t("general.negative") %></p>
         <% end %>
         <%= link_to StateFile::Questions::NjDisabledExemptionController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
@@ -127,11 +115,11 @@
     <section id="veterans_exemption" class="white-group">
       <div class="spacing-below-5">
         <% unless current_intake.primary_veteran_unfilled? %>
-          <h2 class="text--body text--bold spacing-below-5"><%= t(".primary_veteran")  %></h2>
+          <h3 class="text--body text--bold spacing-below-5"><%= t(".primary_veteran")  %></h3>
           <p><%= current_intake.primary_veteran_yes? ? t("general.affirmative") : t("general.negative") %></p>
         <% end %>
         <% unless current_intake.spouse_veteran_unfilled? %>
-          <h2 class="text--body text--bold spacing-below-5"><%= t(".spouse_veteran")  %></h2>
+          <h3 class="text--body text--bold spacing-below-5"><%= t(".spouse_veteran")  %></h3>
           <p><%= current_intake.spouse_veteran_yes? ? t("general.affirmative") : t("general.negative") %></p>
         <% end %>
         <%= link_to StateFile::Questions::NjVeteransExemptionController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
@@ -142,10 +130,30 @@
     </section>
   <% end %>
 
+  <% if current_intake.dependents.count(&:under_22?).positive? %>
+    <section id="college-dependents" class="white-group">
+      <div class="spacing-below-5">
+        <h3 class="text--body text--bold spacing-below-5"><%=t(".college_dependents") %></h3>
+        <% current_intake.dependents.each do | dependent | %>
+          <% if dependent.nj_qualifies_for_college_exemption? %>
+            <p><%=dependent.full_name %></p>
+          <% end %>
+        <% end %>
+        <% if current_intake.dependents.all? { |dependent| !dependent.nj_qualifies_for_college_exemption? } %>
+          <p><%= t(".college_dependents_none") %></p>
+        <% end %>
+        <%= link_to StateFile::Questions::NjCollegeDependentsExemptionController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
+          <%= t(".review_and_edit") %>
+          <span class="sr-only"><%= t(".college_dependents") %></span>
+        <% end %>
+      </div>
+    </section>
+  <% end %>
+
   <% if !current_intake.eligibility_made_less_than_threshold? %>
     <section id="medical_expenses" class="white-group">
       <div class="spacing-below-5">
-        <h2 class="text--body text--bold spacing-below-5"><%=t(".medical_expenses") %></h2>
+        <h3 class="text--body text--bold spacing-below-5"><%=t(".medical_expenses") %></h3>
         <p><%= number_to_currency(current_intake.medical_expenses || 0, precision: 0) %></p>
         <%= link_to StateFile::Questions::NjMedicalExpensesController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
           <%= t(".review_and_edit") %>
@@ -155,42 +163,17 @@
     </section>
   <% end %>
 
-
-  <section id="property-tax" class="white-group">
-    <div class="spacing-below-5">
-      <h2 class="text--body text--bold spacing-below-5"><%=t(".property_tax_credit_deduction") %></h2>
-
-      <h3 class="text--body spacing-below-5"><%=t(".household_rent_own", filing_year: current_tax_year) %></h3>
-      <p><%=t(".household_rent_own_#{current_intake.household_rent_own}") unless current_intake.household_rent_own_unfilled? %></p>
-
-      <% unless current_intake.property_tax_paid.nil? %>
-        <h3 class="text--body text--bold spacing-below-5"><%= t(".property_tax_paid", filing_year: current_tax_year)  %></h3>
-        <p><%= number_to_currency(current_intake.property_tax_paid, precision: 0) %></p>
-      <% end %>
-
-      <% unless current_intake.rent_paid.nil? %>
-        <h3 class="text--body text--bold spacing-below-5"><%=t(".rent_paid", filing_year: current_tax_year) %></h3>
-        <p><%= number_to_currency(current_intake.rent_paid, precision: 0) %></p>
-      <% end %>
-
-      <%= link_to StateFile::Questions::NjHouseholdRentOwnController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
-        <%= t(".review_and_edit") %>
-        <span class="sr-only"><%= t(".property_tax_credit_deduction") %></span>
-      <% end %>
-    </div>
-  </section>
-
   <% unless current_intake.claimed_as_eitc_qualifying_child_unfilled? && current_intake.spouse_claimed_as_eitc_qualifying_child_unfilled? %>
     <section id="eitc_qualifying_child" class="white-group">
       <div class="spacing-below-5">
-        <h2 class="text--body text--bold spacing-below-5"><%=t(".eitc") %></h2>
+        <h3 class="text--body text--bold spacing-below-5"><%=t(".eitc") %></h3>
 
         <% unless current_intake.claimed_as_eitc_qualifying_child_unfilled? %>
-          <h3 class="text--body text--bold spacing-below-5"><%=t(".primary_claimed_as_eitc_qualifying_child") %></h3>
+          <h4 class="text--body text--bold spacing-below-5"><%=t(".primary_claimed_as_eitc_qualifying_child") %></h4>
           <p><%=current_intake.claimed_as_eitc_qualifying_child_yes? ? t("general.affirmative") : t("general.negative") %></p>
         <% end %>
         <% unless current_intake.spouse_claimed_as_eitc_qualifying_child_unfilled? %>
-        <h3 class="text--body text--bold spacing-below-5"><%=t(".spouse_claimed_as_eitc_qualifying_child") %></h3>
+        <h4 class="text--body text--bold spacing-below-5"><%=t(".spouse_claimed_as_eitc_qualifying_child") %></h4>
           <p><%=current_intake.spouse_claimed_as_eitc_qualifying_child_yes? ? t("general.affirmative") : t("general.negative") %></p>
         <% end %>
         <%= link_to StateFile::Questions::NjEitcQualifyingChildController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
@@ -201,9 +184,37 @@
     </section>
   <% end %>
 
+  <section id="property-tax" class="white-group">
+    <div class="spacing-below-5">
+      <h3 class="text--body text--bold spacing-below-5"><%=t(".property_tax_credit_deduction") %></h3>
+
+      <h4 class="text--body spacing-below-5"><%=t(".household_rent_own", filing_year: current_tax_year) %></h4>
+      <p><%=t(".household_rent_own_#{current_intake.household_rent_own}") unless current_intake.household_rent_own_unfilled? %></p>
+
+      <% unless current_intake.property_tax_paid.nil? %>
+        <h4 class="text--body text--bold spacing-below-5"><%= t(".property_tax_paid", filing_year: current_tax_year)  %></h4>
+        <p><%= number_to_currency(current_intake.property_tax_paid, precision: 0) %></p>
+      <% end %>
+
+      <% unless current_intake.rent_paid.nil? %>
+        <h4 class="text--body text--bold spacing-below-5"><%=t(".rent_paid", filing_year: current_tax_year) %></h4>
+        <p><%= number_to_currency(current_intake.rent_paid, precision: 0) %></p>
+      <% end %>
+
+      <%= link_to StateFile::Questions::NjHouseholdRentOwnController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
+        <%= t(".review_and_edit") %>
+        <span class="sr-only"><%= t(".property_tax_credit_deduction") %></span>
+      <% end %>
+    </div>
+  </section>
+
+  <div class="spacing-below-25">
+    <h2 class="text--body text--bold spacing-below-5"><%=t("state_file.navigation.nj.section_4", filing_year: current_tax_year) %></h2>
+  </div>
+
   <section id="use-tax" class="white-group">
     <div class="spacing-below-5">
-      <h2 class="text--body text--bold spacing-below-5"><%=t(".use_tax_applied") %></h2>
+      <h3 class="text--body text--bold spacing-below-5"><%=t(".use_tax_applied") %></h3>
       <p><%=current_intake.untaxed_out_of_state_purchases_yes? ? t("general.affirmative") : t("general.negative") %></p>
       <% if current_intake.untaxed_out_of_state_purchases_yes? %>
         <p class="text--bold spacing-below-5">
@@ -220,7 +231,7 @@
 
   <section id="estimated-tax-payments" class="white-group">
     <div class="spacing-below-5">
-      <h2 class="text--body text--bold spacing-below-5"><%=t(".has_estimated_payments") %></h2>
+      <h3 class="text--body text--bold spacing-below-5"><%=t(".has_estimated_payments") %></h3>
       <p><%=current_intake.has_estimated_payments_yes? ? t("general.affirmative") : t("general.negative") %></p>
       <% if current_intake.has_estimated_payments_yes? %>
         <p class="text--bold spacing-below-5"><%=t(".estimated_tax_payments") %></p>
@@ -238,7 +249,7 @@
   </section>
 
   <section class="reveal" id="calculation-details">
-    <h2 class="text--body text--bold spacing-below-5"><button class="reveal__button"><%= t(".reveal.header") %></button></h2>
+    <button class="reveal__button"><%= t(".reveal.header") %></button>
     <div class="reveal__content">
       <% @detailed_return_info.each.with_index do |section, i| %>
         <div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4182,7 +4182,7 @@ en:
           dependent_dob: Their date of birth
           dependent_months_in_home: Number of months they lived with you
           dependent_name: Your dependent's name
-          household_info: Household details
+          household_info: Household Details
           nth_dependent_name: Your %{ordinal} dependent's name
           spouse_name: Your spouse's name
           taxes_owed_header: Your refund or taxes owed
@@ -4218,7 +4218,7 @@ en:
           uniformed_survivor_benefit_plan: Payments from a qualifying Survivor Benefit Plan to a beneficiary of a retired member who served at least 20 years or who was medically retired from the Uniformed Services
           uniformed_twenty_years_medical_retired: Retired member who served at least 20 years or were medically retired from the Uniformed Services
         review_header:
-          income_details: Income details
+          income_details: Income Details
           income_forms_collected: 'Income form(s) collected:'
           state_details_title: State Details
           your_refund: Your refund amount

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3819,7 +3819,7 @@ en:
           household_rent_own_rent: Rented
           medical_expenses: Total medical expenses
           missing_health_insurance: Dependents who DO NOT have health insurance
-          more_household_details: More Household Details
+          more_household_details: More household details
           overpayments: Refund carried forward
           primary_claimed_as_eitc_qualifying_child: You could be someone's qualifying child
           primary_disabled: Disability exemption
@@ -4182,7 +4182,7 @@ en:
           dependent_dob: Their date of birth
           dependent_months_in_home: Number of months they lived with you
           dependent_name: Your dependent's name
-          household_info: Household Details
+          household_info: Household details
           nth_dependent_name: Your %{ordinal} dependent's name
           spouse_name: Your spouse's name
           taxes_owed_header: Your refund or taxes owed
@@ -4218,7 +4218,7 @@ en:
           uniformed_survivor_benefit_plan: Payments from a qualifying Survivor Benefit Plan to a beneficiary of a retired member who served at least 20 years or who was medically retired from the Uniformed Services
           uniformed_twenty_years_medical_retired: Retired member who served at least 20 years or were medically retired from the Uniformed Services
         review_header:
-          income_details: Income Details
+          income_details: Income details
           income_forms_collected: 'Income form(s) collected:'
           state_details_title: State Details
           your_refund: Your refund amount

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3794,6 +3794,7 @@ en:
           household_rent_own_rent: Rented
           medical_expenses: Total medical expenses
           missing_health_insurance: Dependents who DO NOT have health insurance
+          more_household_details: More Household Details
           overpayments: Amount of refund carried forward
           primary_claimed_as_eitc_qualifying_child: You could be someone's qualifying child
           primary_disabled: Disability exemption

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3790,7 +3790,7 @@ es:
           household_rent_own_rent: Inquilino/a
           medical_expenses: Gastos médicos totales
           missing_health_insurance: Dependientes que NO tienen seguro médico
-          more_household_details: Mas Detalles del Hogar
+          more_household_details: Mas detalles del hogar
           overpayments: Monto del reembolso transferido del año anterior
           primary_claimed_as_eitc_qualifying_child: Podrías ser hijo/a calificado/a de otra persona
           primary_disabled: Exención por discapacidad

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3765,6 +3765,7 @@ es:
           household_rent_own_rent: Inquilino/a
           medical_expenses: Gastos médicos totales
           missing_health_insurance: Dependientes que NO tienen seguro médico
+          more_household_details: Mas Detalles del hogar
           overpayments: Amount of refund carried forward
           primary_claimed_as_eitc_qualifying_child: Podrías ser hijo/a calificado/a de otra persona
           primary_disabled: Exención por discapacidad

--- a/spec/features/state_file/nj/complete_intake_spec.rb
+++ b/spec/features/state_file/nj/complete_intake_spec.rb
@@ -272,7 +272,8 @@ RSpec.feature "Completing a state file intake", active_job: true do
       expect(page).to be_axe_clean.within "main"
 
       groups = page.all(:css, '.white-group').count
-      expect(groups).to eq(0)
+      expect(groups).to eq(11)
+      # one white group per exemption/section
 
       h2s = page.all(:css, 'h2').count
       # one h2 per section header (e.g.Household Information)

--- a/spec/features/state_file/nj/complete_intake_spec.rb
+++ b/spec/features/state_file/nj/complete_intake_spec.rb
@@ -272,10 +272,11 @@ RSpec.feature "Completing a state file intake", active_job: true do
       expect(page).to be_axe_clean.within "main"
 
       groups = page.all(:css, '.white-group').count
+      expect(groups).to eq(0)
+
       h2s = page.all(:css, 'h2').count
-      expect(groups).to eq(h2s - 2)
-      # total should be h2s -1 to account for the h2 reveal button
-      # there's also an extra h2 in the veteran exemption box
+      # one h2 per section header (e.g.Household Information)
+      expect(h2s).to eq(4)
 
       edit_buttons = page.all(:css, '.white-group a')
       edit_buttons_count = edit_buttons.count

--- a/spec/features/state_file/nj/complete_intake_spec.rb
+++ b/spec/features/state_file/nj/complete_intake_spec.rb
@@ -272,12 +272,12 @@ RSpec.feature "Completing a state file intake", active_job: true do
       expect(page).to be_axe_clean.within "main"
 
       groups = page.all(:css, '.white-group').count
-      expect(groups).to eq(11)
       # one white group per exemption/section
+      expect(groups).to eq(11)
 
       h2s = page.all(:css, 'h2').count
-      # one h2 per section header (e.g.Household Information)
-      expect(h2s).to eq(4)
+      # one h2 for each of 5 section headers (e.g Household Information), "Your refund amount" is also an h2
+      expect(h2s).to eq(5 + 1)
 
       edit_buttons = page.all(:css, '.white-group a')
       edit_buttons_count = edit_buttons.count


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/336#issue-2977593519

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Added headers and rearranged final review screen to match design: 
<img width="697" alt="image" src="https://github.com/user-attachments/assets/46b35362-9ab7-47fb-b8d6-9dd6ed239fc2" />

- aligned header structure with Shared Header, previous NJ used h2 for group headers, now follows standard structure below

```
  - <h2> section header (e.g. Deductions and Credits)
     - <white group>
        - <h3> group header (e.g. Veterans Exemption) 
```
## How to test?
- Go to review screen and verify that headers have been added and content appears correct

## Screenshots (for visual changes)
- Before
<img width="264" alt="image" src="https://github.com/user-attachments/assets/13983828-2131-4e11-975e-d67aee31b32c" />
<img width="244" alt="image" src="https://github.com/user-attachments/assets/fb1d3637-0830-4a5d-b43a-9e2afa6d6a2c" />

- After
<img width="286" alt="image" src="https://github.com/user-attachments/assets/b4e99f2a-6c0e-4560-97d3-b7f63663433c" />
<img width="224" alt="image" src="https://github.com/user-attachments/assets/888b0249-435c-4c67-a65b-55c358416a23" />

