### PR TITLE
[FYST-2192] Update StateFile end of intake dates

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -125,8 +125,8 @@ module VitaMin
 
     # StateFile
     config.state_file_start_of_open_intake = et.parse('2025-01-15 00:00:00')
-    config.state_file_end_of_new_intakes = et.parse('2025-10-15 23:59:59')
-    config.state_file_end_of_in_progress_intakes = et.parse('2025-10-25 23:59:59')
+    config.state_file_end_of_new_intakes = et.parse('2025-10-22 23:59:59')
+    config.state_file_end_of_in_progress_intakes = et.parse('2025-10-31 23:59:59')
     config.state_file_show_faq_date_start = pt.parse('2024-12-10 00:00:00')
     config.state_file_show_faq_date_end = pt.parse('2025-10-15 23:59:59')
 

--- a/config/environments/demo.rb
+++ b/config/environments/demo.rb
@@ -32,19 +32,4 @@ Rails.application.configure do
 
   Rails.application.default_url_options = config.action_mailer.default_url_options
   config.efile_environment = "test"
-
-  # CTC
-  config.ctc_soft_launch = Time.find_zone("America/New_York").parse("2022-03-01 09:00:00")
-  config.ctc_full_launch = Time.find_zone("America/New_York").parse("2022-04-01 09:00:00")
-
-  # StateFile
-  config.state_file_start_of_open_intake = Time.find_zone('America/New_York').parse('2024-01-01 7:59:59')
-
-  # Keep FYST 'open' until the end of 2040 ^_^
-  # use the session toggles if you want to emulate/test 'closed' behaviors
-  # use the year "2040" to test what it looks like between these milestones
-  the_earlier_future = Time.find_zone('America/New_York').parse('2039-12-31 23:59:59')
-  the_further_future = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
-  config.state_file_end_of_new_intakes = the_earlier_future
-  config.state_file_end_of_in_progress_intakes = the_further_future
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -134,19 +134,7 @@ Rails.application.configure do
   config.gyr_url = "http://localhost:3000"
   config.efile_environment = "test"
 
-  # CTC
-  config.ctc_soft_launch = Time.find_zone("America/New_York").parse("2022-03-01 09:00:00")
-  config.ctc_full_launch = Time.find_zone("America/New_York").parse("2022-04-01 09:00:00")
-
-  # StateFile
-  config.state_file_start_of_open_intake = Time.find_zone('America/New_York').parse('2024-01-01 7:59:59')
-
-  # Keep GYR and FYST 'open' until the end of 2040 ^_^
-  # use the session toggles if you want to emulate/test 'closed' behaviors
-  # use the year "2040" to test what it looks like between these milestones
-  the_earlier_future = Time.find_zone('America/New_York').parse('2039-12-31 23:59:59')
-  the_further_future = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
-  config.end_of_intake = the_further_future
-  config.state_file_end_of_new_intakes = the_earlier_future
-  config.state_file_end_of_in_progress_intakes = the_further_future
+  # Keep GYR 'open' until the end of 2040 ^_^
+  the_future = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
+  config.end_of_intake = the_future
 end

--- a/config/environments/heroku.rb
+++ b/config/environments/heroku.rb
@@ -39,15 +39,7 @@ Rails.application.configure do
   config.efile_environment = "test"
   config.google_login_enabled = (ENV['GOOGLE_LOGIN_ENABLED'] == 'true')
 
-  # StateFile
-  config.state_file_start_of_open_intake = Time.find_zone('America/New_York').parse('2024-01-01 7:59:59')
-
-  # Keep GYR and FYST 'open' until the end of 2040 ^_^
-  # use the session toggles if you want to emulate/test 'closed' behaviors
-  # use the year "2040" to test what it looks like between these milestones
-  the_earlier_future = Time.find_zone('America/New_York').parse('2039-12-31 23:59:59')
-  the_further_future = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
-  config.end_of_intake = the_further_future
-  config.state_file_end_of_new_intakes = the_earlier_future
-  config.state_file_end_of_in_progress_intakes = the_further_future
+  # Keep GYR 'open' until the end of 2040 ^_^
+  the_future = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
+  config.end_of_intake = the_future
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -33,15 +33,7 @@ Rails.application.configure do
   Rails.application.default_url_options = config.action_mailer.default_url_options
   config.efile_environment = "test"
 
