### PR TITLE
Hide april 15 due date from homepage if after tax deadline

### DIFF
--- a/app/views/public_pages/home.html.erb
+++ b/app/views/public_pages/home.html.erb
@@ -22,9 +22,11 @@
             <% end %>
           </strong>
         </p>
-        <p>
-          <strong><%= t("views.public_pages.home.subheader_warning", tax_day: I18n.l(Rails.configuration.tax_deadline.to_date, format: :medium, locale: locale)) %></strong>
-        </p>
+        <% if app_time <= Rails.configuration.tax_deadline %>
+          <p>
+            <strong><%= t("views.public_pages.home.subheader_warning", tax_day: I18n.l(Rails.configuration.tax_deadline.to_date, format: :medium, locale: locale)) %></strong>
+          </p>
+        <% end %>
         <% if open_for_gyr_intake? %>
           <%= link_to t("general.get_started"), eligibility_wages_questions_path, id: "firstCta", class: "button button--med-wide button--primary" %>
         <% else %>


### PR DESCRIPTION
## Link to Jira issue

- e.g. https://codeforamerica.atlassian.net/browse/GYR1-1100

## Is PM acceptance required?

- Yes - don't merge until Jira issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main

## What was done?

- Hides confusing "File by April 15th to avoid any penalties." after tax deadline so we don't discourage folks from filing

## Screenshots (visual changes)

- Before
<img width="1048" height="629" alt="Screenshot 2026-07-09 at 12 46 25 PM" src="https://github.com/user-attachments/assets/ef401a03-a8dc-4a0a-9576-e769eefb32d0" />

- After
![Uploading Screenshot 2026-07-09 at 12.47.19 PM.png…]()

