### PR TITLE
[FYST-2043] Handle negative federal AGI in NC D400 tax calculator

### DIFF
--- a/app/lib/efile/nc/d400_calculator.rb
+++ b/app/lib/efile/nc/d400_calculator.rb
@@ -92,11 +92,11 @@ module Efile
 
       def calculate_line_10b
         income_ranges = if filing_status_single? || filing_status_mfs?
-                          [0..20_000, 20_001..30_000, 30_001..40_000, 40_001..50_000, 50_001..60_000, 60_001..70_000, 70_001..Float::INFINITY]
+                          [-Float::INFINITY..20_000, 20_001..30_000, 30_001..40_000, 40_001..50_000, 50_001..60_000, 60_001..70_000, 70_001..Float::INFINITY]
                         elsif filing_status_hoh?
-                          [0..30_000, 30_001..45_000, 45_001..60_000, 60_001..75_000, 75_001..90_000, 90_001..105_000, 105_001..Float::INFINITY]
+                          [-Float::INFINITY..30_000, 30_001..45_000, 45_001..60_000, 60_001..75_000, 75_001..90_000, 90_001..105_000, 105_001..Float::INFINITY]
                         elsif filing_status_mfj? || filing_status_qw?
-                          [0..40_000, 40_001..60_000, 60_001..80_000, 80_001..100_000, 100_001..120_000, 120_001..140_000, 140_001..Float::INFINITY]
+                          [-Float::INFINITY..40_000, 40_001..60_000, 60_001..80_000, 80_001..100_000, 100_001..120_000, 120_001..140_000, 140_001..Float::INFINITY]
                         end
         income_range_index = income_ranges.find_index { |range| range.include?(@direct_file_data.fed_agi) }
 

--- a/spec/lib/efile/nc/d400_calculator_spec.rb
+++ b/spec/lib/efile/nc/d400_calculator_spec.rb
@@ -58,16 +58,24 @@ describe Efile::Nc::D400Calculator do
     end
 
     context "with negative AGI" do
-      let(:intake) { create(:state_file_nc_intake, filing_status: :single, raw_direct_file_data: StateFile::DirectFileApiResponseSampleService.new.read_xml("nc_nala_hoh")) }
-      let(:calculator_instance) { described_class.new(year: MultiTenantService.statefile.current_tax_year, intake: intake) }
+      let(:raw_direct_file_data) { StateFile::DirectFileApiResponseSampleService.new.read_xml("nc_nala_hoh") }
+      let(:tax_year) { MultiTenantService.statefile.current_tax_year }
 
-      it "uses the lowest income range" do
-        intake.direct_file_data.fed_agi = -5000
-        intake.direct_file_data.qualifying_children_under_age_ssn_count = 2
-
-        calculator_instance.calculate
-        # For single filer, AGI <= 20_000 results in $3000 per child
-        expect(calculator_instance.lines[:NCD400_LINE_10B].value).to eq(6000)
+      it "uses the lowest income range in each filing status" do
+        [
+          :single,
+          :head_of_household,
+          :married_filing_jointly,
+          :married_filing_separately,
+          :qualifying_widow,
+        ].each do |filing_status|
+          intake = create(:state_file_nc_intake, filing_status: filing_status, raw_direct_file_data: raw_direct_file_data)
+          intake.direct_file_data.fed_agi = -5000
+          intake.direct_file_data.qualifying_children_under_age_ssn_count = 2
+          calculator_instance = described_class.new(year: tax_year, intake: intake)
+          calculator_instance.calculate
+          expect(calculator_instance.lines[:NCD400_LINE_10B].value).to eq(6000)
+        end
       end
     end
   end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/FYST-2043

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
Expanded the lowest range by replacing [the zeros on these lines](https://github.com/codeforamerica/vita-min/blob/fcefeeb54a84bda06ba3e94d3018fd536913a1ef/app/lib/efile/nc/d400_calculator.rb#L95-L99) with `-Float::INFINITY`

## How to test?
Start any NC intake, edit xml to make income negative, then verify `nc-subtractions` page loads without error
## Screenshots (for visual changes)
- Before
- After
