### PR TITLE
GYR1-729 Not Ready Status Bug

### DIFF
--- a/app/helpers/tax_return_status_helper.rb
+++ b/app/helpers/tax_return_status_helper.rb
@@ -2,8 +2,16 @@ module TaxReturnStatusHelper
   def grouped_status_options_for_select(unwanted_statuses: [])
     TaxReturnStateMachine.states_to_show_for_client_filter(role_type: current_user.role_type).map do |stage, statuses|
       translated_stage = TaxReturnStatusHelper.stage_translation(stage)
-      filtered_statuses = statuses.reject { |status| unwanted_statuses.include?(status.to_s) }
-      translated_statuses = filtered_statuses.map { |status| [TaxReturnStatusHelper.status_translation(status), status.to_s] }
+
+      translated_statuses = statuses.map do |status|
+        translated = TaxReturnStatusHelper.status_translation(status)
+        if unwanted_statuses.include?(status.to_s)
+          [translated, status.to_s, { disabled: true }]
+        else
+          [translated, status.to_s]
+        end
+      end
+
       [translated_stage, translated_statuses]
     end
   end

--- a/spec/features/hub/take_action_spec.rb
+++ b/spec/features/hub/take_action_spec.rb
@@ -85,7 +85,7 @@ RSpec.feature "Change tax return status on a client", :js do
       click_on "Cancel"
 
       expect(current_path).to eq(hub_client_path(id: client.id))
-      expect(page).to have_select("tax_return[current_state]", selected: "Needs doc help")
+      expect(page).to have_select("tax_return[current_state]", selected: "Not ready")
     end
 
     context "for an online intake ctc tax return" do

--- a/spec/features/hub/take_action_spec.rb
+++ b/spec/features/hub/take_action_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature "Change tax return status on a client", :js do
 
     scenario "can change a status on a tax return and send a templated message" do
       visit hub_client_path(id: client.id)
-      expect(page).to have_select("tax_return[current_state]", selected: "Needs doc help")
+      expect(page).to have_select("tax_return[current_state]", selected: "Not ready")
 
       within "#tax-return-#{tax_return.id}" do
         select "Greeter - info requested"
@@ -74,7 +74,7 @@ RSpec.feature "Change tax return status on a client", :js do
 
     scenario "can cancel the updates and return to client's profile" do
       visit hub_client_path(id: client.id)
-      expect(page).to have_select("tax_return[current_state]", selected: "Needs doc help")
+      expect(page).to have_select("tax_return[current_state]", selected: "Not ready")
 
       within "#tax-return-#{tax_return.id}" do
         select "Accepted"

--- a/spec/helpers/tax_return_status_helper_spec.rb
+++ b/spec/helpers/tax_return_status_helper_spec.rb
@@ -77,6 +77,7 @@ describe TaxReturnStatusHelper do
     expected = [
       ["Intake",
        [
+         ["Not ready", "intake_in_progress", {:disabled=>true}],
          ["Needs doc help", "intake_needs_doc_help"],
          ["Info requested", "intake_info_requested"],
          ["Greeter - info requested", "intake_greeter_info_requested"],


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/GYR1-729

## Is PM acceptance required? 
- Yes - don't merge until JIRA issue is accepted!


**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
This fixes a bug where the status “Not Ready” (internally called intake_in_progress) was missing from status dropdowns. That caused confusion because when a client is in the “Not Ready” status, on their profile it showed a different status like “Needs Doc Help”. This caused clients in this status not to be able finish their intake
This was fixed this by adding “Not Ready” back to the dropdown, but made sure it’s disabled, so it can’t be selected manually. This way the status is visible and the status is consistent across all pages but still protected from manual updates.

## How to test?
Client in intake_in_progress status:
- Should see "Not Ready" on All Clients page and in client profile
- Status dropdown (e.g., Take Action) should include "Not Ready" as a disabled option
Verified by updating the tax_return_status_helper_spec.rb spec with expectations for a disabled option

## Screenshots (for visual changes)
- Before
<img width="529" alt="Screenshot 2025-05-07 at 6 04 32 PM" src="https://github.com/user-attachments/assets/3dbb6695-43a4-4ed9-8035-a861e318786b" />

- After
<img width="476" alt="Screenshot 2025-05-07 at 5 46 54 PM" src="https://github.com/user-attachments/assets/d4441154-e471-41b0-9534-249a299c21c5" />
