### PR TITLE
GYR1-966 SmartScan feature into Ability

### DIFF
--- a/app/controllers/hub/documents_controller.rb
+++ b/app/controllers/hub/documents_controller.rb
@@ -3,6 +3,7 @@ module Hub
     include FilesConcern
     load_and_authorize_resource :client
     load_and_authorize_resource through: :client
+    load_and_authorize_resource :doc_assessment, :doc_assessment_feedback, :only => [:rerun_screener, :record_feedback]
     before_action :load_document_type_options
     helper_method :transient_storage_url
     before_action :require_admin, only: [:rerun_screener, :record_feedback]

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -47,9 +47,11 @@ class Ability
         cannot :manage, :flipper_dashboard
       end
 
-      can :manage, :smartscan_doc_screener
+      can :read, DocAssessment
+      can :update, DocAssessment
       can :read, DocAssessmentFeedback
       can :create, DocAssessmentFeedback
+
       return
     end
 

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -46,6 +46,9 @@ class Ability
       unless user.email.downcase.include?("@codeforamerica.org")
         cannot :manage, :flipper_dashboard
       end
+
+      can :manage, :smartscan_doc_screener
+      can :manage, DocAssessmentFeedback
       return
     end
 

--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -48,7 +48,8 @@ class Ability
       end
 
       can :manage, :smartscan_doc_screener
-      can :manage, DocAssessmentFeedback
+      can :read, DocAssessmentFeedback
+      can :create, DocAssessmentFeedback
       return
     end
 

--- a/app/views/hub/documents/_ai_screener.html.erb
+++ b/app/views/hub/documents/_ai_screener.html.erb
@@ -1,4 +1,4 @@
-<% if current_user.admin? && !@document.latest_assessment&.confirmed? %>
+<% if can? :manage, :smartscan_doc_screener && !@document.latest_assessment&.confirmed? %>
   <% verdict = @document.latest_assessment&.matches_doc_type_verdict %>
   <% unless verdict.blank? %>
     <%= render "hub/documents/smart_scan_card",

--- a/app/views/hub/documents/_ai_screener.html.erb
+++ b/app/views/hub/documents/_ai_screener.html.erb
@@ -1,4 +1,4 @@
-<% if can? :read, :DocAssessmentFeedback && !@document.latest_assessment&.confirmed? %>
+<% if can?(:read, :DocAssessmentFeedback) && !@document&.latest_assessment&.confirmed? %>
   <% verdict = @document.latest_assessment&.matches_doc_type_verdict %>
   <% unless verdict.blank? %>
     <%= render "hub/documents/smart_scan_card",

--- a/app/views/hub/documents/_ai_screener.html.erb
+++ b/app/views/hub/documents/_ai_screener.html.erb
@@ -1,4 +1,4 @@
-<% if can?(:read, :DocAssessmentFeedback) && !@document&.latest_assessment&.confirmed? %>
+<% if can?(:read, :DocAssessmentFeedback) && !@document.latest_assessment&.confirmed? %>
   <% verdict = @document.latest_assessment&.matches_doc_type_verdict %>
   <% unless verdict.blank? %>
     <%= render "hub/documents/smart_scan_card",

--- a/app/views/hub/documents/_ai_screener.html.erb
+++ b/app/views/hub/documents/_ai_screener.html.erb
@@ -1,4 +1,4 @@
-<% if can?(:read, :DocAssessmentFeedback) && !@document.latest_assessment&.confirmed? %>
+<% if can? :read, :DocAssessmentFeedback && !@document.latest_assessment&.confirmed? %>
   <% verdict = @document.latest_assessment&.matches_doc_type_verdict %>
   <% unless verdict.blank? %>
     <%= render "hub/documents/smart_scan_card",

--- a/app/views/hub/documents/_ai_screener.html.erb
+++ b/app/views/hub/documents/_ai_screener.html.erb
@@ -1,4 +1,4 @@
-<% if can? :manage, :smartscan_doc_screener && !@document.latest_assessment&.confirmed? %>
+<% if can? :read, :DocAssessmentFeedback && !@document.latest_assessment&.confirmed? %>
   <% verdict = @document.latest_assessment&.matches_doc_type_verdict %>
   <% unless verdict.blank? %>
     <%= render "hub/documents/smart_scan_card",

