### PR TITLE
Gyr1 1175 add missing indexes for columns to filter sort

### DIFF
--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -388,17 +388,24 @@
 #  index_intakes_on_email_address                          (email_address)
 #  index_intakes_on_email_domain                           (email_domain)
 #  index_intakes_on_hashed_primary_ssn                     (hashed_primary_ssn)
+#  index_intakes_on_locale                                 (locale)
 #  index_intakes_on_matching_previous_year_intake_id       (matching_previous_year_intake_id)
 #  index_intakes_on_needs_to_flush_searchable_data_set_at  (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_intakes_on_phone_number                           (phone_number)
+#  index_intakes_on_preferred_interview_language           (preferred_interview_language)
 #  index_intakes_on_primary_consented_to_service           (primary_consented_to_service)
 #  index_intakes_on_primary_drivers_license_id             (primary_drivers_license_id)
 #  index_intakes_on_searchable_data                        (searchable_data) USING gin
 #  index_intakes_on_sms_phone_number                       (sms_phone_number)
 #  index_intakes_on_spouse_drivers_license_id              (spouse_drivers_license_id)
 #  index_intakes_on_spouse_email_address                   (spouse_email_address)
+#  index_intakes_on_state_of_residence                     (state_of_residence)
 #  index_intakes_on_type                                   (type)
 #  index_intakes_on_vita_partner_id                        (vita_partner_id)
+#  index_intakes_on_with_general_navigator                 (with_general_navigator) WHERE (with_general_navigator = true)
+#  index_intakes_on_with_incarcerated_navigator            (with_incarcerated_navigator) WHERE (with_incarcerated_navigator = true)
+#  index_intakes_on_with_limited_english_navigator         (with_limited_english_navigator) WHERE (with_limited_english_navigator = true)
+#  index_intakes_on_with_unhoused_navigator                (with_unhoused_navigator) WHERE (with_unhoused_navigator = true)
 #
 # Foreign Keys
 #

--- a/db/migrate/20260828193552_add_filter_indexes_to_intakes.rb
+++ b/db/migrate/20260828193552_add_filter_indexes_to_intakes.rb
@@ -1,0 +1,13 @@
+class AddFilterIndexesToIntakes < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :intakes, :locale,                        algorithm: :concurrently
+    add_index :intakes, :preferred_interview_language,  algorithm: :concurrently
+    add_index :intakes, :state_of_residence,            algorithm: :concurrently
+    add_index :intakes, :with_general_navigator,        algorithm: :concurrently, where: "with_general_navigator = true"
+    add_index :intakes, :with_incarcerated_navigator,   algorithm: :concurrently, where: "with_incarcerated_navigator = true"
+    add_index :intakes, :with_limited_english_navigator, algorithm: :concurrently, where: "with_limited_english_navigator = true"
+    add_index :intakes, :with_unhoused_navigator,       algorithm: :concurrently, where: "with_unhoused_navigator = true"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_17_210604) do
+ActiveRecord::Schema[7.2].define(version: 2026_08_28_193552) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -1631,17 +1631,24 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_17_210604) do
     t.index ["email_address"], name: "index_intakes_on_email_address"
     t.index ["email_domain"], name: "index_intakes_on_email_domain"
     t.index ["hashed_primary_ssn"], name: "index_intakes_on_hashed_primary_ssn"
+    t.index ["locale"], name: "index_intakes_on_locale"
     t.index ["matching_previous_year_intake_id"], name: "index_intakes_on_matching_previous_year_intake_id"
     t.index ["needs_to_flush_searchable_data_set_at"], name: "index_intakes_on_needs_to_flush_searchable_data_set_at", where: "(needs_to_flush_searchable_data_set_at IS NOT NULL)"
     t.index ["phone_number"], name: "index_intakes_on_phone_number"
