### PR TITLE
[FYST-238] Update cfa_styleguide gem to latest version (uses url instead of font-url for icons)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'rack', '>= 2.0.8'
 gem 'rails', '~> 7.1'
 gem 'puma', '>= 5.3.2'
 gem 'sass-rails', '~> 5.0'
-gem 'cfa-styleguide', '0.16.0', git: 'https://github.com/codeforamerica/honeycrisp-gem', branch: 'main', ref: '0e15fc7d74a330866049d58516c6f2449958fb1b'
+gem 'cfa-styleguide', '0.17.1', git: 'https://github.com/codeforamerica/honeycrisp-gem', branch: 'main', ref: '40a4356dd217dacfba82a7b92010111999954c91'
 gem 'nokogiri', '>= 1.10.8'
 gem 'recaptcha'
 

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'rack', '>= 2.0.8'
 gem 'rails', '~> 7.1'
 gem 'puma', '>= 5.3.2'
 gem 'sass-rails', '~> 5.0'
-gem 'cfa-styleguide', '0.17.1', git: 'https://github.com/codeforamerica/honeycrisp-gem', branch: 'main', ref: '40a4356dd217dacfba82a7b92010111999954c91'
+gem 'cfa-styleguide', '0.16.0', git: 'https://github.com/codeforamerica/honeycrisp-gem', branch: 'main', ref: '0e15fc7d74a330866049d58516c6f2449958fb1b'
 gem 'nokogiri', '>= 1.10.8'
 gem 'recaptcha'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 GIT
   remote: https://github.com/codeforamerica/honeycrisp-gem
-  revision: 0e15fc7d74a330866049d58516c6f2449958fb1b
-  ref: 0e15fc7d74a330866049d58516c6f2449958fb1b
+  revision: 40a4356dd217dacfba82a7b92010111999954c91
+  ref: 40a4356dd217dacfba82a7b92010111999954c91
   branch: main
   specs:
-    cfa-styleguide (0.16.0)
+    cfa-styleguide (0.17.1)
       autoprefixer-rails
       bourbon
       jquery-rails
@@ -105,7 +105,7 @@ GEM
     ast (2.4.2)
     auto_strip_attributes (2.6.0)
       activerecord (>= 4.0)
-    autoprefixer-rails (10.4.19.0)
+    autoprefixer-rails (10.4.21.0)
       execjs (~> 2)
     awesome_print (1.9.2)
     aws-eventstream (1.2.0)
@@ -750,7 +750,7 @@ DEPENDENCIES
   byebug
   cancancan
   capybara (>= 2.15)
-  cfa-styleguide (= 0.16.0)!
+  cfa-styleguide (= 0.17.1)!
   combine_pdf
   csv (~> 3.3)
   data_migrate

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 GIT
   remote: https://github.com/codeforamerica/honeycrisp-gem
-  revision: 40a4356dd217dacfba82a7b92010111999954c91
-  ref: 40a4356dd217dacfba82a7b92010111999954c91
+  revision: 0e15fc7d74a330866049d58516c6f2449958fb1b
+  ref: 0e15fc7d74a330866049d58516c6f2449958fb1b
   branch: main
   specs:
-    cfa-styleguide (0.17.1)
+    cfa-styleguide (0.16.0)
       autoprefixer-rails
       bourbon
       jquery-rails
@@ -105,7 +105,7 @@ GEM
     ast (2.4.2)
     auto_strip_attributes (2.6.0)
       activerecord (>= 4.0)
-    autoprefixer-rails (10.4.21.0)
+    autoprefixer-rails (10.4.19.0)
       execjs (~> 2)
     awesome_print (1.9.2)
     aws-eventstream (1.2.0)
@@ -750,7 +750,7 @@ DEPENDENCIES
   byebug
   cancancan
   capybara (>= 2.15)
-  cfa-styleguide (= 0.17.1)!
+  cfa-styleguide (= 0.16.0)!
   combine_pdf
   csv (~> 3.3)
   data_migrate

--- a/Gemfile_next.lock
+++ b/Gemfile_next.lock
@@ -1,10 +1,10 @@
 GIT
   remote: https://github.com/codeforamerica/honeycrisp-gem
-  revision: 40a4356dd217dacfba82a7b92010111999954c91
-  ref: 40a4356dd217dacfba82a7b92010111999954c91
+  revision: 0e15fc7d74a330866049d58516c6f2449958fb1b
+  ref: 0e15fc7d74a330866049d58516c6f2449958fb1b
   branch: main
   specs:
