### PR TITLE
GYR1-1038 Fix missing speed badge

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -499,7 +499,7 @@ GEM
     pycall (1.5.1)
     racc (1.8.1)
     rack (3.2.6)
-    rack-mini-profiler (3.1.1)
+    rack-mini-profiler (4.0.1)
       rack (>= 1.2.0)
     rack-protection (4.2.1)
       base64 (>= 0.1.0)

--- a/Gemfile_next.lock
+++ b/Gemfile_next.lock
@@ -499,7 +499,7 @@ GEM
     pycall (1.5.1)
     racc (1.8.1)
     rack (3.2.6)
-    rack-mini-profiler (3.1.1)
+    rack-mini-profiler (4.0.1)
       rack (>= 1.2.0)
     rack-protection (4.2.1)
       base64 (>= 0.1.0)

--- a/config/initializers/rack_profiler.rb
+++ b/config/initializers/rack_profiler.rb
@@ -1,7 +1,9 @@
-Rack::MiniProfiler.config.start_hidden = true if Rails.env.demo?
-Rack::MiniProfiler.config.toggle_shortcut = 'CTRL+Y'
+if defined?(Rack::MiniProfiler)
+  Rack::MiniProfiler.config.start_hidden = true if Rails.env.demo?
+  Rack::MiniProfiler.config.toggle_shortcut = 'CTRL+Y'
 
-if ENV['REDIS_URL'].present? && (Rails.env.demo? || Rails.env.development? || Rails.env.heroku? || Rails.env.staging?)
-  Rack::MiniProfiler.config.storage_options = { url: ENV["REDIS_URL"] }
-  Rack::MiniProfiler.config.storage = Rack::MiniProfiler::RedisStore
+  if ENV['REDIS_URL'].present? && (Rails.env.demo? || Rails.env.development? || Rails.env.heroku? || Rails.env.staging?)
+    Rack::MiniProfiler.config.storage_options = { url: ENV["REDIS_URL"] }
+    Rack::MiniProfiler.config.storage = Rack::MiniProfiler::RedisStore
+  end
 end

--- a/config/initializers/rack_profiler.rb
+++ b/config/initializers/rack_profiler.rb
@@ -1,7 +1,5 @@
-if Rails.env.heroku? || Rails.env.demo?
-  # Use the "Alt+P" keyboard shortcut to toggle visibility
-  Rack::MiniProfiler.config.start_hidden = true
-end
+Rack::MiniProfiler.config.start_hidden = true if Rails.env.demo?
+Rack::MiniProfiler.config.toggle_shortcut = 'CTRL+Y'
 
 if ENV['REDIS_URL'].present? && (Rails.env.demo? || Rails.env.development? || Rails.env.heroku? || Rails.env.staging?)
   Rack::MiniProfiler.config.storage_options = { url: ENV["REDIS_URL"] }

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,3 +11,4 @@
 - [Refactor zendesk routing logic](2020-05-07-refactor-zendesk-routing-logic.md)
 - [Debug feature tests](2021-05-27-debug-feature-tests.md)
 - [Fraud indicators](2022-04-28-fraud-indicators.md)
+- [Speed Badge](speed-badge.md)

--- a/docs/speed-badge.md
+++ b/docs/speed-badge.md
@@ -1,0 +1,9 @@
+Speed Badge
+===========
+
+A "speed badge" is available in the upper-left corner when running the app in a 
+non-production context. (It's part of `rack-mini-profiler`.)
+
+You can click on it to get technical details about page-load metrics.
+
+It can be toggled on or off by pressing `CTRL+Y`.


### PR DESCRIPTION
## Link to Jira issue

- https://codeforamerica.atlassian.net/browse/GYR1-1038

## Is PM acceptance required?

- No - merge after code review approval

## What was done?

- The 'speed badge' (appears in the upper-left corner of pages in non-prod 
  instances) was missing. Solution was to upgrade `rack-mini-profiler`.
- Changed the hide/show keyboard shortcut to be `CTRL+Y` (to be compatible 
  with macOS).
- Made the badge visible by default in Heroku apps.
- Added a page to the docs.