### PR TITLE
[FYST-2038] ID Disability: Show persisted mfj_disability option parsed from intake attributes

### DIFF
--- a/app/forms/state_file/id_disability_form.rb
+++ b/app/forms/state_file/id_disability_form.rb
@@ -32,7 +32,7 @@ module StateFile
           @intake.update(primary_disabled: "no", spouse_disabled: "no")
         end
       else
-        @intake.update(attributes_for(:intake))
+        @intake.update(attributes_for(:intake).except(:mfj_disability))
       end
 
       clean_up_followups

--- a/app/forms/state_file/id_disability_form.rb
+++ b/app/forms/state_file/id_disability_form.rb
@@ -21,7 +21,7 @@ module StateFile
           else
             "none"
           end
-        self.mfj_disability = mfj_disability
+        self.mfj_disability ||= mfj_disability
       end
     end
 

--- a/app/forms/state_file/id_disability_form.rb
+++ b/app/forms/state_file/id_disability_form.rb
@@ -1,9 +1,8 @@
 module StateFile
   class IdDisabilityForm < QuestionsForm
-    set_attributes_for :intake, :primary_disabled, :spouse_disabled
+    set_attributes_for :intake, :primary_disabled, :spouse_disabled, :mfj_disability
 
     attr_accessor :mfj_disability
-    set_attributes_for :intake, :mfj_disability
     validates_presence_of :mfj_disability, if: -> { intake.show_mfj_disability_options? }
     validates :primary_disabled, inclusion: { in: %w[yes no], message: :blank }, if: -> { should_check_primary_disabled? }
     validates :spouse_disabled, inclusion: { in: %w[yes no], message: :blank }, if: -> { should_check_spouse_disabled? }

--- a/app/forms/state_file/id_disability_form.rb
+++ b/app/forms/state_file/id_disability_form.rb
@@ -50,7 +50,7 @@ module StateFile
           @intake.update(primary_disabled: "no", spouse_disabled: "no")
         end
       else
-        @intake.update(attributes_for(:intake).except(:mfj_disability))
+        @intake.update(attributes_for(:intake))
       end
 
       clean_up_followups

--- a/app/forms/state_file/id_disability_form.rb
+++ b/app/forms/state_file/id_disability_form.rb
@@ -3,6 +3,7 @@ module StateFile
     set_attributes_for :intake, :primary_disabled, :spouse_disabled
 
     attr_accessor :mfj_disability
+    set_attributes_for :intake, :mfj_disability
     validates_presence_of :mfj_disability, if: -> { intake.show_mfj_disability_options? }
     validates :primary_disabled, inclusion: { in: %w[yes no], message: :blank }, if: -> { should_check_primary_disabled? }
     validates :spouse_disabled, inclusion: { in: %w[yes no], message: :blank }, if: -> { should_check_spouse_disabled? }
@@ -36,6 +37,27 @@ module StateFile
       end
 
       clean_up_followups
+    end
+
+    def self.existing_attributes(intake)
+      already_answered_disability = !intake.primary_disabled_unfilled? && !intake.spouse_disabled_unfilled?
+      if intake.show_mfj_disability_options? && already_answered_disability
+        mfj_disability =
+          if intake.primary_disabled_yes? && intake.spouse_disabled_yes?
+            "both"
+          elsif intake.primary_disabled_yes?
+            "primary"
+          elsif intake.spouse_disabled_yes?
+            "spouse"
+          else
+            "none"
+          end
+        super.merge(
+          mfj_disability: mfj_disability
+        )
+      else
+        super
+      end
     end
 
     private

--- a/app/forms/state_file/id_disability_form.rb
+++ b/app/forms/state_file/id_disability_form.rb
@@ -21,7 +21,7 @@ module StateFile
 
     def save
       if intake.show_mfj_disability_options?
