### PR TITLE
Add post submission page warnings for clients who owe

### DIFF
--- a/app/controllers/state_file/questions/return_status_controller.rb
+++ b/app/controllers/state_file/questions/return_status_controller.rb
@@ -19,6 +19,7 @@ module StateFile
         @voucher_path = StateFile::StateInformationService.voucher_path(current_state_code)
         @survey_link = StateFile::StateInformationService.survey_link(current_state_code, locale: I18n.locale)
         @tax_form_number = StateFile::StateInformationService.return_type(current_state_code).gsub("Form", "")
+        @after_tax_deadline = StateInformationService.after_payment_deadline?(app_time, current_intake.state_code)
       end
 
       def prev_path

--- a/app/controllers/state_file/questions/submission_confirmation_controller.rb
+++ b/app/controllers/state_file/questions/submission_confirmation_controller.rb
@@ -4,6 +4,7 @@ module StateFile
       def edit
         raise ActiveRecord::RecordNotFound unless EfileSubmission.where(data_source: current_intake).present?
         @show_download_button = current_intake.submission_pdf.attached?
+        @after_tax_deadline = StateInformationService.after_payment_deadline?(app_time, current_intake.state_code)
       end
 
       def prev_path

--- a/app/controllers/state_file/questions/taxes_owed_controller.rb
+++ b/app/controllers/state_file/questions/taxes_owed_controller.rb
@@ -29,9 +29,7 @@ module StateFile
       helper_method :current_time_before_payment_deadline?
 
       def current_time_after_tax_deadline?
-        timezone = StateInformationService.timezone(current_intake.state_code)
-        deadline = Rails.configuration.tax_deadline.to_date
-        app_time.in_time_zone(timezone).to_date.after?(deadline)
+        StateInformationService.after_payment_deadline?(app_time, current_intake.state_code)
       end
       helper_method :current_time_after_tax_deadline?
     end

--- a/app/services/state_file/state_information_service.rb
+++ b/app/services/state_file/state_information_service.rb
@@ -66,11 +66,18 @@ module StateFile
         Rails.configuration.tax_deadline.to_date
       end
 
-      # Check if the day of a given DateTime is before the deadline date, using the state-specific/government timezone
+      # Check if the day of a given DateTime is before the payment deadline date, using the state-specific/government timezone
       def before_payment_deadline?(datetime, state_code)
         payment_deadline_date = StateInformationService.payment_deadline_date(state_code, datetime)
         timezone = StateInformationService.timezone(state_code)
         datetime.in_time_zone(timezone).to_date.before?(payment_deadline_date)
+      end
+
+      # Check if the day of a given DateTime is after the tax deadline date, using the state-specific/government timezone
+      def after_payment_deadline?(time, state_code)
+        timezone = StateInformationService.timezone(state_code)
+        deadline = Rails.configuration.tax_deadline.to_date
+        time.in_time_zone(timezone).to_date.after?(deadline)
       end
 
       # Maryland has different payment deadline logic from all our other States

--- a/app/views/state_file/questions/return_status/_accepted.html.erb
+++ b/app/views/state_file/questions/return_status/_accepted.html.erb
@@ -13,8 +13,12 @@
   <% # i18n-tasks-use t('state_file.questions.return_status.accepted.refund_details_html') # hint for the i18n linter that, yes, we are using this key (sometimes) %>
   <p><%= t(".#{current_state_code}.refund_details_html", default: :'.refund_details_html', website_name: @department_of_taxation_initials, tax_refund_url: @tax_refund_url) %></p>
 <% elsif refund_or_owed_amount.negative? %>
