### PR TITLE
GYR-1008 Create env feature flag

### DIFF
--- a/app/controllers/concerns/state_file/irs_data_transfer_links_concern.rb
+++ b/app/controllers/concerns/state_file/irs_data_transfer_links_concern.rb
@@ -11,7 +11,7 @@ module StateFile
     end
 
     def irs_df_transfer_link
-      df_transfer_auth = EnvironmentCredentials.dig('statefile', 'df_transfer_auth')
+      df_transfer_auth = EnvironmentCredentials['STATEFILE_DF_TRANSFER_AUTH']
       return nil unless df_transfer_auth
 
       if df_transfer_auth

--- a/app/controllers/mailgun_webhooks_controller.rb
+++ b/app/controllers/mailgun_webhooks_controller.rb
@@ -230,8 +230,8 @@ class MailgunWebhooksController < ActionController::Base
 
   def authenticate_mailgun_request
     authenticate_or_request_with_http_basic do |name, password|
-      expected_name = EnvironmentCredentials.dig(:mailgun, :basic_auth_name)
-      expected_password = EnvironmentCredentials.dig(:mailgun, :basic_auth_password)
+      expected_name = EnvironmentCredentials['MAILGUN_BASIC_AUTH_NAME']
+      expected_password = EnvironmentCredentials['MAILGUN_BASIC_AUTH_PASSWORD']
       ActiveSupport::SecurityUtils.secure_compare(name, expected_name) &&
         ActiveSupport::SecurityUtils.secure_compare(password, expected_password)
     end

--- a/app/forms/hub/outbound_call_form.rb
+++ b/app/forms/hub/outbound_call_form.rb
@@ -17,7 +17,7 @@ module Hub
       @user = kwargs[:user]
       @client = Hub::ClientsController::HubClientPresenter.new(kwargs[:client])
 
-      self.twilio_phone_number = EnvironmentCredentials.dig(:twilio, :voice_phone_number)
+      self.twilio_phone_number = EnvironmentCredentials['TWILIO_VOICE_PHONE_NUMBER']
       self.user_phone_number = @user&.phone_number
       self.client_phone_number = @client&.phone_number
       super(attrs)

--- a/app/lib/datadog_api.rb
+++ b/app/lib/datadog_api.rb
@@ -11,7 +11,7 @@ module DatadogApi
     end
 
     def api_key
-      Rails.application.credentials.dig(:datadog_api_key)
+      EnvironmentalCredentials['DATADOG_API_KEY']
     end
 
     def namespace

--- a/app/lib/datadog_api.rb
+++ b/app/lib/datadog_api.rb
@@ -11,7 +11,7 @@ module DatadogApi
     end
 
     def api_key
-      EnvironmentalCredentials['DATADOG_API_KEY']
+      EnvironmentCredentials['DATADOG_API_KEY']
     end
 
     def namespace

--- a/app/lib/deduplication_service.rb
+++ b/app/lib/deduplication_service.rb
@@ -1,5 +1,5 @@
 class DeduplicationService
-  def self.sensitive_attribute_hashed(instance, attr, key = EnvironmentCredentials.dig(:duplicate_hashing_key))
+  def self.sensitive_attribute_hashed(instance, attr, key = EnvironmentCredentials['DUPLICATE_HASHING_KEY'])
     value = instance.send(attr)
     return unless value.present?
     # we want to hash all ssns the same way so that data can dedupe across the board
@@ -20,7 +20,7 @@ class DeduplicationService
     _, attr_without_hashed = attr.to_s.split("hashed_")
     return instance.send(attr) if attr_without_hashed.nil?
 
-    old_key = EnvironmentCredentials.dig(:previous_duplicate_hashing_key)
+    old_key = EnvironmentCredentials['PREVIOUS_DUPLICATE_HASHING_KEY']
     return instance.send(attr) unless old_key.present?
 
     [sensitive_attribute_hashed(instance, attr_without_hashed), sensitive_attribute_hashed(instance, attr_without_hashed, old_key)]

--- a/app/lib/environment_credentials.rb
+++ b/app/lib/environment_credentials.rb
@@ -18,7 +18,7 @@ class EnvironmentCredentials
       else
         credentials_value(name)
       end
-    rescue ActiveRecordError
+    rescue ActiveRecord::ActiveRecordError
       # Necessary when starting from scratch because flipper tables are not
       # established yet
       ENV.fetch(name, nil) || credentials_value(name)

--- a/app/lib/environment_credentials.rb
+++ b/app/lib/environment_credentials.rb
@@ -18,7 +18,7 @@ class EnvironmentCredentials
       else
         credentials_value(name)
       end
-    rescue ActiveRecord::NoDatabaseError, ActiveRecord::StatementInvalid
+    rescue ActiveRecordError
       # Necessary when starting from scratch because flipper tables are not
       # established yet
       ENV.fetch(name, nil) || credentials_value(name)

--- a/app/lib/environment_credentials.rb
+++ b/app/lib/environment_credentials.rb
@@ -12,11 +12,16 @@ class EnvironmentCredentials
 
   class << self
     def [](name)
+      
       if Flipper.enabled?(:use_env_secrets)
         ENV.fetch(name, nil)
       else
         credentials_value(name)
       end
+    rescue ActiveRecord::NoDatabaseError, ActiveRecord::StatementInvalid
+      # Necessary when starting from scratch because flipper tables are not
+      # established yet
+      ENV.fetch(name, nil) || credentials_value(name)
     end
 
     def dig(*keys)

--- a/app/lib/environment_credentials.rb
+++ b/app/lib/environment_credentials.rb
@@ -1,10 +1,5 @@
 class EnvironmentCredentials
