### PR TITLE
[FYST-2074] Offboard MD MFJ clients if primary or spouse is claimed as dependent

### DIFF
--- a/app/models/state_file_md_intake.rb
+++ b/app/models/state_file_md_intake.rb
@@ -145,6 +145,7 @@ class StateFileMdIntake < StateFileBaseIntake
     return :has_out_of_state_w2 if w2_states.any? do |state|
       (state.text || '').upcase != state_code.upcase
     end
+    return :mfj_and_dependent_html if mfj_and_dependent?
   end
 
   def disqualifying_eligibility_rules
@@ -280,6 +281,11 @@ class StateFileMdIntake < StateFileBaseIntake
 
   def nra_spouse?
     filing_status == :married_filing_separately && !spouse.ssn.present?
+  end
+
+  def mfj_and_dependent?
+    has_dependent_filer = direct_file_data.claimed_as_dependent? || direct_file_data.spouse_is_a_dependent?
+    filing_status == :married_filing_jointly && has_dependent_filer
   end
 
   def direct_file_address_is_po_box?

--- a/app/services/state_file/submission_id_lookup.yml
+++ b/app/services/state_file/submission_id_lookup.yml
@@ -74,6 +74,7 @@ md_omar_mfj: 1016422024340a0c6hev
 md_percival_hoh: 7812652024354l7dqzzt
 md_ray_dependent: 7812652024354bg51kiy
 md_roan_income_ca: 1016422024339ljpztol
+md_simpson_mfj_dep: 10164220251152jltzfp
 md_spongebob: 1016422024339jf9cpjn
 md_superman_mfj: 10164220250073ividn3
 md_tiger_55: 101642202504484is6i5

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2591,11 +2591,11 @@ en:
             exempt_interest_exceeds_10k: you had more than $10,000 in tax-exempt interest income.
             has_irc_125_code: W2 lists IRC 125 benefit plan amounts.
             has_out_of_state_w2: you earned income in another state in %{filing_year}.
+            has_yonkers_income: lived, earned income, or maintained a home in Yonkers in 2024.
+            married_filing_separately: you are filing “married filing separately”.
             mfj_and_dependent_html: |
               you or your spouse indicated that you can be claimed on someone else’s return.<br><br>
               Maryland does not allow married filers to file a joint return if the taxpayer or spouse is claimed as a dependent.
-            has_yonkers_income: lived, earned income, or maintained a home in Yonkers in 2024.
-            married_filing_separately: you are filing “married filing separately”.
             spouse_nra_html: |
               you didn’t include your spouse’s SSN or ITIN in your federal return.<br><br>
               Maryland does not allow Married Filing Separately taxpayers to electronically file their state tax return without their spouse’s SSN or ITIN.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2591,6 +2591,9 @@ en:
             exempt_interest_exceeds_10k: you had more than $10,000 in tax-exempt interest income.
             has_irc_125_code: W2 lists IRC 125 benefit plan amounts.
             has_out_of_state_w2: you earned income in another state in %{filing_year}.
+            mfj_and_dependent_html: |
+              you or your spouse indicated that you can be claimed on someone else’s return.<br><br>
+              Maryland does not allow married filers to file a joint return if the taxpayer or spouse is claimed as a dependent.
             has_yonkers_income: lived, earned income, or maintained a home in Yonkers in 2024.
             married_filing_separately: you are filing “married filing separately”.
             spouse_nra_html: |

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2605,6 +2605,9 @@ es:
             exempt_interest_exceeds_10k: you had more than $10,000 in tax-exempt interest income.
             has_irc_125_code: tu formulario W-2 incluye cantidades del plan de beneficios del Código de Rentas Internas (IRC 125).
             has_out_of_state_w2: recibiste ingresos en otro estado en el %{filing_year}
+            mfj_and_dependent_html: |
+              you or your spouse indicated that you can be claimed on someone else’s return.<br><br>
+              Maryland does not allow married filers to file a joint return if the taxpayer or spouse is claimed as a dependent.
             has_yonkers_income: viviste, recibiste ingresos o mantuviste un hogar en Yonkers en 2024.
             married_filing_separately: estás presentando una declaración de impuestos "casado, declarando por separado".
             spouse_nra_html: |

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2608,8 +2608,8 @@ es:
             has_yonkers_income: viviste, recibiste ingresos o mantuviste un hogar en Yonkers en 2024.
             married_filing_separately: estás presentando una declaración de impuestos "casado, declarando por separado".
             mfj_and_dependent_html: |
