### PR TITLE
Change selected intakes for oct 21 and 22 to only send to intakes with df data imported

### DIFF
--- a/app/models/state_file_base_intake.rb
+++ b/app/models/state_file_base_intake.rb
@@ -77,9 +77,12 @@ class StateFileBaseIntake < ApplicationRecord
   delegate :state_code, to: :class
 
   def self.selected_intakes_for_deadline_reminder_soon_notifications
-    self.where.missing(:efile_submissions)
-        .has_verified_contact_info
-        .where(created_at: Time.current.beginning_of_year..Time.current.end_of_year)
+    intakes = self.where.missing(:efile_submissions)
+                  .where.not(df_data_imported_at: nil)
+                  .has_verified_contact_info
+                  .where(created_at: Time.current.beginning_of_year..Time.current.end_of_year)
+
+    intakes.select { |i| !i.disqualifying_df_data_reason.present? && !i.other_intake_with_same_ssn_has_submission? }
   end
 
   def self.selected_intakes_for_deadline_reminder_notifications

--- a/app/services/state_file/send_deadline_reminder_today_service.rb
+++ b/app/services/state_file/send_deadline_reminder_today_service.rb
@@ -10,20 +10,10 @@ module StateFile
 
       intakes_to_notify.each_slice(BATCH_SIZE) do |batch|
         batch.each do |intake|
-          begin
-            if (intake.raw_direct_file_data.present? && intake.disqualifying_df_data_reason.present?) || intake.other_intake_with_same_ssn_has_submission?
-              next
-            end
-            StateFile::MessagingService.new(
-              message: StateFile::AutomatedMessage::DeadlineReminderToday,
-              intake: intake
-            ).send_message
-          rescue Exception => e
-            Sentry.capture_exception(e, extra: {
-              intake_id: intake.id,
-              intake_class: intake.class.table_name
-            })
-          end
+          StateFile::MessagingService.new(
+            message: StateFile::AutomatedMessage::DeadlineReminderToday,
+            intake: intake
+          ).send_message
         end
       end
     end

--- a/spec/models/state_file_base_intake_spec.rb
+++ b/spec/models/state_file_base_intake_spec.rb
@@ -594,14 +594,16 @@ describe StateFileBaseIntake do
       create :state_file_az_intake,
              email_address: 'test_1@example.com',
              email_address_verified_at: 5.minutes.ago,
-             email_notification_opt_in: 1
+             email_notification_opt_in: 1,
+             df_data_imported_at: 2.minutes.ago
     }
     let!(:az_intake_from_last_year) {
       create :state_file_az_intake,
              email_address: 'test_2@example.com',
              email_address_verified_at: 5.minutes.ago,
              email_notification_opt_in: 1,
-             created_at: 1.year.ago
+             created_at: 1.year.ago,
+             df_data_imported_at: 2.minutes.ago
     }
     let!(:az_intake_with_email_notifications_without_df_import) {
       create :state_file_az_intake,
@@ -615,7 +617,8 @@ describe StateFileBaseIntake do
              email_address: 'test_4@example.com',
              phone_number: "+15551115511",
              sms_notification_opt_in: 1,
-             phone_number_verified_at: 5.minutes.ago
+             phone_number_verified_at: 5.minutes.ago,
+             df_data_imported_at: 2.minutes.ago
     }
     let!(:az_intake_with_unverified_text_notifications_and_df_import) {
       create :state_file_az_intake,
@@ -623,13 +626,15 @@ describe StateFileBaseIntake do
              phone_number: "+15551115511",
              sms_notification_opt_in: "yes",
              email_address_verified_at: 5.minutes.ago,
-             email_notification_opt_in: "no"
+             email_notification_opt_in: "no",
+             df_data_imported_at: 2.minutes.ago
     }
     let!(:az_intake_submitted) {
       create :state_file_az_intake,
              email_address: 'test_6@example.com',
              email_address_verified_at: 5.minutes.ago,
-             email_notification_opt_in: 1
+             email_notification_opt_in: 1,
+             df_data_imported_at: 2.minutes.ago
     }
     let!(:efile_submission) { create :efile_submission, :for_state, data_source: az_intake_submitted }
     let!(:az_intake_has_disqualifying_df_data) {
@@ -637,7 +642,8 @@ describe StateFileBaseIntake do
              filing_status: :married_filing_separately,
              email_address: "test_7@example.com",
              email_address_verified_at: 1.hour.ago,
-             email_notification_opt_in: 1
+             email_notification_opt_in: 1,
+             df_data_imported_at: 2.minutes.ago
     }
     let!(:az_intake_submitted_ssn_duplicate) {
       create :state_file_az_intake,
@@ -645,7 +651,8 @@ describe StateFileBaseIntake do
              email_address_verified_at: 1.hour.ago,
              email_notification_opt_in: 1,
              phone_number: nil,
-             hashed_ssn: "111443333"
+             hashed_ssn: "111443333",
+             df_data_imported_at: 2.minutes.ago
     }
     let!(:efile_submission_for_duplicate) { create :efile_submission, :for_state, data_source: az_intake_submitted_ssn_duplicate }
     let!(:az_intake_submitted_ssn_duplicate_1) {
@@ -654,7 +661,8 @@ describe StateFileBaseIntake do
              email_address_verified_at: 1.hour.ago,
              email_notification_opt_in: 1,
              phone_number: nil,
-             hashed_ssn: "111443333"
+             hashed_ssn: "111443333",
+             df_data_imported_at: 2.minutes.ago
     }
 
     before do