--- a/app/views/hub/documents/_ai_screener_dev_info.html.erb
+++ b/app/views/hub/documents/_ai_screener_dev_info.html.erb
@@ -1,4 +1,4 @@
-<% if can? :manage, :smartscan_doc_screener && !acts_like_production? %>
+<% if can? :create, :DocAssessmentFeedback && !acts_like_production? %>
   <div id="doc-assessments-table">
     <%= button_to "Re-run screener",
                   rerun_screener_hub_client_document_path(client_id: @document.client.id, id: @document.id),

--- a/app/views/hub/documents/_ai_screener_dev_info.html.erb
+++ b/app/views/hub/documents/_ai_screener_dev_info.html.erb
@@ -1,4 +1,4 @@
-<% if current_user.admin? && !acts_like_production? %>
+<% if can? :manage, :smartscan_doc_screener && !acts_like_production? %>
   <div id="doc-assessments-table">
     <%= button_to "Re-run screener",
                   rerun_screener_hub_client_document_path(client_id: @document.client.id, id: @document.id),

--- a/app/views/hub/documents/_feedback_collection.html.erb
+++ b/app/views/hub/documents/_feedback_collection.html.erb
@@ -1,4 +1,4 @@
-<% if current_user.admin? && (@document.latest_assessment.present? && @document.latest_assessment&.feedbacks.blank?) %>
+<% if can? :manage, :smartscan_doc_screener && (@document.latest_assessment.present? && @document.latest_assessment&.feedbacks.blank?) %>
   <div class="feedback-box spacing-above-15">
     <div id="top-question">
       <span>Is the Smart Scan label correct?</span>

--- a/app/views/hub/documents/_feedback_collection.html.erb
+++ b/app/views/hub/documents/_feedback_collection.html.erb
@@ -1,4 +1,4 @@
-<% if can? :read, :DocAssessmentFeedback && @document.latest_assessment&.feedbacks&.blank?) %>
+<% if can? :read, :DocAssessmentFeedback && @document.latest_assessment&.feedbacks&.blank? %>
   <div class="feedback-box spacing-above-15">
     <div id="top-question">
       <span>Is the Smart Scan label correct?</span>

--- a/app/views/hub/documents/_feedback_collection.html.erb
+++ b/app/views/hub/documents/_feedback_collection.html.erb
@@ -1,4 +1,4 @@
-<% if can? :manage, :smartscan_doc_screener && (@document.latest_assessment.present? && @document.latest_assessment&.feedbacks.blank?) %>
+<% if can? :read, :DocAssessmentFeedback && (@document.latest_assessment.present? && @document.latest_assessment&.feedbacks.blank?) %>
   <div class="feedback-box spacing-above-15">
     <div id="top-question">
       <span>Is the Smart Scan label correct?</span>

--- a/app/views/hub/documents/_feedback_collection.html.erb
+++ b/app/views/hub/documents/_feedback_collection.html.erb
@@ -1,4 +1,4 @@
-<% if can? :read, :DocAssessmentFeedback && (@document.latest_assessment.present? && @document.latest_assessment&.feedbacks.blank?) %>
+<% if can? :read, :DocAssessmentFeedback && @document.latest_assessment&.feedbacks&.blank?) %>
   <div class="feedback-box spacing-above-15">
     <div id="top-question">
       <span>Is the Smart Scan label correct?</span>

--- a/app/views/hub/documents/index.html.erb
+++ b/app/views/hub/documents/index.html.erb
@@ -59,11 +59,6 @@
         <th scope="col" class="index-table__header document-column__upload-date">
           <%= render "shared/column_sort_link", title: t(".upload_date"), column_name: "created_at" %>
         </th>
