### PR TITLE
change closed changeover date for fyst state landing page and change post-close copy for that page

### DIFF
--- a/app/controllers/state_file/landing_page_controller.rb
+++ b/app/controllers/state_file/landing_page_controller.rb
@@ -4,7 +4,7 @@ module StateFile
     layout "state_file"
 
     def edit
-      @closed = app_time.after?(Rails.configuration.state_file_end_of_in_progress_intakes)
+      @closed = app_time.after?(Rails.configuration.state_file_end_of_new_intakes)
       if current_intake.present?
         if current_intake.primary_first_name.present?
           @user_name = current_intake.primary_first_name

--- a/app/views/state_file/landing_page/edit.html.erb
+++ b/app/views/state_file/landing_page/edit.html.erb
@@ -16,6 +16,9 @@
               <%= t(".#{@state_code}.closed_html") %>
             </p>
             <p class="h2">
+              <%= t(".rejected_return_html", sign_in_url: StateFile::StateFilePagesController.to_path_helper(action: :login_options)) %>
+            </p>
+            <p class="h2">
               <%= t(".already_filed_html") %>
             </p>
             <div class="partner-logo-wrapper spacing-below-35">
@@ -26,7 +29,7 @@
                 <%= t(".#{@state_code}.supported_by") %>
               </div>
             </div>
-            <%= link_to StateFile::StateFilePagesController.to_path_helper(action: :login_options), class: "button button--primary button--wide", role: "button", id: "firstCta" do %>
+            <%= link_to questions_return_status_path(locale: I18n.locale), class: "button button--primary button--wide", role: "button", id: "firstCta" do %>
               <%= t(".download_your_record") %>
             <% end %>
           <% else %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2293,13 +2293,14 @@ en:
       no_match_sms: Someone tried to sign in to FileYourStateTaxes with this phone number, but we couldn't find a match. Did you sign up with a different phone number? You can also visit %{url} to get started.
     landing_page:
       edit:
-        already_filed_html: Already filed your state taxes with us? <strong>You can download a copy of your state return until December 31, 2024.</strong>
+        already_filed_html: <strong>Already filed your state taxes with us?</strong> You can download a copy of your 2024 state return below.
         already_started_html: <strong>Already started your state taxes with us and need to complete them?</strong> <a href="%{sign_in_url}">Sign in here</a> to continue filing.
+        rejected_return_html: <strong>Was the state return you filed with FileYourStateTaxes rejected?</strong> <a href="%{sign_in_url}">Sign in here</a> to correct and resubmit your return.
         az:
           closed_html: |
             We're closed for the tax season.<br /><br />
             <strong>FileYourStateTaxes</strong> is built in partnership with the state of Arizona to integrate with IRS Direct File.<br /><br />
-            Unfortunately you cannot file your state return with us this year.
+            Unfortunately, you can no longer file your state return with us this year.
           supported_by: Supported by the state of Arizona
           title: File your Arizona state taxes for free
         az_get_2023_return_html: <strong>Filed your 2023 return with us and want a copy?</strong> <a href="%{sign_in_path}">Sign in here</a> to download a copy of your state return.
@@ -2309,7 +2310,7 @@ en:
           This service is built in partnership with the state of %{state_name} to integrate with IRS Direct File.
         closing_soon_html: "<strong>October 22nd is the last day you can file your state return with FileYourStateTaxes.</strong> To do this, you must have submitted a federal return using IRS Direct File by its closing date, October 15th. You can transfer your data to FileYourStateTaxes until October 22nd."
         continue: To continue filing your %{state_name} State return, please sign in below.
-        download_your_record: Download Your Record
+        download_your_record: Download your 2024 return
         help_text_html: |
           <ul class="list--bulleted">
             <li>An <strong>accepted</strong> %{filing_year} federal return using <a href="https://directfile.irs.gov/?utm_source=CA-Nonprofit&utm_medium=email&utm_campaign=gyr&utm_id=directfile&utm_content=QRcode">IRS Direct File</a>. (You don’t need a copy of this return; you’ll transfer your return here.)
@@ -2323,21 +2324,21 @@ en:
           closed_html: |
             We're closed for the tax season.<br /><br />
             <strong>FileYourStateTaxes</strong> is built in partnership with the state of Idaho to integrate with IRS Direct File.<br /><br />
