### PR TITLE
Gyr1 1165 remove redundant client load

### DIFF
--- a/app/controllers/hub/assigned_clients_controller.rb
+++ b/app/controllers/hub/assigned_clients_controller.rb
@@ -11,7 +11,7 @@ module Hub
       @page_title = I18n.t("hub.assigned_clients.index.title")
       @client_sorter.filters[:assigned_to_me] = true
       @tax_return_count = TaxReturn.where(client: @client_sorter.filtered_clients.with_eager_loaded_associations.without_pagination).size
-      @clients = @client_sorter.filtered_and_sorted_clients.page(params[:page]).load
+      @clients = @client_sorter.filtered_and_sorted_clients.with_eager_loaded_associations.page(params[:page]).load
       @message_summaries = RecentMessageSummaryService.messages(@clients.map(&:id))
       render "hub/clients/index"
     end

--- a/app/controllers/hub/clients_controller.rb
+++ b/app/controllers/hub/clients_controller.rb
@@ -14,7 +14,7 @@ module Hub
 
     def index
       @page_title = I18n.t("hub.clients.index.title")
-      @clients = @client_sorter.filtered_and_sorted_clients.page(params[:page]).load
+      @clients = @client_sorter.filtered_and_sorted_clients.with_eager_loaded_associations.page(params[:page]).load
       @message_summaries = RecentMessageSummaryService.messages(@clients.map(&:id))
       related_models_cache
     end

--- a/app/views/hub/clients/index.html.erb
+++ b/app/views/hub/clients/index.html.erb
@@ -76,7 +76,7 @@
         </thead>
 
         <tbody class="index-table__body clients-table">
-        <% @clients.with_eager_loaded_associations.map { |client| Hub::ClientsController::HubClientPresenter.new(client, @related_models_cache) }.each do |client| %>
+        <% @clients.map { |client| Hub::ClientsController::HubClientPresenter.new(client, @related_models_cache) }.each do |client| %>
           <tr id="client-<%= client.id %>" class="index-table__row client-row">
             <td class="index-table__cell client-attribute__needs-response">
               <label class="toggle-switch flag-toggle">


### PR DESCRIPTION
## Link to Jira issue

- https://codeforamerica.atlassian.net/browse/GYR1-1165

## Is PM acceptance required?

- No - merge after code review approval

## What was done?

- Moved with_eager_loaded_associations into both controllers and remove it from the view.

## How to test?

- Describe the testing approach taken to verify the changes, including:
  - In Docker app or your log check for Client Load, it should appear only once(before it was loading the data twice per request)

## Screenshots (visual changes)

- Before
<img width="1092" height="516" alt="Screenshot 2026-08-31 at 4 15 07 PM" src="https://github.com/user-attachments/assets/840b8388-3a37-4819-bd3a-92856c1fdacd" />

- After
<img width="1073" height="325" alt="Screenshot 2026-08-31 at 4 15 22 PM" src="https://github.com/user-attachments/assets/0146c847-b796-4e0c-a76e-0554b5277fc0" />

