### PR TITLE
[FYST-2023] Refactor filing_status (state vs. federal) and audit MD

### DIFF
--- a/app/lib/efile/az/az140_calculator.rb
+++ b/app/lib/efile/az/az140_calculator.rb
@@ -108,7 +108,7 @@ module Efile
       def calculate_line_8
         count = 0
         count += 1 if @intake.primary_senior?
-        count += 1 if @intake.filing_status_mfj? && @intake.spouse_senior?
+        count += 1 if state_filing_status_mfj? && @intake.spouse_senior?
         count
       end
 
@@ -128,7 +128,7 @@ module Efile
         # total subtraction amount for pensions up to the maximum of $2,500 each for primary and spouse
         primary_pension_amount = @intake.sum_1099_r_followup_type_for_filer(:primary, :income_source_pension_plan?)
         primary_max_allowed_subtraction = [primary_pension_amount, 2500].min
-        return primary_max_allowed_subtraction unless @intake.filing_status_mfj?
+        return primary_max_allowed_subtraction unless state_filing_status_mfj?
 
         spouse_pension_amount = @intake.sum_1099_r_followup_type_for_filer(:spouse, :income_source_pension_plan?)
         [primary_max_allowed_subtraction, [spouse_pension_amount, 2500].min].sum
@@ -137,7 +137,7 @@ module Efile
       def calculate_line_29b
         # total subtraction amount for uniformed services
         primary_uniformed_retirement_amount = @intake.sum_1099_r_followup_type_for_filer(:primary, :income_source_uniformed_services?)
-        return primary_uniformed_retirement_amount unless @intake.filing_status_mfj?
+        return primary_uniformed_retirement_amount unless state_filing_status_mfj?
 
         [primary_uniformed_retirement_amount, @intake.sum_1099_r_followup_type_for_filer(:spouse, :income_source_uniformed_services?)].sum
       end
@@ -185,11 +185,11 @@ module Efile
 
       def calculate_line_43
         # AZ Standard Deductions for 2023
-        if filing_status_single?
+        if state_filing_status_single?
           14_600
-        elsif filing_status_mfj?
+        elsif state_filing_status_mfj?
           29_200
-        elsif filing_status_hoh?
+        elsif state_filing_status_hoh?
           21_900
         end
       end
@@ -231,7 +231,7 @@ module Efile
           wrksht_1_line_8 += line_or_zero("AZ140_LINE_#{line_num}").to_i
         end
         wrksht_2_line_2 = 1
