### PR TITLE
Don't send FYST reminder notifications in demo

### DIFF
--- a/crontab
+++ b/crontab
@@ -12,7 +12,7 @@
 0 18 13,23 4 * bundle exec rake send_reject_resolution_reminder_notifications:send
 0 18 08,15 4 * bundle exec rake state_file:pre_deadline_reminder
 0 18 17,23 4 * bundle exec rake state_file:post_deadline_reminder
-0 21 27 10 * bundle exec rake users:suspend_non_admins
+0 18 16 10 * bundle exec rake state_file:send_october_transfer_reminder
 0 18 21 10 * bundle exec rake state_file:send_deadline_reminder_tomorrow
 0 18 22 10 * bundle exec rake state_file:send_deadline_reminder_today
-0 18 16 10 * bundle exec rake state_file:send_october_transfer_reminder
+0 21 27 10 * bundle exec rake users:suspend_non_admins

--- a/lib/tasks/state_file.rake
+++ b/lib/tasks/state_file.rake
@@ -12,32 +12,39 @@ namespace :state_file do
   end
 
   task pre_deadline_reminder: :environment do
-    return unless DateTime.now.year == 2025
+    next unless DateTime.now.year == 2025
     StateFile::SendPreDeadlineReminderService.run
   end
 
   task post_deadline_reminder: :environment do
-    return unless DateTime.now.year == 2025
+    next unless DateTime.now.year == 2025
+
     StateFile::SendPostDeadlineReminderService.run
   end
 
+  task send_october_transfer_reminder: :environment do
+    next if Rails.env.demo?
+    next unless DateTime.now.year == 2025
+
+    StateFile::OctoberTransferReminderService.run
+  end
+
   task send_deadline_reminder_tomorrow: :environment do
-    return unless DateTime.now.year == 2025
+    next if Rails.env.demo?
+    next unless DateTime.now.year == 2025
+
     StateFile::SendDeadlineReminderTomorrowService.run
   end
 
   task send_deadline_reminder_today: :environment do
-    return unless DateTime.now.year == 2025
+    next if Rails.env.demo?
+    next unless DateTime.now.year == 2025
+
     StateFile::SendDeadlineReminderTodayService.run
   end
 
   task send_marketing_email: :environment do
     StateFile::SendMarketingEmailService.run
-  end
-
-  task send_october_transfer_reminder: :environment do
-    return unless DateTime.now.year == 2025
-    StateFile::OctoberTransferReminderService.run
   end
 
   task backfill_intake_submission_pdfs: :environment do

--- a/spec/tasks/october_transfer_reminder_spec.rb
+++ b/spec/tasks/october_transfer_reminder_spec.rb
@@ -1,31 +1,56 @@
-# frozen_string_literal: true
 require 'rails_helper'
 
 describe 'state_file:october_transfer_reminder' do
-  before(:all) do
+  let(:messaging_service) { spy('StateFile::MessagingService') }
+  let!(:az_intake_to_notify) { create(:state_file_az_intake) }
+  let!(:az_intake_to_not_notify) { create(:state_file_az_intake) }
+  let!(:nc_intake) { create(:state_file_nc_intake) }
+
+  before do
     Rake.application.rake_require "tasks/state_file"
+    allow(StateFileAzIntake).to receive(:selected_intakes_for_first_deadline_reminder_notification).and_return([az_intake_to_notify])
+    allow(StateFileNcIntake).to receive(:selected_intakes_for_first_deadline_reminder_notification).and_return([nc_intake])
+    allow(StateFile::MessagingService).to receive(:new).and_return(messaging_service)
   end
 
-  around do |example|
-    Timecop.freeze(DateTime.parse("2-12-2025")) do
-      example.run
+  context "in 2025" do
+    around do |example|
+      Timecop.freeze(DateTime.parse("16-10-2025")) do
+        example.run
+      end
+    end
+
+    it 'sends messages via appropriate contact method to intakes without submissions, with or without df data that is not disqualifying' do
+      Rake::Task['state_file:send_october_transfer_reminder'].execute
+
+      expect(StateFile::MessagingService).to have_received(:new).exactly(2).times
+      expect(StateFile::MessagingService).to have_received(:new).with(message: StateFile::AutomatedMessage::OctoberTransferReminder, intake: az_intake_to_notify)
+      expect(StateFile::MessagingService).to have_received(:new).with(message: StateFile::AutomatedMessage::OctoberTransferReminder, intake: nc_intake)
+      expect(StateFile::MessagingService).to_not have_received(:new).with(message: StateFile::AutomatedMessage::OctoberTransferReminder, intake: az_intake_to_not_notify)
+    end
+
+    context "when environment is demo" do
+      before do
+        allow(Rails.env).to receive(:demo?).and_return true
+      end
+
+      it "doesn't run the task" do
+        Rake::Task['state_file:send_october_transfer_reminder'].execute
+        expect(StateFile::MessagingService).not_to have_received(:new)
+      end
     end
   end
 
