### PR TITLE
Check for presence of raw direct data when calling disqualifying_df_data_reason

### DIFF
--- a/app/models/state_file_az_intake.rb
+++ b/app/models/state_file_az_intake.rb
@@ -134,7 +134,8 @@ class StateFileAzIntake < StateFileBaseIntake
   end
 
   def disqualifying_df_data_reason
-    return unless direct_file_data.present?
+    return unless raw_direct_file_data.present?
+
     return :married_filing_separately if direct_file_data.filing_status == 3
 
     w2_states = direct_file_data.parsed_xml.css('W2StateLocalTaxGrp W2StateTaxGrp StateAbbreviationCd')

--- a/app/models/state_file_md_intake.rb
+++ b/app/models/state_file_md_intake.rb
@@ -143,12 +143,15 @@ class StateFileMdIntake < StateFileBaseIntake
   enum paid_extension_payments: { unfilled: 0, yes: 1, no: 2 }, _prefix: :paid_extension_payments
 
   def disqualifying_df_data_reason
-    return unless direct_file_data.present?
+    return unless raw_direct_file_data.present?
+
     return :spouse_nra_html if nra_spouse?
+
     w2_states = direct_file_data.parsed_xml.css('W2StateLocalTaxGrp W2StateTaxGrp StateAbbreviationCd')
     return :has_out_of_state_w2 if w2_states.any? do |state|
       (state.text || '').upcase != state_code.upcase
     end
+
     return :mfj_and_dependent_html if mfj_and_dependent?
   end
 

--- a/app/models/state_file_nc_intake.rb
+++ b/app/models/state_file_nc_intake.rb
@@ -142,7 +142,8 @@ class StateFileNcIntake < StateFileBaseIntake
   end
 
   def disqualifying_df_data_reason
-    return unless direct_file_data.present?
+    return unless raw_direct_file_data.present?
+
     w2_states = direct_file_data.parsed_xml.css('W2StateLocalTaxGrp W2StateTaxGrp StateAbbreviationCd')
     :has_out_of_state_w2 if w2_states.any? do |state|
       (state.text || '').upcase != state_code.upcase

--- a/app/models/state_file_nj_intake.rb
+++ b/app/models/state_file_nj_intake.rb
@@ -174,7 +174,8 @@ class StateFileNjIntake < StateFileBaseIntake
   end
 
   def disqualifying_df_data_reason
-    return unless direct_file_data.present?
+    return unless raw_direct_file_data.present?
+
     w2_states = direct_file_data.parsed_xml.css('W2StateLocalTaxGrp W2StateTaxGrp StateAbbreviationCd')
     return :has_out_of_state_w2 if w2_states.any? do |state|
       !(state.text || '').casecmp(state_code).zero?

--- a/app/models/state_file_ny_intake.rb
+++ b/app/models/state_file_ny_intake.rb
@@ -208,7 +208,8 @@ class StateFileNyIntake < StateFileBaseIntake
   IRC_125_CODES = ['IRC125S', 'IRS125']
   YONKERS_CODES = ['YK', 'YON', 'YNK', 'CITYOFYK', 'CTYOFYKR', 'CITYOF YK', 'CTY OF YK']
   def disqualifying_df_data_reason
-    return unless direct_file_data.present?
+    return unless raw_direct_file_data.present?
+
     w2_states = direct_file_data.parsed_xml.css('W2StateLocalTaxGrp W2StateTaxGrp StateAbbreviationCd')
     return :has_out_of_state_w2 if w2_states.any? do |state|
       (state.text || '').upcase != state_code.upcase


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. related to https://codeforamerica.atlassian.net/browse/FYST-2264 and https://codeforamerica.atlassian.net/browse/FYST-2263
## Is PM acceptance required? (delete one)
- No - merge after code review approval

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
* Check for presence of raw direct data when calling disqualifying_df_data_reason, was checking for direct_file_data before but this will still be present even if data is empty