-        <% if can? :read, :DocAssessmentFeedback %>
-          <th scope="col" class="index-table__header document-column__screener_verdict">
-            <%= render "shared/column_sort_link", title: "Matches doc-type", column_name: "screener_verdict" %>
-          </th>
-        <% end %>
         <th></th>
       </tr>
       </thead>

--- a/app/views/hub/documents/index.html.erb
+++ b/app/views/hub/documents/index.html.erb
@@ -41,7 +41,7 @@
           <%= render "shared/column_sort_link", title: t("general.document_type"), column_name: "document_type" %>
         </th>
 
-        <% if current_user.admin? %>
+        <% if can? :manage, :smartscan_doc_screener %>
           <th scope="col" class="index-table__header document-column__smart-scan">
             <%= render "shared/column_sort_link", title: t(".smart_scan"), column_name: "smart_scan" %>
           </th>
@@ -59,7 +59,7 @@
         <th scope="col" class="index-table__header document-column__upload-date">
           <%= render "shared/column_sort_link", title: t(".upload_date"), column_name: "created_at" %>
         </th>
-        <% if current_user.admin? %>
+        <% if can? :manage, :smartscan_doc_screener %>
           <th scope="col" class="index-table__header document-column__screener_verdict">
             <%= render "shared/column_sort_link", title: "Matches doc-type", column_name: "screener_verdict" %>
           </th>
@@ -84,7 +84,7 @@
               <%= id_prefix + document.document_type_label.to_s %>
             </td>
 
-            <% if current_user.admin? %>
+            <% if can? :manage, :smartscan_doc_screener %>
               <td class="index-table__cell document-column__smart-scan">
                 <% if document.assessments.count > 0 %>
                   <% latest_assessment = document.assessments.order(created_at: :desc).first %>

--- a/app/views/hub/documents/index.html.erb
+++ b/app/views/hub/documents/index.html.erb
@@ -41,7 +41,7 @@
           <%= render "shared/column_sort_link", title: t("general.document_type"), column_name: "document_type" %>
         </th>
 
-        <% if can? :manage, :smartscan_doc_screener %>
+        <% if can? :read, :DocAssessmentFeedback %>
           <th scope="col" class="index-table__header document-column__smart-scan">
             <%= render "shared/column_sort_link", title: t(".smart_scan"), column_name: "smart_scan" %>
           </th>
@@ -59,7 +59,7 @@
         <th scope="col" class="index-table__header document-column__upload-date">
           <%= render "shared/column_sort_link", title: t(".upload_date"), column_name: "created_at" %>
         </th>
-        <% if can? :manage, :smartscan_doc_screener %>
+        <% if can? :read, :DocAssessmentFeedback %>
           <th scope="col" class="index-table__header document-column__screener_verdict">
             <%= render "shared/column_sort_link", title: "Matches doc-type", column_name: "screener_verdict" %>
           </th>
@@ -84,7 +84,7 @@
               <%= id_prefix + document.document_type_label.to_s %>
             </td>
 
-            <% if can? :manage, :smartscan_doc_screener %>
+            <% if can? :read, :DocAssessmentFeedback %>
               <td class="index-table__cell document-column__smart-scan">
                 <% if document.assessments.count > 0 %>
                   <% latest_assessment = document.assessments.order(created_at: :desc).first %>

--- a/spec/features/hub/client/documents_spec.rb
+++ b/spec/features/hub/client/documents_spec.rb
@@ -54,7 +54,7 @@ RSpec.feature "View and edit documents for a client" do
       expect(page).to have_selector("#document-#{document_1.id}", text: "Secondary ID")
 
       # Smart Scan column should be hidden for non-admin users.
-      expect_page.to_not have_text('Smart Scan')
+      expect(page).to_not have_text('Smart Scan')
       within "#document-#{document_1.id}" do
         expect(page).not_to have_selector('[data-status="pass"]')
       end

--- a/spec/features/hub/client/documents_spec.rb
+++ b/spec/features/hub/client/documents_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 require 'mini_magick'
 
-
 RSpec.feature "View and edit documents for a client" do
   context "As an authenticated (non-admin) user" do
     let(:user) { create :organization_lead_user, name: "Org Lead" }