-            Unfortunately you cannot file your state return with us this year.
+            Unfortunately, you can no longer file your state return with us this year.
           supported_by: Supported by the state of Idaho
           title: File your Idaho state taxes for free
         md:
           closed_html: |
             We're closed for the tax season.<br /><br />
             <strong>FileYourStateTaxes</strong> is built in partnership with the state of Maryland to integrate with IRS Direct File.<br /><br />
-            Unfortunately you cannot file your state return with us this year.
+            Unfortunately, you can no longer file your state return with us this year.
           supported_by: Supported by the state of Maryland
           title: File your Maryland state taxes for free
         nc:
           closed_html: |
             We're closed for the tax season.<br /><br />
             <strong>FileYourStateTaxes</strong> is built in partnership with the state of North Carolina to integrate with IRS Direct File.<br /><br />
-            Unfortunately you cannot file your state return with us this year.
+            Unfortunately, you can no longer file your state return with us this year.
           supported_by: Supported by the state of North Carolina
           title: File your North Carolina state taxes for free
         nj:
@@ -2345,7 +2346,7 @@ en:
             <strong>FileYourStateTaxes</strong> takes about 10 to 15 minutes to complete. Get started by setting up your account.
             <br/><br/>
             This service is built in partnership with the New Jersey Office of Innovation to integrate with IRS Direct File.
-          closed_html: "<strong>FileYourStateTaxes</strong> is built in partnership with the New Jersey Office of Innovation to integrate with IRS Direct File.<br /><br />\nWe're closed for the tax season. Unfortunately you can no longer file your state return with us this year.              \n"
+          closed_html: "<strong>FileYourStateTaxes</strong> is built in partnership with the New Jersey Office of Innovation to integrate with IRS Direct File.<br /><br />\nWe're closed for the tax season. Unfortunately, you can no longer file your state return with us this year.              \n"
           help_text_html: |
             <ul class="list--bulleted">
               <li>To have filed your 2024 federal return using <a href="https://directfile.irs.gov/?utm_source=CA-Nonprofit&utm_medium=email&utm_campaign=gyr&utm_id=directfile&utm_content=QRcode" target="_blank" rel="noopener nofollow">IRS Direct File</a></li>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2304,20 +2304,21 @@ es:
       no_match_sms: Alguien intentó iniciar sesión en FileYourStateTaxes con este número de teléfono, pero no pudimos encontrar una coincidencia. ¿Te registraste con otro número de teléfono? También puedes visitar %{url} para comenzar.
     landing_page:
       edit:
-        already_filed_html: "¿Ya presentaste tus impuestos estatales con nosotros? <strong>Puedes descargar una copia de tu declaración de impuestos estatales hasta el 31 de diciembre de 2024.</strong>"
+        already_filed_html: "<strong>¿Ya presentaste tus impuestos estatales con nosotros?</strong> You can download a copy of your state return below."
         already_started_html: "<strong>¿Ya comenzaste tu declaración de impuestos estatales con nosotros y necesitas completarlos?</strong> <a href='%{sign_in_url}'>Inicia sesión aquí</a> para continuar con la declaración."
+        rejected_return_html: "<strong>¿La declaración estatal que presentaste con FileYourStateTaxes fue rechazada?</strong> <a href='%{sign_in_url}'>Inicia sesión aquí</a> para corregir y volver a enviar tu declaración."
         az:
           closed_html: |
             Ya cerramos por esta temporada de impuestos. <br /><br />
             <strong>FileYourStateTaxes</strong> ha sido creado en colaboración con el estado de Arizona para integrarse con el servicio Direct File del IRS.<br /><br />
-            Desafortunadamente, ya no puedes presentar tu declaración de impuestos estatales con nosotros este año.
+            Desafortunadamente, ya no puedes presentar tu declaración estatal con nosotros este año.
           supported_by: Respaldada por el estado de Arizona
           title: Declara tus impuestos estatales de Arizona sin costo
         az_get_2023_return_html: "<strong>¿Presentaste tu declaración de 2023 de Arizona o Nueva York con nosotros y quieres una copia?</strong> <a href='%{sign_in_path}'>Inicia sesión aquí</a> para descargar una copia de tu declaración estatal."
         built_with_html: "Te tomará alrededor de 10 y 15 minutos completar tu declaración con <strong>FileYourStateTaxes</strong>. \n<br/><br/>\nEste servicio ha sido creado en colaboración con el estado de %{state_name} para conectarse con el servicio Direct File del IRS.\n"
         closing_soon_html: "<strong>El 22 de octubre es el último día en que puedes presentar tu declaración estatal con FileYourStateTaxes.</strong> Para hacerlo, debes haber enviado una declaración federal utilizando IRS Direct File antes de su fecha de cierre, el 15 de octubre. Puedes transferir tus datos a FileYourStateTaxes hasta el 22 de octubre."
         continue: Para continuar presentando su declaración estatal de %{state_name}, inicie sesión a continuación.
