### PR TITLE
[closed w/o merging] GYR1-1050 Client portal improvements for statuses of "Intake, Not Ready" & "Intake, Needs Doc Help"

### DIFF
--- a/app/assets/stylesheets/components/_portal-status-line-items.scss
+++ b/app/assets/stylesheets/components/_portal-status-line-items.scss
@@ -27,3 +27,26 @@
     }
   }
 }
+
+.portal-status-badge {
+  background-color: #fece68;
+  border-color: #fece68;
+  border-radius: 0.5rem;
+  color: black;
+  display: inline-block;
+  font-size: 1.7rem;
+  font-weight: 500;
+  line-height: 1.5rem;
+  margin-left: 0.5rem;
+  padding: 0.75rem 1rem;
+  position: relative;
+  top: -.1em;
+}
+
+.portal-info-box {
+  background-color: #fff4d1;
+  border: 3px solid #fab323;
+  color: black;
+  margin-bottom: 2.5rem;
+  padding: 1rem 2rem;
+}

--- a/app/controllers/portal/portal_controller.rb
+++ b/app/controllers/portal/portal_controller.rb
@@ -9,6 +9,9 @@ module Portal
     def home
       @tax_returns = current_client.tax_returns.order(year: :desc).to_a
       @tax_returns << PseudoTaxReturn.new(intake: current_intake, time: app_time) if @tax_returns.empty?
+
+      current_state = current_intake.tax_returns.last.current_state
+      send_mixpanel_event(event_name: 'client_portal_visited', data: {return_status: current_state})
     end
 
     def current_intake

--- a/app/controllers/portal/portal_controller.rb
+++ b/app/controllers/portal/portal_controller.rb
@@ -10,7 +10,7 @@ module Portal
       @tax_returns = current_client.tax_returns.order(year: :desc).to_a
       @tax_returns << PseudoTaxReturn.new(intake: current_intake, time: app_time) if @tax_returns.empty?
 
-      current_state = current_intake.tax_returns.last.current_state
+      current_state = current_intake&.tax_returns&.last&.current_state || 'intake_in_progress'
       send_mixpanel_event(event_name: 'client_portal_visited', data: {return_status: current_state})
     end
 

--- a/app/helpers/tax_return_card_helper.rb
+++ b/app/helpers/tax_return_card_helper.rb
@@ -27,7 +27,9 @@ module TaxReturnCardHelper
                     t('portal.portal.home.help_text.intake_incomplete'),
         percent_complete: 10,
         button_type: :complete_intake,
-        link: current_step,
+        link: Flipper.enabled?(:client_portal_improvements) && state == :intake_needs_doc_help ?
+                Portal::UploadDocumentsController.to_path_helper(action: :index) :
+                current_step,
         call_to_action_title: t('portal.portal.home.calls_to_action.finish_intake_title'),
         call_to_action_text: Flipper.enabled?(:client_portal_improvements) ?
                               t('portal.portal.home.calls_to_action.finish_intake_2') :

--- a/app/helpers/tax_return_card_helper.rb
+++ b/app/helpers/tax_return_card_helper.rb
@@ -19,13 +19,19 @@ module TaxReturnCardHelper
       end
     end
 
-    if ask_for_answers && !current_step&.include?("/documents")
+    if (Flipper.enabled?(:client_portal_improvements) && (ask_for_answers || state == :intake_needs_doc_help)) ||
+        (ask_for_answers && !current_step&.include?("/documents"))
       {
-        help_text: t('portal.portal.home.help_text.intake_incomplete'),
+        help_text: Flipper.enabled?(:client_portal_improvements) ?
+                    t('portal.portal.home.help_text.intake_incomplete_2') :
+                    t('portal.portal.home.help_text.intake_incomplete'),
         percent_complete: 10,
         button_type: :complete_intake,
         link: current_step,
-        call_to_action_text: t('portal.portal.home.calls_to_action.finish_intake')
+        call_to_action_title: t('portal.portal.home.calls_to_action.finish_intake_title'),
+        call_to_action_text: Flipper.enabled?(:client_portal_improvements) ?
+                              t('portal.portal.home.calls_to_action.finish_intake_2') :
+                              t('portal.portal.home.calls_to_action.finish_intake')
       }
     elsif ask_for_answers && current_step&.include?("/documents")
       {
@@ -88,7 +94,9 @@ module TaxReturnCardHelper
         percent_complete: 90,
         button_type: :view_documents,
       }
