### PR TITLE
check if we capped w2 state wages and show an error if so

### DIFF
--- a/app/models/state_file_base_intake.rb
+++ b/app/models/state_file_base_intake.rb
@@ -1,4 +1,6 @@
 class StateFileBaseIntake < ApplicationRecord
+  DB_NUMERIC_MAX = 9_999_999_999.99
+
   self.ignored_columns = [:df_data_import_failed_at, :bank_name]
 
   devise :lockable, :unlock_strategy => :time
@@ -173,7 +175,6 @@ class StateFileBaseIntake < ApplicationRecord
   def synchronize_df_w2s_to_database
     direct_file_data.w2s.each_with_index do |direct_file_w2, i|
       state_file_w2 = state_file_w2s.where(w2_index: i).first || state_file_w2s.build
-      db_numeric_max = 9_999_999_999.99
       box_14_values = {}
       direct_file_w2.w2_box14.each do |deduction|
         box_14_values[deduction[:other_description]] = deduction[:other_amount]
@@ -192,7 +193,7 @@ class StateFileBaseIntake < ApplicationRecord
         local_wages_and_tips_amount: direct_file_w2.LocalWagesAndTipsAmt,
         locality_nm: direct_file_w2.LocalityNm,
         state_income_tax_amount: direct_file_w2.StateIncomeTaxAmt,
-        state_wages_amount: [direct_file_w2.StateWagesAmt, db_numeric_max].min,
+        state_wages_amount: [direct_file_w2.StateWagesAmt, DB_NUMERIC_MAX].min,
         state_file_intake: self,
         wages: direct_file_w2.WagesAmt,
         w2_index: i,

--- a/app/models/state_file_w2.rb
+++ b/app/models/state_file_w2.rb
@@ -128,6 +128,9 @@ class StateFileW2 < ApplicationRecord
       elsif state_income_tax_amount.present? && state_income_tax_amount > w2.WagesAmt
         errors.add(:state_income_tax_amount, I18n.t("state_file.questions.w2.edit.wages_amt_error", wages_amount: w2.WagesAmt))
       end
+      if state_wages_amount != w2.StateWagesAmt && state_wages_amount == StateFileBaseIntake::DB_NUMERIC_MAX
+        errors.add(:state_wages_amount, I18n.t("state_file.questions.w2.edit.review_box_14"))
+      end
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4583,6 +4583,7 @@ en:
           local_wages_and_tips_amt_error: Please enter local wages and tips
           locality_nm_missing_error: Please select locality name
           no_money_amount: Please enter an amount. If amount is blank, enter $0.
+          review_box_14: Please review and update this number from Box 14 of your W-2.
           save_and_continue: Save and Continue
           state_income_tax_amt_error: Cannot be greater than State wages and tips.
           state_wages_amt_error: Please enter State wages and tips

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4598,6 +4598,7 @@ es:
           local_wages_and_tips_amt_error: Ingresa los salarios y propinas locales
           locality_nm_missing_error: Selecciona el nombre de la localidad
           no_money_amount: Please enter an amount. If amount is blank, enter $0.
+          review_box_14: Please review and update this number from Box 14 of your W-2.
           save_and_continue: Guardar y Continuar
           state_income_tax_amt_error: No puede ser mayor que los salarios y propinas estatales.
           state_wages_amt_error: Ingresa los salarios y propinas estatales


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-2048
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- We already have a way to show a blocking error on the income review page with a "please review" box next to the offending income form
- I reused this for a new error on W-2s that should only show up if we modified their state wages by capping it to a maximum with the code added in https://github.com/codeforamerica/vita-min/commit/06ec557be385797650cf6b3506f20de2537cde98
## How to test?
- Go through the flow for any state with a persona with a W2
- Modify the W2 in the XML editor to set state wages to a number greater than $9999999999.99
- On the income review screen, verify that a blocking error shows up, and that there is a warning next to the correct W2
- On the W2 edit form, verify that the  state wages has been capped
- Verify that you cannot submit the form without modifying the state wages amount
- Verify that if you modify it to a lower amount, you can succesfully submit the W2 form
- Verify that if you modify it to a higher amount, it gets capped again and fails to submit 