-  # Maps environment variable names to Rails credential dig paths for keys
-  # where the service name doesn't match the first segment of the ENV var name.
-  #
-  # Most keys are resolved automatically by trying 2-level and 3-level
-  # credential paths (e.g. MAILGUN_API_KEY -> [:mailgun, :api_key]).
-  # Only truly non-obvious mappings go here.
+  # Some variables don't map obviously.
   SECRET_KEYS = {
     'VITA_MIN_EFIN' => [:irs, :efin],
     'MD_SIN' => [:irs, :md_sin],

--- a/app/lib/environment_credentials.rb
+++ b/app/lib/environment_credentials.rb
@@ -1,5 +1,29 @@
 class EnvironmentCredentials
+  # Maps environment variable names to Rails credential dig paths for keys
+  # where the service name doesn't match the first segment of the ENV var name.
+  #
+  # Most keys are resolved automatically by trying 2-level and 3-level
+  # credential paths (e.g. MAILGUN_API_KEY -> [:mailgun, :api_key]).
+  # Only truly non-obvious mappings go here.
+  SECRET_KEYS = {
+    'VITA_MIN_EFIN' => [:irs, :efin],
+    'MD_SIN' => [:irs, :md_sin],
+    'VITA_MIN_SIN' => [:irs, :sin],
+    'GYR_EFILER_CERT' => [:irs, :efile_cert_base64],
+    'GYR_EFILER_ETIN' => [:irs, :etin],
+    'GYR_EFILER_APP_SYS_ID' => [:irs, :app_sys_id],
+    'INTERCOM_ACCESS_TOKEN' => [:intercom, :intercom, :access_token]
+  }.freeze
+
   class << self
+    def [](name)
+      if Flipper.enabled?(:use_env_secrets)
+        ENV.fetch(name, nil)
+      else
+        credentials_value(name)
+      end
+    end
+
     def dig(*keys)
       Rails.application.credentials.dig(*keys)
     end
@@ -14,6 +38,37 @@ class EnvironmentCredentials
         sin: 'VITA_MIN_SIN',
       }
       ENV[env_var_names[key]].presence || dig(:irs, key)
+    end
+
+    private
+
+    # Imperfectly attempts to find keys within credentials, if the credential
+    # isn't found in the SECRET_KEYS hash map. Note, this means that FOO_BAR_BAZ
+    # will first match dig(:foo, :bar_baz) if it is present and will therefore
+    # not match dig(:foo, :bar, :baz)
+    def credentials_value(name)
+      return dig(*SECRET_KEYS[name]) if SECRET_KEYS.key?(name)
+
+      keys = []
+      string = name.downcase
+
+      value = dig(string.to_sym) 
+
+      return value if value.present?
+
+      while string.present?
+        head, _, string = string.partition('_')
+
+        keys << head.to_sym
+
+        value = dig(*(keys + [string.to_sym]))
+
+        return value if value.present?
+      end
+    # Catch when a value is found, but subsequent #dig calls will be on a type
+    # other than a hash
+    rescue TypeError
+      nil
     end
   end
 end

--- a/app/models/airtable/organization.rb
+++ b/app/models/airtable/organization.rb
@@ -1,9 +1,9 @@
 module Airtable
   class Organization < Airrecord::Table
-    self.base_key = EnvironmentalCredentials['AIRTABLE_BASE_KEY']
-    self.table_name = EnvironmentalCredentials['AIRTABLE_TABLE_NAME']
+    self.base_key = EnvironmentCredentials['AIRTABLE_BASE_KEY']
+    self.table_name = EnvironmentCredentials['AIRTABLE_TABLE_NAME']
 
-    Airrecord.api_key = EnvironmentalCredentials['AIRTABLE_TOKEN']
+    Airrecord.api_key = EnvironmentCredentials['AIRTABLE_TOKEN']
 
     def self.language_offerings
       all.each_with_object({}) do |record, hash|

--- a/app/models/airtable/organization.rb
+++ b/app/models/airtable/organization.rb
@@ -1,9 +1,9 @@
 module Airtable
   class Organization < Airrecord::Table
-    self.base_key = Rails.application.credentials.dig(:airtable, :base_key)
-    self.table_name = Rails.application.credentials.dig(:airtable, :table_name)
+    self.base_key = EnvironmentalCredentials['AIRTABLE_BASE_KEY']
+    self.table_name = EnvironmentalCredentials['AIRTABLE_TABLE_NAME']
 
-    Airrecord.api_key = Rails.application.credentials.dig(:airtable, :token)
+    Airrecord.api_key = EnvironmentalCredentials['AIRTABLE_TOKEN']
 
     def self.language_offerings
       all.each_with_object({}) do |record, hash|

--- a/app/models/outbound_call.rb
+++ b/app/models/outbound_call.rb
@@ -36,7 +36,7 @@ class OutboundCall < ApplicationRecord
   # the "queued" status until the dial event to the client is completed.
   #
   def self.twilio_number
-    EnvironmentCredentials.dig(:twilio, :voice_phone_number)
+    EnvironmentCredentials['TWILIO_VOICE_PHONE_NUMBER']
   end
 
   def to

--- a/app/services/intercom_service.rb
+++ b/app/services/intercom_service.rb
@@ -40,23 +40,27 @@ class IntercomService
   end
 
   def self.generate_user_hash(user_id)
-    cred = EnvironmentCredentials.dig(:intercom, :secure_mode_secret_key)
+    cred = EnvironmentCredentials['INTERCOM_SECURE_MODE_SECRET_KEY']
 
-    OpenSSL::HMAC.hexdigest(
-      'sha256',
-      cred,
-      user_id.to_s
-    ) unless user_id.nil?
+    unless user_id.nil?
+      OpenSSL::HMAC.hexdigest(
+        'sha256',
+        cred,
+        user_id.to_s
+      )
+    end
   end
 
   def self.generate_statefile_user_hash(user_id)
-    cred = EnvironmentCredentials.dig(:intercom, :statefile_secure_mode_secret_key)
+    cred = EnvironmentCredentials['INTERCOM_STATEFILE_SECURE_MODE_SECRET_KEY']
 