-        mfj_disability_to_disabled_attributes = self.class.mfj_disability_to_disabled_attributes_hash[mfj_disability&.to_sym]
+        mfj_disability_to_disabled_attributes = self.class.mfj_disability_to_disabled_attributes_hash[mfj_disability&.to_sym] || {}
 
         @intake.update(
           primary_disabled: mfj_disability_to_disabled_attributes && mfj_disability_to_disabled_attributes[:primary],

--- a/app/forms/state_file/id_disability_form.rb
+++ b/app/forms/state_file/id_disability_form.rb
@@ -24,8 +24,8 @@ module StateFile
         mfj_disability_to_disabled_attributes = self.class.mfj_disability_to_disabled_attributes_hash[mfj_disability&.to_sym]
 
         @intake.update(
-          primary_disabled: mfj_disability_to_disabled_attributes && mfj_disability_to_disabled_attributes[0],
-          spouse_disabled: mfj_disability_to_disabled_attributes && mfj_disability_to_disabled_attributes[1]
+          primary_disabled: mfj_disability_to_disabled_attributes && mfj_disability_to_disabled_attributes[:primary],
+          spouse_disabled: mfj_disability_to_disabled_attributes && mfj_disability_to_disabled_attributes[:spouse]
         )
       else
         @intake.update(attributes_for(:intake).except(:mfj_disability))
@@ -38,8 +38,8 @@ module StateFile
     def self.existing_attributes(intake)
       already_answered_disability = !intake.primary_disabled_unfilled? && !intake.spouse_disabled_unfilled?
       if intake.show_mfj_disability_options? && already_answered_disability
-        disability_to_mfj_disability_hash = self.mfj_disability_to_disabled_attributes_hash.invert
-        previously_answered_mfj_disability = disability_to_mfj_disability_hash[[intake.primary_disabled, intake.spouse_disabled]]&.to_s
+        value = {primary: intake.primary_disabled, spouse: intake.spouse_disabled}
+        previously_answered_mfj_disability = self.mfj_disability_to_disabled_attributes_hash.key(value)&.to_s
         super.merge(
           mfj_disability: previously_answered_mfj_disability,
         )
@@ -50,10 +50,10 @@ module StateFile
 
     def self.mfj_disability_to_disabled_attributes_hash
       {
-        both: %w[yes yes],
-        none: %w[no no],
-        primary: %w[yes no],
-        spouse: %w[no yes]
+        both: {primary: "yes", spouse: "yes"},
+        none: {primary: "no", spouse: "no"},
+        primary: {primary: "yes", spouse: "no"},
+        spouse: {primary: "no", spouse: "yes"},
       }
     end
 
@@ -70,6 +70,5 @@ module StateFile
         spouse_followups.each(&:destroy)
       end
     end
-
   end
 end

--- a/spec/features/state_file/review_page_spec.rb
+++ b/spec/features/state_file/review_page_spec.rb
@@ -457,14 +457,14 @@ RSpec.feature "Completing a state file intake", active_job: true, js: true do
           it "can persist mfj disability question on review & change and persist a new disability state" do
             visit "/questions/id-review"
 
-            expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
+            page_change_check(I18n.t("state_file.questions.shared.abstract_review_header.title"))
 
             within "#disability-info" do
               expect(page).to have_text I18n.t("general.affirmative")
               click_on I18n.t("general.review_and_edit")
             end
 
-            expect(page).to have_text I18n.t("state_file.questions.id_disability.edit.title")
+            page_change_check(I18n.t("state_file.questions.id_disability.edit.title"))
             expect(page.find(:css, '#state_file_id_disability_form_mfj_disability_both')).to be_checked
             choose "Yes, my spouse is"
 
@@ -475,7 +475,7 @@ RSpec.feature "Completing a state file intake", active_job: true, js: true do
               click_on I18n.t("general.review_and_edit")
             end
 
-            expect(page).to have_text I18n.t("state_file.questions.id_disability.edit.title")
+            page_change_check(I18n.t("state_file.questions.id_disability.edit.title"))
             expect(page.find(:css, '#state_file_id_disability_form_mfj_disability_spouse')).to be_checked
           end
         end

--- a/spec/features/state_file/review_page_spec.rb
+++ b/spec/features/state_file/review_page_spec.rb
@@ -454,7 +454,7 @@ RSpec.feature "Completing a state file intake", active_job: true, js: true do
             StateFileId1099RFollowup.create(state_file1099_r: third_1099r, income_source: "police_officer", police_retirement_fund: "yes")
           end
 
-          it "can persist mfj disability question on review" do
+          it "can persist mfj disability question on review & change and persist a new disability state" do
             visit "/questions/id-review"
 
             expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
@@ -466,6 +466,17 @@ RSpec.feature "Completing a state file intake", active_job: true, js: true do
 
             expect(page).to have_text I18n.t("state_file.questions.id_disability.edit.title")
             expect(page.find(:css, '#state_file_id_disability_form_mfj_disability_both')).to be_checked
+            choose "Yes, my spouse is"
+
+            click_on I18n.t("general.continue")
+
+            within "#disability-info" do
+              expect(page).to have_text I18n.t("general.affirmative")
+              click_on I18n.t("general.review_and_edit")
+            end
+
+            expect(page).to have_text I18n.t("state_file.questions.id_disability.edit.title")
+            expect(page.find(:css, '#state_file_id_disability_form_mfj_disability_spouse')).to be_checked
           end
         end
       end

--- a/spec/features/state_file/review_page_spec.rb
+++ b/spec/features/state_file/review_page_spec.rb
@@ -438,6 +438,36 @@ RSpec.feature "Completing a state file intake", active_job: true, js: true do
           expect(page).to have_text I18n.t("state_file.questions.shared.id_disability_review_header.meets_qualifications")
         end
 
+        context "mfj" do
+          before do
+            allow_any_instance_of(StateFileIdIntake).to receive(:show_mfj_disability_options?).and_return(true)
+            @intake.update(
+              raw_direct_file_data: StateFile::DirectFileApiResponseSampleService.new.read_xml("id_barrel_roll"),
+              raw_direct_file_intake_data: StateFile::DirectFileApiResponseSampleService.new.read_json("id_barrel_roll"),
+              spouse_first_name: "Beepbeep",
+              spouse_last_name: "Boop",
+              spouse_birth_date: Date.new((MultiTenantService.statefile.current_tax_year - 65), 12, 2),
+              spouse_disabled: "yes" # both disabled
+            )
+
+            third_1099r = create(:state_file1099_r, intake: @intake, payer_name: "Third Spouse Inc", taxable_amount: 750, recipient_ssn: @intake.spouse.ssn)
+            StateFileId1099RFollowup.create(state_file1099_r: third_1099r, income_source: "police_officer", police_retirement_fund: "yes")
+          end
+
+          it "can persist mfj disability question on review" do
+            visit "/questions/id-review"
+
+            expect(page).to have_text I18n.t("state_file.questions.shared.abstract_review_header.title")
+
+            within "#disability-info" do
+              expect(page).to have_text I18n.t("general.affirmative")
+              click_on I18n.t("general.review_and_edit")
+            end
+
+            expect(page).to have_text I18n.t("state_file.questions.id_disability.edit.title")
+            expect(page.find(:css, '#state_file_id_disability_form_mfj_disability_both')).to be_checked
+          end
+        end
       end
 
       context "with eligible senior over 65 years old" do

--- a/spec/forms/state_file/id_disability_form_spec.rb
+++ b/spec/forms/state_file/id_disability_form_spec.rb
@@ -341,7 +341,7 @@ RSpec.describe StateFile::IdDisabilityForm do
       end
 
       context "unfilled" do
-        it "returns a hash with the mfj_disabled attribute not populated" do
+        it "does not set mfj_disability on the form" do
           expect(form.mfj_disability).to eq nil
         end
       end
@@ -350,7 +350,7 @@ RSpec.describe StateFile::IdDisabilityForm do
         let(:primary_disabled) { "yes" }
         let(:spouse_disabled) { "no" }
 
-        it "returns a hash with the mfj_disabled attribute populated 'primary'" do
+        it "sets mfj_disability to primary" do
           expect(form.mfj_disability).to eq "primary"
         end
       end
@@ -359,7 +359,7 @@ RSpec.describe StateFile::IdDisabilityForm do
         let(:primary_disabled) { "no" }
         let(:spouse_disabled) { "yes" }
 
-        it "returns a hash with the mfj_disabled attribute populated 'spouse'" do
+        it "sets mfj_disability to spouse" do
           expect(form.mfj_disability).to eq "spouse"
         end
       end
@@ -368,7 +368,7 @@ RSpec.describe StateFile::IdDisabilityForm do
         let(:primary_disabled) { "yes" }
         let(:spouse_disabled) { "yes" }
 
-        it "returns a hash with the mfj_disabled attribute populated 'both'" do
+        it "sets mfj_disability to both" do
           expect(form.mfj_disability).to eq "both"
         end
 
@@ -377,7 +377,7 @@ RSpec.describe StateFile::IdDisabilityForm do
             form.mfj_disability = "primary"
           end
 
-          it "should preserve the updated disability state, instead of overwriting from db" do
+          it "should preserve the updated disability, instead of overwriting with persisted values from db" do
             expect(form.mfj_disability).to eq "primary"
           end
         end
@@ -387,7 +387,7 @@ RSpec.describe StateFile::IdDisabilityForm do
         let(:primary_disabled) { "no" }
         let(:spouse_disabled) { "no" }
 
-        it "returns a hash with the mfj_disabled attribute populated 'none" do
+        it "sets mfj_disability to none" do
           expect(form.mfj_disability).to eq "none"
         end
       end

--- a/spec/forms/state_file/id_disability_form_spec.rb
+++ b/spec/forms/state_file/id_disability_form_spec.rb
@@ -326,21 +326,23 @@ RSpec.describe StateFile::IdDisabilityForm do
     end
   end
 
-  describe "#existing_attributes" do
+  describe "#initialize" do
     let(:primary_disabled) { "unfilled" }
     let(:spouse_disabled) { "unfilled" }
+    let(:form) { described_class.new(intake, {})}
 
     before do
-      allow(intake).to receive(:show_mfj_disability_options?).and_return true
       intake.update(primary_disabled: primary_disabled, spouse_disabled: spouse_disabled)
     end
 
     context "mfj_disabled" do
+      before do
+        allow(intake).to receive(:show_mfj_disability_options?).and_return true
+      end
+
       context "unfilled" do
         it "returns a hash with the mfj_disabled attribute not populated" do
-          attributes = StateFile::IdDisabilityForm.existing_attributes(intake)
-
-          expect(attributes[:mfj_disability]).to eq nil
+          expect(form.mfj_disability).to eq nil
         end
       end
 
@@ -349,9 +351,7 @@ RSpec.describe StateFile::IdDisabilityForm do
         let(:spouse_disabled) { "no" }
 
         it "returns a hash with the mfj_disabled attribute populated 'primary'" do
-          attributes = StateFile::IdDisabilityForm.existing_attributes(intake)
-
-          expect(attributes[:mfj_disability]).to eq "primary"
+          expect(form.mfj_disability).to eq "primary"
         end
       end
 
@@ -360,9 +360,7 @@ RSpec.describe StateFile::IdDisabilityForm do
         let(:spouse_disabled) { "yes" }
 
         it "returns a hash with the mfj_disabled attribute populated 'spouse'" do
-          attributes = StateFile::IdDisabilityForm.existing_attributes(intake)
-
-          expect(attributes[:mfj_disability]).to eq "spouse"
+          expect(form.mfj_disability).to eq "spouse"
         end
       end
 
@@ -371,9 +369,7 @@ RSpec.describe StateFile::IdDisabilityForm do
         let(:spouse_disabled) { "yes" }
 
         it "returns a hash with the mfj_disabled attribute populated 'both'" do
-          attributes = StateFile::IdDisabilityForm.existing_attributes(intake)
-
-          expect(attributes[:mfj_disability]).to eq "both"
+          expect(form.mfj_disability).to eq "both"
         end
       end
 
@@ -382,9 +378,7 @@ RSpec.describe StateFile::IdDisabilityForm do
         let(:spouse_disabled) { "no" }
 
         it "returns a hash with the mfj_disabled attribute populated 'none" do
-          attributes = StateFile::IdDisabilityForm.existing_attributes(intake)
-
-          expect(attributes[:mfj_disability]).to eq "none"
+          expect(form.mfj_disability).to eq "none"
         end
       end
     end

--- a/spec/forms/state_file/id_disability_form_spec.rb
+++ b/spec/forms/state_file/id_disability_form_spec.rb
@@ -371,6 +371,16 @@ RSpec.describe StateFile::IdDisabilityForm do
         it "returns a hash with the mfj_disabled attribute populated 'both'" do
           expect(form.mfj_disability).to eq "both"
         end
+
+        context "if changing to new disability state (form gets initialized from update)" do
+          before do
+            form.mfj_disability = "primary"
+          end
+
+          it "should preserve the updated disability state, instead of overwriting from db" do
+            expect(form.mfj_disability).to eq "primary"
+          end
+        end
       end
 
       context "none disabled" do

--- a/spec/forms/state_file/id_disability_form_spec.rb
+++ b/spec/forms/state_file/id_disability_form_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe StateFile::IdDisabilityForm do
           let(:params) { { primary_disabled: "yes" } }
 
           it "updates intake using attributes_for" do
-            expect(intake).to receive(:update).with(form.send(:attributes_for, :intake))
+            expect(intake).to receive(:update).with(form.send(:attributes_for, :intake).except(:mfj_disability))
             form.save
           end
         end
@@ -262,7 +262,7 @@ RSpec.describe StateFile::IdDisabilityForm do
           let(:params) { { primary_disabled: "no" } }
 
           it "updates intake using attributes_for" do
-            expect(intake).to receive(:update).with(form.send(:attributes_for, :intake))
+            expect(intake).to receive(:update).with(form.send(:attributes_for, :intake).except(:mfj_disability))
             expect do
               form.save
             end.to change(StateFileId1099RFollowup, :count).by(-1)
@@ -279,7 +279,7 @@ RSpec.describe StateFile::IdDisabilityForm do
           let(:params) { { spouse_disabled: "yes" } }
 
           it "updates intake using attributes_for" do
-            expect(intake).to receive(:update).with(form.send(:attributes_for, :intake))
+            expect(intake).to receive(:update).with(form.send(:attributes_for, :intake).except(:mfj_disability))
             form.save
           end
         end
@@ -289,7 +289,7 @@ RSpec.describe StateFile::IdDisabilityForm do
           let(:params) { { spouse_disabled: "no" } }
 
           it "updates intake using attributes_for" do
-            expect(intake).to receive(:update).with(form.send(:attributes_for, :intake))
+            expect(intake).to receive(:update).with(form.send(:attributes_for, :intake).except(:mfj_disability))
             expect do
               form.save
             end.to change(StateFileId1099RFollowup, :count).by(-1)
@@ -307,7 +307,7 @@ RSpec.describe StateFile::IdDisabilityForm do
         let(:params) { { primary_disabled: "yes" } }
 
         it "updates intake using attributes_for" do
-          expect(intake).to receive(:update).with(form.send(:attributes_for, :intake))
+          expect(intake).to receive(:update).with(form.send(:attributes_for, :intake).except(:mfj_disability))
           form.save
         end
       end
@@ -317,7 +317,7 @@ RSpec.describe StateFile::IdDisabilityForm do
         let(:params) { { primary_disabled: "no" } }
 
         it "updates intake using attributes_for" do
-          expect(intake).to receive(:update).with(form.send(:attributes_for, :intake))
+          expect(intake).to receive(:update).with(form.send(:attributes_for, :intake).except(:mfj_disability))
           expect do
             form.save
           end.to change(StateFileId1099RFollowup, :count).by(-1)
@@ -326,10 +326,11 @@ RSpec.describe StateFile::IdDisabilityForm do
     end
   end
 
-  describe "#initialize" do
+  describe "#existing_attributes" do
     let(:primary_disabled) { "unfilled" }
     let(:spouse_disabled) { "unfilled" }
     let(:form) { described_class.new(intake, {})}
+    let(:existing_attributes) { StateFile::IdDisabilityForm.existing_attributes(intake) }
 
     before do
       intake.update(primary_disabled: primary_disabled, spouse_disabled: spouse_disabled)
@@ -342,7 +343,7 @@ RSpec.describe StateFile::IdDisabilityForm do
 
       context "unfilled" do
         it "does not set mfj_disability on the form" do
-          expect(form.mfj_disability).to eq nil
+          expect(existing_attributes[:mfj_disability]).to eq nil
         end
       end
 
@@ -351,7 +352,7 @@ RSpec.describe StateFile::IdDisabilityForm do
         let(:spouse_disabled) { "no" }
 
         it "sets mfj_disability to primary" do
-          expect(form.mfj_disability).to eq "primary"
+          expect(existing_attributes[:mfj_disability]).to eq "primary"
         end
       end
 
@@ -360,7 +361,7 @@ RSpec.describe StateFile::IdDisabilityForm do
         let(:spouse_disabled) { "yes" }
 
         it "sets mfj_disability to spouse" do
-          expect(form.mfj_disability).to eq "spouse"
+          expect(existing_attributes[:mfj_disability]).to eq "spouse"
         end
       end
 
@@ -369,17 +370,7 @@ RSpec.describe StateFile::IdDisabilityForm do
         let(:spouse_disabled) { "yes" }
 
         it "sets mfj_disability to both" do
-          expect(form.mfj_disability).to eq "both"
-        end
-
-        context "if changing to new disability state (form gets initialized from update)" do
-          before do
-            form.mfj_disability = "primary"
-          end
-
-          it "should preserve the updated disability, instead of overwriting with persisted values from db" do
-            expect(form.mfj_disability).to eq "primary"
-          end
+          expect(existing_attributes[:mfj_disability]).to eq "both"
         end
       end
 
@@ -388,7 +379,7 @@ RSpec.describe StateFile::IdDisabilityForm do
         let(:spouse_disabled) { "no" }
 
         it "sets mfj_disability to none" do
-          expect(form.mfj_disability).to eq "none"
+          expect(existing_attributes[:mfj_disability]).to eq "none"
         end
       end
     end

--- a/spec/forms/state_file/id_disability_form_spec.rb
+++ b/spec/forms/state_file/id_disability_form_spec.rb
@@ -325,4 +325,68 @@ RSpec.describe StateFile::IdDisabilityForm do
       end
     end
   end
+
+  describe "#existing_attributes" do
+    let(:primary_disabled) { "unfilled" }
+    let(:spouse_disabled) { "unfilled" }
+
+    before do
+      allow(intake).to receive(:show_mfj_disability_options?).and_return true
+      intake.update(primary_disabled: primary_disabled, spouse_disabled: spouse_disabled)
+    end
+
+    context "mfj_disabled" do
+      context "unfilled" do
+        it "returns a hash with the mfj_disabled attribute not populated" do
+          attributes = StateFile::IdDisabilityForm.existing_attributes(intake)
+
+          expect(attributes[:mfj_disability]).to eq nil
+        end
+      end
+
+      context "primary_disabled" do
+        let(:primary_disabled) { "yes" }
+        let(:spouse_disabled) { "no" }
+
+        it "returns a hash with the mfj_disabled attribute populated 'primary'" do
+          attributes = StateFile::IdDisabilityForm.existing_attributes(intake)
+
+          expect(attributes[:mfj_disability]).to eq "primary"
+        end
+      end
+
+      context "spouse_disabled" do
+        let(:primary_disabled) { "no" }
+        let(:spouse_disabled) { "yes" }
+
+        it "returns a hash with the mfj_disabled attribute populated 'spouse'" do
+          attributes = StateFile::IdDisabilityForm.existing_attributes(intake)
+
+          expect(attributes[:mfj_disability]).to eq "spouse"
+        end
+      end
+
+      context "both disabled" do
+        let(:primary_disabled) { "yes" }
+        let(:spouse_disabled) { "yes" }
+
+        it "returns a hash with the mfj_disabled attribute populated 'both'" do
+          attributes = StateFile::IdDisabilityForm.existing_attributes(intake)
+
+          expect(attributes[:mfj_disability]).to eq "both"
+        end
+      end
+
+      context "none disabled" do
+        let(:primary_disabled) { "no" }
+        let(:spouse_disabled) { "no" }
+
+        it "returns a hash with the mfj_disabled attribute populated 'none" do
+          attributes = StateFile::IdDisabilityForm.existing_attributes(intake)
+
+          expect(attributes[:mfj_disability]).to eq "none"
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-2038
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Utilized `initialize` method to fill out `mfj_disability` option, deduced from `intake.primary_disabled` & `intake.spouse_disabled` columns
- Alternatives considered:
  - I tried using `existing_attributes` at first, but ran into issues with this approach b/c I had to `set_attributes_for :intake, :mfj_disability` but then the form would try to save the `mfj_disability` attribute in the db, which ofc does not have this column. 
  - Creating a migration to add a column for `mfj_disabled` which would be redundant. Refactoring to utilize the new column instead of `primary_disabled` / `spouse_disabled` seemed tricky
  - Different controllers based on whether we need to show mfj or not? I think we still need a migration for that?
  - If there were other suggestions that I don't quite remember pls let me know!
## How to test?
- Describe the testing approach taken to verify the changes, including:
  - Wrote unit & feature spec
  - Test data used: 
    - make sure retirement_ui flag is set
    - Use Barrel_roll for mfj, both 62-65 filers who need to answer disability questions. Answer them & return to the page either by using back button or using "review and edit" button from final review page. You should see the selected answer
- Specify any relevant testing environments used (e.g., development, staging, demo, Heroku).