### PR TITLE
GYR1-1031 (2/2) Cache refresh job for AiScreenerMetricsService

### DIFF
--- a/app/jobs/refresh_caches_job.rb
+++ b/app/jobs/refresh_caches_job.rb
@@ -1,0 +1,16 @@
+class RefreshCachesJob < ApplicationJob
+  # Each class/item in the MANIFEST needs to have a
+  # public method named `refresh_cache`; from there, the
+  # internal impl. is up to the maintainer of that class.
+  #
+  # Suggested crontab entry:
+  # 2 2 * * * bundle exec rake refresh_caches:perform
+
+  MANIFEST = [
+    AiScreenerMetricsService
+  ]
+
+  def perform
+    MANIFEST.map(&:refresh_cache)
+  end
+end

--- a/app/jobs/refresh_caches_job.rb
+++ b/app/jobs/refresh_caches_job.rb
@@ -2,13 +2,9 @@ class RefreshCachesJob < ApplicationJob
   # Each class/item in the MANIFEST needs to have a
   # public method named `refresh_cache`; from there, the
   # internal impl. is up to the maintainer of that class.
-  #
-  # Suggested crontab entry:
-  # 2 2 * * * bundle exec rake refresh_caches:perform
 
   MANIFEST = [
-    AiScreenerMetricsService
-  ]
+    AiScreenerMetricsService ]
 
   def perform
     MANIFEST.map(&:refresh_cache)

--- a/app/jobs/refresh_caches_job.rb
+++ b/app/jobs/refresh_caches_job.rb
@@ -2,9 +2,8 @@ class RefreshCachesJob < ApplicationJob
   # Each class/item in the MANIFEST needs to have a
   # public method named `refresh_cache`; from there, the
   # internal impl. is up to the maintainer of that class.
-
   MANIFEST = [
-    AiScreenerMetricsService ]
+    AiScreenerMetricsService]
 
   def perform
     MANIFEST.map(&:refresh_cache)

--- a/app/jobs/refresh_caches_job.rb
+++ b/app/jobs/refresh_caches_job.rb
@@ -1,7 +1,7 @@
 class RefreshCachesJob < ApplicationJob
   # Each class/item in the MANIFEST needs to have a
   # public method named `refresh_cache`; from there, the
-  # internal impl. is up to the maintainer of that class.
+  # internal implementation is up to the maintainer of that class.
   MANIFEST = [
     AiScreenerMetricsService]
 

--- a/app/services/ai_screener_metrics_service.rb
+++ b/app/services/ai_screener_metrics_service.rb
@@ -1,15 +1,25 @@
 class AiScreenerMetricsService
   def self.call
-    {
-      client_classification_accuracy: client_classification_accuracy,
-      ai_efficacy: ai_efficacy,
-      most_common_wrong_ai_suggestions: most_common_wrong_ai_suggestions,
-      most_common_document_types_ai_struggles_with: most_common_document_types_ai_struggles_with,
-      ai_suggested_document_type_distribution: ai_suggested_document_type_distribution,
-    }
+    Rails.cache.fetch(@@CACHE_KEY, expires_in: 25.hours) do
+      {
+        client_classification_accuracy: client_classification_accuracy,
+        ai_efficacy: ai_efficacy,
+        most_common_wrong_ai_suggestions: most_common_wrong_ai_suggestions,
+        most_common_document_types_ai_struggles_with: most_common_document_types_ai_struggles_with,
+        ai_suggested_document_type_distribution: ai_suggested_document_type_distribution,
+      }
+    end
+  end
+
+  # Called by RefreshCachesJob
+  def self.refresh_cache
+    Rails.cache.delete(@@CACHE_KEY)
+    self.call
   end
 
   private
+
+  @@CACHE_KEY = 'AiScreenerMetricsService/payload'
 
   def self.scoped_documents
     Document.with_assessments.reorder(nil) # `reorder(nil)` needed for DISTINCT ON qy below.

--- a/app/services/ai_screener_metrics_service.rb
+++ b/app/services/ai_screener_metrics_service.rb
@@ -1,6 +1,8 @@
 class AiScreenerMetricsService
+  CACHE_KEY = 'AiScreenerMetricsService/payload'
+
   def self.call
