### PR TITLE
[FYST-2014] ID Disability: Show persisted mfj_disability option parsed from intake attributes

### DIFF
--- a/app/forms/state_file/id_disability_form.rb
+++ b/app/forms/state_file/id_disability_form.rb
@@ -1,9 +1,8 @@
 module StateFile
   class IdDisabilityForm < QuestionsForm
-    set_attributes_for :intake, :primary_disabled, :spouse_disabled
+    set_attributes_for :intake, :primary_disabled, :spouse_disabled, :mfj_disability
 
     attr_accessor :mfj_disability
-    set_attributes_for :intake, :mfj_disability
     validates_presence_of :mfj_disability, if: -> { intake.show_mfj_disability_options? }
     validates :primary_disabled, inclusion: { in: %w[yes no], message: :blank }, if: -> { should_check_primary_disabled? }
     validates :spouse_disabled, inclusion: { in: %w[yes no], message: :blank }, if: -> { should_check_spouse_disabled? }

--- a/app/forms/state_file/id_disability_form.rb
+++ b/app/forms/state_file/id_disability_form.rb
@@ -3,6 +3,7 @@ module StateFile
     set_attributes_for :intake, :primary_disabled, :spouse_disabled
 
     attr_accessor :mfj_disability
+    set_attributes_for :intake, :mfj_disability
     validates_presence_of :mfj_disability, if: -> { intake.show_mfj_disability_options? }
     validates :primary_disabled, inclusion: { in: %w[yes no], message: :blank }, if: -> { should_check_primary_disabled? }
     validates :spouse_disabled, inclusion: { in: %w[yes no], message: :blank }, if: -> { should_check_spouse_disabled? }
@@ -36,6 +37,27 @@ module StateFile
       end
 
       clean_up_followups
+    end
+
+    def self.existing_attributes(intake)
+      already_answered_disability = !intake.primary_disabled_unfilled? && !intake.spouse_disabled_unfilled?
+      if intake.show_mfj_disability_options? && already_answered_disability
+        mfj_disability =
+          if intake.primary_disabled_yes? && intake.spouse_disabled_yes?
+            "both"
+          elsif intake.primary_disabled_yes?
+            "primary"
+          elsif intake.spouse_disabled_yes?
+            "spouse"
+          else
+            "none"
+          end
+        super.merge(
+          mfj_disability: mfj_disability
+        )
+      else
+        super
+      end
     end
 
     private

--- a/spec/features/state_file/review_page_spec.rb
+++ b/spec/features/state_file/review_page_spec.rb
@@ -438,6 +438,36 @@ RSpec.feature "Completing a state file intake", active_job: true, js: true do
           expect(page).to have_text I18n.t("state_file.questions.shared.id_disability_review_header.meets_qualifications")
         end
 
+        context "mfj" do
+          before do
+            allow_any_instance_of(StateFileIdIntake).to receive(:show_mfj_disability_options?).and_return(true)
+            @intake.update(
+              raw_direct_file_data: StateFile::DirectFileApiResponseSampleService.new.read_xml("id_barrel_roll"),
+              raw_direct_file_intake_data: StateFile::DirectFileApiResponseSampleService.new.read_json("id_barrel_roll"),
+              spouse_first_name: "Beepbeep",
+              spouse_last_name: "Boop",
+              spouse_birth_date: Date.new((MultiTenantService.statefile.current_tax_year - 65), 12, 2),
+              spouse_disabled: "yes" # both disabled
+            )
+
+            third_1099r = create(:state_file1099_r, intake: @intake, payer_name: "Third Spouse Inc", taxable_amount: 750, recipient_ssn: @intake.spouse.ssn)
+            StateFileId1099RFollowup.create(state_file1099_r: third_1099r, income_source: "police_officer", police_retirement_fund: "yes")
+          end
+
+          it "can persist mfj disability question on review" do
+            visit "/questions/id-review"
+
+            expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
+
+            within "#disability-info" do
+              expect(page).to have_text I18n.t("general.affirmative")
+              click_on I18n.t("general.review_and_edit")
+            end
+
+            expect(page).to have_text I18n.t("state_file.questions.id_disability.edit.title")
+            expect(page.find(:css, '#state_file_id_disability_form_mfj_disability_both')).to be_checked
+          end
+        end
       end
 
       context "with eligible senior over 65 years old" do

--- a/spec/forms/state_file/id_disability_form_spec.rb
+++ b/spec/forms/state_file/id_disability_form_spec.rb
@@ -325,4 +325,68 @@ RSpec.describe StateFile::IdDisabilityForm do
       end
     end
   end
+
+  describe "#existing_attributes" do
+    let(:primary_disabled) { "unfilled" }
+    let(:spouse_disabled) { "unfilled" }
+
+    before do
+      allow(intake).to receive(:show_mfj_disability_options?).and_return true
+      intake.update(primary_disabled: primary_disabled, spouse_disabled: spouse_disabled)
+    end
+
+    context "mfj_disabled" do
+      context "unfilled" do
+        it "returns a hash with the mfj_disabled attribute not populated" do
+          attributes = StateFile::IdDisabilityForm.existing_attributes(intake)
+
+          expect(attributes[:mfj_disability]).to eq nil
+        end
+      end
+
+      context "primary_disabled" do
+        let(:primary_disabled) { "yes" }
+        let(:spouse_disabled) { "no" }
+
+        it "returns a hash with the mfj_disabled attribute populated 'primary'" do
+          attributes = StateFile::IdDisabilityForm.existing_attributes(intake)
+
+          expect(attributes[:mfj_disability]).to eq "primary"
+        end
+      end
+
+      context "spouse_disabled" do
+        let(:primary_disabled) { "no" }
+        let(:spouse_disabled) { "yes" }
+
+        it "returns a hash with the mfj_disabled attribute populated 'spouse'" do
+          attributes = StateFile::IdDisabilityForm.existing_attributes(intake)
+
+          expect(attributes[:mfj_disability]).to eq "spouse"
+        end
+      end
+
+      context "both disabled" do
+        let(:primary_disabled) { "yes" }
+        let(:spouse_disabled) { "yes" }
+
+        it "returns a hash with the mfj_disabled attribute populated 'both'" do
+          attributes = StateFile::IdDisabilityForm.existing_attributes(intake)
+
+          expect(attributes[:mfj_disability]).to eq "both"
+        end
+      end
+
+      context "none disabled" do
+        let(:primary_disabled) { "no" }
+        let(:spouse_disabled) { "no" }
+
+        it "returns a hash with the mfj_disabled attribute populated 'none" do
+          attributes = StateFile::IdDisabilityForm.existing_attributes(intake)
+
+          expect(attributes[:mfj_disability]).to eq "none"
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-2014
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Utilized `self.existing_attributes` to fill out `mfj_disability` option, deduced from `intake.primary_disabled` & `intake.spouse_disabled` columns
## How to test?
- Describe the testing approach taken to verify the changes, including:
  - Wrote unit & feature spec
  - Test data used: Use Barrel_roll for mfj, both 62-65 filers who need to answer disability questions. Answer them & return to the page either by using back button or using "review and edit" button from final review page
- Specify any relevant testing environments used (e.g., development, staging, demo, Heroku).