-  <p><%= t('.direct_debit_html', tax_payment_info_text: @tax_payment_info_text, tax_payment_info_url: @tax_payment_info_url) %></p>
-  <%= render "state_file/questions/submission_confirmation/penalty_interest_warning"  %>
+  <% if @after_tax_deadline %>
+    <p><%= t('.direct_debit.after_deadline_html', tax_payment_info_text: @tax_payment_info_text, tax_payment_info_url: @tax_payment_info_url) %></p>
+    <%= render "state_file/questions/submission_confirmation/penalty_interest_warning"  %>
+  <% else %>
+    <p><%= t('.direct_debit.before_deadline_html', tax_payment_info_text: @tax_payment_info_text, tax_payment_info_url: @tax_payment_info_url) %></p>
+  <% end %>
 <% end %>
 
 <hr class="spacing-above-25 spacing-below-25"/>

--- a/app/views/state_file/questions/return_status/_accepted.html.erb
+++ b/app/views/state_file/questions/return_status/_accepted.html.erb
@@ -14,6 +14,7 @@
   <p><%= t(".#{current_state_code}.refund_details_html", default: :'.refund_details_html', website_name: @department_of_taxation_initials, tax_refund_url: @tax_refund_url) %></p>
 <% elsif refund_or_owed_amount.negative? %>
   <p><%= t('.direct_debit_html', tax_payment_info_text: @tax_payment_info_text, tax_payment_info_url: @tax_payment_info_url) %></p>
+  <%= render "state_file/questions/submission_confirmation/penalty_interest_warning"  %>
 <% end %>
 
 <hr class="spacing-above-25 spacing-below-25"/>

--- a/app/views/state_file/questions/submission_confirmation/_penalty_interest_warning.html.erb
+++ b/app/views/state_file/questions/submission_confirmation/_penalty_interest_warning.html.erb
@@ -1,0 +1,6 @@
+<% if @after_tax_deadline %>
+  <div class="notice--warning">
+    <p><%= t('state_file.questions.submission_confirmation.penalty_interest_warning.p1') %></p>
+    <p><%= t('state_file.questions.submission_confirmation.penalty_interest_warning.p2', billing_agency: t("state_file.questions.submission_confirmation.penalty_interest_warning.billing_agency.#{current_state_code}")) %></p>
+  </div>
+<% end %>

--- a/app/views/state_file/questions/submission_confirmation/_penalty_interest_warning.html.erb
+++ b/app/views/state_file/questions/submission_confirmation/_penalty_interest_warning.html.erb
@@ -1,4 +1,8 @@
-<div class="notice--warning">
-  <p><%= t('state_file.questions.submission_confirmation.penalty_interest_warning.p1') %></p>
-  <p><%= t('state_file.questions.submission_confirmation.penalty_interest_warning.p2', billing_agency: t("state_file.questions.submission_confirmation.penalty_interest_warning.billing_agency.#{current_state_code}")) %></p>
-</div>
+<% billing_agency_key = "state_file.questions.submission_confirmation.penalty_interest_warning.billing_agency.#{current_state_code}" %>
+<% state_specific_billing_agency = I18n.exists?(billing_agency_key, locale) ? t(billing_agency_key) : nil %>
+<% if state_specific_billing_agency %>
+  <div class="notice--warning">
+    <p><%= t('state_file.questions.submission_confirmation.penalty_interest_warning.p1') %></p>
+    <p><%= t('state_file.questions.submission_confirmation.penalty_interest_warning.p2', billing_agency: state_specific_billing_agency) %></p>
+  </div>
+<% end %>

--- a/app/views/state_file/questions/submission_confirmation/_penalty_interest_warning.html.erb
+++ b/app/views/state_file/questions/submission_confirmation/_penalty_interest_warning.html.erb
@@ -1,6 +1,4 @@
-<% if @after_tax_deadline %>
-  <div class="notice--warning">
-    <p><%= t('state_file.questions.submission_confirmation.penalty_interest_warning.p1') %></p>
-    <p><%= t('state_file.questions.submission_confirmation.penalty_interest_warning.p2', billing_agency: t("state_file.questions.submission_confirmation.penalty_interest_warning.billing_agency.#{current_state_code}")) %></p>
-  </div>
-<% end %>
+<div class="notice--warning">
+  <p><%= t('state_file.questions.submission_confirmation.penalty_interest_warning.p1') %></p>
+  <p><%= t('state_file.questions.submission_confirmation.penalty_interest_warning.p2', billing_agency: t("state_file.questions.submission_confirmation.penalty_interest_warning.billing_agency.#{current_state_code}")) %></p>
+</div>

