### PR TITLE
Fyst 2039 id implement the apply 2023 refund page

### DIFF
--- a/app/controllers/state_file/questions/apply_refund_controller.rb
+++ b/app/controllers/state_file/questions/apply_refund_controller.rb
@@ -1,0 +1,9 @@
+module StateFile
+  module Questions
+    class ApplyRefundController < QuestionsController
+      def self.show?(intake)
+        Flipper.enabled?(:extension_period)
+      end
+    end
+  end
+end

--- a/app/forms/state_file/apply_refund_form.rb
+++ b/app/forms/state_file/apply_refund_form.rb
@@ -1,0 +1,22 @@
+module StateFile
+  class ApplyRefundForm < QuestionsForm
+    set_attributes_for :intake, :paid_prior_year_refund_payments, :prior_year_refund_payments_amount
+    validates :paid_prior_year_refund_payments, inclusion: { in: %w[yes no], message: :blank }
+    validates :prior_year_refund_payments_amount,
+              presence: true,
+              numericality: {
+                allow_blank: false,
+                greater_than: 0,
+                message: I18n.t("validators.not_a_number")
+              },
+              if: -> { paid_prior_year_refund_payments == "yes" }
+
+    def save
+      if paid_prior_year_refund_payments == "no"
+        @intake.update(paid_prior_year_refund_payments: "no", prior_year_refund_payments_amount: 0)
+      else
+        @intake.update(attributes_for(:intake))
+      end
+    end
+  end
+end

--- a/app/lib/efile/id/id40_calculator.rb
+++ b/app/lib/efile/id/id40_calculator.rb
@@ -262,7 +262,15 @@ module Efile
       end
 
       def calculate_line_47
-        @intake.paid_extension_payments_yes? ? @intake.extension_payments_amount&.round : 0
+        value = 0
+        if @intake.paid_extension_payments_yes?
+          value += @intake.extension_payments_amount&.round
+        end
+
+        if @intake.paid_prior_year_refund_payments_yes?
+          value += @intake.prior_year_refund_payments_amount&.round
+        end
+        value
       end
 
       def calculate_line_50

--- a/app/lib/efile/id/id40_calculator.rb
+++ b/app/lib/efile/id/id40_calculator.rb
@@ -264,11 +264,11 @@ module Efile
       def calculate_line_47
         value = 0
         if @intake.paid_extension_payments_yes?
-          value += @intake.extension_payments_amount&.round
+          value += @intake.extension_payments_amount&.round || 0
         end
 
         if @intake.paid_prior_year_refund_payments_yes?
-          value += @intake.prior_year_refund_payments_amount&.round
+          value += @intake.prior_year_refund_payments_amount&.round || 0
         end
         value
       end

--- a/app/lib/navigation/state_file_id_question_navigation.rb
+++ b/app/lib/navigation/state_file_id_question_navigation.rb
@@ -43,6 +43,7 @@ module Navigation
         Navigation::NavigationStep.new(StateFile::Questions::IdGroceryCreditReviewController),
         Navigation::NavigationStep.new(StateFile::Questions::IdSalesUseTaxController),
         Navigation::NavigationStep.new(StateFile::Questions::ExtensionPaymentsController),
+        Navigation::NavigationStep.new(StateFile::Questions::ApplyRefundController),
         Navigation::NavigationStep.new(StateFile::Questions::IdPermanentBuildingFundController),
         Navigation::NavigationStep.new(StateFile::Questions::PrimaryStateIdController),
         Navigation::NavigationStep.new(StateFile::Questions::SpouseStateIdController),

--- a/app/models/state_file_id_intake.rb
+++ b/app/models/state_file_id_intake.rb
@@ -41,7 +41,7 @@
 #  nongame_wildlife_fund_donation                 :decimal(12, 2)
 #  opportunity_scholarship_program_donation       :decimal(12, 2)
 #  paid_extension_payments                        :integer          default("unfilled"), not null
-#  paid_prior_year_refund_payments                :integer          default(0), not null
+#  paid_prior_year_refund_payments                :integer          default("unfilled"), not null
 #  payment_or_deposit_type                        :integer          default("unfilled"), not null
 #  phone_number                                   :string
 #  phone_number_verified_at                       :datetime

