### PR TITLE
[GYR1-786] Do not allow hub users to upload documents with the selfie document type

### DIFF
--- a/app/lib/document_types.rb
+++ b/app/lib/document_types.rb
@@ -25,7 +25,6 @@ module DocumentTypes
     DocumentTypes::SecondaryIdentification::BirthCertificate,
   ].freeze
   OTHER_TYPES = [
-    DocumentTypes::Selfie,
     DocumentTypes::Employment,
     DocumentTypes::FinalTaxDocument,
     DocumentTypes::Form1040,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -415,7 +415,6 @@ en:
         ssa_notice: SSA Notice
         ssn: Social Security Card
         w2: Current Year W-2
-      selfie: Photo Holding ID
       ssn_or_itin: Secondary ID
       student_account_statement: Student Account Statement
       text_message_attachment: Text message attachment

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -416,7 +416,6 @@ es:
         ssa_notice: Aviso SSA
         ssn: Tarjeta de Seguridad Social
         w2: Año actual W-2
-      selfie: Identificación con foto
       ssn_or_itin: Identificación secundaria
       student_account_statement: Estado de cuenta del estudiante
       text_message_attachment: Adjunto de mensaje de texto

--- a/spec/controllers/documents/intro_controller_spec.rb
+++ b/spec/controllers/documents/intro_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Documents::IntroController do
       before do
         create :document, intake: intake, document_type: DocumentTypes::Identity.key
         create :document, intake: intake, document_type: DocumentTypes::SsnItin.key
-        create :document, intake: intake, document_type: DocumentTypes::Selfie.key
+        create :document, intake: intake, document_type: DocumentTypes::Employment.key
       end
 
       it "returns false" do

--- a/spec/controllers/documents/ssn_itins_controller_spec.rb
+++ b/spec/controllers/documents/ssn_itins_controller_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Documents::SsnItinsController do
       context 'all three required doc types are present' do
         before do
           create :document, document_type: DocumentTypes::Identity.key, intake: intake, client: intake.client
-          create :document, document_type: DocumentTypes::Selfie.key, intake: intake, client: intake.client
+          create :document, document_type: DocumentTypes::Employment.key, intake: intake, client: intake.client
         end
 
         it "updates the tax return status(es) to intake_ready" do

--- a/spec/features/hub/client/documents_spec.rb
+++ b/spec/features/hub/client/documents_spec.rb
@@ -42,14 +42,14 @@ RSpec.feature "View and edit documents for a client" do
 
       fill_in("Display name", with: "Updated Document Title")
       select("2017", from: "Tax return")
-      select("Photo Holding ID", from: "Document type")
+      select("Secondary ID", from: "Document type")
 
       click_on "Save"
 
       expect(page).to have_selector("h1", text: "Bart Simpson")
       expect(page).to have_selector("#document-#{document_1.id}", text: "Updated Document Title")
       expect(page).to have_selector("#document-#{document_1.id}", text: "2017")
-      expect(page).to have_selector("#document-#{document_1.id}", text: "Photo Holding ID")
+      expect(page).to have_selector("#document-#{document_1.id}", text: "Secondary ID")
       expect(page).to have_selector("#document-#{document_3.id}", text: "Auto-generated")
     end
 


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. https://codeforamerica.atlassian.net/browse/GYR1-786
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
* removed selfie from document type list 
* remove translations for seflies
* have tests refer to a different document type 

## How to test?
- Describe the testing approach taken to verify the changes, including:
* refer to the document page in the hub and see that there are no selfies
## Screenshots (for visual changes)
- Before
<img width="513" alt="Screenshot 2025-07-07 at 10 38 01 AM" src="https://github.com/user-attachments/assets/847337f0-595e-4d76-ab4a-8eab9814f3ea" />

- After
<img width="448" alt="Screenshot 2025-07-07 at 10 37 52 AM" src="https://github.com/user-attachments/assets/ec90eafd-4a26-43ec-9e24-19f602984d4d" />


