### PR TITLE
Update FYST reject notification copy

### DIFF
--- a/app/models/state_file/automated_message/base_automated_message.rb
+++ b/app/models/state_file/automated_message/base_automated_message.rb
@@ -11,6 +11,7 @@ module StateFile::AutomatedMessage
 
     # Convenience methods for time
     def tax_deadline = Rails.application.config.tax_deadline
+    def end_of_login = Rails.configuration.end_of_login
 
     def app_time(body_args)
       body_args.fetch(:app_time, Time.current).to_datetime

--- a/app/models/state_file/automated_message/rejected.rb
+++ b/app/models/state_file/automated_message/rejected.rb
@@ -14,7 +14,12 @@ module StateFile::AutomatedMessage
     end
 
     def sms_body(**args)
-      I18n.t("messages.state_file.rejected.sms", **args)
+      time = app_time(args)
+      if time >= end_of_login.beginning_of_day
+        I18n.t("messages.state_file.rejected.sms_with_deadline", **args)
+      else
+        I18n.t("messages.state_file.rejected.sms", **args)
+      end
     end
 
     def email_subject(**args)
@@ -22,7 +27,12 @@ module StateFile::AutomatedMessage
     end
 
     def email_body(**args)
-      I18n.t("messages.state_file.rejected.email.body", **args)
+      time = app_time(args)
+      if time >= end_of_login.beginning_of_day
+        I18n.t("messages.state_file.rejected.email.body_with_deadline", **args)
+      else
+        I18n.t("messages.state_file.rejected.email.body", **args)
+      end
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1736,6 +1736,8 @@ en:
             Hi %{primary_first_name},
 
             Unfortunately, %{state_name} rejected your state tax return. Don't worry! We can help you fix and resubmit it at <a href="%{return_status_link}" target="_blank" rel="noopener nofollow">%{return_status_link}</a>.
+            
+            The last day to resubmit is October 31st.
 
             Need help? Reply to this email.
 
@@ -1744,6 +1746,8 @@ en:
           subject: 'Action Needed: %{state_name} State Return Rejected'
         sms: |
           Hi %{primary_first_name} - Unfortunately, %{state_name} rejected your state tax return. Don't worry! We can help you fix and resubmit it at %{return_status_link}.
+          
+          The last day to resubmit is October 31st.
 
           Need help? Email us at help@fileyourstatetaxes.org.
       still_processing:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1737,6 +1737,15 @@ en:
 
             Unfortunately, %{state_name} rejected your state tax return. Don't worry! We can help you fix and resubmit it at <a href="%{return_status_link}" target="_blank" rel="noopener nofollow">%{return_status_link}</a>.
 
+            Need help? Reply to this email.
+
+            Best,
+            The FileYourStateTaxes team
+          body_with_deadline: |
+            Hi %{primary_first_name},
+
+            Unfortunately, %{state_name} rejected your state tax return. Don't worry! We can help you fix and resubmit it at <a href="%{return_status_link}" target="_blank" rel="noopener nofollow">%{return_status_link}</a>.
+
             The last day to resubmit is October 31st.
 
             Need help? Reply to this email.
@@ -1745,6 +1754,10 @@ en:
             The FileYourStateTaxes team
           subject: 'Action Needed: %{state_name} State Return Rejected'
         sms: |
+          Hi %{primary_first_name} - Unfortunately, %{state_name} rejected your state tax return. Don't worry! We can help you fix and resubmit it at %{return_status_link}.
+
+          Need help? Email us at help@fileyourstatetaxes.org.
+        sms_with_deadline: |
           Hi %{primary_first_name} - Unfortunately, %{state_name} rejected your state tax return. Don't worry! We can help you fix and resubmit it at %{return_status_link}.
 
           The last day to resubmit is October 31st.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1736,7 +1736,7 @@ en:
             Hi %{primary_first_name},
 
             Unfortunately, %{state_name} rejected your state tax return. Don't worry! We can help you fix and resubmit it at <a href="%{return_status_link}" target="_blank" rel="noopener nofollow">%{return_status_link}</a>.
-            
+
             The last day to resubmit is October 31st.
 
             Need help? Reply to this email.
@@ -1746,7 +1746,7 @@ en:
           subject: 'Action Needed: %{state_name} State Return Rejected'
         sms: |
           Hi %{primary_first_name} - Unfortunately, %{state_name} rejected your state tax return. Don't worry! We can help you fix and resubmit it at %{return_status_link}.
-          
+
           The last day to resubmit is October 31st.
 
           Need help? Email us at help@fileyourstatetaxes.org.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1744,6 +1744,8 @@ es:
 
             Lamentablemente, %{state_name} rechazó tu declaración de impuestos estatales. ¡No te preocupes! Podemos ayudarte a corregirla y volver a enviarla en <a href="%{return_status_link}" target="_blank" rel="noopener nofollow">%{return_status_link}</a>.
 