-              you or your spouse indicated that you can be claimed on someone else’s return.<br><br>
-              Maryland does not allow married filers to file a joint return if the taxpayer or spouse is claimed as a dependent.
+              tú o tu cónyuge indicaron que pueden ser incluidos en la declaración de otra persona.<br><br>
+              Maryland no permite que las parejas casadas presenten una declaración conjunta si el contribuyente o el cónyuge está incluido como dependiente en la declaración de alguien más.
             spouse_nra_html: |
               no incluiste el Número de Seguro Social (SSN) o Número de Identificación Personal (ITIN) de tu cónyuge en tu declaración federal.<br><br>
               Maryland no permite contribuyentes con el estado Casado declarando por separado presentar la declaración estatal de forma electrónica sin el SSN o ITIN de su cónyuge.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2605,11 +2605,11 @@ es:
             exempt_interest_exceeds_10k: you had more than $10,000 in tax-exempt interest income.
             has_irc_125_code: tu formulario W-2 incluye cantidades del plan de beneficios del Código de Rentas Internas (IRC 125).
             has_out_of_state_w2: recibiste ingresos en otro estado en el %{filing_year}
+            has_yonkers_income: viviste, recibiste ingresos o mantuviste un hogar en Yonkers en 2024.
+            married_filing_separately: estás presentando una declaración de impuestos "casado, declarando por separado".
             mfj_and_dependent_html: |
               you or your spouse indicated that you can be claimed on someone else’s return.<br><br>
               Maryland does not allow married filers to file a joint return if the taxpayer or spouse is claimed as a dependent.
-            has_yonkers_income: viviste, recibiste ingresos o mantuviste un hogar en Yonkers en 2024.
-            married_filing_separately: estás presentando una declaración de impuestos "casado, declarando por separado".
             spouse_nra_html: |
               no incluiste el Número de Seguro Social (SSN) o Número de Identificación Personal (ITIN) de tu cónyuge en tu declaración federal.<br><br>
               Maryland no permite contribuyentes con el estado Casado declarando por separado presentar la declaración estatal de forma electrónica sin el SSN o ITIN de su cónyuge.

--- a/spec/factories/state_file_md_intakes.rb
+++ b/spec/factories/state_file_md_intakes.rb
@@ -207,11 +207,6 @@ FactoryBot.define do
       after(:create, &:synchronize_df_w2s_to_database)
     end
 
-
-    trait :with_w2s_synced do
-      after(:create, &:synchronize_df_w2s_to_database)
-    end
-
     trait :with_spouse do
       raw_direct_file_data { StateFile::DirectFileApiResponseSampleService.new.read_xml("md_minimal_with_spouse") }
       raw_direct_file_intake_data { StateFile::DirectFileApiResponseSampleService.new.read_json('md_minimal_with_spouse') }

--- a/spec/fixtures/state_file/fed_return_jsons/md/simpson_mfj_dep.json
+++ b/spec/fixtures/state_file/fed_return_jsons/md/simpson_mfj_dep.json
@@ -1,0 +1,59 @@
+{
+  "familyAndHousehold": [],
+  "socialSecurityReports": [
+    {
+      "formType": "SSA-1099",
+      "recipientTin": "400-00-4321",
+      "netBenefits": "5000.00"
+    }
+  ],
+  "filers": [
+    {
+      "lastName": "Simpson",
+      "dateOfBirth": "1989-05-12",
+      "suffix": null,
+      "isPrimaryFiler": false,
+      "firstName": "Homer",
+      "middleInitial": null,
+      "educatorExpenses": null,
+      "tin": "400-00-4321",
+      "interestReportsTotal": "0.00",
+      "isDisabled": true,
+      "form1099GsTotal": "0.00",
+      "isStudent": false,
+      "hsaTotalDeductibleAmount": null,
+      "ssnNotValidForEmployment": null
+    },
+    {
+      "lastName": "Simpson",
+      "dateOfBirth": "1990-01-01",
+      "suffix": null,
+      "isPrimaryFiler": true,
+      "firstName": "Marjorie",
+      "middleInitial": "J",
+      "educatorExpenses": null,
+      "tin": "400-00-1234",
+      "interestReportsTotal": "0.00",
+      "isDisabled": false,
+      "form1099GsTotal": "10000.00",
+      "isStudent": false,
+      "ssnNotValidForEmployment": null,
+      "hsaTotalDeductibleAmount": null
+    }
+  ],
+  "form1099Gs": [
+    {
+      "stateTaxWithheld": "0.00",
+      "has1099": true,
+      "amount": "10000.00",
+      "federalTaxWithheld": "100.00",
+      "amountPaidBackForBenefitsInTaxYear": "0.00",
+      "stateIdNumber": null,
+      "payerTin": "00-1234545",
+      "recipientTin": "400-00-1234",
+      "payer": "State of MD"
+    }
+  ],
+  "formW2s": [],
+  "interestReports": []
+}

