### PR TITLE
add `initiated_by_user_id` metadata to initial transition for manually created tax returns

### DIFF
--- a/app/controllers/hub/tax_returns_controller.rb
+++ b/app/controllers/hub/tax_returns_controller.rb
@@ -11,7 +11,7 @@ module Hub
 
     def new
       redirect_to hub_client_path(@client.id) unless @client.intake
-      @form = TaxReturnForm.new(@client, gyr_filing_years)
+      @form = TaxReturnForm.new(@client, current_user, gyr_filing_years)
       @tax_return = @form.tax_return
 
       if @form.remaining_years.blank?
@@ -21,7 +21,7 @@ module Hub
     end
 
     def create
-      @form = TaxReturnForm.new(@client, gyr_filing_years, tax_return_params)
+      @form = TaxReturnForm.new(@client, current_user, gyr_filing_years, tax_return_params)
       @tax_return = @form.tax_return
       if @form.valid?
         @form.save

--- a/app/forms/hub/tax_return_form.rb
+++ b/app/forms/hub/tax_return_form.rb
@@ -13,8 +13,9 @@ module Hub
     validates :current_state, presence: true
     validates :year, presence: true
 
-    def initialize(client, gyr_filing_years, params={})
+    def initialize(client, current_user, gyr_filing_years, params={})
       @client = client
+      @current_user = current_user
       super(params)
       @service_type ||= client.tax_returns.pluck(:service_type).include?("drop_off") ? "drop_off" : "online_intake"
       @current_state ||= "intake_in_progress"
@@ -25,7 +26,7 @@ module Hub
     def save
       @tax_return.assign_attributes(attributes_for(:tax_return))
       @tax_return.save!
-      tax_return.transition_to!(current_state)
+      tax_return.transition_to!(current_state, initiated_by_user_id: @current_user.id)
     end
 
     def self.permitted_params

--- a/spec/forms/hub/tax_return_form_spec.rb
+++ b/spec/forms/hub/tax_return_form_spec.rb
@@ -2,7 +2,8 @@ require "rails_helper"
 
 describe Hub::TaxReturnForm do
   describe "#new" do
-    subject { described_class.new(client, params) }
+    subject { described_class.new(client, current_user, params) }
+    let(:current_user) { tax_return.assigned_user }
 
     context "with no params" do
       let(:params) { {} }
@@ -27,7 +28,7 @@ describe Hub::TaxReturnForm do
     end
 
     context "when explicit service_type is passed as a param" do
-      subject { described_class.new(client, MultiTenantService.gyr.filing_years, { service_type: "custom" }) }
+      subject { described_class.new(client, current_user, MultiTenantService.gyr.filing_years, { service_type: "custom" }) }
       let(:params) { {} }
       let(:tax_return) { create :gyr_tax_return, :intake_in_progress, service_type: "drop_off" }
       let(:client) { tax_return.client }
@@ -39,7 +40,7 @@ describe Hub::TaxReturnForm do
   end
 
   describe "#save" do
-    subject { described_class.new(client, MultiTenantService.gyr.filing_years, params) }
+    subject { described_class.new(client, user, MultiTenantService.gyr.filing_years, params) }
 
     let(:client) { create :client, intake: (build :intake) }
     let(:user) { create :user }
@@ -58,6 +59,8 @@ describe Hub::TaxReturnForm do
       expect(tax_return.assigned_user).to eq user
       expect(tax_return.certification_level).to eq "basic"
       expect(tax_return.year).to eq 2019
+
+      expect(tax_return.last_transition.metadata).to eq({ "initiated_by_user_id" => user.id })
     end
   end
 end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/GYR1-803
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- add initiated_by_user_id metadata to tax return state transitions created by the TaxReturnForm (ie when hub users manually create tax returns) so that they match the transitions created by TaxReturnService (ie when hub users manually update tax returns)
## How to test?
- Automatic test was added
- You can create tax returns on the hub and then have an engineer verify in the database that their initial state transition has the `initiated_by_user_id` metadata
