### PR TITLE
fully migrate nj 1099R followups to subflows, and preserve their intended functionality of showing followup pages for all 1099Rs instead of just ones with a non-zero taxable amount

### DIFF
--- a/app/controllers/state_file/questions/nj_retirement_income_source_controller.rb
+++ b/app/controllers/state_file/questions/nj_retirement_income_source_controller.rb
@@ -1,68 +1,14 @@
 module StateFile
   module Questions
-    class NjRetirementIncomeSourceController < QuestionsController
+    class NjRetirementIncomeSourceController < RetirementIncomeSubtractionController
+      def followup_class = StateFileNc1099RFollowup
 
-      before_action :load_1099r
-
-      def load_1099r
-        @index = params[:index].present? ? params[:index].to_i : 0
-        @state_file_1099r =
-          if params[:index].present?
-            current_intake.state_file1099_rs[params[:index].to_i]
-          else
-            current_intake.state_file1099_rs.first
-          end
-
-        @name_1099r = @state_file_1099r.payer_name
-        @taxpayer_name = @state_file_1099r.recipient_name
-        @amount = @state_file_1099r.taxable_amount
-      end
-
-      def initialized_edit_form
-        attribute_keys = Attributes.new(form_class.attribute_names).to_sym
-        state_specific_followup = retrieve_or_create_state_specific_followup
-        form_class.new(state_specific_followup, form_class.existing_attributes(state_specific_followup).slice(*attribute_keys))
-      end
-
-      def initialized_update_form
-        form_class.new(retrieve_or_create_state_specific_followup, form_params)
-      end
-
-      def retrieve_or_create_state_specific_followup
-        unless @state_file_1099r.state_specific_followup.present?
-          @state_file_1099r.state_specific_followup = StateFileNj1099RFollowup.create
-          @state_file_1099r.save
-        end
-
-        @state_file_1099r.state_specific_followup
-      end
-
-      def self.show?(intake)
+      def self.show?(intake, item_index: nil)
         Flipper.enabled?(:show_retirement_ui) && intake.state_file1099_rs.length.positive?
       end
 
-      def prev_path
-        options = {}
-        options[:return_to_review] = params[:return_to_review] if params[:return_to_review].present?
-        prev_index = @index - 1
-        if prev_index.negative?
-          super
-        else
-          options[:index] = prev_index
-          NjRetirementIncomeSourceController.to_path_helper(options)
-        end
-      end
-
-      def next_path
-        options = {}
-        options[:return_to_review] = params[:return_to_review] if params[:return_to_review].present?
-        next_index = @index + 1
-        if next_index >= current_intake.direct_file_data.form1099r_nodes.length
-          super
-        else
-          options[:index] = next_index
-          NjRetirementIncomeSourceController.to_path_helper(options)
-        end
+      def self.load_1099r(intake, index)
+        intake.state_file1099_rs[index]
       end
     end
   end

--- a/app/controllers/state_file/questions/nj_retirement_income_source_controller.rb
+++ b/app/controllers/state_file/questions/nj_retirement_income_source_controller.rb
@@ -1,7 +1,7 @@
 module StateFile
   module Questions
     class NjRetirementIncomeSourceController < RetirementIncomeSubtractionController
-      def followup_class = StateFileNc1099RFollowup
+      def followup_class = StateFileNj1099RFollowup
 
       def self.show?(intake, item_index: nil)
         Flipper.enabled?(:show_retirement_ui) && intake.state_file1099_rs.length.positive?

--- a/app/controllers/state_file/questions/nj_retirement_income_source_controller.rb
+++ b/app/controllers/state_file/questions/nj_retirement_income_source_controller.rb
@@ -2,14 +2,6 @@ module StateFile
   module Questions
     class NjRetirementIncomeSourceController < RetirementIncomeSubtractionController
       def followup_class = StateFileNj1099RFollowup
-
-      def self.show?(intake, item_index: nil)
-        Flipper.enabled?(:show_retirement_ui) && intake.state_file1099_rs.length.positive?
-      end
-
-      def self.load_1099r(intake, index)
-        intake.state_file1099_rs[index]
-      end
     end
   end
 end