-        download_your_record: Descarga tu declaración
+        download_your_record: Descarga tu declaración 2024
         help_text_html: |
           <ul class="list--bulleted">
             <li>Una declaración federal de impuestos de %{filing_year} <strong>aceptada</strong> a través de <a href="https://directfile.irs.gov/?utm_source=CA-Nonprofit&utm_medium=email&utm_campaign=gyr&utm_id=directfile&utm_content=QRcode">IRS Direct File</a>. (No necesitas una copia de esta declaración; transferirás tu declaración aquí)
@@ -2331,21 +2332,21 @@ es:
           closed_html: |
             Ya cerramos por esta temporada de impuestos. <br /><br />
             <strong>FileYourStateTaxes</strong> ha sido creado en colaboración con el estado de Idaho para integrarse con el servicio Direct File del IRS.<br /><br />
-            Desafortunadamente, ya no puedes presentar tu declaración de impuestos estatales con nosotros este año.
+            Desafortunadamente, ya no puedes presentar tu declaración estatal con nosotros este año.
           supported_by: Respaldada por el estado de Idaho
           title: Declara tus impuestos estatales de Idaho sin costo
         md:
           closed_html: |
             Ya cerramos por esta temporada de impuestos. <br /><br />
             <strong>FileYourStateTaxes</strong> ha sido creado en colaboración con el estado de Maryland para integrarse con el servicio Direct File del IRS.<br /><br />
-            Desafortunadamente, ya no puedes presentar tu declaración de impuestos estatales con nosotros este año.
+            Desafortunadamente, ya no puedes presentar tu declaración estatal con nosotros este año.
           supported_by: Respaldada por el estado de Maryland
           title: Declara tus impuestos estatales de Maryland sin costo
         nc:
           closed_html: |
             Ya cerramos por esta temporada de impuestos. <br /><br />
             <strong>FileYourStateTaxes</strong> ha sido creado en colaboración con el estado de Carolina del Norte para integrarse con el servicio Direct File del IRS.<br /><br />
-            Desafortunadamente, ya no puedes presentar tu declaración de impuestos estatales con nosotros este año.
+            Desafortunadamente, ya no puedes presentar tu declaración estatal con nosotros este año.
           supported_by: Respaldada por el estado de Carolina del Norte
           title: Declara tus impuestos estatales de Carolina del Norte sin costo
         nj:
@@ -2355,7 +2356,7 @@ es:
             Este servicio se creó en colaboración con la Oficina de Innovación de New Jersey para integrarse con el servicio IRS Direct File.
           closed_html: |
             <strong>FileYourStateTaxes</strong> ha sido creado en colaboración con el estado de New Jersey Office of Innovation para integrarse con el servicio Direct File del IRS.<br /><br />
-            Ya cerramos por esta temporada de impuestos. Desafortunadamente, ya no puedes presentar tu declaración de impuestos estatales con nosotros este año.
+            Ya cerramos por esta temporada de impuestos. Desafortunadamente, ya no puedes presentar tu declaración estatal con nosotros este año.
           help_text_html: |
             <ul class="list--bulleted">
               <li>Haber presentado tu declaración federal de 2024 usando <a href="https://directfile.irs.gov/?utm_source=CA-Nonprofit&utm_medium=email&utm_campaign=gyr&utm_id=directfile&utm_content=QRcode" target="_blank" rel="noopener nofollow">IRS Direct File</a></li>


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-2258
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Changed copy on FYST state landing page after 10/22
- Changed date we check to determine when to display that page as closed, per the story
## How to test?
- Manually 
## Screenshots (for visual changes)
- Before
<img width="627" height="1056" alt="image" src="https://github.com/user-attachments/assets/7c6c665d-e104-4b86-9de1-1419cebc6d88" />

- After
<img width="627" height="1056" alt="image" src="https://github.com/user-attachments/assets/8f58d8c0-328a-48ce-8890-5c675fa3a9c3" />
