### PR TITLE
GYR1-1064 Fix smart scan card width

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -480,6 +480,8 @@ ol.with-bullets {
 }
 
 .smart-scan-card {
+  flex-direction: column;
+  max-width: 25em;
   border: 1px solid #000000;
 }
 


### PR DESCRIPTION
## Link to Jira issue

- https://codeforamerica.atlassian.net/browse/GYR1-1064 

## Is PM acceptance required?

- Yes - don't merge until Jira issue is accepted!

## What was done?

Updated some CSS so that very long text blocks don't stretch out the smart scan card width.

## Screenshots (visual changes)

- Before

<img width="676" height="482" alt="image" src="https://github.com/user-attachments/assets/858d6b07-5083-4661-9347-efde9442e4b2" />

- After

<img width="585" height="473" alt="image" src="https://github.com/user-attachments/assets/838eb2e8-7414-4f8e-880d-84a5fbc08850" />
