### PR TITLE
Remove email notifications column

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,6 @@
 #  current_sign_in_ip              :string
 #  document_upload_notification    :integer          default("yes"), not null
 #  email                           :citext           not null
-#  email_notification              :integer          default("yes"), not null
 #  encrypted_password              :string           default(""), not null
 #  external_provider               :string
 #  external_uid                    :string
@@ -92,7 +91,6 @@ class User < ApplicationRecord
   enum document_upload_notification: { yes: 0, no: 1 }, _prefix: :document_upload_notification
   enum tagged_in_note_notification: { yes: 0, no: 2 }, _prefix: :tagged_in_note_notification
   enum signed_8879_notification: { yes: 0, no: 2 }, _prefix: :signed_8879_notification
-  enum email_notification: { yes: 0, no: 1}, _prefix: :email_notification
 
   def valid?(*_args)
     [super, role&.valid?].all?

--- a/db/migrate/20250923204400_remove_email_notifications_column_from_users_table.rb
+++ b/db/migrate/20250923204400_remove_email_notifications_column_from_users_table.rb
@@ -1,0 +1,5 @@
+class RemoveEmailNotificationsColumnFromUsersTable < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured { remove_column :users, :email_notification, :integer }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_09_02_173338) do
+ActiveRecord::Schema[7.1].define(version: 2025_09_23_204400) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -2817,7 +2817,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_02_173338) do
     t.string "current_sign_in_ip"
     t.integer "document_upload_notification", default: 0, null: false
     t.citext "email", null: false
-    t.integer "email_notification", default: 0, null: false
     t.string "encrypted_password", default: "", null: false
     t.string "external_provider"
     t.string "external_uid"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,7 +8,6 @@
 #  current_sign_in_ip              :string
 #  document_upload_notification    :integer          default("yes"), not null
 #  email                           :citext           not null
-#  email_notification              :integer          default("yes"), not null
 #  encrypted_password              :string           default(""), not null
 #  external_provider               :string
 #  external_uid                    :string

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,7 +8,6 @@
 #  current_sign_in_ip              :string
 #  document_upload_notification    :integer          default("yes"), not null
 #  email                           :citext           not null
-#  email_notification              :integer          default("yes"), not null
 #  encrypted_password              :string           default(""), not null
 #  external_provider               :string
 #  external_uid                    :string


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. https://codeforamerica.atlassian.net/browse/GYR1-741
## Is PM acceptance required? (delete one)
- No - merge after code review approval

## What was done?
- This is a follow up PR for https://github.com/codeforamerica/vita-min/pull/6053 because previously removing the email_notifications column created errors in the db in the Heroku instance. The column is no longer used for the email notifications settings 

