### PR TITLE
Add new dismissible banner component for fresh look warning on homepage

### DIFF
--- a/app/assets/images/info--purple.svg
+++ b/app/assets/images/info--purple.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="#2206C0" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M12 16V12" stroke="#2206C0" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M12 8H12.01" stroke="#2206C0" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,6 +20,7 @@
 @import "typography";
 @import "components/flash-messages";
 @import "components/banner";
+@import "components/dismissible-banner";
 @import "components/accordion";
 @import 'components/breadcrumb';
 @import "components/form-molecules";

--- a/app/assets/stylesheets/components/_dismissible-banner.scss
+++ b/app/assets/stylesheets/components/_dismissible-banner.scss
@@ -19,6 +19,13 @@
 
   &__text {
     flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  &__header {
+    font-weight: $font-weight-bold;
   }
 
   &__close {

--- a/app/assets/stylesheets/components/_dismissible-banner.scss
+++ b/app/assets/stylesheets/components/_dismissible-banner.scss
@@ -1,0 +1,32 @@
+.dismissible-banner {
+  padding: 1rem 2rem;
+  border-radius: var(--radius-sm, 4px);
+  border: 1px solid var(--border-informational, #1B059A);
+  background: var(--shade-informational, #F4F3FC);
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+
+  &.is-hidden {
+    display: none;
+  }
+
+  img {
+    flex-shrink: 0;
+    margin-right: 0.75rem;
+  }
+
+  &__text {
+    flex: 1;
+  }
+
+  &__close {
+    background: none;
+    border: none;
+    font-size: 3rem; // size of X
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 0.5rem;
+    flex-shrink: 0;
+  }
+}

--- a/app/assets/stylesheets/components/_dismissible-banner.scss
+++ b/app/assets/stylesheets/components/_dismissible-banner.scss
@@ -6,6 +6,7 @@
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
+  font-size: 16px;
 
   &.is-hidden {
     display: none;

--- a/app/javascript/lib/dismissible_banner.js
+++ b/app/javascript/lib/dismissible_banner.js
@@ -1,0 +1,25 @@
+const STORAGE_KEY_PREFIX = "dismissibleBannerDismissed:";
+
+function initDismissibleBanner() {
+    const banners = document.querySelectorAll("[data-dismissible-banner]");
+
+    banners.forEach((banner) => {
+        const bannerId = banner.dataset.dismissibleBannerId || "default";
+        const storageKey = `${STORAGE_KEY_PREFIX}${bannerId}`;
+
+        if (localStorage.getItem(storageKey) === "true") {
+            banner.classList.add("is-hidden");
+            return;
+        }
+
+        const closeBtn = banner.querySelector("[data-dismissible-banner-close]");
+        if (!closeBtn) return;
+
+        closeBtn.addEventListener("click", () => {
+            banner.classList.add("is-hidden");
+            localStorage.setItem(storageKey, "true");
+        });
+    });
+}
+
+export { initDismissibleBanner };

--- a/app/javascript/listeners/index.js
+++ b/app/javascript/listeners/index.js
@@ -9,7 +9,7 @@ import { initStateRoutingsListeners } from "../lib/state_routings";
 import tooltip from "../components/tooltip";
 import { initTaggableNote, initMultiSelectVitaPartner, initMultiSelectState, initSelectVitaPartner } from '../lib/tagging';
 import { initBulkAction } from "../lib/bulk_action";
-import { getEfileSecurityInformation } from "../lib/efile_security_information";``
+import { getEfileSecurityInformation } from "../lib/efile_security_information";
 import { initTINTypeSelector } from "../lib/tin_type_selector";
 import { addTargetBlankToLinks } from "../lib/action_text_target_blank";
 import { limitTextMessageLength } from "../lib/text_message_length_limiter";
@@ -20,6 +20,7 @@ import ClientMenuComponent from "../components/ClientMenuComponent";
 import WarningForSelectComponent from "../components/WarningForSelectComponent";
 import MixpanelEventTracking from "../lib/mixpanel_event_tracking";
 import IntercomBehavior from "../lib/intercom_behavior";
+import { initDismissibleBanner } from "../lib/dismissible_banner";
 const Listeners =  (function(){
     return {
         init: function () {
@@ -67,6 +68,9 @@ const Listeners =  (function(){
 
                 if (document.querySelector('.taggable-note')) {
                     initTaggableNote();
+                }
+                if (document.querySelector('[data-dismissible-banner]')) {
+                    initDismissibleBanner();
                 }
                 if (document.querySelector('.multi-select-vita-partner')) {
                     initMultiSelectVitaPartner();

--- a/app/views/public_pages/home.html.erb
+++ b/app/views/public_pages/home.html.erb
@@ -10,7 +10,7 @@
   <div class="slab slab--hero slab--gyr-green">
     <div class="grid">
       <%= render "shared/dismissible_banner", banner_id: "fresh-look", banner_content: t("views.public_pages.home.fresh_look_banner_html") %>
-      <div class="grid__item width-one-half">
+      <div class="grid__item width-one-half spacing-above-25">
         <h1>
           <%= t("views.public_pages.home.header") %>
         </h1>

--- a/app/views/public_pages/home.html.erb
+++ b/app/views/public_pages/home.html.erb
@@ -9,7 +9,10 @@
 <div class="main-content-inner">
   <div class="slab slab--hero slab--gyr-green">
     <div class="grid">
-      <%= render "shared/dismissible_banner", banner_id: "fresh-look", banner_content: t("views.public_pages.home.fresh_look_banner_html") %>
+      <%= render "shared/dismissible_banner",
+                 banner_id: "fresh-look",
+                 banner_header: t("views.public_pages.home.fresh_look_banner.header"),
+                 banner_body: t("views.public_pages.home.fresh_look_banner.body") %>
       <div class="grid__item width-one-half spacing-above-25">
         <h1>
           <%= t("views.public_pages.home.header") %>

--- a/app/views/public_pages/home.html.erb
+++ b/app/views/public_pages/home.html.erb
@@ -9,6 +9,7 @@
 <div class="main-content-inner">
   <div class="slab slab--hero slab--gyr-green">
     <div class="grid">
+      <%= render "shared/dismissible_banner", banner_id: "fresh-look", banner_content: t("views.public_pages.home.fresh_look_banner_html") %>
       <div class="grid__item width-one-half">
         <h1>
           <%= t("views.public_pages.home.header") %>

--- a/app/views/shared/_dismissible_banner.html.erb
+++ b/app/views/shared/_dismissible_banner.html.erb
@@ -1,7 +1,9 @@
 <div class="dismissible-banner" data-dismissible-banner data-dismissible-banner-id="<%= local_assigns[:banner_id] || "default" %>">
   <%= image_tag('info--purple.svg', alt: "") %>
-  <span class="dismissible-banner__text">
-    <%= banner_content %>
-  </span>
+
+  <div class="dismissible-banner__text">
+    <div class="dismissible-banner__header"><%= banner_header %></div>
+    <div><%= banner_body %></div>
+  </div>
   <button type="button" class="dismissible-banner__close" data-dismissible-banner-close aria-label="Dismiss banner">&times;</button>
 </div>

--- a/app/views/shared/_dismissible_banner.html.erb
+++ b/app/views/shared/_dismissible_banner.html.erb
@@ -1,0 +1,7 @@
+<div class="dismissible-banner" data-dismissible-banner data-dismissible-banner-id="<%= local_assigns[:banner_id] || "default" %>">
+  <%= image_tag('info--purple.svg', alt: "") %>
+  <span class="dismissible-banner__text">
+    <%= banner_content %>
+  </span>
+  <button type="button" class="dismissible-banner__close" data-dismissible-banner-close aria-label="Dismiss banner">&times;</button>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5266,7 +5266,7 @@ en:
         faq:
           faq_cta: Read our FAQ
           header: 'Common Tax Questions:'
-        fresh_look_banner_html: "<strong>A fresh look is coming to GetYourRefund.</strong> Coming in mid August, you'll see a new design, same trusted service."
+        fresh_look_banner_html: "<strong>A fresh look is coming to GetYourRefund.</strong> Coming in mid-August, you'll see a new design, same trusted service."
         header: Free tax filing, made simple.
         open_intake_post_tax_deadline_banner: Get started with GetYourRefund by %{end_of_intake} if you want to file with us in %{product_year}. If your return is in progress, sign in and submit your documents by %{end_of_docs}.
         security:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5266,7 +5266,9 @@ en:
         faq:
           faq_cta: Read our FAQ
           header: 'Common Tax Questions:'
-        fresh_look_banner_html: "<strong>A fresh look is coming to GetYourRefund.</strong> Coming in mid-August, you'll see a new design, same trusted service."
+        fresh_look_banner:
+          body: Coming in mid-August, you'll see a new design, same trusted service.
+          header: A fresh look is coming to GetYourRefund
         header: Free tax filing, made simple.
         open_intake_post_tax_deadline_banner: Get started with GetYourRefund by %{end_of_intake} if you want to file with us in %{product_year}. If your return is in progress, sign in and submit your documents by %{end_of_docs}.
         security:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5266,6 +5266,7 @@ en:
         faq:
           faq_cta: Read our FAQ
           header: 'Common Tax Questions:'
+        fresh_look_banner_html: "<strong>A fresh look is coming to GetYourRefund.</strong> Coming in mid August, you'll see a new design, same trusted service."
         header: Free tax filing, made simple.
         open_intake_post_tax_deadline_banner: Get started with GetYourRefund by %{end_of_intake} if you want to file with us in %{product_year}. If your return is in progress, sign in and submit your documents by %{end_of_docs}.
         security:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -5242,7 +5242,9 @@ es:
         faq:
           faq_cta: Lee nuestras preguntas frecuentes
           header: 'Preguntas frecuentes:'
-        fresh_look_banner_html: "<strong>GetYourRefund tendrá un nuevo diseño.</strong> En agosto verás un nuevo diseño de nuestra página. Seguirás contando con el mismo servicio de confianza de siempre."
+        fresh_look_banner:
+          body: En agosto verás un nuevo diseño de nuestra página. Seguirás contando con el mismo servicio de confianza de siempre.
+          header: GetYourRefund tendrá un nuevo diseño
         header: Declare sus impuestos sin costo. ¡Es sencillo!
         open_intake_post_tax_deadline_banner: Comience con GetYourRefund antes del %{end_of_intake} si desea presentar su declaración con nosotros en %{product_year}. Si su declaración está en progreso, inicie sesión y envíe sus documentos antes del %{end_of_docs}.
         security:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -5242,6 +5242,7 @@ es:
         faq:
           faq_cta: Lee nuestras preguntas frecuentes
           header: 'Preguntas frecuentes:'
+        fresh_look_banner_html: "<strong>GetYourRefund tendrá un nuevo diseño.</strong> En agosto verás un nuevo diseño de nuestra página. Seguirás contando con el mismo servicio de confianza de siempre."
         header: Declare sus impuestos sin costo. ¡Es sencillo!
         open_intake_post_tax_deadline_banner: Comience con GetYourRefund antes del %{end_of_intake} si desea presentar su declaración con nosotros en %{product_year}. Si su declaración está en progreso, inicie sesión y envíe sus documentos antes del %{end_of_docs}.
         security:


### PR DESCRIPTION
## Link to Jira issue

- https://codeforamerica.atlassian.net/browse/GYR1-1087

## Is PM acceptance required?

- Yes - don't merge until Jira issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main

## What was done?

- Added new dismissible banner component
- Used dismissible banner component for fresh look in August warning
- the dismissal is tied to local storage on the browser, which means it'll persist per browser/per device indefinitely (until something clears it)

## How to test?

- go to the homepage
- click "X" on the banner and see it disappear 

## Screenshots (visual changes)

- Before
<img width="1105" height="660" alt="Screenshot 2026-07-28 at 5 25 20 PM" src="https://github.com/user-attachments/assets/70ecdc8b-2cd5-4b3c-ad13-f8a23245ad59" />


- After
<img width="1064" height="641" alt="Screenshot 2026-07-28 at 5 25 47 PM" src="https://github.com/user-attachments/assets/578b98d9-93f8-4d80-9bfb-e4d388f286cb" />