--- a/app/models/state_file_id_intake.rb
+++ b/app/models/state_file_id_intake.rb
@@ -41,6 +41,7 @@
 #  nongame_wildlife_fund_donation                 :decimal(12, 2)
 #  opportunity_scholarship_program_donation       :decimal(12, 2)
 #  paid_extension_payments                        :integer          default("unfilled"), not null
+#  paid_prior_year_refund_payments                :integer          default(0), not null
 #  payment_or_deposit_type                        :integer          default("unfilled"), not null
 #  phone_number                                   :string
 #  phone_number_verified_at                       :datetime
@@ -54,6 +55,7 @@
 #  primary_middle_initial                         :string
 #  primary_months_ineligible_for_grocery_credit   :integer
 #  primary_suffix                                 :string
+#  prior_year_refund_payments_amount              :decimal(12, 2)
 #  raw_direct_file_data                           :text
 #  raw_direct_file_intake_data                    :jsonb
 #  received_id_public_assistance                  :integer          default("unfilled"), not null
@@ -105,6 +107,7 @@ class StateFileIdIntake < StateFileBaseIntake
   enum primary_disabled: { unfilled: 0, yes: 1, no: 2 }, _prefix: :primary_disabled
   enum spouse_disabled: { unfilled: 0, yes: 1, no: 2 }, _prefix: :spouse_disabled
   enum paid_extension_payments: { unfilled: 0, yes: 1, no: 2 }, _prefix: :paid_extension_payments
+  enum paid_prior_year_refund_payments: { unfilled: 0, yes: 1, no: 2 }, _prefix: :paid_prior_year_refund_payments
 
   def disqualifying_df_data_reason; end
 

--- a/app/views/state_file/questions/apply_refund/edit.html.erb
+++ b/app/views/state_file/questions/apply_refund/edit.html.erb
@@ -14,7 +14,7 @@
     <div class="question-with-follow-up">
       <div class="question-with-follow-up__question">
         <div class="white-group">
