### PR TITLE
handle missing app_time param in nc taxes owed form

### DIFF
--- a/app/forms/state_file/nc_taxes_owed_form.rb
+++ b/app/forms/state_file/nc_taxes_owed_form.rb
@@ -17,7 +17,8 @@ module StateFile
 
     def save
       attrs = attributes_for(:intake)
-      date = form_submitted_before_payment_deadline? ? date_electronic_withdrawal : @intake.next_available_date(Time.parse(app_time))
+      current_time = app_time.present? ? DateTime.parse(app_time) : DateTime.current
+      date = form_submitted_before_payment_deadline? ? date_electronic_withdrawal : @intake.next_available_date(current_time)
 
       @intake.update(attrs.merge(date_electronic_withdrawal: date))
     end


### PR DESCRIPTION
## Link to Sentry issue
- https://codeforamerica.sentry.io/issues/6538054649/?alert_rule_id=1046555&alert_type=issue&notification_uuid=8596efa0-24df-4def-b875-5efe91a3d2c8&project=1880327&referrer=slack
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Our followup question javascript has been disabling the hidden `app_time` field that we use to pass the `app_time` to the taxes owed form, which was meant to allow testing submission at different simulated dates
- This only surfaced now because until now, submissions were before the payment deadline and we were using  `date_electronic_withdrawal` instead of the application's current time (and therefore we were never checking the presence of the `app_time` param)
## How to test?
- On DEMO: Go through the NC flow with a filer who owes (Bert will work) and try to move past the `/nc-taxes-owed` page. Verify that the app crashes.
- On this PR's HEROKU: Do the same thing. Verify that the app does not crash