-  # StateFile
-  config.state_file_start_of_open_intake = Time.find_zone('America/New_York').parse('2024-01-01 7:59:59')
-
-  # Keep GYR and FYST 'open' until the end of 2040 ^_^
-  # use the session toggles if you want to emulate/test 'closed' behaviors
-  # use the year "2040" to test what it looks like between these milestones
-  the_earlier_future = Time.find_zone('America/New_York').parse('2039-12-31 23:59:59')
-  the_further_future = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
-  config.end_of_intake = the_further_future
-  config.state_file_end_of_new_intakes = the_earlier_future
-  config.state_file_end_of_in_progress_intakes = the_further_future
+  # Keep GYR 'open' until the end of 2040 ^_^
+  the_future = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
+  config.end_of_intake = the_future
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -98,16 +98,11 @@ Rails.application.configure do
   # Allow stub views for base controller classes https://stackoverflow.com/questions/5147734/rspec-stubing-view-for-anonymous-controller
   config.paths['app/views'] << "spec/test_views"
 
-  # By default, intake is open in the test suite
-  # GYR
-  config.start_of_unique_links_only_intake = Time.find_zone('America/Los_Angeles').parse('2001-01-01 00:00:00')
-  config.start_of_open_intake = Time.find_zone('America/Los_Angeles').parse('2001-01-01 00:00:00')
-  config.end_of_intake = Time.find_zone('America/Los_Angeles').parse('2038-12-31 23:59:59')
-
-  # StateFile
-  config.state_file_start_of_open_intake = Time.find_zone('America/New_York').parse('2024-01-01 7:59:59')
-  config.state_file_end_of_new_intakes = Time.find_zone('America/New_York').parse('2038-04-15 23:59:59')
-  config.state_file_end_of_in_progress_intakes = Time.find_zone('America/New_York').parse('2038-04-25 23:59:59')
+  # Keep applications open indefinitely for the test suite to pass
+  the_future = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
+  config.end_of_intake = the_future
+  config.state_file_end_of_new_intakes = the_future
+  config.state_file_end_of_in_progress_intakes = the_future
 
   config.active_record.encryption.primary_key = 'test'
   config.active_record.encryption.deterministic_key = 'test'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -98,11 +98,16 @@ Rails.application.configure do
   # Allow stub views for base controller classes https://stackoverflow.com/questions/5147734/rspec-stubing-view-for-anonymous-controller
   config.paths['app/views'] << "spec/test_views"
 
-  # Keep applications open indefinitely for the test suite to pass
-  the_future = Time.find_zone('America/New_York').parse('2040-12-31 23:59:59')
-  config.end_of_intake = the_future
-  config.state_file_end_of_new_intakes = the_future
-  config.state_file_end_of_in_progress_intakes = the_future
+  # By default, intake is open in the test suite
+  # GYR
+  config.start_of_unique_links_only_intake = Time.find_zone('America/Los_Angeles').parse('2001-01-01 00:00:00')
+  config.start_of_open_intake = Time.find_zone('America/Los_Angeles').parse('2001-01-01 00:00:00')
+  config.end_of_intake = Time.find_zone('America/Los_Angeles').parse('2038-12-31 23:59:59')
+
+  # StateFile
+  config.state_file_start_of_open_intake = Time.find_zone('America/New_York').parse('2024-01-01 7:59:59')
+  config.state_file_end_of_new_intakes = Time.find_zone('America/New_York').parse('2038-04-15 23:59:59')
+  config.state_file_end_of_in_progress_intakes = Time.find_zone('America/New_York').parse('2038-04-25 23:59:59')
 
   config.active_record.encryption.primary_key = 'test'
   config.active_record.encryption.deterministic_key = 'test'


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-2192

## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main

## What was done?
1. updated the two FYST close date defaults to be new values
2. removed all FYST date config overrides in other environments, to match prod
3. kept GYR closing date override  (`config.end_of_intake`) as it was
4. cleaned up other date configs that aren't needed

Note: previously we overrode these dates to keep envs open post-closing to make ongoing development easier, but that won't be an issue for FYST anymore 🫠 (and session toggles can still be used to view the app in the past once we are post-close, if anyone wants to review the way it was during the filing seasson)

## How to test?
View/use session toggles in relevant environments