-    cfa-styleguide (0.17.1)
+    cfa-styleguide (0.16.0)
       autoprefixer-rails
       bourbon
       jquery-rails
@@ -105,7 +105,7 @@ GEM
     ast (2.4.2)
     auto_strip_attributes (2.6.0)
       activerecord (>= 4.0)
-    autoprefixer-rails (10.4.21.0)
+    autoprefixer-rails (10.4.19.0)
       execjs (~> 2)
     awesome_print (1.9.2)
     aws-eventstream (1.2.0)
@@ -143,9 +143,9 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
-    base64 (0.3.0)
+    base64 (0.2.0)
     bcrypt (3.1.19)
-    benchmark (0.4.1)
+    benchmark (0.4.0)
     better_html (2.0.2)
       actionview (>= 6.0)
       activesupport (>= 6.0)
@@ -153,7 +153,7 @@ GEM
       erubi (~> 1.4)
       parser (>= 2.4)
       smart_properties
-    bigdecimal (3.2.2)
+    bigdecimal (3.1.8)
     bindex (0.8.1)
     bootsnap (1.17.0)
       msgpack (~> 1.2)
@@ -187,8 +187,8 @@ GEM
     combine_pdf (1.0.24)
       matrix
       ruby-rc4 (>= 0.1.5)
-    concurrent-ruby (1.3.5)
-    connection_pool (2.5.3)
+    concurrent-ruby (1.3.4)
+    connection_pool (2.4.1)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -238,13 +238,12 @@ GEM
     dogapi (1.45.0)
       multi_json
     domain_name (0.6.20231109)
-    drb (2.2.3)
+    drb (2.2.1)
     dumb_delegator (1.0.0)
     easy_translate (0.5.1)
       thread
       thread_safe
-    erb (5.0.2)
-    erubi (1.13.1)
+    erubi (1.13.0)
     erubis (2.7.0)
     excon (0.104.0)
     execjs (2.10.0)
@@ -258,7 +257,7 @@ GEM
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
-    ffi (1.17.2)
+    ffi (1.16.3)
     fix-db-schema-conflicts (3.1.1)
       rubocop (>= 0.38.0)
     flamegraph (0.9.5)
@@ -307,7 +306,7 @@ GEM
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     http_accept_language (2.1.1)
-    i18n (1.14.7)
+    i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     i18n-tasks (1.0.13)
       activesupport (>= 4.0.2)
@@ -325,9 +324,8 @@ GEM
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
     intercom (4.1.3)
-    io-console (0.8.1)
-    irb (1.15.2)
-      pp (>= 0.6.0)
+    io-console (0.7.2)
+    irb (1.13.1)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jmespath (1.6.2)
@@ -348,13 +346,13 @@ GEM
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    logger (1.7.0)
+    logger (1.6.2)
     lograge (0.14.0)
       actionpack (>= 4)
       activesupport (>= 4)
       railties (>= 4)
       request_store (~> 1.0)
-    loofah (2.24.1)
+    loofah (2.23.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     lumberjack (1.2.10)
@@ -374,8 +372,8 @@ GEM
     mime-types-data (3.2023.1003)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.9)
-    minitest (5.25.5)
+    mini_portile2 (2.8.8)
+    minitest (5.25.4)
     mixpanel-ruby (2.3.0)
     moneta (1.0.0)
     msgpack (1.7.2)
@@ -396,7 +394,7 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.7.3)
-    nokogiri (1.18.9)
+    nokogiri (1.18.8)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     notiffany (0.1.3)
@@ -460,9 +458,6 @@ GEM
       heroics (~> 0.1.1)
       moneta (~> 1.0.0)
       rate_throttle_client (~> 0.1.0)
-    pp (0.6.2)
-      prettyprint
-    prettyprint (0.2.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -477,7 +472,7 @@ GEM
       nio4r (~> 2.0)
     pycall (1.5.1)
     racc (1.8.1)
-    rack (2.2.17)
+    rack (2.2.14)
     rack-attack (6.7.0)
       rack (>= 1.0, < 4)
     rack-mini-profiler (3.1.1)
@@ -488,9 +483,9 @@ GEM
       rack
     rack-session (1.0.2)
       rack (< 3)
-    rack-test (2.2.0)
+    rack-test (2.1.0)
       rack (>= 1.3)
-    rackup (1.0.1)
+    rackup (1.0.0)
       rack (< 3)
       webrick
     rails (7.1.5.1)
@@ -511,11 +506,11 @@ GEM
       actionpack (>= 5.0.1.rc1)
       actionview (>= 5.0.1.rc1)
       activesupport (>= 5.0.1.rc1)
-    rails-dom-testing (2.3.0)
+    rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.6.2)
+    rails-html-sanitizer (1.6.1)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rails-i18n (7.0.8)
@@ -534,13 +529,12 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
-    rake (13.3.0)
+    rake (13.2.1)
     rate_throttle_client (0.1.2)
     rb-fsevent (0.11.2)
