### PR TITLE
GYR1-1025 Allow coalition leads to unlock clients

### DIFF
--- a/app/lib/ability.rb
+++ b/app/lib/ability.rb
@@ -100,7 +100,7 @@ class Ability
           Client, vita_partner_id: accessible_group_ids, intake: { product_year: Rails.configuration.product_year }
     end
 
-    if user.role?([:admin, :org_lead, :site_coordinator])
+    if user.role?([:admin, :org_lead, :site_coordinator, :coalition_lead])
       can :unlock, Client, vita_partner_id: accessible_group_ids, intake: { product_year: Rails.configuration.product_year }
     end
 

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -182,6 +182,39 @@ describe Ability do
         end
       end
 
+      shared_examples :can_unlock_client do
+        context 'user can unlock client' do
+          let(:accessible_site) { create(:site) }
+          let(:accessible_client) do
+            create(
+              :client,
+              vita_partner: accessible_site,
+              intake: build(
+                :intake,
+                :filled_out,
+                preferred_name: "George Sr.",
+              ),
+              tax_returns: [
+                build(
+                  :tax_return,
+                  :intake_ready,
+                  year: 2019,
+                  assigned_user: user
+                ),
+              ]
+            )
+          end
+
+          before do
+            allow(user).to receive(:accessible_vita_partners).and_return(VitaPartner.where(id: accessible_site))
+          end
+
+          it "can unlock client" do
+            expect(subject.can?(:unlock, accessible_client)).to eq true
+          end
+        end
+      end
+
       shared_examples :can_manage_but_not_delete_accessible_client do
         context "when the user can access a particular site" do
           let(:accessible_site) { create(:site) }
@@ -529,6 +562,7 @@ describe Ability do
           it_behaves_like :cannot_manage_inaccessible_client
           it_behaves_like :can_only_read_accessible_org_or_site
           it_behaves_like :cannot_manage_any_sites_or_orgs
+          it_behaves_like :can_unlock_client
         end
 
         context "an organization lead" do
@@ -538,6 +572,7 @@ describe Ability do
           it_behaves_like :cannot_manage_inaccessible_client
           it_behaves_like :can_only_read_accessible_org_or_site
           it_behaves_like :cannot_manage_any_sites_or_orgs
+          it_behaves_like :can_unlock_client
         end
 
         context "a site coordinator" do
@@ -547,6 +582,7 @@ describe Ability do
           it_behaves_like :cannot_manage_inaccessible_client
           it_behaves_like :can_only_read_accessible_org_or_site
           it_behaves_like :cannot_manage_any_sites_or_orgs
+          it_behaves_like :can_unlock_client
         end
 
         context "a team member" do


### PR DESCRIPTION
## Link to Jira issue

- https://codeforamerica.atlassian.net/browse/GYR1-1025

## Is PM acceptance required?

- Yes - don't merge until JIRA issue is accepted!

## What was done?

- Allow coalition leads to unlock clients (via Ability class)
- Added spec tests for this capability

## How to test?

Familiarity with seeder.rb and the user and client test accounts therein 
will be useful here.

First, lock out a client account:
- Visit /portal
- Use the Tinker account (see seeder.rb), login via email
- the verification code can be found by running `bin/rails jobs:work` in the 
  console (not sure how it works for heroku/staging).
- enter the *correct* verification code
- then, at the next screen, keep entering _wrong_ inputs until you get the client 
  lockout message

Second, log into the Hub specifically as a coalition lead -- use the 'Lola 
Lemon' account.
- inside the Hub, go to the Tinker client
- at the top of the screen, you should be able to see an "Unlock Client" button 
  in red letters.