### PR TITLE
TBE-164 Put rack attack behind a flipper flag

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -14,6 +14,7 @@ begin
   Flipper.disable :get_your_pdf unless Flipper.exist?(:get_your_pdf)
   Flipper.disable :extension_period unless Flipper.exist?(:extension_period)
   Flipper.disable :income_review_v2 unless Flipper.exist?(:income_review_v2)
+  Flipper.disable :enable_rack_attack unless Flipper.exist?(:enable_rack_attack)
   if Rails.env.heroku? || Rails.env.demo?
     Flipper.disable :prevent_duplicate_accepted_statefile_submissions unless Flipper.exist?(:prevent_duplicate_accepted_statefile_submissions)
     Flipper.disable :prevent_duplicate_ssn_messaging unless Flipper.exist?(:prevent_duplicate_ssn_messaging)

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,9 +1,11 @@
-# limit to 5 requests per second
+# limit to 5 requests per 15 seconds
 Rack::Attack.throttle("login requests by ip", limit: 5, period: 15) do |request|
-  # only limit on posts to login pages
-  if request.path.include?("/login") && request.post?
-    request.ip
-  elsif request.path.include?("/verification-code")
-    request.ip
+  if Flipper.enabled?(:enable_rack_attack)
+    # only limit on posts to login pages
+    if request.path.include?("/login") && request.post?
+      request.ip
+    elsif request.path.include?("/verification-code")
+      request.ip
+    end
   end
 end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. https://codeforamerica.atlassian.net/browse/TBE-164

**Reminder**: merge main into this branch and get green tests before merging to main
### What was done?
The rate limit is different between rack attack and the WAF, so we’ve added a flipper flag to reenable rack attack if we’re getting too many requests.
### Describe the testing approach taken to verify the changes, including:
* rspec test has been added to test the flipper flag is working as we expect.
