### PR TITLE
Show new version of portal states design if Flipper flag is enabled

### DIFF
--- a/app/controllers/hub/portal_states_controller.rb
+++ b/app/controllers/hub/portal_states_controller.rb
@@ -8,15 +8,20 @@ module Hub
         PseudoTaxReturn.new(state)
       end
 
-      intake_incomplete_tr_index = @tax_returns.index { |tr| tr.current_state == 'intake_in_progress' }
-      @tax_returns.insert(intake_incomplete_tr_index + 1, PseudoTaxReturn.new('intake_in_progress', current_step: "/documents"))
+      @client_portal_improvements = Flipper.enabled?(:client_portal_improvements)
 
-      signature_tr_index = @tax_returns.index { |tr| tr.current_state == 'review_signature_requested' }
-      @tax_returns.insert(
-        signature_tr_index + 1,
-        PseudoTaxReturn.new('review_signature_requested', primary_has_signed: false, unsigned_8879s: [:some_doc]),
-        PseudoTaxReturn.new('review_signature_requested', primary_has_signed: true, unsigned_8879s: [:some_doc])
-      )
+      unless @client_portal_improvements
+        intake_incomplete_tr_index = @tax_returns.index { |tr| tr.current_state == 'intake_in_progress' }
+        @tax_returns.insert(intake_incomplete_tr_index + 1, PseudoTaxReturn.new('intake_in_progress', current_step: "/documents"))
+
+        signature_tr_index = @tax_returns.index { |tr| tr.current_state == 'review_signature_requested' }
+        @tax_returns.insert(
+          signature_tr_index + 1,
+          PseudoTaxReturn.new('review_signature_requested', primary_has_signed: false, unsigned_8879s: [:some_doc]),
+          PseudoTaxReturn.new('review_signature_requested', primary_has_signed: true, unsigned_8879s: [:some_doc])
+        )
+      end
+
     end
 
     private
@@ -62,7 +67,7 @@ module Hub
       end
 
       def intake
-        OpenStruct.new(current_step: @current_step)
+        OpenStruct.new(current_step: @current_step, pseudo?:true)
       end
 
       def id

--- a/app/helpers/tax_return_card_helper.rb
+++ b/app/helpers/tax_return_card_helper.rb
@@ -129,6 +129,7 @@ module TaxReturnCardHelper
   end
 
   def contact_method_of_last_tax_team_message(intake)
+
     last = MessagePresenter.grouped_messages(intake.client)&.values&.last&.last
     # ^^^ MessagePresenter.grouped_messages returns a map where a key is a datestamp
     # and a value is an array of messages for that date
@@ -199,6 +200,7 @@ module TaxReturnCardHelper
         button_type: :message_tax_team,
         return_status: state
       }
+      # Added pseudo check to skip Contact Method calls in event of PseudoTaxReturn
     elsif [:prep_info_requested].include?(state)
       {
         badge_text: t('portal.portal2.home.badge.tax_prep'),
@@ -207,7 +209,7 @@ module TaxReturnCardHelper
         call_to_action_title: t('portal.portal2.home.calls_to_action.prep_info_requested_title'),
         call_to_action_text:
           t('portal.portal2.home.calls_to_action.prep_info_requested',
-            contact_method: contact_method_of_last_tax_team_message(intake)),
+            contact_method: intake.pseudo? ? "Contact Method" : contact_method_of_last_tax_team_message(intake)),
         return_status: state
       }
     elsif [:review_ready_for_qr, :review_reviewing, :review_ready_for_call].include?(state)
@@ -217,6 +219,7 @@ module TaxReturnCardHelper
         button_type: :message_tax_team,
         return_status: state
       }
+      # Added pseudo check to skip Contact Method calls in event of PseudoTaxReturn
     elsif [:review_info_requested].include?(state)
       {
         badge_text: t('portal.portal2.home.badge.final_check'),
@@ -225,7 +228,7 @@ module TaxReturnCardHelper
         call_to_action_title: t('portal.portal2.home.calls_to_action.review_info_requested_title'),
         call_to_action_text:
           t('portal.portal2.home.calls_to_action.review_info_requested',
-            contact_method: contact_method_of_last_tax_team_message(intake)),
+            contact_method: intake.pseudo? ? "Contact Method" : contact_method_of_last_tax_team_message(intake)),
         return_status: state
       }
     elsif [:file_ready_to_file, :file_accepted, :file_rejected, :file_hold, :file_fraud_hold,

--- a/app/views/hub/portal_states/index.html.erb
+++ b/app/views/hub/portal_states/index.html.erb
@@ -9,7 +9,11 @@
 
         <% @tax_returns.each_with_index do |tax_return, _index| %>
           <h2><%= tax_return._description %></h2>
-          <%= render "portal/portal/tax_return_card", tax_return: tax_return %>
+          <% if @client_portal_improvements %>
+            <%= render "portal/portal2/tax_return_card", tax_return: tax_return %>
+          <% else %>
+            <%= render "portal/portal/tax_return_card", tax_return: tax_return %>
+          <% end %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
## Link to Jira issue

- https://codeforamerica.atlassian.net/browse/GYR1-1157?atlOrigin=eyJpIjoiYzQ0YzFkMWFlYmNlNDc0OWE0ZmQ1YTk4NWE2MDJmOGMiLCJwIjoiaiJ9

## Is PM acceptance required?

- Yes - don't merge until Jira issue is accepted!

## What was done?

- Update to show new design for portal states tax return status cards when Flipper flag is enabled

## How to test?

- Manual Testing
  - Log in to the Hub with user with permissions to view Portal States page and update Flipper flags
  - If 'client_portal_improvements' flag is not enabled, enable it
  - View Portal States page to see updated designs for tax return status cards
  - Disable 'client_portal_improvements' flag to view previous design and confirm Flipper flag functionality

- Risk Assessment
  - N/A

## Screenshots (visual changes)

- Before
- 
<img width="896" height="699" alt="image" src="https://github.com/user-attachments/assets/ea689706-5acf-4d8f-a9f1-2fa48c1cc9d1" />

- After
<img width="896" height="765" alt="image" src="https://github.com/user-attachments/assets/fe5a6d06-0bf5-4119-a1d5-8d46ab1f2b79" />