-          <%= f.cfa_radio_set(:paid_extension_payments, collection: [
+          <%= f.cfa_radio_set(:paid_prior_year_refund_payments, collection: [
             {
               value: "yes",
               label: t(".affirmative", current_tax_year: current_year, prior_tax_year: prior_year),
@@ -31,7 +31,7 @@
       <div class="question-with-follow-up__follow-up" id="used_refund">
         <div class="white-group">
           <p><%= t(".enter_amount_html", current_tax_year: current_year, prior_tax_year: prior_year) %></p>
-          <%= f.vita_min_money_field(:extension_payments_amount, t(".amount_label", current_tax_year: current_year, prior_tax_year: prior_year), classes: ["form-width--long"]) %>
+          <%= f.vita_min_money_field(:prior_year_refund_payments_amount, t(".amount_label", current_tax_year: current_year, prior_tax_year: prior_year), classes: ["form-width--long"]) %>
         </div>
       </div>
     </div>

--- a/app/views/state_file/questions/apply_refund/edit.html.erb
+++ b/app/views/state_file/questions/apply_refund/edit.html.erb
@@ -3,7 +3,7 @@
 
 <% title = t(".title", current_tax_year: current_year, prior_tax_year: prior_year) %>
 
-<% content_for :page_title, title.presence || "Default Page Title" %>
+<% content_for :page_title %>
 <% content_for :card do %>
   <h1 class="h2"><%= title %></h1>
 

--- a/app/views/state_file/questions/apply_refund/edit.html.erb
+++ b/app/views/state_file/questions/apply_refund/edit.html.erb
@@ -1,0 +1,41 @@
+<% current_year = current_tax_year %>
+<% prior_year = current_tax_year - 1 %>
+
+<% title = t(".title", current_tax_year: current_year, prior_tax_year: prior_year) %>
+
+<% content_for :page_title, title.presence || "Default Page Title" %>
+<% content_for :card do %>
+  <h1 class="h2"><%= title %></h1>
+
+  <p><%= t(".subtitle_1", current_tax_year: current_year, prior_tax_year: prior_year) %></p>
+  <p><%= t(".subtitle_2_html", current_tax_year: current_year, prior_tax_year: prior_year) %></p>
+
+  <%= form_with model: @form, url: { action: :update }, local: true, method: "put", builder: VitaMinFormBuilder do |f| %>
+    <div class="question-with-follow-up">
+      <div class="question-with-follow-up__question">
+        <div class="white-group">
+          <%= f.cfa_radio_set(:paid_extension_payments, collection: [
+            {
+              value: "yes",
+              label: t(".affirmative", current_tax_year: current_year, prior_tax_year: prior_year),
+              input_html: { "data-follow-up": "#used_refund" }
+            },
+            {
+              value: "no",
+              label: t(".negative", current_tax_year: current_year, prior_tax_year: prior_year)
+            }
+          ]) %>
+        </div>
+      </div>
+
+      <div class="question-with-follow-up__follow-up" id="used_refund">
+        <div class="white-group">
+          <p><%= t(".enter_amount_html", current_tax_year: current_year, prior_tax_year: prior_year) %></p>
+          <%= f.vita_min_money_field(:extension_payments_amount, t(".amount_label", current_tax_year: current_year, prior_tax_year: prior_year), classes: ["form-width--long"]) %>
+        </div>
+      </div>
+    </div>
+
+    <%= f.continue %>
+  <% end %>
+<% end %>

--- a/app/views/state_file/questions/extension_payments/_form.html.erb
+++ b/app/views/state_file/questions/extension_payments/_form.html.erb
@@ -7,7 +7,7 @@
 <% affirmative = I18n.t(:affirmative, scope: i18n_scope) %>
 <% negative = I18n.t(:negative, scope: i18n_scope) %>
 
-<% content_for :page_title, title.presence || "Default Page Title" %>
+<% content_for :page_title %>
 <% content_for :card do %>
   <h1 class="h2"><%= title %></h1>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2335,6 +2335,15 @@ en:
         mistake: Is this a mistake?
         title: You've opted out of email notifications from FileYourStateTaxes.
     questions:
+      apply_refund:
+        edit:
+          affirmative: Yes, I used a portion of my %{prior_tax_year} refund towards my %{current_tax_year} taxes
+          amount_label: "<strong>Amount of %{prior_tax_year} Idaho refund used towards %{current_tax_year} state taxes</strong>"
+          enter_amount_html: Enter the amount next to “Apply to %{current_tax_year}” on line 56 of your %{prior_tax_year} Individual Income Tax Return <a href="https://tax.idaho.gov/wp-content/uploads/forms/EFO00089/EFO00089_09-04-2024.pdf" target="_blank">Form 40</a>.
+          negative: No, I didn’t use a portion of my %{prior_tax_year} refund towards my %{current_tax_year} taxes
+          subtitle_1: If you received a refund from your %{prior_tax_year} state taxes, you could have applied a portion of that amount to help pay your income tax for %{current_tax_year}. This is an uncommon scenario for our service.
+          subtitle_2_html: You can find this amount next to “Apply to %{current_tax_year}” on line 56 of your %{prior_tax_year} Individual Income Tax Return <a href="https://tax.idaho.gov/wp-content/uploads/forms/EFO00089/EFO00089_09-04-2024.pdf" target="_blank">Form 40</a>.
+          title: Did you apply a portion of your %{prior_tax_year} Idaho state refund toward your %{current_tax_year} taxes?
       az_charitable_contributions:
         edit:
           amount_cannot_exceed: This amount may not exceed $500

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2317,6 +2317,15 @@ es:
         mistake: "¿Fue un error?"
         title: Has optado por no recibir notificaciones por correo electrónico de FileYourStateTaxes.
     questions:
+      apply_refund:
+        edit:
+          affirmative: Sí, usé una parte de tu reembolso del estado de Idaho de %{prior_tax_year} a tus impuestos de %{current_tax_year}
+          amount_label: "<strong>Cantidad del reembolso de Idaho de %{prior_tax_year} utilizada para los impuestos estatales de %{current_tax_year}</strong>"
+          enter_amount_html: Ingresa la cantidad al lado de “Apply to %{current_tax_year}” en la línea 56 de tu Declaración de Impuestos Individual de %{prior_tax_year} <a href="https://tax.idaho.gov/wp-content/uploads/forms/EFO00089/EFO00089_09-04-2024.pdf" target="_blank">Formulario 40</a>.
+          negative: No, no usé una parte de tu reembolso del estado de Idaho de %{prior_tax_year} a tus impuestos de %{current_tax_year}
+          subtitle_1: Si recibiste un reembolso de tus impuestos estatales de %{prior_tax_year}, podrías haber aplicado una parte de esa cantidad para ayudar a pagar tu impuesto de %{current_tax_year}. Este es un escenario poco común para nuestro servicio.
+          subtitle_2_html: Puedes encontrar esta cantidad al lado de “Apply to %{current_tax_year}” en la línea 56 de tu Declaración de Impuestos Individual de %{prior_tax_year} <a href="https://tax.idaho.gov/wp-content/uploads/forms/EFO00089/EFO00089_09-04-2024.pdf" target="_blank">Formulario 40</a>.
+          title: "¿Aplicaste una parte de tu reembolso del estado de Idaho de %{prior_tax_year} a tus impuestos de %{current_tax_year}?"
       az_charitable_contributions:
         edit:
           amount_cannot_exceed: La cantidad no puede ser mayor a $500

--- a/db/migrate/20250414203545_add_prior_year_payments_to_id_intake.rb
+++ b/db/migrate/20250414203545_add_prior_year_payments_to_id_intake.rb
@@ -1,0 +1,6 @@
+class AddPriorYearPaymentsToIdIntake < ActiveRecord::Migration[7.1]
+  def change
+    add_column :state_file_id_intakes, :prior_year_refund_payments_amount, :decimal, precision: 12, scale: 2
+    add_column :state_file_id_intakes, :paid_prior_year_refund_payments, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_08_171015) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_14_203545) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -2041,6 +2041,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_08_171015) do
     t.decimal "nongame_wildlife_fund_donation", precision: 12, scale: 2
     t.decimal "opportunity_scholarship_program_donation", precision: 12, scale: 2
     t.integer "paid_extension_payments", default: 0, null: false
+    t.integer "paid_prior_year_refund_payments", default: 0, null: false
     t.integer "payment_or_deposit_type", default: 0, null: false
     t.string "phone_number"
     t.datetime "phone_number_verified_at"
@@ -2055,6 +2056,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_08_171015) do
     t.integer "primary_months_ineligible_for_grocery_credit"
     t.bigint "primary_state_id_id"
     t.string "primary_suffix"
+    t.decimal "prior_year_refund_payments_amount", precision: 12, scale: 2
     t.text "raw_direct_file_data"
     t.jsonb "raw_direct_file_intake_data"
     t.integer "received_id_public_assistance", default: 0, null: false

--- a/spec/controllers/state_file/questions/apply_refund_controller_spec.rb
+++ b/spec/controllers/state_file/questions/apply_refund_controller_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StateFile::Questions::ApplyRefundController do
+  let(:intake) { create :state_file_id_intake }
+
+  describe ".show?" do
+    context "when extension period is enabled" do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:extension_period).and_return(true)
+      end
+
+      it "returns true" do
+        expect(described_class.show?(intake)).to eq true
+      end
+    end
+
+    context "when extension period is disabled" do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:extension_period).and_return(false)
+      end
+
+      it "returns false" do
+        expect(described_class.show?(intake)).to eq false
+      end
+    end
+  end
+end
+