@@ -10,8 +9,8 @@ RSpec.feature "View and edit documents for a client" do
     let!(:document_1) { create :document, display_name: "ID.jpg", client: client, intake: client.intake, tax_return: tax_return_1, document_type: "Care Provider Statement", uploaded_by: client }
     let!(:document_2) { create :document, display_name: "W-2.pdf", client: client, intake: client.intake, tax_return: tax_return_1, document_type: "Care Provider Statement" }
     let!(:document_3) { create :document, display_name: "consent.pdf", client: client, intake: client.intake, uploaded_by: nil }
-    let!(:assessment_pass)  { create(:doc_assessment, :pass, document: document_1) }
-    let!(:assessment_fail)  { create(:doc_assessment, :fail, document: document_2) }
+    let!(:assessment_pass) { create(:doc_assessment, :pass, document: document_1) }
+    let!(:assessment_fail) { create(:doc_assessment, :fail, document: document_2) }
     let!(:assessment_attention) { create(:doc_assessment, :attention, document: document_3) }
 
     before do
@@ -55,14 +54,13 @@ RSpec.feature "View and edit documents for a client" do
       expect(page).to have_selector("#document-#{document_1.id}", text: "Secondary ID")
 
       # Smart Scan column should be hidden for non-admin users.
+      expect_page.to_not have_text('Smart Scan')
       within "#document-#{document_1.id}" do
         expect(page).not_to have_selector('[data-status="pass"]')
       end
-
       within "#document-#{document_2.id}" do
         expect(page).not_to have_selector('[data-status="fail"]')
       end
-
       within "#document-#{document_3.id}" do
         expect(page).not_to have_selector('[data-status="attention"]')
       end
@@ -84,7 +82,6 @@ RSpec.feature "View and edit documents for a client" do
 
       click_on "Rotate Image"
 
-
       click_on "Save"
 
       retries = 10
@@ -98,6 +95,14 @@ RSpec.feature "View and edit documents for a client" do
       new_dimensions = image_dimensions(document_1.reload)
 
       expect(original_dimensions[:height]).not_to eq(new_dimensions[:height])
+    end
+
+    scenario 'cannot see smartscan card on Edit page' do
+      visit hub_client_documents_path(client_id: client.id)
+      within "#document-#{document_1.id}" do
+        click_on 'Edit'
+      end
+      expect(page).to_not have_text('Smart Scan Notes')
     end
 
     scenario "uploading a document to a client's documents page" do


### PR DESCRIPTION
## Link to Jira issue

- https://codeforamerica.atlassian.net/browse/GYR1-966

## Is PM acceptance required?

- Yes - don't merge until Jira issue is accepted!

## What was done?

Ensured that access to the SmartScan feature is managed through the Ability
class. This will make it easy to enable the feature for other groups of users as 
needed.

## How to test?

Functionality should be unchanged: as before, right now only admin users should 
be able to see SmartScan-related UI.

Testing involves uploading a document to a client's account in the Hub, and 
then:
- as an admin, checking that the SmartScan columns appear in the Documents page
- checking that the SmartScan card appears on the document's details page (in a 
  non-prod environment, this can be simulated via the Rerun Screener button; 
  there will be an error, but when you navigate back to the page, you'll see 
  that a card will now be present -- edit: correction, in this non-prod scenario,
  it's not the standard card that's displayed, but rather the assessment output in a table form, 
  which should suffice for testing purposes here).
- Then, logout and login as a non-admin user; the above UI pieces should now be 
  hidden.

## Screenshots

Admin:

<img width="466" height="387" alt="a - Screenshot 2026-04-14 at 5 59 43 PM" src="https://github.com/user-attachments/assets/06c19cdd-fedc-4dd9-8e7b-c7c173a9c357" />


Non-admin:

<img width="313" height="367" alt="b - Screenshot 2026-04-14 at 6 01 23 PM" src="https://github.com/user-attachments/assets/439bb800-9763-43ca-bd68-b8207ff491d6" />
