### PR TITLE
bump heroku review app stack to v24

### DIFF
--- a/app.json
+++ b/app.json
@@ -13,7 +13,7 @@
       "quantity": 1
     }
   },
-  "stack": "heroku-18",
+  "stack": "heroku-24",
   "buildpacks": [
     {
       "url": "heroku/ruby"


### PR DESCRIPTION
current heroku-18 is super EOL'd. Is heroku defaulting to v22 (based on [quoted emails from slack](https://cfastaff.slack.com/archives/C065H2FNCJX/p1782235063802669)?)
heroku-26 exists as well, but going for the middle-ground here to play it safe.

based on https://github.com/codeforamerica/gyraffe/pull/618
