### PR TITLE
Add shared method to query for intakes that should get the deadline reminder tomorrow and today messages

### DIFF
--- a/app/models/state_file_base_intake.rb
+++ b/app/models/state_file_base_intake.rb
@@ -79,7 +79,6 @@ class StateFileBaseIntake < ApplicationRecord
   def self.selected_intakes_for_deadline_reminder_soon_notifications
     intakes = left_joins(:efile_submissions)
                 .where(efile_submissions: { id: nil })
-                .where.not(df_data_imported_at: nil)
                 .has_verified_contact_info
                 .where(created_at: Time.current.beginning_of_year..Time.current.end_of_year)
 

--- a/spec/models/state_file_base_intake_spec.rb
+++ b/spec/models/state_file_base_intake_spec.rb
@@ -669,11 +669,12 @@ describe StateFileBaseIntake do
       allow(Flipper).to receive(:enabled?).with(:prevent_duplicate_ssn_messaging).and_return(true)
     end
 
-    it "returns intakes with verified contact info, valid df data, and without recent finish return messages or efile submissions or duplicate (same hashed_ssn) intake with efile submission" do
+    it "returns intakes with verified contact info, valid df data, no df data, and without recent finish return messages or efile submissions or duplicate (same hashed_ssn) intake with efile submission" do
       results = StateFileAzIntake.selected_intakes_for_deadline_reminder_soon_notifications
       intakes_to_message = [
         az_intake_with_email_notifications_and_df_import,
         az_intake_with_text_notifications_and_df_import,
+        az_intake_with_email_notifications_without_df_import,
         az_intake_with_unverified_text_notifications_and_df_import,
       ]
       expect(results).to match_array(intakes_to_message)


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. not explicitly tied to a JIRA issue but need this method for both https://codeforamerica.atlassian.net/browse/FYST-2263?atlOrigin=eyJpIjoiOTYwOWIxMTBkODVlNDliNjlhMGRlMDJlNTJkNGJhYjYiLCJwIjoiaiJ9 and https://codeforamerica.atlassian.net/browse/FYST-2264?atlOrigin=eyJpIjoiNzc2OGQ4OWZiNTZhNDI2ZmJlMTdhY2RhNTMzYzhiMWUiLCJwIjoiaiJ9
## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
grabs clients that:
- have imported df data but also have no efile submission present OR no df data but account present
- has verified contact info
- intake was created this year
- don't have a disqualifying DF issue present
- doesn't have a duplicate intake that has an efile submission present

