### PR TITLE
Add priority to refresh_caches job

### DIFF
--- a/app/jobs/refresh_caches_job.rb
+++ b/app/jobs/refresh_caches_job.rb
@@ -8,4 +8,8 @@ class RefreshCachesJob < ApplicationJob
   def perform
     MANIFEST.map(&:refresh_cache)
   end
+
+  def priority
+    PRIORITY_LOW
+  end
 end


### PR DESCRIPTION
Remediates `NotImplementedError` (which gets raised by the default superclass's (ApplicationJob's) `priority` function when the subclass doesn't override)