### PR TITLE
GYR-1090 Automate removal of red dot

### DIFF
--- a/app/controllers/hub/outgoing_emails_controller.rb
+++ b/app/controllers/hub/outgoing_emails_controller.rb
@@ -10,7 +10,10 @@ module Hub
           body: outgoing_email_params[:body],
           attachment: outgoing_email_params[:attachment]
         )
+
+        @client.update!(flagged_at: nil)
       end
+
       redirect_to hub_client_messages_path(client_id: @client, anchor: "last-item")
     end
 

--- a/app/controllers/hub/outgoing_text_messages_controller.rb
+++ b/app/controllers/hub/outgoing_text_messages_controller.rb
@@ -9,7 +9,10 @@ module Hub
           user: current_user,
           body: outgoing_text_message_params[:body]
         )
+
+        @client.update!(flagged_at: nil)
       end
+
       redirect_to hub_client_messages_path(client_id: @client.id, anchor: "last-item")
     end
 

--- a/spec/controllers/hub/outgoing_emails_controller_spec.rb
+++ b/spec/controllers/hub/outgoing_emails_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Hub::OutgoingEmailsController do
   let(:user) { create :organization_lead_user }
 
   describe "#create" do
-    let(:client) { create :client, vita_partner: user.role.organization }
+    let(:client) { create :client, vita_partner: user.role.organization, flagged_at: Time.now }
     let!(:intake) { create :intake, client: client, email_address: "loose.seal@example.com" }
     let(:params) do
       { client_id: client.id, outgoing_email: { body: "hi client" } }
@@ -33,6 +33,9 @@ RSpec.describe Hub::OutgoingEmailsController do
           post :create, params: params
 
           expect(ClientMessagingService).to have_received(:send_email).with(client: client, user: user, body: "hi client", attachment: instance_of(ActionDispatch::Http::UploadedFile))
+
+          expect(Client.find(client.id).flagged_at).to equal(nil)
+
           expect(response).to redirect_to hub_client_messages_path(client_id: client.id, anchor: "last-item")
         end
       end

--- a/spec/controllers/hub/outgoing_text_messages_controller_spec.rb
+++ b/spec/controllers/hub/outgoing_text_messages_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Hub::OutgoingTextMessagesController do
   let(:user) { create :organization_lead_user }
 
   describe "#create" do
-    let(:client) { create :client, vita_partner: user.role.organization, intake: build(:intake, sms_phone_number: "+15105551234", phone_number: "+15105551777") }
+    let(:client) { create :client, vita_partner: user.role.organization, flagged_at: Time.now, intake: build(:intake, sms_phone_number: "+15105551234", phone_number: "+15105551777") }
     let(:params) do
       {
         client_id: client.id,
@@ -25,6 +25,9 @@ RSpec.describe Hub::OutgoingTextMessagesController do
         post :create, params: params
 
         expect(ClientMessagingService).to have_received(:send_text_message).with(client: client, user: user, body: "This is an outgoing text")
+
+        expect(Client.find(client.id).flagged_at).to equal(nil)
+
         expect(response).to redirect_to(hub_client_messages_path(client_id: client.id, anchor: "last-item"))
       end
 


### PR DESCRIPTION
## Link to Jira issue

- https://codeforamerica.atlassian.net/browse/GYR1-1090

## Is PM acceptance required?

- Yes - don't merge until Jira issue is accepted!

## What was done?

- Added logic to set client `flagged_at` to nil when a message is sent
- spec test updates

Reference:

- the red dot render logic is here: `app/views/shared/_urgent_icon.html.erb`

## How to test?

- One the main clients page, chose a client record with a red dot.
- Go to messages tab, fill out the email form (make sure it's non-empty), and 
  submit ("Send").
- Verify on the client record page that the red toggle is *off*.
- Verify on the main clients page that the red dot has now been removed (at
  the LHS of the client record in question).