### PR TITLE
Add Puma::HttpParserError to the list of ignored errors in sentry initializer

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -11,5 +11,6 @@ Sentry.init do |config|
   config.excluded_exceptions = Sentry::Configuration::IGNORE_DEFAULT + Sentry::Rails::IGNORE_DEFAULT + %w(
     ActionController::UnknownFormat
     ActionDispatch::RemoteIp::IpSpoofAttackError
+    Puma::HttpParserError
   )
 end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/TBE-222
## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- we upgraded puma so now we're getting a ton of distinct sentry issues (where they used to all be grouped under one issue). let's ignore all of them for now so they don't clog up the alerts channel and the sentry queue