### PR TITLE
Update NJ Flat EITC rate to TY24 amount

### DIFF
--- a/app/lib/efile/nj/nj1040_calculator.rb
+++ b/app/lib/efile/nj/nj1040_calculator.rb
@@ -493,7 +493,7 @@ module Efile
         if @direct_file_data.fed_eic.positive?
           (@direct_file_data.fed_eic * 0.4).round
         elsif Efile::Nj::NjFlatEitcEligibility.eligible?(@intake)
-          240
+          253
         else
           0
         end

--- a/spec/lib/efile/nj/nj1040_calculator_spec.rb
+++ b/spec/lib/efile/nj/nj1040_calculator_spec.rb
@@ -1895,7 +1895,7 @@ describe Efile::Nj::Nj1040Calculator do
         allow(Efile::Nj::NjFlatEitcEligibility).to receive(:eligible?).and_return true
         instance.calculate
 
-        expect(instance.lines[:NJ1040_LINE_58].value).to eq(240)
+        expect(instance.lines[:NJ1040_LINE_58].value).to eq(253)
         expect(instance.lines[:NJ1040_LINE_58_IRS].value).to eq(false)
       end
     end

--- a/spec/lib/pdf_filler/nj1040_pdf_spec.rb
+++ b/spec/lib/pdf_filler/nj1040_pdf_spec.rb
@@ -2202,15 +2202,15 @@ RSpec.describe PdfFiller::Nj1040Pdf do
           )
         }
 
-        it "fills line 58 with $240 and does not check federal checkbox" do
+        it "fills line 58 with $253 and does not check federal checkbox" do
           allow(Efile::Nj::NjFlatEitcEligibility).to receive(:eligible?).and_return true
 
           # thousands
           expect(pdf_fields["58"]).to eq ""
           # hundreds
           expect(pdf_fields["undefined_152"]).to eq "2"
-          expect(pdf_fields["undefined_153"]).to eq "4"
-          expect(pdf_fields["Text170"]).to eq "0"
+          expect(pdf_fields["undefined_153"]).to eq "5"
+          expect(pdf_fields["Text170"]).to eq "3"
           # decimals
           expect(pdf_fields["Text171"]).to eq "0"
           expect(pdf_fields["Text172"]).to eq "0"


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://github.com/newjersey/affordability-pm/issues/347

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- The Flat EITC amount for NJ should have been 253$ for TY24 instead of 240$, see https://www.nj.gov/treasury/taxation/eitc/knoweitc.shtml

## How to test?
- On Heroku, use the Childless EITC persona
- answer "no" to the question about being claimed as someone else's qualifying child for EITC
- verify that EITC credit is 253$

## Screenshots (for visual changes)
- Before
<img width="979" alt="image" src="https://github.com/user-attachments/assets/345dad5f-ca24-477d-b27a-ef133aeaafb4" />
<img width="970" alt="image" src="https://github.com/user-attachments/assets/6157d270-fdaf-4834-945c-512c163c95ec" />


- After
<img width="712" alt="image" src="https://github.com/user-attachments/assets/3ed76574-90de-482f-8add-d107e08883b5" />
<img width="973" alt="image" src="https://github.com/user-attachments/assets/92553a63-70c7-4302-b051-4a8d4876b97f" />
<img width="683" alt="image" src="https://github.com/user-attachments/assets/a77dd1bb-9f41-49e3-b182-efa85df32d52" />

