### PR TITLE
GYR1-1047 Site-specific zip code routing with capacity

### DIFF
--- a/app/services/partner_routing_service.rb
+++ b/app/services/partner_routing_service.rb
@@ -136,7 +136,7 @@ class PartnerRoutingService
     return unless @zip_code.present?
 
     # Step 1/2: Check sites.
-    eligible_with_capacity = @base_sites.joins(:serviced_zip_codes)
+    eligible_with_capacity = @base_sites.with_capacity.joins(:serviced_zip_codes)
                                         .where(vita_partner_zip_codes: { zip_code: @zip_code })
 
     vita_partner = eligible_with_capacity.sample

--- a/spec/services/partner_routing_service_spec.rb
+++ b/spec/services/partner_routing_service_spec.rb
@@ -281,6 +281,23 @@ describe PartnerRoutingService do
         end
       end
 
+     context "when client zip corresponds to a Site but parent Org is at capacity" do
+        let!(:org) { create :organization }
+        let!(:zip) { create :vita_partner_zip_code, zip_code: "97001", vita_partner: org }
+        let!(:site) { create :site, parent_organization: org }
+        let!(:zip) { create :vita_partner_zip_code, zip_code: "12345", vita_partner: site }
+        subject { PartnerRoutingService.new(zip_code: "12345") }
+
+        before do
+          org.update(capacity_limit: 0)
+        end
+
+        it "returns at capacity" do
+          expect(subject.determine_partner).to eq nil
+          expect(subject.routing_method).to eq :at_capacity
+        end
+      end
+
       context "when clients zip code doesn't correspond to a Vita Partner" do
         context "when state for that zip code has associated Vita Partners" do
           subject { PartnerRoutingService.new(zip_code: "28806") } #NC

--- a/spec/services/partner_routing_service_spec.rb
+++ b/spec/services/partner_routing_service_spec.rb
@@ -281,7 +281,7 @@ describe PartnerRoutingService do
         end
       end
 
-     context "when client zip corresponds to a Site but parent Org is at capacity" do
+      context "when client zip corresponds to a Site but parent Org is at capacity" do
         let!(:org) { create :organization }
         let!(:zip) { create :vita_partner_zip_code, zip_code: "97001", vita_partner: org }
         let!(:site) { create :site, parent_organization: org }


### PR DESCRIPTION
## Link to Jira issue

- https://codeforamerica.atlassian.net/browse/GYR1-1047

## Is PM acceptance required?

- Yes - don't merge until Jira issue is accepted!

## What was done?

- Updated site-specific zip-code routing logic to check for capacity
- Added spec test for this

## How to test?

1. Set up a coalition + org + site by following the screenshots below.
2. In the Hub, create a new client with zip codd 12345; check to see that the 
client record has, e.g., "Initial Routing Method: National overflow" (though i 
think it will depend on the vita-partner-related test data you have set up in 
your environment); but it should *not* be Professor Farnsworth site.

Coalition:

<img width="452" height="357" alt="image" src="https://github.com/user-attachments/assets/9422088f-de51-44a8-97dc-2b90144ead18" />

Org:

<img width="474" height="592" alt="image" src="https://github.com/user-attachments/assets/2a0f12b4-c7cd-488e-8d27-f11f39b14954" />

<img width="487" height="633" alt="image" src="https://github.com/user-attachments/assets/db28f6bc-18d5-498f-bafb-f4e7f53c873e" />

<img width="509" height="396" alt="image" src="https://github.com/user-attachments/assets/de458d1d-1359-4860-ac35-434cb889ee6d" />

Site:

<img width="423" height="555" alt="image" src="https://github.com/user-attachments/assets/0fe46056-cbb1-483b-a8ce-09d961722706" />
