### PR TITLE
GYR1-1173 Datadog fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,8 +53,7 @@ gem 'lograge'
 gem 'fix-db-schema-conflicts', require: false
 gem 'valid_email2', '~> 4.0.6' # test failures on 5.x, try again if you're bold
 gem 'auto_strip_attributes'
-# gemn 'ddtrace', '~> 1.9.0', next_version: '~> 2.2.0', next_name: 'datadog'
-gem 'datadog', '~> 2.40.0', require: 'datadog/auto_instrument'
+gem 'datadog', '~> 2.41.0', require: 'datadog/auto_instrument'
 gem 'dogapi'
 gem 'http_accept_language'
 gem 'rails-i18n'

--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem 'fix-db-schema-conflicts', require: false
 gem 'valid_email2', '~> 4.0.6' # test failures on 5.x, try again if you're bold
 gem 'auto_strip_attributes'
 # gemn 'ddtrace', '~> 1.9.0', next_version: '~> 2.2.0', next_name: 'datadog'
-gem 'datadog', '~> 2.32.0'
+gem 'datadog', '~> 2.40.0', require: 'datadog/auto_instrument'
 gem 'dogapi'
 gem 'http_accept_language'
 gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,14 +205,14 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0)
     database_cleaner-core (2.0.1)
-    datadog (2.32.0)
+    datadog (2.40.0)
       cgi
-      datadog-ruby_core_source (~> 3.5, >= 3.5.2)
-      libdatadog (~> 30.0.0.1.0)
+      datadog-ruby_core_source (~> 3.5, >= 3.5.4)
+      libdatadog (~> 36.0.0.1.0)
       libddwaf (~> 1.30.0.0.0)
       logger
       msgpack
-    datadog-ruby_core_source (3.5.3)
+    datadog-ruby_core_source (3.5.4)
     date (3.5.1)
     delayed_job (4.2.0)
       activesupport (>= 3.0, < 9.0)
@@ -359,7 +359,7 @@ GEM
       logger (~> 1.6)
     letter_opener (1.10.0)
       launchy (>= 2.2, < 4)
-    libdatadog (30.0.0.1.0)
+    libdatadog (36.0.0.1.0)
     libddwaf (1.30.0.0.2)
       ffi (~> 1.0)
     listen (3.8.0)
@@ -806,7 +806,7 @@ DEPENDENCIES
   csv (~> 3.3)
   data_migrate (>= 10.0)
   database_cleaner
-  datadog (~> 2.32.0)
+  datadog (~> 2.40.0)
   delayed_job
   delayed_job_active_record
   delayed_job_web

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,10 +205,10 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0)
     database_cleaner-core (2.0.1)
-    datadog (2.40.0)
+    datadog (2.41.0)
       cgi
       datadog-ruby_core_source (~> 3.5, >= 3.5.4)
-      libdatadog (~> 36.0.0.1.0)
+      libdatadog (~> 40.0.0.1.0)
       libddwaf (~> 1.30.0.0.0)
       logger
       msgpack
@@ -359,7 +359,7 @@ GEM
       logger (~> 1.6)
     letter_opener (1.10.0)
       launchy (>= 2.2, < 4)
-    libdatadog (36.0.0.1.0)
+    libdatadog (40.0.0.1.0)
     libddwaf (1.30.0.0.2)
       ffi (~> 1.0)
     listen (3.8.0)
@@ -806,7 +806,7 @@ DEPENDENCIES
   csv (~> 3.3)
   data_migrate (>= 10.0)
   database_cleaner
-  datadog (~> 2.40.0)
+  datadog (~> 2.41.0)
   delayed_job
   delayed_job_active_record
   delayed_job_web

--- a/Gemfile_next.lock
+++ b/Gemfile_next.lock
@@ -207,10 +207,10 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0)
     database_cleaner-core (2.0.1)
-    datadog (2.40.0)
+    datadog (2.41.0)
       cgi
       datadog-ruby_core_source (~> 3.5, >= 3.5.4)
-      libdatadog (~> 36.0.0.1.0)
+      libdatadog (~> 40.0.0.1.0)
       libddwaf (~> 1.30.0.0.0)
       logger
       msgpack
@@ -361,7 +361,7 @@ GEM
       logger (~> 1.6)
     letter_opener (1.10.0)
       launchy (>= 2.2, < 4)
-    libdatadog (36.0.0.1.0)
+    libdatadog (40.0.0.1.0)
     libddwaf (1.30.0.0.2)
       ffi (~> 1.0)
     listen (3.8.0)
@@ -810,7 +810,7 @@ DEPENDENCIES
   csv (~> 3.3)
   data_migrate (>= 10.0)
   database_cleaner
