### PR TITLE
Monkey patch capybara resize_to method to increase wait time to five seconds

### DIFF
--- a/config/initializers/capybara_overrides.rb
+++ b/config/initializers/capybara_overrides.rb
@@ -1,0 +1,7 @@
+class Capybara::Window
+  def resize_to(width, height, override: false)
+    return super(width, height) unless override
+
+    wait_for_stable_size(10.seconds) { @driver.resize_window_to(handle, width, height) }
+  end
+end

--- a/config/initializers/capybara_overrides.rb
+++ b/config/initializers/capybara_overrides.rb
@@ -2,6 +2,6 @@ class Capybara::Window
   def resize_to(width, height, override: false)
     return super(width, height) unless override
 
-    wait_for_stable_size(10.seconds) { @driver.resize_window_to(handle, width, height) }
+    wait_for_stable_size(5.seconds) { @driver.resize_window_to(handle, width, height) }
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -182,7 +182,7 @@ RSpec.configure do |config|
 
   config.before(:each, js: true) do |example|
     Capybara.page.current_window.send(:wait_for_stable_size, 5) do
-      Capybara.current_driver.resize_to(*capybara_window_size)
+      Capybara.current_driver.resize_window_to(*capybara_window_size)
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -189,7 +189,8 @@ RSpec.configure do |config|
     if config.filter.rules[:flow_explorer_screenshot]
       example.metadata[:js] = true
       Capybara.current_driver = Capybara.javascript_driver
-      Capybara.page.current_window.resize_to(*capybara_window_size)
+      # Monkey patched in config/initializers/capybara_overrides.rb
+      Capybara.page.current_window.resize_to(*capybara_window_size, override: true)
     end
 
     unless Capybara.current_driver == Capybara.javascript_driver

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -181,7 +181,9 @@ RSpec.configure do |config|
   capybara_window_size = [2000, 4000]
 
   config.before(:each, js: true) do |example|
-    Capybara.page.current_window.resize_to(*capybara_window_size)
+    Capybara.page.wait_for_stable_size(5) do
+      Capybara.current_driver.resize_to(*capybara_window_size)
+    end
   end
 
   config.before(type: :feature) do |example|

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -181,7 +181,7 @@ RSpec.configure do |config|
   capybara_window_size = [2000, 4000]
 
   config.before(:each, js: true) do |example|
-    Capybara.page.current_window.wait_for_stable_size(5) do
+    Capybara.page.current_window.send(:wait_for_stable_size, 5) do
       Capybara.current_driver.resize_to(*capybara_window_size)
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -181,7 +181,7 @@ RSpec.configure do |config|
   capybara_window_size = [2000, 4000]
 
   config.before(:each, js: true) do |example|
-    Capybara.page.wait_for_stable_size(5) do
+    Capybara.page.current_window.wait_for_stable_size(5) do
       Capybara.current_driver.resize_to(*capybara_window_size)
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -180,10 +180,9 @@ RSpec.configure do |config|
   # the browser window needs to be large enough that no elements are outside the viewport, or capybara won't find them
   capybara_window_size = [2000, 4000]
 
-  config.before(:each, js: true) do |example|
-    Capybara.page.current_window.send(:wait_for_stable_size, 5) do
-      Capybara.current_driver.resize_window_to(*capybara_window_size)
-    end
+  config.before(:each, js: true) do |_example|
+    # Monkey patched in config/initializers/capybara_overrides.rb
+    Capybara.page.current_window.resize_to(*capybara_window_size, override: true)
   end
 
   config.before(type: :feature) do |example|

--- a/spec/support/helpers/responsive_helper.rb
+++ b/spec/support/helpers/responsive_helper.rb
@@ -20,7 +20,8 @@ module ResponsiveHelper
   def resize_window(width, height)
     case Capybara.current_driver
     when :selenium_chrome_headless
-      Capybara.current_session.driver.browser.manage.window.resize_to(width, height)
+      # Monkey patched in config/initializers/capybara_overrides.rb
+      Capybara.current_session.driver.browser.manage.window.resize_to(width, height, override: true)
     when :webkit
       handle = Capybara.current_session.driver.current_window_handle
       Capybara.current_session.driver.resize_window_to(handle, width, height)

--- a/spec/support/helpers/responsive_helper.rb
+++ b/spec/support/helpers/responsive_helper.rb
@@ -20,8 +20,7 @@ module ResponsiveHelper
   def resize_window(width, height)
     case Capybara.current_driver
     when :selenium_chrome_headless
-      # Monkey patched in config/initializers/capybara_overrides.rb
-      Capybara.current_session.driver.browser.manage.window.resize_to(width, height, override: true)
+      Capybara.current_session.driver.browser.manage.window.resize_to(width, height)
     when :webkit
       handle = Capybara.current_session.driver.current_window_handle
       Capybara.current_session.driver.resize_window_to(handle, width, height)


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. https://codeforamerica.atlassian.net/browse/ABCD-123
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- monkey patched capybara private method to specify the wait time to be five seconds because we didn't want it to use the default capybara wait time since we only needed it to be longer for the resize method
## How to test?
- Do the tests that use resize window work? for example: ./spec/features/hub/clients_searching_sorting_and_filtering_spec.rb:11

