### PR TITLE
Add a script to test the DF state API v2, and factor out IRS response decryption

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -143,6 +143,7 @@ group :development do
   gem 'stackprof'
   gem 'memory_profiler'
   gem "letter_opener"
+  gem "faraday"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -769,6 +769,7 @@ DEPENDENCIES
   dogapi
   easy_translate
   factory_bot_rails
+  faraday
   fix-db-schema-conflicts
   flamegraph
   flipper

--- a/scripts/test_state_api_v2.rb
+++ b/scripts/test_state_api_v2.rb
@@ -1,0 +1,85 @@
+#!/usr/bin/env ruby
+
+require_relative "../config/environment"
+
+class TestStateApiV2 < Thor
+  desc 'access_token <kid> <client_id> <private_key_path>', 'Retrieves an OAuth access token for subsequent requests'
+  def access_token(kid, client_id, private_key_path)
+    say "Retrieving an access token", :green
+
+    host = "https://api.alt.www4.irs.gov"
+    path = "/auth/oauth/v2/token"
+
+    headers = {
+      alg: "RS256",
+      typ: "JWT",
+      kid: kid
+    }
+    body = {
+      aud: host + path,
+      iss: client_id,
+      sub: client_id,
+      exp: Time.now.to_i + 15 * 60,
+      jti: SecureRandom.uuid
+    }
+    private_key = OpenSSL::PKey::RSA.new(File.binread(private_key_path))
+    jwt = JWT.encode(body, private_key, "RS256", headers)
+
+    connection = Faraday.new(
+      url: host,
+      headers: {"Content-Type" => " application/x-www-form-urlencoded"}
+    )
+    response = connection.post(path) do |req|
+      req.params = {
+        grant_type: "client_credentials",
+        client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+        client_assertion: jwt
+      }
+    end
+
+    if JSON.parse(response.body).key?("access_token")
+      say "Retrieved access token: #{JSON.parse(response.body)["access_token"]}", :green
+    else
+      say "Failed to retrieve access token", :red
+      say response.body, :red
+    end
+  end
+
+  desc 'test_connection <access_token> <client_id> <private_key_path>', 'Hits an endpoint meant to test an access token'
+  def test_connection(access_token, client_id, private_key_path)
+    say "Sending request to test connection endpoint", :green
+
+    host = "https://api.alt.www4.irs.gov"
+    path = "/direct-file/state-api/v2/test/connection"
+
+    connection = Faraday.new(
+      url: host,
+      headers: {
+        "Content-Type" => " application/json",
+        "Authorization" => "Bearer #{access_token}",
+        "enterpriseBusCorrelationId" => "#{SecureRandom.uuid}:DFS00:#{client_id[-12..]}:T"
+      }
+    )
+    response = connection.post(path)
+    response_json = JSON.parse(response.body)
+
+    unless response_json.key?("data")
+      say "Received an invalid response", :red
+      say response.body, :red
+      exit
+    end
+
+    decrypted_response = IrsApiService.decrypt_response(
+      OpenSSL::PKey::RSA.new(File.binread(private_key_path)),
+      Base64.decode64(response_json["decryptionInputs"]["encryptedSecret"]),
+      Base64.decode64(response_json["decryptionInputs"]["initializationVector"]),
+      Base64.decode64(response_json["data"]),
+      Base64.decode64(response_json["decryptionInputs"]["authenticationTag"])
+    )
+
+    say "Received a valid response", :green
+    say JSON.parse(decrypted_response), :green
+  end
+end
+
+TestStateApiV2.start


### PR DESCRIPTION
## Link to pivotal/JIRA issue
https://codeforamerica.atlassian.net/browse/TBE-277

## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- We initially tested this API with a combination of postman and irb invocations. That felt hard to share with the team & less documentable, so I made a script that can both grab an access token and hit the test endpoint, as long as you have the key id (from our jwk), the private key we used to generate the public key in the jwk, and the client ID (from the IRS ESAM site) for a state. Most people don't have this, but at least this way we can all see the code and if we securely share those values, they can run the code too.
- I additionally extracted decryption of IRS API responses into a class method on `IrsApiService`, since it's relatively complex and I didn't want to duplicate it. I tested that `IrsApiService.import_federal_data` is still able to decrypt API responses manually by generating an auth code on the ATS site, passing it `import_federal_data` and observed that the response was still decrypted successfully.
## How to test?
- I didn't add tests for the script, and `IrsApiService` doesn't have any tests but I tested it manually.