### PR TITLE
Strip client input from sentry messages but allow error sending

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -2,10 +2,34 @@ Sentry.init do |config|
   config.dsn = Rails.application.credentials.dig(:sentry_dsn)
   config.enabled_environments = %w(production staging demo)
 
-  filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters - [:name, :filename])
+  # Aggressively strip ALL client input while preserving error details
   config.before_send = lambda do |event, _hint|
-    # use Rails' parameter filter to sanitize the event
-    filter.filter(event.to_hash)
+    # Keep: exception class, message, stacktrace, timestamps
+    # Remove: ALL request data, parameters, headers, cookies, user input
+
+    if event.request
+      # Keep only safe request metadata
+      safe_request = {
+        method: event.request[:method],
+        # Strip path parameters and query strings for privacy
+        url: event.request[:url]&.split('?')&.first&.gsub(/\/\d+/, '/:id'),
+      }
+      event.request = safe_request
+    end
+
+    # Remove all breadcrumbs that might contain user input
+    event.breadcrumbs&.list&.clear
+
+    # Remove user context
+    event.user = {}
+
+    # Remove extra context that might have been added
+    event.extra&.clear
+
+    # Remove tags that might contain user data
+    event.tags&.delete_if { |key, _| ![:environment, :server_name, :ruby_version, :rails_version].include?(key.to_sym) }
+
+    event
   end
 
   config.excluded_exceptions = Sentry::Configuration::IGNORE_DEFAULT + Sentry::Rails::IGNORE_DEFAULT + %w(

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -2,31 +2,22 @@ Sentry.init do |config|
   config.dsn = Rails.application.credentials.dig(:sentry_dsn)
   config.enabled_environments = %w(production staging demo)
 
-  # Aggressively strip ALL client input while preserving error details
   config.before_send = lambda do |event, _hint|
-    # Keep: exception class, message, stacktrace, timestamps
-    # Remove: ALL request data, parameters, headers, cookies, user input
 
     if event.request
-      # Keep only safe request metadata
       safe_request = {
         method: event.request[:method],
-        # Strip path parameters and query strings for privacy
         url: event.request[:url]&.split('?')&.first&.gsub(/\/\d+/, '/:id'),
       }
       event.request = safe_request
     end
 
-    # Remove all breadcrumbs that might contain user input
-    event.breadcrumbs&.list&.clear
+    event.breadcrumbs = Sentry::BreadcrumbBuffer.new(0) if event.breadcrumbs
 
-    # Remove user context
     event.user = {}
 
-    # Remove extra context that might have been added
     event.extra&.clear
 
-    # Remove tags that might contain user data
     event.tags&.delete_if { |key, _| ![:environment, :server_name, :ruby_version, :rails_version].include?(key.to_sym) }
 
     event


### PR DESCRIPTION
## Link to Jira issue

- e.g. https://codeforamerica.atlassian.net/browse/GYR1-1016

## Is PM acceptance required?

- Yes - don't merge until Jira issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main

## What was done?

* Strip user input from sentry configuration instead of passing it through the filter params which right now is filtering all params

  What is sent:
  - exception class, message, and stack traces
  - HTTP method and sanitized URL paths (IDs replaced with :id placeholders)
  - safe metadata like environment, server name, Ruby/Rails versions

  What is not sent:
  - all request parameters, query strings, headers, and cookies
  - user context and identifying information
  - breadcrumbs (navigation history)
  - any extra context that might contain user input

## How to test?

- I tested by pushing to staging and sending a sentry message through staging `Sentry.capture_message("staging sentry test from rails console #{Time.current}")`

## Screenshots (visual changes)
<img width="1009" height="710" alt="Screenshot 2026-05-13 at 4 31 19 PM" src="https://github.com/user-attachments/assets/6940b885-82e2-427a-9aa8-657b4104d158" />