@@ -662,15 +670,12 @@ describe StateFileBaseIntake do
       allow(Flipper).to receive(:enabled?).with(:prevent_duplicate_ssn_messaging).and_return(true)
     end
 
-    it "returns intakes with verified contact info, with or without df data, and without efile submissions" do
+    it "returns intakes WITH verified contact info & df data import and WITHOUT efile submissions, duplicates (where one has an efile submission) & disqualifying df data reasons" do
       results = StateFileAzIntake.selected_intakes_for_deadline_reminder_soon_notifications
       intakes_to_message = [
         az_intake_with_email_notifications_and_df_import,
         az_intake_with_text_notifications_and_df_import,
-        az_intake_with_email_notifications_without_df_import,
         az_intake_with_unverified_text_notifications_and_df_import,
-        az_intake_has_disqualifying_df_data,
-        az_intake_submitted_ssn_duplicate_1
       ]
       expect(results).to match_array(intakes_to_message)
     end

--- a/spec/tasks/send_deadline_reminder_today_service_spec.rb
+++ b/spec/tasks/send_deadline_reminder_today_service_spec.rb
@@ -7,146 +7,25 @@ describe 'state_file:send_deadline_reminder_today' do
     allow(Flipper).to receive(:enabled?).with(:prevent_duplicate_ssn_messaging).and_return(true)
     messaging_service = spy('StateFile::MessagingService')
     allow(StateFile::MessagingService).to receive(:new).and_return(messaging_service)
+    allow(StateFileAzIntake).to receive(:selected_intakes_for_deadline_reminder_soon_notifications).and_return([az_intake_1, az_intake_2, az_intake_3])
   end
 
   around do |example|
+    # freezing the time to any time in 2025, since this task will only run in 2025
     Timecop.freeze(DateTime.parse("2-12-2025")) do
       example.run
     end
   end
 
-  context "for AZ intakes" do
-    let!(:az_intake_with_email_notifications_and_df_import) {
-      create :state_file_az_intake,
-             email_address: 'test_1@example.com',
-             email_address_verified_at: 5.minutes.ago,
-             email_notification_opt_in: 1
-    }
-    let!(:az_intake_with_email_notifications_and_df_import_from_last_year) {
-      create :state_file_az_intake,
-             email_address: 'test_2@example.com',
-             email_address_verified_at: 5.minutes.ago,
-             email_notification_opt_in: 1,
-             created_at: (1.year.ago)
-    }
-    let!(:az_intake_with_email_notifications_without_df_import) {
-      create :state_file_az_intake,
-             raw_direct_file_data: nil,
-             email_address: 'test_3@example.com',
-             email_address_verified_at: 5.minutes.ago,
-             email_notification_opt_in: 1
-    }
-    let!(:az_intake_with_sms_and_df_import) {
-      create :state_file_az_intake,
-             email_address: 'test_4@example.com',
-             phone_number: "+15551115511",
-             sms_notification_opt_in: 1,
-             phone_number_verified_at: 5.minutes.ago
-    }
-    let!(:az_intake_with_unverified_sms_verified_email) {
-      create :state_file_az_intake,
-             phone_number: "+15551115511",
-             sms_notification_opt_in: "yes",
-             email_address: 'test_5@example.com',
-             email_address_verified_at: 5.minutes.ago,
-             email_notification_opt_in: "no"
-    }
-    let!(:az_intake_submitted) {
-      create :state_file_az_intake,
-             email_address: 'test_6@example.com',
-             email_address_verified_at: 5.minutes.ago,
-             email_notification_opt_in: 1
-    }
-    let!(:efile_submission) { create :efile_submission, :for_state, data_source: az_intake_submitted }
-    let!(:az_intake_has_disqualifying_df_data) {
-      create :state_file_az_intake,
-             filing_status: :married_filing_separately,
-             email_address: "test_7@example.com",
-             email_address_verified_at: 1.hour.ago,
-             email_notification_opt_in: 1
-    }
-    let!(:az_intake_with_no_raw_direct_file_data) {
-      create :state_file_az_intake,
-             raw_direct_file_data: nil,
-             raw_direct_file_intake_data: nil,
-             email_address: 'test_9@example.com',
-             email_address_verified_at: 5.minutes.ago,
-             email_notification_opt_in: 1
-    }
-    let!(:az_intake_submitted_ssn_dupe_with_submission) {
-      create :state_file_az_intake,
-             email_address: "test_8@example.com",
-             email_address_verified_at: 1.hour.ago,
-             email_notification_opt_in: 1,
-             phone_number: nil,
-             hashed_ssn: "111443333"
-    }
-    let!(:efile_submission_for_duplicate) {
-      create :efile_submission,
-             :for_state,
-             data_source: az_intake_submitted_ssn_dupe_with_submission
-    }
-    let!(:az_intake_submitted_ssn_match_for_dupe) {
-      create :state_file_az_intake,
-             email_address: "test_8@example.com",
-             email_address_verified_at: 1.hour.ago,
-             email_notification_opt_in: 1,
-             phone_number: nil,
-             hashed_ssn: "111443333"
-    }
+  let!(:az_intake_1) { create :state_file_az_intake, email_address: 'test_1@example.com', email_address_verified_at: 5.minutes.ago, email_notification_opt_in: 1 }
+  let!(:az_intake_2) { create :state_file_az_intake, email_address: 'test_4@example.com', phone_number: "+15551115511", sms_notification_opt_in: 1, phone_number_verified_at: 5.minutes.ago }
+  let!(:az_intake_3) { create :state_file_az_intake, phone_number: "+15551115511", sms_notification_opt_in: "yes", email_address: 'test_5@example.com', email_address_verified_at: 5.minutes.ago, email_notification_opt_in: "no" }
 