-  datadog (~> 2.40.0)
+  datadog (~> 2.41.0)
   delayed_job
   delayed_job_active_record
   delayed_job_web

--- a/Gemfile_next.lock
+++ b/Gemfile_next.lock
@@ -207,14 +207,14 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0)
     database_cleaner-core (2.0.1)
-    datadog (2.32.0)
+    datadog (2.40.0)
       cgi
-      datadog-ruby_core_source (~> 3.5, >= 3.5.2)
-      libdatadog (~> 30.0.0.1.0)
+      datadog-ruby_core_source (~> 3.5, >= 3.5.4)
+      libdatadog (~> 36.0.0.1.0)
       libddwaf (~> 1.30.0.0.0)
       logger
       msgpack
-    datadog-ruby_core_source (3.5.3)
+    datadog-ruby_core_source (3.5.4)
     date (3.5.1)
     delayed_job (4.2.0)
       activesupport (>= 3.0, < 9.0)
@@ -361,7 +361,7 @@ GEM
       logger (~> 1.6)
     letter_opener (1.10.0)
       launchy (>= 2.2, < 4)
-    libdatadog (30.0.0.1.0)
+    libdatadog (36.0.0.1.0)
     libddwaf (1.30.0.0.2)
       ffi (~> 1.0)
     listen (3.8.0)
@@ -399,7 +399,7 @@ GEM
     minitest (5.27.0)
     mixpanel-ruby (2.3.0)
     moneta (1.0.0)
-    msgpack (1.7.2)
+    msgpack (1.8.4)
     multi_json (1.15.0)
     multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)
@@ -810,7 +810,7 @@ DEPENDENCIES
   csv (~> 3.3)
   data_migrate (>= 10.0)
   database_cleaner
-  datadog (~> 2.32.0)
+  datadog (~> 2.40.0)
   delayed_job
   delayed_job_active_record
   delayed_job_web

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -10,7 +10,7 @@ Rails.application.config.to_prepare do
       c.tracing.instrument :aws
       c.tracing.instrument :delayed_job
       c.tracing.instrument :http
-   
+      c.tracing.instrument :postgis
     end
   end
 end

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -6,11 +6,10 @@ Rails.application.config.to_prepare do
     enable_tracing = Rails.env.staging? || Rails.env.demo? || Rails.env.production?
     c.tracing.enabled = enable_tracing
     if enable_tracing
-      c.tracing.instrument :rails
-      c.tracing.instrument :aws
-      c.tracing.instrument :delayed_job
-      c.tracing.instrument :http
-   
+      c.use :rails
+      c.use :aws
+      c.use :delayed_job
+      c.use :http
     end
   end
 end

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,4 +1,4 @@
-Rails.application.config.to_prepare do
+#Rails.application.config.to_prepare do
   Datadog.configure do |c|
     c.service = 'getyourrefund-app'
     c.env = Rails.env
@@ -6,10 +6,11 @@ Rails.application.config.to_prepare do
     enable_tracing = Rails.env.staging? || Rails.env.demo? || Rails.env.production?
     c.tracing.enabled = enable_tracing
     if enable_tracing
-      c.use :rails
-      c.use :aws
-      c.use :delayed_job
-      c.use :http
+      c.tracing.instrument :rails
+      c.tracing.instrument :aws
+      c.tracing.instrument :delayed_job
+      c.tracing.instrument :http
+   
     end
   end
-end
+#end

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,4 +1,4 @@
-#Rails.application.config.to_prepare do
+Rails.application.config.to_prepare do
   Datadog.configure do |c|
     c.service = 'getyourrefund-app'
     c.env = Rails.env
@@ -13,4 +13,4 @@
    
     end
   end
-#end
+end

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -10,7 +10,7 @@ Rails.application.config.to_prepare do
       c.tracing.instrument :aws
       c.tracing.instrument :delayed_job
       c.tracing.instrument :http
-      c.tracing.instrument :postgis
+   
     end
   end
 end


### PR DESCRIPTION
## Link to Jira issue

- https://codeforamerica.atlassian.net/browse/GYR1-1173

## Is PM acceptance required?

- No - merge after code review approval

## What was done?
This fixes an issue where data for these Datadog trace metrics had stopped 
showing up. (See notes on the ticket.)

- `trace.rails.action_controller`
- `trace.rack.request`
- `trace.rack.request.hits.by_http_status`
- `trace.rack.request.errors.by_http_status`

Details:

- Bumped `datadog` gem to 2.41.0
- On that same line (in the Gemfile), also added this directive:  `require: 'datadog/auto_instrument`
