### PR TITLE
use MMS for messaging if message contains non-GSM7 characters or is very long

### DIFF
--- a/spec/services/twilio_service_spec.rb
+++ b/spec/services/twilio_service_spec.rb
@@ -23,6 +23,16 @@ describe TwilioService do
     })
   end
 
+  describe ".is_gsm7?" do
+    it "returns true for GSM-7 text" do
+      expect(described_class.is_gsm7?("hello\n\n[mañana]\\")).to eq(true)
+    end
+
+    it "returns false for non-GSM-7 text" do
+      expect(described_class.is_gsm7?("“hello” `")).to eq(false)
+    end
+  end
+
   describe "multi-tenant support" do
     it "instantiates as a gyr messanger by default" do
       actual = TwilioService.new.messaging_service_sid


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/GYR1-703
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- There have been deliverability issues when we send text messages which are made up of a large number of segments, either because they are very long or because they contain non-GSM7 characters
- This change detects both of those cases and uses MMS to send the message instead, which is treated as a single segment and has a large maximum size
- Note that MMS does have a hard maximum size of 1600 characters, so we will still use SMS in cases where we are trying to send an _extremely_ long message, despite the chance that it will fail to be delivered
## How to test?
- Try sending messages from the hub of various lengths, and check Twilio logs to see their segment counts. Messages sent as MMS should show up with a segment count of 1 and an unknown encoding.