### PR TITLE
returns not ready for admins

### DIFF
--- a/app/helpers/tax_return_status_helper.rb
+++ b/app/helpers/tax_return_status_helper.rb
@@ -17,7 +17,8 @@ module TaxReturnStatusHelper
   end
 
   def grouped_status_options_for_partner
-    grouped_status_options_for_select(unwanted_statuses: ["intake_in_progress"])
+    unwanted_status = current_user.role_type == "AdminRole" ? [] : ["intake_in_progress"]
+    grouped_status_options_for_select(unwanted_statuses: unwanted_status)
   end
 
   def stage_and_status_translation(status)

--- a/spec/helpers/tax_return_status_helper_spec.rb
+++ b/spec/helpers/tax_return_status_helper_spec.rb
@@ -144,6 +144,24 @@ describe TaxReturnStatusHelper do
                  )
       end
     end
+
+    context "as an admin" do
+      let(:user_double) { double(User) }
+
+      before do
+        allow(helper).to receive(:current_user).and_return user_double
+        allow(user_double).to receive(:role_type).and_return "AdminRole"
+      end
+
+      it "does not disable any statuses" do
+        result = helper.grouped_status_options_for_partner
+
+        intake_group = result.find { |group| group[0] == "Intake" }
+        intake_in_progress_option = intake_group[1].find { |opt| opt[1] == "intake_in_progress" }
+
+        expect(intake_in_progress_option).to eq(["Not ready", "intake_in_progress"])
+      end
+    end
   end
 
   describe "#language_options" do


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. https://codeforamerica.atlassian.net/browse/GYR1-731
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Allow Admins to set intakes to "not ready" where the functionality had previously been removed
## How to test?
- Check the following pages as an admin and as a different user type All clients, My clients, Client Ticket, Take action page, bulk take action page

