### PR TITLE
Remove rotate image option for plain text files

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -98,6 +98,10 @@ class Document < ApplicationRecord
     upload&.content_type == "application/pdf"
   end
 
+  def is_txt_file?
+    upload&.content_type == "text/plain"
+  end
+
   def is_heic?
     upload&.filename&.extension_without_delimiter&.downcase == "heic"
   end

--- a/app/views/hub/documents/edit.html.erb
+++ b/app/views/hub/documents/edit.html.erb
@@ -16,7 +16,7 @@
             <%= image_tag transient_storage_url(@document.upload.blob), id: 'image', class: 'rotatable-image', data: { rotation: 0 } %>
           <% end %>
         </div>
-        <% if !@document.is_pdf? %>
+        <% unless @document.is_pdf? || @document.is_txt_file? %>
           <button id="rotate-button" class="button">Rotate Image <%= image_tag("rotate.svg", alt: "") %></button>
         <% end %>
       </div>


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. https://codeforamerica.atlassian.net/browse/GYR1-687
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Removed image rotation option when editing document for plain text files because they can't rotate
## How to test?
- upload a plain text document
- after its uploaded click "Edit file info"
- see if the "rotate image" button is there
## Screenshots (for visual changes)
- Before
<img width="907" alt="Screenshot 2025-05-14 at 12 27 48 PM" src="https://github.com/user-attachments/assets/4fbde9fd-925a-430b-929e-83a44d9ffc20" />

- After
<img width="904" alt="Screenshot 2025-05-14 at 12 20 33 PM" src="https://github.com/user-attachments/assets/2cbbcbfd-0389-4f6d-9ea0-6cb1d6143157" />