+    t.index ["preferred_interview_language"], name: "index_intakes_on_preferred_interview_language"
     t.index ["primary_consented_to_service"], name: "index_intakes_on_primary_consented_to_service"
     t.index ["primary_drivers_license_id"], name: "index_intakes_on_primary_drivers_license_id"
     t.index ["searchable_data"], name: "index_intakes_on_searchable_data", using: :gin
     t.index ["sms_phone_number"], name: "index_intakes_on_sms_phone_number"
     t.index ["spouse_drivers_license_id"], name: "index_intakes_on_spouse_drivers_license_id"
     t.index ["spouse_email_address"], name: "index_intakes_on_spouse_email_address"
+    t.index ["state_of_residence"], name: "index_intakes_on_state_of_residence"
     t.index ["type"], name: "index_intakes_on_type"
     t.index ["vita_partner_id"], name: "index_intakes_on_vita_partner_id"
+    t.index ["with_general_navigator"], name: "index_intakes_on_with_general_navigator", where: "(with_general_navigator = true)"
+    t.index ["with_incarcerated_navigator"], name: "index_intakes_on_with_incarcerated_navigator", where: "(with_incarcerated_navigator = true)"
+    t.index ["with_limited_english_navigator"], name: "index_intakes_on_with_limited_english_navigator", where: "(with_limited_english_navigator = true)"
+    t.index ["with_unhoused_navigator"], name: "index_intakes_on_with_unhoused_navigator", where: "(with_unhoused_navigator = true)"
   end
 
   create_table "internal_emails", force: :cascade do |t|

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -388,17 +388,24 @@
 #  index_intakes_on_email_address                          (email_address)
 #  index_intakes_on_email_domain                           (email_domain)
 #  index_intakes_on_hashed_primary_ssn                     (hashed_primary_ssn)
+#  index_intakes_on_locale                                 (locale)
 #  index_intakes_on_matching_previous_year_intake_id       (matching_previous_year_intake_id)
 #  index_intakes_on_needs_to_flush_searchable_data_set_at  (needs_to_flush_searchable_data_set_at) WHERE (needs_to_flush_searchable_data_set_at IS NOT NULL)
 #  index_intakes_on_phone_number                           (phone_number)
+#  index_intakes_on_preferred_interview_language           (preferred_interview_language)
 #  index_intakes_on_primary_consented_to_service           (primary_consented_to_service)
 #  index_intakes_on_primary_drivers_license_id             (primary_drivers_license_id)
 #  index_intakes_on_searchable_data                        (searchable_data) USING gin
 #  index_intakes_on_sms_phone_number                       (sms_phone_number)
 #  index_intakes_on_spouse_drivers_license_id              (spouse_drivers_license_id)
 #  index_intakes_on_spouse_email_address                   (spouse_email_address)
+#  index_intakes_on_state_of_residence                     (state_of_residence)
 #  index_intakes_on_type                                   (type)
 #  index_intakes_on_vita_partner_id                        (vita_partner_id)
+#  index_intakes_on_with_general_navigator                 (with_general_navigator) WHERE (with_general_navigator = true)
+#  index_intakes_on_with_incarcerated_navigator            (with_incarcerated_navigator) WHERE (with_incarcerated_navigator = true)
+#  index_intakes_on_with_limited_english_navigator         (with_limited_english_navigator) WHERE (with_limited_english_navigator = true)
+#  index_intakes_on_with_unhoused_navigator                (with_unhoused_navigator) WHERE (with_unhoused_navigator = true)
 #
 # Foreign Keys
 #


### PR DESCRIPTION
## Link to Jira issue

- https://codeforamerica.atlassian.net/browse/GYR1-1175

## Is PM acceptance required?

- No - merge after code review approval


## What was done?

- We had some fields use for sorting and filter that were not indexed. Fields affected: locale, preferred_interview_language, state_of_residence, with_general_navigator, with_incarcerated_navigator, with_limited_english_navigator, with_unhoused_navigator.

## How to test?

- Describe the testing approach taken to verify the changes, including:
  - Go to the client search(in /en/hub/clients) and use the filter and sorts.
  - Another way to test is doing some EXPLAIN in the DB, something like: EXPLAIN ANALYZE SELECT * FROM intakes
  WHERE type = 'Intake::GyrIntake' AND state_of_residence = 'CA';
  

