### PR TITLE
[FYST-2211] Copy archived intake submission_pdfs (with same blob key) and move them into its own S3 bucket

### DIFF
--- a/scripts/copy_to_new_s3_bucket.rb
+++ b/scripts/copy_to_new_s3_bucket.rb
@@ -53,8 +53,6 @@ class CopyToNewS3Bucket < Thor
     end
 
     say "Success!", :green
-  rescue => e
-    say "Something went wrong: #{e.message}"
   end
 
   private
@@ -106,6 +104,9 @@ class CopyToNewS3Bucket < Thor
       key: "#{Rails.env}-#{filename}-#{timestamp_string}.json",
       body: JSON.generate(hash_data)
     )
+  rescue => e
+    say "Unable to upload #{filename}"
+    raise e
   end
 
   def s3_credentials

--- a/scripts/copy_to_new_s3_bucket.rb
+++ b/scripts/copy_to_new_s3_bucket.rb
@@ -3,6 +3,10 @@
 require_relative "../config/environment"
 require 'json'
 
+# This script should only be used to move StateFileArchivedIntake submission_pdfs from the generic GetYourRefund
+# vita-min-#{environment}-docs (containing mix of all ActiveStorage blobs from vita-min)
+# to a specific bucket to ONLY store StateFileArchivedIntake submission_pdfs
+# Utilize by running `scripts/copy_to_new_s3_bucket.rb copy` in heroku console or aptible ssh session
 class CopyToNewS3Bucket < Thor
   # Exits with error instead of status 0
   # issue: https://github.com/rails/thor/issues/244
@@ -58,7 +62,7 @@ class CopyToNewS3Bucket < Thor
   private
 
   def copy_submission_pdfs_to_new_s3_bucket(key, intake_id)
-    `aws s3 cp s3://#{source_bucket}/#{key} s3://#{destination_bucket}/#{key}`
+    `aws s3 cp s3://#{source_bucket}/#{key} s3://#{destination_bucket}`
   rescue => error
     # do not raise the error so that we can upload the intakes-to-key for the previously successfully copied intake-key hash
     say "was not able to copy #{intake_id} blob #{key} due to error: #{error.message}"

--- a/scripts/copy_to_new_s3_bucket.rb
+++ b/scripts/copy_to_new_s3_bucket.rb
@@ -94,7 +94,7 @@ class CopyToNewS3Bucket < Thor
     end
   end
 
-  def upload_json_to_s3(hash_data, filename)
+  def upload_json_to_s3(data, filename)
     s3_client = Aws::S3::Client.new(region: "us-east-1", credentials: s3_credentials)
     current_time = Time.current
     timestamp_string = current_time.strftime("%Y%m%d-%H%M%S")
@@ -102,11 +102,11 @@ class CopyToNewS3Bucket < Thor
     s3_client.put_object(
       bucket: destination_bucket,
       key: "#{Rails.env}-#{filename}-#{timestamp_string}.json",
-      body: JSON.generate(hash_data)
+      body: JSON.generate(data)
     )
   rescue => e
-    say "Unable to upload #{filename}"
-    raise e
+    # Swallow error since we might try to upload more data
+    say "Unable to upload #{filename} with data #{data} with error: #{e.message}"
   end
 
   def s3_credentials

--- a/scripts/copy_to_new_s3_bucket.rb
+++ b/scripts/copy_to_new_s3_bucket.rb
@@ -59,9 +59,9 @@ class CopyToNewS3Bucket < Thor
 
   def copy_submission_pdfs_to_new_s3_bucket(key, intake_id)
     `aws s3 cp s3://#{source_bucket}/#{key} s3://#{destination_bucket}/#{key}`
-  rescue => e
-    say "was not able to copy #{intake_id} blob #{key}"
-    raise e
+  rescue => error
+    # do not raise the error so that we can upload the intakes-to-key for the previously successfully copied intake-key hash
+    say "was not able to copy #{intake_id} blob #{key} due to error: #{error.message}"
   end
 
   def source_bucket

