### PR TITLE
Gyr1 479 gyr clients cannot upload images on portal upload documents page

### DIFF
--- a/app/controllers/portal/upload_documents_controller.rb
+++ b/app/controllers/portal/upload_documents_controller.rb
@@ -40,6 +40,12 @@ module Portal
         redirect_to portal_upload_documents_path(document_type: form_params[:document_type])
       else
         flash.now[:error] = I18n.t("portal.upload_documents.error")
+        if form_params[:document_type].present?
+          @documents = current_client.documents.active.where(document_type: form_params[:document_type])
+          @document_type = DocumentTypes::ALL_TYPES.find { |doc_type| doc_type.key == form_params[:document_type] }
+        else
+          @documents = current_client.documents.active
+        end
         render :edit
       end
     end

--- a/app/views/layouts/document_upload.html.erb
+++ b/app/views/layouts/document_upload.html.erb
@@ -57,9 +57,7 @@
 
           <%# document upload form %>
           <%= form_with model: @form, url: current_path, method: "put", local: true, builder: VitaMinFormBuilder, id: "file-upload-form" do |f| %>
-            <% if @document_type %>
-              <%= f.hidden_field :document_type, value: @document_type.key %>
-            <% end %>
+            <%= f.hidden_field :document_type, value: document_type.key %>
             <div class="document-upload">
               <div class="file-upload">
                 <% file_input_data = { "upload-immediately" => true } %>

--- a/spec/controllers/portal/upload_documents_controller_spec.rb
+++ b/spec/controllers/portal/upload_documents_controller_spec.rb
@@ -107,6 +107,26 @@ describe Portal::UploadDocumentsController do
           expect(response).to render_template :edit
           expect(flash[:error]).to eq I18n.t("portal.upload_documents.error")
         end
+
+        context "when a document_type param is present" do
+          let!(:id_document) { create :document, client: client, document_type: "ID" }
+
+          it "preserves @document_type and filters @documents to that type" do
+            put :update, params: { portal_document_upload_form: { document_type: "ID" } }
+            expect(assigns(:document_type).key).to eq "ID"
+            expect(assigns(:documents)).to match_array([id_document])
+          end
+        end
+
+        context "when no document_type param is present" do
+          let!(:document) { create :document, client: client }
+
+          it "assigns all active documents and leaves @document_type nil" do
+            put :update
+            expect(assigns(:document_type)).to be_nil
+            expect(assigns(:documents)).to match_array([document])
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Link to Jira issue

  - https://codeforamerica.atlassian.net/browse/GYR1-479

## Is PM acceptance required?

  - Yes - don't merge until Jira issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main

## What was done?

  - Fixed the issue related to upload documents in portal/still-need-help/upload-documents. The issue was the hidden document_type field that was only rendered when document_type is set, but document_type is only set when a the param ?document_type is present in the URL. When visiting /en/portal/upload-documents directly (no param), document_type is nil, no hidden field is rendered, and the form submits without a document_type that causes the “Can't be blank.” error message.
   
  - Another issue that I found: When an error happens, it will render the Edit view but with an empty list, but it should display the already uploaded documents(if document exist). This is fixed as well.

## How to test?

- Describe the testing approach taken to verify the changes, including:
  - Manual tests
    - Log in as GYR Client
    - Visit [portal/still-need-help/upload-documents](http://localhost:3000/en//portal/still-need-help/upload-documents)
    - Click “Upload Additional Documents”
    - Click “Select a file”

## Screenshots (visual changes)

- Before
<img width="1208" height="776" alt="Before_updates2" src="https://github.com/user-attachments/assets/aec2d867-81e3-4449-91f2-26a847f64e32" />

<img width="1039" height="756" alt="Before_updates" src="https://github.com/user-attachments/assets/5b6cb8ad-8721-46ae-a4f1-512911fa92c7" />

- After
<img width="1223" height="790" alt="before_upload" src="https://github.com/user-attachments/assets/a01bfc5e-0811-42ee-979a-646702da899e" />

<img width="1224" height="790" alt="after_upload" src="https://github.com/user-attachments/assets/a492a461-457b-4e32-9eba-fd86d27745d7" />