--- a/app/controllers/state_file/questions/retirement_income_subtraction_controller.rb
+++ b/app/controllers/state_file/questions/retirement_income_subtraction_controller.rb
@@ -21,10 +21,6 @@ module StateFile
 
       private
 
-      def num_items
-        current_intake.eligible_1099rs.count
-      end
-
       def load_item(index)
         @state_file_1099r = self.class.load_1099r(current_intake, index)
         if state_file_1099r.nil?

--- a/app/lib/navigation/state_file_nj_question_navigation.rb
+++ b/app/lib/navigation/state_file_nj_question_navigation.rb
@@ -34,7 +34,7 @@ module Navigation
                                           Navigation::RepeatedMultiPageStep.new(
                                             "retirement_income_deduction",
                                             [StateFile::Questions::NjRetirementIncomeSourceController],
-                                            ->(intake) { intake&.state_file1099_rs&.count }),
+                                            ->(intake) { intake&.eligible_1099rs&.count }),
                                           Navigation::NavigationStep.new(StateFile::Questions::NjRetirementWarningController),
                                         ]),
       Navigation::NavigationSection.new("state_file.navigation.nj.section_2", [

--- a/app/lib/navigation/state_file_nj_question_navigation.rb
+++ b/app/lib/navigation/state_file_nj_question_navigation.rb
@@ -34,7 +34,7 @@ module Navigation
                                           Navigation::RepeatedMultiPageStep.new(
                                             "retirement_income_deduction",
                                             [StateFile::Questions::NjRetirementIncomeSourceController],
-                                            ->(intake) { intake&.eligible_1099rs&.count }),
+                                            ->(intake) { intake&.state_file1099_rs&.count }),
                                           Navigation::NavigationStep.new(StateFile::Questions::NjRetirementWarningController),
                                         ]),
       Navigation::NavigationSection.new("state_file.navigation.nj.section_2", [

--- a/app/models/state_file_nj_intake.rb
+++ b/app/models/state_file_nj_intake.rb
@@ -236,4 +236,8 @@ class StateFileNjIntake < StateFileBaseIntake
       w2.errors.add(:state_wages_amount, I18n.t("state_file.questions.w2.edit.state_wages_amt_error"))
     end
   end
+
+  def eligible_1099rs
+    self.state_file1099_rs
+  end
 end

--- a/app/models/state_file_nj_intake.rb
+++ b/app/models/state_file_nj_intake.rb
@@ -238,6 +238,6 @@ class StateFileNjIntake < StateFileBaseIntake
   end
 
   def eligible_1099rs
-    self.state_file1099_rs
+    state_file1099_rs
   end
 end

--- a/app/views/state_file/questions/nj_retirement_income_source/edit.html.erb
+++ b/app/views/state_file/questions/nj_retirement_income_source/edit.html.erb
@@ -8,9 +8,9 @@
     <h1 class="h2"><%= title %></h1>
     <p><%= t(".subtitle") %></p>
   </hgroup>
-  <p><%= t(".doc_1099r_label") %> <b><%= @name_1099r %></b></p>
-  <p><%= t(".taxpayer_name_label") %> <b><%= @taxpayer_name %></b></p>
-  <p><%= t(".taxable_amount_label") %> <b><%= number_to_currency(@amount, precision: 0) %></b></p>
+  <p><%= t(".doc_1099r_label") %> <b><%= @state_file_1099r.payer_name %></b></p>
+  <p><%= t(".taxpayer_name_label") %> <b><%= @state_file_1099r.recipient_name %></b></p>
+  <p><%= t(".taxable_amount_label") %> <b><%= number_to_currency(@state_file_1099r.taxable_amount, precision: 0) %></b></p>
 
   <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
     <div class="white-group">

--- a/app/views/state_file/questions/nj_review/edit.html.erb
+++ b/app/views/state_file/questions/nj_review/edit.html.erb
@@ -2,13 +2,13 @@
 <% content_for :card do %>
 
   <%= render "state_file/questions/shared/review_header" %>
-  
-  <% if current_intake.state_file1099_rs.length.positive? && Flipper.enabled?(:show_retirement_ui) %>
+
+  <% if current_intake.eligible_1099rs.length.positive? && Flipper.enabled?(:show_retirement_ui) %>
     <section id="retirement-income-source" class="white-group">
       <div class="spacing-below-5">
         <h2 class="text--body text--bold spacing-below-25"><%=t(".retirement_income_source") %></h2>
 
-        <% current_intake.state_file1099_rs.each do |state_file1099_r| %>
+        <% current_intake.eligible_1099rs.each do |state_file1099_r| %>
           <% unless state_file1099_r.state_specific_followup.nil? %>
             <div class="spacing-below-5 with-top-separator">
               <p><%= t(".retirement_income_source_doc_1099r_label") %> <b><%= state_file1099_r.payer_name %></b></p>

--- a/app/views/state_file/questions/nj_review/edit.html.erb
+++ b/app/views/state_file/questions/nj_review/edit.html.erb
@@ -29,7 +29,8 @@
             </div>
           <% end %>
         <% end %>
-        <%= link_to StateFile::Questions::NjRetirementIncomeSourceController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
+        <%= link_to StateFile::Questions::NjRetirementIncomeSourceController.to_path_helper(return_to_review_after: "retirement_income_deduction",
+                                                                                            return_to_review_before: "retirement_income_deduction"), class: "button--small" do %>
           <%= t("general.review_and_edit") %>
           <span class="sr-only"><%= t(".retirement_income_source") %></span>
         <% end %>

--- a/spec/controllers/state_file/questions/nj_retirement_income_source_controller_spec.rb
+++ b/spec/controllers/state_file/questions/nj_retirement_income_source_controller_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe StateFile::Questions::NjRetirementIncomeSourceController do
 
     context "when an index param is provided" do
       it "renders the data for the 1099R at that index" do
-        get :edit, params: { index: 1 }
+        get :edit, params: { item_index: 1 }
         expect(response.body).to include("Payer 2 Name")
         expect(response.body).to include("$3,000")
         expect(response.body).to include("Hera Thunder")
@@ -74,15 +74,15 @@ RSpec.describe StateFile::Questions::NjRetirementIncomeSourceController do
       context "when there are additional 1099Rs to view" do
         it "next path is NjRetirementIncomeSourceController with new index set" do
           post :update
-          expect(subject.next_path).to eq("/en/questions/nj-retirement-income-source?index=1")
+          expect(subject.send(:next_path)).to eq("/en/questions/nj-retirement-income-source?item_index=1")
         end
       end
 
       context "when there are no additional 1099Rs to view" do
         it "next path is whichever is next overall" do
-          post :update, params: {index: "1"}
+          post :update, params: {item_index: "1"}
           allow_any_instance_of(described_class.superclass).to receive(:next_path).and_return("/mocked/super/path")
-          expect(subject.next_path).to eq("/mocked/super/path")
+          expect(subject.send(:next_path)).to eq("/mocked/super/path")
         end
       end
     end
@@ -90,15 +90,15 @@ RSpec.describe StateFile::Questions::NjRetirementIncomeSourceController do
     context 'when return_to_review' do
       context "when there are additional 1099Rs to view" do
         it "next path is NjRetirementIncomeSourceController with new index set and review param" do
-          post :update, params: { return_to_review: "y" }
-          expect(subject.next_path).to eq("/en/questions/nj-retirement-income-source?index=1&return_to_review=y")
+          post :update, params: { return_to_review_after: "retirement_income_deduction" }
+          expect(subject.send(:next_path)).to eq("/en/questions/nj-retirement-income-source?item_index=1&return_to_review_after=retirement_income_deduction")
         end
       end
 
       context "when there are no additional 1099Rs to view" do
         it "next path is Review Controller" do
-          post :update, params: {index: "1", return_to_review: "y"}
-          expect(subject.next_path).to eq("/en/questions/#{intake.state_code}-review")
+          post :update, params: {item_index: "1", return_to_review_after: "retirement_income_deduction"}
+          expect(subject.send(:next_path)).to eq("/en/questions/#{intake.state_code}-review")
         end
       end
     end
@@ -110,8 +110,8 @@ RSpec.describe StateFile::Questions::NjRetirementIncomeSourceController do
     context 'when not return_to_review' do
       context "when there are previous 1099Rs to view" do
         it "prev path is NjRetirementIncomeSourceController with prev index set" do
-          get :edit, params: { index: "1" }
-          expect(subject.prev_path).to eq("/en/questions/nj-retirement-income-source?index=0")
+          get :edit, params: { item_index: "1" }
+          expect(subject.send(:prev_path)).to eq("/en/questions/nj-retirement-income-source?item_index=0")
         end
       end
 
@@ -119,7 +119,7 @@ RSpec.describe StateFile::Questions::NjRetirementIncomeSourceController do
         it "prev path is whichever is previous overall" do
           get :edit
           allow_any_instance_of(described_class.superclass).to receive(:prev_path).and_return("/mocked/super/path")
-          expect(subject.prev_path).to eq("/mocked/super/path")
+          expect(subject.send(:prev_path)).to eq("/mocked/super/path")
         end
       end
     end
@@ -127,15 +127,15 @@ RSpec.describe StateFile::Questions::NjRetirementIncomeSourceController do
     context 'when return_to_review' do
       context "when there are previous 1099Rs to view" do
         it "prev path is NjRetirementIncomeSourceController with prev index and return to review set" do
-          get :edit, params: { index: "1", return_to_review: "y" }
-          expect(subject.prev_path).to eq("/en/questions/nj-retirement-income-source?index=0&return_to_review=y")
+          get :edit, params: { item_index: "1", return_to_review_before: "retirement_income_deduction" }
+          expect(subject.send(:prev_path)).to eq("/en/questions/nj-retirement-income-source?item_index=0&return_to_review_before=retirement_income_deduction")
         end
       end
 
       context "when there are no previous 1099Rs to view" do
         it "prev path is review screen" do
-          get :edit, params: { return_to_review: "y" }
-          expect(subject.prev_path).to eq("/en/questions/nj-review")
+          get :edit, params: { return_to_review_before: "retirement_income_deduction" }
+          expect(subject.send(:prev_path)).to eq("/en/questions/nj-review")
         end
       end
     end

--- a/spec/models/state_file_base_intake_spec.rb
+++ b/spec/models/state_file_base_intake_spec.rb
@@ -385,7 +385,7 @@ describe StateFileBaseIntake do
   end
 
   describe "#eligible_1099rs" do
-    %w[az md nc nj].each do |state_code|
+    %w[az md nc].each do |state_code|
       let(:intake) { create "state_file_#{state_code}_intake".to_sym }
       let!(:eligible_1099r) { create(:state_file1099_r, intake: intake, taxable_amount: 200) }
       let!(:ineligible_1099r) { create(:state_file1099_r, intake: intake, taxable_amount: 0) }

--- a/spec/models/state_file_nj_intake_spec.rb
+++ b/spec/models/state_file_nj_intake_spec.rb
@@ -345,4 +345,14 @@ RSpec.describe StateFileNjIntake, type: :model do
       expect(intake.medical_expenses_threshold).to eq 246
     end
   end
+
+  describe "#eligible_1099rs" do
+    let(:intake) { create :state_file_nj_intake }
+    let!(:eligible_1099r) { create(:state_file1099_r, intake: intake, taxable_amount: 200) }
+    let!(:ineligible_1099r) { create(:state_file1099_r, intake: intake, taxable_amount: 0) }
+
+    it "should return all 1099Rs" do
+      expect(intake.eligible_1099rs).to contain_exactly(eligible_1099r, ineligible_1099r)
+    end
+  end
 end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-2041
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- NJ's 1099-R followup pages were partially migrated onto the subflows code - I changed their question navigation class and what params were carried from page to page by the continue button partial, but didn't update the controller, tests or review page link.
- This PR updates their controller to use the same `RetirementIncomeSubtractionController` superclass as the other controllers doing the same job, while overriding the `self.show?` and `self.load_1099r` methods to use the full list of 1099rs instead of just those with taxable amounts, as other states do.
- It also updates the review page link to return to review before or after the full `retirement_income_deduction` step, which was already their implemented functionality, but which now is something they get for free with subflows.
## How to test?
- Go through the NJ flow using a persona with multiple 1099-Rs and verify that you can proceed past the second one. Verify that you can return to retirement income deduction from the final review page and that you return to review after using the back button from the first 1099-R or the continue button from the last 1099-R.
