### PR TITLE
NJ 339 - remove payment amount box from taxes_owed screen, fill automatically instead

### DIFF
--- a/app/services/state_file/state_information_service.rb
+++ b/app/services/state_file/state_information_service.rb
@@ -27,6 +27,7 @@ module StateFile
       :voucher_path,
       :w2_supported_box14_codes,
       :w2_include_local_income_boxes,
+      :auto_calculate_withdraw_amount,
     ].freeze
 
     class << self
@@ -125,6 +126,7 @@ module StateFile
         voucher_path: "/pdfs/AZ-140V.pdf",
         w2_supported_box14_codes: [],
         w2_include_local_income_boxes: false,
+        auto_calculate_withdraw_amount: false
       },
       id: {
         intake_class: StateFileIdIntake,
@@ -153,6 +155,7 @@ module StateFile
         voucher_path: "/pdfs/idformIDVP-TY2024.pdf",
         w2_supported_box14_codes: [],
         w2_include_local_income_boxes: false,
+        auto_calculate_withdraw_amount: false
       },
       md: {
         intake_class: StateFileMdIntake,
@@ -182,6 +185,7 @@ module StateFile
         voucher_path: "/pdfs/md-pv-TY2024.pdf",
         w2_supported_box14_codes: [{name: "STPICKUP"}],
         w2_include_local_income_boxes: true,
+        auto_calculate_withdraw_amount: false
       },
       nc: {
         intake_class: StateFileNcIntake,
@@ -210,6 +214,7 @@ module StateFile
         voucher_path: "https://eservices.dor.nc.gov/vouchers/d400v.jsp?year=2024",
         w2_supported_box14_codes: [],
         w2_include_local_income_boxes: false,
+        auto_calculate_withdraw_amount: false
       },
       nj: {
         intake_class: StateFileNjIntake,
@@ -239,6 +244,7 @@ module StateFile
         voucher_path: "/pdfs/nj1040v-TY2024.pdf",
         w2_supported_box14_codes: [{name: "UI_WF_SWF", limit: 180}, {name: "FLI", limit: 145.26}],
         w2_include_local_income_boxes: false,
+        auto_calculate_withdraw_amount: true
       },
       ny: {
         intake_class: StateFileNyIntake,
@@ -268,6 +274,7 @@ module StateFile
         voucher_path: "/pdfs/it201v_1223.pdf",
         w2_supported_box14_codes: [],
         w2_include_local_income_boxes: false,
+        auto_calculate_withdraw_amount: false
       }
     }.with_indifferent_access)
   end

--- a/app/views/state_file/questions/tax_refund/_bank_details.html.erb
+++ b/app/views/state_file/questions/tax_refund/_bank_details.html.erb
@@ -4,7 +4,11 @@
   <div>
     <% if owe_taxes %>
       <%= form.hidden_field :app_time, value: app_time %>
-      <%= form.vita_min_money_field(:withdraw_amount, t('.withdraw_amount', owed_amount: taxes_owed), classes: ["form-width--long"]) %>
+      <% if StateFile::StateInformationService.auto_calculate_withdraw_amount(current_intake.state_code) %>
+        <p><%= t(".authorized_amount", owed_amount: taxes_owed) %></p>
+      <% else %>
+        <%= form.vita_min_money_field(:withdraw_amount, t('.withdraw_amount', owed_amount: taxes_owed), classes: ["form-width--long"]) %>
+      <% end %>
       <% if current_time_before_payment_deadline? %>
         <div class="date-select">
           <% year = current_tax_year + 1 %>

--- a/app/views/state_file/questions/tax_refund/_bank_details.html.erb
+++ b/app/views/state_file/questions/tax_refund/_bank_details.html.erb
@@ -1,12 +1,14 @@
 <div class="white-group">
+  <% if owe_taxes && StateFile::StateInformationService.auto_calculate_withdraw_amount(current_intake.state_code) %>
+    <p><strong><%= t(".authorized_amount", owed_amount: taxes_owed) %></strong></p>
+    <hr class="spacing-above-25 spacing-below-25"/>
+  <% end %>
   <p class="spacing-below-0"><%= t(".bank_title") %></p>
   <p class="text--small"><%= t(".foreign_accounts") %></p>
   <div>
     <% if owe_taxes %>
       <%= form.hidden_field :app_time, value: app_time %>