-
-    it 'sends to intakes with verified contact info, with or without df data, and without efile submissions or duplicate (same hashed_ssn) intakes with efile submission' do
-      Rake::Task['state_file:send_deadline_reminder_today'].execute
-      expect(StateFile::MessagingService).to have_received(:new).exactly(5).times
-      expect(StateFile::MessagingService).to have_received(:new).with(
-        message: StateFile::AutomatedMessage::DeadlineReminderToday,
-        intake: az_intake_with_email_notifications_and_df_import
-      )
-      expect(StateFile::MessagingService).to have_received(:new).with(
-        message: StateFile::AutomatedMessage::DeadlineReminderToday,
-        intake: az_intake_with_email_notifications_without_df_import
-      )
-      expect(StateFile::MessagingService).to have_received(:new).with(
-        message: StateFile::AutomatedMessage::DeadlineReminderToday,
-        intake: az_intake_with_sms_and_df_import
-      )
-      expect(StateFile::MessagingService).to have_received(:new).with(
-        message: StateFile::AutomatedMessage::DeadlineReminderToday,
-        intake: az_intake_with_unverified_sms_verified_email
-      )
-      expect(StateFile::MessagingService).to have_received(:new).with(
-        message: StateFile::AutomatedMessage::DeadlineReminderToday,
-        intake: az_intake_with_no_raw_direct_file_data
-      )
-    end
-  end
-
-  context "for NJ intakes" do
-    let!(:nj_intake_with_email_notifications_and_df_import) {
-      create :state_file_nj_intake,
-             email_address: 'test_1@example.com',
-             email_address_verified_at: 5.minutes.ago,
-             email_notification_opt_in: 1
-    }
-    let!(:nj_intake_with_email_notifications_without_df_import) {
-      create :state_file_nj_intake,
-             raw_direct_file_data: nil,
-             email_address: 'test_3@example.com',
-             email_address_verified_at: 5.minutes.ago,
-             email_notification_opt_in: 1
-    }
-    it 'sends to intakes with verified contact info, with or without df data, and without efile submissions or duplicate (same hashed_ssn) intakes with efile submission' do
-      Rake::Task['state_file:send_deadline_reminder_today'].execute
-      expect(StateFile::MessagingService).to have_received(:new).exactly(2).times
-      expect(StateFile::MessagingService).to have_received(:new).with(
-        message: StateFile::AutomatedMessage::DeadlineReminderToday,
-        intake: nj_intake_with_email_notifications_and_df_import
-      )
-      expect(StateFile::MessagingService).to have_received(:new).with(
-        message: StateFile::AutomatedMessage::DeadlineReminderToday,
-        intake: nj_intake_with_email_notifications_without_df_import
-      )
-    end
+  it 'sends to intakes with verified contact info, with or without df data, and without efile submissions or duplicate (same hashed_ssn) intakes with efile submission' do
+    Rake::Task['state_file:send_deadline_reminder_today'].execute
+    expect(StateFile::MessagingService).to have_received(:new).exactly(3).times
+    expect(StateFile::MessagingService).to have_received(:new).with(message: StateFile::AutomatedMessage::DeadlineReminderToday, intake: az_intake_1)
+    expect(StateFile::MessagingService).to have_received(:new).with(message: StateFile::AutomatedMessage::DeadlineReminderToday, intake: az_intake_2)
+    expect(StateFile::MessagingService).to have_received(:new).with(message: StateFile::AutomatedMessage::DeadlineReminderToday, intake: az_intake_3)
   end
 end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. https://codeforamerica.atlassian.net/browse/FYST-2287
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- only send reminder notifications to clients with df data imported
## How to test?
- Can test on the today message

