### PR TITLE
[TBE-243] No longer reference ctc_root_path from the maintenance page

### DIFF
--- a/app/views/public_pages/maintenance.html.erb
+++ b/app/views/public_pages/maintenance.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, t("views.ctc.questions.at_capacity.title") %>
 <% content_for :header do %>
-  <%= render 'shared/header', variation: "ctc", home_link: ctc_root_path %>
+  <%= render 'shared/header', variation: "gyr", home_link: root_path %>
 <% end %>
 <% content_for :footer do %>
   <footer class="footer">
@@ -12,8 +12,8 @@
           </p>
           <p>
             <% cfa_link = link_to("Code for America", "https://www.codeforamerica.org", target: "_blank", rel: "noopener", class: "footer__link") %>
-            <%= t("views.shared.footer.ctc_service_description_html", link: cfa_link) %>
-          </p>
+            <%= t("views.shared.footer.service_description_html", cfa_link: cfa_link) %>
+            </p>
         </div>
       </div>
     </div>

--- a/app/views/public_pages/maintenance.html.erb
+++ b/app/views/public_pages/maintenance.html.erb
@@ -13,7 +13,7 @@
           <p>
             <% cfa_link = link_to("Code for America", "https://www.codeforamerica.org", target: "_blank", rel: "noopener", class: "footer__link") %>
             <%= t("views.shared.footer.service_description_html", cfa_link: cfa_link) %>
-            </p>
+          </p>
         </div>
       </div>
     </div>

--- a/spec/controllers/public_pages_controller_spec.rb
+++ b/spec/controllers/public_pages_controller_spec.rb
@@ -217,4 +217,11 @@ RSpec.describe PublicPagesController do
       expect(response.body).to include "GetYourRefund - Volunteer Signup"
     end
   end
+
+  describe "#maintenance" do
+    it "renders successfully" do
+      get :maintenance
+      expect(response).to be_ok
+    end
+  end
 end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/TBE-243
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Noticed during audit hour that [we saw increased 500 errors (from `hund.io` source param)](https://www.notion.so/cfa/07-21-2025-237373fd79b28079af15df564087d030?source=copy_link#237373fd79b28018889cf661de71d387)
- Looked into datadog logs (and the surrounding context) and saw that the requests to `/maintenance` page was leading to the 500 error
- Fixed the maintenance page to not refer to `ctc_root_path` which was breaking the page, and instead use get your refund `root_path` as the default. Now the "at capacity" message (for the `maintenance` page) will be branded for GYR by default.
## How to test?
- Added a test to make sure the page can load
- Manually navigate to `/maintenance` page
## Screenshots (for visual changes)
- Before
<img width="1008" height="222" alt="Screenshot 2025-07-23 at 11 26 02 PM" src="https://github.com/user-attachments/assets/9a06c6bc-4695-4078-a3af-f79f6a91c865" />

- After
<img width="1037" height="716" alt="Screenshot 2025-07-23 at 11 44 57 PM" src="https://github.com/user-attachments/assets/d32a3df2-422f-485c-bd2c-2f6dccb05629" />
