### PR TITLE
update max width for breakpoints on GYR home page

### DIFF
--- a/app/assets/stylesheets/templates/_home.scss
+++ b/app/assets/stylesheets/templates/_home.scss
@@ -1,4 +1,6 @@
 .body--home {
+  min-width:368px;
+
   .button {
     padding: $s35/2 4rem;
   }
@@ -52,6 +54,22 @@
     .grid {
       position: relative;
       min-height: 355px;
+
+      max-width: 368px;
+      margin-left: auto;
+      margin-right: auto;
+
+      @media screen and (min-width: 768px) {
+        max-width: 688px;
+      }
+
+      @media screen and (min-width: 1280px) {
+        max-width: 944px;
+      }
+
+      @media screen and (min-width: 1536px) {
+        max-width: 1344px;
+      }
 
       @media screen and (max-width: $site-max-up) {
         position: static;

--- a/app/assets/stylesheets/templates/_home.scss
+++ b/app/assets/stylesheets/templates/_home.scss
@@ -1,8 +1,28 @@
 .body--home {
-  min-width:368px;
 
   .button {
     padding: $s35/2 4rem;
+  }
+
+  .slab{
+    .grid{
+
+      margin-left: auto;
+      margin-right: auto;
+      max-width: 368px;
+
+      @media screen and (min-width: 768px) {
+        max-width: 688px;
+      }
+
+      @media screen and (min-width: 1280px) {
+        max-width: 944px;
+      }
+
+      @media screen and (min-width: 1536px) {
+        max-width: 1344px;
+      }
+    }
   }
 
   .slab--hero {
@@ -54,22 +74,6 @@
     .grid {
       position: relative;
       min-height: 355px;
-
-      max-width: 368px;
-      margin-left: auto;
-      margin-right: auto;
-
-      @media screen and (min-width: 768px) {
-        max-width: 688px;
-      }
-
-      @media screen and (min-width: 1280px) {
-        max-width: 944px;
-      }
-
-      @media screen and (min-width: 1536px) {
-        max-width: 1344px;
-      }
 
       @media screen and (max-width: $site-max-up) {
         position: static;


### PR DESCRIPTION
## Link to Jira issue

- https://codeforamerica.atlassian.net/browse/GYR1-1196

## Is PM acceptance required?

- Yes - don't merge until Jira issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main

## What was done?

- Updated max-width for content for each screen size

## How to test?

- Visit deployed demo site
  - Should see max-width set at 368px, 688px, 944px, and 1344px as you resize
- Compare to current, fluid resizing in production

## Screenshots (visual changes)

- Before
<img width="2429" height="1157" alt="Screenshot 2026-08-31 at 2 26 17 PM" src="https://github.com/user-attachments/assets/d5f6b836-18b1-42d1-a486-9268916977c6" />
<img width="839" height="1013" alt="Screenshot 2026-08-31 at 2 32 25 PM" src="https://github.com/user-attachments/assets/c537abc6-2897-4be0-99a5-53957d99145a" />

- After
<img width="1550" height="1157" alt="Screenshot 2026-08-31 at 2 24 44 PM" src="https://github.com/user-attachments/assets/8a80dbd4-ba9c-49a7-bbc7-e14b84295aa4" />
<img width="1438" height="1157" alt="Screenshot 2026-08-31 at 2 25 23 PM" src="https://github.com/user-attachments/assets/c96bfdec-a68f-47fa-b20e-1b86e1bd730e" />
<img width="1062" height="1157" alt="Screenshot 2026-08-31 at 2 28 54 PM" src="https://github.com/user-attachments/assets/a79e653b-5bd1-462e-bec1-a3f6f1acb33b" />
<img width="399" height="1330" alt="Screenshot 2026-08-31 at 4 17 06 PM" src="https://github.com/user-attachments/assets/4fa33563-9977-491e-8598-feb396d46173" />