-    Rails.cache.fetch(@@CACHE_KEY, expires_in: 25.hours) do
+    Rails.cache.fetch(CACHE_KEY, expires_in: 25.hours) do
       {
         client_classification_accuracy: client_classification_accuracy,
         ai_efficacy: ai_efficacy,
@@ -13,13 +15,11 @@ class AiScreenerMetricsService
 
   # Called by RefreshCachesJob
   def self.refresh_cache
-    Rails.cache.delete(@@CACHE_KEY)
+    Rails.cache.delete(CACHE_KEY)
     self.call
   end
 
   private
-
-  @@CACHE_KEY = 'AiScreenerMetricsService/payload'
 
   def self.scoped_documents
     Document.with_assessments.reorder(nil) # `reorder(nil)` needed for DISTINCT ON qy below.

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -78,7 +78,7 @@
 # `write` are given an invalid `expires_at` or `expires_in` time.
 # Options are `true`, and `false`. If `false`, the exception will be reported
 # as `handled` and logged instead.
-# Rails.application.config.active_support.raise_on_invalid_cache_expiration_time = true
+Rails.application.config.active_support.raise_on_invalid_cache_expiration_time = true
 
 # Specify whether Query Logs will format tags using the SQLCommenter format
 # (https://open-telemetry.github.io/opentelemetry-sqlcommenter/), or using the legacy format.

--- a/crontab
+++ b/crontab
@@ -15,4 +15,4 @@
 # 0 18 21 10 * bundle exec rake state_file:send_deadline_reminder_tomorrow
 # 0 18 22 10 * bundle exec rake state_file:send_deadline_reminder_today
 0 21 27 10 * bundle exec rake users:suspend_non_admins
-2 2 * * * bundle exec rake refresh_caches:do
+2 2 * * * bundle exec rake refresh_caches:go

--- a/crontab
+++ b/crontab
@@ -15,3 +15,4 @@
 # 0 18 21 10 * bundle exec rake state_file:send_deadline_reminder_tomorrow
 # 0 18 22 10 * bundle exec rake state_file:send_deadline_reminder_today
 0 21 27 10 * bundle exec rake users:suspend_non_admins
+2 2 * * * bundle exec rake refresh_caches:perform

--- a/crontab
+++ b/crontab
@@ -15,4 +15,4 @@
 # 0 18 21 10 * bundle exec rake state_file:send_deadline_reminder_tomorrow
 # 0 18 22 10 * bundle exec rake state_file:send_deadline_reminder_today
 0 21 27 10 * bundle exec rake users:suspend_non_admins
-2 2 * * * bundle exec rake refresh_caches:perform
+2 2 * * * bundle exec rake refresh_caches:do

--- a/lib/tasks/refresh_caches.rake
+++ b/lib/tasks/refresh_caches.rake
@@ -1,0 +1,6 @@
+namespace :refresh_caches do
+  desc 'Refresh caches for registered classes'
+  task go: [:environment] do
+    RefreshCachesJob.perform_later    
+  end
+end

--- a/spec/jobs/refresh_caches_job_spec.rb
+++ b/spec/jobs/refresh_caches_job_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe RefreshCachesJob, type: :job do
+  describe '#perform' do
+    let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }    
+    let(:cache) { Rails.cache }
+    let(:cache_key) { AiScreenerMetricsService::CACHE_KEY }
+    before do
+      allow(Rails).to receive(:cache).and_return(memory_store)
+      Rails.cache.clear
+    end
+    it 'refreshes cache for registered classes' do
+      expect(cache.exist?(cache_key)).to be(false)
+      RefreshCachesJob.new.perform
+      expect(cache.exist?(cache_key)).to be(true)
+    end
+  end
+end

--- a/spec/jobs/refresh_caches_job_spec.rb
+++ b/spec/jobs/refresh_caches_job_spec.rb
@@ -3,16 +3,15 @@ require 'rails_helper'
 describe RefreshCachesJob, type: :job do
   describe '#perform' do
     let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }    
-    let(:cache) { Rails.cache }
     let(:cache_key) { AiScreenerMetricsService::CACHE_KEY }
     before do
       allow(Rails).to receive(:cache).and_return(memory_store)
       Rails.cache.clear
     end
     it 'refreshes cache for registered classes' do
-      expect(cache.exist?(cache_key)).to be(false)
+      expect(Rails.cache.exist?(cache_key)).to be(false)
       RefreshCachesJob.new.perform
-      expect(cache.exist?(cache_key)).to be(true)
+      expect(Rails.cache.exist?(cache_key)).to be(true)
     end
   end
 end


### PR DESCRIPTION
## Link to Jira issue

- https://codeforamerica.atlassian.net/browse/GYR1-1031

## Is PM acceptance required?

- No - merge after code review approval

## What was done?

We noticed the AiScreenerMetricsController was a bit sluggish; internally, it uses
AiScreenerMetricService. A previous PR (#6291) did a bit of refactoring, and this
PR sets things up so that caching is used and that cache is refreshed 
overnight (resolves the problem of the "once-a-day unlucky customer"
(so to speak) encountering a cache miss upon visiting the Web page in question).

- a `Rails.cache` directive and suppporting logic was added to the 
  AiScreenerMetricsService class, specifically around the data payload it 
  generates, along with a `refresh_cache` method.
- A job (with accompanying rake task and crontab entry) calls 
  `refresh_cache` on all classes 'registered' with this job. The cron job is 
  set to run nightly.

Would appreciate a close review of this PR to make sure I got the rake task, 
cron job, etc., all set up correctly. Thanks!