--- a/spec/factories/state_file_id_intakes.rb
+++ b/spec/factories/state_file_id_intakes.rb
@@ -41,7 +41,7 @@
 #  nongame_wildlife_fund_donation                 :decimal(12, 2)
 #  opportunity_scholarship_program_donation       :decimal(12, 2)
 #  paid_extension_payments                        :integer          default("unfilled"), not null
-#  paid_prior_year_refund_payments                :integer          default(0), not null
+#  paid_prior_year_refund_payments                :integer          default("unfilled"), not null
 #  payment_or_deposit_type                        :integer          default("unfilled"), not null
 #  phone_number                                   :string
 #  phone_number_verified_at                       :datetime

--- a/spec/factories/state_file_id_intakes.rb
+++ b/spec/factories/state_file_id_intakes.rb
@@ -41,6 +41,7 @@
 #  nongame_wildlife_fund_donation                 :decimal(12, 2)
 #  opportunity_scholarship_program_donation       :decimal(12, 2)
 #  paid_extension_payments                        :integer          default("unfilled"), not null
+#  paid_prior_year_refund_payments                :integer          default(0), not null
 #  payment_or_deposit_type                        :integer          default("unfilled"), not null
 #  phone_number                                   :string
 #  phone_number_verified_at                       :datetime