-    OpenSSL::HMAC.hexdigest(
-      'sha256',
-      cred,
-      user_id.to_s
-    ) unless user_id.nil?
+    unless user_id.nil?
+      OpenSSL::HMAC.hexdigest(
+        'sha256',
+        cred,
+        user_id.to_s
+      )
+    end
   end
 
   private
@@ -146,7 +150,7 @@ class IntercomService
   end
 
   def self.intercom
-    @intercom ||= Intercom::Client.new(token: EnvironmentCredentials.dig(:intercom, :intercom_access_token))
+    @intercom ||= Intercom::Client.new(token: EnvironmentCredentials['INTERCOM_ACCESS_TOKEN'])
   end
 
   MAX_RETRY_COUNT = 3
@@ -160,12 +164,11 @@ class IntercomService
 
     begin
       result = intercom.send(collection).send(verb, params)
-    rescue
-      Intercom::AuthenticationError => e
-        retry_counts += 1
-        DatadogApi.increment("intercom.api.authentication_failure_retry")
-        retry if retry_counts <= MAX_RETRY_COUNT
-        raise e, "Failed #{MAX_RETRY_COUNT} times to authenticate with Intercom"
+    rescue Intercom::AuthenticationError => e
+      retry_counts += 1
+      DatadogApi.increment("intercom.api.authentication_failure_retry")
+      retry if retry_counts <= MAX_RETRY_COUNT
+      raise e, "Failed #{MAX_RETRY_COUNT} times to authenticate with Intercom"
     end
 
     if Rails.env.development?

--- a/app/services/irs_api_service.rb
+++ b/app/services/irs_api_service.rb
@@ -25,7 +25,7 @@ class IrsApiService
       end
     end
 
