### PR TITLE
[FYST-2075] Remove default from extension payment for state_file_az_intakes

### DIFF
--- a/db/migrate/20250327180616_add_extension_payments_to_state_file_az_intake.rb
+++ b/db/migrate/20250327180616_add_extension_payments_to_state_file_az_intake.rb
@@ -1,6 +1,6 @@
 class AddExtensionPaymentsToStateFileAzIntake < ActiveRecord::Migration[7.1]
   def change
-    add_column :state_file_az_intakes, :extension_payments_amount, :decimal, precision: 12, scale: 2
+    add_column :state_file_az_intakes, :extension_payments_amount, :decimal, default: 0, precision: 12, scale: 2
     add_column :state_file_az_intakes, :paid_extension_payments, :integer, default: 0, null: false
   end
 end

--- a/db/migrate/20250502204822_change_column_default_for_state_file_az_intake_extension_payment_amount.rb
+++ b/db/migrate/20250502204822_change_column_default_for_state_file_az_intake_extension_payment_amount.rb
@@ -1,0 +1,5 @@
+class ChangeColumnDefaultForStateFileAzIntakeExtensionPaymentAmount < ActiveRecord::Migration[7.1]
+  def change
+    change_column_default :state_file_az_intakes, :extension_payments_amount, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_14_203545) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_02_204822) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/FYST-2075
## Is PM acceptance required?
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
This is copied from the ticket: 

We noticed that for StateFileAzIntake after running migrations we kept on seeing 0.0 default value get annotated on the model/schema. We were able to bypass the annotations by rolling back & re-applying the new migration. However, demo/prod environments had already run the migration which had a default value, and later removed the default value (~6 days later). Since the migration had already run, it did not detect the change in default value and is currently still persisting 0.0 in these columns when it’s empty.
PR when this migration was tweaked: [Fyst 1903 implement md, id and nc state extension questions pdf xml by DrewProebstel · Pull Request #5862 · codeforamerica/vita-min](https://github.com/codeforamerica/vita-min/pull/5862/files#diff-7b96f6e78a06f47c5e2dd1804491ba958196f8fb63d6847e7987b3816b473e47R3) 
Slack convo: https://cfastaff.slack.com/archives/C0544ERAFQV/p1744746473813329