--- a/spec/fixtures/state_file/fed_return_xmls/md/simpson_mfj_dep.xml
+++ b/spec/fixtures/state_file/fed_return_xmls/md/simpson_mfj_dep.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Return xmlns="http://www.irs.gov/efile" xmlns:efile="http://www.irs.gov/efile" returnVersion="2024v5.1">
+    <ReturnHeader binaryAttachmentCnt="0">
+        <TaxYr>2024</TaxYr>
+        <TaxPeriodBeginDt>2024-01-01</TaxPeriodBeginDt>
+        <TaxPeriodEndDt>2024-12-31</TaxPeriodEndDt>
+        <SoftwareVersionNum>7b964ef3f</SoftwareVersionNum>
+        <ReturnTypeCd>1040</ReturnTypeCd>
+        <Filer>
+            <PrimarySSN>400001234</PrimarySSN>
+            <SpouseSSN>400004321</SpouseSSN>
+            <NameLine1Txt>MARJORIE J &amp; HOMER&lt;SIMPSON</NameLine1Txt>
+            <PrimaryNameControlTxt>SIMP</PrimaryNameControlTxt>
+            <SpouseNameControlTxt>SIMP</SpouseNameControlTxt>
+            <USAddress>
+                <AddressLine1Txt>742 Evergreen Terrace</AddressLine1Txt>
+                <CityNm>Smith Island</CityNm>
+                <StateAbbreviationCd>MD</StateAbbreviationCd>
+                <ZIPCd>21824</ZIPCd>
+            </USAddress>
+            <PhoneNum>2223334444</PhoneNum>
+        </Filer>
+        <AdditionalFilerInformation>
+            <AtSubmissionFilingGrp>
+                <EmailAddressTxt>test-user+40000123-4526-461b-8aca-61167770b29f@directfile.test</EmailAddressTxt>
+            </AtSubmissionFilingGrp>
+        </AdditionalFilerInformation>
+    </ReturnHeader>
+    <ReturnData documentCnt="3">
+        <IRS1040 documentId="IRS10400001">
+            <IndividualReturnFilingStatusCd>2</IndividualReturnFilingStatusCd>
+            <VirtualCurAcquiredDurTYInd>false</VirtualCurAcquiredDurTYInd>
+            <SpouseClaimAsDependentInd>X</SpouseClaimAsDependentInd>
+            <TotalExemptPrimaryAndSpouseCnt>2</TotalExemptPrimaryAndSpouseCnt>
+            <ChldWhoLivedWithYouCnt>0</ChldWhoLivedWithYouCnt>
+            <OtherDependentsListedCnt>0</OtherDependentsListedCnt>
+            <TotalExemptionsCnt>2</TotalExemptionsCnt>
+            <SocSecBnftAmt>5000</SocSecBnftAmt>
+            <TotalAdditionalIncomeAmt>10000</TotalAdditionalIncomeAmt>
+            <TotalIncomeAmt>10000</TotalIncomeAmt>
+            <AdjustedGrossIncomeAmt>10000</AdjustedGrossIncomeAmt>
+            <TotalItemizedOrStandardDedAmt>1300</TotalItemizedOrStandardDedAmt>
+            <TotalDeductionsAmt>1300</TotalDeductionsAmt>
+            <TaxableIncomeAmt>8700</TaxableIncomeAmt>
+            <TaxAmt>873</TaxAmt>
+            <TotalTaxBeforeCrAndOthTaxesAmt>873</TotalTaxBeforeCrAndOthTaxesAmt>
+            <TaxLessCreditsAmt>873</TaxLessCreditsAmt>
+            <TotalTaxAmt>873</TotalTaxAmt>
+            <Form1099WithheldTaxAmt referenceDocumentId="OTHERWITHHOLDING0001" referenceDocumentName="OtherWithholdingStatement">100</Form1099WithheldTaxAmt>
+            <WithholdingTaxAmt>100</WithholdingTaxAmt>
+            <TotalPaymentsAmt>100</TotalPaymentsAmt>
+            <OwedAmt>773</OwedAmt>
+            <ThirdPartyDesigneeInd>false</ThirdPartyDesigneeInd>
+            <PrimaryOccupationTxt>Homemaker</PrimaryOccupationTxt>
+            <SpouseOccupationTxt>Safety Inspector</SpouseOccupationTxt>
+            <RefundProductCd>NO FINANCIAL PRODUCT</RefundProductCd>
+        </IRS1040>
+        <IRS1040Schedule1 documentId="IRS1040S1001">
+            <UnemploymentCompAmt>10000</UnemploymentCompAmt>
+            <TotalAdditionalIncomeAmt>10000</TotalAdditionalIncomeAmt>
+        </IRS1040Schedule1>
+        <OtherWithholdingStatement documentId="OTHERWITHHOLDING0001" documentName="OtherWithholdingStatement">
+            <OtherWithholdingStmt>
+                <WithholdingCd>FORM 1099</WithholdingCd>
+                <EIN>001234545</EIN>
+                <WithholdingAmt>100</WithholdingAmt>
+            </OtherWithholdingStmt>
+        </OtherWithholdingStatement>
+    </ReturnData>
+</Return>

