### PR TITLE
[GYR1-659] Do not install rack-mini-profiler in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,9 +87,10 @@ group :demo, :development, :test do
 end
 
 group :demo, :development, :heroku, :staging, :production do
-  # for storing results of rack-mini-profiler
   gem 'redis'
+end
 
+group :demo, :development, :heroku, :staging do
   gem 'rack-mini-profiler'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,7 @@ gem 'ordinalize_full'
 gem 'awesome_print'
 gem 'rack-attack'
 gem 'holidays'
+gem 'redis'
 
 # Use Flipper for feature flagging
 gem 'flipper'
@@ -84,10 +85,6 @@ gem 'flipper-ui'
 
 group :demo, :development, :test do
   gem 'factory_bot_rails' # added to demo for creating fake data
-end
-
-group :demo, :development, :heroku, :staging, :production do
-  gem 'redis'
 end
 
 group :demo, :development, :heroku, :staging do

--- a/config/initializers/rack_profiler.rb
+++ b/config/initializers/rack_profiler.rb
@@ -3,7 +3,7 @@ if Rails.env.heroku? || Rails.env.demo?
   Rack::MiniProfiler.config.start_hidden = true
 end
 
-if ENV['REDIS_URL'].present?
+if ENV['REDIS_URL'].present? && (Rails.env.demo? || Rails.env.development? || Rails.env.heroku? || Rails.env.staging?)
   Rack::MiniProfiler.config.storage_options = { url: ENV["REDIS_URL"] }
   Rack::MiniProfiler.config.storage = Rack::MiniProfiler::RedisStore
 end

--- a/config/initializers/rack_profiler.rb
+++ b/config/initializers/rack_profiler.rb
@@ -1,4 +1,4 @@
-if Rails.env.heroku? || Rails.env.demo? || Rails.env.production?
+if Rails.env.heroku? || Rails.env.demo?
   # Use the "Alt+P" keyboard shortcut to toggle visibility
   Rack::MiniProfiler.config.start_hidden = true
 end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/GYR1-659
## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- not installing rack-mini-profiler in production, which would lead `Rack::MiniProfiler` to be not defined
- `application_controller.rb` has this code:
```
  before_action do
    if defined?(Rack::MiniProfiler) && current_user&.admin?
      Rack::MiniProfiler.authorize_request
    end
  end
```
and b/c `Rack::MiniProfiler` is not defined without the gem installation, this code should not run. 
- Other than that Rack::MiniProfiler is referred to in the initializer. I removed `Rails.env.production?` check there & excluding the rest of the set up unless its in an env with REDIS _and_ rack-mini-profiler
## How to test?
- Describe the testing approach taken to verify the changes, including:
  - Since this impacts production specifically, we won't really be able to test it 
  - I tested this by treating `:development` like `:production` env in the `Gemfile` (you have to restart server after you make changes) and visiting statefile.localhost:3000 and not seeing the profiler result in the corner anymore.
- Risk Assessment
  - I don't think there's a risk, since we're just removing a gem??? but i tried to minimize potential errors on our side