### PR TITLE
FYST-2175 Update closing date configs

### DIFF
--- a/app/controllers/session_toggles_controller.rb
+++ b/app/controllers/session_toggles_controller.rb
@@ -23,7 +23,6 @@ class SessionTogglesController < ApplicationController
         service_url: url_for(host: MultiTenantService.new(:statefile).host, controller: :session_toggles),
         times: [
           SessionToggleTime.new(name: 'Start of open intake', property: :state_file_start_of_open_intake),
-          SessionToggleTime.new(name: 'Withdrawal date deadline for New York', property: :state_file_withdrawal_date_deadline_ny),
           SessionToggleTime.new(name: 'End of new intakes', property: :state_file_end_of_new_intakes),
           SessionToggleTime.new(name: 'End of in-progress intakes', property: :state_file_end_of_in_progress_intakes),
         ]

--- a/config/application.rb
+++ b/config/application.rb
@@ -125,10 +125,8 @@ module VitaMin
 
     # StateFile
     config.state_file_start_of_open_intake = et.parse('2025-01-15 00:00:00')
-    config.state_file_end_of_new_intakes = pt.parse('2025-04-15 23:59:59')
-    config.state_file_withdrawal_date_deadline_ny = et.parse('2024-04-15 23:59:59') # TODO: Deprecate
-    config.state_file_withdrawal_date_deadline_md = et.parse('2025-04-30 23:59:59') # TODO: Deprecate
-    config.state_file_end_of_in_progress_intakes = pt.parse('2025-10-15 23:59:59')
+    config.state_file_end_of_new_intakes = et.parse('2025-10-15 23:59:59')
+    config.state_file_end_of_in_progress_intakes = et.parse('2025-10-25 23:59:59')
     config.state_file_show_faq_date_start = pt.parse('2024-12-10 00:00:00')
     config.state_file_show_faq_date_end = pt.parse('2025-10-15 23:59:59')
 

--- a/config/environments/demo.rb
+++ b/config/environments/demo.rb
@@ -40,12 +40,11 @@ Rails.application.configure do
   # StateFile
   config.state_file_start_of_open_intake = Time.find_zone('America/New_York').parse('2024-01-01 7:59:59')
 
-  # GYR
-  config.end_of_intake = Time.find_zone('America/New_York').parse('2025-10-01 23:59:59')
-
   # Keep FYST 'open' until the end of 2040 ^_^
   # use the session toggles if you want to emulate/test 'closed' behaviors
-  the_future = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
-  config.state_file_end_of_new_intakes = the_future
-  config.state_file_end_of_in_progress_intakes = the_future
+  # use the year "2040" to test what it looks like between these milestones
+  the_earlier_future = Time.find_zone('America/New_York').parse('2039-12-31 23:59:59')
+  the_further_future = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
+  config.state_file_end_of_new_intakes = the_earlier_future
+  config.state_file_end_of_in_progress_intakes = the_further_future
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -143,8 +143,10 @@ Rails.application.configure do
 
   # Keep GYR and FYST 'open' until the end of 2040 ^_^
   # use the session toggles if you want to emulate/test 'closed' behaviors
-  the_future = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
-  config.end_of_intake = the_future
-  config.state_file_end_of_new_intakes = the_future
-  config.state_file_end_of_in_progress_intakes = the_future
+  # use the year "2040" to test what it looks like between these milestones
+  the_earlier_future = Time.find_zone('America/New_York').parse('2039-12-31 23:59:59')
+  the_further_future = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
+  config.end_of_intake = the_further_future
+  config.state_file_end_of_new_intakes = the_earlier_future
+  config.state_file_end_of_in_progress_intakes = the_further_future
 end

--- a/config/environments/heroku.rb
+++ b/config/environments/heroku.rb
@@ -44,8 +44,10 @@ Rails.application.configure do
 
   # Keep GYR and FYST 'open' until the end of 2040 ^_^
   # use the session toggles if you want to emulate/test 'closed' behaviors
-  the_future = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
-  config.end_of_intake = the_future
-  config.state_file_end_of_new_intakes = the_future
-  config.state_file_end_of_in_progress_intakes = the_future
+  # use the year "2040" to test what it looks like between these milestones
+  the_earlier_future = Time.find_zone('America/New_York').parse('2039-12-31 23:59:59')
+  the_further_future = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
+  config.end_of_intake = the_further_future
+  config.state_file_end_of_new_intakes = the_earlier_future
+  config.state_file_end_of_in_progress_intakes = the_further_future
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -38,8 +38,10 @@ Rails.application.configure do
 
   # Keep GYR and FYST 'open' until the end of 2040 ^_^
   # use the session toggles if you want to emulate/test 'closed' behaviors
-  the_future = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
-  config.end_of_intake = the_future
-  config.state_file_end_of_new_intakes = the_future
-  config.state_file_end_of_in_progress_intakes = the_future
+  # use the year "2040" to test what it looks like between these milestones
+  the_earlier_future = Time.find_zone('America/New_York').parse('2039-12-31 23:59:59')
+  the_further_future = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
+  config.end_of_intake = the_further_future
+  config.state_file_end_of_new_intakes = the_earlier_future
+  config.state_file_end_of_in_progress_intakes = the_further_future
 end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
-https://codeforamerica.atlassian.net/browse/FYST-2175
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Updated prod configs to be the expected datetimes
- Updated non-prod configs to make the gap between datetimes testatble with session toggles
- Cleaned up some unused configs that could be confusing

## How to test?
- See ticket for details
- The prod change can only be tested in prod, but it is very low impact/risk

## Screenshots (for visual changes)
- Before (pre "end of new intakes")
<img width="1017" height="203" alt="image" src="https://github.com/user-attachments/assets/5d8b97ee-9167-417e-934e-9f1e05581ec3" />

- After (between "end of new intakes" and "end of in-progress intakes")
<img width="875" height="207" alt="image" src="https://github.com/user-attachments/assets/2e1a8d92-b569-4159-8d41-79d313ca298e" />
