### PR TITLE
Archived clients should not trigger external Hub notifications

### DIFF
--- a/app/services/interaction_tracking_service.rb
+++ b/app/services/interaction_tracking_service.rb
@@ -56,7 +56,7 @@ class InteractionTrackingService
             interaction_type: interaction_type,
           )
         )
-        SendInternalEmailJob.perform_later(internal_email)
+        SendInternalEmailJob.perform_later(internal_email) unless client.has_archived_intake?
       end
     end
 

--- a/app/services/interaction_tracking_service.rb
+++ b/app/services/interaction_tracking_service.rb
@@ -19,7 +19,7 @@ class InteractionTrackingService
 
         users_to_contact.each do |user|
           interaction = ClientInteraction.create!(client: client, interaction_type: interaction_type)
-          ClientInteractionNotificationEmailJob.set(wait: 10.minutes).perform_later(interaction, user, **email_attrs)
+          ClientInteractionNotificationEmailJob.set(wait: 10.minutes).perform_later(interaction, user, **email_attrs) unless client.has_archived_intake?
         end
       end
     end

--- a/app/services/tax_return_assignment_service.rb
+++ b/app/services/tax_return_assignment_service.rb
@@ -19,6 +19,7 @@ class TaxReturnAssignmentService
   end
 
   def send_notifications
+    return if @client.has_archived_intake?
     if @assigned_user.present? && (@assigned_user != @assigned_by) && @assigned_user.client_assignments_notification_yes?
       UserNotification.create!(
         user: @assigned_user,

--- a/spec/services/interaction_tracking_service_spec.rb
+++ b/spec/services/interaction_tracking_service_spec.rb
@@ -205,6 +205,15 @@ describe InteractionTrackingService do
           expect(internal_email.mail_args).to match_array ActiveJob::Arguments.serialize(client: client, user: user, interaction_type: "tagged_in_note", received_at: received_at)
           expect(SendInternalEmailJob).to have_received(:perform_later)
         end
+
+        context "when client has an archived intake" do
+          let!(:archived_intake) {  create(:archived_2021_gyr_intake, client: client) }
+
+          it "doesn't send any email notifications" do
+            described_class.record_internal_interaction(client, interaction_type: "tagged_in_note", user: user, received_at: received_at)
+            expect(SendInternalEmailJob).not_to have_received(:perform_later)
+          end
+        end
       end
     end
   end

--- a/spec/services/interaction_tracking_service_spec.rb
+++ b/spec/services/interaction_tracking_service_spec.rb
@@ -138,6 +138,20 @@ describe InteractionTrackingService do
         end
       end
     end
+
+    context "when client has an archived intake" do
+      let!(:archived_intake) {  create(:archived_2021_gyr_intake, client: client) }
+
+      it "doesn't send any email notifications" do
+        described_class.record_incoming_interaction(client, received_at: fake_time, interaction_type: "new_client_message")
+        expect(ClientInteraction).to have_received(:create!).with(
+          client: client,
+          interaction_type: "new_client_message"
+        )
+        expect(ClientInteractionNotificationEmailJob).not_to have_received(:set)
+        expect(job).not_to have_received(:perform_later)
+      end
+    end
   end
 
   describe "#record_internal_interaction" do
@@ -189,7 +203,7 @@ describe InteractionTrackingService do
           expect(internal_email.mail_class).to eq "UserMailer"
           expect(internal_email.mail_method).to eq "internal_interaction_notification_email"
           expect(internal_email.mail_args).to match_array ActiveJob::Arguments.serialize(client: client, user: user, interaction_type: "tagged_in_note", received_at: received_at)
-          expect(SendInternalEmailJob).to have_received(:perform_later).with(internal_email)
+          expect(SendInternalEmailJob).to have_received(:perform_later)
         end
       end
     end

--- a/spec/services/tax_return_assignment_service_spec.rb
+++ b/spec/services/tax_return_assignment_service_spec.rb
@@ -120,5 +120,17 @@ describe TaxReturnAssignmentService do
         }.not_to change(InternalEmail, :count).from(0)
       end
     end
+
+    context "when client has an archived intake" do
+      before do
+        allow_any_instance_of(Client).to receive(:has_archived_intake?).and_return true
+      end
+
+      it "does not send email" do
+        expect {
+          subject.send_notifications
+        }.not_to change(InternalEmail, :count).from(0)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. https://codeforamerica.atlassian.net/browse/GYR1-811
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Archived clients should not trigger any of the external Hub notifications to the assigned user
- new message, document upload, client assignment, signed 8879, tagged in internal note
## How to test?
messages
1. Be assigned to an archived client
2. Send message as client (from email associated with the archived client)
3. Check email inbox 

document upload and 8879
I don't think archived clients can login to the portal

client assignment
as a hub user assign an archived client to another hub user that has their notification on

Tagged in note
as a hub user tag another user in the notes of an archived client