--- a/app/views/state_file/questions/submission_confirmation/edit.html.erb
+++ b/app/views/state_file/questions/submission_confirmation/edit.html.erb
@@ -40,11 +40,9 @@
       <% end %>
     </p>
 
-    <div class="notice--warning">
-      <p><%= t('.penalty_interest_warning.p1') %></p>
-      <p><%= t('.penalty_interest_warning.p2', billing_agency: t(".penalty_interest_warning.billing_agency.#{current_state_code}")) %></p>
-    </div>
-
+    <% if current_intake.calculated_refund_or_owed_amount.negative? %>
+      <%= render "state_file/questions/submission_confirmation/penalty_interest_warning"  %>
+    <% end %>
     <p>
       <a target="_blank" rel="noopener nofollow" href="https://vote.gov/"><%= t('state_file.general.register_to_vote') %></a>
     </p>

--- a/app/views/state_file/questions/submission_confirmation/edit.html.erb
+++ b/app/views/state_file/questions/submission_confirmation/edit.html.erb
@@ -44,7 +44,7 @@
       <% end %>
     </p>
 
-    <% if current_intake.calculated_refund_or_owed_amount.negative? %>
+    <% if current_intake.calculated_refund_or_owed_amount.negative? && @after_tax_deadline %>
       <%= render "state_file/questions/submission_confirmation/penalty_interest_warning"  %>
     <% end %>
     <p>

--- a/app/views/state_file/questions/submission_confirmation/edit.html.erb
+++ b/app/views/state_file/questions/submission_confirmation/edit.html.erb
@@ -21,11 +21,7 @@
     </div>
   <% end %>
 
-  <% if @show_download_button %>
-    <div>
-  <% else %>
-    <div class="download-link-container" style="display: none;">
-  <% end %>
+  <div class="<%= 'download-link-container' unless @show_download_button %>" style="<%= 'display: none;' unless @show_download_button %>">
     <div class='return-status'>
       <p>
         <%= image_tag("icons/check.svg", alt: "") %>
@@ -43,6 +39,12 @@
         <%= t('.text_update') %>
       <% end %>
     </p>
+
+    <div class="notice--warning">
+      <p><%= t('.penalty_interest_warning.p1') %></p>
+      <p><%= t('.penalty_interest_warning.p2', billing_agency: t(".penalty_interest_warning.billing_agency.#{current_state_code}")) %></p>
+    </div>
+
     <p>
       <a target="_blank" rel="noopener nofollow" href="https://vote.gov/"><%= t('state_file.general.register_to_vote') %></a>
     </p>
@@ -62,8 +64,7 @@
     <%= t(".download_state_return_pdf") %>
     <%= image_tag("icons/link-white.svg", alt: "", class: "button__icon") %>
   <% end %>
-
-
+  </div>
 
   <% if show_xml? %>
     <p>

--- a/app/views/state_file/questions/submission_confirmation/edit.html.erb
+++ b/app/views/state_file/questions/submission_confirmation/edit.html.erb
@@ -21,7 +21,11 @@
     </div>
   <% end %>
 
-  <div class="<%= 'download-link-container' unless @show_download_button %>" style="<%= 'display: none;' unless @show_download_button %>">
+  <% if @show_download_button %>
+    <div>
+  <% else %>
+    <div class="download-link-container" style="display: none;">
+  <% end %>
     <div class='return-status'>
       <p>
         <%= image_tag("icons/check.svg", alt: "") %>
@@ -62,7 +66,6 @@
     <%= t(".download_state_return_pdf") %>
     <%= image_tag("icons/link-white.svg", alt: "", class: "button__icon") %>
   <% end %>