-      <% if StateFile::StateInformationService.auto_calculate_withdraw_amount(current_intake.state_code) %>
-        <p><%= t(".authorized_amount", owed_amount: taxes_owed) %></p>
-      <% else %>
+      <% unless StateFile::StateInformationService.auto_calculate_withdraw_amount(current_intake.state_code) %>
         <%= form.vita_min_money_field(:withdraw_amount, t('.withdraw_amount', owed_amount: taxes_owed), classes: ["form-width--long"]) %>
       <% end %>
       <% if current_time_before_payment_deadline? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4360,6 +4360,7 @@ en:
         bank_details:
           account_number: Account Number
           after_deadline_default_withdrawal_info: Because you are submitting your return on or after %{payment_deadline_date}, %{payment_deadline_year}, the state will withdraw your payment as soon as they process your return.
+          authorized_amount: By filling in your information here, you authorize a withdrawal of $%{owed_amount} from your account. The amount will be withdrawn when your return is processed.
           bank_title: 'Please provide your bank details:'
           confirm_account_number: Confirm Account Number
           confirm_routing_number: Confirm Routing Number

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4360,7 +4360,7 @@ en:
         bank_details:
           account_number: Account Number
           after_deadline_default_withdrawal_info: Because you are submitting your return on or after %{payment_deadline_date}, %{payment_deadline_year}, the state will withdraw your payment as soon as they process your return.
-          authorized_amount: By filling in your information here, you authorize a withdrawal of $%{owed_amount} from your account. The amount will be withdrawn when your return is processed.
+          authorized_amount: By filling in your information here, you authorize a withdrawal of $%{owed_amount} from your account.
           bank_title: 'Please provide your bank details:'
           confirm_account_number: Confirm Account Number
           confirm_routing_number: Confirm Routing Number

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4373,7 +4373,7 @@ es:
         bank_details:
           account_number: Número de cuenta
           after_deadline_default_withdrawal_info: Debido al hecho de que estás enviando tu declaración el %{payment_deadline_date} de %{payment_deadline_year} o después, el estado retirará tu pago tan pronto como se procese tu declaración.
-          authorized_amount: By filling in your information here, you authorize a withdrawal of $%{owed_amount} from your account. The amount will be withdrawn when your return is processed.
+          authorized_amount: By filling in your information here, you authorize a withdrawal of $%{owed_amount} from your account.
           bank_title: 'Comparte los detalles de tu cuenta bancaria:'
           confirm_account_number: Confirma el número de cuenta
           confirm_routing_number: Confirma el número de ruta bancaria (routing number)

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4373,6 +4373,7 @@ es:
         bank_details:
           account_number: Número de cuenta
           after_deadline_default_withdrawal_info: Debido al hecho de que estás enviando tu declaración el %{payment_deadline_date} de %{payment_deadline_year} o después, el estado retirará tu pago tan pronto como se procese tu declaración.
+          authorized_amount: By filling in your information here, you authorize a withdrawal of $%{owed_amount} from your account. The amount will be withdrawn when your return is processed.
           bank_title: 'Comparte los detalles de tu cuenta bancaria:'
           confirm_account_number: Confirma el número de cuenta
           confirm_routing_number: Confirma el número de ruta bancaria (routing number)

--- a/spec/controllers/state_file/questions/taxes_owed_controller_spec.rb
+++ b/spec/controllers/state_file/questions/taxes_owed_controller_spec.rb
@@ -98,6 +98,36 @@ describe StateFile::Questions::TaxesOwedController do
             )
           end
         end
+
+        shared_examples "withdraw amount is user-entered" do
+          it "shows withdraw_amount field" do
+            get :edit
+            expect(response.body).to include("How much do you authorize to be withdrawn from your account?")
+          end
+
+          it "does not show authorization alert text" do
+            get :edit
+            expect(response.body).not_to include("By filling in your information here, you authorize a withdrawal")
+          end
+        end
+
+        shared_examples "withdraw amount is auto-calculated" do
+          it "does not show withdraw_amount field" do
+            get :edit
+            expect(response.body).not_to include("How much do you authorize to be withdrawn from your account?")
+          end
+
+          it "shows authorization alert text" do
+            get :edit
+            expect(response.body).to include("By filling in your information here, you authorize a withdrawal")
+          end
+        end
+
+        if StateFile::StateInformationService.auto_calculate_withdraw_amount(state_code)
+          it_behaves_like "withdraw amount is auto-calculated"
+        else
+          it_behaves_like "withdraw amount is user-entered"
+        end
       end
     end
 

