### PR TITLE
add closing-soon warning to return-status page for clients whose return was rejected

### DIFF
--- a/app/views/state_file/questions/return_status/_rejected.html.erb
+++ b/app/views/state_file/questions/return_status/_rejected.html.erb
@@ -8,6 +8,10 @@
   <%= t("state_file.questions.return_status.rejected.title", state_name: current_state_name, filing_year: current_tax_year) %>
 </h1>
 
+<div class="warning spacing-below-25">
+  <%= t("state_file.questions.return_status.rejected.closing_soon_html") %>
+</div>
+
 <% if @error&.expose %>
   <% if @error.code.present? %>
     <section class="spacing-below-15">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4303,6 +4303,7 @@ en:
           title: You have submitted your %{filing_year} %{state_name} state tax return
           waiting_for acceptance: Your state tax return is still waiting to be accepted.
         rejected:
+          closing_soon_html: "<strong>You can edit and resubmit your state tax return until October 31st.</strong> After that date, you can only download a copy of your submitted state tax return."
           edit_return: Edit your state return
           email_us_html: Email us at <a href="mailto:help@fileyourstatetaxes.org">help@fileyourstatetaxes.org</a>
           have_questions: Have questions?

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4312,6 +4312,7 @@ es:
           title: Has enviado tu declaración de impuestos de %{state_name} de %{filing_year}
           waiting_for acceptance: Tu declaración de impuestos estatal aún está esperando ser aceptada.
         rejected:
+          closing_soon_html: "<strong>Puedes editar y volver a enviar tu declaración de impuestos estatal hasta el 31 de octubre.</strong> Después de esa fecha, solo podrás descargar una copia de la declaración estatal que enviaste."
           edit_return: Edita tu declaración estatal
           email_us_html: Envíanos un correo electrónico a <a href="mailto:help@fileyourstatetaxes.org">help@fileyourstatetaxes.org</a>
           have_questions: "¿Tienes preguntas?"
@@ -4324,7 +4325,7 @@ es:
               title: "¿Qué puedo hacer a continuación?"
           reject_code: 'Código de Rechazo:'
           reject_desc: 'Descripción del Rechazo:'
-          title: Lamentablemente, tu declaración de impuestos estatal de %{state_name}de %{filing_year} fue rechazada
+          title: Lamentablemente, tu declaración de impuestos estatal de %{state_name} de %{filing_year} fue rechazada
       review:
         county: Condado donde vivías el 31 de diciembre de %{filing_year}
         county_during_hurricane: Otro condado donde vivías (o actualmente vives) entre el 25 de septiembre y la fecha de hoy


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-2259
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Added a warning box to the return status page for rejected returns
## How to test?
- Submit a return
- Go to the hub, and transition it to "Notified of rejection"
## Screenshots (for visual changes)
- Before
<img width="663" height="1056" alt="image" src="https://github.com/user-attachments/assets/631839c6-1d55-4e1f-8764-8801b8c1cd56" />

- After
<img width="663" height="1056" alt="image" src="https://github.com/user-attachments/assets/9ab8e028-217d-4f44-8482-a81c8d7c94af" />