+            El último día para enviar tu declaración estatal es el 31 de octubre.
+            
             ¿Necesitas ayuda? Responde a este correo electrónico.
 
             Atentamente,
@@ -1751,6 +1753,8 @@ es:
           subject: 'Acción necesaria: La declaración de Impuestos Estatales de %{state_name} fue rechazada.'
         sms: |
           Hola %{primary_first_name} - Lamentablemente, %{state_name} rechazó tu declaración de impuestos estatales. ¡No te preocupes! Podemos ayudarte a corregirla y volver a enviarla en %{return_status_link}.
+          
+          El último día para enviar tu declaración estatal es el 31 de octubre.  
 
           ¿Necesitas ayuda? Envíanos un email a help@fileyourstatetaxes.org.
       still_processing:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1745,18 +1745,13 @@ es:
             Lamentablemente, %{state_name} rechazó tu declaración de impuestos estatales. ¡No te preocupes! Podemos ayudarte a corregirla y volver a enviarla en <a href="%{return_status_link}" target="_blank" rel="noopener nofollow">%{return_status_link}</a>.
 
             El último día para enviar tu declaración estatal es el 31 de octubre.
-            
+
             ¿Necesitas ayuda? Responde a este correo electrónico.
 
             Atentamente,
             El equipo de FileYourStateTaxes
           subject: 'Acción necesaria: La declaración de Impuestos Estatales de %{state_name} fue rechazada.'
-        sms: |
-          Hola %{primary_first_name} - Lamentablemente, %{state_name} rechazó tu declaración de impuestos estatales. ¡No te preocupes! Podemos ayudarte a corregirla y volver a enviarla en %{return_status_link}.
-          
-          El último día para enviar tu declaración estatal es el 31 de octubre.  
-
-          ¿Necesitas ayuda? Envíanos un email a help@fileyourstatetaxes.org.
+        sms: "Hola %{primary_first_name} - Lamentablemente, %{state_name} rechazó tu declaración de impuestos estatales. ¡No te preocupes! Podemos ayudarte a corregirla y volver a enviarla en %{return_status_link}.\n\nEl último día para enviar tu declaración estatal es el 31 de octubre.  \n\n¿Necesitas ayuda? Envíanos un email a help@fileyourstatetaxes.org.\n"
       still_processing:
         email:
           body: |

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1744,6 +1744,15 @@ es:
 
             Lamentablemente, %{state_name} rechazó tu declaración de impuestos estatales. ¡No te preocupes! Podemos ayudarte a corregirla y volver a enviarla en <a href="%{return_status_link}" target="_blank" rel="noopener nofollow">%{return_status_link}</a>.
 
+            ¿Necesitas ayuda? Responde a este correo electrónico.
+
+            Atentamente,
+            El equipo de FileYourStateTaxes
+          body_with_deadline: |
+            Hola %{primary_first_name},
+
+            Lamentablemente, %{state_name} rechazó tu declaración de impuestos estatales. ¡No te preocupes! Podemos ayudarte a corregirla y volver a enviarla en <a href="%{return_status_link}" target="_blank" rel="noopener nofollow">%{return_status_link}</a>.
+
             El último día para enviar tu declaración estatal es el 31 de octubre.
 
             ¿Necesitas ayuda? Responde a este correo electrónico.
@@ -1751,7 +1760,11 @@ es:
             Atentamente,
             El equipo de FileYourStateTaxes
           subject: 'Acción necesaria: La declaración de Impuestos Estatales de %{state_name} fue rechazada.'
-        sms: "Hola %{primary_first_name} - Lamentablemente, %{state_name} rechazó tu declaración de impuestos estatales. ¡No te preocupes! Podemos ayudarte a corregirla y volver a enviarla en %{return_status_link}.\n\nEl último día para enviar tu declaración estatal es el 31 de octubre.  \n\n¿Necesitas ayuda? Envíanos un email a help@fileyourstatetaxes.org.\n"
+        sms: |
+          Hola %{primary_first_name} - Lamentablemente, %{state_name} rechazó tu declaración de impuestos estatales. ¡No te preocupes! Podemos ayudarte a corregirla y volver a enviarla en %{return_status_link}.
+
+          ¿Necesitas ayuda? Envíanos un email a help@fileyourstatetaxes.org.
+        sms_with_deadline: "Hola %{primary_first_name} - Lamentablemente, %{state_name} rechazó tu declaración de impuestos estatales. ¡No te preocupes! Podemos ayudarte a corregirla y volver a enviarla en %{return_status_link}.\n\nEl último día para enviar tu declaración estatal es el 31 de octubre.  \n\n¿Necesitas ayuda? Envíanos un email a help@fileyourstatetaxes.org.\n"
       still_processing:
         email:
           body: |