--- a/spec/forms/state_file/taxes_owed_form_spec.rb
+++ b/spec/forms/state_file/taxes_owed_form_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe StateFile::TaxesOwedForm do
 
       shared_examples "withdraw amount is user-entered" do
         it "rejects withdraw amount value nil" do
-          form = described_class.new(intake, params.merge(withdraw_amount: nil))
+          form = described_class.new(intake, direct_deposit_params_with_date.merge(withdraw_amount: nil))
           expect(form).not_to be_valid
           expect(form.errors).to include :withdraw_amount
           expect(form.errors.first&.type).to eq :blank
@@ -198,7 +198,7 @@ RSpec.describe StateFile::TaxesOwedForm do
 
       shared_examples "withdraw amount is auto-calculated" do
         it "auto-fills withdraw amount to save" do
-          form = described_class.new(intake, params.merge(withdraw_amount: nil))
+          form = described_class.new(intake, direct_deposit_params_with_date.merge(withdraw_amount: nil))
           expect(form).to be_valid
           form.save
 

--- a/spec/forms/state_file/taxes_owed_form_spec.rb
+++ b/spec/forms/state_file/taxes_owed_form_spec.rb
@@ -158,7 +158,6 @@ RSpec.describe StateFile::TaxesOwedForm do
             account_number: "123",
             account_number_confirmation: "",
             account_type: nil,
-            withdraw_amount: nil,
             app_time: DateTime.new(filing_year, 3, 15).to_s
           }
         }
@@ -170,8 +169,16 @@ RSpec.describe StateFile::TaxesOwedForm do
           expect(form.errors).to include :routing_number_confirmation
           expect(form.errors).to include :account_number_confirmation
           expect(form.errors).to include :account_type
-          expect(form.errors).to include :withdraw_amount
           expect(form.errors).to include :date_electronic_withdrawal
+        end
+      end
+
+      shared_examples "withdraw amount is user-entered" do
+        it "rejects withdraw amount value nil" do
+          form = described_class.new(intake, params.merge(withdraw_amount: nil))
+          expect(form).not_to be_valid
+          expect(form.errors).to include :withdraw_amount
+          expect(form.errors.first&.type).to eq :blank
         end
 
         it "rejects withdraw amount value 0" do
@@ -187,6 +194,23 @@ RSpec.describe StateFile::TaxesOwedForm do
           expect(form.errors).to include :withdraw_amount
           expect(form.errors.first&.type).to eq "Please enter in an amount less than or equal to " + taxes_owed.to_s
         end
+      end
+
+      shared_examples "withdraw amount is auto-calculated" do
+        it "auto-fills withdraw amount to save" do
+          form = described_class.new(intake, params.merge(withdraw_amount: nil))
+          expect(form).to be_valid
+          form.save
+
+          intake.reload
+          expect(intake.withdraw_amount).to eq taxes_owed
+        end
+      end
+
+      if StateFile::StateInformationService.auto_calculate_withdraw_amount(state_code)
+        it_behaves_like "withdraw amount is auto-calculated"
+      else
+        it_behaves_like "withdraw amount is user-entered"
       end
     end
   end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/339

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Rather than making this just NJ-specific, add new `auto_calculate_withdraw_amount` flag to StateInformationService, any state that implements it will receive this behavior
- When `auto_calculate_withdraw_amount` is true, on the taxes_owed screen, remove the input box for `withdraw_amount` and instead auto-fill the amount on save based on taxes owed. Show an authorization text instead.

## How to test?
Use `jones mfj` for a persona that will owe taxes

## Screenshots (for visual changes)
![image](https://github.com/user-attachments/assets/8ebaaed2-9d92-46b7-8bcd-1003bb31ecaf)