-  it 'sends messages via appropriate contact method to intakes without submissions, with or without df data that is not disqualifying' do
-    az_intake_to_notify = create(:state_file_az_intake)
-    az_intake_to_not_notify = create(:state_file_az_intake)
-    nc_intake = create(:state_file_nc_intake)
-    allow(StateFileAzIntake).to receive(:selected_intakes_for_first_deadline_reminder_notification).and_return([az_intake_to_notify])
-    allow(StateFileNcIntake).to receive(:selected_intakes_for_first_deadline_reminder_notification).and_return([nc_intake])
-    messaging_service = spy('StateFile::MessagingService')
-    allow(StateFile::MessagingService).to receive(:new).and_return(messaging_service)
+  context "when not in 2025" do
+    around do |example|
+      Timecop.freeze(DateTime.parse("16-10-2026")) do
+        example.run
+      end
+    end
 
-    Rake::Task['state_file:send_october_transfer_reminder'].execute
-
-    expect(StateFile::MessagingService).to have_received(:new).exactly(2).times
-    expect(StateFile::MessagingService).to have_received(:new).with(message: StateFile::AutomatedMessage::OctoberTransferReminder, intake: az_intake_to_notify)
-    expect(StateFile::MessagingService).to have_received(:new).with(message: StateFile::AutomatedMessage::OctoberTransferReminder, intake: nc_intake)
-    expect(StateFile::MessagingService).to_not have_received(:new).with(message: StateFile::AutomatedMessage::OctoberTransferReminder, intake: az_intake_to_not_notify)
+    it "doesn't run the task" do
+      Rake::Task['state_file:send_october_transfer_reminder'].execute
+      expect(StateFile::MessagingService).not_to have_received(:new)
+    end
   end
 end

--- a/spec/tasks/send_deadline_reminder_tomorrow_service_spec.rb
+++ b/spec/tasks/send_deadline_reminder_tomorrow_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'state_file:send_deadline_reminder_today' do
+describe 'state_file:send_deadline_reminder_tomorrow' do
   let(:az_intake_1) { create :state_file_az_intake }
   let!(:az_intake_2) { create :state_file_az_intake }
   let(:md_intake) { create :state_file_md_intake }
@@ -19,16 +19,16 @@ describe 'state_file:send_deadline_reminder_today' do
   context "in 2025" do
     around do |example|
       # freezing the time to any time in 2025, since this task will only run in 2025
-      Timecop.freeze(DateTime.parse("22-10-2025")) do
+      Timecop.freeze(DateTime.parse("21-10-2025")) do
         example.run
       end
     end
 
     it 'sends to intakes with verified contact info, with or without df data, and without efile submissions or duplicate (same hashed_ssn) intakes with efile submission' do
-      message = StateFile::AutomatedMessage::DeadlineReminderToday
+      message = StateFile::AutomatedMessage::DeadlineReminderTomorrow
       service = StateFile::MessagingService
 
-      Rake::Task['state_file:send_deadline_reminder_today'].execute
+      Rake::Task['state_file:send_deadline_reminder_tomorrow'].execute
       expect(service).to have_received(:new).exactly(5).times
 
       expect(service).to have_received(:new).with(message: message, intake: az_intake_1)
@@ -47,7 +47,7 @@ describe 'state_file:send_deadline_reminder_today' do
       end
 
       it "doesn't run the task" do
-        Rake::Task['state_file:send_deadline_reminder_today'].execute
+        Rake::Task['state_file:send_deadline_reminder_tomorrow'].execute
         expect(StateFile::MessagingService).not_to have_received(:new)
       end
     end
@@ -55,13 +55,13 @@ describe 'state_file:send_deadline_reminder_today' do
 
   context "when not in 2025" do
     around do |example|
-      Timecop.freeze(DateTime.parse("22-10-2026")) do
+      Timecop.freeze(DateTime.parse("21-10-2026")) do
         example.run
       end
     end
 
     it "doesn't run the task" do
-      Rake::Task['state_file:send_deadline_reminder_today'].execute
+      Rake::Task['state_file:send_deadline_reminder_tomorrow'].execute
       expect(StateFile::MessagingService).not_to have_received(:new)
     end
   end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. https://codeforamerica.atlassian.net/browse/FYST-2293
## Is PM acceptance required? (delete one)
- No (not sure what PM would test)

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
- Don't send State-file reminder notifications in demo
- Added tests for year and environment differences in rake task specs
- replaced all instances of `return` with `next` since I was getting a `LocalJumpError: unexpected return` error during testing which happens because a Rake task’s block is a proc, not a method/lambda and returns can’t exit from a proc.
## How to test?
- not sure the best way to test this, i think the tests suffice?

