### PR TITLE
Increase the Capybara.default_max_wait_time back up to 5 seconds

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -18,7 +18,7 @@ else
   Capybara.javascript_driver = :selenium_chrome_headless
 end
 
-Capybara.default_max_wait_time = 2
+Capybara.default_max_wait_time = 5
 Capybara.server = :puma, { Silent: true }
 Capybara.server_port = 9887 + ENV['TEST_ENV_NUMBER'].to_i
 if ENV['DOCKER']


### PR DESCRIPTION
## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Increase Capybara.default_max_wait_time to 5 seconds because of flakey capybara resize window issues we've been seeing
- apparently capybara resize window uses:
```
def resize_to(width, height)
  wait_for_stable_size { @driver.resize_window_to(handle, width, height) }
end
def wait_for_stable_size(seconds = session.config.default_max_wait_time)

```