-        if filing_status_mfj?
+        if state_filing_status_mfj?
           max_income = [
             [1, 20_000],
             [2, 23_600],
@@ -243,7 +243,7 @@ module Efile
           end
           wrksht_2_line_2 = 2
           wrksht_2_line_5 = 240
-        elsif filing_status_hoh? # or qualifying_widow
+        elsif state_filing_status_hoh? # or qualifying_widow
           max_income = [
             [1, 20_000],
             [2, 20_135],
@@ -294,7 +294,7 @@ module Efile
         else
           # TODO question: if they are filing with us does that automatically mean no AZ-140PTC?
           number_of_eligible_filers =
-            if filing_status_mfj?
+            if state_filing_status_mfj?
               [@intake.direct_file_json_data.primary_filer.ssn_not_valid_for_employment,
                @intake.direct_file_json_data.spouse_filer.ssn_not_valid_for_employment].count(&:blank?)
             else

--- a/app/lib/efile/az/az140_calculator.rb
+++ b/app/lib/efile/az/az140_calculator.rb
@@ -108,7 +108,7 @@ module Efile
       def calculate_line_8
         count = 0
         count += 1 if @intake.primary_senior?
-        count += 1 if state_filing_status_mfj? && @intake.spouse_senior?
+        count += 1 if @intake.state_filing_status_mfj? && @intake.spouse_senior?
         count
       end
 
@@ -128,7 +128,7 @@ module Efile
         # total subtraction amount for pensions up to the maximum of $2,500 each for primary and spouse
         primary_pension_amount = @intake.sum_1099_r_followup_type_for_filer(:primary, :income_source_pension_plan?)
         primary_max_allowed_subtraction = [primary_pension_amount, 2500].min
-        return primary_max_allowed_subtraction unless state_filing_status_mfj?
+        return primary_max_allowed_subtraction unless @intake.state_filing_status_mfj?
 
         spouse_pension_amount = @intake.sum_1099_r_followup_type_for_filer(:spouse, :income_source_pension_plan?)
         [primary_max_allowed_subtraction, [spouse_pension_amount, 2500].min].sum
@@ -137,7 +137,7 @@ module Efile
       def calculate_line_29b
         # total subtraction amount for uniformed services
         primary_uniformed_retirement_amount = @intake.sum_1099_r_followup_type_for_filer(:primary, :income_source_uniformed_services?)
-        return primary_uniformed_retirement_amount unless state_filing_status_mfj?
+        return primary_uniformed_retirement_amount unless @intake.state_filing_status_mfj?
 
         [primary_uniformed_retirement_amount, @intake.sum_1099_r_followup_type_for_filer(:spouse, :income_source_uniformed_services?)].sum
       end
@@ -185,11 +185,11 @@ module Efile
 
       def calculate_line_43
         # AZ Standard Deductions for 2023
-        if state_filing_status_single?
+        if @intake.state_filing_status_single?
           14_600
-        elsif state_filing_status_mfj?
+        elsif @intake.state_filing_status_mfj?
           29_200
-        elsif state_filing_status_hoh?
+        elsif @intake.state_filing_status_hoh?
           21_900
         end
       end
@@ -231,7 +231,7 @@ module Efile
           wrksht_1_line_8 += line_or_zero("AZ140_LINE_#{line_num}").to_i
         end
         wrksht_2_line_2 = 1
-        if state_filing_status_mfj?
+        if @intake.state_filing_status_mfj?
           max_income = [
             [1, 20_000],
             [2, 23_600],
@@ -243,7 +243,7 @@ module Efile
           end
           wrksht_2_line_2 = 2
           wrksht_2_line_5 = 240
-        elsif state_filing_status_hoh? # or qualifying_widow
+        elsif @intake.state_filing_status_hoh? # or qualifying_widow
           max_income = [
             [1, 20_000],
             [2, 20_135],
@@ -294,7 +294,7 @@ module Efile
         else
           # TODO question: if they are filing with us does that automatically mean no AZ-140PTC?
           number_of_eligible_filers =
-            if state_filing_status_mfj?
+            if @intake.state_filing_status_mfj?
               [@intake.direct_file_json_data.primary_filer.ssn_not_valid_for_employment,
                @intake.direct_file_json_data.spouse_filer.ssn_not_valid_for_employment].count(&:blank?)
             else

--- a/app/lib/efile/az/az321_calculator.rb
+++ b/app/lib/efile/az/az321_calculator.rb
@@ -5,6 +5,7 @@ class Efile::Az::Az321Calculator < ::Efile::TaxCalculator
     @value_access_tracker = value_access_tracker
     @lines = lines
     @intake = intake
+    @filing_status = intake.state_filing_status
   end
 
   def calculate
@@ -44,7 +45,7 @@ class Efile::Az::Az321Calculator < ::Efile::TaxCalculator
 
   def calculate_line_12
     # Single taxpayers or heads of household, enter $470. MFJ taxpayers, enter $938
-    case @intake.filing_status.to_sym
+    case @intake.state_filing_status
     when :married_filing_jointly
       938
     else

--- a/app/lib/efile/az/az322_calculator.rb
+++ b/app/lib/efile/az/az322_calculator.rb
@@ -38,7 +38,7 @@ module Efile
 
       def calculate_line_12
         # Single taxpayers or heads of household, enter $200. MFJ taxpayers, enter $400
-        case @intake.filing_status.to_sym
+        case @intake.state_filing_status.to_sym
         when :married_filing_jointly
           400
         else

--- a/app/lib/efile/id/id39_r_calculator.rb
+++ b/app/lib/efile/id/id39_r_calculator.rb
@@ -7,6 +7,7 @@ module Efile
         @value_access_tracker = value_access_tracker
         @lines = lines
         @intake = intake
+        @filing_status = intake.state_filing_status
         @direct_file_data = intake.direct_file_data
         @direct_file_json_data = intake.direct_file_json_data
       end
@@ -69,9 +70,9 @@ module Efile
       end
 
       def calculate_sec_b_line_8a
-        if @intake.filing_status_single? || @intake.filing_status_hoh? || @intake.filing_status_qw?
+        if state_filing_status_single? || state_filing_status_hoh? || state_filing_status_qw?
           45_864
-        elsif @intake.filing_status_mfj?
+        elsif state_filing_status_mfj?
           68_796
         end
       end

--- a/app/lib/efile/id/id40_calculator.rb
+++ b/app/lib/efile/id/id40_calculator.rb
@@ -75,7 +75,7 @@ module Efile
       end
 
       def calculate_line_6b
-        (@intake.filing_status_mfj? && !@direct_file_data.spouse_is_a_dependent?) ? 1 : 0
+        (state_filing_status_mfj? && !@direct_file_data.spouse_is_a_dependent?) ? 1 : 0
       end
 
       def calculate_line_6c
@@ -226,7 +226,7 @@ module Efile
         end
         credit += primary_eligible_months * (@intake.primary_senior? ? 11.67 : 10)
 
-        if filing_status_mfj?
+        if state_filing_status_mfj?
           spouse_eligible_months = 12
           if @intake.household_has_grocery_credit_ineligible_months_yes? && @intake.spouse_has_grocery_credit_ineligible_months_yes?
             spouse_eligible_months -= @intake.spouse_months_ineligible_for_grocery_credit

--- a/app/lib/efile/id/id40_calculator.rb
+++ b/app/lib/efile/id/id40_calculator.rb
@@ -75,7 +75,7 @@ module Efile
       end
 
       def calculate_line_6b
-        (state_filing_status_mfj? && !@direct_file_data.spouse_is_a_dependent?) ? 1 : 0
+        (@intake.state_filing_status_mfj? && !@direct_file_data.spouse_is_a_dependent?) ? 1 : 0
       end
 
       def calculate_line_6c

--- a/app/lib/efile/md/md502_calculator.rb
+++ b/app/lib/efile/md/md502_calculator.rb
@@ -355,7 +355,7 @@ module Efile
 
       def calculate_line_17
         if deduction_method_is_standard?
-          md_filing_status = md_filing_status_dependent? ? :dependent : @intake.filing_status
+          md_filing_status = @intake.state_filing_status
           status_group_key = FILING_STATUS_GROUPS.find { |_, group| group.include?(md_filing_status) }[0]
           deduction_table = DEDUCTION_TABLES[status_group_key]
           md_agi = line_or_zero(:MD502_LINE_16)
@@ -402,7 +402,7 @@ module Efile
                        [1_000..2_000, 20, 0.03],
                        [2_000..3_000, 50, 0.04],
                      ]
-                   elsif filing_status_single? || filing_status_mfs? || md_filing_status_dependent?
+                   elsif filing_status_single? || filing_status_mfs? || filing_status_dependent?
                      [
                        [3_000..100_000, 90, 0.0475],
                        [100_000..125_000, 4_697.5, 0.05],
@@ -432,7 +432,7 @@ module Efile
 
       def calculate_line_22
         # Earned Income Credit (EIC)
-        return if md_filing_status_dependent?
+        return if filing_status_dependent?
 
         if filing_status_mfj? || filing_status_mfs? || @direct_file_data.fed_eic_qc_claimed
           (@direct_file_data.fed_eic * 0.50).round
@@ -446,7 +446,7 @@ module Efile
       end
 
       def calculate_line_23
-        return 0 if md_filing_status_dependent? || @lines[:MD502_LINE_1B].value <= 0 || !deduction_method_is_standard?
+        return 0 if filing_status_dependent? || @lines[:MD502_LINE_1B].value <= 0 || !deduction_method_is_standard?
 
         comparison_amount = [@lines[:MD502_LINE_7].value, @lines[:MD502_LINE_1B].value].max
 
@@ -508,7 +508,7 @@ module Efile
                    when "Anne Arundel"
                      anne_arundel_local_tax_brackets.find { |bracket| taxable_net_income <= bracket[:threshold] }[:rate]
                    when "Frederick"
-                     if md_filing_status_dependent? || filing_status_single? || filing_status_mfs?
+                     if filing_status_dependent? || filing_status_single? || filing_status_mfs?
                        if taxable_net_income <= 25_000
                          0.0225
                        elsif taxable_net_income <= 50_000
@@ -543,7 +543,7 @@ module Efile
       end
 
       def anne_arundel_local_tax_brackets
-        if md_filing_status_dependent? || filing_status_single? || filing_status_mfs?
+        if filing_status_dependent? || filing_status_single? || filing_status_mfs?
           [
             { threshold: 50_000, rate: 0.0270 },
             { threshold: 400_000, rate: 0.0281 },
@@ -632,7 +632,7 @@ module Efile
 
       def calculate_line_42
         # Earned Income Credit (EIC)
-        return if md_filing_status_dependent?
+        return if filing_status_dependent?
 
         if filing_status_mfj? || filing_status_mfs? || @direct_file_data.fed_eic_qc_claimed
           [(@direct_file_data.fed_eic * 0.45).round - line_or_zero(:MD502_LINE_21), 0].max

--- a/app/lib/efile/md/md502_r_calculator.rb
+++ b/app/lib/efile/md/md502_r_calculator.rb
@@ -7,6 +7,7 @@ module Efile
         @value_access_tracker = value_access_tracker
         @lines = lines
         @intake = intake
+        @filing_status = intake.state_filing_status
         @direct_file_json_data = intake.direct_file_json_data
       end
 
@@ -33,7 +34,7 @@ module Efile
       end
 
       def calculate_spouse_disabled
-        return unless @intake.filing_status_mfj?
+        return unless state_filing_status_mfj?
 
         @intake.spouse_disabled_yes? ? "X" : nil
       end
@@ -60,7 +61,7 @@ module Efile
 
       def calculate_line_9a
         if @intake.direct_file_data.fed_ssb.positive?
-          if @intake.filing_status_mfj?
+          if state_filing_status_mfj?
             @intake.primary_ssb_amount&.round || @intake.direct_file_json_data.primary_filer_social_security_benefit_amount&.round
           else
             @intake.direct_file_data.fed_ssb.round
@@ -69,7 +70,7 @@ module Efile
       end
 
       def calculate_line_9b
-        if @intake.filing_status_mfj? && @intake.direct_file_data.fed_ssb.positive?
+        if state_filing_status_mfj? && @intake.direct_file_data.fed_ssb.positive?
           @intake.spouse_ssb_amount&.round || @intake.direct_file_json_data.spouse_filer_social_security_benefit_amount&.round
         end
       end
@@ -100,7 +101,7 @@ module Efile
 
       def calculate_line_11b
         if Flipper.enabled?(:show_retirement_ui)
-          @intake.filing_status_mfj? && @intake.qualifies_for_pension_exclusion?(:spouse) ? calculate_line_11(:spouse) : 0
+          state_filing_status_mfj? && @intake.qualifies_for_pension_exclusion?(:spouse) ? calculate_line_11(:spouse) : 0
         else
           0
         end

--- a/app/lib/efile/md/md502_su_calculator.rb
+++ b/app/lib/efile/md/md502_su_calculator.rb
@@ -9,6 +9,7 @@ module Efile
         @value_access_tracker = value_access_tracker
         @lines = lines
         @intake = intake
+        @filing_status = intake.state_filing_status
         @direct_file_json_data = intake.direct_file_json_data
       end
 
@@ -42,7 +43,7 @@ module Efile
       end
 
       def calculate_line_u_spouse
-        @intake.filing_status_mfj? ? calculate_military_per_filer(:spouse) : 0
+        state_filing_status_mfj? ? calculate_military_per_filer(:spouse) : 0
       end
 
       def calculate_line_v_primary
@@ -50,7 +51,7 @@ module Efile
       end
 
       def calculate_line_v_spouse
-        @intake.filing_status_mfj? ? calculate_public_safety_employee(:spouse) : 0
+        state_filing_status_mfj? ? calculate_public_safety_employee(:spouse) : 0
       end
 
       private

--- a/app/lib/efile/md/md502cr_calculator.rb
+++ b/app/lib/efile/md/md502cr_calculator.rb
@@ -7,8 +7,8 @@ module Efile
         @value_access_tracker = value_access_tracker
         @lines = lines
         @intake = intake
+        @filing_status = intake.state_filing_status.to_sym
         @direct_file_data = intake.direct_file_data
-        @filing_status = intake.filing_status.to_sym
       end
 
       def calculate
@@ -42,17 +42,17 @@ module Efile
       def calculate_md502_cr_part_m_line_1
         agi = line_or_zero(:MD502_LINE_1)
         credit = 0
-        if filing_status_mfj? && agi <= 150_000 && deduction_method_is_standard?
+        if state_filing_status_mfj? && agi <= 150_000 && deduction_method_is_standard?
           if @intake.primary_senior? && @intake.spouse_senior?
             credit = 1750
           elsif @intake.primary_senior? ^ @intake.spouse_senior?
             credit = 1000
           end
-        elsif (filing_status_qw? || filing_status_hoh?) && agi <= 150_000
+        elsif (state_filing_status_qw? || state_filing_status_hoh?) && agi <= 150_000
           if @intake.primary_senior?
             credit = 1750
           end
-        elsif (filing_status_single? || filing_status_mfs? || filing_status_dependent?) && agi <= 100_000
+        elsif (state_filing_status_single? || state_filing_status_mfs? || state_filing_status_dependent?) && agi <= 100_000
           if @intake.primary_senior?
             credit = 1000
           end
@@ -125,7 +125,7 @@ module Efile
 
         agi = line_or_zero(:MD502_LINE_1)
         agi_band = agi_bands.find do |row|
-          if filing_status_mfj?
+          if state_filing_status_mfj?
             row.mfj_floor <= agi && agi < row.mfj_ceiling
           else
             row.non_mfj_floor <= agi && agi < row.non_mfj_ceiling
@@ -153,7 +153,7 @@ module Efile
       end
 
       def calculate_part_cc_line_7
-        qualifying_fed_agi_limit = filing_status_mfj? ? 89_100 : 59_400
+        qualifying_fed_agi_limit = state_filing_status_mfj? ? 89_100 : 59_400
 
         return unless @direct_file_data.fed_agi <= qualifying_fed_agi_limit
         [line_or_zero(:MD502CR_PART_B_LINE_4) - line_or_zero(:MD502_LINE_21), 0].max

--- a/app/lib/efile/md/md502cr_calculator.rb
+++ b/app/lib/efile/md/md502cr_calculator.rb
@@ -52,7 +52,7 @@ module Efile
           if @intake.primary_senior?
             credit = 1750
           end
-        elsif (filing_status_single? || filing_status_mfs? || md_filing_status_dependent?) && agi <= 100_000
+        elsif (filing_status_single? || filing_status_mfs? || filing_status_dependent?) && agi <= 100_000
           if @intake.primary_senior?
             credit = 1000
           end

--- a/app/lib/efile/nc/d400_calculator.rb
+++ b/app/lib/efile/nc/d400_calculator.rb
@@ -76,7 +76,7 @@ module Efile
         sum = 0
 
         @intake.state_file1099_gs.each do |state_file_1099_g|
-          if @intake.filing_status_mfj? || state_file_1099_g.recipient_primary?
+          if state_filing_status_mfj? || state_file_1099_g.recipient_primary?
             sum += state_file_1099_g.unemployment_compensation_amount&.round
           end
         end
@@ -91,11 +91,11 @@ module Efile
       end
 
       def calculate_line_10b
-        income_ranges = if filing_status_single? || filing_status_mfs?
+        income_ranges = if state_filing_status_single? || state_filing_status_mfs?
                           [-Float::INFINITY..20_000, 20_001..30_000, 30_001..40_000, 40_001..50_000, 50_001..60_000, 60_001..70_000, 70_001..Float::INFINITY]
-                        elsif filing_status_hoh?
+                        elsif state_filing_status_hoh?
                           [-Float::INFINITY..30_000, 30_001..45_000, 45_001..60_000, 60_001..75_000, 75_001..90_000, 90_001..105_000, 105_001..Float::INFINITY]
-                        elsif filing_status_mfj? || filing_status_qw?
+                        elsif state_filing_status_mfj? || state_filing_status_qw?
                           [-Float::INFINITY..40_000, 40_001..60_000, 60_001..80_000, 80_001..100_000, 100_001..120_000, 120_001..140_000, 140_001..Float::INFINITY]
                         end
         income_range_index = income_ranges.find_index { |range| range.include?(@direct_file_data.fed_agi) }
@@ -115,7 +115,7 @@ module Efile
       }.freeze
 
       def calculate_line_11
-        STANDARD_DEDUCTIONS[@intake.filing_status]
+        STANDARD_DEDUCTIONS[@intake.state_filing_status]
       end
 
       def calculate_line_12a

--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -98,7 +98,7 @@ module Efile
       end
 
       def get_tax_rate_and_subtraction_amount(income)
-        if @intake.filing_status_mfs? || @intake.filing_status_single?
+        if state_filing_status_mfs? || state_filing_status_single?
           case income
           when 1..20_000
             [0.014, 0]
@@ -259,7 +259,7 @@ module Efile
       end
 
       def line_59_spouse
-        if @intake.filing_status_mfj?
+        if state_filing_status_mfj?
           get_personal_excess(@intake.spouse.ssn, ->(w2) { w2.get_box14_ui_overwrite }, excess_ui_wf_swf_max)
         end
       end
@@ -269,7 +269,7 @@ module Efile
       end
 
       def line_61_spouse
-        if @intake.filing_status_mfj?
+        if state_filing_status_mfj?
           get_personal_excess(@intake.spouse.ssn, ->(w2) { w2[:box14_fli] }, excess_fli_max)
         end
       end
@@ -283,14 +283,14 @@ module Efile
       end
 
       def filer_below_income_eligibility_threshold?(gross_income)
-        threshold = @intake.filing_status_single? || @intake.filing_status_mfs? ? 10_000 : 20_000
+        threshold = state_filing_status_single? || state_filing_status_mfs? ? 10_000 : 20_000
         gross_income <= threshold
       end
 
       private
 
       def line_6_spouse_checkbox
-        @intake.filing_status_mfj?
+        state_filing_status_mfj?
       end
 
       def line_8_self_checkbox
@@ -403,7 +403,7 @@ module Efile
           return nil unless @intake.rent_paid&.positive? || @intake.property_tax_paid&.positive?
           property_tax_paid = [@intake.property_tax_paid.to_f, 0].max
           rent_paid = [@intake.rent_paid.to_f * RENT_CONVERSION, 0].max
-          is_mfs = @intake.filing_status_mfs?
+          is_mfs = state_filing_status_mfs?
           
           if is_mfs && @intake.tenant_same_home_spouse_yes?
             rent_paid /= 2
@@ -558,7 +558,7 @@ module Efile
       end
 
       def calculate_line_65
-        return nil if @intake.filing_status == :married_filing_separately
+        return nil if state_filing_status_mfs?
 
         eligible_dependents_count = number_of_dependents_age_5_younger
         return nil if eligible_dependents_count.zero?
@@ -689,7 +689,7 @@ module Efile
       end
 
       def is_mfs_same_home
-        is_mfs = @intake.filing_status_mfs?
+        is_mfs = state_filing_status_mfs?
         is_same_home = @intake.tenant_same_home_spouse_yes? || @intake.homeowner_same_home_spouse_yes?
         is_mfs && is_same_home
       end

--- a/app/lib/efile/nj/nj_flat_eitc_eligibility.rb
+++ b/app/lib/efile/nj/nj_flat_eitc_eligibility.rb
@@ -5,13 +5,13 @@ module Efile
         def eligible?(intake)
           possibly_eligible?(intake) &&
             intake.claimed_as_eitc_qualifying_child_no? &&
-            (!intake.filing_status_mfj? || intake.spouse_claimed_as_eitc_qualifying_child_no?)
+            (!intake.state_filing_status_mfj? || intake.spouse_claimed_as_eitc_qualifying_child_no?)
         end
 
         def possibly_eligible?(intake)
           return false if intake.direct_file_data.fed_eic.positive?
 
-          return false if intake.filing_status_mfs?
+          return false if intake.state_filing_status_mfs?
 
           return false if investment_income_over_limit?(intake)
 
@@ -36,7 +36,7 @@ module Efile
           primary_age_exclusive = intake.calculate_age(intake.primary_birth_date, inclusive_of_jan_1: false)
           primary_age_inclusive = intake.calculate_age(intake.primary_birth_date, inclusive_of_jan_1: true)
 
-          if intake.filing_status_mfj?
+          if intake.state_filing_status_mfj?
             spouse_age_exclusive = intake.calculate_age(intake.spouse_birth_date, inclusive_of_jan_1: false)
             spouse_age_inclusive = intake.calculate_age(intake.spouse_birth_date, inclusive_of_jan_1: true)
 
@@ -57,7 +57,7 @@ module Efile
         end
 
         def is_under_income_total_limit?(intake)
-          income_threshold = if intake.filing_status_mfj?
+          income_threshold = if intake.state_filing_status_mfj?
                                25_511
                              else
                                18_591
@@ -69,7 +69,7 @@ module Efile
           return false if intake.primary.has_itin?
           return false if intake.direct_file_json_data.primary_filer.ssn_not_valid_for_employment
 
-          if intake.filing_status_mfj? && intake.direct_file_json_data.spouse_filer.present?
+          if intake.state_filing_status_mfj? && intake.direct_file_json_data.spouse_filer.present?
             return false if intake.spouse.has_itin?
             return false if intake.direct_file_json_data.spouse_filer.ssn_not_valid_for_employment
           end
@@ -79,7 +79,7 @@ module Efile
 
         def claimed_as_dependent?(intake)
           intake.direct_file_data.claimed_as_dependent? ||
-            (intake.filing_status_mfj? && intake.direct_file_data.spouse_is_a_dependent?)
+            (intake.state_filing_status_mfj? && intake.direct_file_data.spouse_is_a_dependent?)
         end
       end
     end

--- a/app/lib/efile/nj/nj_property_tax_eligibility.rb
+++ b/app/lib/efile/nj/nj_property_tax_eligibility.rb
@@ -21,7 +21,7 @@ module Efile
         def determine_eligibility(intake)
           total_income = intake.calculator.lines[:NJ1040_LINE_29].value
 
-          wage_minimum = if intake.filing_status_mfs? || intake.filing_status_single?
+          wage_minimum = if intake.state_filing_status_mfs? || intake.state_filing_status_single?
                            10_000
                          else
                            20_000
@@ -33,7 +33,7 @@ module Efile
                             intake.primary_disabled_yes? ||
                             intake.primary_senior?
 
-          spouse_meets_exception = intake.filing_status_mfj? &&
+          spouse_meets_exception = intake.state_filing_status_mfj? &&
                                    (
                                      intake.direct_file_data.is_spouse_blind? ||
                                      intake.spouse_disabled_yes? ||

--- a/app/lib/efile/nj/nj_retirement_income_helper.rb
+++ b/app/lib/efile/nj/nj_retirement_income_helper.rb
@@ -16,9 +16,9 @@ module Efile
         end
 
         box_1_gross_income = non_military_1099r_box_1_total + line_15 + line_16a
-        max_exclusion_threshold = if @intake.filing_status_mfs? 
+        max_exclusion_threshold = if @intake.state_filing_status_mfs?
                                     50_000
-                                  elsif @intake.filing_status_mfj?
+                                  elsif @intake.state_filing_status_mfj?
                                     100_000
                                   else
                                     75_000
@@ -126,7 +126,7 @@ module Efile
       end
 
       def calculate_maximum_exclusion(total_income, income_for_exclusion)
-        if @intake.filing_status_mfs?
+        if @intake.state_filing_status_mfs?
           case total_income
           when 0..100_000
             50_000
@@ -137,7 +137,7 @@ module Efile
           else
             0
           end
-        elsif @intake.filing_status_mfj?
+        elsif @intake.state_filing_status_mfj?
           case total_income
           when 0..100_000
             100_000

--- a/app/lib/efile/ny/it201.rb
+++ b/app/lib/efile/ny/it201.rb
@@ -27,6 +27,7 @@ module Efile
           value_access_tracker: @value_access_tracker,
           lines: @lines
         )
+        @filing_status = @intake.state_filing_status
       end
 
       def calculate
@@ -141,13 +142,13 @@ module Efile
 
       def calculate_line_34
         # NY Standard Deductions for 2023
-        if filing_status_single? && @direct_file_data.claimed_as_dependent?
+        if state_filing_status_single? && @direct_file_data.claimed_as_dependent?
           3_100
-        elsif filing_status_single? || filing_status_mfs?
+        elsif state_filing_status_single? || state_filing_status_mfs?
           8_000
-        elsif filing_status_mfj? || filing_status_qw?
+        elsif state_filing_status_mfj? || state_filing_status_qw?
           16_050
-        elsif filing_status_hoh?
+        elsif state_filing_status_hoh?
           11_200
         end
       end
@@ -368,14 +369,14 @@ module Efile
         # I want to leave it in here until we have at least one more such tax table.
         row = Struct.new(:floor, :ceiling, :cumulative, :rate)
         table =
-          if filing_status_mfj? || filing_status_qw?
+          if state_filing_status_mfj? || state_filing_status_qw?
             [
               row.new(-Float::INFINITY, 21_600, 0, 0.03078),
               row.new(21_600, 45_000, 665, 0.03762),
               row.new(45_000, 90_000, 1_545, 0.03819),
               row.new(90_000, Float::INFINITY, 3_264, 0.03876)
             ]
-          elsif filing_status_hoh?
+          elsif state_filing_status_hoh?
             [
               row.new(-Float::INFINITY, 14_400, 0, 0.03078),
               row.new(14_400, 30_000, 443, 0.03762),
@@ -404,7 +405,7 @@ module Efile
         # size of 1.
         row = Struct.new(:floor, :ceiling, :amounts, :household_member_increment)
         table =
-          if filing_status_single?
+          if state_filing_status_single?
             [
               row.new(-Float::INFINITY, 5000, [75, 75, 75, 75, 75, 75, 75], 0),
               row.new(5_000, 6_000, [60, 60, 60, 60, 60, 60, 60], 0),
@@ -414,7 +415,7 @@ module Efile
               row.new(25_000, 28_000, [20, 20, 20, 20, 20, 20, 20], 0),
               row.new(28_000, Float::INFINITY, [0, 0, 0, 0, 0, 0, 0], 0)
             ]
-          elsif filing_status_mfs?
+          elsif state_filing_status_mfs?
             [
               row.new(-Float::INFINITY, 5_000, [45, 53, 60, 68, 75, 83, 90], 8),
               row.new(5_000, 6_000, [38, 45, 53, 60, 68, 75, 84], 8),
@@ -439,7 +440,7 @@ module Efile
               row.new(32_000, Float::INFINITY, [0, 0, 0, 0, 0, 0, 0], 0)
             ]
           end
-        num_filers = filing_status_mfj? || filing_status_mfs? ? 2 : 1
+        num_filers = state_filing_status_mfj? || state_filing_status_mfs? ? 2 : 1
         household_size = @dependent_count + num_filers
         table_row = table.reverse.find do |tr|
           amount > tr.floor && (amount <= tr.ceiling)
@@ -457,13 +458,13 @@ module Efile
         # size of 1.
         row = Struct.new(:floor, :ceiling, :amounts, :household_member_increment)
         table =
-          if filing_status_single?
+          if state_filing_status_single?
             [
               row.new(-Float::INFINITY, 10_000, [15, 15, 15, 15, 15, 15, 15], 0),
               row.new(10_000, 12_500, [10, 10, 10, 10, 10, 10, 10], 0),
               row.new(12_500, Float::INFINITY, [0, 0, 0, 0, 0, 0, 0], 0)
             ]
-          elsif filing_status_mfs?
+          elsif state_filing_status_mfs?
             [
               row.new(-Float::INFINITY, 15_000, [15, 30, 45, 60, 75, 90, 105], 15),
               row.new(15_000, 17_500, [13, 25, 38, 50, 63, 75, 88], 13),
@@ -480,7 +481,7 @@ module Efile
               row.new(22_500, Float::INFINITY, [0, 0, 0, 0, 0, 0, 0], 0)
             ]
           end
-        num_filers = filing_status_mfj? || filing_status_mfs? ? 2 : 1
+        num_filers = state_filing_status_mfj? || state_filing_status_mfs? ? 2 : 1
         household_size = @dependent_count + num_filers
         table_row = table.reverse.find do |tr|
           amount > tr.floor && (amount <= tr.ceiling)

--- a/app/lib/efile/ny/it213.rb
+++ b/app/lib/efile/ny/it213.rb
@@ -260,7 +260,7 @@ module Efile
       end
 
       def cutoff_for_filing_status
-        case @intake.filing_status.to_sym
+        case @intake.state_filing_status.to_sym
         when :married_filing_jointly
           110_000
         when :single, :head_of_household, :qualifying_widow

--- a/app/lib/efile/ny/it215.rb
+++ b/app/lib/efile/ny/it215.rb
@@ -50,7 +50,7 @@ module Efile
       end
 
       def calculate_line_3
-        @lines[:IT215_LINE_1].value == true && @intake.filing_status == :married_filing_separately
+        @lines[:IT215_LINE_1].value == true && @intake.state_filing_status == :married_filing_separately
       end
 
       def calculate_wk_a_line_3

--- a/app/lib/efile/tax_calculator.rb
+++ b/app/lib/efile/tax_calculator.rb
@@ -5,7 +5,7 @@ module Efile
     def initialize(year:, intake:, include_source: false)
       @year = year
       @intake = intake
-      @filing_status = intake.state_filing_status.to_sym
+      @filing_status = intake.state_filing_status
       @dependent_count = intake.dependents.length
       @direct_file_data = intake.direct_file_data
       @value_access_tracker = Efile::ValueAccessTracker.new(include_source: include_source)
@@ -58,27 +58,27 @@ module Efile
       @lines[line_id].value_access_tracker = @value_access_tracker
     end
 
-    def filing_status_mfj?
+    def state_filing_status_mfj?
       @filing_status == :married_filing_jointly
     end
 
-    def filing_status_mfs?
+    def state_filing_status_mfs?
       @filing_status == :married_filing_separately
     end
 
-    def filing_status_single?
+    def state_filing_status_single?
       @filing_status == :single
     end
 
-    def filing_status_hoh?
+    def state_filing_status_hoh?
       @filing_status == :head_of_household
     end
 
-    def filing_status_qw?
+    def state_filing_status_qw?
       @filing_status == :qualifying_widow
     end
 
-    def filing_status_dependent?
+    def state_filing_status_dependent?
       @filing_status == :dependent
     end
   end

--- a/app/lib/efile/tax_calculator.rb
+++ b/app/lib/efile/tax_calculator.rb
@@ -5,7 +5,7 @@ module Efile
     def initialize(year:, intake:, include_source: false)
       @year = year
       @intake = intake
-      @filing_status = intake.filing_status.to_sym
+      @filing_status = intake.state_filing_status.to_sym
       @dependent_count = intake.dependents.length
       @direct_file_data = intake.direct_file_data
       @value_access_tracker = Efile::ValueAccessTracker.new(include_source: include_source)
@@ -78,8 +78,8 @@ module Efile
       @filing_status == :qualifying_widow
     end
 
-    def md_filing_status_dependent?
-      @direct_file_data.claimed_as_dependent?
+    def filing_status_dependent?
+      @filing_status == :dependent
     end
   end
 end

--- a/app/lib/pdf_filler/az140_pdf.rb
+++ b/app/lib/pdf_filler/az140_pdf.rb
@@ -166,7 +166,7 @@ module PdfFiller
 
     FILING_STATUS_OPTIONS = {
       "MarriedJoint" => 'Choice1',
-      "HeadHousehold" => 'Choice2', # Qualifying Widow based state_file_az_intake#filing_status
+      "HeadHousehold" => 'Choice2', # Qualifying Widow based state_file_az_intake#state_filing_status
       "MarriedFilingSeparateReturn" => 'Choice3',
       "Single" => 'Choice4',
     }

--- a/app/lib/pdf_filler/id39r_pdf.rb
+++ b/app/lib/pdf_filler/id39r_pdf.rb
@@ -51,7 +51,7 @@ module PdfFiller
     def formatted_display_name
       primary_capitalized_first_name = @intake.primary.first_name.capitalize
       primary_capitalized_last_name = @intake.primary.last_name.capitalize
-      if @intake.filing_status_mfj?
+      if @intake.state_filing_status_mfj?
         spouse_capitalized_first_name = @intake.spouse.first_name.capitalize
         spouse_capitalized_last_name = @intake.spouse.last_name.capitalize
         if primary_capitalized_last_name == spouse_capitalized_last_name

--- a/app/lib/pdf_filler/it201_additional_dependents_pdf.rb
+++ b/app/lib/pdf_filler/it201_additional_dependents_pdf.rb
@@ -12,7 +12,7 @@ module PdfFiller
     def hash_for_pdf
       primary = @intake.primary
       name = primary.full_name
-      if @intake.filing_status_mfj?
+      if @intake.state_filing_status_mfj?
         name = "#{name} and #{@intake.spouse.full_name}"
       end
       answers = {

--- a/app/lib/pdf_filler/ny213_att_pdf.rb
+++ b/app/lib/pdf_filler/ny213_att_pdf.rb
@@ -39,7 +39,7 @@ module PdfFiller
 
     def names_on_return
       primary_name = "#{@xml_document.at('tiPrime FIRST_NAME')&.text} #{@xml_document.at('tiPrime LAST_NAME')&.text}"
-      if @intake.filing_status_mfj?
+      if @intake.state_filing_status_mfj?
         spouse_name = "#{@xml_document.at('tiSpouse FIRST_NAME')&.text} #{@xml_document.at('tiSpouse LAST_NAME')&.text}"
         "#{primary_name} and #{spouse_name}"
       else

--- a/app/lib/submission_builder/return_header.rb
+++ b/app/lib/submission_builder/return_header.rb
@@ -43,8 +43,8 @@ module SubmissionBuilder
             xml.DateSigned date_type_for_timezone(@submission.data_source.primary_esigned_at)&.strftime("%F") if @submission.data_source.primary_esigned_yes?
             xml.USPhone @submission.data_source.direct_file_data.phone_number if @submission.data_source.direct_file_data.phone_number.present?
           end
-          has_nra_spouse = @intake.check_nra_status? && @intake.direct_file_data.non_resident_alien == "NRA" && @intake.filing_status_mfs?
-          spouse_with_ssn = @submission.data_source.spouse&.ssn.present? && @submission.data_source.spouse&.first_name.present? && !@intake.filing_status_mfs?
+          has_nra_spouse = @intake.check_nra_status? && @intake.direct_file_data.non_resident_alien == "NRA" && @intake.state_filing_status_mfs?
+          spouse_with_ssn = @submission.data_source.spouse&.ssn.present? && @submission.data_source.spouse&.first_name.present? && !@intake.state_filing_status_mfs?
           if spouse_with_ssn || has_nra_spouse
             xml.Secondary do
               xml.TaxpayerName do

--- a/app/lib/submission_builder/ty2022/states/az/az_return_xml.rb
+++ b/app/lib/submission_builder/ty2022/states/az/az_return_xml.rb
@@ -176,7 +176,7 @@ module SubmissionBuilder
           end
 
           def filing_status
-            FILING_STATUS_OPTIONS[@submission.data_source.filing_status]
+            FILING_STATUS_OPTIONS[@submission.data_source.state_filing_status]
           end
 
           def financial_transaction

--- a/app/lib/submission_builder/ty2022/states/ny/documents/it201.rb
+++ b/app/lib/submission_builder/ty2022/states/ny/documents/it201.rb
@@ -20,7 +20,7 @@ module SubmissionBuilder
             def document
               build_xml_doc("IT201") do |xml|
                 xml.PR_DOB_DT claimed: intake.primary.birth_date.strftime("%Y-%m-%d") if intake.primary.birth_date.present?
-                xml.FS_CD claimed: FILING_STATUSES[intake.filing_status.to_sym] if intake.filing_status.present?
+                xml.FS_CD claimed: FILING_STATUSES[intake.state_filing_status.to_sym] if intake.state_filing_status.present?
                 xml.FED_ITZDED_IND claimed: 2 # Always 2 == NO
                 xml.DEP_CLAIM_IND claimed: intake.direct_file_data.claimed_as_dependent? ? 1 : 2 # 1 == YES, 2 == NO
                 xml.FORGN_ACCT_IND claimed: 2 # Always 2 == NO
@@ -28,7 +28,7 @@ module SubmissionBuilder
                 xml.YNK_WRK_LVNG_IND claimed: 2 # Always 2 == NO
                 if intake.nyc_residency_full_year?
                   xml.PR_NYC_MNTH_NMBR claimed: 12
-                  xml.SP_NYC_MNTH_NMBR claimed: 12 if intake.filing_status_mfj?
+                  xml.SP_NYC_MNTH_NMBR claimed: 12 if intake.state_filing_status_mfj?
                 elsif intake.nyc_residency_none? && intake.nyc_maintained_home_no?
                   xml.NYC_LVNG_QTR_IND claimed: 2
                 end

--- a/app/lib/submission_builder/ty2024/states/id/documents/id40.rb
+++ b/app/lib/submission_builder/ty2024/states/id/documents/id40.rb
@@ -29,7 +29,7 @@ module SubmissionBuilder
                     xml.DependentDOB date_type(@intake.primary.birth_date)
                   end
                 end
-                if @intake.filing_status_mfj?
+                if @intake.state_filing_status_mfj?
                   xml.DependentGrid do
                     xml.DependentFirstName sanitize_for_xml(@intake.spouse.first_name, 20)
                     xml.DependentLastName sanitize_for_xml(@intake.spouse.last_name, 20)
@@ -53,14 +53,14 @@ module SubmissionBuilder
                 if @direct_file_data.primary_over_65 == "X"
                   xml.PrimeOver65 1
                 end
-                if @intake.filing_status_mfj? && @direct_file_data.spouse_over_65 == "X"
+                if @intake.state_filing_status_mfj? && @direct_file_data.spouse_over_65 == "X"
                   xml.SpouseOver65 1
                 end
 
                 if @direct_file_data.primary_blind == "X"
                   xml.PrimeBlind 1
                 end
-                if @intake.filing_status_mfj? && @direct_file_data.spouse_blind == "X"
+                if @intake.state_filing_status_mfj? && @direct_file_data.spouse_blind == "X"
                   xml.SpouseBlind 1
                 end
                 if @direct_file_data.primary_claim_as_dependent == "X"

--- a/app/lib/submission_builder/ty2024/states/id/documents/id40.rb
+++ b/app/lib/submission_builder/ty2024/states/id/documents/id40.rb
@@ -98,7 +98,7 @@ module SubmissionBuilder
             private
 
             def filing_status
-              FILING_STATUS_OPTIONS[@submission.data_source.filing_status]
+              FILING_STATUS_OPTIONS[@submission.data_source.state_filing_status]
             end
 
             def calculated_fields

--- a/app/lib/submission_builder/ty2024/states/md/documents/md502.rb
+++ b/app/lib/submission_builder/ty2024/states/md/documents/md502.rb
@@ -63,7 +63,7 @@ class SubmissionBuilder::Ty2024::States::Md::Documents::Md502 < SubmissionBuilde
         xml.FilingStatus do
           xml.DependentTaxpayer "X"
         end
-      elsif @intake.filing_status == :married_filing_separately
+      elsif @intake.state_filing_status == :married_filing_separately
         xml.FilingStatus do
           xml.MarriedFilingSeparately "X", spouseSSN: @intake.direct_file_data.spouse_ssn
         end
@@ -79,7 +79,7 @@ class SubmissionBuilder::Ty2024::States::Md::Documents::Md502 < SubmissionBuilde
             add_element_if_present(xml, "Over65", :MD502_LINE_B_PRIMARY_SENIOR)
             add_element_if_present(xml, "Blind", :MD502_LINE_B_PRIMARY_BLIND)
           end
-          if @intake.filing_status_mfj? || @intake.filing_status_qw? # qw?
+          if @intake.state_filing_status_mfj? || @intake.state_filing_status_qw? # qw?
             xml.Spouse do
               add_element_if_present(xml, "Standard", :MD502_LINE_A_SPOUSE)
               add_element_if_present(xml, "Over65", :MD502_LINE_B_SPOUSE_SENIOR)
@@ -261,7 +261,7 @@ class SubmissionBuilder::Ty2024::States::Md::Documents::Md502 < SubmissionBuilde
   end
 
   def filing_status
-    FILING_STATUS_OPTIONS[@intake.filing_status]
+    FILING_STATUS_OPTIONS[@intake.state_filing_status]
   end
 
   def county_abbreviation

--- a/app/lib/submission_builder/ty2024/states/md/documents/md502_r.rb
+++ b/app/lib/submission_builder/ty2024/states/md/documents/md502_r.rb
@@ -11,7 +11,7 @@ module SubmissionBuilder
             def document
               xml_doc = build_xml_doc("Form502R", documentId: "Form502R") do |xml|
                 xml.PrimaryAge @intake.calculate_age(@intake.primary_birth_date, inclusive_of_jan_1: false)
-                xml.SecondaryAge @intake.calculate_age(@intake.spouse_birth_date, inclusive_of_jan_1: false) if @intake.filing_status_mfj?
+                xml.SecondaryAge @intake.calculate_age(@intake.spouse_birth_date, inclusive_of_jan_1: false) if @intake.state_filing_status_mfj?
                 if Flipper.enabled?(:show_retirement_ui)
                   add_element_if_present(xml, :PriTotalPermDisabledIndicator, :MD502R_LINE_PRIMARY_DISABLED)
                   add_element_if_present(xml, :SecTotalPermDisabledIndicator, :MD502R_LINE_SPOUSE_DISABLED)
@@ -21,7 +21,7 @@ module SubmissionBuilder
                       add_non_zero_value(xml, :OtherAndForeign, :MD502R_LINE_7A)
                     end
 
-                    if @intake.filing_status_mfj?
+                    if @intake.state_filing_status_mfj?
                       xml.SecondaryTaxpayer do
                         add_non_zero_value(xml, :EmployeeRetirementSystem, :MD502R_LINE_1B)
                         add_non_zero_value(xml, :OtherAndForeign, :MD502R_LINE_7B)

--- a/app/lib/submission_builder/ty2024/states/nc/documents/d400.rb
+++ b/app/lib/submission_builder/ty2024/states/nc/documents/d400.rb
@@ -93,7 +93,7 @@ module SubmissionBuilder
             private
 
             def filing_status
-              FILING_STATUS_OPTIONS[@submission.data_source.filing_status]
+              FILING_STATUS_OPTIONS[@submission.data_source.state_filing_status]
             end
 
             def calculated_fields

--- a/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
+++ b/app/lib/submission_builder/ty2024/states/nj/documents/nj1040.rb
@@ -24,7 +24,7 @@ module SubmissionBuilder
               build_xml_doc("FormNJ1040") do |xml|
                 xml.Header do
                   xml.FilingStatus do
-                    status = intake.filing_status.to_sym
+                    status = intake.state_filing_status.to_sym
                     case status
                     when :married_filing_separately
                       xml.MarriedCuPartFilingSeparate do

--- a/app/models/state_file_az_intake.rb
+++ b/app/models/state_file_az_intake.rb
@@ -118,6 +118,14 @@ class StateFileAzIntake < StateFileBaseIntake
   validates :az321_contributions, length: { maximum: 10 }
   validates :az322_contributions, length: { maximum: 10 }
 
+  def state_filing_status
+    if filing_status == :qualifying_widow
+      :head_of_household
+    else
+      super
+    end
+  end
+
   def federal_dependent_count_under_17
     self.dependents.select{ |dependent| dependent.under_17? }.length
   end
@@ -183,11 +191,6 @@ class StateFileAzIntake < StateFileBaseIntake
     all_filers_incarcerated = was_incarcerated_yes? || (primary_was_incarcerated_yes? && spouse_was_incarcerated_yes?)
     whole_credit_already_claimed = use_old_incarcerated_column? && household_excise_credit_claimed_yes?
     all_filers_incarcerated || whole_credit_already_claimed || direct_file_data.claimed_as_dependent?
-  end
-
-  def filing_status
-    return :head_of_household if direct_file_data&.filing_status == 5 # Treat qualifying_widow as hoh
-    super
   end
 
   def total_subtractions

--- a/app/models/state_file_az_intake.rb
+++ b/app/models/state_file_az_intake.rb
@@ -159,9 +159,9 @@ class StateFileAzIntake < StateFileBaseIntake
   def disqualified_from_excise_credit_df?
     return false if raw_direct_file_data.blank?
 
-    agi_limit = if filing_status_mfj? || filing_status_hoh?
+    agi_limit = if state_filing_status_mfj? || state_filing_status_hoh?
                   25000
-                elsif filing_status_single? || filing_status_mfs?
+                elsif state_filing_status_single? || state_filing_status_mfs?
                   12500
                 end
     agi_over_limit = direct_file_data.fed_agi > agi_limit

--- a/app/models/state_file_base_intake.rb
+++ b/app/models/state_file_base_intake.rb
@@ -280,6 +280,26 @@ class StateFileBaseIntake < ApplicationRecord
     filing_status == :qualifying_widow
   end
 
+  def state_filing_status_single?
+    state_filing_status == :single
+  end
+
+  def state_filing_status_mfj?
+    state_filing_status == :married_filing_jointly
+  end
+
+  def state_filing_status_mfs?
+    state_filing_status == :married_filing_separately
+  end
+
+  def state_filing_status_hoh?
+    state_filing_status == :head_of_household
+  end
+
+  def state_filing_status_qw?
+    state_filing_status == :qualifying_widow
+  end
+
   def filer_count
     filing_status_mfj? ? 2 : 1
   end

--- a/app/models/state_file_base_intake.rb
+++ b/app/models/state_file_base_intake.rb
@@ -256,6 +256,10 @@ class StateFileBaseIntake < ApplicationRecord
     }[direct_file_data&.filing_status]
   end
 
+  def state_filing_status
+    filing_status
+  end
+
   def filing_status_single?
     filing_status == :single
   end

--- a/app/models/state_file_md_intake.rb
+++ b/app/models/state_file_md_intake.rb
@@ -143,8 +143,12 @@ class StateFileMdIntake < StateFileBaseIntake
     if direct_file_data.claimed_as_dependent?
       :dependent
     else
-      filing_status
+      super
     end
+  end
+
+  def state_filing_status_dependent?
+    state_filing_status == :dependent
   end
 
   def disqualifying_df_data_reason
@@ -213,10 +217,6 @@ class StateFileMdIntake < StateFileBaseIntake
     dependents.any? do |dependent|
       dependent.md_did_not_have_health_insurance_yes?
     end
-  end
-
-  def filing_status_dependent?
-    filing_status == :dependent
   end
 
   def address

--- a/app/models/state_file_md_intake.rb
+++ b/app/models/state_file_md_intake.rb
@@ -139,6 +139,14 @@ class StateFileMdIntake < StateFileBaseIntake
   enum spouse_proof_of_disability_submitted: { unfilled: 0, yes: 1, no: 2 }, _prefix: :spouse_proof_of_disability_submitted
   enum paid_extension_payments: { unfilled: 0, yes: 1, no: 2 }, _prefix: :paid_extension_payments
 
+  def state_filing_status
+    if direct_file_data.claimed_as_dependent?
+      :dependent
+    else
+      filing_status
+    end
+  end
+
   def disqualifying_df_data_reason
     return :spouse_nra_html if nra_spouse?
     w2_states = direct_file_data.parsed_xml.css('W2StateLocalTaxGrp W2StateTaxGrp StateAbbreviationCd')

--- a/spec/controllers/flows_controller_spec.rb
+++ b/spec/controllers/flows_controller_spec.rb
@@ -134,7 +134,8 @@ RSpec.describe FlowsController do
         expect do
           post :generate, params: default_params.merge({ submit_qualifying_widow: 'Qualifying Widow ✨' })
         end.to change(StateFileAzIntake, :count).by(1)
-        expect(controller.current_intake.filing_status).to eq(:head_of_household) # In the AZ intake model we treat qualifying widow as hoh
+        expect(controller.current_intake.filing_status).to eq(:qualifying_widow) # In the AZ intake model we treat qualifying widow as hoh
+        expect(controller.current_intake.state_filing_status).to eq(:head_of_household) # In the AZ intake model we treat qualifying widow as hoh
       end
 
       it 'can generate a married filing separately intake' do

--- a/spec/lib/efile/az/az140_calculator_spec.rb
+++ b/spec/lib/efile/az/az140_calculator_spec.rb
@@ -154,7 +154,7 @@ describe Efile::Az::Az140Calculator do
 
       context "mfj" do
         before do
-          allow_any_instance_of(StateFileAzIntake).to receive(:filing_status_mfj?).and_return true
+          allow_any_instance_of(StateFileAzIntake).to receive(:state_filing_status_mfj?).and_return true
           allow_any_instance_of(StateFileAzIntake).to receive(:sum_1099_r_followup_type_for_filer).with(:primary, :income_source_pension_plan?).and_return 100
         end
 
@@ -201,7 +201,7 @@ describe Efile::Az::Az140Calculator do
 
         context "mfj" do
           before do
-            allow_any_instance_of(StateFileAzIntake).to receive(:filing_status_mfj?).and_return true
+            allow_any_instance_of(StateFileAzIntake).to receive(:state_filing_status_mfj?).and_return true
             allow_any_instance_of(StateFileAzIntake).to receive(:sum_1099_r_followup_type_for_filer).with(:primary, :income_source_uniformed_services?).and_return 100
             allow_any_instance_of(StateFileAzIntake).to receive(:sum_1099_r_followup_type_for_filer).with(:spouse, :income_source_uniformed_services?).and_return 300
           end

--- a/spec/lib/efile/id/id39_r_calculator_spec.rb
+++ b/spec/lib/efile/id/id39_r_calculator_spec.rb
@@ -156,7 +156,7 @@ describe Efile::Id::Id39RCalculator do
   describe "Section B Line 8a: Base Amount" do
     context "when filing single" do
       before do
-        allow(intake).to receive(:filing_status_single?).and_return(true)
+        allow(id40_calculator).to receive(:state_filing_status_single?).and_return(true)
       end
 
       it "returns $45,864" do
@@ -167,8 +167,8 @@ describe Efile::Id::Id39RCalculator do
 
     context "when filing married filing jointly" do
       before do
-        allow(intake).to receive(:filing_status_single?).and_return(false)
-        allow(intake).to receive(:filing_status_mfj?).and_return(true)
+        allow(instance).to receive(:state_filing_status_single?).and_return(false)
+        allow(instance).to receive(:state_filing_status_mfj?).and_return(true)
       end
 
       it "returns $68,796" do
@@ -179,8 +179,8 @@ describe Efile::Id::Id39RCalculator do
 
     context "when filing head of household" do
       before do
-        allow(intake).to receive(:filing_status_single?).and_return(false)
-        allow(intake).to receive(:filing_status_hoh?).and_return(true)
+        allow(instance).to receive(:state_filing_status_single?).and_return(false)
+        allow(instance).to receive(:state_filing_status_hoh?).and_return(true)
       end
 
       it "returns $45,864" do
@@ -191,8 +191,8 @@ describe Efile::Id::Id39RCalculator do
 
     context "when filing qualified widow" do
       before do
-        allow(intake).to receive(:filing_status_single?).and_return(false)
-        allow(intake).to receive(:filing_status_qw?).and_return(true)
+        allow(instance).to receive(:state_filing_status_single?).and_return(false)
+        allow(instance).to receive(:state_filing_status_qw?).and_return(true)
       end
 
       it "returns $45,864" do

--- a/spec/lib/efile/id/id40_calculator_spec.rb
+++ b/spec/lib/efile/id/id40_calculator_spec.rb
@@ -30,7 +30,7 @@ describe Efile::Id::Id40Calculator do
   describe "Line 6b: Spouse Exemption" do
     context "when filing jointly and spouse is not a dependent" do
       it "returns 1" do
-        allow(intake).to receive(:filing_status_mfj?).and_return(true)
+        allow(intake).to receive(:state_filing_status_mfj?).and_return(true)
         allow(intake.direct_file_data).to receive(:spouse_is_a_dependent?).and_return(false)
         instance.calculate
         expect(instance.lines[:ID40_LINE_6B].value).to eq(1)


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. https://codeforamerica.atlassian.net/browse/FYST-2023
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Using `state_filing_status` for calculators/xml/pdf
  - For all states, `state_filing_status` is same as `filing_status` (federal)
    - MD: if `direct_file_data.claimed_as_dependent`, the state filing status changes to `:dependent`
      - the change is more benign -- the "dependent" status was only in the calculator anyways. BUT running into some situations where we use filing status for filling out things in xml/pdf and wondering if we need to rely on federal filing for those...it's confusing 🙃 
    - AZ: if filing_status is `:qualifying_widow`, we consider their status `:head_of_household` 
      - bit more dangerous b/c AZ flow had basically operated with `filing_status` that is overwritten (unless `direct_file.filing_status` was directly called instead). it's actually "safer" to use `state_filing_status` since it's exactly what `filing_status` used to be. But now I need to think through on the flip side of the coin if this will have adverse effects where we use `intake.filing_status`
- do we want to use state_filing_status for controller logic?  
## How to test?
- Describe the testing approach taken to verify the changes, including:
  - Unit/integration/manual tests
  - Test data used
- Specify any relevant testing environments used (e.g., development, staging, demo, Heroku).
- Risk Assessment
  - Risks or side effects associated with the changes and how they were mitigated.
  - Highlight areas that may need extra attention during code review or testing.
  - Paste SQL queries or output where relevant
## Screenshots (for visual changes)
- Before
- After