-    elsif [:intake_greeter_info_requested, :intake_needs_doc_help, :intake_info_requested, :prep_info_requested, :review_info_requested].include?(state)
+    # when enabled, we don't check for :intake_needs_doc_help here
+    elsif (Flipper.enabled?(:client_portal_improvements) && [:intake_greeter_info_requested, :intake_info_requested, :prep_info_requested, :review_info_requested].include?(state)) ||
+          [:intake_greeter_info_requested, :intake_needs_doc_help, :intake_info_requested, :prep_info_requested, :review_info_requested].include?(state)
       {
         help_text: t('portal.portal.home.help_text.info_requested'),
         percent_complete: {intake_greeter_info_requested: 45, intake_needs_doc_help: 45, intake_info_requested: 45, prep_info_requested: 65, review_info_requested: 85}[state],

--- a/app/views/portal/portal/_tax_return_card.html.erb
+++ b/app/views/portal/portal/_tax_return_card.html.erb
@@ -48,9 +48,9 @@
       <%= link_to t("portal.portal.home.document_link.add_missing_documents"), Portal::UploadDocumentsController.to_path_helper(action: :index), class: "button spacing-below-0" %>
     <% elsif card_props[:button_type] == :complete_intake %>
       <% if Flipper.enabled?(:client_portal_improvements) %>
-        <%= link_to(t("portal.portal.home.document_link.complete_tax_questions_2"), card_props[:link], class: "button spacing-below-0"), "data-track-click": "client_portal_finish_intake" %>
+        <%= link_to(t("portal.portal.home.document_link.complete_tax_questions_2"), card_props[:link], class: "button spacing-below-0", "data-track-click": "client_portal_finish_intake") %>
       <% else %>
-        <%= link_to(t("portal.portal.home.document_link.complete_tax_questions"), card_props[:link], class: "button spacing-below-0"), "data-track-click": "client_portal_finish_intake" %>
+        <%= link_to(t("portal.portal.home.document_link.complete_tax_questions"), card_props[:link], class: "button spacing-below-0", "data-track-click": "client_portal_finish_intake") %>
       <% end %>
     <% elsif card_props[:button_type] == :complete_intake_documents %>
       <%= link_to(t("portal.portal.home.document_link.add_missing_documents"), card_props[:link], class: "button spacing-below-0") %>

--- a/app/views/portal/portal/_tax_return_card.html.erb
+++ b/app/views/portal/portal/_tax_return_card.html.erb
@@ -3,18 +3,33 @@
 <div class="review-box" id="tax-year-<%= tax_return.year %>">
   <div class="grid-flex space-between spacing-below-25">
     <div>
-      <h2 class="h3"><%= t('portal.portal.home.tax_return_heading', year: tax_return.year) %></h2>
+      <h2 class="h3">
+        <%= t('portal.portal.home.tax_return_heading', year: tax_return.year) %>
+        <% if Flipper.enabled?(:client_portal_improvements) %>
+          <span class="portal-status-badge"><%= t('portal.portal.home.status.in_progress') %></span>
+        <% end %>
+      </h2>
       <p class="spacing-below-0"><%= card_props[:help_text] %></p>
     </div>
-    <% if card_props.has_key?(:percent_complete) && card_props[:percent_complete].present? %>
-      <div style="flex-shrink: 0;">
-        <%= render "shared/svg/percent_complete_circle", percent: card_props[:percent_complete] %>
-      </div>
+
+    <% if ! Flipper.enabled?(:client_portal_improvements) %>
+      <% if card_props.has_key?(:percent_complete) && card_props[:percent_complete].present? %>
+        <div style="flex-shrink: 0;">
+          <%= render "shared/svg/percent_complete_circle", percent: card_props[:percent_complete] %>
+        </div>
+      <% end %>
     <% end %>
   </div>
   <% if card_props[:call_to_action_text].present? %>
-    <%= render "portal/portal/action_state", link: false do %>
-      <%= card_props[:call_to_action_text] %>
+    <% if Flipper.enabled?(:client_portal_improvements) %>
+      <div class="portal-info-box">
+        <p style="margin-bottom: 1rem"><b><%= card_props[:call_to_action_title] %></b></br>
+        <p style="margin: 0.1rem"><%= card_props[:call_to_action_text] %>
+      </div>
+    <% else %>
+      <%= render "portal/portal/action_state", link: false do %>
+        <%= card_props[:call_to_action_text] %>
+      <% end %>
     <% end %>
   <% end %>
 
@@ -32,7 +47,11 @@
     <% elsif card_props[:button_type] == :add_missing_documents %>
       <%= link_to t("portal.portal.home.document_link.add_missing_documents"), Portal::UploadDocumentsController.to_path_helper(action: :index), class: "button spacing-below-0" %>
     <% elsif card_props[:button_type] == :complete_intake %>
-      <%= link_to(t("portal.portal.home.document_link.complete_tax_questions"), card_props[:link], class: "button spacing-below-0") %>
+      <% if Flipper.enabled?(:client_portal_improvements) %>
+        <%= link_to(t("portal.portal.home.document_link.complete_tax_questions_2"), card_props[:link], class: "button spacing-below-0"), "data-track-click": "client_portal_finish_intake" %>
+      <% else %>
+        <%= link_to(t("portal.portal.home.document_link.complete_tax_questions"), card_props[:link], class: "button spacing-below-0"), "data-track-click": "client_portal_finish_intake" %>
+      <% end %>
     <% elsif card_props[:button_type] == :complete_intake_documents %>
       <%= link_to(t("portal.portal.home.document_link.add_missing_documents"), card_props[:link], class: "button spacing-below-0") %>
     <% elsif card_props[:button_type] == :add_signature_primary %>

--- a/app/views/portal/portal/home.html.erb
+++ b/app/views/portal/portal/home.html.erb
@@ -3,14 +3,17 @@
 <% content_for :card do %>
   <h2 class="spacing-below-10"><%= t(".title", name: current_client.intake.preferred_name) %></h2>
 
-  <div class="spacing-below-15">
-    <h2 class="text--teal h3">
-      <%= t(".client_id", id: current_client.id) %>
-    </h2>
-  </div>
-  <div class="spacing-below-15">
-    <%= t('.subtitle') %>
-  </div>
+  <% if ! Flipper.enabled?(:client_portal_improvements) %>
+    <div class="spacing-below-15">
+      <h2 class="text--teal h3">
+        <%= t(".client_id", id: current_client.id) %>
+      </h2>
+    </div>
+
+    <div class="spacing-below-15">
+      <%= t('.subtitle') %>
+    </div>
+  <% end %>
 
   <% if @tax_returns.present? %>
     <% @tax_returns.each_with_index do |tax_return, index| %>

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -8,6 +8,7 @@ end
 # This structure is borrowed from https://github.com/department-of-veterans-affairs/vets-api/blob/247c84c0226d4cc90477b96a46107c6bace62bd5/config/initializers/flipper.rb
 # Make sure that each feature we reference in code is present in the UI, as long as we have a Database already
 begin
+  Flipper.disable :client_portal_improvements unless Flipper.exist?(:client_portal_improvements)
   Flipper.disable :extension_period unless Flipper.exist?(:extension_period)
   Flipper.disable :get_your_pdf unless Flipper.exist?(:get_your_pdf)
   Flipper.disable :hub_dashboard unless Flipper.exist?(:hub_dashboard)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2120,11 +2120,14 @@ en:
           add_signature_primary: Please add your final signature to your tax return
           add_signature_spouse: Please add your spouse's final signature to your tax return
           finish_intake: Please answer remaining tax questions to continue.
+          finish_intake_2: When you finish your tax form you'll get paired with your tax team.
+          finish_intake_title: Continue answering tax questions
         client_id: 'Client ID: %{id}'
         document_link:
           add_final_signature: Add final signature
           add_missing_documents: Add missing documents
           complete_tax_questions: Complete tax questions
+          complete_tax_questions_2: Finish tax form
           view_document: View or download %{display_name}
           view_documents: View your uploaded documents
           view_final_tax_document: Download final tax papers %{year}
@@ -2141,6 +2144,7 @@ en:
           info_requested: We need more documents from you to start your tax return.
           intake_documents_incomplete: We need more documents from you to start your tax return.
           intake_incomplete: You have not finished answering all the tax questions so we cannot start your tax return.
+          intake_incomplete_2: You're still filling out your tax form.
           intake_ready: Your tax team is going to schedule an initial review call with you.
           intake_ready_for_call: Your tax team is going to schedule an initial review call with you.
           prep_ready_for_prep: Your tax team is preparing the return.
@@ -2148,8 +2152,10 @@ en:
           review_reviewing: Your return is being reviewed.
           review_signature_requested_primary: We are waiting for a final signature from you.
           review_signature_requested_spouse: We are waiting for a final signature from your spouse.
+        status:
+          in_progress: In progress
         subtitle: 'Here is a snapshot of your taxes:'
-        tax_return_heading: "%{year} return"
+        tax_return_heading: Your %{year} return
         title: Welcome back %{name}!
     still_needs_helps:
       chat_later:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2092,11 +2092,14 @@ es:
           add_signature_primary: Agregue su firma final a su declaración de impuestos
           add_signature_spouse: Agregue la firma final de su cónyuge a su declaración de impuestos
           finish_intake: Responda las preguntas fiscales restantes para continuar.
+          finish_intake_2: Cuando termine su formulario, lo conectaremos con el equipo de impuestos.
+          finish_intake_title: Siga respondiendo las preguntas
         client_id: 'Identificación del cliente: %{id}'
         document_link:
           add_final_signature: Agregar firma final
           add_missing_documents: Agregar documentos faltantes
           complete_tax_questions: Preguntas completas sobre impuestos
+          complete_tax_questions_2: Finalizar formulario
           view_document: Ver o descargar el documento %{display_name}
           view_documents: Ver sus documentos cargados
           view_final_tax_document: Descargar los documentos de impuestos finales %{year}
@@ -2113,6 +2116,7 @@ es:
           info_requested: Necesitamos más documentos de usted para comenzar su declaración de impuestos.
           intake_documents_incomplete: Necesitamos más documentos de usted para comenzar su declaración de impuestos.
           intake_incomplete: No ha terminado de responder todas las preguntas sobre impuestos, por lo que no podemos comenzar su declaración de impuestos.
+          intake_incomplete_2: Aún debe finalizar su formulario de impuestos.
           intake_ready: Su equipo de impuestos programará una llamada de revisión inicial con usted.
           intake_ready_for_call: Su equipo de impuestos programará una llamada de revisión inicial con usted.
           prep_ready_for_prep: Tu equipo fiscal está preparando la declaración
@@ -2120,8 +2124,10 @@ es:
           review_reviewing: Tu devolución está siendo revisada
           review_signature_requested_primary: Estamos esperando una firma final de usted.
           review_signature_requested_spouse: Estamos esperando una firma final de su cónyuge.
+        status:
+          in_progress: En proceso
         subtitle: 'Aquí hay una instantánea de sus impuestos:'
-        tax_return_heading: Declaración de impuestos de %{year}
+        tax_return_heading: Su declaración del %{year}
         title: Bienvenido de nuevo %{name}!
     still_needs_helps:
       chat_later:


### PR DESCRIPTION
> [!NOTE]
> _Closed w/o merging in favor of another PR:_ https://github.com/codeforamerica/vita-min/pull/6358

## Link to Jira issue

- https://codeforamerica.atlassian.net/browse/GYR1-1050

## Is PM acceptance required?

- Yes - don't merge until Jira issue is accepted!

## What was done?

- Flipper flag added: `:client_portal_improvements`; most changes in this PR 
  (where it made sense) are wrapped with this flag
- TaxReturnCardHelper logic update: slight change to how the state 
  `intake_needs_doc_help` is reflected/handled by the client portal home page: 
  per the Figma document, the client portal should now look the same (in terms 
  of copy and button etc) for both `intake_in_progress` or 
  `intake_needs_doc_help`.  (The current behavior is for `intake_needs_doc_help` 
  to invoke the complete_intake_documents button and associated copy, etc.).
  - the button itself still should take the user to the correct url, so some 
    additional logic was added to ensure this happens in the case of 
    `intake_needs_doc_help`
- simple copy changes
  - removed the "Client ID" bit at the top above the card
  - removed the "here's a snapshot" copy (also above the card)
  - added "Your" (i.e., "Your 2025 return")
  - added new body text (just above card)
  - updated button text
- UI widgets
  - removed circle/pie chart progress widget
  - added an "In Progress" yellow badge
  - added new CTA yellow box (this replaces the red text) inside card + new copy
- mixpanel
  - client portal home now sends up a 'client_portal_visited' event along with a 
    key-value pair of `{return_status: current_state}`
  - button inside card now has a `"data-track-click": 
    "client_portal_finish_intake"` added to it (for versions of that button 
    which are in scope for this ticket/PR).

## How to test?

Toggle the Flipper flag on/off as well as flip between the 'en' and 'es' 
versions and ensure that the text, UI, and layout aspects are looking good as 
you do so.

## Note to reviewer

Would appreciate a close review around ... 
- the new logic around intake_needs_doc_help inside TaxReturnCardHelper
- the flipper flag being tucked into various nooks and crannies
- and just the overall number of details that i want to ensure we get right

## Screenshots (visual changes)

- Before

Before, the `intake_in_progress` (that is, 'Intake, Not Ready') and
  `intake_needs_doc_help` statuses invoked slightly different versions of the page:

Intake, Not Ready:

<img width="874" height="776" alt="image" src="https://github.com/user-attachments/assets/e202d91e-35ce-433e-b740-01a085c2fc8f" />

Intake, Need Doc Help:

<img width="886" height="738" alt="image" src="https://github.com/user-attachments/assets/9d58c347-8c21-456c-88c2-253248eeee53" />

- After

Now, the page is the same for both statuses:

<img width="862" height="699" alt="image" src="https://github.com/user-attachments/assets/2e995497-3ba0-4095-9f1f-6b525043189c" />

Spanish version:

<img width="851" height="691" alt="image" src="https://github.com/user-attachments/assets/7dafaf09-1739-4ccd-be89-f0fda7fd4c85" />

