### PR TITLE
Proposal: output deprecation messages to log in test env

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -70,8 +70,8 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
-  # Print deprecation notices to the stderr.
-  config.active_support.deprecation = :stderr
+  # Print deprecation notices to the log.
+  config.active_support.deprecation = :log
 
   # Raise exceptions for disallowed deprecations.
   config.active_support.disallowed_deprecation = :raise


### PR DESCRIPTION
Proposal: let's move these deprecation messages to the log, instead of stderr. 
There seems to be a lot of them right now.
I have found that these messages sort of get in the way when running rspec 
locally, and also when investigating CircleCI test failures. But, if we'd prefer to leave
as-is, then that's cool too.