-  </div>
 
   <% if show_xml? %>
     <p>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -124,6 +124,7 @@ ignore_unused:
   - 'state_file.questions.extension_payments.*'
   - 'state_file.questions.tax_refund.bank_details.after_deadline_withdrawal_info.*'
   - 'state_file.questions.taxes_owed.edit.interest_warning.*'
+  - 'state_file.questions.submission_confirmation.penalty_interest_warning.billing_agency.*'
 # - 'activerecord.attributes.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4166,8 +4166,8 @@ en:
               Make your check or money order payable to %{payable_to}. Write your full SSN or ITIN, “%{filing_year} Tax”, and "Form %{form_number}" on your payment.
             </li>
           direct_debit:
-            before_deadline_html: If you have a remaining tax balance, remember to <strong>pay it online at <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a></strong> or by mail as soon as you can can.
-            after_deadline_html: If you have a remaining tax balance, remember to <strong>pay it online at <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a></strong> or by mail before the April 15 filing deadline.
+            after_deadline_html: If you have a remaining tax balance, remember to <strong>pay it online at <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a></strong> or by mail as soon as you can can.
+            before_deadline_html: If you have a remaining tax balance, remember to <strong>pay it online at <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a></strong> or by mail before the April 15 filing deadline.
           download_voucher: Download and print the completed payment voucher.
           feedback: We value your feedback—let us know what you think of this service.
           include_payment: Fill out your payment voucher

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4166,7 +4166,7 @@ en:
               Make your check or money order payable to %{payable_to}. Write your full SSN or ITIN, “%{filing_year} Tax”, and "Form %{form_number}" on your payment.
             </li>
           direct_debit:
-            after_deadline_html: If you have a remaining tax balance, remember to <strong>pay it online at <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a></strong> or by mail as soon as you can can.
+            after_deadline_html: If you have a remaining tax balance, remember to <strong>pay it online at <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a></strong> or by mail as soon as you can.
             before_deadline_html: If you have a remaining tax balance, remember to <strong>pay it online at <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a></strong> or by mail before the April 15 filing deadline.
           download_voucher: Download and print the completed payment voucher.
           feedback: We value your feedback—let us know what you think of this service.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4165,7 +4165,9 @@ en:
             <li>
               Make your check or money order payable to %{payable_to}. Write your full SSN or ITIN, “%{filing_year} Tax”, and "Form %{form_number}" on your payment.
             </li>
-          direct_debit_html: If you have a remaining tax balance, remember to <strong>pay it online at <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a></strong> or by mail as soon as you can can.
+          direct_debit:
+            before_deadline_html: If you have a remaining tax balance, remember to <strong>pay it online at <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a></strong> or by mail as soon as you can can.
+            after_deadline_html: If you have a remaining tax balance, remember to <strong>pay it online at <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a></strong> or by mail before the April 15 filing deadline.
           download_voucher: Download and print the completed payment voucher.
           feedback: We value your feedback—let us know what you think of this service.
           include_payment: Fill out your payment voucher

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4165,7 +4165,7 @@ en:
             <li>
               Make your check or money order payable to %{payable_to}. Write your full SSN or ITIN, “%{filing_year} Tax”, and "Form %{form_number}" on your payment.
             </li>
-          direct_debit_html: If you have a remaining tax balance, remember to <strong>pay it online at <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a></strong> or by mail before the April 15 filing deadline.
+          direct_debit_html: If you have a remaining tax balance, remember to <strong>pay it online at <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a></strong> or by mail as soon as you can can.
           download_voucher: Download and print the completed payment voucher.
           feedback: We value your feedback—let us know what you think of this service.
           include_payment: Fill out your payment voucher
@@ -4307,6 +4307,15 @@ en:
         edit:
           title_html: We need some details from <strong>your spouse’s</strong> state-issued ID, if they have one
       submission_confirmation:
+        penalty_interest_warning:
+          p1: Since you filed your return after April 15th, you may be charged interest and/or penalties on your taxes owed. Interest will continue to accrue until you pay the tax.
+          p2: This amount wasn't calculated on your state return, and %{billing_agency} will separately send you a bill for this amount.
+          billing_agency:
+            az: Arizona’s Department of Revenue
+            id: the Idaho State Tax Commission
+            md: the Comptroller of Maryland
+            nc: North Carolina’s Department of Revenue
+            nj: the New Jersey Division of Taxation
         edit:
           download_state_return_pdf: Download your state return
           email_text_update: You'll receive an email and text update when your state tax return is accepted.
@@ -4316,15 +4325,6 @@ en:
           text_update: You'll receive an sms update when your state tax return is accepted.
           title: Your %{filing_year} %{state_name} state tax return is now submitted!
           title_resubmit: Your %{filing_year} %{state_name} state tax return is now resubmitted!
-          penalty_interest_warning:
-            p1: Since you filed your return after April 15th, you may be charged interest and/or penalties on your taxes owed. Interest will continue to accrue until you pay the tax.
-            p2: This amount wasn't calculated on your state return, and %{billing_agency} will separately send you a bill for this amount.
-            billing_agency:
-              az: Arizona’s Department of Revenue
-              id: the Idaho State Tax Commission
-              md: the Comptroller of Maryland
-              nc: North Carolina’s Department of Revenue
-              nj: the New Jersey Division of Taxation
         nj_additional_content:
           body_html: |-
             <p>You said you are filing for the veteran exemption. If it's your first time filing for <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/military/vetexemption.shtml">this exemption</a>, you have to provide <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/military/vetexemption-documentation.shtml">documentation</a> and a <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/pdf/veteransexemptionform.pdf">form</a> to the New Jersey Division of Taxation.</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4307,15 +4307,6 @@ en:
         edit:
           title_html: We need some details from <strong>your spouse’s</strong> state-issued ID, if they have one
       submission_confirmation:
-        penalty_interest_warning:
-          p1: Since you filed your return after April 15th, you may be charged interest and/or penalties on your taxes owed. Interest will continue to accrue until you pay the tax.
-          p2: This amount wasn't calculated on your state return, and %{billing_agency} will separately send you a bill for this amount.
-          billing_agency:
-            az: Arizona’s Department of Revenue
-            id: the Idaho State Tax Commission
-            md: the Comptroller of Maryland
-            nc: North Carolina’s Department of Revenue
-            nj: the New Jersey Division of Taxation
         edit:
           download_state_return_pdf: Download your state return
           email_text_update: You'll receive an email and text update when your state tax return is accepted.
@@ -4353,6 +4344,15 @@ en:
               <li>Select “VET” from the dropdown menu under Notice Code.</li>
               <li>Enter the rest of your information, including your Social Security Number, to make sure that the documents get linked to your tax return.</li>
             </ol>
+        penalty_interest_warning:
+          billing_agency:
+            az: Arizona’s Department of Revenue
+            id: the Idaho State Tax Commission
+            md: the Comptroller of Maryland
+            nc: North Carolina’s Department of Revenue
+            nj: the New Jersey Division of Taxation
+          p1: Since you filed your return after April 15th, you may be charged interest and/or penalties on your taxes owed. Interest will continue to accrue until you pay the tax.
+          p2: This amount wasn't calculated on your state return, and %{billing_agency} will separately send you a bill for this amount.
       tax_refund:
         bank_details:
           account_number: Account Number

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4316,6 +4316,15 @@ en:
           text_update: You'll receive an sms update when your state tax return is accepted.
           title: Your %{filing_year} %{state_name} state tax return is now submitted!
           title_resubmit: Your %{filing_year} %{state_name} state tax return is now resubmitted!