@@ -54,6 +55,7 @@
 #  primary_middle_initial                         :string
 #  primary_months_ineligible_for_grocery_credit   :integer
 #  primary_suffix                                 :string
+#  prior_year_refund_payments_amount              :decimal(12, 2)
 #  raw_direct_file_data                           :text
 #  raw_direct_file_intake_data                    :jsonb
 #  received_id_public_assistance                  :integer          default("unfilled"), not null

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -433,6 +433,11 @@ RSpec.feature "Completing a state file intake", active_job: true, js: true do
       choose I18n.t("state_file.questions.extension_payments.id.negative")
       click_on I18n.t("general.continue")
 
+      #Apply Refund
+      expect(page).to have_text I18n.t("state_file.questions.apply_refund.edit.title",  current_tax_year: MultiTenantService.statefile.current_tax_year, prior_tax_year: MultiTenantService.statefile.current_tax_year - 1)
+      choose I18n.t("state_file.questions.apply_refund.edit.negative")
+      click_on I18n.t("general.continue")
+
       # Permanent Building Fund
       page_change_check(I18n.t('state_file.questions.id_permanent_building_fund.edit.title'))
       choose I18n.t("general.negative")

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -439,6 +439,7 @@ RSpec.feature "Completing a state file intake", active_job: true, js: true do
       click_on I18n.t("general.continue")
 
       # Permanent Building Fund
+
       page_change_check(I18n.t('state_file.questions.id_permanent_building_fund.edit.title'))
       choose I18n.t("general.negative")
       click_on I18n.t("general.continue")

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -437,7 +437,6 @@ RSpec.feature "Completing a state file intake", active_job: true, js: true do
       expect(page).to have_text I18n.t("state_file.questions.apply_refund.edit.title", current_tax_year: MultiTenantService.statefile.current_tax_year, prior_tax_year: MultiTenantService.statefile.current_tax_year - 1)
       choose I18n.t("state_file.questions.apply_refund.edit.negative", current_tax_year: MultiTenantService.statefile.current_tax_year, prior_tax_year: MultiTenantService.statefile.current_tax_year - 1)
       click_on I18n.t("general.continue")
-
       # Permanent Building Fund
 
       page_change_check(I18n.t('state_file.questions.id_permanent_building_fund.edit.title'))

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -437,8 +437,8 @@ RSpec.feature "Completing a state file intake", active_job: true, js: true do
       expect(page).to have_text I18n.t("state_file.questions.apply_refund.edit.title", current_tax_year: MultiTenantService.statefile.current_tax_year, prior_tax_year: MultiTenantService.statefile.current_tax_year - 1)
       choose I18n.t("state_file.questions.apply_refund.edit.negative", current_tax_year: MultiTenantService.statefile.current_tax_year, prior_tax_year: MultiTenantService.statefile.current_tax_year - 1)
       click_on I18n.t("general.continue")
-      # Permanent Building Fund
 
+      # Permanent Building Fund
       page_change_check(I18n.t('state_file.questions.id_permanent_building_fund.edit.title'))
       choose I18n.t("general.negative")
       click_on I18n.t("general.continue")

--- a/spec/features/state_file/complete_intake_spec.rb
+++ b/spec/features/state_file/complete_intake_spec.rb
@@ -428,14 +428,14 @@ RSpec.feature "Completing a state file intake", active_job: true, js: true do
       fill_in 'state_file_id_sales_use_tax_form_total_purchase_amount', with: "290"
       click_on I18n.t("general.continue")
 
-      #Extension Payments
+      # Extension Payments
       expect(page).to have_text I18n.t("state_file.questions.extension_payments.id.title",  current_year: (MultiTenantService.statefile.current_tax_year + 1), tax_year: MultiTenantService.statefile.current_tax_year)
       choose I18n.t("state_file.questions.extension_payments.id.negative")
       click_on I18n.t("general.continue")
 
