### PR TITLE
[gyr1-700] small typo, unbreaks click tracking (probably)

### DIFF
--- a/app/javascript/lib/mixpanel_event_tracking.js
+++ b/app/javascript/lib/mixpanel_event_tracking.js
@@ -36,8 +36,8 @@ const MixpanelEventTracking = (function () {
           }
           const csrfParam = document.querySelector('meta[name=csrf-param]')?.content
           const csrfToken = document.querySelector('meta[name=csrf-token]')?.content
-          eventData.append(csrfParam, csrfToken);
-          if (pageData.sendMixpanelBeacon) {
+          if (pageData.sendMixpanelBeacon && csrfParam !== undefined && csrfToken !== undefined ) {
+            eventData.append(csrfParam, csrfToken);
             navigator.sendBeacon("/ajax_mixpanel_events", eventData);
           }
         });

--- a/app/javascript/lib/mixpanel_event_tracking.js
+++ b/app/javascript/lib/mixpanel_event_tracking.js
@@ -34,7 +34,7 @@ const MixpanelEventTracking = (function () {
           if (clickedElement.dataset.trackClickHref === "true") {
             eventData.append("event[data][href]", clickedElement.href);
           }
-          const csrfParam = document.querySelector('meta[name=param]')?.content
+          const csrfParam = document.querySelector('meta[name=csrf-param]')?.content
           const csrfToken = document.querySelector('meta[name=csrf-token]')?.content
           eventData.append(csrfParam, csrfToken);
           if (pageData.sendMixpanelBeacon) {

--- a/spec/javascript/lib/mixpanel_event_tracking.spec.js
+++ b/spec/javascript/lib/mixpanel_event_tracking.spec.js
@@ -3,6 +3,8 @@ import MixpanelEventTracking from "lib/mixpanel_event_tracking";
 describe('MixpanelEventTracking', () => {
   beforeEach(() => {
     document.body.innerHTML = `
+          <meta name="csrf-param">iamaparam</meta>
+          <meta name="csrf-token">iamatoken</meta>
           <meta id="mixpanelData" data-controller-action="fake#action" 
                 data-full-path="/fake/path" data-send-mixpanel-beacon="true" />
           <a data-track-click="fake-event" data-track-attribute-is-welcoming="yup" href="/en/welcome">A Link</a>
@@ -12,6 +14,13 @@ describe('MixpanelEventTracking', () => {
   });
 
   describe('tracked clicks via [data-track-click]', () => {
+    test('does not track clicks when csrf info is missing', () => {
+      document.querySelector('meta[name=csrf-param]').remove();
+      MixpanelEventTracking.listenForTrackedClicks();
+      document.querySelector("a").click();
+      expect(navigator.sendBeacon).not.toBeCalled();
+    });
+
     test('sends tracked click event to mixpanel', () => {
       MixpanelEventTracking.listenForTrackedClicks();
       document.querySelector("a").click();


### PR DESCRIPTION
## Link to pivotal/JIRA issue
[GYR1-700](https://codeforamerica.atlassian.net/browse/GYR1-700)
## Is PM acceptance required? (delete one)
- No - merge after code review approval

## What was done?
In the first go around of this ticket, I advised @jenny-heath to snag the csrf info directly from the dom, but in both implementation and review we failed to notice a typo in the call to `querySelector` that resulted in an `undefined` being passed as part of the csrf pair. Bbvs that's not valid so those requests were being silently dropped. 
## How to test?
This is tricky to test. Best way is to run the branch locally and trigger a few tracked click events. The service comparison/selection links on the gyr landing page, for example, have the `data-track-click` property. In dev, you should see log entries like:
```
Sending Mixpanel event: id 073590a5d1a3ddfa99997228f8805edc7e66477b12664d685d1f, event_name click_service-comparison-full-service [...]
```

The important bit is that the `event_name` begins with `click_`. As for really truly sending data to mixpanel, only prod does that. So there's no easy way to test in heroku, demo, or staging. That said, I tried to add a bit of safety by ensuring we have actual values for csrf-param and csrf-token before firing off the ajax request.

[GYR1-700]: https://codeforamerica.atlassian.net/browse/GYR1-700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