### PR TITLE
Add flag toggles on client index page

### DIFF
--- a/app/views/hub/clients/index.html.erb
+++ b/app/views/hub/clients/index.html.erb
@@ -79,7 +79,11 @@
         <% @clients.with_eager_loaded_associations.map { |client| Hub::ClientsController::HubClientPresenter.new(client, @related_models_cache) }.each do |client| %>
           <tr id="client-<%= client.id %>" class="index-table__row client-row">
             <td class="index-table__cell client-attribute__needs-response">
-              <%= render "shared/urgent_icon", client: client %>
+              <label class="toggle-switch flag-toggle">
+                <span class="sr-only"><%= t("general.flagged") %></span>
+                <input type="checkbox" id="toggle-flag-<%= client.id %>" data-url="<%= flag_hub_client_path(client) %>" <%= "checked" if client.flagged? %> onchange="toggleClientFlag(this)">
+                <span class="slider round"></span>
+              </label>
             </td>
             <%= tag.td(
               scope: "row",
@@ -181,4 +185,28 @@
       </div>
     </section>
   </div>
+<% end %>
+
+<% content_for :script do %>
+  <script>
+      function toggleClientFlag(checkbox) {
+          const isChecked = checkbox.checked;
+          const action = isChecked ? "set" : "clear";
+          const url = checkbox.dataset.url;
+
+          fetch(url, {method: "PATCH", redirect: "manual",
+              headers: {
+                  "Content-Type": "application/json",
+                  "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content
+              },
+              body: JSON.stringify({ client: { action: action } })
+          }).then(function(response) {
+              if (!response.ok && response.type !== "opaqueredirect") {
+                  checkbox.checked = !isChecked;
+              }
+          }).catch(function() {
+              checkbox.checked = !isChecked;
+          });
+      }
+  </script>
 <% end %>

--- a/spec/controllers/hub/clients_controller_spec.rb
+++ b/spec/controllers/hub/clients_controller_spec.rb
@@ -386,12 +386,12 @@ RSpec.describe Hub::ClientsController do
         context "when a client is flagged" do
           before { tobias.touch(:flagged_at) }
 
-          it "adds the flagged icon into the DOM" do
+          it "shows the flag toggle as checked only for the flagged client" do
             get :index
 
             html = Nokogiri::HTML.parse(response.body)
-            expect(html.at_css("#client-#{michael.id}")).not_to have_css("i.urgent")
-            expect(html.at_css("#client-#{tobias.id}")).to have_css("i.urgent")
+            expect(html.at_css("#toggle-flag-#{michael.id}")["checked"]).to be_nil
+            expect(html.at_css("#toggle-flag-#{tobias.id}")["checked"]).to eq("checked")
           end
         end
 


### PR DESCRIPTION
## Link to Jira issue

- https://codeforamerica.atlassian.net/browse/GYR1-1091

## Is PM acceptance required?

- Yes - don't merge until Jira issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main

## What was done?

- Add toggle instead of red dot for each client on the client index page

## How to test?

- go to `/hub/clients` and test the toggle to see if it updates the flag status on the client

## Screenshots (visual changes)

- Before
<img width="1208" height="628" alt="Screenshot 2026-07-30 at 3 00 27 PM" src="https://github.com/user-attachments/assets/b8985106-d1a8-4b16-8de1-17cc88283963" />


- After
<img width="1138" height="611" alt="Screenshot 2026-07-30 at 3 00 01 PM" src="https://github.com/user-attachments/assets/bbf9b52b-fb30-4e84-88c3-623bd185eec2" />