-    account_id = EnvironmentCredentials.dig('statefile', _state_code, "account_id")
+    account_id = EnvironmentCredentials["STATEFILE_#{_state_code}_ACCOUNT_ID"]
     cert_finder = CertificateFinder.new(server_url, _state_code)
 
     claim = {
@@ -147,7 +147,7 @@ class IrsApiService
 
     def client_cert_bytes
       if server_url.host.ends_with?('irs.gov')
-        Base64.decode64(EnvironmentCredentials.dig('statefile', state_code, "cert_base64"))
+        Base64.decode64(EnvironmentCredentials["STATEFILE_#{state_code}_CERT_BASE64"])
       elsif server_url.host.include?('localhost')
         File.read(File.join(certs_dir, 'client.crt'))
       end
@@ -159,7 +159,7 @@ class IrsApiService
 
     def client_key_bytes
       if server_url.host.ends_with?('irs.gov')
-        Base64.decode64(EnvironmentCredentials.dig('statefile', state_code, "private_key_base64"))
+        Base64.decode64(EnvironmentCredentials["STATEFILE_#{state_code}_PRIVATE_KEY_BASE64"])
       elsif server_url.host.include?('localhost')
         File.read(File.join(certs_dir, 'client.key'))
       end
@@ -170,7 +170,7 @@ class IrsApiService
     if ENV['IRS_API_LOCALHOST']
       URI.parse('https://localhost:443/')
     else
-      URI.parse(EnvironmentCredentials.dig(:statefile, :df_api_mtls))
+      URI.parse(EnvironmentCredentials['STATEFILE_DF_API_MTLS'])
     end
   end
 

--- a/app/services/mixpanel_service.rb
+++ b/app/services/mixpanel_service.rb
@@ -13,7 +13,7 @@ class MixpanelService
   include Singleton
 
   def initialize
-    mixpanel_key = Rails.application.credentials.dig(:mixpanel_token)
+    mixpanel_key = EnvironmentalCredentials['MIXPANEL_TOKEN']
     return if mixpanel_key.nil?
 
     @buffer = []

--- a/app/services/mixpanel_service.rb
+++ b/app/services/mixpanel_service.rb
@@ -13,7 +13,7 @@ class MixpanelService
   include Singleton
 
   def initialize
-    mixpanel_key = EnvironmentalCredentials['MIXPANEL_TOKEN']
+    mixpanel_key = EnvironmentCredentials['MIXPANEL_TOKEN']
     return if mixpanel_key.nil?
 
     @buffer = []

--- a/app/services/multi_tenant_service.rb
+++ b/app/services/multi_tenant_service.rb
@@ -68,15 +68,15 @@ class MultiTenantService
   end
 
   def delivery_method_options
-    if service_type == :ctc && EnvironmentCredentials.dig(:mailgun, :ctc_api_key)
+    if service_type == :ctc && EnvironmentCredentials['MAILGUN_CTC_API_KEY']
       {
-        api_key: EnvironmentCredentials.dig(:mailgun, :ctc_api_key),
-        domain: EnvironmentCredentials.dig(:mailgun, :ctc_domain)
+        api_key: EnvironmentCredentials['MAILGUN_CTC_API_KEY'],
+        domain: EnvironmentCredentials['MAILGUN_CTC_DOMAIN']
       }
-    elsif service_type == :statefile && EnvironmentCredentials.dig(:mailgun, :statefile_api_key)
+    elsif service_type == :statefile && EnvironmentCredentials['MAILGUN_STATEFILE_API_KEY']
       {
-        api_key: EnvironmentCredentials.dig(:mailgun, :statefile_api_key),
-        domain: EnvironmentCredentials.dig(:mailgun, :statefile_domain)
+        api_key: EnvironmentCredentials['MAILGUN_STATEFILE_API_KEY'],
+        domain: EnvironmentCredentials['MAILGUN_STATEFILE_DOMAIN']
       }
     else
       Rails.configuration.action_mailer.mailgun_settings
@@ -115,9 +115,9 @@ class MultiTenantService
 
   def twilio_creds
     @_twlio_creds ||= {
-      account_sid: EnvironmentCredentials.dig(:twilio, service_type, :account_sid),
-      auth_token: EnvironmentCredentials.dig(:twilio, service_type, :auth_token),
-      messaging_service_sid: EnvironmentCredentials.dig(:twilio, service_type, :messaging_service_sid)
+      account_sid: EnvironmentCredentials["TWILIO_#{service_type}_ACCOUNT_SID"],
+      auth_token: EnvironmentCredentials["TWILIO_#{service_type}_AUTH_TOKEN"],
+      messaging_service_sid: EnvironmentCredentials["TWILIO_#{service_type}_MESSAGING_SERVICE_SID"]
     }
   end
 

--- a/app/services/ssn_hashing_service.rb
+++ b/app/services/ssn_hashing_service.rb
@@ -2,7 +2,7 @@ class SsnHashingService
   def self.hash(ssn)
     OpenSSL::HMAC.hexdigest(
       "SHA256",
-      EnvironmentCredentials.dig(:duplicate_hashing_key),
+      EnvironmentCredentials['DUPLICATE_HASHING_KEY'],
       "ssn|#{ssn}"
     )
   end

--- a/app/services/standardize_address_service.rb
+++ b/app/services/standardize_address_service.rb
@@ -103,7 +103,7 @@ class StandardizeAddressService
   end
 
   def get_usps_address_xml
-    usps_user_id = EnvironmentCredentials.dig(:usps, :user_id)
+    usps_user_id = EnvironmentCredentials['USPS_USER_ID']
     builder = Nokogiri::XML::Builder.new do |xml|
       xml.AddressValidateRequest(:USERID => usps_user_id) {
         xml.Revision 1

--- a/app/views/shared/_facebook_pixel.html.erb
+++ b/app/views/shared/_facebook_pixel.html.erb
@@ -1,4 +1,4 @@
-<% if Rails.application.credentials.dig(:facebook_pixel_id).present? %>
+<% if EnvironmentalCredentials['FACEBOOK_PIXEL_ID'].present? %>
 <!-- Facebook Pixel Code -->
 <script>
     !function(f,b,e,v,n,t,s)
@@ -9,7 +9,7 @@
         t.src=v;s=b.getElementsByTagName(e)[0];
         s.parentNode.insertBefore(t,s)}(window, document,'script',
         'https://connect.facebook.net/en_US/fbevents.js');
-    fbq('init', '<%=Rails.application.credentials.dig(:facebook_pixel_id) %>');
+    fbq('init', '<%=EnvironmentalCredentials['FACEBOOK_PIXEL_ID'];
     fbq('track', 'PageView');
     <% if local_assigns[:track_conversion] %>
       fbq('trackCustom', '<%="#{track_conversion}" %>');
@@ -17,7 +17,7 @@
 </script>
 <noscript>
   <img height="1" width="1"
-       style="display:none" src="https://www.facebook.com/tr?id=<%=Rails.application.credentials.dig(:facebook_pixel_id) %>&ev=PageView&noscript=1"/>
+       style="display:none" src="https://www.facebook.com/tr?id=<%=EnvironmentalCredentials['FACEBOOK_PIXEL_ID'] %>&ev=PageView&noscript=1"/>
 </noscript>
 <!-- End Facebook Pixel Code -->
 <% end %>

--- a/app/views/shared/_facebook_pixel.html.erb
+++ b/app/views/shared/_facebook_pixel.html.erb
@@ -9,7 +9,7 @@
         t.src=v;s=b.getElementsByTagName(e)[0];
         s.parentNode.insertBefore(t,s)}(window, document,'script',
         'https://connect.facebook.net/en_US/fbevents.js');
-    fbq('init', '<%=EnvironmentCredentials['FACEBOOK_PIXEL_ID'];
+    fbq('init', '<%= EnvironmentCredentials['FACEBOOK_PIXEL_ID'] %>');
     fbq('track', 'PageView');
     <% if local_assigns[:track_conversion] %>
       fbq('trackCustom', '<%="#{track_conversion}" %>');

--- a/app/views/shared/_facebook_pixel.html.erb
+++ b/app/views/shared/_facebook_pixel.html.erb
@@ -1,4 +1,4 @@
-<% if EnvironmentalCredentials['FACEBOOK_PIXEL_ID'].present? %>
+<% if EnvironmentCredentials['FACEBOOK_PIXEL_ID'].present? %>
 <!-- Facebook Pixel Code -->
 <script>
     !function(f,b,e,v,n,t,s)
@@ -9,7 +9,7 @@
         t.src=v;s=b.getElementsByTagName(e)[0];
         s.parentNode.insertBefore(t,s)}(window, document,'script',
         'https://connect.facebook.net/en_US/fbevents.js');
-    fbq('init', '<%=EnvironmentalCredentials['FACEBOOK_PIXEL_ID'];
+    fbq('init', '<%=EnvironmentCredentials['FACEBOOK_PIXEL_ID'];
     fbq('track', 'PageView');
     <% if local_assigns[:track_conversion] %>
       fbq('trackCustom', '<%="#{track_conversion}" %>');
@@ -17,7 +17,7 @@
 </script>
 <noscript>
   <img height="1" width="1"
-       style="display:none" src="https://www.facebook.com/tr?id=<%=EnvironmentalCredentials['FACEBOOK_PIXEL_ID'] %>&ev=PageView&noscript=1"/>
+       style="display:none" src="https://www.facebook.com/tr?id=<%=EnvironmentCredentials['FACEBOOK_PIXEL_ID'] %>&ev=PageView&noscript=1"/>
 </noscript>
 <!-- End Facebook Pixel Code -->
 <% end %>

--- a/config/environments/shared_deployment_config.rb
+++ b/config/environments/shared_deployment_config.rb
@@ -74,8 +74,8 @@ Rails.application.configure do
 
   config.action_mailer.delivery_method = :mailgun
   config.action_mailer.mailgun_settings = {
-    api_key: EnvironmentCredentials.dig(:mailgun, :api_key),
-    domain: EnvironmentCredentials.dig(:mailgun, :domain)
+    api_key: EnvironmentCredentials['MAILGUN_API_KEY'],
+    domain: EnvironmentCredentials['MAILGUN_DOMAIN']
   }
   config.action_mailer.perform_caching = false
 

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -87,7 +87,7 @@ search:
 translation:
 #   # Google Translate
 #   # Get an API key and set billing info at https://code.google.com/apis/console to use Google Translate
-  google_translate_api_key: <%#Rails.application.credentials.dig(:google_translate_api_key)%>
+  google_translate_api_key: <%#EnvironmentalCredentials['GOOGLE_TRANSLATE_API_KEY']%>
 #   # DeepL Pro Translate
 #   # Get an API key and subscription at https://www.deepl.com/pro to use DeepL Pro
 #   deepl_api_key: "48E92789-57A3-466A-9959-1A1A1A1A1A1A"

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -87,7 +87,7 @@ search:
 translation:
 #   # Google Translate
 #   # Get an API key and set billing info at https://code.google.com/apis/console to use Google Translate
-  google_translate_api_key: <%#EnvironmentalCredentials['GOOGLE_TRANSLATE_API_KEY']%>
+  google_translate_api_key: <%#EnvironmentCredentials['GOOGLE_TRANSLATE_API_KEY']%>
 #   # DeepL Pro Translate
 #   # Get an API key and subscription at https://www.deepl.com/pro to use DeepL Pro
 #   deepl_api_key: "48E92789-57A3-466A-9959-1A1A1A1A1A1A"

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,13 +1,16 @@
-Datadog.configure do |c|
-  c.service = 'getyourrefund-app'
-  c.env = Rails.env
-  c.agent.host = EnvironmentalCredentials['DATADOG_AGENT_HOST']
-  enable_tracing = Rails.env.staging? || Rails.env.demo? || Rails.env.production?
-  c.tracing.enabled = enable_tracing
-  if enable_tracing
-    c.tracing.instrument :rails
-    c.tracing.instrument :aws
-    c.tracing.instrument :delayed_job
-    c.tracing.instrument :http
+Rails.application.config.to_prepare do
+  Datadog.configure do |c|
+    c.service = 'getyourrefund-app'
+    c.env = Rails.env
+    c.agent.host = EnvironmentCredentials['DATADOG_AGENT_HOST']
+    enable_tracing = Rails.env.staging? || Rails.env.demo? || Rails.env.production?
+    c.tracing.enabled = enable_tracing
+    if enable_tracing
+      c.tracing.instrument :rails
+      c.tracing.instrument :aws
+      c.tracing.instrument :delayed_job
+      c.tracing.instrument :http
+   
+    end
   end
 end

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,7 +1,7 @@
 Datadog.configure do |c|
   c.service = 'getyourrefund-app'
   c.env = Rails.env
-  c.agent.host = Rails.application.credentials.dig(:datadog_agent_host)
+  c.agent.host = EnvironmentalCredentials['DATADOG_AGENT_HOST']
   enable_tracing = Rails.env.staging? || Rails.env.demo? || Rails.env.production?
   c.tracing.enabled = enable_tracing
   if enable_tracing

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -16,6 +16,7 @@ begin
   Flipper.disable :show_retirement_ui unless Flipper.exist?(:show_retirement_ui)
   Flipper.disable :sms_notifications unless Flipper.exist?(:sms_notifications)
   Flipper.disable :use_pundit unless Flipper.exist?(:use_pundit)
+  Flipper.disable :use_env_secrets unless Flipper.exist?(:use_env_secrets)
   if Rails.env.heroku? || Rails.env.demo?
     Flipper.disable :prevent_duplicate_accepted_statefile_submissions unless Flipper.exist?(:prevent_duplicate_accepted_statefile_submissions)
     Flipper.disable :prevent_duplicate_ssn_messaging unless Flipper.exist?(:prevent_duplicate_ssn_messaging)

--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -1,4 +1,6 @@
-Recaptcha.configure do |config|
-  config.site_key = Rails.env.test? ? "test_key" : EnvironmentCredentials['RECAPTCHA_SITE_KEY']
-  config.secret_key = Rails.env.test? ? "test_key" : EnvironmentCredentials['RECAPTCHA_SECRET_KEY']
+Rails.application.config.to_prepare do
+  Recaptcha.configure do |config|
+    config.site_key = Rails.env.test? ? "test_key" : EnvironmentCredentials['RECAPTCHA_SITE_KEY']
+    config.secret_key = Rails.env.test? ? "test_key" : EnvironmentCredentials['RECAPTCHA_SECRET_KEY']
+  end
 end

--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -1,4 +1,4 @@
 Recaptcha.configure do |config|
-  config.site_key = Rails.env.test? ? "test_key" : EnvironmentalCredentials['RECAPTCHA_SITE_KEY']
-  config.secret_key = Rails.env.test? ? "test_key" : EnvironmentalCredentials['RECAPTCHA_SECRET_KEY']
+  config.site_key = Rails.env.test? ? "test_key" : EnvironmentCredentials['RECAPTCHA_SITE_KEY']
+  config.secret_key = Rails.env.test? ? "test_key" : EnvironmentCredentials['RECAPTCHA_SECRET_KEY']
 end

--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -1,4 +1,4 @@
 Recaptcha.configure do |config|
-  config.site_key = Rails.env.test? ? "test_key" : Rails.application.credentials.dig(:recaptcha, :site_key)
-  config.secret_key = Rails.env.test? ? "test_key" : Rails.application.credentials.dig(:recaptcha, :secret_key)
+  config.site_key = Rails.env.test? ? "test_key" : EnvironmentalCredentials['RECAPTCHA_SITE_KEY']
+  config.secret_key = Rails.env.test? ? "test_key" : EnvironmentalCredentials['RECAPTCHA_SECRET_KEY']
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,31 +1,33 @@
-Sentry.init do |config|
-  config.dsn = EnvironmentalCredentials['SENTRY_DSN']
-  config.enabled_environments = %w(production staging demo)
+Rails.application.config.to_prepare do
+  Sentry.init do |config|
+    config.dsn = EnvironmentCredentials['SENTRY_DSN']
+    config.enabled_environments = %w(production staging demo)
 
-  config.before_send = lambda do |event, _hint|
+    config.before_send = lambda do |event, _hint|
 
-    if event.request
-      safe_request = {
-        method: event.request[:method],
-        url: event.request[:url]&.split('?')&.first&.gsub(/\/\d+/, '/:id'),
-      }
-      event.request = safe_request
+      if event.request
+        safe_request = {
+          method: event.request[:method],
+          url: event.request[:url]&.split('?')&.first&.gsub(%r{/\d+}, '/:id'),
+        }
+        event.request = safe_request
+      end
+
+      event.breadcrumbs = Sentry::BreadcrumbBuffer.new(0) if event.breadcrumbs
+
+      event.user = {}
+
+      event.extra&.clear
+
+      event.tags&.delete_if { |key, _| ![:environment, :server_name, :ruby_version, :rails_version].include?(key.to_sym) }
+
+      event
     end
 
-    event.breadcrumbs = Sentry::BreadcrumbBuffer.new(0) if event.breadcrumbs
-
-    event.user = {}
-
-    event.extra&.clear
-
-    event.tags&.delete_if { |key, _| ![:environment, :server_name, :ruby_version, :rails_version].include?(key.to_sym) }
-
-    event
+    config.excluded_exceptions = Sentry::Configuration::IGNORE_DEFAULT + Sentry::Rails::IGNORE_DEFAULT + %w(
+      ActionController::UnknownFormat
+      ActionDispatch::RemoteIp::IpSpoofAttackError
+      Puma::HttpParserError
+    )
   end
-
-  config.excluded_exceptions = Sentry::Configuration::IGNORE_DEFAULT + Sentry::Rails::IGNORE_DEFAULT + %w(
-    ActionController::UnknownFormat
-    ActionDispatch::RemoteIp::IpSpoofAttackError
-    Puma::HttpParserError
-  )
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,5 @@
 Sentry.init do |config|
-  config.dsn = Rails.application.credentials.dig(:sentry_dsn)
+  config.dsn = EnvironmentalCredentials['SENTRY_DSN']
   config.enabled_environments = %w(production staging demo)
 
   config.before_send = lambda do |event, _hint|

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,7 +1,7 @@
 deploy_default: &deploy_default
   service: S3
-  access_key_id: <%= EnvironmentalCredentials['AWS_ACCESS_KEY_ID'] %>
-  secret_access_key: <%= EnvironmentalCredentials['AWS_SECRET_ACCESS_KEY'] %>
+  access_key_id: <%= EnvironmentCredentials['AWS_ACCESS_KEY_ID'] %>
+  secret_access_key: <%= EnvironmentCredentials['AWS_SECRET_ACCESS_KEY'] %>
   region: us-east-1
 
 test:
@@ -41,7 +41,7 @@ s3_heroku:
 # microsoft:
 #   service: AzureStorage
 #   storage_account_name: your_account_name
-#   storage_access_key: <%= EnvironmentalCredentials['AZURE_STORAGE_STORAGE_ACCESS_KEY'] %>
+#   storage_access_key: <%= EnvironmentCredentials['AZURE_STORAGE_STORAGE_ACCESS_KEY'] %>
 #   container: your_container_name
 
 # mirror:

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,7 +1,7 @@
 deploy_default: &deploy_default
   service: S3
-  access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-  secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
+  access_key_id: <%= EnvironmentalCredentials['AWS_ACCESS_KEY_ID'] %>
+  secret_access_key: <%= EnvironmentalCredentials['AWS_SECRET_ACCESS_KEY'] %>
   region: us-east-1
 
 test:
@@ -41,7 +41,7 @@ s3_heroku:
 # microsoft:
 #   service: AzureStorage
 #   storage_account_name: your_account_name
-#   storage_access_key: <%= Rails.application.credentials.dig(:azure_storage, :storage_access_key) %>
+#   storage_access_key: <%= EnvironmentalCredentials['AZURE_STORAGE_STORAGE_ACCESS_KEY'] %>
 #   container: your_container_name
 
 # mirror:

--- a/lib/tasks/outgoing_messages.rake
+++ b/lib/tasks/outgoing_messages.rake
@@ -1,7 +1,7 @@
 namespace :outgoing_messages do
   def backfill_mailgun_statuses
     # The global API key, not the same as EnvironmentCredentials.dig(:mailgun, :api_key)
-    mg_client = Mailgun::Client.new(ENV['MAILGUN_API_KEY'] || EnvironmentCredentials.dig(:mailgun, :api_key))
+    mg_client = Mailgun::Client.new(EnvironmentCredentials['MAILGUN_API_KEY'])
     OutgoingEmail
       .where(mailgun_status: 'sending')
       .where.not(message_id: nil)

--- a/spec/controllers/concerns/state_file/irs_data_transfer_links_concern_spec.rb
+++ b/spec/controllers/concerns/state_file/irs_data_transfer_links_concern_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe StateFile::IrsDataTransferLinksConcern, type: :controller do
 
   describe "#irs_df_transfer_link" do
     before do
-      allow(EnvironmentCredentials).to receive(:dig).with("statefile", "df_transfer_auth").and_return "https://example.df.gov/auth-state"
+      allow(EnvironmentCredentials).to receive(:[]).with('STATEFILE_DF_TRANSFER_AUTH').and_return "https://example.df.gov/auth-state"
     end
 
     it "returns link" do

--- a/spec/features/web_intake/menu_spec.rb
+++ b/spec/features/web_intake/menu_spec.rb
@@ -6,13 +6,13 @@ RSpec.feature "Menu spec", js: true do
     visit "/"
     within ".toolbar" do
       # TODO: address why this fails locally; the resize_window_to_mobile will not size width < 500px
-      expect(page).not_to have_selector("a", text: "Login")
+      expect(page).not_to have_css("a", text: "Login")
     end
     within ".toolbar" do
-      expect(page).to have_selector("[data-component='ClientMenuTrigger']", text: "Menu")
+      expect(page).to have_css("[data-component='ClientMenuTrigger']", text: "Menu")
       find("[data-component='ClientMenuTrigger']").click
     end
-    expect(page).to have_selector("a", text: "Login")
+    expect(page).to have_css("a", text: "Login")
   end
 
   scenario "menu when desktop" do
@@ -20,7 +20,7 @@ RSpec.feature "Menu spec", js: true do
 
     visit "/"
     within ".toolbar" do
-      expect(page).to have_selector("a", text: "Login")
+      expect(page).to have_css("a", text: "Login")
     end
   end
 end

--- a/spec/jobs/state_file/import_from_direct_file_job_spec.rb
+++ b/spec/jobs/state_file/import_from_direct_file_job_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe StateFile::ImportFromDirectFileJob, type: :job do
         expect(intake.dependents.count).to eq(3)
         expected_hashed_ssn = OpenSSL::HMAC.hexdigest(
           "SHA256",
-          EnvironmentCredentials.dig(:duplicate_hashing_key),
+          EnvironmentCredentials['DUPLICATE_HASHING_KEY'],
           "ssn|400000010"
         )
         expect(intake.hashed_ssn).to eq expected_hashed_ssn

--- a/spec/lib/environment_credentials_spec.rb
+++ b/spec/lib/environment_credentials_spec.rb
@@ -1,6 +1,73 @@
 require "rails_helper"
 
 RSpec.describe EnvironmentCredentials do
+  describe ".[]" do
+    let(:mock_credentials) do
+      {
+        mailgun: {
+          api_key: "mailgun-key",
+          domain: "mg.example.com",
+        },
+        twilio: {
+          voice_phone_number: "+15551234567",
+        },
+        duplicate_hashing_key: "hash-key",
+      }
+    end
+
+    before do
+      allow(Rails.application).to receive(:credentials).and_return(mock_credentials)
+      allow(ENV).to receive(:[]).and_call_original
+    end
+
+    context "when flipper flag is disabled (default)" do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:use_env_secrets).and_return(false)
+      end
+
+      it "returns the value from Rails credentials" do
+        expect(EnvironmentCredentials['MAILGUN_API_KEY']).to eq("mailgun-key")
+      end
+
+      it "returns the value for a single-level credential key" do
+        expect(EnvironmentCredentials['DUPLICATE_HASHING_KEY']).to eq("hash-key")
+      end
+
+      it "returns nil for unknown keys" do
+        expect(EnvironmentCredentials['NONEXISTENT_KEY']).to be_nil
+      end
+
+      it "returns nil when both ENV and credentials are missing" do
+        expect(EnvironmentCredentials['MAILGUN_NONEXISTENT_KEY']).to be_nil
+      end
+
+      it "uses SECRET_KEYS mapping for non-obvious names" do
+        allow(Rails.application).to receive(:credentials).and_return({ irs: { efin: "123456" } })
+        expect(EnvironmentCredentials['VITA_MIN_EFIN']).to eq("123456")
+      end
+    end
+
+    context "when flipper flag is enabled" do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:use_env_secrets).and_return(true)
+      end
+
+      it "returns the value from ENV" do
+        allow(ENV).to receive(:fetch).with('MAILGUN_API_KEY', nil).and_return("env-key")
+        expect(EnvironmentCredentials['MAILGUN_API_KEY']).to eq("env-key")
+      end
+
+      it "returns nil when ENV value is not set (no credential fallback)" do
+        allow(ENV).to receive(:[]).with('MAILGUN_API_KEY').and_return(nil)
+        expect(EnvironmentCredentials['MAILGUN_API_KEY']).to be_nil
+      end
+
+      it "returns nil for unknown keys" do
+        expect(EnvironmentCredentials['NONEXISTENT_KEY']).to be_nil
+      end
+    end
+  end
+
   describe ".dig" do
     let(:mock_credentials) do
       {

--- a/spec/lib/submission_builder/ty2021/return1040_spec.rb
+++ b/spec/lib/submission_builder/ty2021/return1040_spec.rb
@@ -84,7 +84,15 @@ describe SubmissionBuilder::Ty2021::Return1040, required_schema: "federal" do
 
     context "schedule EIC" do
       before do
-        allow(Flipper).to receive(:enabled?).with(:eitc).and_return(true)
+        allow(Flipper).to receive(:enabled?) do |arg| 
+          case arg
+          in :eitc
+            true
+          in :use_env_secrets
+            false
+          end
+        end
+
         submission.intake.update(
           claim_eitc: "yes",
           exceeded_investment_income_limit: "no",

--- a/spec/lib/submission_builder/ty2022/states/return_header_spec.rb
+++ b/spec/lib/submission_builder/ty2022/states/return_header_spec.rb
@@ -26,6 +26,9 @@ describe SubmissionBuilder::ReturnHeader do
           allow(EnvironmentCredentials).to receive(:irs).with(:efin).and_return efin
           software_id = StateFile::StateInformationService.software_id_key(state_code).to_sym
           allow(EnvironmentCredentials).to receive(:irs).with(software_id).and_return sin
+          # allow(EnvironmentCredentials).to receive(:[]).with('VITA_MIN_EFIN').and_return efin
+          # software_id_env_var = StateFile::StateInformationService.software_id_key(state_code) == "md_sin" ? "MD_SIN" : "VITA_MIN_SIN"
+          # allow(EnvironmentCredentials).to receive(:[]).with(software_id_env_var).and_return sin
         end
 
         it "generates xml with the right values" do

--- a/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
+++ b/spec/lib/submission_builder/ty2024/states/nj/documents/nj1040_spec.rb
@@ -442,7 +442,14 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
 
     describe "disabled show_retirement_ui flag" do
       before do
-        allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(false)
+        allow(Flipper).to receive(:enabled?) do |arg| 
+          case arg
+          in :show_retirement_ui
+            false
+          in :use_env_secrets
+            false
+          end
+        end
       end
 
       it "does not show line 20a PensAnnuitAndIraWithdraw even when there is a value" do
@@ -463,7 +470,14 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
 
     describe "taxable retirement income - line 20a" do
       before do
-        allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)
+        allow(Flipper).to receive(:enabled?) do |arg| 
+          case arg
+          in :show_retirement_ui
+            true
+          in :use_env_secrets
+            false
+          end
+        end
       end
 
       context "when applicable taxable retirement income exists" do
@@ -484,7 +498,14 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
 
     describe "excludable retirement income - line 20b" do
       before do
-        allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)
+        allow(Flipper).to receive(:enabled?) do |arg| 
+          case arg
+          in :show_retirement_ui
+            true
+          in :use_env_secrets
+            false
+          end
+        end
       end
 
       context "when applicable excludable retirement income exists" do
@@ -522,7 +543,14 @@ describe SubmissionBuilder::Ty2024::States::Nj::Documents::Nj1040, required_sche
 
     describe "Pension/Retirement Exclusion - line 28a" do
       before do
-        allow(Flipper).to receive(:enabled?).with(:show_retirement_ui).and_return(true)
+        allow(Flipper).to receive(:enabled?) do |arg| 
+          case arg
+          in :show_retirement_ui
+            true
+          in :use_env_secrets
+            false
+          end
+        end
       end
 
       context "when line 28a has a value" do

--- a/spec/models/efile_submission_spec.rb
+++ b/spec/models/efile_submission_spec.rb
@@ -51,7 +51,7 @@ describe EfileSubmission do
 
       it "the first 6 digits are our 6 digit EFIN" do
         submission.generate_irs_submission_id!
-        expect(submission.irs_submission_id[0..5]).to eq EnvironmentCredentials.dig(:irs, :efin)
+        expect(submission.irs_submission_id[0..5]).to eq EnvironmentCredentials['VITA_MIN_EFIN']
       end
 
       it "the next 7 digits are a date in format ccyyddd" do
@@ -62,7 +62,7 @@ describe EfileSubmission do
       context "dealing with duplicates" do
         before do
           allow(SecureRandom).to receive(:base36).with(7).and_return "1234567"
-          create :efile_submission, irs_submission_id: "#{EnvironmentCredentials.dig(:irs, :efin)}20220011234567"
+          create :efile_submission, irs_submission_id: "#{EnvironmentCredentials['VITA_MIN_EFIN']}20220011234567"
         end
 
         context "after trying 5 times" do

--- a/spec/services/intercom_service_spec.rb
+++ b/spec/services/intercom_service_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe IntercomService do
     allow(fake_intercom.conversations).to receive(:reply)
 
     @test_environment_credentials.merge!(intercom: { intercom_access_token: "fake_access_token", secure_mode_secret_key: "a-fake-key-to-use-for-hashing" })
+    allow(EnvironmentCredentials).to receive(:[]) do |arg| 
+      case arg
+      in "INTERCOM_ACCESS_TOKEN"
+        "fake_access_token"
+      in "SECURE_MODE_SECRET_KEY"
+        "a-fake-key-to-use-for-hashing"
+      end
+    end
     allow(Intercom::Client).to receive(:new).with(token: "fake_access_token").and_return(fake_intercom)
     described_class.instance_variable_set(:@intercom, nil)
   end
@@ -257,7 +265,7 @@ RSpec.describe IntercomService do
     context "when there's an upstream authentication failure" do
       before do
         allow(fake_intercom.messages).to receive(:create).with(params) {
-          raise Intercom::AuthenticationError.new("fake error")
+          raise Intercom::AuthenticationError, "fake error"
         }
       end
 
@@ -275,7 +283,7 @@ RSpec.describe IntercomService do
         allow(fake_intercom.messages).to receive(:create).with(params) {
           call_count += 1
           if call_count <= 3
-            raise Intercom::AuthenticationError.new("fake error")
+            raise Intercom::AuthenticationError, "fake error"
           end
         }.exactly(4).times
 

--- a/spec/services/intercom_service_spec.rb
+++ b/spec/services/intercom_service_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe IntercomService do
       case arg
       in "INTERCOM_ACCESS_TOKEN"
         "fake_access_token"
-      in "SECURE_MODE_SECRET_KEY"
+      in "INTERCOM_SECURE_MODE_SECRET_KEY"
         "a-fake-key-to-use-for-hashing"
       end
     end


### PR DESCRIPTION
## Link to Jira issue

- https://codeforamerica.atlassian.net/browse/GYR1-1008

## Is PM acceptance required?

- Yes - don't merge until Jira issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main

## What was done?

This is part of a process to move to doppler.
- [x] Take an inventory of doppler secrets
- [x] Implement a thin class to swap between credentials and env var style variables (you are here)
- [ ] Move development to `fnox` and/or `doppler run`
- [ ] Add tofu to support env vars and make sure doppler has valid values for these env vars
- [ ] Turn on a percentage of credential access to use env vars
- [ ] Rotate credentials

## How to test?

This change is mostly cosmetic at this stage, until the flag is turned on. There are tests that should pass and in many cases the application won't boot unless these variables are set. Clicking around where the variables are used should indicate whether or not this was successful.

## Additional notes
Bulk of renaming was done with this script, which wasn't included in source control due to it being a one time thing:

```ruby
#!/usr/bin/env ruby -i

ARGF.each_line do |line| 
  captures = line.match(/Rails.application.credentials.dig\(([a-zA-Z,:_\s)]+)\)/)&.captures

  if captures
    env_var = captures[0].delete(":").gsub(", ", '_').upcase

    puts line.gsub(/Rails.application.credentials.dig\(.+\)/, "EnvironmentCredentials['#{env_var}']")
  else
    puts line
  end
end
```

## Screenshots (visual changes)

- Before

- After

