### PR TITLE
GYR1-1078 Update SmartScan label when a hub user agrees with the input

### DIFF
--- a/app/models/doc_assessment.rb
+++ b/app/models/doc_assessment.rb
@@ -34,7 +34,7 @@ class DocAssessment < ApplicationRecord
   def smart_scan_status
     verdict = matches_doc_type_verdict
 
-    return "pass" if verdict == "pass"
+    return "pass" if (verdict == "pass" || confirmed?)
     return "fail" if verdict.present?
 
     "attention"

--- a/spec/models/doc_assessment_spec.rb
+++ b/spec/models/doc_assessment_spec.rb
@@ -55,6 +55,22 @@ RSpec.describe DocAssessment, type: :model do
       end
     end
 
+    context "when matches_doc_type_verdict is present but not 'pass' but also user confirmed correct" do
+      # in other words, screener-predicted type does not match client-selected type,
+      # but partner confirms that the screener's suggested_document_type is correct
+      let(:assessment) do
+        described_class.new(
+          document: document,
+          result_json: { "matches_doc_type_verdict" => "fail" },
+          confirmed: true
+        )
+      end
+
+      it "returns 'pass'" do
+        expect(assessment.smart_scan_status).to eq("pass")
+      end
+    end
+
     context "when matches_doc_type_verdict is nil" do
       let(:assessment) do
         described_class.new(


### PR DESCRIPTION
## Link to Jira issue

- https://github.com/codeforamerica/vita-min/pull/6345

## Is PM acceptance required?

- Yes - don't merge until Jira issue is accepted!

## What was done?

- Added logic that effectively sets the Smart Scan status to 'pass' for the 
  specific scenario where the uploader-chosen doc type is different from the 
  screener-predicted doc type but a partner has confirmed the screener is 
  correct (by clicking the green checkbox on the "Is the Smart Scan label 
  correct?" card).
- Added a spec test,

## How to test?

I believe this will need to be done in Demo (since Demo is hooked up to the 
screener backend):
- upload a doc that that the screener will likely predict the doc type 
  correctly, but go ahead and set the doc type (when uploading) to an obviously 
  incorrec type
- confirm in the Documents list that this newly-uploaded doc has a "Warning" 
  label int he Smart Scan column.
- go to the doc, click the green checkmark "Is the Smart Scan label correct?" 
  card.
- go back to the Documents list; now your document should have a green "Pass" in 
  the Smart Scan Column.