### PR TITLE
GYR1-1005 SmartScan UI updates

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -38,10 +38,6 @@ $color-link-visited: #4c2c92;
 $color-focused-link-background: #f9c802;
 $color-focused-link: #000000;
 $color-smart-scan-pink: #FFF7F7;
-$color-smart-scan-brick: #922B02;
-$color-smart-scan-light-green: #F5FFDE;
-$color-smart-scan-dark-green: #629587;
-
 
 // state file / usds colors
 $color-state-file-black: #3C3A3A;

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -38,6 +38,9 @@ $color-link-visited: #4c2c92;
 $color-focused-link-background: #f9c802;
 $color-focused-link: #000000;
 $color-smart-scan-pink: #FFF7F7;
+$color-smart-scan-brick: #922B02;
+$color-smart-scan-light-green: #F5FFDE;
+$color-smart-scan-dark-green: #629587;
 
 // state file / usds colors
 $color-state-file-black: #3C3A3A;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -491,11 +491,28 @@ ol.with-bullets {
 
 .smart-scan-card--fail {
   background-color: $color-smart-scan-pink;
-  border: 1px solid #B30000;
+  border: 1px solid $color-smart-scan-brick;
 }
 
 .smart-scan-card--fail .smart-scan-card__header {
-  color: #B30000;
+  color: $color-smart-scan-brick;
+}
+
+.smart-scan-card--fail .smart-scan-card__divider {
+  background-color: $color-smart-scan-brick;
+}
+
+.smart-scan-card--success {
+  background-color: $color-smart-scan-light-green;
+  border: 2px solid $color-smart-scan-dark-green;
+}
+
+.smart-scan-card--success .smart-scan-card__header {
+  color: $color-smart-scan-dark-green;
+}
+
+.smart-scan-card--success .smart-scan-card__divider {
+  background-color: $color-smart-scan-dark-green;
 }
 
 .smart-scan-card__icon {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -480,15 +480,7 @@ ol.with-bullets {
 }
 
 .smart-scan-card {
-  border-radius: 2rem;
-  padding: 2rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-  max-width: 25em;
-  width: 100%;
-  overflow-wrap: anywhere;
-  word-break: break-word;
+  border: 1px solid #000000;
 }
 
 .smart-scan-card__header {
@@ -497,36 +489,9 @@ ol.with-bullets {
   gap: 0.75rem;
 }
 
-.smart-scan-card__divider {
-  height: 1px;
-  width: 100%;
-  opacity: 0.3;
-}
-
 .smart-scan-card--fail {
   background-color: $color-smart-scan-pink;
-  border: 2px solid $color-smart-scan-brick;
-}
-
-.smart-scan-card--fail .smart-scan-card__header {
-  color: $color-smart-scan-brick;
-}
-
-.smart-scan-card--fail .smart-scan-card__divider {
-  background-color: $color-smart-scan-brick;
-}
-
-.smart-scan-card--success {
-  background-color: $color-smart-scan-light-green;
-  border: 2px solid $color-smart-scan-dark-green;
-}
-
-.smart-scan-card--success .smart-scan-card__header {
-  color: $color-smart-scan-dark-green;
-}
-
-.smart-scan-card--success .smart-scan-card__divider {
-  background-color: $color-smart-scan-dark-green;
+  border: 2px solid #B30000;
 }
 
 .smart-scan-card__icon {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -494,6 +494,10 @@ ol.with-bullets {
   border: 2px solid #B30000;
 }
 
+.smart-scan-card--fail .smart-scan-card__header {
+  color: #B30000;
+}
+
 .smart-scan-card__icon {
   width: 13px;
   height: 15px;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -491,7 +491,7 @@ ol.with-bullets {
 
 .smart-scan-card--fail {
   background-color: $color-smart-scan-pink;
-  border: 2px solid #B30000;
+  border: 1px solid #B30000;
 }
 
 .smart-scan-card--fail .smart-scan-card__header {

--- a/app/assets/stylesheets/components/_hub-doc-assessment.scss
+++ b/app/assets/stylesheets/components/_hub-doc-assessment.scss
@@ -33,7 +33,7 @@
 .feedback-box {
   padding: 2.5rem 2rem;
   border: 1px solid #525252;
-  border-radius: 8px;
+  border-radius: 6px;
   word-break: break-word;
   background-color: #F7F7F7;
   font-weight: bold;

--- a/app/views/hub/documents/_ai_screener.html.erb
+++ b/app/views/hub/documents/_ai_screener.html.erb
@@ -1,10 +1,12 @@
 <% if can? :read, :DocAssessmentFeedback && !@document.latest_assessment&.confirmed? %>
-  <% verdict = @document.latest_assessment&.matches_doc_type_verdict %>
-  <% unless verdict.blank? %>
-    <%= render "hub/documents/smart_scan_card",
-               document: @document,
-               state: verdict == "pass" ? "success" : "fail" %>
+  <div style='padding-bottom: 2em'>
+    <% verdict = @document.latest_assessment&.matches_doc_type_verdict %>
+    <% unless verdict.blank? %>
+      <%= render "hub/documents/smart_scan_card",
+                 document: @document,
+                 state: verdict == "pass" ? "success" : "fail" %>
 
-    <%= render "hub/documents/feedback_collection" %>
-  <% end %>
+      <%= render "hub/documents/feedback_collection" %>
+    <% end %>
+  </div>
 <% end %>

--- a/app/views/hub/documents/_form.html.erb
+++ b/app/views/hub/documents/_form.html.erb
@@ -16,6 +16,9 @@
         <% end %>
       </div>
     <% end %>
+
+    <%= render 'hub/documents/ai_screener' %>
+
     <%= f.vita_min_text_field :display_name,
                           t("hub.documents.display_name"),
                           classes: ["form-width--long"] %>
@@ -42,7 +45,5 @@
     hub_client_documents_path(client_id: @client),
     class: "button" %>
   <% end %>
-
-  <%= render 'hub/documents/ai_screener' %>
 </div>
 

--- a/app/views/hub/documents/_smart_scan_card.html.erb
+++ b/app/views/hub/documents/_smart_scan_card.html.erb
@@ -1,14 +1,16 @@
-<div class="smart-scan-card smart-scan-card--<%= state %>">
+<div class="eligibility-card smart-scan-card smart-scan-card--<%= state %>">
   <div class="smart-scan-card__header">
     <span class="smart-scan-card__icon" aria-hidden="true"></span>
     <strong><%= t("hub.documents.smart_scan_card.validoc_notes") %></strong>
   </div>
 
-  <div class="smart-scan-card__divider"></div>
+  &nbsp;<br>
 
   <div>
-    <strong><%= state == "success" ? t("hub.documents.smart_scan_card.validation_passed") : t("hub.documents.smart_scan_card.validation_fail") %></strong>
+    <strong><%= state == "success" ? t("hub.documents.smart_scan_card.validation_passed") : 'Validation Warning' %></strong>
   </div>
+
+  &nbsp;<br>
 
   <% if state == "fail" %>
     <div>

--- a/app/views/hub/documents/index.html.erb
+++ b/app/views/hub/documents/index.html.erb
@@ -87,7 +87,7 @@
                   <% when "pass" %>
                     <span class="label--status" data-status="pass"><%= t(".pass") %></span>
                   <% when "fail" %>
-                    <span class="label--status" data-status="fail"><%= t(".fail") %></span>
+                    <span class="label--status" data-status="fail">Warning</span>
                   <% else %>
                     <span class="label--status" data-status="attention"><%= t(".needs_review") %></span>
                   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1123,7 +1123,6 @@ en:
         client_doc: Client
         edit_file_info: Edit File Info
         empty_file: "(empty file)"
-        fail: Fail
         file_name: File Name
         needs_review: Needs Review
         not_needed_docs: documents not needed due to experiment.
@@ -1134,7 +1133,6 @@ en:
       smart_scan_card:
         is_accurate: "%{document_type} is accurate"
         is_inaccurate: 'Suggested document type: %{document_type}.'
-        validation_fail: Validation Fail
         validation_passed: Validation Passed
         validoc_notes: Smart Scan Notes
     has_duplicates: Potential duplicates detected

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1130,7 +1130,6 @@ es:
         client_doc: Cliente
         edit_file_info: Editar información del archivo
         empty_file: "(archivo vacío)"
-        fail: Fail
         file_name: Nombre de archivo
         needs_review: Needs Review
         not_needed_docs: documentos no necesario debido al experimento.
@@ -1141,7 +1140,6 @@ es:
       smart_scan_card:
         is_accurate: "%{document_type} is accurate"
         is_inaccurate: 'Suggested document type: %{document_type}.'
-        validation_fail: Validation Fail
         validation_passed: Validation Passed
         validoc_notes: Smart Scan Notes
     has_duplicates: Posibles duplicados detectados


### PR DESCRIPTION
## Link to Jira issue

- https://codeforamerica.atlassian.net/browse/GYR1-966

## Is PM acceptance required?

- Yes - don't merge until Jira issue is accepted!

## What was done?

Style and placement updates were made to SmartScan-related UI.

## How to test?

Confirm:
- Documents page/tab: in the SmartScan column, the text "Warning" should be used 
  now instead of "Fail"
- In the Document Edit page, SmartScan card:
  - updated corner 'radius' to match design scheme of rest of app
  - no longer has a horizontal bar in it
  - is placed near the top (just under the title)

## Screenshots

<img width="1200" height="1334" alt="pass" src="https://github.com/user-attachments/assets/8b9cb2f9-9683-4ddf-afd7-162e68a8cd89" />

<img width="1274" height="1352" alt="warn" src="https://github.com/user-attachments/assets/502d2c7f-065c-4f25-b6a6-cd9ddb8bcc72" />

