### PR TITLE
Take out websocket-driver from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -172,5 +172,3 @@ gem "aws-sdk-core", "~> 3.190"
 gem "aws-sdk-bedrockruntime", "~> 1.2"
 
 gem 'oauth2', '>= 2.0.22'
-
-gem 'websocket-driver', '>= 0.8.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -904,7 +904,6 @@ DEPENDENCIES
   warning
   web-console (>= 3.3.0)
   webmock
-  websocket-driver (>= 0.8.2)
   websocket-extensions (>= 0.1.5)
   will_paginate
   zxcvbn-ruby

--- a/Gemfile_next.lock
+++ b/Gemfile_next.lock
@@ -908,7 +908,6 @@ DEPENDENCIES
   warning
   web-console (>= 3.3.0)
   webmock
-  websocket-driver (>= 0.8.2)
   websocket-extensions (>= 0.1.5)
   will_paginate
   zxcvbn-ruby


### PR DESCRIPTION
websocket-driver doesn't need to be pulled into the Gemfile anymore (though it is a transitive dependency of actioncable).