--- a/db/migrate/20250917173937_remove_email_notification_column_from_user.rb
+++ b/db/migrate/20250917173937_remove_email_notification_column_from_user.rb
@@ -1,0 +1,5 @@
+class RemoveEmailNotificationColumnFromUser < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured { remove_column :users, :email_notification }
+  end
+end

--- a/db/migrate/20250917173937_remove_email_notification_column_from_user.rb
+++ b/db/migrate/20250917173937_remove_email_notification_column_from_user.rb
@@ -1,5 +1,0 @@
-class RemoveEmailNotificationColumnFromUser < ActiveRecord::Migration[7.1]
-  def change
-    safety_assured { remove_column :users, :email_notification }
-  end
-end

--- a/spec/models/state_file/automated_message/rejected_spec.rb
+++ b/spec/models/state_file/automated_message/rejected_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe StateFile::AutomatedMessage::Rejected do
+  let(:i18n_required_args) do
+    {
+      return_status_link: 'google.com',
+      primary_first_name: 'Test',
+      state_name: 'Arizona',
+    }
+  end
+
+  let(:i18n_key) { 'messages.state_file.rejected' }
+
+  describe "#sms_body" do
+    it "should call sms_with_deadline when at or after end_of_login date" do
+      Timecop.freeze(Rails.configuration.end_of_login.beginning_of_day) do
+        expect(subject.sms_body(**i18n_required_args)).to eql(I18n.t("#{i18n_key}.sms_with_deadline", **i18n_required_args))
+      end
+    end
+
+    it "should call sms_with_deadline after end_of_login date" do
+      Timecop.freeze(Rails.configuration.end_of_login + 1.day) do
+        expect(subject.sms_body(**i18n_required_args)).to eql(I18n.t("#{i18n_key}.sms_with_deadline", **i18n_required_args))
+      end
+    end
+
+    it "should call sms before end_of_login date" do
+      Timecop.freeze(Rails.configuration.end_of_login - 1.day) do
+        expect(subject.sms_body(**i18n_required_args)).to eql(I18n.t("#{i18n_key}.sms", **i18n_required_args))
+      end
+    end
+  end
+
+  describe "#email_body" do
+    it "should call body_with_deadline when at or after end_of_login date" do
+      Timecop.freeze(Rails.configuration.end_of_login.beginning_of_day) do
+        expect(subject.email_body(**i18n_required_args)).to eql(I18n.t("#{i18n_key}.email.body_with_deadline", **i18n_required_args))
+      end
+    end
+
+    it "should call body_with_deadline after end_of_login date" do
+      Timecop.freeze(Rails.configuration.end_of_login + 1.day) do
+        expect(subject.email_body(**i18n_required_args)).to eql(I18n.t("#{i18n_key}.email.body_with_deadline", **i18n_required_args))
+      end
+    end
+
+    it "should call body before end_of_login date" do
+      Timecop.freeze(Rails.configuration.end_of_login - 1.day) do
+        expect(subject.email_body(**i18n_required_args)).to eql(I18n.t("#{i18n_key}.email.body", **i18n_required_args))
+      end
+    end
+  end
+
+  describe "#email_subject" do
+    it "should always use the same subject regardless of date" do
+      Timecop.freeze(Rails.configuration.end_of_login - 1.day) do
+        expect(subject.email_subject(**i18n_required_args)).to eql(I18n.t("#{i18n_key}.email.subject", **i18n_required_args))
+      end
+    end
+
+    it "should always use the same subject regardless of date (after end_of_login)" do
+      Timecop.freeze(Rails.configuration.end_of_login + 1.day) do
+        expect(subject.email_subject(**i18n_required_args)).to eql(I18n.t("#{i18n_key}.email.subject", **i18n_required_args))
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-2246
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

## What was done?
- Updated copy of fyst rejection email and sms to have the deadline to resubmit only after its Oct 23rd

## How to test?
- Use [session toggles](https://gyr-review-app-6054-b9f104e95782.herokuapp.com/session_toggles?locale=en) to test before, during and after Oct 23rd for the reject notification on automated messages in the Hub FYST Admin tools 

## Screenshots (for visual changes)
Before
<img width="779" height="757" alt="Screenshot 2025-09-19 at 8 58 02 AM" src="https://github.com/user-attachments/assets/88217de0-95fa-464a-9cca-ea7c2f617768" />

After
<img width="753" height="807" alt="Screenshot 2025-09-19 at 8 57 42 AM" src="https://github.com/user-attachments/assets/f710930b-34fb-40a4-ae0c-89b1081c9c23" />