-    rb-inotify (0.11.1)
+    rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rdoc (6.14.2)
-      erb
+    rdoc (6.7.0)
       psych (>= 4.0.0)
     recaptcha (5.16.0)
     redcarpet (3.6.0)
@@ -549,7 +543,7 @@ GEM
     redis-client (0.18.0)
       connection_pool
     regexp_parser (2.8.2)
-    reline (0.6.2)
+    reline (0.5.8)
       io-console (~> 0.5)
     request_store (1.5.1)
       rack (>= 1.4)
@@ -634,7 +628,7 @@ GEM
     scenic (1.7.0)
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
-    securerandom (0.4.1)
+    securerandom (0.4.0)
     selenium-webdriver (4.15.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
@@ -689,7 +683,7 @@ GEM
       activerecord (>= 5.2)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    thor (1.4.0)
+    thor (1.3.1)
     thread (0.2.2)
     thread_safe (0.3.6)
     tilt (2.3.0)
@@ -726,7 +720,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.9.1)
+    webrick (1.8.2)
     websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -734,7 +728,7 @@ GEM
     will_paginate (4.0.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.7.3)
+    zeitwerk (2.6.15)
     zxcvbn-ruby (1.2.0)
 
 PLATFORMS
@@ -756,7 +750,7 @@ DEPENDENCIES
   byebug
   cancancan
   capybara (>= 2.15)
-  cfa-styleguide (= 0.17.1)!
+  cfa-styleguide (= 0.16.0)!
   combine_pdf
   csv (~> 3.3)
   data_migrate

--- a/Gemfile_next.lock
+++ b/Gemfile_next.lock
@@ -1,10 +1,10 @@
 GIT
   remote: https://github.com/codeforamerica/honeycrisp-gem
-  revision: 0e15fc7d74a330866049d58516c6f2449958fb1b
-  ref: 0e15fc7d74a330866049d58516c6f2449958fb1b
+  revision: 40a4356dd217dacfba82a7b92010111999954c91
+  ref: 40a4356dd217dacfba82a7b92010111999954c91
   branch: main
   specs:
-    cfa-styleguide (0.16.0)
+    cfa-styleguide (0.17.1)
       autoprefixer-rails
       bourbon
       jquery-rails
@@ -105,7 +105,7 @@ GEM
     ast (2.4.2)
     auto_strip_attributes (2.6.0)
       activerecord (>= 4.0)
-    autoprefixer-rails (10.4.19.0)
+    autoprefixer-rails (10.4.21.0)
       execjs (~> 2)
     awesome_print (1.9.2)
     aws-eventstream (1.2.0)
@@ -143,9 +143,9 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
-    base64 (0.2.0)
+    base64 (0.3.0)
     bcrypt (3.1.19)
-    benchmark (0.4.0)
+    benchmark (0.4.1)
     better_html (2.0.2)
       actionview (>= 6.0)
       activesupport (>= 6.0)
@@ -153,7 +153,7 @@ GEM
       erubi (~> 1.4)
       parser (>= 2.4)
       smart_properties
-    bigdecimal (3.1.8)
+    bigdecimal (3.2.2)
     bindex (0.8.1)
     bootsnap (1.17.0)
       msgpack (~> 1.2)
@@ -187,8 +187,8 @@ GEM
     combine_pdf (1.0.24)
       matrix
       ruby-rc4 (>= 0.1.5)
-    concurrent-ruby (1.3.4)
-    connection_pool (2.4.1)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.3)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -238,12 +238,13 @@ GEM
     dogapi (1.45.0)
       multi_json
     domain_name (0.6.20231109)
-    drb (2.2.1)
+    drb (2.2.3)
     dumb_delegator (1.0.0)
     easy_translate (0.5.1)
       thread
       thread_safe
-    erubi (1.13.0)
+    erb (5.0.2)
+    erubi (1.13.1)
     erubis (2.7.0)
     excon (0.104.0)
     execjs (2.10.0)
@@ -257,7 +258,7 @@ GEM
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
-    ffi (1.16.3)
+    ffi (1.17.2)
     fix-db-schema-conflicts (3.1.1)
       rubocop (>= 0.38.0)
     flamegraph (0.9.5)