+          penalty_interest_warning:
+            p1: Since you filed your return after April 15th, you may be charged interest and/or penalties on your taxes owed. Interest will continue to accrue until you pay the tax.
+            p2: This amount wasn't calculated on your state return, and %{billing_agency} will separately send you a bill for this amount.
+            billing_agency:
+              az: Arizona’s Department of Revenue
+              id: the Idaho State Tax Commission
+              md: the Comptroller of Maryland
+              nc: North Carolina’s Department of Revenue
+              nj: the New Jersey Division of Taxation
         nj_additional_content:
           body_html: |-
             <p>You said you are filing for the veteran exemption. If it's your first time filing for <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/military/vetexemption.shtml">this exemption</a>, you have to provide <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/military/vetexemption-documentation.shtml">documentation</a> and a <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/pdf/veteransexemptionform.pdf">form</a> to the New Jersey Division of Taxation.</p>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4320,15 +4320,6 @@ es:
         edit:
           title_html: Necesitamos algunos detalles del documento de identidad emitida por el estado de <strong>tu cónyuge</strong>, si tiene una
       submission_confirmation:
-        penalty_interest_warning:
-          p1: Debido a que presentaste tu declaración después del 15 de abril de 2025, es posible que se te cobren intereses, multas o ambos sobre los impuestos que debes. Los intereses seguirán acumulándose hasta que pagues tus impuestos.
-          p2: Esta cantidad no fue calculada en tu declaración estatal, y %{billing_agency} te enviará una factura aparte por esta cantidad.
-          billing_agency:
-            az: el Departamento de Ingresos de Arizona
-            id: el Departamento de Ingresos de Idaho
-            md: el Contralor de Maryland
-            nc: el Departamento de Ingresos de Carolina del Norte
-            nj: la División de Impuestos de Nueva Jersey
         edit:
           download_state_return_pdf: Descarga tu declaración estatal
           email_text_update: Recibirás una actualización por correo electrónico y mensaje de texto cuando tu declaración de impuestos estatal sea aceptada.
@@ -4366,6 +4357,15 @@ es:
               <li>Selecciona “VET” en el menú desplegable debajo de Código de notificación (en inglés “Notice Code”).</li>
               <li>Ingresa el resto de tu información, incluido tu número de Seguro Social, para asegurar que los documentos se vinculen con tu declaración de impuestos.</li>
             </ol>
+        penalty_interest_warning:
+          billing_agency:
+            az: el Departamento de Ingresos de Arizona
+            id: el Departamento de Ingresos de Idaho
+            md: el Contralor de Maryland
+            nc: el Departamento de Ingresos de Carolina del Norte
+            nj: la División de Impuestos de Nueva Jersey
+          p1: Debido a que presentaste tu declaración después del 15 de abril de 2025, es posible que se te cobren intereses, multas o ambos sobre los impuestos que debes. Los intereses seguirán acumulándose hasta que pagues tus impuestos.
+          p2: Esta cantidad no fue calculada en tu declaración estatal, y %{billing_agency} te enviará una factura aparte por esta cantidad.
       tax_refund:
         bank_details:
           account_number: Número de cuenta

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4178,7 +4178,7 @@ es:
             <li>
              Hacer tu cheque o giro postal a nombre de %{payable_to}. Escribe tu SSN o ITIN completo, "%{filing_year} Tax", y "Form %{form_number}" en tu pago.
             </li>
-          direct_debit_html: Si tienes un saldo de impuestos pendiente, recuerda <strong>pagarlo en línea en <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a></strong> o por correo o más pronto que puedas.
+          direct_debit_html: Si tienes un saldo de impuestos pendiente, recuerda <strong>pagarlo en línea en <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a></strong> o por correo lo más pronto que puedas.
           download_voucher: Descarga e imprime el formulario de comprobante de pago completado.
           feedback: Valoramos sus comentarios; háganos saber lo que piensa de esta herramienta.
           include_payment: Completa el formulario de comprobante de pago

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4178,7 +4178,7 @@ es:
             <li>
              Hacer tu cheque o giro postal a nombre de %{payable_to}. Escribe tu SSN o ITIN completo, "%{filing_year} Tax", y "Form %{form_number}" en tu pago.
             </li>
