### PR TITLE
Harden Heroku review-app push against shell injection

### DIFF
--- a/.github/workflows/heroku-pull-request.yml
+++ b/.github/workflows/heroku-pull-request.yml
@@ -100,7 +100,9 @@ jobs:
             git commit -m "Disable Reline autocomplete"
 
       - name: Push to Heroku
-        run: git push heroku ${{ github.head_ref }}:main --force
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: git push heroku "$HEAD_REF":main --force
 
       - name: Wait for deploy to finish
         if: ${{ env.RUN_APP_SETUP == 'true' }}


### PR DESCRIPTION
The review-app workflow in `.github/workflows/heroku-pull-request.yml` deploys each PR branch to Heroku with:

```yaml
- name: Push to Heroku
  run: git push heroku ${{ github.head_ref }}:main --force
```

`github.head_ref` is the head branch name of the pull request, set by whoever opens it. GitHub evaluates the `${{ }}` expression and splices the value into the script text before the shell parses it, so a branch name containing shell metacharacters could break out of the `git push` and run commands on the runner. This is the script-injection risk covered in GitHub's hardening guide: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections

This change moves the value into a step-level environment variable and uses the quoted variable in the command:

```yaml
- name: Push to Heroku
  env:
    HEAD_REF: ${{ github.head_ref }}
  run: git push heroku "$HEAD_REF":main --force
```

Read through `env`, the branch name reaches the shell as plain data rather than as part of the command, so it can no longer be interpreted as code. The push target is unchanged. I left the `ref:` expression on the checkout step alone, since that is an action input and not a shell expansion. CodeQL's `actions/expression-injection` query and zizmor both flag the `run:` form.