### PR TITLE
NJ 343 - add federal extensions response to review screen

### DIFF
--- a/app/views/state_file/questions/federal_extension_payments/edit.html.erb
+++ b/app/views/state_file/questions/federal_extension_payments/edit.html.erb
@@ -21,6 +21,6 @@
       ]) %>
     </div>
 
-    <%= f.continue %>
+    <%= render "state_file/questions/shared/continue_button", f: f %>
   <% end %>
 <% end %>

--- a/app/views/state_file/questions/nj_review/edit.html.erb
+++ b/app/views/state_file/questions/nj_review/edit.html.erb
@@ -230,6 +230,19 @@
     </div>
   </section>
 
+  <% if Flipper.enabled?(:extension_period) %>
+    <section id="federal-extensions" class="white-group">
+      <div class="spacing-below-5">
+        <h3 class="text--body text--bold spacing-below-5"><%=t(".federal_extension") %></h3>
+        <p><%=current_intake.paid_federal_extension_payments_yes? ? t("general.affirmative") : t("general.negative") %></p>
+        <%= link_to StateFile::Questions::FederalExtensionPaymentsController.to_path_helper(return_to_review: "y"), class: "button--small" do %>
+          <%= t(".review_and_edit") %>
+          <span class="sr-only"><%= t(".federal_extension") %></span>
+        <% end %>
+      </div>
+    </section>
+  <% end %>
+
   <section id="estimated-tax-payments" class="white-group">
     <div class="spacing-below-5">
       <h3 class="text--body text--bold spacing-below-5"><%=t(".has_estimated_payments") %></h3>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3872,6 +3872,7 @@ en:
           eitc: New Jersey Earned Income Tax Credit (NJEITC)
           estimated_tax_payments: Estimated quarterly payments
           extension_payments: Payment made when you filed for an extension
+          federal_extension: Federal extension
           has_estimated_payments: Estimated or other payments
           household_rent_own: Living situation in %{filing_year}
           household_rent_own_both: Owned and rented

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3871,7 +3871,7 @@ es:
           eitc: Crédito Tributario por Ingreso del Trabajo de New Jersey (NJEITC por las siglas en inglés)
           estimated_tax_payments: Monto de pagos estimados trimestrales
           extension_payments: Pago realizado cuando pediste una prórroga
-          federal_extension: Federal extension
+          federal_extension: Extensión Federal
           has_estimated_payments: Pagos estimados u otros pagos
           household_rent_own: Situación de vivienda en %{filing_year}
           household_rent_own_both: Dueño/a e inquilino/a

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3871,7 +3871,8 @@ es:
           eitc: Crédito Tributario por Ingreso del Trabajo de New Jersey (NJEITC por las siglas en inglés)
           estimated_tax_payments: Monto de pagos estimados trimestrales
           extension_payments: Pago realizado cuando pediste una prórroga
-          has_estimated_payments: Estimated or other payments
+          federal_extension: Federal extension
+          has_estimated_payments: Pagos estimados u otros pagos
           household_rent_own: Situación de vivienda en %{filing_year}
           household_rent_own_both: Dueño/a e inquilino/a
           household_rent_own_neither: Ni dueño/a ni inquilino/a

--- a/spec/features/state_file/nj/complete_intake_spec.rb
+++ b/spec/features/state_file/nj/complete_intake_spec.rb
@@ -273,7 +273,7 @@ RSpec.feature "Completing a state file intake", active_job: true do
 
       groups = page.all(:css, '.white-group').count
       # one white group per exemption/section
-      expect(groups).to eq(11)
+      expect(groups).to eq(12)
 
       h2s = page.all(:css, 'h2').count
       # one h2 for each of 5 section headers (e.g Household Information), "Your refund amount" is also an h2


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://github.com/newjersey/affordability-pm/issues/343

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Add federal extension to review screen
- Update federal extension page to use continue button with "return to review" functionality

## How to test?
Any persona with `:extension-period` enabled

## Screenshots (for visual changes)
![image](https://github.com/user-attachments/assets/51db5efc-12a2-49e8-8198-b0407cee06fc)
