### PR TITLE
Fix Dependabot bundler security updates by removing registries block

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,4 @@
 version: 2
-registries:
-  authenticated_github:
-    type: git
-    url: https://github.com
-    username: x-access-token
-    password: ${{secrets.DEPENDABOT_GITHUB_TOKEN}}
 updates:
   - package-ecosystem: "bundler"
     directory: "/"
@@ -14,8 +8,6 @@ updates:
       default-days: 7
     # don't make PRs for regular dependency things, just security updates
     open-pull-requests-limit: 0
-    registries:
-      - authenticated_github
   - package-ecosystem: "npm"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Problem

Dependabot bundler security-update jobs are failing (e.g. [run 28197203528](https://github.com/codeforamerica/vita-min/actions/runs/28197203528/job/83527041302)) after `insecure-external-code-execution: allow` was removed from `dependabot.yml`.

The job definition shows `"reject-external-code":true`. Because the bundler update referenced a `registries` entry, Dependabot defaults external code execution to **deny**. Resolving the git-sourced `cfa-styleguide` gem requires cloning honeycrisp-gem and evaluating its `.gemspec` (arbitrary Ruby) — which `deny` blocks, failing the update. Removing the custom Ruby helpers from the Gemfile didn't fix it because the `git:` gem source is itself external code.

## Fix

Remove the `authenticated_github` registry (and the bundler update's reference to it).

- `codeforamerica/honeycrisp-gem` is **public** and is the only git source — no PATH or private gem sources exist in `Gemfile.lock`.
- The registry only provided an authenticated PAT for cloning, which a public repo doesn't need.
- With no registries configured, `reject-external-code` defaults to `false`, so the honeycrisp gemspec evaluates and security updates resolve again.

## Notes

- The `DEPENDABOT_GITHUB_TOKEN` secret is now unused by this config.
- If honeycrisp-gem ever becomes private again, this will need to be reverted and paired with `insecure-external-code-execution: allow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)