-          direct_debit_html: Si tienes un saldo de impuestos pendiente, recuerda <strong>pagarlo en línea en <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a></strong> o por correo antes de la fecha límite de declaración que es el 15 de abril.
+          direct_debit_html: Si tienes un saldo de impuestos pendiente, recuerda <strong>pagarlo en línea en <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a></strong> o por correo o más pronto que puedas.
           download_voucher: Descarga e imprime el formulario de comprobante de pago completado.
           feedback: Valoramos sus comentarios; háganos saber lo que piensa de esta herramienta.
           include_payment: Completa el formulario de comprobante de pago
@@ -4320,6 +4320,15 @@ es:
         edit:
           title_html: Necesitamos algunos detalles del documento de identidad emitida por el estado de <strong>tu cónyuge</strong>, si tiene una
       submission_confirmation:
+        penalty_interest_warning:
+          p1: Debido a que presentaste tu declaración después del 15 de abril de 2025, es posible que se te cobren intereses, multas o ambos sobre los impuestos que debes. Los intereses seguirán acumulándose hasta que pagues tus impuestos.
+          p2: Esta cantidad no fue calculada en tu declaración estatal, y %{billing_agency} te enviará una factura aparte por esta cantidad.
+          billing_agency:
+            az: el Departamento de Ingresos de Arizona
+            id: el Departamento de Ingresos de Idaho
+            md: el Contralor de Maryland
+            nc: el Departamento de Ingresos de Carolina del Norte
+            nj: la División de Impuestos de Nueva Jersey
         edit:
           download_state_return_pdf: Descarga tu declaración estatal
           email_text_update: Recibirás una actualización por correo electrónico y mensaje de texto cuando tu declaración de impuestos estatal sea aceptada.
@@ -4329,15 +4338,6 @@ es:
           text_update: Recibirás una actualización por SMS cuando una vez tu declaración de impuestos haya sido aceptada.
           title: "¡Tu declaración de impuestos de %{state_name} de %{filing_year} ha sido enviada! "
           title_resubmit: "¡Tu declaración de impuestos de %{filing_year} de %{state_name} ha sido enviada de nuevo!"
-          penalty_interest_warning:
-            p1: Debido a que presentaste tu declaración después del 15 de abril de 2025, es posible que se te cobren intereses, multas o ambos sobre los impuestos que debes. Los intereses seguirán acumulándose hasta que pagues tus impuestos.
-            p2: Esta cantidad no fue calculada en tu declaración estatal, y %{billing_agency} te enviará una factura aparte por esta cantidad.
-            billing_agency:
-              az: el Departamento de Ingresos de Arizona
-              id: el Departamento de Ingresos de Idaho
-              md: el Contralor de Maryland
-              nc: el Departamento de Ingresos de Carolina del Norte
-              nj: la División de Impuestos de Nueva Jersey
         nj_additional_content:
           body_html: |-
             <p>Dijiste que tú están solicitando la exención de veterano/a de guerra. Si es la primera vez que <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/military/vetexemption.shtml">la</a> solicitas, tienes que presentar <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/military/vetexemption-documentation.shtml">documentación</a> y completar un <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/pdf/veteransexemptionform.pdf">formulario</a> de la División de Impuestos del Estado de New Jersey.</p>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4178,7 +4178,9 @@ es:
             <li>
              Hacer tu cheque o giro postal a nombre de %{payable_to}. Escribe tu SSN o ITIN completo, "%{filing_year} Tax", y "Form %{form_number}" en tu pago.
             </li>