@@ -306,7 +307,7 @@ GEM
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     http_accept_language (2.1.1)
-    i18n (1.14.6)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     i18n-tasks (1.0.13)
       activesupport (>= 4.0.2)
@@ -324,8 +325,9 @@ GEM
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
     intercom (4.1.3)
-    io-console (0.7.2)
-    irb (1.13.1)
+    io-console (0.8.1)
+    irb (1.15.2)
+      pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jmespath (1.6.2)
@@ -346,13 +348,13 @@ GEM
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    logger (1.6.2)
+    logger (1.7.0)
     lograge (0.14.0)
       actionpack (>= 4)
       activesupport (>= 4)
       railties (>= 4)
       request_store (~> 1.0)
-    loofah (2.23.1)
+    loofah (2.24.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     lumberjack (1.2.10)
@@ -372,8 +374,8 @@ GEM
     mime-types-data (3.2023.1003)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.8)
-    minitest (5.25.4)
+    mini_portile2 (2.8.9)
+    minitest (5.25.5)
     mixpanel-ruby (2.3.0)
     moneta (1.0.0)
     msgpack (1.7.2)
@@ -394,7 +396,7 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.7.3)
-    nokogiri (1.18.8)
+    nokogiri (1.18.9)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     notiffany (0.1.3)
@@ -458,6 +460,9 @@ GEM
       heroics (~> 0.1.1)
       moneta (~> 1.0.0)
       rate_throttle_client (~> 0.1.0)
+    pp (0.6.2)
+      prettyprint
+    prettyprint (0.2.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -472,7 +477,7 @@ GEM
       nio4r (~> 2.0)
     pycall (1.5.1)
     racc (1.8.1)
-    rack (2.2.14)
+    rack (2.2.17)
     rack-attack (6.7.0)
       rack (>= 1.0, < 4)
     rack-mini-profiler (3.1.1)
@@ -483,9 +488,9 @@ GEM
       rack
     rack-session (1.0.2)
       rack (< 3)
-    rack-test (2.1.0)
+    rack-test (2.2.0)
       rack (>= 1.3)
-    rackup (1.0.0)
+    rackup (1.0.1)
       rack (< 3)
       webrick
     rails (7.1.5.1)
@@ -506,11 +511,11 @@ GEM
       actionpack (>= 5.0.1.rc1)
       actionview (>= 5.0.1.rc1)
       activesupport (>= 5.0.1.rc1)
-    rails-dom-testing (2.2.0)
+    rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.6.1)
+    rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rails-i18n (7.0.8)
@@ -529,12 +534,13 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
-    rake (13.2.1)
+    rake (13.3.0)
     rate_throttle_client (0.1.2)
     rb-fsevent (0.11.2)
-    rb-inotify (0.10.1)
+    rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rdoc (6.7.0)
+    rdoc (6.14.2)
+      erb
       psych (>= 4.0.0)
     recaptcha (5.16.0)
     redcarpet (3.6.0)
@@ -543,7 +549,7 @@ GEM
     redis-client (0.18.0)
       connection_pool
     regexp_parser (2.8.2)
-    reline (0.5.8)
+    reline (0.6.2)
       io-console (~> 0.5)
     request_store (1.5.1)
       rack (>= 1.4)
@@ -628,7 +634,7 @@ GEM
     scenic (1.7.0)
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
-    securerandom (0.4.0)
+    securerandom (0.4.1)
     selenium-webdriver (4.15.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
@@ -683,7 +689,7 @@ GEM
       activerecord (>= 5.2)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    thor (1.3.1)
+    thor (1.4.0)
     thread (0.2.2)
     thread_safe (0.3.6)
     tilt (2.3.0)
@@ -720,7 +726,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.2)
+    webrick (1.9.1)
     websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -728,7 +734,7 @@ GEM
     will_paginate (4.0.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.15)
+    zeitwerk (2.7.3)
     zxcvbn-ruby (1.2.0)
 
 PLATFORMS
@@ -750,7 +756,7 @@ DEPENDENCIES
   byebug
   cancancan
   capybara (>= 2.15)
-  cfa-styleguide (= 0.16.0)!
+  cfa-styleguide (= 0.17.1)!
   combine_pdf
   csv (~> 3.3)
   data_migrate


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-238
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Updated the gem
- Check on heroku whether the icons (`icon-warning`, `icon-close`, `icon-person`)
- Check on heroku **mobile** icons (`icon-keyboard_arrow_left`,  icon-keyboard_arrow_right`) still work
## How to test?
- Test icons still work
## Screenshots (for visual changes)
- Before
- After
