### PR TITLE
[GYR1-719] Show faq description on GYR faq category

### DIFF
--- a/app/views/faq/section_index.html.erb
+++ b/app/views/faq/section_index.html.erb
@@ -14,6 +14,9 @@
       <div class="grid__item width-one-whole faq-wrapper">
         <h1 class="h2"><%= @faq_category.name(I18n.locale) %></h1>
 
+        <% if @faq_category.description_en || @faq_category.description_es %>
+          <p><%= @faq_category.description(I18n.locale) %></p>
+        <% end %>
         <% @faq_items.each do |faq_item| %>
           <p>
             <%= link_to faq_item.question(I18n.locale),


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/GYR1-719
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Due to the recent events, we want to update faq categories with information (see [doc - FAQ category descriptions
](https://docs.google.com/document/d/17HRp9yW9c3mSvTIC-JaySdFAaNl-zagmS31PRvHBjzY/edit?tab=t.0#bookmark=id.qmmr00rvwam4). Even though Rae had updated the descriptions, it appeared to not save (which is a separate bug https://codeforamerica.atlassian.net/browse/GYR1-720)
- At least show description_en / description_es if it was added to the faq_category when you go to "View all questions" section (url: `/faq/stimulus`)

## How to test?
- Describe the testing approach taken to verify the changes, including:
  - Visual
## Screenshots (for visual changes)
- Before
<img width="353" alt="Screenshot 2025-04-11 at 3 40 28 PM" src="https://github.com/user-attachments/assets/a1c26779-5abe-499f-9204-e2022de8f4eb" />

- After
<img width="422" alt="Screenshot 2025-04-11 at 3 35 21 PM" src="https://github.com/user-attachments/assets/52b99bc7-9376-4309-a5d7-b8dad1505357" />
<img width="569" alt="Screenshot 2025-04-11 at 3 35 24 PM" src="https://github.com/user-attachments/assets/ca438c58-1107-4762-a1ce-8c56457d606a" />