--- a/spec/models/state_file_md_intake_spec.rb
+++ b/spec/models/state_file_md_intake_spec.rb
@@ -186,18 +186,9 @@ RSpec.describe StateFileMdIntake, type: :model do
     context "is mfj and has dependent filer" do
       let(:intake) { create :state_file_md_intake, :with_spouse }
 
-      context "has primary dependent" do
-        it "returns mfj_and_dependent_html" do
-          allow(intake.direct_file_data).to receive(:claimed_as_dependent?).and_return(true)
-          expect(intake.disqualifying_df_data_reason).to eq :mfj_and_dependent_html
-        end
-      end
-
-      context "has spouse dependent" do
-        it "returns mfj_and_dependent_html" do
-          allow(intake.direct_file_data).to receive(:spouse_is_a_dependent?).and_return(true)
-          expect(intake.disqualifying_df_data_reason).to eq :mfj_and_dependent_html
-        end
+      it "returns mfj_and_dependent_html" do
+        allow(intake.direct_file_data).to receive(:claimed_as_dependent?).and_return(true)
+        expect(intake.disqualifying_df_data_reason).to eq :mfj_and_dependent_html
       end
     end
   end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-2074
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Added a data offboarding scenario -- "we should offboard MD MFJ if primary or spouse is claimed as a dependent to ensure that they do not create an inaccurate return through FYST."

- Adding the simpson_mfj_dep fixture newly created to demonstrate the issue
- removing repeated `with_w2s_synced` trait from test factory
- added `#disqualifying_df_data_reason` tests

## How to test?
- Describe the testing approach taken to verify the changes, including:
  - Unit/manual tests
  - Test data used: MD simpson_mfj_dep
- Risk Assessment
  - it should not offboard except in this specific scenario
  - ~~we are still missing translations: https://codeforamerica.atlassian.net/browse/FYST-2074?focusedCommentId=18356~~
## Screenshots (for visual changes)
- Before
just proceeded as normal to the next screens

- After
<img width="577" alt="Screenshot 2025-04-28 at 11 08 38 AM" src="https://github.com/user-attachments/assets/8781fa0b-7df2-43d9-8282-68d5128f465b" />
<img width="624" alt="Screenshot 2025-04-29 at 9 21 22 AM" src="https://github.com/user-attachments/assets/28fb74ab-e7bc-4e39-83e6-de80d3be618d" />