-      #Apply Refund
-      expect(page).to have_text I18n.t("state_file.questions.apply_refund.edit.title",  current_tax_year: MultiTenantService.statefile.current_tax_year, prior_tax_year: MultiTenantService.statefile.current_tax_year - 1)
-      choose I18n.t("state_file.questions.apply_refund.edit.negative")
+      # Apply Refund
+      expect(page).to have_text I18n.t("state_file.questions.apply_refund.edit.title", current_tax_year: MultiTenantService.statefile.current_tax_year, prior_tax_year: MultiTenantService.statefile.current_tax_year - 1)
+      choose I18n.t("state_file.questions.apply_refund.edit.negative", current_tax_year: MultiTenantService.statefile.current_tax_year, prior_tax_year: MultiTenantService.statefile.current_tax_year - 1)
       click_on I18n.t("general.continue")
 
       # Permanent Building Fund

--- a/spec/forms/state_file/apply_refund_form_spec.rb
+++ b/spec/forms/state_file/apply_refund_form_spec.rb
@@ -1,0 +1,144 @@
+require "rails_helper"
+
+RSpec.describe StateFile::ApplyRefundForm do
+  describe "#valid?" do
+    let(:intake) { create :state_file_id_intake }
+
+    context "with out entering an amount" do
+      let(:invalid_params) do
+        {
+          paid_prior_year_refund_payments: "yes",
+          prior_year_refund_payments_amount: ""
+        }
+      end
+
+      it "returns false" do
+        form = described_class.new(intake, invalid_params)
+        expect(form).not_to be_valid
+      end
+    end
+
+    context "with no radio selected" do
+      let(:invalid_params) do
+        {
+          paid_prior_year_refund_payments: "unfilled",
+          prior_year_refund_payments_amount: ""
+        }
+      end
+
+      it "returns false" do
+        form = described_class.new(intake, invalid_params)
+        expect(form).not_to be_valid
+      end
+    end
+
+    context "with no selected" do
+      let(:params) do
+        {
+          paid_prior_year_refund_payments: "no",
+          prior_year_refund_payments_amount: ""
+        }
+      end
+
+      it "returns true" do
+        form = described_class.new(intake, params)
+        expect(form).to be_valid
+      end
+    end
+
+    context "with yes selected and a valid amount" do
+      let(:invalid_params) do
+        {
+          paid_prior_year_refund_payments: "yes",
+          prior_year_refund_payments_amount: "2112"
+        }
+      end
+
+      it "returns true" do
+        form = described_class.new(intake, invalid_params)
+        expect(form).to be_valid
+      end
+    end
+
+    context "with yes selected and a non number" do
+      let(:invalid_params) do
+        {
+          paid_prior_year_refund_payments: "yes",
+          prior_year_refund_payments_amount: "Nyarlathotep"
+        }
+      end
+
+      it "returns false" do
+        form = described_class.new(intake, invalid_params)
+        expect(form).not_to be_valid
+      end
+    end
+
+    context "with yes selected and zero" do
+      let(:invalid_params) do
+        {
+          paid_prior_year_refund_payments: "yes",
+          prior_year_refund_payments_amount: "0"
+        }
+      end
+
+      it "returns false" do
+        form = described_class.new(intake, invalid_params)
+        expect(form).not_to be_valid
+      end
+    end
+  end
+
+  describe "#save" do
+    let(:intake) { create :state_file_id_intake }
+    let(:valid_params) do
+      {
+        paid_prior_year_refund_payments: "yes",
+        prior_year_refund_payments_amount: "2112"
+      }
+    end
+
+    it "saves the prior year refund payment amount to the intake" do
+      form = described_class.new(intake, valid_params)
+      expect(form).to be_valid
+      expect do
+        form.save
+      end.to change { intake.reload.prior_year_refund_payments_amount }.to(2112)
+    end
+  end
+
+  describe "no prior year refund payment amount to save" do
+    let(:intake) { create :state_file_id_intake }
+    let(:valid_params) do
+      {
+        paid_prior_year_refund_payments: "no",
+        prior_year_refund_payments_amount: ""
+      }
+    end
+
+    it "proceeds with no prior last names" do
+      form = described_class.new(intake, valid_params)
+      expect(form).to be_valid
+      form.save
+      expect(intake.reload.prior_year_refund_payments_amount).to eq(0)
+    end
+  end
+
+  describe "going back and removing amount" do
+    let(:intake) { create :state_file_id_intake, prior_year_refund_payments_amount: 2112 }
+    let(:valid_params) do
+      {
+        paid_prior_year_refund_payments: "no",
+        prior_year_refund_payments_amount: "2112"
+      }
+    end
+
+    it "proceeds with 0 amount" do
+      form = described_class.new(intake, valid_params)
+      expect(form).to be_valid
+      expect do
+        form.save
+      end.to change { intake.reload.prior_year_refund_payments_amount }.to(0)
+    end
+  end
+end