-          direct_debit_html: Si tienes un saldo de impuestos pendiente, recuerda <strong>pagarlo en línea en <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a></strong> o por correo lo más pronto que puedas.
+          direct_debit:
+            before_deadline_html: Si tienes un saldo de impuestos pendiente, recuerda <strong>pagarlo en línea en <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a></strong> o por correo antes de la fecha límite de declaración que es el 15 de abril.
+            after_deadline_html: Si tienes un saldo de impuestos pendiente, recuerda <strong>pagarlo en línea en <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a></strong> o por correo lo más pronto que puedas.
           download_voucher: Descarga e imprime el formulario de comprobante de pago completado.
           feedback: Valoramos sus comentarios; háganos saber lo que piensa de esta herramienta.
           include_payment: Completa el formulario de comprobante de pago

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4329,6 +4329,15 @@ es:
           text_update: Recibirás una actualización por SMS cuando una vez tu declaración de impuestos haya sido aceptada.
           title: "¡Tu declaración de impuestos de %{state_name} de %{filing_year} ha sido enviada! "
           title_resubmit: "¡Tu declaración de impuestos de %{filing_year} de %{state_name} ha sido enviada de nuevo!"
+          penalty_interest_warning:
+            p1: Debido a que presentaste tu declaración después del 15 de abril de 2025, es posible que se te cobren intereses, multas o ambos sobre los impuestos que debes. Los intereses seguirán acumulándose hasta que pagues tus impuestos.
+            p2: Esta cantidad no fue calculada en tu declaración estatal, y %{billing_agency} te enviará una factura aparte por esta cantidad.
+            billing_agency:
+              az: el Departamento de Ingresos de Arizona
+              id: el Departamento de Ingresos de Idaho
+              md: el Contralor de Maryland
+              nc: el Departamento de Ingresos de Carolina del Norte
+              nj: la División de Impuestos de Nueva Jersey
         nj_additional_content:
           body_html: |-
             <p>Dijiste que tú están solicitando la exención de veterano/a de guerra. Si es la primera vez que <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/military/vetexemption.shtml">la</a> solicitas, tienes que presentar <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/military/vetexemption-documentation.shtml">documentación</a> y completar un <a target="_blank" rel="noopener nofollow" href="https://www.nj.gov/treasury/taxation/pdf/veteransexemptionform.pdf">formulario</a> de la División de Impuestos del Estado de New Jersey.</p>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4179,8 +4179,8 @@ es:
              Hacer tu cheque o giro postal a nombre de %{payable_to}. Escribe tu SSN o ITIN completo, "%{filing_year} Tax", y "Form %{form_number}" en tu pago.
             </li>
           direct_debit:
-            before_deadline_html: Si tienes un saldo de impuestos pendiente, recuerda <strong>pagarlo en línea en <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a></strong> o por correo antes de la fecha límite de declaración que es el 15 de abril.
             after_deadline_html: Si tienes un saldo de impuestos pendiente, recuerda <strong>pagarlo en línea en <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a></strong> o por correo lo más pronto que puedas.
+            before_deadline_html: Si tienes un saldo de impuestos pendiente, recuerda <strong>pagarlo en línea en <a target="_blank" rel="noopener nofollow" href="%{tax_payment_info_url}">%{tax_payment_info_text}</a></strong> o por correo antes de la fecha límite de declaración que es el 15 de abril.
           download_voucher: Descarga e imprime el formulario de comprobante de pago completado.
           feedback: Valoramos sus comentarios; háganos saber lo que piensa de esta herramienta.
           include_payment: Completa el formulario de comprobante de pago


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. https://codeforamerica.atlassian.net/browse/FYST-2037
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!
**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Shows penalty/interest warning for return-status page and submission-confirmation page
- shows on submission confirmation if post April 15th and owe taxes
- shows on return-status page if post April 15th, owe taxes and has accepted status
-  replaces copy “before the April 15 filing deadline” with: EN: “as soon as you can can.” and ES: “lo más pronto que puedas.” after the 15th
## How to test?
- Go through each state flow in heroku with intakes that owe taxes and test before and after April 15
- can change efile submission status to accepted in the hub when looking at the individual efile submission
## Screenshots (for visual changes)
screenshots [here](https://docs.google.com/document/d/1DpwecVv_HkUqQOnvcyVEcJPhoWcZYSY4Wkc2dPIvX-I/edit?usp=sharing)
