### PR TITLE
Skip spouse contact and signature pages if widowed

### DIFF
--- a/app/controllers/questions/spouse_consent_controller.rb
+++ b/app/controllers/questions/spouse_consent_controller.rb
@@ -5,7 +5,7 @@ module Questions
     layout "application"
 
     def self.show?(intake)
-      intake.filing_joint_yes?
+      intake.filing_joint_yes? && !(intake.widowed_yes? && intake.married_last_day_of_year_no?)
     end
 
     private

--- a/app/controllers/questions/spouse_email_address_controller.rb
+++ b/app/controllers/questions/spouse_email_address_controller.rb
@@ -3,7 +3,11 @@ module Questions
     include AuthenticatedClientConcern
 
     def self.show?(intake)
-      intake.filing_joint_yes?
+      # don't show if Conditions:
+      # If client answers “NO” to “As of December 31, {filing year}, were you legally married?”
+      # and “YES” to “As of December 31, {filing year}, were you widowed?”
+      intake.filing_joint_yes? && !(intake.widowed_yes? && intake.married_last_day_of_year_no?)
+
     end
 
     def tracking_data

--- a/spec/controllers/questions/spouse_consent_controller_spec.rb
+++ b/spec/controllers/questions/spouse_consent_controller_spec.rb
@@ -2,7 +2,14 @@ require "rails_helper"
 
 RSpec.describe Questions::SpouseConsentController do
   let(:filing_joint) { "yes" }
-  let(:intake) { create :intake, filing_joint: filing_joint }
+  let(:widowed) { "no" }
+  let(:married_last_day_of_year) { "yes" }
+  let(:intake) {
+    create :intake,
+           filing_joint: filing_joint,
+           widowed: widowed,
+           married_last_day_of_year: married_last_day_of_year
+  }
 
   before do
     sign_in intake.client
@@ -13,6 +20,22 @@ RSpec.describe Questions::SpouseConsentController do
       let(:filing_joint) { "yes" }
       it "returns true" do
         expect(Questions::SpouseConsentController.show?(intake)).to eq true
+      end
+
+      context "when they weren't legally married AND were widowed at the end of the filing year" do
+        let(:widowed) { "yes" }
+        let(:married_last_day_of_year) { "no" }
+        it "returns false" do
+          expect(subject.class.show?(intake)).to eq false
+        end
+      end
+
+      context "when they were legally married AND widowed at the end of the filing year" do
+        let(:widowed) { "yes" }
+        let(:married_last_day_of_year) { "yes" }
+        it "returns true" do
+          expect(subject.class.show?(intake)).to eq true
+        end
       end
     end
 

--- a/spec/controllers/questions/spouse_email_address_controller_spec.rb
+++ b/spec/controllers/questions/spouse_email_address_controller_spec.rb
@@ -4,7 +4,14 @@ RSpec.describe Questions::SpouseEmailAddressController do
   render_views
 
   let(:filing_joint) { "yes" }
-  let(:intake) { create :intake, filing_joint: filing_joint }
+  let(:widowed) { "no" }
+  let(:married_last_day_of_year) { "yes" }
+  let(:intake) {
+    create :intake,
+           filing_joint: filing_joint,
+           widowed: widowed,
+           married_last_day_of_year: married_last_day_of_year
+  }
 
   before do
     sign_in intake.client
@@ -16,6 +23,22 @@ RSpec.describe Questions::SpouseEmailAddressController do
       let(:filing_joint) { "yes" }
       it "returns true" do
         expect(subject.class.show?(intake)).to eq true
+      end
+
+      context "when they weren't legally married AND were widowed at the end of the filing year" do
+        let(:widowed) { "yes" }
+        let(:married_last_day_of_year) { "no" }
+        it "returns false" do
+          expect(subject.class.show?(intake)).to eq false
+        end
+      end
+
+      context "when they were legally married AND widowed at the end of the filing year" do
+        let(:widowed) { "yes" }
+        let(:married_last_day_of_year) { "yes" }
+        it "returns true" do
+          expect(subject.class.show?(intake)).to eq true
+        end
       end
     end
 


### PR DESCRIPTION
## Link to Jira issue

- e.g. https://codeforamerica.atlassian.net/browse/GYR1-1074

## Is PM acceptance required?

- Yes - don't merge until Jira issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main

## What was done?

- Skip the spouse email address page and the spouse consent page if client was widowed and were not married at the end of the filing year

## How to test?

- answer “NO” to “As of December 31, {filing year}, were you legally married?” and “YES” to “As of December 31, {filing year}, were you widowed?” in the flow