--- a/spec/forms/state_file/apply_refund_form_spec.rb
+++ b/spec/forms/state_file/apply_refund_form_spec.rb
@@ -105,22 +105,22 @@ RSpec.describe StateFile::ApplyRefundForm do
         form.save
       end.to change { intake.reload.prior_year_refund_payments_amount }.to(2112)
     end
-  end
 
-  describe "no prior year refund payment amount to save" do
-    let(:intake) { create :state_file_id_intake }
-    let(:valid_params) do
-      {
-        paid_prior_year_refund_payments: "no",
-        prior_year_refund_payments_amount: ""
-      }
-    end
+    describe "no prior year refund payment amount to save" do
+      let(:intake) { create :state_file_id_intake }
+      let(:valid_params) do
+        {
+          paid_prior_year_refund_payments: "no",
+          prior_year_refund_payments_amount: ""
+        }
+      end
 
-    it "proceeds with no prior last names" do
-      form = described_class.new(intake, valid_params)
-      expect(form).to be_valid
-      form.save
-      expect(intake.reload.prior_year_refund_payments_amount).to eq(0)
+      it "proceeds with no prior year refund" do
+        form = described_class.new(intake, valid_params)
+        expect(form).to be_valid
+        form.save
+        expect(intake.reload.prior_year_refund_payments_amount).to eq(0)
+      end
     end
   end
 

--- a/spec/models/efile_error_spec.rb
+++ b/spec/models/efile_error_spec.rb
@@ -35,6 +35,7 @@ describe 'EfileError' do
 
   it 'returns the expected array of paths' do
     expect(EfileError.paths).to eq [
+      "apply-refund",
       "az-charitable-contributions",
       "az-excise-credit",
       "az-prior-last-names",

--- a/spec/models/state_file_id_intake_spec.rb
+++ b/spec/models/state_file_id_intake_spec.rb
@@ -41,7 +41,7 @@
 #  nongame_wildlife_fund_donation                 :decimal(12, 2)
 #  opportunity_scholarship_program_donation       :decimal(12, 2)
 #  paid_extension_payments                        :integer          default("unfilled"), not null
-#  paid_prior_year_refund_payments                :integer          default(0), not null
+#  paid_prior_year_refund_payments                :integer          default("unfilled"), not null
 #  payment_or_deposit_type                        :integer          default("unfilled"), not null
 #  phone_number                                   :string
 #  phone_number_verified_at                       :datetime

--- a/spec/models/state_file_id_intake_spec.rb
+++ b/spec/models/state_file_id_intake_spec.rb
@@ -41,6 +41,7 @@
 #  nongame_wildlife_fund_donation                 :decimal(12, 2)
 #  opportunity_scholarship_program_donation       :decimal(12, 2)
 #  paid_extension_payments                        :integer          default("unfilled"), not null
+#  paid_prior_year_refund_payments                :integer          default(0), not null
 #  payment_or_deposit_type                        :integer          default("unfilled"), not null
 #  phone_number                                   :string
 #  phone_number_verified_at                       :datetime
@@ -54,6 +55,7 @@
 #  primary_middle_initial                         :string
 #  primary_months_ineligible_for_grocery_credit   :integer
 #  primary_suffix                                 :string
+#  prior_year_refund_payments_amount              :decimal(12, 2)
 #  raw_direct_file_data                           :text
 #  raw_direct_file_intake_data                    :jsonb
 #  received_id_public_assistance                  :integer          default("unfilled"), not null


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. https://codeforamerica.atlassian.net/browse/FYST-2039
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Adds the ID apply refund page
## How to test?
- make sure the extension period flipper is flipped
## Screenshots
<img width="829" alt="Screenshot 2025-04-14 at 2 15 00 PM" src="https://github.com/user-attachments/assets/1a5bdc5f-a523-4e2c-ac7f-7ef5fc5d7df1" />
