### PR TITLE
Update `net-imap` to a recent version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -405,7 +405,7 @@ GEM
       uri (>= 0.11.1)
     net-http-persistent (4.0.6)
       connection_pool (~> 2.2, >= 2.2.4)
-    net-imap (0.6.4)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)

--- a/Gemfile_next.lock
+++ b/Gemfile_next.lock
@@ -102,9 +102,11 @@ GEM
     annotate (3.2.0)
       activerecord (>= 3.2, < 8.0)
       rake (>= 10.4, < 14.0)
+    anonymous_loader (0.1.1)
+      version_gem (~> 1.1, >= 1.1.12)
     ast (2.4.3)
-    auth-sanitizer (0.1.4)
-      version_gem (~> 1.1, >= 1.1.9)
+    auth-sanitizer (0.2.2)
+      version_gem (~> 1.1, >= 1.1.10)
     auto_strip_attributes (2.6.0)
       activerecord (>= 4.0)
     autoprefixer-rails (10.4.21.0)
@@ -406,7 +408,7 @@ GEM
       uri (>= 0.11.1)
     net-http-persistent (4.0.6)
       connection_pool (~> 2.2, >= 2.2.4)
-    net-imap (0.6.4)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -423,15 +425,16 @@ GEM
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    oauth2 (2.0.20)
-      auth-sanitizer (~> 0.1, >= 0.1.3)
+    oauth2 (2.0.24)
+      anonymous_loader (~> 0.1, >= 0.1.1)
+      auth-sanitizer (~> 0.2, >= 0.2.2)
       faraday (>= 0.17.3, < 4.0)
       jwt (>= 1.0, < 4.0)
       logger (~> 1.2)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
-      snaky_hash (~> 2.0, >= 2.0.4)
-      version_gem (~> 1.1, >= 1.1.9)
+      snaky_hash (~> 2.0, >= 2.0.6)
+      version_gem (~> 1.1, >= 1.1.12)
     observer (0.1.2)
     omniauth (2.1.4)
       hashie (>= 3.4.6)
@@ -499,7 +502,7 @@ GEM
       date
       stringio
     public_suffix (6.0.2)
-    puma (6.6.1)
+    puma (8.0.2)
       nio4r (~> 2.0)
     pundit (2.5.0)
       activesupport (>= 3.0.0)
@@ -703,7 +706,7 @@ GEM
       rack-protection (= 4.2.1)
       rack-session (>= 2.0.0, < 3)
       tilt (~> 2.0)
-    snaky_hash (2.0.4)
+    snaky_hash (2.0.6)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
     spring (4.1.2)
@@ -747,7 +750,7 @@ GEM
     valid_email2 (4.0.6)
       activemodel (>= 3.2)
       mail (~> 2.5)
-    version_gem (1.1.9)
+    version_gem (1.1.12)
     virtus (2.0.0)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
@@ -841,6 +844,7 @@ DEPENDENCIES
   mixpanel-ruby
   net-imap (>= 0.6.4)
   nokogiri (>= 1.19.3)
+  oauth2 (>= 2.0.22)
   observer (~> 0.1.2)
   omniauth
   omniauth-google-oauth2 (~> 1.2)
@@ -858,7 +862,7 @@ DEPENDENCIES
   phony
   platform-api
   pry-byebug
-  puma (>= 6.6.1)
+  puma (>= 7.2.1)
   pundit (~> 2.5)
   pycall
   rack (>= 3.2.6)


### PR DESCRIPTION
Dependabot issue resolution. Dependabot didn't create the PR because of some kind of code execution? I'm not 100% sure what that means but it's been up for a couple of weeks and seems fine.