--- a/scripts/copy_to_new_s3_bucket.rb
+++ b/scripts/copy_to_new_s3_bucket.rb
@@ -1,0 +1,105 @@
+#!/usr/bin/env ruby
+
+require_relative "../config/environment"
+require 'json'
+
+class CopyToNewS3Bucket < Thor
+  desc 'copy', 'Copies only the archived intakes\'s submission pdfs to a new bucket'
+  def copy
+    unless Rails.env.production? || Rails.env.staging? || Rails.env.demo? || Rails.env.heroku?
+      say "Please run this from deployed environments that utilize AWS S3 buckets"
+    end
+
+    say "Finding all archived intakes and copying over the submission_pdfs to new bucket...", :green
+    intake_to_key_hash = {}
+
+    # Default batch 1000 https://apidock.com/rails/ActiveRecord/Batches/find_in_batches
+    StateFileArchivedIntake.find_in_batches.with_index do |intakes, batch|
+      puts "Processing group ##{batch}..."
+
+      intakes.each do |intake|
+        key = intake.submission_pdf&.blob&.key
+
+        if key.nil?
+          # add key to some log out so that we can track which ones do not have
+          say "Intake #{intake.id} does not have a submission_pdf blob key"
+          next
+        end
+        intake_to_key_hash[intake.id] = key
+        copy_submission_pdfs_to_new_s3_bucket(key)
+      end
+    end
+
+    upload_json_to_s3(intake_to_key_hash)
+
+    say "Copying over the submission_pdfs to new bucket", :green
+
+  rescue
+    say "Something went wrong"
+  end
+
+  private
+
+  def copy_submission_pdfs_to_new_s3_bucket(key)
+    `aws s3 cp s3://#{source_bucket}/#{key} s3://#{destination_bucket}/#{key}`
+  rescue
+    # Silently move on if something happens during copying?
+    say e.message
+  end
+
+  def source_bucket
+    case Rails.env
+    when 'production'
+      'vita-min-prod-docs'
+    when 'staging'
+      'vita-min-staging-docs'
+    when 'demo'
+      'vita-min-demo-docs'
+    when 'heroku'
+      'vita-min-heroku-docs'
+    else
+      'vita-min-demo-docs'
+    end
+  end
+
+  def destination_bucket
+    case Rails.env
+    when 'production'
+      'vita-min-archived-intakes-submission-pdfs'
+    when 'staging'
+      'vita-min-staging-archived-intakes-submission-pdfs'
+    when 'demo'
+      'vita-min-demo-archived-intakes-submission-pdfs'
+    when 'heroku'
+      'vita-min-heroku-archived-intakes-submission-pdfs'
+    else
+      'vita-min-demo-archived-intakes-submission-pdfs'
+    end
+  end
+
+  def upload_json_to_s3(hash_data)
+    s3_client = Aws::S3::Client.new(region: "us-east-1", credentials: s3_credentials)
+    current_time = Time.current
+    timestamp_string = current_time.strftime("%Y%m%d-%H%M%S")
+
+
+    s3_client.put_object(
+      bucket: destination_bucket,
+      key: "#{Rails.env}-intakes-to-submission-pdf-key-#{timestamp_string}.json",
+      body: JSON.generate(hash_data)
+    )
+  end
+
+  def s3_credentials
+    if ENV["AWS_ACCESS_KEY_ID"].present? # is this for local?
+      Aws::Credentials.new(ENV["AWS_ACCESS_KEY_ID"], ENV["AWS_SECRET_ACCESS_KEY"])
+    else
+      Aws::Credentials.new(
+        Rails.application.credentials.dig(:aws, :access_key_id),
+        Rails.application.credentials.dig(:aws, :secret_access_key)
+      )
+    end
+  end
+end
+
+CopyToNewS3Bucket.start

--- a/scripts/copy_to_new_s3_bucket.rb
+++ b/scripts/copy_to_new_s3_bucket.rb
@@ -22,7 +22,7 @@ class CopyToNewS3Bucket < Thor
 
     # Default batch 1000 https://apidock.com/rails/ActiveRecord/Batches/find_in_batches
     StateFileArchivedIntake.find_in_batches.with_index do |intakes, batch|
-      puts "Processing group ##{batch}..."
+      say "Processing group ##{batch}..."
 
       intakes.each do |intake|
         key = intake.submission_pdf&.blob&.key
@@ -37,10 +37,9 @@ class CopyToNewS3Bucket < Thor
       end
     end
 
