### PR TITLE
[FYST-2089] Show correct es return status links

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1522,7 +1522,7 @@ es:
 
               Si aún no has pagado mediante débito directo al presentar tu declaración, por favor haz tu pago lo antes posible para evitar multas y costos adicionales en %{state_pay_taxes_link}.
 
-              Descarga tu declaración en <a href=\"%{return_status_link}\" target=\"_blank\" rel=\"noopener nofollow\">%{return_status_link}</a>.
+              Descarga tu declaración en <a href="%{return_status_link}" target="_blank" rel="noopener nofollow">%{return_status_link}</a>.
 
               ¿Necesitas ayuda? Responde a este correo electrónico.
 
@@ -1551,7 +1551,7 @@ es:
 
               <strong>Si no pagaste ya mediante débito directo al presentar tu declaración, por favor, haz tu pago antes del 15 de abril visitando %{state_pay_taxes_link}</strong>. Cualquier cantidad no pagada antes de la fecha límite de presentación podría significar multas y costos adicionales.
 
-              Descarga tu declaración visitando <a href=\"%{return_status_link}\" target=\"_blank\" rel=\"noopener nofollow\">%{return_status_link}</a>.
+              Descarga tu declaración visitando <a href="%{return_status_link}" target="_blank" rel="noopener nofollow">%{return_status_link}</a>.
 
               ¿Necesitas ayuda? Responde a este correo.
 
@@ -1577,7 +1577,7 @@ es:
 
               Si no pagaste ya mediante débito directo al presentar tu declaración, por favor, haz tu pago hoy visitando %{state_pay_taxes_link}. Cualquier cantidad no pagada antes de la fecha límite de presentación podría significar multas y costos adicionales.
 
-              Descarga tu declaración visitando <a href=\"%{return_status_link}\" target=\"_blank\" rel=\"noopener nofollow\">%{return_status_link}</a>.
+              Descarga tu declaración visitando <a href="%{return_status_link}" target="_blank" rel="noopener nofollow">%{return_status_link}</a>.
 
               ¿Necesitas ayuda? Responde a este correo electrónico.
 
@@ -1590,7 +1590,7 @@ es:
           body: |
             Hola %{primary_first_name},
 
-            ¡Tu declaración de impuestos estatales de %{state_name} ha sido <strong>aceptada</strong>! Descarga tu declaración y verifica el estado de tu reembolso visitando <a href=\"%{return_status_link}\" target=\"_blank\" rel=\"noopener nofollow\">%{return_status_link}</a>.
+            ¡Tu declaración de impuestos estatales de %{state_name} ha sido <strong>aceptada</strong>! Descarga tu declaración y verifica el estado de tu reembolso visitando <a href="%{return_status_link}" target="_blank" rel="noopener nofollow">%{return_status_link}</a>.
 
             Atentamente,
             El equipo de FileYourStateTaxes
@@ -1757,7 +1757,7 @@ es:
           body: |
             Hola %{primary_first_name},
 
-            Lamentablemente, %{state_name} rechazó tu declaración de impuestos estatales. ¡No te preocupes! Podemos ayudarte a corregirla y volver a enviarla en <a href=\"%{return_status_link}\" target=\"_blank\" rel=\"noopener nofollow\">%{return_status_link}</a>.
+            Lamentablemente, %{state_name} rechazó tu declaración de impuestos estatales. ¡No te preocupes! Podemos ayudarte a corregirla y volver a enviarla en <a href="%{return_status_link}" target="_blank" rel="noopener nofollow">%{return_status_link}</a>.
 
             ¿Necesitas ayuda? Responde a este correo electrónico.
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-2089
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Removed the escape characters (`\` ) from the yml string. b/c the `"` was being escaped, `"%{return_status_link}"` (i.e. `"https://demo.fileyourstatetaxes.org/es/questions/return-status"`) `""` was seen as part of a url string (instead of being just necessary for interpolating a variable) and the default behavior for a random string without hostname is to concatenate it to the current host url + append
## How to test?
- Describe the testing approach taken to verify the changes, including:
  - No tests - maybe there could be something written to check if `\` are being used in yml string, but sometimes we _do_ need them, so need to figure out when to check.
  - To reproduce: follow steps in Jira ticket & hover over the links, they should all look as expected
## Screenshots (for visual changes)
- Before 

rejected:
<img width="573" alt="Screenshot 2025-05-23 at 9 02 25 AM" src="https://github.com/user-attachments/assets/26bbfda6-e580-4a9f-b402-a262fcf212e8" />

accepted_refund:
<img width="537" alt="Screenshot 2025-05-23 at 9 02 39 AM" src="https://github.com/user-attachments/assets/90775353-fc61-4248-ac0e-2bc17efa2918" />

accepted_owed:
<img width="567" alt="Screenshot 2025-05-23 at 9 02 45 AM" src="https://github.com/user-attachments/assets/49a1ac69-8c9b-4d27-aa1a-95009f45f147" />


- After (note the bottom left corner previewing the link I hovered over)

rejected:
<img width="524" alt="Screenshot 2025-05-23 at 9 00 33 AM" src="https://github.com/user-attachments/assets/07cdb39d-64e6-4566-902a-0c7e59489538" />

accepted_refund:
<img width="515" alt="Screenshot 2025-05-23 at 9 00 18 AM" src="https://github.com/user-attachments/assets/9758d8c3-9188-4a4b-ab91-1a926ca244b4" />

accepted_owed:
<img width="543" alt="Screenshot 2025-05-23 at 9 00 00 AM" src="https://github.com/user-attachments/assets/ee2bc79e-fb60-4263-81ad-5ef381751d3e" />
