### PR TITLE
prevent reject resolution reminders from being sent if another intake exists with the same hashed ssn and a submission

### DIFF
--- a/spec/jobs/state_file/send_reject_resolution_reminder_notification_job_spec.rb
+++ b/spec/jobs/state_file/send_reject_resolution_reminder_notification_job_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe StateFile::SendRejectResolutionReminderNotificationJob, type: :jo
              primary_first_name: "Mona",
              email_address: "monalisa@example.com",
              email_address_verified_at: 1.minute.ago,
+             hashed_ssn: "fake_hashed_ssn",
              message_tracker: {}
     }
     let(:current_state) { :notified_of_rejection }
@@ -16,9 +17,9 @@ RSpec.describe StateFile::SendRejectResolutionReminderNotificationJob, type: :jo
     let(:body_args) { { return_status_link: "http://statefile.test.localhost/en/questions/return-status" } }
     let(:sf_messaging_service) {
       StateFile::MessagingService.new(
-      intake: intake,
-      message: message,
-      body_args: body_args)
+        intake: intake,
+        message: message,
+        body_args: body_args)
     }
 
     before do
@@ -110,7 +111,36 @@ RSpec.describe StateFile::SendRejectResolutionReminderNotificationJob, type: :jo
               message: message,
               body_args: body_args).exactly(2).times
           end
+        end
+
+        context "when another intake exists with the same hashed SSN" do
+          let!(:other_intake) {
+            create other_intake_class,
+                   efile_submissions: [create(:efile_submission, :accepted)],
+                   primary_first_name: "Mona",
+                   email_address: "monalisa@example.com",
+                   email_address_verified_at: 1.minute.ago,
+                   hashed_ssn: intake.hashed_ssn,
+                   message_tracker: {}
+          }
+
+          context "and which was filed in the same state" do
+            let(:other_intake_class) { :state_file_az_intake }
+
+            it "does not send the message" do
+              expect { described_class.perform_now(intake) }.not_to change(StateFileNotificationEmail, :count)
+            end
           end
+
+          context "and which was filed in another state" do
+            let(:other_intake_class) { :state_file_nc_intake }
+
+            it "does not send the message" do
+              expect { described_class.perform_now(intake) }.not_to change(StateFileNotificationEmail, :count)
+            end
+          end
+        end
+
       end
     end
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-2058
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- This PR adds a check to `SendRejectResolutionReminderNotificationJob` to prevent the message from being sent if another intake exists with the same hashed SSN at at least one efile submission.
- There are other messages which will need the same treatment (described in https://codeforamerica.atlassian.net/browse/FYST-2057) but I'm pushing this up first to get it into acceptance so that we can figure out our acceptance process as well as find any corner cases where we want to potentially send the message despite the existence of such an intake.
## How to test?
- Automated testing of the job's new functionality has been added
- Manual testing would look like (per @mpidcock):
  - if testing in heroku, these would be the steps:
    - partially complete an intake for a persona (don't submit)
    - start a new intake with a different email or phone
    - can be the same login type or not
    - complete the same persona all the way through submission
    - run the reminder rake task
    - verify no message is sent