+    say "Uploading the json containing intakes-key hash...", :green
     upload_json_to_s3(intake_to_key_hash)
-
-    say "Copying over the submission_pdfs to new bucket", :green
-
+    say "Success!", :green
   rescue
     say "Something went wrong"
   end

--- a/scripts/copy_to_new_s3_bucket.rb
+++ b/scripts/copy_to_new_s3_bucket.rb
@@ -61,8 +61,16 @@ class CopyToNewS3Bucket < Thor
 
   private
 
+  def s3_client
+    Aws::S3::Client.new(region: "us-east-1", credentials: s3_credentials)
+  end
+
   def copy_submission_pdfs_to_new_s3_bucket(key, intake_id)
-    `aws s3 cp s3://#{source_bucket}/#{key} s3://#{destination_bucket}`
+    s3_client.copy_object(
+      bucket: destination_bucket,
+      key: key,
+      copy_source: "#{source_bucket}/#{key}"
+    )
   rescue => error
     # do not raise the error so that we can upload the intakes-to-key for the previously successfully copied intake-key hash
     say "was not able to copy #{intake_id} blob #{key} due to error: #{error.message}"
@@ -99,7 +107,6 @@ class CopyToNewS3Bucket < Thor
   end
 
   def upload_json_to_s3(data, filename)
-    s3_client = Aws::S3::Client.new(region: "us-east-1", credentials: s3_credentials)
     current_time = Time.current
     timestamp_string = current_time.strftime("%Y%m%d-%H%M%S")
 

--- a/scripts/copy_to_new_s3_bucket.rb
+++ b/scripts/copy_to_new_s3_bucket.rb
@@ -4,6 +4,13 @@ require_relative "../config/environment"
 require 'json'
 
 class CopyToNewS3Bucket < Thor
+  # Exits with error instead of status 0
+  # issue: https://github.com/rails/thor/issues/244
+  # code: https://github.com/rails/thor/blob/v1.0.0/lib/thor/base.rb#L521
+  def self.exit_on_failure?
+    true
+  end
+
   desc 'copy', 'Copies only the archived intakes\'s submission pdfs to a new bucket'
   def copy
     unless Rails.env.production? || Rails.env.staging? || Rails.env.demo? || Rails.env.heroku?


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-2211
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

Acceptance Plan:

For each environment, set up a list of archived intakes that you want to see copied over. Keep note of intakes that do not have any blob keys (make sure they get captured). Check `intakes-to-key` json file is in the s3 bucket as well (we need this for record keeping & reconciling records on the PYA side). Check for `intakes-without-keys` json file as well which should list the intakes that didn't have any keys. Update permission for the AWS user to be able to access the new buckets (`-archived-intakes-submission-pdfs` buckets)

1. Local: **ended up not doing a local test, just did it on heroku since it's all hooked up to aws**
 - utilize AWS credentials for demo and test out `vita-min-demo-docs` -> `vita-min-demo-archived-intakes-submission-pdfs`
- You can update the rails credentials locally by doing `VISUAL="vi" bin/rails credentials:edit` and switching the values for `aws` creds to match values found in the same fields when you do `VISUAL="vi" bin/rails credentials:edit --environment demo`
- demo has 189 archived intakes with blob keys & 166 intakes without. After transfer, we should see 189 items in the new bucket (vita-min-demo-archived-intakes-submission-pdfs).
3. Heroku:
 - `vita-min-heroku-docs` -> `vita-min-heroku-archived-intakes-submission-pdfs`

4. Demo:
  - destroy all previously copied over `vita-min-demo-archived-intakes-submission-pdfs` records (from step 1; if needed)
  - `vita-min-demo-docs` -> `vita-min-demo-archived-intakes-submission-pdfs` 
  - demo has 189 archived intakes with blob keys & 166 intakes without. After transfer, we should see 189 items in the new bucket (vita-min-demo-archived-intakes-submission-pdfs). We may see ~1-2 more items since we save the intakes-to-key hash (and potentially json file for the intakes that don't have keys for whatever reason)

5. Prod: I don't think we'll do this on prod (yet) since we haven't archived fully on that environment. The final check should be the demo environment and if we want even more certainty, maybe staging.
- From aptible ssh: `scripts/copy_to_new_s3_bucket.rb copy`